### PR TITLE
Promote `ShootForceDeletion` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -29,7 +29,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | MachineControllerManagerDeployment | `false` | `Alpha` | `1.73` |        |
 | MachineControllerManagerDeployment | `true`  | `Beta`  | `1.81` | `1.81` |
 | MachineControllerManagerDeployment | `true`  | `GA`    | `1.82` |        |
-| ShootForceDeletion                 | `false` | `Alpha` | `1.81` |        |
+| ShootForceDeletion                 | `false` | `Alpha` | `1.81` | `1.90` |
+| ShootForceDeletion                 | `true`  | `Beta`  | `1.91` |        |
 | APIServerFastRollout               | `true`  | `Beta`  | `1.82` | `1.89` |
 | APIServerFastRollout               | `true`  | `GA`    | `1.90` |        |
 | UseGardenerNodeAgent               | `false` | `Alpha` | `1.82` | `1.88` |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -62,6 +62,7 @@ const (
 	// See https://github.com/gardener/gardener/blob/master/docs/usage/shoot_operations.md#shoot-force-deletion for more details.
 	// owner: @acumino @ary1992 @shafeeqes
 	// alpha: v1.81.0
+	// beta: v1.91.0
 	ShootForceDeletion featuregate.Feature = "ShootForceDeletion"
 
 	// MachineControllerManagerDeployment enables Gardener to take over the deployment of the
@@ -122,7 +123,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CoreDNSQueryRewriting:              {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:                    {Default: false, PreRelease: featuregate.Alpha},
 	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
-	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
+	ShootForceDeletion:                 {Default: true, PreRelease: featuregate.Beta},
 	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	APIServerFastRollout:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	UseGardenerNodeAgent:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Promote `ShootForceDeletion` feature gate to beta and turn it on by default.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3110

**Special notes for your reviewer**:
/cc @shafeeqes @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `ShootForceDeletion` feature gate has been graduated to GA and is locked to `true`. 
```