### PR TITLE
Save a few allocations

### DIFF
--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -386,7 +386,7 @@ var gardenletManagedPriorityClasses = []struct {
 }
 
 func priorityClassResources() []client.Object {
-	var out []client.Object
+	out := make([]client.Object, 0, len(gardenletManagedPriorityClasses))
 
 	for _, class := range gardenletManagedPriorityClasses {
 		out = append(out, &schedulingv1.PriorityClass{
@@ -428,7 +428,7 @@ func (s *shootSystem) shootInfoData() map[string]string {
 }
 
 func (s *shootSystem) readOnlyRBACResources() []client.Object {
-	apiGroupToReadableResourcesNames := make(map[string][]string)
+	apiGroupToReadableResourcesNames := make(map[string][]string, len(s.values.APIResourceList))
 	for _, api := range s.values.APIResourceList {
 		apiGroup := strings.Split(api.GroupVersion, "/")[0]
 		if apiGroup == corev1.SchemeGroupVersion.Version {
@@ -453,7 +453,7 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 	}
 
 	// Sort keys to get a stable order of the RBAC rules when iterating.
-	var allAPIGroups []string
+	allAPIGroups := make([]string, 0, len(apiGroupToReadableResourcesNames))
 	for key := range apiGroupToReadableResourcesNames {
 		allAPIGroups = append(allAPIGroups, key)
 	}
@@ -463,6 +463,7 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "gardener.cloud:system:read-only",
 		},
+		Rules: make([]rbacv1.PolicyRule, 0, len(allAPIGroups)),
 	}
 
 	for _, apiGroup := range allAPIGroups {

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -457,7 +456,7 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 	for key := range apiGroupToReadableResourcesNames {
 		allAPIGroups = append(allAPIGroups, key)
 	}
-	sort.Strings(allAPIGroups)
+	slices.Sort(allAPIGroups)
 
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Was looking at the code of `ShootSystem` component and I found a few places where capacity size/hint can be passed. Also [strings.Sort](https://pkg.go.dev/sort#Strings) calls `slices.Sort` as of 1.22 so I changed that as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
