### PR TITLE
Align care controller with respect to incorporating `ManagedResource` statuses

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -361,6 +361,13 @@ If at least one `ManagedResource` is unhealthy and there is threshold configurat
 The condition thresholds can be used to prevent reporting issues too early just because there is a rollout or a short disruption.
 Only if the unhealthiness persists for at least the configured threshold duration, then the issues will be reported (by setting the status to `False`).
 
+In order to compute the condition statuses, this reconciler considers `ManagedResource`s (in the `garden` and `istio-system` namespace) and their status, see [this document](resource-manager.md#conditions) for more information.
+The following table explains which `ManagedResource`s are considered for which condition type:
+
+| Condition Type                | `ManagedResource`s are considered when |
+|-------------------------------|----------------------------------------|
+| `SeedSystemComponentsHealthy` | `.spec.class=seed`                     |
+
 #### ["Lease" Reconciler](../../pkg/gardenlet/controller/seed/lease)
 
 This reconciler checks whether the connection to the seed cluster's `/healthz` endpoint works.

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -366,7 +366,7 @@ The following table explains which `ManagedResource`s are considered for which c
 
 | Condition Type                | `ManagedResource`s are considered when |
 |-------------------------------|----------------------------------------|
-| `SeedSystemComponentsHealthy` | `.spec.class=seed`                     |
+| `SeedSystemComponentsHealthy` | `.spec.class` is set                   |
 
 #### ["Lease" Reconciler](../../pkg/gardenlet/controller/seed/lease)
 
@@ -451,7 +451,7 @@ The following table explains which `ManagedResource`s are considered for which c
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | `ControlPlaneHealthy`            | `.spec.class=seed` and `care.gardener.cloud/condition-type` label either unset, or set to `ControlPlaneHealthy` |
 | `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                              |
-| `SystemComponentsHealthy`        | `.spec.class` and `care.gardener.cloud/condition-type` label either unet, or set to `SystemComponentsHealthy`   |
+| `SystemComponentsHealthy`        | `.spec.class` unset or `care.gardener.cloud/condition-type` label set to `SystemComponentsHealthy`              |
 
 ##### Constraints And Automatic Webhook Remediation
 

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -437,6 +437,15 @@ If at least one check fails and there is threshold configuration for the conditi
 The condition thresholds can be used to prevent reporting issues too early just because there is a rollout or a short disruption.
 Only if the unhealthiness persists for at least the configured threshold duration, then the issues will be reported (by setting the status to `False`).
 
+Besides directly checking the status of `Deployment`s, `Etcd`s, `StatefulSet`s in the shoot namespace, this reconciler also considers `ManagedResource`s (in the shoot namespace) and their status in order to compute the condition statuses, see [this document](resource-manager.md#conditions) for more information.
+The following table explains which `ManagedResource`s are considered for which condition type:
+
+| Condition Type                   | `ManagedResource`s are considered when                                                                          |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `ControlPlaneHealthy`            | `.spec.class=seed` and `care.gardener.cloud/condition-type` label either unset, or set to `ControlPlaneHealthy` |
+| `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                              |
+| `SystemComponentsHealthy`        | `.spec.class` and `care.gardener.cloud/condition-type` label either unet, or set to `SystemComponentsHealthy`   |
+
 ##### Constraints And Automatic Webhook Remediation
 
 Please see [Shoot Status](../usage/shoot_status.md#constraints) for more details.

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -157,9 +157,9 @@ This reconciler performs four "care" actions related to `Garden`s.
 
 It maintains the following conditions:
 
+- `VirtualGardenAPIServerAvailable`: The `/healthz` endpoint of the garden's `virtual-garden-kube-apiserver` is called and considered healthy when it responds with `200 OK`.
 - `RuntimeComponentsHealthy`: The conditions of the `ManagedResource`s applied to the runtime cluster are checked (e.g., `ResourcesApplied`).
 - `VirtualComponentsHealthy`: The virtual components are considered healthy when the respective `Deployment`s (for example `virtual-garden-kube-apiserver`,`virtual-garden-kube-controller-manager`), and `Etcd`s (for example `virtual-garden-etcd-main`) exist and are healthy. Additionally, the conditions of the `ManagedResource`s applied to the virtual cluster are checked (e.g., `ResourcesApplied`).
-- `VirtualGardenAPIServerAvailable`: The `/healthz` endpoint of the garden's `virtual-garden-kube-apiserver` is called and considered healthy when it responds with `200 OK`.
 - `ObservabilityComponentsHealthy`: This condition is considered healthy when the respective `Deployment`s (for example `plutono`) and `StatefulSet`s (for example `prometheus`, `vali`) exist and are healthy.
 
 If all checks for a certain condition are succeeded, then its `status` will be set to `True`.
@@ -173,6 +173,15 @@ If at least one check fails and there is threshold configuration for the conditi
 
 The condition thresholds can be used to prevent reporting issues too early just because there is a rollout or a short disruption.
 Only if the unhealthiness persists for at least the configured threshold duration, then the issues will be reported (by setting the status to `False`).
+
+In order to compute the condition statuses, this reconciler considers `ManagedResource`s (in the `garden` and `istio-system` namespace) and their status, see [this document](resource-manager.md#conditions) for more information.
+The following table explains which `ManagedResource`s are considered for which condition type:
+
+| Condition Type                   | `ManagedResource`s are considered when                                                                               |
+|----------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `RuntimeComponentsHealthy`       | `.spec.class=seed` and `care.gardener.cloud/condition-type` label either unset, or set to `RuntimeComponentsHealthy` |
+| `VirtualComponentsHealthy`       | `.spec.class` unset or `care.gardener.cloud/condition-type` label set to `VirtualComponentsHealthy`                  |
+| `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                                   |
 
 #### [`Reference` Reconciler](../../pkg/operator/controller/garden/reference)
 

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -189,7 +189,7 @@ This document provides a checklist for them that you can walk through.
 
    [`gardener-operators`'s](../concepts/operator.md#controllers) and [`gardenlet`'s](../concepts/gardenlet.md#controllers) care controllers regularly check the health status of components relevant to the respective cluster (garden/seed/shoot).
    For shoot control plane components, you need to enhance the lists of components to make sure your component is checked, see example above.
-   For components deployed via `ManagedResource`, please consult the respective care controller documentation for more information.
+   For components deployed via `ManagedResource`, please consult the respective care controller documentation for more information ([garden](../concepts/operator.md#care-reconciler), [seed](../concepts/gardenlet.md#-care--reconciler-1), [shoot](../concepts/gardenlet.md#-care--reconciler-2)).
 
 5. **Configure automatic restarts in shoot maintenance time window** ([example 1](https://github.com/gardener/gardener/blob/b0de7db96ad436fe32c25daae5e8cb552dac351f/pkg/component/kubescheduler/kube_scheduler.go#L250), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/coredns.go#L90-L107))
 

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -185,10 +185,11 @@ This document provides a checklist for them that you can walk through.
 
    In order to allow easy inspection of two `ReplicaSet`s to quickly find the changes that lead to a rolling update, the [revision history limit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit) should be set to `2`.
 
-4. **Define health checks** ([example 1](https://github.com/gardener/gardener/blob/180951eac9b8183175d4dcadc305c7722ce8122d/pkg/gardenlet/controller/shoot/care/health.go#L763-L795), [example 2](https://github.com/gardener/gardener/blob/180951eac9b8183175d4dcadc305c7722ce8122d/pkg/gardenlet/controller/seed/care/health.go#L48-L55))
+4. **Define health checks** ([example 1](https://github.com/gardener/gardener/blob/180951eac9b8183175d4dcadc305c7722ce8122d/pkg/gardenlet/controller/shoot/care/health.go#L763-L795))
 
-   `gardenlet`'s [care controllers](../concepts/gardenlet.md#controllers) regularly check the health status of system or control plane components.
-   You need to enhance the lists of components to check if your component related to the seed system or shoot control plane (shoot system components are automatically checked via their respective [`ManagedResource` conditions](../concepts/resource-manager.md#managedresource-controller)), see examples above.
+   [`gardener-operators`'s](../concepts/operator.md#controllers) and [`gardenlet`'s](../concepts/gardenlet.md#controllers) care controllers regularly check the health status of components relevant to the respective cluster (garden/seed/shoot).
+   For shoot control plane components, you need to enhance the lists of components to make sure your component is checked, see example above.
+   For components deployed via `ManagedResource`, please consult the respective care controller documentation for more information.
 
 5. **Configure automatic restarts in shoot maintenance time window** ([example 1](https://github.com/gardener/gardener/blob/b0de7db96ad436fe32c25daae5e8cb552dac351f/pkg/component/kubescheduler/kube_scheduler.go#L250), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/coredns.go#L90-L107))
 

--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -99,7 +99,7 @@ The health check library will automatically transition the status to `False` if 
 It is up to the extension to decide how to conduct health checks, though it is recommended to make use of the build-in health check functionality of `managed-resources` for trivial checks.
 By [deploying the depending resources via managed resources](../../extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go), the [gardener resource manager](https://github.com/gardener/gardener-resource-manager) conducts basic checks for different API objects out-of-the-box (e.g `Deployments`, `DaemonSets`, ...) - and writes health conditions.
 
-By default, Gardener performs health check for all the `ManagedResource`s created in the shoot namespaces.
+By default, Gardener performs health checks for all the `ManagedResource`s created in the shoot namespaces.
 Their status will be aggregated to the `Shoot` conditions according to the following rules:
 
 - Health checks of `ManagedResource` with `.spec.class=nil` are aggregated to the `SystemComponentsHealthy` condition

--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -98,6 +98,11 @@ The health check library will automatically transition the status to `False` if 
 
 It is up to the extension to decide how to conduct health checks, though it is recommended to make use of the build-in health check functionality of `managed-resources` for trivial checks.
 By [deploying the depending resources via managed resources](../../extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go), the [gardener resource manager](https://github.com/gardener/gardener-resource-manager) conducts basic checks for different API objects out-of-the-box (e.g `Deployments`, `DaemonSets`, ...) - and writes health conditions.
-By default, Gardener performs health check for all the `ManagedResource`s with `.spec.class=nil` created in the shoot namespaces.
+
+By default, Gardener performs health check for all the `ManagedResource`s created in the shoot namespaces.
+Their status will be aggregated to the `Shoot` conditions according to the following rules:
+
+- Health checks of `ManagedResource` with `.spec.class=nil` are aggregated to the `SystemComponentsHealthy` condition
+- Health checks of `ManagedResource` with `.spec.class!=nil` are aggregated to the `ControlPlaneHealthy` condition unless the `ManagedResource` is labeled with `care.gardener.cloud/condition-type=<other-condition-type>`. In such case, it is aggregated to the `<other-condition-type>`.
 
 More sophisticated health checks should be implemented by the extension controller itself (implementing the `HealthCheck` interface).

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -669,6 +669,10 @@ const (
 	LabelControllerRegistrationName = "controllerregistration.core.gardener.cloud/name"
 	// LabelPodMaintenanceRestart is a constant for a label that describes that a pod should be restarted during maintenance.
 	LabelPodMaintenanceRestart = "maintenance.gardener.cloud/restart"
+	// LabelCareConditionType is a key for a label on a ManagedResource indicating to which condition type its status
+	// should be aggregated.
+	LabelCareConditionType = "care.gardener.cloud/condition-type"
+
 	// LabelWorkerPool is a constant for a label that indicates the worker pool the node belongs to
 	LabelWorkerPool = "worker.gardener.cloud/pool"
 	// LabelWorkerKubernetesVersion is a constant for a label that indicates the Kubernetes version used for the worker pool nodes.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -672,6 +672,8 @@ const (
 	// LabelCareConditionType is a key for a label on a ManagedResource indicating to which condition type its status
 	// should be aggregated.
 	LabelCareConditionType = "care.gardener.cloud/condition-type"
+	// ObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
+	ObservabilityComponentsHealthy = "ObservabilityComponentsHealthy"
 
 	// LabelWorkerPool is a constant for a label that indicates the worker pool the node belongs to
 	LabelWorkerPool = "worker.gardener.cloud/pool"

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 // +genclient
@@ -1699,7 +1701,7 @@ const (
 	// ShootControlPlaneHealthy is a constant for a condition type indicating the health of core control plane components.
 	ShootControlPlaneHealthy ConditionType = "ControlPlaneHealthy"
 	// ShootObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
-	ShootObservabilityComponentsHealthy ConditionType = "ObservabilityComponentsHealthy"
+	ShootObservabilityComponentsHealthy ConditionType = v1beta1constants.ObservabilityComponentsHealthy
 	// ShootEveryNodeReady is a constant for a condition type indicating the node health.
 	ShootEveryNodeReady ConditionType = "EveryNodeReady"
 	// ShootSystemComponentsHealthy is a constant for a condition type indicating the system components health.

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -572,7 +572,7 @@ const (
 	// VirtualGardenAPIServerAvailable is a constant for a condition type indicating that the virtual garden's API server is available.
 	VirtualGardenAPIServerAvailable gardencorev1beta1.ConditionType = "VirtualGardenAPIServerAvailable"
 	// ObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
-	ObservabilityComponentsHealthy gardencorev1beta1.ConditionType = "ObservabilityComponentsHealthy"
+	ObservabilityComponentsHealthy gardencorev1beta1.ConditionType = v1beta1constants.ObservabilityComponentsHealthy
 )
 
 // AvailableOperationAnnotations is the set of available operation annotations for Garden resources.

--- a/pkg/component/autoscaling/vpa/vpa.go
+++ b/pkg/component/autoscaling/vpa/vpa.go
@@ -172,7 +172,7 @@ func (v *vpa) Deploy(ctx context.Context) error {
 		}
 	}
 
-	return component.DeployResourceConfigs(ctx, v.client, v.namespace, v.values.ClusterType, v.managedResourceName(), registry, allResources)
+	return component.DeployResourceConfigs(ctx, v.client, v.namespace, v.values.ClusterType, v.managedResourceName(), nil, registry, allResources)
 }
 
 func (v *vpa) Destroy(ctx context.Context) error {

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -36,6 +36,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	settingsv1alpha1 "github.com/gardener/gardener/pkg/apis/settings/v1alpha1"
@@ -74,7 +75,7 @@ func (g *gardenSystem) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, g.client, g.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
+	return managedresources.CreateForShootWithLabels(ctx, g.client, g.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)}, data)
 }
 
 func (g *gardenSystem) Destroy(ctx context.Context) error {

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -609,7 +609,10 @@ var _ = Describe("Virtual", func() {
 					Name:            managedResource.Name,
 					Namespace:       managedResource.Namespace,
 					ResourceVersion: "1",
-					Labels:          map[string]string{"origin": "gardener"},
+					Labels: map[string]string{
+						"origin":                             "gardener",
+						"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+					},
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
 					InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},

--- a/pkg/component/gardener/access/access.go
+++ b/pkg/component/gardener/access/access.go
@@ -66,6 +66,8 @@ type Values struct {
 	ServerOutOfCluster string
 	// ServerInCluster is the in-cluster address of a kube-apiserver.
 	ServerInCluster string
+	// ManagedResourceLabels are labels added to the ManagedResource.
+	ManagedResourceLabels map[string]string
 }
 
 type accessNameToServer struct {
@@ -109,7 +111,7 @@ func (g *gardener) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, g.client, g.namespace, ManagedResourceName, managedresources.LabelValueGardener, true, data)
+	return managedresources.CreateForShootWithLabels(ctx, g.client, g.namespace, ManagedResourceName, managedresources.LabelValueGardener, true, g.values.ManagedResourceLabels, data)
 }
 
 func (g *gardener) Destroy(ctx context.Context) error {

--- a/pkg/component/gardener/access/access_test.go
+++ b/pkg/component/gardener/access/access_test.go
@@ -90,8 +90,9 @@ subjects:
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: namespace}})).To(Succeed())
 
 		access = New(fakeClient, namespace, sm, Values{
-			ServerOutOfCluster: serverOutOfCluster,
-			ServerInCluster:    serverInCluster,
+			ServerOutOfCluster:    serverOutOfCluster,
+			ServerInCluster:       serverInCluster,
+			ManagedResourceLabels: map[string]string{"foo": "bar"},
 		})
 
 		expectedGardenerSecret = &corev1.Secret{
@@ -182,7 +183,10 @@ users:
 				Name:            managedResourceName,
 				Namespace:       namespace,
 				ResourceVersion: "1",
-				Labels:          map[string]string{"origin": "gardener"},
+				Labels: map[string]string{
+					"origin": "gardener",
+					"foo":    "bar",
+				},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs:   []corev1.LocalObjectReference{},

--- a/pkg/component/gardener/admissioncontroller/admission_controller.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller.go
@@ -92,6 +92,7 @@ func (a *gardenerAdmissionController) Deploy(ctx context.Context) error {
 	var (
 		runtimeRegistry           = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 		virtualGardenAccessSecret = a.newVirtualGardenAccessSecret()
+		managedResourceLabels     = map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)}
 	)
 
 	secretServerCert, err := a.reconcileSecretServerCert(ctx)
@@ -124,7 +125,7 @@ func (a *gardenerAdmissionController) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := managedresources.CreateForSeed(ctx, a.client, a.namespace, ManagedResourceNameRuntime, false, runtimeResources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, a.client, a.namespace, ManagedResourceNameRuntime, false, managedResourceLabels, runtimeResources); err != nil {
 		return err
 	}
 
@@ -144,7 +145,7 @@ func (a *gardenerAdmissionController) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, a.client, a.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, virtualResources)
+	return managedresources.CreateForShootWithLabels(ctx, a.client, a.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, managedResourceLabels, virtualResources)
 }
 
 func (a *gardenerAdmissionController) Wait(ctx context.Context) error {

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -455,6 +455,10 @@ func verifyExpectations(ctx context.Context, fakeClient client.Client, fakeSecre
 		Namespace: namespace,
 	}}
 	Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(runtimeMr), runtimeMr)).To(Succeed())
+	Expect(runtimeMr.Labels).To(Equal(map[string]string{
+		"gardener.cloud/role":                "seed-system-component",
+		"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+	}))
 
 	runtimeManagedResourceSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -478,6 +482,11 @@ func verifyExpectations(ctx context.Context, fakeClient client.Client, fakeSecre
 		Namespace: namespace,
 	}}
 	Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(virtualMr), virtualMr)).To(Succeed())
+	Expect(virtualMr.Labels).To(Equal(map[string]string{
+		"origin":                             "gardener",
+		"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+	}))
+
 	virtualManagedResourceSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      virtualMr.Spec.SecretRefs[0].Name,

--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -94,6 +94,8 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 		virtualRegistry = managedresources.NewRegistry(operatorclient.VirtualScheme, operatorclient.VirtualCodec, operatorclient.VirtualSerializer)
 
+		managedResourceLabels = map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)}
+
 		configMapAuditPolicy              = g.emptyConfigMap(configMapAuditPolicyNamePrefix)
 		configMapAdmissionConfigs         = g.emptyConfigMap(configMapAdmissionNamePrefix)
 		secretAdmissionKubeconfigs        = g.emptySecret(secretAdmissionKubeconfigsNamePrefix)
@@ -160,7 +162,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := managedresources.CreateForSeed(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, runtimeResources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, managedResourceLabels, runtimeResources); err != nil {
 		return err
 	}
 
@@ -185,7 +187,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, virtualResources)
+	return managedresources.CreateForShootWithLabels(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, managedResourceLabels, virtualResources)
 }
 
 func (g *gardenerAPIServer) Destroy(ctx context.Context) error {

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -1380,7 +1380,10 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 							Namespace:       managedResourceRuntime.Namespace,
 							ResourceVersion: "2",
 							Generation:      1,
-							Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+							Labels: map[string]string{
+								"gardener.cloud/role":                "seed-system-component",
+								"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+							},
 						},
 						Spec: resourcesv1alpha1.ManagedResourceSpec{
 							Class:       ptr.To("seed"),
@@ -1401,7 +1404,10 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 							Namespace:       managedResourceVirtual.Namespace,
 							ResourceVersion: "2",
 							Generation:      1,
-							Labels:          map[string]string{"origin": "gardener"},
+							Labels: map[string]string{
+								"origin":                             "gardener",
+								"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+							},
 						},
 						Spec: resourcesv1alpha1.ManagedResourceSpec{
 							InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},

--- a/pkg/component/gardener/controllermanager/controller_manager.go
+++ b/pkg/component/gardener/controllermanager/controller_manager.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
@@ -86,6 +87,7 @@ func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 	var (
 		runtimeRegistry           = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 		virtualGardenAccessSecret = g.newVirtualGardenAccessSecret()
+		managedResourceLabels     = map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)}
 	)
 
 	if err := virtualGardenAccessSecret.Reconcile(ctx, g.client); err != nil {
@@ -113,7 +115,7 @@ func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := managedresources.CreateForSeed(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, runtimeResources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, managedResourceLabels, runtimeResources); err != nil {
 		return err
 	}
 
@@ -129,7 +131,7 @@ func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, virtualResources)
+	return managedresources.CreateForShootWithLabels(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, managedResourceLabels, virtualResources)
 }
 
 func (g *gardenerControllerManager) Wait(ctx context.Context) error {

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -295,7 +295,10 @@ var _ = Describe("GardenerControllerManager", func() {
 						Namespace:       managedResourceRuntime.Namespace,
 						ResourceVersion: "2",
 						Generation:      1,
-						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+						Labels: map[string]string{
+							"gardener.cloud/role":                "seed-system-component",
+							"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						Class:       ptr.To("seed"),
@@ -317,7 +320,10 @@ var _ = Describe("GardenerControllerManager", func() {
 						Namespace:       managedResourceVirtual.Namespace,
 						ResourceVersion: "2",
 						Generation:      1,
-						Labels:          map[string]string{"origin": "gardener"},
+						Labels: map[string]string{
+							"origin":                             "gardener",
+							"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -271,6 +271,8 @@ type Values struct {
 	LogLevel string
 	// LogFormat is the output format for the logs. Must be one of [text,json].
 	LogFormat string
+	// ManagedResourceLabels are labels added to the ManagedResource.
+	ManagedResourceLabels map[string]string
 	// MaxConcurrentHealthWorkers configures the number of worker threads for concurrent health reconciliation of resources.
 	MaxConcurrentHealthWorkers *int
 	// MaxConcurrentTokenInvalidatorWorkers configures the number of worker threads for concurrent token invalidator reconciliations.
@@ -1254,7 +1256,7 @@ func (r *resourceManager) ensureShootResources(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, r.client, r.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
+	return managedresources.CreateForShootWithLabels(ctx, r.client, r.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, r.values.ManagedResourceLabels, data)
 }
 
 func (r *resourceManager) newShootAccessSecret() *gardenerutils.AccessSecret {

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -355,6 +355,7 @@ var _ = Describe("ResourceManager", func() {
 			LogLevel:                            "info",
 			LogFormat:                           "json",
 			Zones:                               []string{"a", "b"},
+			ManagedResourceLabels:               map[string]string{"foo": "bar"},
 		}
 		resourceManager = New(c, deployNamespace, sm, cfg)
 		resourceManager.SetSecrets(secrets)
@@ -1885,7 +1886,10 @@ subjects:
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "shoot-core-gardener-resource-manager",
 				Namespace: deployNamespace,
-				Labels:    map[string]string{"origin": "gardener"},
+				Labels: map[string]string{
+					"origin": "gardener",
+					"foo":    "bar",
+				},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{

--- a/pkg/component/gardener/scheduler/scheduler.go
+++ b/pkg/component/gardener/scheduler/scheduler.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -83,6 +84,7 @@ func (g *gardenerScheduler) Deploy(ctx context.Context) error {
 	var (
 		runtimeRegistry           = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 		virtualGardenAccessSecret = g.newVirtualGardenAccessSecret()
+		managedResourceLabels     = map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)}
 	)
 
 	if err := virtualGardenAccessSecret.Reconcile(ctx, g.client); err != nil {
@@ -110,7 +112,7 @@ func (g *gardenerScheduler) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := managedresources.CreateForSeed(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, runtimeResources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, managedResourceLabels, runtimeResources); err != nil {
 		return err
 	}
 
@@ -126,7 +128,7 @@ func (g *gardenerScheduler) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, virtualResources)
+	return managedresources.CreateForShootWithLabels(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, managedResourceLabels, virtualResources)
 }
 
 func (g *gardenerScheduler) Wait(ctx context.Context) error {

--- a/pkg/component/gardener/scheduler/scheduler_test.go
+++ b/pkg/component/gardener/scheduler/scheduler_test.go
@@ -332,7 +332,10 @@ var _ = Describe("GardenerScheduler", func() {
 						Namespace:       managedResourceRuntime.Namespace,
 						ResourceVersion: "2",
 						Generation:      1,
-						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+						Labels: map[string]string{
+							"gardener.cloud/role":                "seed-system-component",
+							"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						Class:       ptr.To("seed"),
@@ -354,7 +357,10 @@ var _ = Describe("GardenerScheduler", func() {
 						Namespace:       managedResourceVirtual.Namespace,
 						ResourceVersion: "2",
 						Generation:      1,
-						Labels:          map[string]string{"origin": "gardener"},
+						Labels: map[string]string{
+							"origin":                             "gardener",
+							"care.gardener.cloud/condition-type": "VirtualComponentsHealthy",
+						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -164,6 +164,8 @@ type Values struct {
 	ControllerSyncPeriods ControllerSyncPeriods
 	// RuntimeConfig contains information about enabled or disabled APIs.
 	RuntimeConfig map[string]bool
+	// ManagedResourceLabels are labels added to the ManagedResource.
+	ManagedResourceLabels map[string]string
 }
 
 // ControllerWorkers is used for configuring the workers for controllers.

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -551,15 +551,16 @@ namespace: kube-system
 		sm = fakesecretsmanager.New(c, namespace)
 
 		values = Values{
-			RuntimeVersion:    runtimeKubernetesVersion,
-			TargetVersion:     semverVersion,
-			Image:             image,
-			Config:            &kcmConfig,
-			PriorityClassName: priorityClassName,
-			HVPAConfig:        hvpaConfigDisabled,
-			IsWorkerless:      isWorkerless,
-			PodNetwork:        podCIDR,
-			ServiceNetwork:    serviceCIDR,
+			RuntimeVersion:        runtimeKubernetesVersion,
+			TargetVersion:         semverVersion,
+			Image:                 image,
+			Config:                &kcmConfig,
+			PriorityClassName:     priorityClassName,
+			HVPAConfig:            hvpaConfigDisabled,
+			IsWorkerless:          isWorkerless,
+			PodNetwork:            podCIDR,
+			ServiceNetwork:        serviceCIDR,
+			ManagedResourceLabels: map[string]string{"foo": "bar"},
 		}
 		kubeControllerManager = New(
 			testLogger,
@@ -582,9 +583,12 @@ namespace: kube-system
 		}
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            managedResourceName,
-				Namespace:       namespace,
-				Labels:          map[string]string{"origin": "gardener"},
+				Name:      managedResourceName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"origin": "gardener",
+					"foo":    "bar",
+				},
 				ResourceVersion: "1",
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{

--- a/pkg/component/kubernetes/controllermanager/shoot_resources.go
+++ b/pkg/component/kubernetes/controllermanager/shoot_resources.go
@@ -50,5 +50,5 @@ func (k *kubeControllerManager) reconcileShootResources(ctx context.Context, ser
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, k.seedClient.Client(), k.namespace, ManagedResourceName, managedresources.LabelValueGardener, true, data)
+	return managedresources.CreateForShootWithLabels(ctx, k.seedClient.Client(), k.namespace, ManagedResourceName, managedresources.LabelValueGardener, true, k.values.ManagedResourceLabels, data)
 }

--- a/pkg/component/observability/logging/fluentoperator/custom_resources.go
+++ b/pkg/component/observability/logging/fluentoperator/custom_resources.go
@@ -86,7 +86,7 @@ func (c *customResources) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeed(ctx, c.client, c.namespace, c.getManagedResourceName(), false, serializedResources)
+	return managedresources.CreateForSeedWithLabels(ctx, c.client, c.namespace, c.getManagedResourceName(), false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, serializedResources)
 }
 
 func (c *customResources) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/logging/fluentoperator/custom_resources.go
+++ b/pkg/component/observability/logging/fluentoperator/custom_resources.go
@@ -86,7 +86,7 @@ func (c *customResources) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, c.client, c.namespace, c.getManagedResourceName(), false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, serializedResources)
+	return managedresources.CreateForSeedWithLabels(ctx, c.client, c.namespace, c.getManagedResourceName(), false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, serializedResources)
 }
 
 func (c *customResources) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/logging/fluentoperator/custom_resources_test.go
+++ b/pkg/component/observability/logging/fluentoperator/custom_resources_test.go
@@ -183,9 +183,12 @@ var _ = Describe("Custom Resources", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 			expectedMr := &resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            customResourcesManagedResourceName,
-					Namespace:       namespace,
-					Labels:          map[string]string{v1beta1constants.GardenRole: "seed-system-component"},
+					Name:      customResourcesManagedResourceName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						v1beta1constants.GardenRole:          "seed-system-component",
+						"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+					},
 					ResourceVersion: "1",
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{

--- a/pkg/component/observability/logging/fluentoperator/fluent_bit.go
+++ b/pkg/component/observability/logging/fluentoperator/fluent_bit.go
@@ -307,7 +307,7 @@ end
 		return err
 	}
 
-	return managedresources.CreateForSeed(ctx, f.client, f.namespace, FluentBitManagedResourceName, false, serializedResources)
+	return managedresources.CreateForSeedWithLabels(ctx, f.client, f.namespace, FluentBitManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, serializedResources)
 }
 
 func (f *fluentBit) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/logging/fluentoperator/fluent_bit.go
+++ b/pkg/component/observability/logging/fluentoperator/fluent_bit.go
@@ -307,7 +307,7 @@ end
 		return err
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, f.client, f.namespace, FluentBitManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, serializedResources)
+	return managedresources.CreateForSeedWithLabels(ctx, f.client, f.namespace, FluentBitManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, serializedResources)
 }
 
 func (f *fluentBit) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/logging/fluentoperator/fluent_bit_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluent_bit_test.go
@@ -253,9 +253,12 @@ var _ = Describe("Fluent Bit", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 			expectedMr := &resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "fluent-bit",
-					Namespace:       namespace,
-					Labels:          map[string]string{v1beta1constants.GardenRole: "seed-system-component"},
+					Name:      "fluent-bit",
+					Namespace: namespace,
+					Labels: map[string]string{
+						v1beta1constants.GardenRole:          "seed-system-component",
+						"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+					},
 					ResourceVersion: "1",
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -268,7 +268,7 @@ func (v *vali) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, valiconstants.ManagedResourceNameRuntime, false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, registry.SerializedObjects())
+	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, valiconstants.ManagedResourceNameRuntime, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, registry.SerializedObjects())
 }
 
 func (v *vali) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -268,7 +268,7 @@ func (v *vali) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeed(ctx, v.client, v.namespace, valiconstants.ManagedResourceNameRuntime, false, registry.SerializedObjects())
+	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, valiconstants.ManagedResourceNameRuntime, false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, registry.SerializedObjects())
 }
 
 func (v *vali) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -168,6 +168,7 @@ var _ = Describe("Vali", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            managedResourceName,
 					Namespace:       namespace,
+					Labels:          map[string]string{"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy"},
 					ResourceVersion: "1",
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
@@ -267,6 +268,7 @@ var _ = Describe("Vali", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            managedResourceName,
 					Namespace:       namespace,
+					Labels:          map[string]string{"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy"},
 					ResourceVersion: "1",
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
@@ -322,6 +324,7 @@ var _ = Describe("Vali", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            managedResourceName,
 					Namespace:       namespace,
+					Labels:          map[string]string{"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy"},
 					ResourceVersion: "1",
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -389,7 +389,10 @@ var _ = Describe("Prometheus", func() {
 					Namespace:       managedResource.Namespace,
 					ResourceVersion: "2",
 					Generation:      1,
-					Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+					Labels: map[string]string{
+						"gardener.cloud/role":                "seed-system-component",
+						"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+					},
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
 					Class:       ptr.To("seed"),

--- a/pkg/component/observability/monitoring/alertmanager/component.go
+++ b/pkg/component/observability/monitoring/alertmanager/component.go
@@ -143,7 +143,7 @@ func (a *alertManager) Deploy(ctx context.Context) error {
 		log.Info("Deploy new AlertManager (with init container for renaming the data directory)")
 	}
 
-	if err := managedresources.CreateForSeedWithLabels(ctx, a.client, a.namespace, a.name(), false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, resources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, a.client, a.namespace, a.name(), false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, resources); err != nil {
 		return err
 	}
 

--- a/pkg/component/observability/monitoring/alertmanager/component.go
+++ b/pkg/component/observability/monitoring/alertmanager/component.go
@@ -143,7 +143,7 @@ func (a *alertManager) Deploy(ctx context.Context) error {
 		log.Info("Deploy new AlertManager (with init container for renaming the data directory)")
 	}
 
-	if err := managedresources.CreateForSeed(ctx, a.client, a.namespace, a.name(), false, resources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, a.client, a.namespace, a.name(), false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, resources); err != nil {
 		return err
 	}
 

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter.go
@@ -79,6 +79,7 @@ func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error {
 	var (
 		runtimeRegistry           = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 		virtualGardenAccessSecret = g.newVirtualGardenAccessSecret()
+		conditionTypeLabels       = map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}
 	)
 
 	if err := virtualGardenAccessSecret.Reconcile(ctx, g.client); err != nil {
@@ -98,7 +99,7 @@ func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := managedresources.CreateForSeed(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, runtimeResources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, conditionTypeLabels, runtimeResources); err != nil {
 		return err
 	}
 
@@ -112,7 +113,7 @@ func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, virtualResources)
+	return managedresources.CreateForShootWithLabels(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, conditionTypeLabels, virtualResources)
 }
 
 func (g *gardenerMetricsExporter) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter.go
@@ -79,7 +79,7 @@ func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error {
 	var (
 		runtimeRegistry           = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 		virtualGardenAccessSecret = g.newVirtualGardenAccessSecret()
-		conditionTypeLabels       = map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}
+		conditionTypeLabels       = map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}
 	)
 
 	if err := virtualGardenAccessSecret.Reconcile(ctx, g.client); err != nil {

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -225,7 +225,10 @@ var _ = Describe("GardenerMetricsExporter", func() {
 						Namespace:       managedResourceRuntime.Namespace,
 						ResourceVersion: "2",
 						Generation:      1,
-						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+						Labels: map[string]string{
+							"gardener.cloud/role":                "seed-system-component",
+							"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						Class:       ptr.To("seed"),
@@ -247,7 +250,10 @@ var _ = Describe("GardenerMetricsExporter", func() {
 						Namespace:       managedResourceVirtual.Namespace,
 						ResourceVersion: "2",
 						Generation:      1,
-						Labels:          map[string]string{"origin": "gardener"},
+						Labels: map[string]string{
+							"origin":                             "gardener",
+							"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
@@ -121,7 +121,7 @@ func (k *kubeStateMetrics) Deploy(ctx context.Context) error {
 		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 	}
 
-	return component.DeployResourceConfigs(ctx, k.client, k.namespace, k.values.ClusterType, k.managedResourceName(), registry, k.getResourceConfigs(genericTokenKubeconfigSecretName, shootAccessSecret))
+	return component.DeployResourceConfigs(ctx, k.client, k.namespace, k.values.ClusterType, k.managedResourceName(), map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, registry, k.getResourceConfigs(genericTokenKubeconfigSecretName, shootAccessSecret))
 }
 
 func (k *kubeStateMetrics) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
@@ -121,7 +121,7 @@ func (k *kubeStateMetrics) Deploy(ctx context.Context) error {
 		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 	}
 
-	return component.DeployResourceConfigs(ctx, k.client, k.namespace, k.values.ClusterType, k.managedResourceName(), map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, registry, k.getResourceConfigs(genericTokenKubeconfigSecretName, shootAccessSecret))
+	return component.DeployResourceConfigs(ctx, k.client, k.namespace, k.values.ClusterType, k.managedResourceName(), map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, registry, k.getResourceConfigs(genericTokenKubeconfigSecretName, shootAccessSecret))
 }
 
 func (k *kubeStateMetrics) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -644,9 +644,12 @@ var _ = Describe("KubeStateMetrics", func() {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				expectedMr := &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            managedResourceName,
-						Namespace:       namespace,
-						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+						Name:      managedResourceName,
+						Namespace: namespace,
+						Labels: map[string]string{
+							"gardener.cloud/role":                "seed-system-component",
+							"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+						},
 						ResourceVersion: "1",
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -188,7 +188,7 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		log.Info("Deploy new Prometheus (with init container for renaming the data directory)")
 	}
 
-	if err := managedresources.CreateForSeed(ctx, p.client, p.namespace, p.name(), false, resources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, p.name(), false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, resources); err != nil {
 		return err
 	}
 

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -188,7 +188,7 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		log.Info("Deploy new Prometheus (with init container for renaming the data directory)")
 	}
 
-	if err := managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, p.name(), false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, resources); err != nil {
+	if err := managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, p.name(), false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, resources); err != nil {
 		return err
 	}
 

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -477,7 +477,10 @@ honor_labels: true`
 						Namespace:       managedResource.Namespace,
 						ResourceVersion: "2",
 						Generation:      1,
-						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+						Labels: map[string]string{
+							"gardener.cloud/role":                "seed-system-component",
+							"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						Class:       ptr.To("seed"),

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
@@ -78,7 +78,7 @@ func (p *prometheusOperator) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeed(ctx, p.client, p.namespace, ManagedResourceName, false, resources)
+	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, ManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, resources)
 }
 
 func (p *prometheusOperator) Wait(ctx context.Context) error {

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
@@ -78,7 +78,7 @@ func (p *prometheusOperator) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, ManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, resources)
+	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, ManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, resources)
 }
 
 func (p *prometheusOperator) Wait(ctx context.Context) error {

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -384,7 +384,10 @@ var _ = Describe("PrometheusOperator", func() {
 						Namespace:       managedResource.Namespace,
 						ResourceVersion: "2",
 						Generation:      1,
-						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+						Labels: map[string]string{
+							"gardener.cloud/role":                "seed-system-component",
+							"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						Class:       ptr.To("seed"),

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -162,7 +162,7 @@ func (p *plutono) Deploy(ctx context.Context) error {
 		}
 	}
 
-	return managedresources.CreateForSeed(ctx, p.client, p.namespace, ManagedResourceName, false, data)
+	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, ManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, data)
 }
 
 func (p *plutono) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -162,7 +162,7 @@ func (p *plutono) Deploy(ctx context.Context) error {
 		}
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, ManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: "ObservabilityComponentsHealthy"}, data)
+	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, ManagedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, data)
 }
 
 func (p *plutono) Destroy(ctx context.Context) error {

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -540,7 +540,10 @@ status:
 					Name:            managedResource.Name,
 					Namespace:       managedResource.Namespace,
 					ResourceVersion: "1",
-					Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+					Labels: map[string]string{
+						v1beta1constants.GardenRole:          "seed-system-component",
+						"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+					},
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
 					Class:       ptr.To("seed"),

--- a/pkg/component/resourceconfig.go
+++ b/pkg/component/resourceconfig.go
@@ -103,6 +103,7 @@ func DeployResourceConfigs(
 	namespace string,
 	clusterType ClusterType,
 	managedResourceName string,
+	managedResourceLabels map[string]string,
 	registry *managedresources.Registry,
 	allResources ResourceConfigs,
 ) error {
@@ -116,7 +117,7 @@ func DeployResourceConfigs(
 			}
 		}
 
-		return managedresources.CreateForSeed(ctx, c, namespace, managedResourceName, false, registry.SerializedObjects())
+		return managedresources.CreateForSeedWithLabels(ctx, c, namespace, managedResourceName, false, managedResourceLabels, registry.SerializedObjects())
 	}
 
 	for _, r := range allResources {

--- a/pkg/component/shared/kubecontrollermanager.go
+++ b/pkg/component/shared/kubecontrollermanager.go
@@ -47,6 +47,7 @@ func NewKubeControllerManager(
 	clusterSigningDuration *time.Duration,
 	controllerWorkers kubecontrollermanager.ControllerWorkers,
 	controllerSyncPeriods kubecontrollermanager.ControllerSyncPeriods,
+	managedResourceLabels map[string]string,
 ) (
 	kubecontrollermanager.Interface,
 	error,
@@ -75,6 +76,7 @@ func NewKubeControllerManager(
 			ClusterSigningDuration: clusterSigningDuration,
 			ControllerWorkers:      controllerWorkers,
 			ControllerSyncPeriods:  controllerSyncPeriods,
+			ManagedResourceLabels:  managedResourceLabels,
 		},
 	), nil
 }

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -62,6 +62,7 @@ func NewRuntimeGardenerResourceManager(
 	endpointSliceHintsEnabled bool,
 	additionalNetworkPolicyNamespaceSelectors []metav1.LabelSelector,
 	zones []string,
+	managedResourceLabels map[string]string,
 ) (
 	component.DeployWaiter,
 	error,
@@ -91,6 +92,7 @@ func NewRuntimeGardenerResourceManager(
 		Image:                                image.String(),
 		LogLevel:                             logLevel,
 		LogFormat:                            logFormat,
+		ManagedResourceLabels:                managedResourceLabels,
 		MaxConcurrentTokenInvalidatorWorkers: ptr.To(5),
 		// TODO(timuthy): Remove PodTopologySpreadConstraints webhook once for all seeds the
 		//  MatchLabelKeysInPodTopologySpread feature gate is beta and enabled by default (probably 1.26+).

--- a/pkg/gardenlet/controller/seed/add.go
+++ b/pkg/gardenlet/controller/seed/add.go
@@ -25,7 +25,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/seed/care"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/seed/lease"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
@@ -57,10 +56,8 @@ func AddToManager(
 	}
 
 	if err := (&care.Reconciler{
-		Config:         *cfg.Controllers.SeedCare,
-		SeedName:       cfg.SeedConfig.Name,
-		LoggingEnabled: gardenlethelper.IsLoggingEnabled(&cfg),
-		ValiEnabled:    gardenlethelper.IsValiEnabled(&cfg),
+		Config:   *cfg.Controllers.SeedCare,
+		SeedName: cfg.SeedConfig.Name,
 	}).AddToManager(ctx, mgr, gardenCluster, seedCluster); err != nil {
 		return fmt.Errorf("failed adding care reconciler: %w", err)
 	}

--- a/pkg/gardenlet/controller/seed/care/health.go
+++ b/pkg/gardenlet/controller/seed/care/health.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,49 +27,16 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/component/autoscaling/clusterautoscaler"
-	"github.com/gardener/gardener/pkg/component/autoscaling/hvpa"
-	"github.com/gardener/gardener/pkg/component/autoscaling/vpa"
-	"github.com/gardener/gardener/pkg/component/clusteridentity"
-	"github.com/gardener/gardener/pkg/component/etcd/etcd"
-	"github.com/gardener/gardener/pkg/component/networking/istio"
-	"github.com/gardener/gardener/pkg/component/networking/nginxingress"
-	"github.com/gardener/gardener/pkg/component/nodemanagement/dependencywatchdog"
-	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
-	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
-	"github.com/gardener/gardener/pkg/component/observability/monitoring/kubestatemetrics"
-	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
-	seedsystem "github.com/gardener/gardener/pkg/component/seed/system"
-	"github.com/gardener/gardener/pkg/features"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	healthchecker "github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
-)
-
-var requiredManagedResourcesSeed = sets.New(
-	etcd.Druid,
-	clusterautoscaler.ManagedResourceControlName,
-	kubestatemetrics.ManagedResourceName,
-	nginxingress.ManagedResourceName,
-	seedsystem.ManagedResourceName,
-	vpa.ManagedResourceControlName,
-	prometheusoperator.ManagedResourceName,
-	"prometheus-cache",
-	"prometheus-seed",
-	"prometheus-aggregate",
 )
 
 // health contains information needed to execute health checks for a seed.
 type health struct {
-	seed                *gardencorev1beta1.Seed
-	seedClient          client.Client
-	clock               clock.Clock
-	namespace           *string
-	seedIsGarden        bool
-	loggingEnabled      bool
-	valiEnabled         bool
-	alertManagerEnabled bool
-	conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration
-	healthChecker       *healthchecker.HealthChecker
+	seed          *gardencorev1beta1.Seed
+	seedClient    client.Client
+	clock         clock.Clock
+	namespace     *string
+	healthChecker *healthchecker.HealthChecker
 }
 
 // NewHealth creates a new Health instance with the given parameters.
@@ -79,23 +45,14 @@ func NewHealth(
 	seedClient client.Client,
 	clock clock.Clock,
 	namespace *string,
-	seedIsGarden bool,
-	loggingEnabled bool,
-	valiEnabled bool,
-	alertManagerEnabled bool,
 	conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration,
 ) HealthCheck {
 	return &health{
-		seedClient:          seedClient,
-		seed:                seed,
-		clock:               clock,
-		namespace:           namespace,
-		seedIsGarden:        seedIsGarden,
-		loggingEnabled:      loggingEnabled,
-		valiEnabled:         valiEnabled,
-		alertManagerEnabled: alertManagerEnabled,
-		conditionThresholds: conditionThresholds,
-		healthChecker:       healthchecker.NewHealthChecker(seedClient, clock, conditionThresholds, seed.Status.LastOperation),
+		seedClient:    seedClient,
+		seed:          seed,
+		clock:         clock,
+		namespace:     namespace,
+		healthChecker: healthchecker.NewHealthChecker(seedClient, clock, conditionThresholds, seed.Status.LastOperation),
 	}
 }
 

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -205,7 +205,7 @@ func (c resultingConditionFunc) Check(_ context.Context, conditions SeedConditio
 }
 
 func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {
-	return func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
+	return func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
 		return fn
 	}
 }

--- a/pkg/gardenlet/controller/seed/care/types.go
+++ b/pkg/gardenlet/controller/seed/care/types.go
@@ -25,11 +25,11 @@ import (
 )
 
 // NewHealthCheckFunc is a function used to create a new instance for performing health checks.
-type NewHealthCheckFunc func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck
+type NewHealthCheckFunc func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck
 
 // defaultNewHealthCheck is the default function to create a new instance for performing health checks.
-var defaultNewHealthCheck NewHealthCheckFunc = func(seed *gardencorev1beta1.Seed, client client.Client, clock clock.Clock, namespace *string, seedIsGarden bool, loggingEnabled, valiEnabled, alertManagerEnabled bool, conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
-	return NewHealth(seed, client, clock, namespace, seedIsGarden, loggingEnabled, valiEnabled, alertManagerEnabled, conditionThresholds)
+var defaultNewHealthCheck NewHealthCheckFunc = func(seed *gardencorev1beta1.Seed, client client.Client, clock clock.Clock, namespace *string, conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
+	return NewHealth(seed, client, clock, namespace, conditionThresholds)
 }
 
 // HealthCheck is an interface used to perform health checks.

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -277,6 +277,7 @@ func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, se
 		v1beta1helper.SeedSettingTopologyAwareRoutingEnabled(seed.Spec.Settings),
 		additionalNetworkPolicyNamespaceSelectors,
 		seed.Spec.Provider.Zones,
+		nil,
 	)
 }
 

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -494,8 +494,8 @@ func (h *Health) checkSystemComponents(
 	error,
 ) {
 	if exitCondition := h.healthChecker.CheckManagedResources(condition, managedResources, func(managedResource resourcesv1alpha1.ManagedResource) bool {
-		return managedResource.Spec.Class == nil &&
-			sets.New("", string(gardencorev1beta1.ShootSystemComponentsHealthy)).Has(managedResource.Labels[v1beta1constants.LabelCareConditionType])
+		return managedResource.Spec.Class == nil ||
+			managedResource.Labels[v1beta1constants.LabelCareConditionType] == string(gardencorev1beta1.ShootSystemComponentsHealthy)
 	}, gardenlethelper.GetManagedResourceProgressingThreshold(h.gardenletConfiguration)); exitCondition != nil {
 		return exitCondition, nil
 	}

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -159,36 +159,18 @@ var _ = Describe("health check", func() {
 	})
 
 	Describe("#ComputeRequiredMonitoringStatefulSets", func() {
-		var commonNames []interface{}
-		BeforeEach(func() {
-			commonNames = []interface{}{"prometheus"}
-		})
-
-		It("should return expected statefulsets when alert manager is not wanted", func() {
-			Expect(ComputeRequiredMonitoringStatefulSets(false, semver.MustParse("1.90")).UnsortedList()).To(ConsistOf(commonNames...))
-		})
-
-		It("should return expected statefulsets when alert manager is wanted", func() {
-			Expect(ComputeRequiredMonitoringStatefulSets(true, semver.MustParse("1.89")).UnsortedList()).To(ConsistOf(append(commonNames, "alertmanager")...))
-		})
-
-		It("should return expected statefulsets when alert manager is wanted when reconciled by Gardener >= v1.90", func() {
-			Expect(ComputeRequiredMonitoringStatefulSets(true, semver.MustParse("1.90")).UnsortedList()).To(ConsistOf(append(commonNames, "alertmanager-shoot")...))
+		It("should return expected statefulsets", func() {
+			Expect(ComputeRequiredMonitoringStatefulSets().UnsortedList()).To(HaveExactElements("prometheus"))
 		})
 	})
 
 	Describe("#ComputeRequiredMonitoringSeedDeployments", func() {
-		var commonNames []interface{}
-		BeforeEach(func() {
-			commonNames = []interface{}{"plutono"}
-		})
-
 		It("should return expected deployments", func() {
-			Expect(ComputeRequiredMonitoringSeedDeployments(shoot).UnsortedList()).To(ConsistOf(append(commonNames, "kube-state-metrics")...))
+			Expect(ComputeRequiredMonitoringSeedDeployments(shoot).UnsortedList()).To(HaveExactElements("kube-state-metrics"))
 		})
 
 		It("should return expected deployments for workerless shoot", func() {
-			Expect(ComputeRequiredMonitoringSeedDeployments(workerlessShoot).UnsortedList()).To(ConsistOf(commonNames))
+			Expect(ComputeRequiredMonitoringSeedDeployments(workerlessShoot).UnsortedList()).To(BeEmpty())
 		})
 	})
 

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
@@ -67,6 +67,7 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interfa
 		nil,
 		kubecontrollermanager.ControllerWorkers{},
 		kubecontrollermanager.ControllerSyncPeriods{},
+		nil,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -310,6 +310,7 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
 		r.Config.Controllers.NetworkPolicy.AdditionalNamespaceSelectors,
 		garden.Spec.RuntimeCluster.Provider.Zones,
+		map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)},
 	)
 }
 
@@ -693,6 +694,7 @@ func (r *Reconciler) newKubeControllerManager(
 		kubecontrollermanager.ControllerSyncPeriods{
 			ResourceQuota: ptr.To(time.Minute),
 		},
+		map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)},
 	)
 }
 
@@ -761,8 +763,9 @@ func (r *Reconciler) newGardenerAccess(garden *operatorv1alpha1.Garden, secretsM
 		r.GardenNamespace,
 		secretsManager,
 		gardeneraccess.Values{
-			ServerInCluster:    fmt.Sprintf("%s%s.%s.svc.cluster.local", namePrefix, v1beta1constants.DeploymentNameKubeAPIServer, r.GardenNamespace),
-			ServerOutOfCluster: gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0]),
+			ServerInCluster:       fmt.Sprintf("%s%s.%s.svc.cluster.local", namePrefix, v1beta1constants.DeploymentNameKubeAPIServer, r.GardenNamespace),
+			ServerOutOfCluster:    gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0]),
+			ManagedResourceLabels: map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)},
 		},
 	)
 }

--- a/pkg/utils/kubernetes/health/checker/checker.go
+++ b/pkg/utils/kubernetes/health/checker/checker.go
@@ -80,28 +80,28 @@ func NewHealthChecker(
 	}
 }
 
-func (b *HealthChecker) checkRequiredResourceNames(condition gardencorev1beta1.Condition, requiredNames, names sets.Set[string], reason, message string) *gardencorev1beta1.Condition {
+func (h *HealthChecker) checkRequiredResourceNames(condition gardencorev1beta1.Condition, requiredNames, names sets.Set[string], reason, message string) *gardencorev1beta1.Condition {
 	if missingNames := requiredNames.Difference(names); missingNames.Len() != 0 {
-		c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, reason, fmt.Sprintf("%s: %v", message, sets.List(missingNames)))
+		c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, reason, fmt.Sprintf("%s: %v", message, sets.List(missingNames)))
 		return &c
 	}
 
 	return nil
 }
 
-func (b *HealthChecker) checkRequiredDeployments(condition gardencorev1beta1.Condition, requiredNames sets.Set[string], objects []appsv1.Deployment) *gardencorev1beta1.Condition {
+func (h *HealthChecker) checkRequiredDeployments(condition gardencorev1beta1.Condition, requiredNames sets.Set[string], objects []appsv1.Deployment) *gardencorev1beta1.Condition {
 	actualNames := sets.New[string]()
 	for _, object := range objects {
 		actualNames.Insert(object.Name)
 	}
 
-	return b.checkRequiredResourceNames(condition, requiredNames, actualNames, "DeploymentMissing", "Missing required deployments")
+	return h.checkRequiredResourceNames(condition, requiredNames, actualNames, "DeploymentMissing", "Missing required deployments")
 }
 
-func (b *HealthChecker) checkDeployments(condition gardencorev1beta1.Condition, objects []appsv1.Deployment) *gardencorev1beta1.Condition {
+func (h *HealthChecker) checkDeployments(condition gardencorev1beta1.Condition, objects []appsv1.Deployment) *gardencorev1beta1.Condition {
 	for _, object := range objects {
 		if err := health.CheckDeployment(&object); err != nil {
-			c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, "DeploymentUnhealthy", fmt.Sprintf("Deployment %q is unhealthy: %v", object.Name, err.Error()))
+			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "DeploymentUnhealthy", fmt.Sprintf("Deployment %q is unhealthy: %v", object.Name, err.Error()))
 			return &c
 		}
 	}
@@ -109,16 +109,16 @@ func (b *HealthChecker) checkDeployments(condition gardencorev1beta1.Condition, 
 	return nil
 }
 
-func (b *HealthChecker) checkRequiredEtcds(condition gardencorev1beta1.Condition, requiredNames sets.Set[string], objects []druidv1alpha1.Etcd) *gardencorev1beta1.Condition {
+func (h *HealthChecker) checkRequiredEtcds(condition gardencorev1beta1.Condition, requiredNames sets.Set[string], objects []druidv1alpha1.Etcd) *gardencorev1beta1.Condition {
 	actualNames := sets.New[string]()
 	for _, object := range objects {
 		actualNames.Insert(object.Name)
 	}
 
-	return b.checkRequiredResourceNames(condition, requiredNames, actualNames, "EtcdMissing", "Missing required etcds")
+	return h.checkRequiredResourceNames(condition, requiredNames, actualNames, "EtcdMissing", "Missing required etcds")
 }
 
-func (b *HealthChecker) checkEtcds(condition gardencorev1beta1.Condition, objects []druidv1alpha1.Etcd) *gardencorev1beta1.Condition {
+func (h *HealthChecker) checkEtcds(condition gardencorev1beta1.Condition, objects []druidv1alpha1.Etcd) *gardencorev1beta1.Condition {
 	for _, object := range objects {
 		if err := health.CheckEtcd(&object); err != nil {
 			var (
@@ -130,7 +130,7 @@ func (b *HealthChecker) checkEtcds(condition gardencorev1beta1.Condition, object
 				message = fmt.Sprintf("%s (%s)", message, *lastError)
 			}
 
-			c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, "EtcdUnhealthy", message, codes...)
+			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "EtcdUnhealthy", message, codes...)
 			return &c
 		}
 	}
@@ -138,19 +138,19 @@ func (b *HealthChecker) checkEtcds(condition gardencorev1beta1.Condition, object
 	return nil
 }
 
-func (b *HealthChecker) checkRequiredStatefulSets(condition gardencorev1beta1.Condition, requiredNames sets.Set[string], objects []appsv1.StatefulSet) *gardencorev1beta1.Condition {
+func (h *HealthChecker) checkRequiredStatefulSets(condition gardencorev1beta1.Condition, requiredNames sets.Set[string], objects []appsv1.StatefulSet) *gardencorev1beta1.Condition {
 	actualNames := sets.New[string]()
 	for _, object := range objects {
 		actualNames.Insert(object.Name)
 	}
 
-	return b.checkRequiredResourceNames(condition, requiredNames, actualNames, "StatefulSetMissing", "Missing required stateful sets")
+	return h.checkRequiredResourceNames(condition, requiredNames, actualNames, "StatefulSetMissing", "Missing required stateful sets")
 }
 
-func (b *HealthChecker) checkStatefulSets(condition gardencorev1beta1.Condition, objects []appsv1.StatefulSet) *gardencorev1beta1.Condition {
+func (h *HealthChecker) checkStatefulSets(condition gardencorev1beta1.Condition, objects []appsv1.StatefulSet) *gardencorev1beta1.Condition {
 	for _, object := range objects {
 		if err := health.CheckStatefulSet(&object); err != nil {
-			c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, "StatefulSetUnhealthy", fmt.Sprintf("Stateful set %q is unhealthy: %v", object.Name, err.Error()))
+			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "StatefulSetUnhealthy", fmt.Sprintf("Stateful set %q is unhealthy: %v", object.Name, err.Error()))
 			return &c
 		}
 	}
@@ -162,7 +162,7 @@ func (b *HealthChecker) checkStatefulSets(condition gardencorev1beta1.Condition,
 var kubeletConfigProblemRegex = regexp.MustCompile(`(?i)(KubeletHasInsufficientMemory|KubeletHasDiskPressure|KubeletHasInsufficientPID)`)
 
 // CheckNodes whether the given nodes are ready and the version in the node status is of the same major-minor as given in 'workerGroupKubernetesVersion'.
-func (b *HealthChecker) CheckNodes(condition gardencorev1beta1.Condition, nodes []corev1.Node, workerGroupName string, workerGroupKubernetesVersion *semver.Version) *gardencorev1beta1.Condition {
+func (h *HealthChecker) CheckNodes(condition gardencorev1beta1.Condition, nodes []corev1.Node, workerGroupName string, workerGroupKubernetesVersion *semver.Version) *gardencorev1beta1.Condition {
 	for _, object := range nodes {
 		if err := health.CheckNode(&object); err != nil {
 			var (
@@ -174,24 +174,24 @@ func (b *HealthChecker) CheckNodes(condition gardencorev1beta1.Condition, nodes 
 				errorCodes = append(errorCodes, gardencorev1beta1.ErrorConfigurationProblem)
 			}
 
-			c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, "NodeUnhealthy", message, errorCodes...)
+			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "NodeUnhealthy", message, errorCodes...)
 			return &c
 		}
 
 		sameMajorMinor, err := semver.NewConstraint("~ " + object.Status.NodeInfo.KubeletVersion)
 		if err != nil {
-			c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, "VersionParseError", fmt.Sprintf("Error checking for same major minor Kubernetes version for node %q: %+v", object.Name, err))
+			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "VersionParseError", fmt.Sprintf("Error checking for same major minor Kubernetes version for node %q: %+v", object.Name, err))
 			return &c
 		}
 		if sameMajorMinor.Check(workerGroupKubernetesVersion) {
 			equal, err := semver.NewConstraint("= " + object.Status.NodeInfo.KubeletVersion)
 			if err != nil {
-				c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, "VersionParseError", fmt.Sprintf("Error checking for equal Kubernetes versions for node %q: %+v", object.Name, err))
+				c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "VersionParseError", fmt.Sprintf("Error checking for equal Kubernetes versions for node %q: %+v", object.Name, err))
 				return &c
 			}
 
 			if !equal.Check(workerGroupKubernetesVersion) {
-				c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (%s) does not match the desired Kubernetes version (v%s)", object.Name, object.Status.NodeInfo.KubeletVersion, workerGroupKubernetesVersion.Original()))
+				c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (%s) does not match the desired Kubernetes version (v%s)", object.Name, object.Status.NodeInfo.KubeletVersion, workerGroupKubernetesVersion.Original()))
 				return &c
 			}
 		}
@@ -225,7 +225,7 @@ func resourcesNotProgressingCheck(clock clock.Clock, threshold *metav1.Duration)
 // CheckManagedResources checks multiple ManagedResources in case the provided filter func returns true. If their state
 // indicates issues then this is reflected in the state of the provided condition. If there are no issues, nil is
 // returned.
-func (b *HealthChecker) CheckManagedResources(
+func (h *HealthChecker) CheckManagedResources(
 	condition gardencorev1beta1.Condition,
 	managedResources []resourcesv1alpha1.ManagedResource,
 	filterFunc func(resourcesv1alpha1.ManagedResource) bool,
@@ -236,7 +236,7 @@ func (b *HealthChecker) CheckManagedResources(
 			continue
 		}
 
-		if exitCondition := b.CheckManagedResource(condition, &managedResource, progressingThreshold); exitCondition != nil {
+		if exitCondition := h.CheckManagedResource(condition, &managedResource, progressingThreshold); exitCondition != nil {
 			return exitCondition
 		}
 	}
@@ -245,30 +245,30 @@ func (b *HealthChecker) CheckManagedResources(
 }
 
 // CheckManagedResource checks the conditions of the given managed resource and reflects the state in the returned condition.
-func (b *HealthChecker) CheckManagedResource(condition gardencorev1beta1.Condition, mr *resourcesv1alpha1.ManagedResource, managedResourceProgressingThreshold *metav1.Duration) *gardencorev1beta1.Condition {
+func (h *HealthChecker) CheckManagedResource(condition gardencorev1beta1.Condition, mr *resourcesv1alpha1.ManagedResource, managedResourceProgressingThreshold *metav1.Duration) *gardencorev1beta1.Condition {
 	conditionsToCheck := map[gardencorev1beta1.ConditionType]func(condition gardencorev1beta1.Condition) bool{
 		resourcesv1alpha1.ResourcesApplied:     defaultSuccessfulCheck(),
 		resourcesv1alpha1.ResourcesHealthy:     defaultSuccessfulCheck(),
-		resourcesv1alpha1.ResourcesProgressing: resourcesNotProgressingCheck(b.clock, managedResourceProgressingThreshold),
+		resourcesv1alpha1.ResourcesProgressing: resourcesNotProgressingCheck(h.clock, managedResourceProgressingThreshold),
 	}
 
-	return b.checkManagedResourceConditions(condition, mr, conditionsToCheck, managedResourceProgressingThreshold)
+	return h.checkManagedResourceConditions(condition, mr, conditionsToCheck, managedResourceProgressingThreshold)
 }
 
 // checkManagedResourceConditions checks the given conditions at the ManagedResource.
-func (b *HealthChecker) checkManagedResourceConditions(
+func (h *HealthChecker) checkManagedResourceConditions(
 	condition gardencorev1beta1.Condition,
 	mr *resourcesv1alpha1.ManagedResource,
 	conditionsToCheck map[gardencorev1beta1.ConditionType]func(condition gardencorev1beta1.Condition) bool,
 	managedResourceProgressingThreshold *metav1.Duration,
 ) *gardencorev1beta1.Condition {
 	if mr.Generation != mr.Status.ObservedGeneration {
-		c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, gardencorev1beta1.OutdatedStatusError, fmt.Sprintf("observed generation of managed resource '%s/%s' outdated (%d/%d)", mr.Namespace, mr.Name, mr.Status.ObservedGeneration, mr.Generation))
+		c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, gardencorev1beta1.OutdatedStatusError, fmt.Sprintf("observed generation of managed resource '%s/%s' outdated (%d/%d)", mr.Namespace, mr.Name, mr.Status.ObservedGeneration, mr.Generation))
 
 		// check if MangedResource `ResourcesApplied` condition is in failed state
 		conditionResourcesApplied := v1beta1helper.GetCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 		if conditionResourcesApplied != nil && conditionResourcesApplied.Status == gardencorev1beta1.ConditionFalse && conditionResourcesApplied.Reason == resourcesv1alpha1.ConditionApplyFailed {
-			c = v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, conditionResourcesApplied.Reason, conditionResourcesApplied.Message)
+			c = v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, conditionResourcesApplied.Reason, conditionResourcesApplied.Message)
 		}
 
 		return &c
@@ -289,9 +289,9 @@ func (b *HealthChecker) checkManagedResourceConditions(
 			continue
 		}
 		if !checkConditionStatus(*cond) {
-			c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, cond.Reason, cond.Message)
+			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, cond.Reason, cond.Message)
 			if cond.Type == resourcesv1alpha1.ResourcesProgressing && managedResourceProgressingThreshold != nil {
-				c = v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, gardencorev1beta1.ManagedResourceProgressingRolloutStuck, fmt.Sprintf("ManagedResource %s is progressing for more than %s", mr.Name, managedResourceProgressingThreshold.Duration))
+				c = v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, gardencorev1beta1.ManagedResourceProgressingRolloutStuck, fmt.Sprintf("ManagedResource %s is progressing for more than %s", mr.Name, managedResourceProgressingThreshold.Duration))
 			}
 			return &c
 		}
@@ -303,7 +303,7 @@ func (b *HealthChecker) checkManagedResourceConditions(
 		for cond := range conditionsToCheck {
 			missing = append(missing, string(cond))
 		}
-		c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, gardencorev1beta1.ManagedResourceMissingConditionError, fmt.Sprintf("ManagedResource %s is missing the following condition(s), %v", mr.Name, missing))
+		c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, gardencorev1beta1.ManagedResourceMissingConditionError, fmt.Sprintf("ManagedResource %s is missing the following condition(s), %v", mr.Name, missing))
 		return &c
 	}
 
@@ -311,7 +311,7 @@ func (b *HealthChecker) checkManagedResourceConditions(
 }
 
 // CheckControlPlane checks whether the given required control-plane component deployments and ETCDs are complete and healthy.
-func (b *HealthChecker) CheckControlPlane(
+func (h *HealthChecker) CheckControlPlane(
 	ctx context.Context,
 	namespace string,
 	requiredControlPlaneDeployments sets.Set[string],
@@ -322,26 +322,26 @@ func (b *HealthChecker) CheckControlPlane(
 	error,
 ) {
 	deploymentList := &appsv1.DeploymentList{}
-	if err := b.reader.List(ctx, deploymentList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: controlPlaneSelector}); err != nil {
+	if err := h.reader.List(ctx, deploymentList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: controlPlaneSelector}); err != nil {
 		return nil, err
 	}
 
 	etcdList := &druidv1alpha1.EtcdList{}
-	if err := b.reader.List(ctx, etcdList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: controlPlaneSelector}); err != nil {
+	if err := h.reader.List(ctx, etcdList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: controlPlaneSelector}); err != nil {
 		return nil, err
 	}
 
-	if exitCondition := b.checkRequiredDeployments(condition, requiredControlPlaneDeployments, deploymentList.Items); exitCondition != nil {
+	if exitCondition := h.checkRequiredDeployments(condition, requiredControlPlaneDeployments, deploymentList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
-	if exitCondition := b.checkDeployments(condition, deploymentList.Items); exitCondition != nil {
+	if exitCondition := h.checkDeployments(condition, deploymentList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
 
-	if exitCondition := b.checkRequiredEtcds(condition, requiredControlPlaneEtcds, etcdList.Items); exitCondition != nil {
+	if exitCondition := h.checkRequiredEtcds(condition, requiredControlPlaneEtcds, etcdList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
-	if exitCondition := b.checkEtcds(condition, etcdList.Items); exitCondition != nil {
+	if exitCondition := h.checkEtcds(condition, etcdList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
 
@@ -349,7 +349,7 @@ func (b *HealthChecker) CheckControlPlane(
 }
 
 // CheckMonitoringControlPlane checks the monitoring components of the control-plane.
-func (b *HealthChecker) CheckMonitoringControlPlane(
+func (h *HealthChecker) CheckMonitoringControlPlane(
 	ctx context.Context,
 	namespace string,
 	requiredMonitoringDeployments sets.Set[string],
@@ -361,27 +361,27 @@ func (b *HealthChecker) CheckMonitoringControlPlane(
 	error,
 ) {
 	deploymentList := &appsv1.DeploymentList{}
-	if err := b.reader.List(ctx, deploymentList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: appsSelector}); err != nil {
+	if err := h.reader.List(ctx, deploymentList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: appsSelector}); err != nil {
 		return nil, err
 	}
 
 	statefulSetList := &appsv1.StatefulSetList{}
-	if err := b.reader.List(ctx, statefulSetList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: appsSelector}); err != nil {
+	if err := h.reader.List(ctx, statefulSetList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: appsSelector}); err != nil {
 		return nil, err
 	}
 
-	if exitCondition := b.checkRequiredDeployments(condition, requiredMonitoringDeployments, deploymentList.Items); exitCondition != nil {
+	if exitCondition := h.checkRequiredDeployments(condition, requiredMonitoringDeployments, deploymentList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
 
-	if exitCondition := b.checkDeployments(condition, deploymentList.Items); exitCondition != nil {
+	if exitCondition := h.checkDeployments(condition, deploymentList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
 
-	if exitCondition := b.checkRequiredStatefulSets(condition, requiredMonitoringStatefulSets, statefulSetList.Items); exitCondition != nil {
+	if exitCondition := h.checkRequiredStatefulSets(condition, requiredMonitoringStatefulSets, statefulSetList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
-	if exitCondition := b.checkStatefulSets(condition, statefulSetList.Items); exitCondition != nil {
+	if exitCondition := h.checkStatefulSets(condition, statefulSetList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
 
@@ -391,7 +391,7 @@ func (b *HealthChecker) CheckMonitoringControlPlane(
 var requiredLoggingDeployments = sets.New(v1beta1constants.DeploymentNameEventLogger)
 
 // CheckLoggingControlPlane checks whether the logging components are complete and healthy.
-func (b *HealthChecker) CheckLoggingControlPlane(
+func (h *HealthChecker) CheckLoggingControlPlane(
 	ctx context.Context,
 	namespace string,
 	eventLoggingEnabled bool,
@@ -402,14 +402,14 @@ func (b *HealthChecker) CheckLoggingControlPlane(
 ) {
 	if eventLoggingEnabled {
 		deploymentList := &appsv1.DeploymentList{}
-		if err := b.reader.List(ctx, deploymentList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: loggingSelector}); err != nil {
+		if err := h.reader.List(ctx, deploymentList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: loggingSelector}); err != nil {
 			return nil, err
 		}
 
-		if exitCondition := b.checkRequiredDeployments(condition, requiredLoggingDeployments, deploymentList.Items); exitCondition != nil {
+		if exitCondition := h.checkRequiredDeployments(condition, requiredLoggingDeployments, deploymentList.Items); exitCondition != nil {
 			return exitCondition, nil
 		}
-		if exitCondition := b.checkDeployments(condition, deploymentList.Items); exitCondition != nil {
+		if exitCondition := h.checkDeployments(condition, deploymentList.Items); exitCondition != nil {
 			return exitCondition, nil
 		}
 	}
@@ -418,7 +418,7 @@ func (b *HealthChecker) CheckLoggingControlPlane(
 }
 
 // CheckExtensionCondition checks whether the conditions provided by extensions are healthy.
-func (b *HealthChecker) CheckExtensionCondition(condition gardencorev1beta1.Condition, extensionsConditions []ExtensionCondition, staleExtensionHealthCheckThreshold *metav1.Duration) *gardencorev1beta1.Condition {
+func (h *HealthChecker) CheckExtensionCondition(condition gardencorev1beta1.Condition, extensionsConditions []ExtensionCondition, staleExtensionHealthCheckThreshold *metav1.Duration) *gardencorev1beta1.Condition {
 	for _, cond := range extensionsConditions {
 		// check if the extension controller's last heartbeat time or the condition's LastUpdateTime is older than the configured staleExtensionHealthCheckThreshold
 		if staleExtensionHealthCheckThreshold != nil {
@@ -426,19 +426,19 @@ func (b *HealthChecker) CheckExtensionCondition(condition gardencorev1beta1.Cond
 			if lastHeartbeatTime == nil {
 				lastHeartbeatTime = &metav1.MicroTime{}
 			}
-			if b.clock.Now().UTC().Sub(lastHeartbeatTime.UTC()) > staleExtensionHealthCheckThreshold.Duration {
-				c := v1beta1helper.UpdatedConditionWithClock(b.clock, condition, gardencorev1beta1.ConditionUnknown, fmt.Sprintf("%sOutdatedHealthCheckReport", cond.ExtensionType), fmt.Sprintf("%s extension (%s/%s) reports an outdated health status (last updated: %s ago at %s).", cond.ExtensionType, cond.ExtensionNamespace, cond.ExtensionName, b.clock.Now().UTC().Sub(lastHeartbeatTime.UTC()).Round(time.Minute).String(), lastHeartbeatTime.UTC().Round(time.Minute).String()))
+			if h.clock.Now().UTC().Sub(lastHeartbeatTime.UTC()) > staleExtensionHealthCheckThreshold.Duration {
+				c := v1beta1helper.UpdatedConditionWithClock(h.clock, condition, gardencorev1beta1.ConditionUnknown, fmt.Sprintf("%sOutdatedHealthCheckReport", cond.ExtensionType), fmt.Sprintf("%s extension (%s/%s) reports an outdated health status (last updated: %s ago at %s).", cond.ExtensionType, cond.ExtensionNamespace, cond.ExtensionName, h.clock.Now().UTC().Sub(lastHeartbeatTime.UTC()).Round(time.Minute).String(), lastHeartbeatTime.UTC().Round(time.Minute).String()))
 				return &c
 			}
 		}
 
 		if cond.Condition.Status == gardencorev1beta1.ConditionProgressing {
-			c := v1beta1helper.UpdatedConditionWithClock(b.clock, condition, cond.Condition.Status, cond.ExtensionType+cond.Condition.Reason, cond.Condition.Message, cond.Condition.Codes...)
+			c := v1beta1helper.UpdatedConditionWithClock(h.clock, condition, cond.Condition.Status, cond.ExtensionType+cond.Condition.Reason, cond.Condition.Message, cond.Condition.Codes...)
 			return &c
 		}
 
 		if cond.Condition.Status == gardencorev1beta1.ConditionFalse || cond.Condition.Status == gardencorev1beta1.ConditionUnknown {
-			c := v1beta1helper.FailedCondition(b.clock, b.lastOperation, b.conditionThresholds, condition, fmt.Sprintf("%sUnhealthyReport", cond.ExtensionType), fmt.Sprintf("%s extension (%s/%s) reports failing health check: %s", cond.ExtensionType, cond.ExtensionNamespace, cond.ExtensionName, cond.Condition.Message), cond.Condition.Codes...)
+			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, fmt.Sprintf("%sUnhealthyReport", cond.ExtensionType), fmt.Sprintf("%s extension (%s/%s) reports failing health check: %s", cond.ExtensionType, cond.ExtensionNamespace, cond.ExtensionName, cond.Condition.Message), cond.Condition.Codes...)
 			return &c
 		}
 	}

--- a/pkg/utils/kubernetes/health/checker/checker.go
+++ b/pkg/utils/kubernetes/health/checker/checker.go
@@ -366,41 +366,18 @@ func (b *HealthChecker) CheckMonitoringControlPlane(
 	return nil, nil
 }
 
-var (
-	requiredLoggingStatefulSets = sets.New(
-		v1beta1constants.StatefulSetNameVali,
-	)
-
-	requiredLoggingDeployments = sets.New(
-		v1beta1constants.DeploymentNameEventLogger,
-	)
-)
+var requiredLoggingDeployments = sets.New(v1beta1constants.DeploymentNameEventLogger)
 
 // CheckLoggingControlPlane checks whether the logging components are complete and healthy.
 func (b *HealthChecker) CheckLoggingControlPlane(
 	ctx context.Context,
 	namespace string,
 	eventLoggingEnabled bool,
-	valiEnabled bool,
 	condition gardencorev1beta1.Condition,
 ) (
 	*gardencorev1beta1.Condition,
 	error,
 ) {
-	if valiEnabled {
-		statefulSetList := &appsv1.StatefulSetList{}
-		if err := b.reader.List(ctx, statefulSetList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: loggingSelector}); err != nil {
-			return nil, err
-		}
-
-		if exitCondition := b.checkRequiredStatefulSets(condition, requiredLoggingStatefulSets, statefulSetList.Items); exitCondition != nil {
-			return exitCondition, nil
-		}
-		if exitCondition := b.checkStatefulSets(condition, statefulSetList.Items); exitCondition != nil {
-			return exitCondition, nil
-		}
-	}
-
 	if eventLoggingEnabled {
 		deploymentList := &appsv1.DeploymentList{}
 		if err := b.reader.List(ctx, deploymentList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: loggingSelector}); err != nil {

--- a/pkg/utils/managedresources/builder/managedresources.go
+++ b/pkg/utils/managedresources/builder/managedresources.go
@@ -27,6 +27,7 @@ import (
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // ManagedResource is a structure managing a ManagedResource.
@@ -62,7 +63,7 @@ func (m *ManagedResource) WithNamespacedName(namespace, name string) *ManagedRes
 
 // WithLabels sets the labels.
 func (m *ManagedResource) WithLabels(labels map[string]string) *ManagedResource {
-	m.labels = labels
+	m.labels = utils.MergeStringMaps(m.labels, labels)
 	return m
 }
 

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -189,6 +189,17 @@ func CreateForSeed(ctx context.Context, client client.Client, namespace, name st
 	return deployManagedResource(ctx, secret, managedResource)
 }
 
+// CreateForSeedWithLabels deploys a ManagedResource CR for the seed's gardener-resource-manager and allows providing
+// additional labels.
+func CreateForSeedWithLabels(ctx context.Context, client client.Client, namespace, name string, keepObjects bool, labels map[string]string, data map[string][]byte) error {
+	var (
+		secretName, secret = NewSecret(client, namespace, name, data, true)
+		managedResource    = NewForSeed(client, namespace, name, keepObjects).WithSecretRef(secretName).WithLabels(labels)
+	)
+
+	return deployManagedResource(ctx, secret, managedResource)
+}
+
 // CreateForShoot deploys a ManagedResource CR for the shoot's gardener-resource-manager.
 // The origin is used to identify the creator of the managed resource. Gardener acts on resources
 // with "origin=gardener" label. External callers (extension controllers or other components)
@@ -197,6 +208,19 @@ func CreateForShoot(ctx context.Context, client client.Client, namespace, name, 
 	var (
 		secretName, secret = NewSecret(client, namespace, name, data, true)
 		managedResource    = NewForShoot(client, namespace, name, origin, keepObjects).WithSecretRef(secretName)
+	)
+
+	return deployManagedResource(ctx, secret, managedResource)
+}
+
+// CreateForShootWithLabels deploys a ManagedResource CR for the shoot's gardener-resource-manager. The origin is used
+// to identify the creator of the managed resource. Gardener acts on resources with "origin=gardener" label. External
+// callers (extension controllers or other components) of this function should provide their own unique origin value.
+// This function allows providing additional labels.
+func CreateForShootWithLabels(ctx context.Context, client client.Client, namespace, name, origin string, keepObjects bool, labels map[string]string, data map[string][]byte) error {
+	var (
+		secretName, secret = NewSecret(client, namespace, name, data, true)
+		managedResource    = NewForShoot(client, namespace, name, origin, keepObjects).WithSecretRef(secretName).WithLabels(labels)
 	)
 
 	return deployManagedResource(ctx, secret, managedResource)

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 					}).Should(And(
 						ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("APIServerDown")),
 						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [gardener-resource-manager kube-apiserver kube-controller-manager kube-scheduler machine-controller-manager]")),
-						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-state-metrics plutono]")),
+						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-state-metrics]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 					))
@@ -308,7 +308,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 					}).Should(And(
 						ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("APIServerDown")),
 						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [gardener-resource-manager kube-apiserver kube-controller-manager]")),
-						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [plutono]")),
+						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("StatefulSetMissing"), WithMessageSubstrings("Missing required stateful sets: [prometheus]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 						Not(ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady))),
 					))
@@ -330,7 +330,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 					}).Should(And(
 						ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("APIServerDown")),
 						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-apiserver kube-scheduler machine-controller-manager]")),
-						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-state-metrics plutono]")),
+						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-state-metrics]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 					))
@@ -354,7 +354,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 					}).Should(And(
 						ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("APIServerDown")),
 						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-apiserver]")),
-						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [plutono]")),
+						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("StatefulSetMissing"), WithMessageSubstrings("Missing required stateful sets: [prometheus]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 						Not(ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady))),
 					))

--- a/test/integration/operator/garden/care/care_test.go
+++ b/test/integration/operator/garden/care/care_test.go
@@ -29,65 +29,11 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/component/autoscaling/hvpa"
-	"github.com/gardener/gardener/pkg/component/autoscaling/vpa"
-	"github.com/gardener/gardener/pkg/component/etcd/etcd"
-	runtimegardensystem "github.com/gardener/gardener/pkg/component/garden/system/runtime"
-	virtualgardensystem "github.com/gardener/gardener/pkg/component/garden/system/virtual"
-	gardeneraccess "github.com/gardener/gardener/pkg/component/gardener/access"
-	gardeneradmissioncontroller "github.com/gardener/gardener/pkg/component/gardener/admissioncontroller"
-	gardenerapiserver "github.com/gardener/gardener/pkg/component/gardener/apiserver"
-	gardenercontrollermanager "github.com/gardener/gardener/pkg/component/gardener/controllermanager"
-	"github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
-	gardenerscheduler "github.com/gardener/gardener/pkg/component/gardener/scheduler"
-	kubecontrollermanager "github.com/gardener/gardener/pkg/component/kubernetes/controllermanager"
-	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
-	"github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
-	"github.com/gardener/gardener/pkg/component/observability/monitoring/gardenermetricsexporter"
-	"github.com/gardener/gardener/pkg/component/observability/monitoring/kubestatemetrics"
-	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
-	"github.com/gardener/gardener/pkg/component/observability/plutono"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Garden Care controller tests", func() {
 	var (
-		requiredRuntimeClusterManagedResources = []string{
-			etcd.Druid,
-			runtimegardensystem.ManagedResourceName,
-			hvpa.ManagedResourceName,
-			vpa.ManagedResourceControlName,
-			"istio-system",
-			"virtual-garden-istio",
-		}
-
-		requiredVirtualGardenManagedResources = []string{
-			resourcemanager.ManagedResourceName,
-			gardeneraccess.ManagedResourceName,
-			kubecontrollermanager.ManagedResourceName,
-			gardenerapiserver.ManagedResourceNameRuntime,
-			gardenerapiserver.ManagedResourceNameVirtual,
-			gardeneradmissioncontroller.ManagedResourceNameRuntime,
-			gardeneradmissioncontroller.ManagedResourceNameVirtual,
-			gardenercontrollermanager.ManagedResourceNameRuntime,
-			gardenercontrollermanager.ManagedResourceNameVirtual,
-			gardenerscheduler.ManagedResourceNameRuntime,
-			gardenerscheduler.ManagedResourceNameVirtual,
-			virtualgardensystem.ManagedResourceName,
-		}
-
-		requiredObservabilityManagedResources = []string{
-			kubestatemetrics.ManagedResourceName,
-			fluentoperator.OperatorManagedResourceName,
-			fluentoperator.CustomResourcesManagedResourceName + "-garden",
-			fluentoperator.FluentBitManagedResourceName,
-			constants.ManagedResourceNameRuntime,
-			plutono.ManagedResourceName,
-			gardenermetricsexporter.ManagedResourceNameRuntime,
-			gardenermetricsexporter.ManagedResourceNameVirtual,
-			prometheusoperator.ManagedResourceName,
-		}
-
 		requiredControlPlaneDeployments = []string{
 			"virtual-garden-" + v1beta1constants.DeploymentNameGardenerResourceManager,
 			"virtual-garden-" + v1beta1constants.DeploymentNameKubeAPIServer,
@@ -167,44 +113,28 @@ var _ = Describe("Garden Care controller tests", func() {
 		})
 	})
 
-	Context("when all ManagedResources for the Garden are missing", func() {
-		It("should set condition to False", func() {
-			By("Expect RuntimeComponentsHealthy condition to be False")
-			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())
-				return garden.Status.Conditions
-			}).Should(ContainCondition(
-				OfType(operatorv1alpha1.RuntimeComponentsHealthy),
-				WithStatus(gardencorev1beta1.ConditionFalse),
-				WithReason("ResourceNotFound"),
-				WithMessageSubstrings("not found"),
-			))
-		})
-	})
-
 	Context("when ManagedResources for Runtime Cluster exist", func() {
-		BeforeEach(func() {
-			for _, name := range requiredRuntimeClusterManagedResources {
-				By("Create ManagedResource for " + name)
-				managedResource := &resourcesv1alpha1.ManagedResource{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: getManagedResourceNamespace(name, testNamespace.Name),
-					},
-					Spec: resourcesv1alpha1.ManagedResourceSpec{
-						SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},
-					},
-				}
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-				log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
-			}
-		})
+		managedResourceName := "foo"
 
-		AfterEach(func() {
-			for _, name := range requiredRuntimeClusterManagedResources {
-				By("Delete ManagedResource for " + name)
-				Expect(testClient.Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: getManagedResourceNamespace(name, testNamespace.Name)}})).To(Succeed())
+		BeforeEach(func() {
+			By("Create ManagedResource for runtime cluster")
+			managedResource := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedResourceName,
+					Namespace: getManagedResourceNamespace(managedResourceName, testNamespace.Name),
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class:      ptr.To("seed"),
+					SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},
+				},
 			}
+			Expect(testClient.Create(ctx, managedResource)).To(Succeed())
+			log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
+
+			DeferCleanup(func() {
+				By("Delete ManagedResource for runtime cluster")
+				Expect(testClient.Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: getManagedResourceNamespace(managedResourceName, testNamespace.Name)}})).To(Succeed())
+			})
 		})
 
 		It("should set condition to False because all ManagedResource statuses are outdated", func() {
@@ -220,27 +150,8 @@ var _ = Describe("Garden Care controller tests", func() {
 			))
 		})
 
-		It("should set condition to False because some ManagedResource statuses are outdated", func() {
-			for _, name := range requiredRuntimeClusterManagedResources[1:] {
-				updateManagedResourceStatusToHealthy(name)
-			}
-
-			By("Expect RuntimeComponentsHealthy condition to be False")
-			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())
-				return garden.Status.Conditions
-			}).Should(ContainCondition(
-				OfType(operatorv1alpha1.RuntimeComponentsHealthy),
-				WithStatus(gardencorev1beta1.ConditionFalse),
-				WithReason("OutdatedStatus"),
-				WithMessageSubstrings("observed generation of managed resource"),
-			))
-		})
-
 		It("should set condition to True because all ManagedResource statuses are healthy", func() {
-			for _, name := range requiredRuntimeClusterManagedResources {
-				updateManagedResourceStatusToHealthy(name)
-			}
+			updateManagedResourceStatusToHealthy(managedResourceName)
 
 			By("Expect RuntimeComponentsHealthy condition to be True")
 			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
@@ -256,6 +167,8 @@ var _ = Describe("Garden Care controller tests", func() {
 	})
 
 	Context("when ManagedResources for Virtual Cluster exist", func() {
+		managedResourceName := "bar"
+
 		BeforeEach(func() {
 			By("Create deployments")
 			createDeployments(requiredControlPlaneDeployments, v1beta1constants.GardenRole, v1beta1constants.GardenRoleControlPlane)
@@ -271,27 +184,23 @@ var _ = Describe("Garden Care controller tests", func() {
 				updateETCDStatusToHealthy(name)
 			}
 
-			for _, name := range requiredVirtualGardenManagedResources {
-				By("Create ManagedResource for " + name)
-				managedResource := &resourcesv1alpha1.ManagedResource{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: getManagedResourceNamespace(name, testNamespace.Name),
-					},
-					Spec: resourcesv1alpha1.ManagedResourceSpec{
-						SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},
-					},
-				}
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-				log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
+			By("Create ManagedResource for virtual Cluster")
+			managedResource := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedResourceName,
+					Namespace: getManagedResourceNamespace(managedResourceName, testNamespace.Name),
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},
+				},
 			}
-		})
+			Expect(testClient.Create(ctx, managedResource)).To(Succeed())
+			log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
 
-		AfterEach(func() {
-			for _, name := range requiredVirtualGardenManagedResources {
-				By("Delete ManagedResource for " + name)
-				Expect(testClient.Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: getManagedResourceNamespace(name, testNamespace.Name)}})).To(Succeed())
-			}
+			DeferCleanup(func() {
+				By("Delete ManagedResource for virtual cluster")
+				Expect(testClient.Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: getManagedResourceNamespace(managedResourceName, testNamespace.Name)}})).To(Succeed())
+			})
 		})
 
 		It("should set condition to False because all ManagedResource statuses are outdated", func() {
@@ -307,27 +216,8 @@ var _ = Describe("Garden Care controller tests", func() {
 			))
 		})
 
-		It("should set condition to False because some ManagedResource statuses are outdated", func() {
-			for _, name := range requiredVirtualGardenManagedResources[1:] {
-				updateManagedResourceStatusToHealthy(name)
-			}
-
-			By("Expect RuntimeComponentsHealthy condition to be False")
-			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())
-				return garden.Status.Conditions
-			}).Should(ContainCondition(
-				OfType(operatorv1alpha1.VirtualComponentsHealthy),
-				WithStatus(gardencorev1beta1.ConditionFalse),
-				WithReason("OutdatedStatus"),
-				WithMessageSubstrings("observed generation of managed resource"),
-			))
-		})
-
 		It("should set condition to True because all ManagedResource statuses are healthy", func() {
-			for _, name := range requiredVirtualGardenManagedResources {
-				updateManagedResourceStatusToHealthy(name)
-			}
+			updateManagedResourceStatusToHealthy(managedResourceName)
 
 			By("Expect VirtualGardenComponentsHealthy condition to be True")
 			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
@@ -361,31 +251,6 @@ var _ = Describe("Garden Care controller tests", func() {
 		BeforeEach(func() {
 			By("Create deployments")
 			createDeployments(requiredControlPlaneDeployments, v1beta1constants.GardenRole, v1beta1constants.GardenRoleControlPlane)
-
-			for _, name := range requiredVirtualGardenManagedResources {
-				By("Create ManagedResource for " + name)
-				managedResource := &resourcesv1alpha1.ManagedResource{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: getManagedResourceNamespace(name, testNamespace.Name),
-					},
-					Spec: resourcesv1alpha1.ManagedResourceSpec{
-						SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},
-					},
-				}
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-				log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
-			}
-			for _, name := range requiredVirtualGardenManagedResources {
-				updateManagedResourceStatusToHealthy(name)
-			}
-		})
-
-		AfterEach(func() {
-			for _, name := range requiredVirtualGardenManagedResources {
-				By("Delete ManagedResource for " + name)
-				Expect(testClient.Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: getManagedResourceNamespace(name, testNamespace.Name)}})).To(Succeed())
-			}
 		})
 
 		It("should set condition to False because status of all deployments are outdated", func() {
@@ -512,28 +377,27 @@ var _ = Describe("Garden Care controller tests", func() {
 	})
 
 	Context("when observability-related ManagedResources exist", func() {
-		BeforeEach(func() {
-			for _, name := range requiredObservabilityManagedResources {
-				By("Create ManagedResource for " + name)
-				managedResource := &resourcesv1alpha1.ManagedResource{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: getManagedResourceNamespace(name, testNamespace.Name),
-					},
-					Spec: resourcesv1alpha1.ManagedResourceSpec{
-						SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},
-					},
-				}
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-				log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
-			}
-		})
+		managedResourceName := "baz"
 
-		AfterEach(func() {
-			for _, name := range requiredObservabilityManagedResources {
-				By("Delete ManagedResource for " + name)
-				Expect(testClient.Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: getManagedResourceNamespace(name, testNamespace.Name)}})).To(Succeed())
+		BeforeEach(func() {
+			By("Create ManagedResource for observability components")
+			managedResource := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedResourceName,
+					Namespace: getManagedResourceNamespace(managedResourceName, testNamespace.Name),
+					Labels:    map[string]string{"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy"},
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},
+				},
 			}
+			Expect(testClient.Create(ctx, managedResource)).To(Succeed())
+			log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
+
+			DeferCleanup(func() {
+				By("Delete ManagedResource for observability components")
+				Expect(testClient.Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: getManagedResourceNamespace(managedResourceName, testNamespace.Name)}})).To(Succeed())
+			})
 		})
 
 		It("should set condition to False because all ManagedResource statuses are outdated", func() {
@@ -549,27 +413,8 @@ var _ = Describe("Garden Care controller tests", func() {
 			))
 		})
 
-		It("should set condition to False because some ManagedResource statuses are outdated", func() {
-			for _, name := range requiredObservabilityManagedResources[1:] {
-				updateManagedResourceStatusToHealthy(name)
-			}
-
-			By("Expect ObservabilityComponentsHealthy condition to be False")
-			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())
-				return garden.Status.Conditions
-			}).Should(ContainCondition(
-				OfType(operatorv1alpha1.ObservabilityComponentsHealthy),
-				WithStatus(gardencorev1beta1.ConditionFalse),
-				WithReason("OutdatedStatus"),
-				WithMessageSubstrings("observed generation of managed resource"),
-			))
-		})
-
 		It("should set condition to True because all ManagedResource statuses are healthy", func() {
-			for _, name := range requiredObservabilityManagedResources {
-				updateManagedResourceStatusToHealthy(name)
-			}
+			updateManagedResourceStatusToHealthy(managedResourceName)
 
 			By("Expect ObservabilityComponentsHealthy condition to be True")
 			Eventually(func(g Gomega) []gardencorev1beta1.Condition {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Motivated by https://github.com/gardener/gardener/pull/9257, this PR aligns all care controllers (`{garden,seed,shoot}-care`) with respect to incorporating `ManagedResource` statuses into their condition statuses.

Concretely, the following is implemented:

<details><summary><code>garden-care</code></summary>

In order to compute the condition statuses, this reconciler considers `ManagedResource`s (in the `garden` and `istio-system` namespace) and their status, see [this document](resource-manager.md#conditions) for more information.
The following table explains which `ManagedResource`s are considered for which condition type:

| Condition Type                   | `ManagedResource`s are considered when                                                                               |
|----------------------------------|----------------------------------------------------------------------------------------------------------------------|
| `RuntimeComponentsHealthy`       | `.spec.class=seed` and `care.gardener.cloud/condition-type` label either unset, or set to `RuntimeComponentsHealthy` |
| `VirtualComponentsHealthy`       | `.spec.class` unset or `care.gardener.cloud/condition-type` label set to `VirtualComponentsHealthy`                  |
| `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                                   |

</details>

<details><summary><code>seed-care</code></summary>

In order to compute the condition statuses, this reconciler considers `ManagedResource`s (in the `garden` and `istio-system` namespace) and their status, see [this document](resource-manager.md#conditions) for more information.
The following table explains which `ManagedResource`s are considered for which condition type:

| Condition Type                | `ManagedResource`s are considered when |
|-------------------------------|----------------------------------------|
| `SeedSystemComponentsHealthy` | `.spec.class=seed`                     |

</details>

<details><summary><code>shoot-care</code></summary>

Besides directly checking the status of `Deployment`s, `Etcd`s, `StatefulSet`s in the shoot namespace, this reconciler also considers `ManagedResource`s (in the shoot namespace) and their status in order to compute the condition statuses, see [this document](resource-manager.md#conditions) for more information.
The following table explains which `ManagedResource`s are considered for which condition type:

| Condition Type                   | `ManagedResource`s are considered when                                                                          |
|----------------------------------|-----------------------------------------------------------------------------------------------------------------|
| `ControlPlaneHealthy`            | `.spec.class=seed` and `care.gardener.cloud/condition-type` label either unset, or set to `ControlPlaneHealthy` |
| `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                              |
| `SystemComponentsHealthy`        | `.spec.class` and `care.gardener.cloud/condition-type` label either unet, or set to `SystemComponentsHealthy`   |

</details>


**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9257

**Special notes for your reviewer**:
/cc @ScheererJ @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `{garden,seed,shoot}-care` controllers now incorporate `ManagedResource`s into all relevant conditions, and it is possible to override the condition type into which a `ManagedResource`'s status gets incorporated via the `care.gardener.cloud/condition-type` label. Please consult the respective documentation for more information ([`garden-care`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#care-reconciler), [`seed-care`](https://github.com/gardener/gardener/blob/master/docs/concepts/gardenlet.md#care-reconciler-1), [`shoot-care`](https://github.com/gardener/gardener/blob/master/docs/concepts/gardenlet.md#care-reconciler-2)).
```
