### PR TITLE
Extend health/progressing checks of `gardener-resource-manager` by `cert-management` resources

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -126,6 +126,8 @@ linters-settings:
         alias: machinev1alpha1
       - pkg: github.com/gardener/etcd-druid/api/v1alpha1
         alias: druidv1alpha1
+      - pkg: github.com/gardener/cert-management/pkg/apis/cert/v1alpha1
+        alias: certv1alpha1
       # Gardener extension package
       - pkg: github.com/gardener/gardener/extensions/.*/(\w+)/mock$
         alias: extensionsmock${1}

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -284,6 +284,7 @@ The following object kinds are considered for health checks:
 - [`Prometheus`](https://github.com/prometheus-operator/prometheus-operator)
 - [`Alertmanager`](https://github.com/prometheus-operator/prometheus-operator)
 - [`Certificate`](https://github.com/gardener/cert-management)
+- [`Issuer`](https://github.com/gardener/cert-management)
 
 #### Skipping Health Check
 

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -263,6 +263,7 @@ The following object kinds are considered for progressing checks:
 - `StatefulSet`
 - [`Prometheus`](https://github.com/prometheus-operator/prometheus-operator)
 - [`Alertmanager`](https://github.com/prometheus-operator/prometheus-operator)
+- [`Certificate`](https://github.com/gardener/cert-management)
 
 #### Health Checks
 

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -282,6 +282,7 @@ The following object kinds are considered for health checks:
 - [`VerticalPodAutoscaler`](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
 - [`Prometheus`](https://github.com/prometheus-operator/prometheus-operator)
 - [`Alertmanager`](https://github.com/prometheus-operator/prometheus-operator)
+- [`Certificate`](https://github.com/gardener/cert-management)
 
 #### Skipping Health Check
 

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -249,7 +249,7 @@ In addition to the origin annotation, all objects managed by the resource manage
 
 ### [`health` Controller](../../pkg/resourcemanager/controller/health)
 
-This controller processes `ManagedResource`s that were reconciled by the main [ManagedResource Controller](#ManagedResource-Controller) at least once.
+This controller processes `ManagedResource`s that were reconciled by the main [ManagedResource Controller](#managedResource-controller) at least once.
 Its main job is to perform checks for maintaining the well [known conditions](#conditions) `ResourcesHealthy` and `ResourcesProgressing`.
 
 #### Progressing Checks

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -249,7 +249,7 @@ In addition to the origin annotation, all objects managed by the resource manage
 
 ### [`health` Controller](../../pkg/resourcemanager/controller/health)
 
-This controller processes `ManagedResource`s that were reconciled by the main [ManagedResource Controller](#ManagedResource-Controller) once.
+This controller processes `ManagedResource`s that were reconciled by the main [ManagedResource Controller](#ManagedResource-Controller) at least once.
 Its main job is to perform checks for maintaining the well [known conditions](#conditions) `ResourcesHealthy` and `ResourcesProgressing`.
 
 #### Progressing Checks
@@ -268,7 +268,7 @@ The following object kinds are considered for progressing checks:
 
 #### Health Checks
 
-`gardener-resource-manager` can evaluate the health of specific resources, often by consulting the resources' conditions.
+`gardener-resource-manager` can evaluate the health of specific resources, often by consulting their conditions.
 Health check results are regularly updated in the `ResourcesHealthy` condition of the corresponding `ManagedResource`.
 
 The following object kinds are considered for health checks:
@@ -289,7 +289,7 @@ The following object kinds are considered for health checks:
 
 #### Skipping Health Check
 
-If a resource in the `ManagedResource` is annotated with `resources.gardener.cloud/skip-health-check=true`, then the resource will be skipped during health checks by the `health` controller. The `ManagedResource` conditions will not reflect the health condition of this resource anymore. The `ResourcesProgressing` condition will also be set to `False`.
+If a resource owned by a `ManagedResource` is annotated with `resources.gardener.cloud/skip-health-check=true`, then the resource will be skipped during health checks by the `health` controller. The `ManagedResource` conditions will not reflect the health condition of this resource anymore. The `ResourcesProgressing` condition will also be set to `False`.
 
 ### [Garbage Collector For Immutable `ConfigMap`s/`Secret`s](../../pkg/resourcemanager/controller/garbagecollector)
 

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -264,6 +264,7 @@ The following object kinds are considered for progressing checks:
 - [`Prometheus`](https://github.com/prometheus-operator/prometheus-operator)
 - [`Alertmanager`](https://github.com/prometheus-operator/prometheus-operator)
 - [`Certificate`](https://github.com/gardener/cert-management)
+- [`Issuer`](https://github.com/gardener/cert-management)
 
 #### Health Checks
 

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+require github.com/gardener/cert-management v0.12.0
+
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 // indirect
@@ -187,7 +189,7 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
-	golang.org/x/oauth2 v0.15.0 // indirect
+	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/containerd/containerd v1.7.13
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/fluent/fluent-operator/v2 v2.7.0
+	github.com/gardener/cert-management v0.12.0
 	github.com/gardener/dependency-watchdog v1.2.1
 	github.com/gardener/etcd-druid v0.22.0
 	github.com/gardener/hvpa-controller/api v0.5.0
@@ -72,8 +73,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 	sigs.k8s.io/yaml v1.4.0
 )
-
-require github.com/gardener/cert-management v0.12.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/errors v0.20.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,6 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/errors v0.20.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,6 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gardener/cert-management v0.12.0 h1:pMT15xtMFKmaKlzgBohBYOwoE29HC/S3QJKmLLU8zG4=
 github.com/gardener/cert-management v0.12.0/go.mod h1:jSqNDV4H1SR/9lLS412Uhqp0+ibPe6rgRupoDDDOxeg=
-github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791 h1:Neqc/RIUyM8sQx3+VgIA+OGA/iOfZ90R5wD67m5mE4k=
-github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791/go.mod h1:aepVXNhGH90BjVr9IGDACutA2Kqy9/2rqZZuE2FqJMo=
 github.com/gardener/dependency-watchdog v1.2.1 h1:Q0zqinZNImBuNYfNQGAXkUh5qrfJyrynO5QjUTzO/7w=
 github.com/gardener/dependency-watchdog v1.2.1/go.mod h1:RgU0VmsdBHxRU8IO9VsLxEinz58xEJdEz5hxvMqLKHQ=
 github.com/gardener/etcd-druid v0.22.0 h1:DVe+Zjrb93r9vI1uUiCTMHBffIUoMAKhNzFZNC6hsQ8=

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gardener/cert-management v0.12.0 h1:pMT15xtMFKmaKlzgBohBYOwoE29HC/S3QJKmLLU8zG4=
 github.com/gardener/cert-management v0.12.0/go.mod h1:jSqNDV4H1SR/9lLS412Uhqp0+ibPe6rgRupoDDDOxeg=
+github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791 h1:Neqc/RIUyM8sQx3+VgIA+OGA/iOfZ90R5wD67m5mE4k=
+github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791/go.mod h1:aepVXNhGH90BjVr9IGDACutA2Kqy9/2rqZZuE2FqJMo=
 github.com/gardener/dependency-watchdog v1.2.1 h1:Q0zqinZNImBuNYfNQGAXkUh5qrfJyrynO5QjUTzO/7w=
 github.com/gardener/dependency-watchdog v1.2.1/go.mod h1:RgU0VmsdBHxRU8IO9VsLxEinz58xEJdEz5hxvMqLKHQ=
 github.com/gardener/etcd-druid v0.22.0 h1:DVe+Zjrb93r9vI1uUiCTMHBffIUoMAKhNzFZNC6hsQ8=

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/gardener/cert-management v0.12.0 h1:pMT15xtMFKmaKlzgBohBYOwoE29HC/S3QJKmLLU8zG4=
+github.com/gardener/cert-management v0.12.0/go.mod h1:jSqNDV4H1SR/9lLS412Uhqp0+ibPe6rgRupoDDDOxeg=
 github.com/gardener/dependency-watchdog v1.2.1 h1:Q0zqinZNImBuNYfNQGAXkUh5qrfJyrynO5QjUTzO/7w=
 github.com/gardener/dependency-watchdog v1.2.1/go.mod h1:RgU0VmsdBHxRU8IO9VsLxEinz58xEJdEz5hxvMqLKHQ=
 github.com/gardener/etcd-druid v0.22.0 h1:DVe+Zjrb93r9vI1uUiCTMHBffIUoMAKhNzFZNC6hsQ8=
@@ -646,8 +648,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
-golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
+golang.org/x/oauth2 v0.16.0 h1:aDkGMBSYxElaoP81NpoUoz2oo2R2wHdZpGToUxfyQrQ=
+golang.org/x/oauth2 v0.16.0/go.mod h1:hqZ+0LWXsiVoZpeld6jVt06P3adbS2Uu911W1SsJv2o=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -82,6 +82,9 @@ get_group_package () {
   "machine.sapcloud.io")
     echo "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
     ;;
+  "cert.gardener.cloud")
+    echo "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+    ;;
   *)
     >&2 echo "unknown group $1"
     return 1

--- a/pkg/resourcemanager/client/scheme.go
+++ b/pkg/resourcemanager/client/scheme.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -59,6 +60,7 @@ func init() {
 			monitoringv1beta1.AddToScheme,
 			monitoringv1.AddToScheme,
 			vpaautoscalingv1.AddToScheme,
+			certv1alpha1.AddToScheme,
 		)
 	)
 

--- a/pkg/resourcemanager/controller/health/progressing/add.go
+++ b/pkg/resourcemanager/controller/health/progressing/add.go
@@ -17,6 +17,7 @@ package progressing
 import (
 	"context"
 
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -86,6 +87,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, sour
 		"daemonsets":    &appsv1.DaemonSet{},
 		"prometheuses":  &monitoringv1.Prometheus{},
 		"alertmanagers": &monitoringv1.Alertmanager{},
+		"certificates":  &certv1alpha1.Certificate{},
 	} {
 		gvr := schema.GroupVersionResource{Group: appsv1.SchemeGroupVersion.Group, Version: appsv1.SchemeGroupVersion.Version, Resource: resource}
 

--- a/pkg/resourcemanager/controller/health/progressing/add.go
+++ b/pkg/resourcemanager/controller/health/progressing/add.go
@@ -88,6 +88,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, sour
 		"prometheuses":  &monitoringv1.Prometheus{},
 		"alertmanagers": &monitoringv1.Alertmanager{},
 		"certificates":  &certv1alpha1.Certificate{},
+		"issuers":       &certv1alpha1.Issuer{},
 	} {
 		gvr := schema.GroupVersionResource{Group: appsv1.SchemeGroupVersion.Group, Version: appsv1.SchemeGroupVersion.Version, Resource: resource}
 

--- a/pkg/resourcemanager/controller/health/progressing/reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing/reconciler.go
@@ -125,6 +125,8 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 			obj = &monitoringv1.Alertmanager{}
 		case "Certificate":
 			obj = &certv1alpha1.Certificate{}
+		case "Issuer":
+			obj = &certv1alpha1.Issuer{}
 		default:
 			continue
 		}
@@ -227,6 +229,9 @@ func (r *Reconciler) checkProgressing(ctx context.Context, obj client.Object) (b
 
 	case *certv1alpha1.Certificate:
 		progressing, reason = health.IsCertificateProgressing(o)
+
+	case *certv1alpha1.Issuer:
+		progressing, reason = health.IsCertificateIssuerProgressing(o)
 	}
 
 	return progressing, reason, nil

--- a/pkg/resourcemanager/controller/health/progressing/reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing/reconciler.go
@@ -106,7 +106,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 	conditionResourcesProgressing := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
 
 	for _, ref := range mr.Status.Resources {
-		// only resources in the apps/v1, monitoring.coreos.com/v1 and cert.gardener.cloud/v1alpha1 API groups are considered for Progressing condition
+		// Skip API groups that are irrelevant for progressing checks.
 		if !sets.New(appsv1.GroupName, monitoring.GroupName, certv1alpha1.GroupName).Has(ref.GroupVersionKind().Group) {
 			continue
 		}

--- a/pkg/resourcemanager/controller/health/utils/health_checker.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"context"
 
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -95,6 +96,8 @@ func CheckHealth(obj client.Object) (bool, error) {
 		return true, health.CheckAlertmanager(o)
 	case *vpaautoscalingv1.VerticalPodAutoscaler:
 		return true, health.CheckVerticalPodAutoscaler(o)
+	case *certv1alpha1.Certificate:
+		return true, health.CheckCertificate(o)
 	}
 
 	return false, nil

--- a/pkg/resourcemanager/controller/health/utils/health_checker.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker.go
@@ -98,6 +98,8 @@ func CheckHealth(obj client.Object) (bool, error) {
 		return true, health.CheckVerticalPodAutoscaler(o)
 	case *certv1alpha1.Certificate:
 		return true, health.CheckCertificate(o)
+	case *certv1alpha1.Issuer:
+		return true, health.CheckCertificateIssuer(o)
 	}
 
 	return false, nil

--- a/pkg/resourcemanager/controller/health/utils/health_checker_test.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker_test.go
@@ -15,6 +15,7 @@
 package utils_test
 
 import (
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -525,6 +526,36 @@ var _ = Describe("CheckHealth", func() {
 					},
 				},
 				Status: vpaautoscalingv1.VerticalPodAutoscalerStatus{Conditions: []vpaautoscalingv1.VerticalPodAutoscalerCondition{{Type: vpaautoscalingv1.ConfigUnsupported, Status: corev1.ConditionTrue}}},
+			}
+		})
+
+		testSuite()
+	})
+
+	Context("Certificate", func() {
+		BeforeEach(func() {
+			healthyReadyCondition := metav1.Condition{Type: "Ready", Status: "True"}
+			unhealthyReadyCondition := metav1.Condition{Type: "Ready", Status: "False"}
+
+			healthy = &certv1alpha1.Certificate{
+				Status: certv1alpha1.CertificateStatus{
+					State:      "Ready",
+					Conditions: []metav1.Condition{healthyReadyCondition},
+				},
+			}
+
+			unhealthy = &certv1alpha1.Certificate{
+				Status: certv1alpha1.CertificateStatus{
+					Conditions: []metav1.Condition{unhealthyReadyCondition},
+				},
+			}
+			unhealthyWithSkipHealthCheckAnnotation = &certv1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						resourcesv1alpha1.SkipHealthCheck: "true",
+					},
+				},
+				Status: certv1alpha1.CertificateStatus{Conditions: []metav1.Condition{unhealthyReadyCondition}},
 			}
 		})
 

--- a/pkg/resourcemanager/controller/health/utils/health_checker_test.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker_test.go
@@ -549,6 +549,7 @@ var _ = Describe("CheckHealth", func() {
 					Conditions: []metav1.Condition{unhealthyReadyCondition},
 				},
 			}
+
 			unhealthyWithSkipHealthCheckAnnotation = &certv1alpha1.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{

--- a/pkg/resourcemanager/controller/health/utils/health_checker_test.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker_test.go
@@ -561,4 +561,25 @@ var _ = Describe("CheckHealth", func() {
 
 		testSuite()
 	})
+
+	Context("Certificate Issuer", func() {
+		BeforeEach(func() {
+			healthy = &certv1alpha1.Issuer{
+				Status: certv1alpha1.IssuerStatus{
+					State: "Ready",
+				},
+			}
+
+			unhealthy = &certv1alpha1.Issuer{}
+			unhealthyWithSkipHealthCheckAnnotation = &certv1alpha1.Issuer{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						resourcesv1alpha1.SkipHealthCheck: "true",
+					},
+				},
+			}
+		})
+
+		testSuite()
+	})
 })

--- a/pkg/utils/kubernetes/health/certificate.go
+++ b/pkg/utils/kubernetes/health/certificate.go
@@ -1,0 +1,39 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"fmt"
+
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CheckCertificate checks whether the given certificate object is healthy.
+func CheckCertificate(cert *certv1alpha1.Certificate) error {
+	for _, condition := range cert.Status.Conditions {
+		if condition.Type == certv1alpha1.CertificateConditionReady {
+			if err := checkConditionState(condition.Type, string(corev1.ConditionTrue), string(condition.Status), condition.Reason, condition.Message); err != nil {
+				return err
+			}
+			break
+		}
+	}
+
+	if certState := cert.Status.State; certState != certv1alpha1.StateReady {
+		return fmt.Errorf("certificate state is %q (%q expected)", certState, certv1alpha1.StateReady)
+	}
+	return nil
+}

--- a/pkg/utils/kubernetes/health/certificate.go
+++ b/pkg/utils/kubernetes/health/certificate.go
@@ -56,3 +56,12 @@ func CheckCertificateIssuer(issuer *certv1alpha1.Issuer) error {
 
 	return nil
 }
+
+// IsCertificateIssuerProgressing returns false if the Issuer's generation matches the observed generation.
+func IsCertificateIssuerProgressing(issuer *certv1alpha1.Issuer) (bool, string) {
+	if issuer.Status.ObservedGeneration < issuer.Generation {
+		return true, fmt.Sprintf("observed generation outdated (%d/%d)", issuer.Status.ObservedGeneration, issuer.Generation)
+	}
+
+	return false, "Issuer is fully rolled out"
+}

--- a/pkg/utils/kubernetes/health/certificate.go
+++ b/pkg/utils/kubernetes/health/certificate.go
@@ -37,3 +37,13 @@ func CheckCertificate(cert *certv1alpha1.Certificate) error {
 	}
 	return nil
 }
+
+// IsCertificateProgressing returns false if the Certificate has been requested successfully.
+// If the certificate's state indicates not ready, it returns true.
+func IsCertificateProgressing(cert *certv1alpha1.Certificate) (bool, string) {
+	if cert.Status.ObservedGeneration < cert.Generation {
+		return true, fmt.Sprintf("observed generation outdated (%d/%d)", cert.Status.ObservedGeneration, cert.Generation)
+	}
+
+	return false, "Certificate is fully rolled out"
+}

--- a/pkg/utils/kubernetes/health/certificate.go
+++ b/pkg/utils/kubernetes/health/certificate.go
@@ -47,3 +47,12 @@ func IsCertificateProgressing(cert *certv1alpha1.Certificate) (bool, string) {
 
 	return false, "Certificate is fully rolled out"
 }
+
+// CheckCertificateIssuer checks whether the given issuer object is healthy.
+func CheckCertificateIssuer(issuer *certv1alpha1.Issuer) error {
+	if issuerState := issuer.Status.State; issuerState != certv1alpha1.StateReady {
+		return fmt.Errorf("issuer state is %q (%q expected)", issuerState, certv1alpha1.StateReady)
+	}
+
+	return nil
+}

--- a/pkg/utils/kubernetes/health/certificate.go
+++ b/pkg/utils/kubernetes/health/certificate.go
@@ -38,8 +38,7 @@ func CheckCertificate(cert *certv1alpha1.Certificate) error {
 	return nil
 }
 
-// IsCertificateProgressing returns false if the Certificate has been requested successfully.
-// If the certificate's state indicates not ready, it returns true.
+// IsCertificateProgressing returns false if the Certificate's generation matches the observed generation.
 func IsCertificateProgressing(cert *certv1alpha1.Certificate) (bool, string) {
 	if cert.Status.ObservedGeneration < cert.Generation {
 		return true, fmt.Sprintf("observed generation outdated (%d/%d)", cert.Status.ObservedGeneration, cert.Generation)

--- a/pkg/utils/kubernetes/health/certificate_test.go
+++ b/pkg/utils/kubernetes/health/certificate_test.go
@@ -23,73 +23,94 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
-var _ = Describe("Certificate", func() {
-	var certificate *certv1alpha1.Certificate
+var _ = Describe("Cert Management", func() {
+	Describe("Certificate", func() {
+		var certificate *certv1alpha1.Certificate
 
-	BeforeEach(func() {
-		certificate = &certv1alpha1.Certificate{}
+		BeforeEach(func() {
+			certificate = &certv1alpha1.Certificate{}
+		})
+
+		Describe("#CheckCertificate", func() {
+			It("should return no error because certificate is ready", func() {
+				certificate.Status.State = "Ready"
+				certificate.Status.Conditions = []metav1.Condition{
+					{Type: "Ready", Status: "True"},
+				}
+
+				Expect(health.CheckCertificate(certificate)).ToNot(HaveOccurred())
+			})
+
+			It("should return an error because state is not ready", func() {
+				certificate.Status.Conditions = []metav1.Condition{
+					{Type: "Ready", Status: "True"},
+				}
+
+				Expect(health.CheckCertificate(certificate)).To(MatchError(`certificate state is "" ("Ready" expected)`))
+			})
+
+			It("should return an error because condition is not ready", func() {
+				certificate.Status.Conditions = []metav1.Condition{
+					{Type: "Ready", Status: "False", Reason: "SomeReason", Message: "Some message"},
+				}
+
+				Expect(health.CheckCertificate(certificate)).To(MatchError(`condition "Ready" has invalid status False (expected True) due to SomeReason: Some message`))
+			})
+		})
+
+		Describe("#IsCertificateProgressing", func() {
+			It("should return false because certificate is rolled out", func() {
+				result, reason := health.IsCertificateProgressing(certificate)
+				Expect(result).To(BeFalse())
+				Expect(reason).To(Equal("Certificate is fully rolled out"))
+			})
+
+			It("should return true because observed generation is outdated", func() {
+				certificate.Generation = 10
+				certificate.Status.ObservedGeneration = 1
+
+				result, reason := health.IsCertificateProgressing(certificate)
+				Expect(result).To(BeTrue())
+				Expect(reason).To(Equal(`observed generation outdated (1/10)`))
+			})
+		})
 	})
 
-	Describe("#CheckCertificate", func() {
-
-		It("should return no error because certificate is ready", func() {
-			certificate.Status.State = "Ready"
-			certificate.Status.Conditions = []metav1.Condition{
-				{Type: "Ready", Status: "True"},
-			}
-
-			Expect(health.CheckCertificate(certificate)).ToNot(HaveOccurred())
-		})
-
-		It("should return an error because state is not ready", func() {
-			certificate.Status.Conditions = []metav1.Condition{
-				{Type: "Ready", Status: "True", Reason: "SomeReason", Message: "Some message"},
-			}
-
-			Expect(health.CheckCertificate(certificate)).To(MatchError(`certificate state is "" ("Ready" expected)`))
-		})
-
-		It("should return an error because condition is not ready", func() {
-			certificate.Status.Conditions = []metav1.Condition{
-				{Type: "Ready", Status: "False", Reason: "SomeReason", Message: "Some message"},
-			}
-
-			Expect(health.CheckCertificate(certificate)).To(MatchError(`condition "Ready" has invalid status False (expected True) due to SomeReason: Some message`))
-		})
-	})
-
-	Describe("#IsCertificateProgressing", func() {
-		It("should return false because certificate is rolled out", func() {
-			result, reason := health.IsCertificateProgressing(certificate)
-			Expect(result).To(BeFalse())
-			Expect(reason).To(Equal("Certificate is fully rolled out"))
-		})
-
-		It("should return true because observed generation is outdated", func() {
-			certificate.Generation = 10
-			certificate.Status.ObservedGeneration = 1
-
-			result, reason := health.IsCertificateProgressing(certificate)
-			Expect(result).To(BeTrue())
-			Expect(reason).To(Equal(`observed generation outdated (1/10)`))
-		})
-	})
-
-	Describe("#CheckCertificateIssuer", func() {
+	Describe("Issuer", func() {
 		var issuer *certv1alpha1.Issuer
 
 		BeforeEach(func() {
 			issuer = &certv1alpha1.Issuer{}
 		})
 
-		It("should return no error because issuer is ready", func() {
-			issuer.Status.State = "Ready"
+		Describe("#CheckCertificateIssuer", func() {
 
-			Expect(health.CheckCertificateIssuer(issuer)).ToNot(HaveOccurred())
+			It("should return no error because issuer is ready", func() {
+				issuer.Status.State = "Ready"
+
+				Expect(health.CheckCertificateIssuer(issuer)).ToNot(HaveOccurred())
+			})
+
+			It("should return an error because issuer is not ready", func() {
+				Expect(health.CheckCertificateIssuer(issuer)).To(MatchError(`issuer state is "" ("Ready" expected)`))
+			})
 		})
 
-		It("should return an error because issuer is not ready", func() {
-			Expect(health.CheckCertificateIssuer(issuer)).To(MatchError(`issuer state is "" ("Ready" expected)`))
+		Describe("#IsCertificateIssuerProgressing", func() {
+			It("should return true because issuer is rolled out", func() {
+				result, reason := health.IsCertificateIssuerProgressing(issuer)
+				Expect(result).To(BeFalse())
+				Expect(reason).To(Equal(`Issuer is fully rolled out`))
+			})
+
+			It("should return true because observed generation is outdated", func() {
+				issuer.Generation = 10
+				issuer.Status.ObservedGeneration = 1
+
+				result, reason := health.IsCertificateIssuerProgressing(issuer)
+				Expect(result).To(BeTrue())
+				Expect(reason).To(Equal(`observed generation outdated (1/10)`))
+			})
 		})
 	})
 })

--- a/pkg/utils/kubernetes/health/certificate_test.go
+++ b/pkg/utils/kubernetes/health/certificate_test.go
@@ -74,4 +74,22 @@ var _ = Describe("Certificate", func() {
 			Expect(reason).To(Equal(`observed generation outdated (1/10)`))
 		})
 	})
+
+	Describe("#CheckCertificateIssuer", func() {
+		var issuer *certv1alpha1.Issuer
+
+		BeforeEach(func() {
+			issuer = &certv1alpha1.Issuer{}
+		})
+
+		It("should return no error because issuer is ready", func() {
+			issuer.Status.State = "Ready"
+
+			Expect(health.CheckCertificateIssuer(issuer)).ToNot(HaveOccurred())
+		})
+
+		It("should return an error because issuer is not ready", func() {
+			Expect(health.CheckCertificateIssuer(issuer)).To(MatchError(`issuer state is "" ("Ready" expected)`))
+		})
+	})
 })

--- a/pkg/utils/kubernetes/health/certificate_test.go
+++ b/pkg/utils/kubernetes/health/certificate_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health_test
+
+import (
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+var _ = Describe("Certificate", func() {
+	Describe("#CheckCertificate", func() {
+		var certificate *certv1alpha1.Certificate
+
+		BeforeEach(func() {
+			certificate = &certv1alpha1.Certificate{}
+		})
+
+		It("should return no error because certificate is ready", func() {
+			certificate.Status.State = "Ready"
+			certificate.Status.Conditions = []metav1.Condition{
+				{Type: "Ready", Status: "True"},
+			}
+
+			Expect(health.CheckCertificate(certificate)).ToNot(HaveOccurred())
+		})
+
+		It("should return an error because state is not ready", func() {
+			certificate.Status.Conditions = []metav1.Condition{
+				{Type: "Ready", Status: "True", Reason: "SomeReason", Message: "Some message"},
+			}
+
+			Expect(health.CheckCertificate(certificate)).To(MatchError(`certificate state is "" ("Ready" expected)`))
+		})
+
+		It("should return an error because condition is not ready", func() {
+			certificate.Status.Conditions = []metav1.Condition{
+				{Type: "Ready", Status: "False", Reason: "SomeReason", Message: "Some message"},
+			}
+
+			Expect(health.CheckCertificate(certificate)).To(MatchError(`condition "Ready" has invalid status False (expected True) due to SomeReason: Some message`))
+		})
+	})
+})

--- a/pkg/utils/kubernetes/health/certificate_test.go
+++ b/pkg/utils/kubernetes/health/certificate_test.go
@@ -84,7 +84,6 @@ var _ = Describe("Cert Management", func() {
 		})
 
 		Describe("#CheckCertificateIssuer", func() {
-
 			It("should return no error because issuer is ready", func() {
 				issuer.Status.State = "Ready"
 

--- a/test/integration/gardenlet/backupentry/backupentry_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry_test.go
@@ -177,7 +177,6 @@ var _ = Describe("BackupEntry controller tests", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "foo-",
 				Labels:       map[string]string{testID: testRunID},
-				Generation:   1,
 			},
 			Spec: gardencorev1beta1.BackupBucketSpec{
 				Provider: gardencorev1beta1.BackupBucketProvider{

--- a/test/integration/gardenlet/controllerinstallation/care/care_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_test.go
@@ -79,9 +79,8 @@ var _ = Describe("ControllerInstallation Care controller tests", func() {
 			By("Create ManagedResource")
 			managedResource = &resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       controllerInstallation.Name,
-					Namespace:  gardenNamespace.Name,
-					Generation: 1,
+					Name:      controllerInstallation.Name,
+					Namespace: gardenNamespace.Name,
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
 					SecretRefs: []corev1.LocalObjectReference{{

--- a/test/integration/resourcemanager/health/crds/10-crd-cert.gardener.cloud_certificaterevocations.yaml
+++ b/test/integration/resourcemanager/health/crds/10-crd-cert.gardener.cloud_certificaterevocations.yaml
@@ -1,0 +1,285 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: certificaterevocations.cert.gardener.cloud
+spec:
+  group: cert.gardener.cloud
+  names:
+    kind: CertificateRevocation
+    listKind: CertificateRevocationList
+    plural: certificaterevocations
+    shortNames:
+    - certrevoke
+    singular: certificaterevocation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Certificate to be revoked
+      jsonPath: .spec.certificateRef.name
+      name: CERTIFICATE
+      type: string
+    - description: status of revocation
+      jsonPath: .status.state
+      name: STATUS
+      type: string
+    - description: timestamp of complete revocation
+      jsonPath: .status.revocationApplied
+      name: REVOKED_AT
+      priority: 500
+      type: date
+    - description: if true certificate objects should be renewed before revoking old
+        certificates certificate(s)
+      jsonPath: .spec.renew
+      name: RENEW
+      type: boolean
+    - description: qualifying all certificates valid before this timestamp
+      jsonPath: .spec.qualifyingDate
+      name: QUALIFIED_AT
+      type: date
+    - description: object creation timestamp
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CertificateRevocation is the certificate revocation custom resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateRevocationSpec is the spec of the certificate
+              revocation.
+            properties:
+              certificateRef:
+                description: CertificateRef is the references to the certificate to
+                  be revoked
+                properties:
+                  name:
+                    description: Name is the name of the certificate in the same namespace.
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the certificate CR.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              qualifyingDate:
+                description: |-
+                  QualifyingDate specifies that any certificate with the same DNS names like the given 'certificateRef' should be revoked
+                  if it is valid before this date. If not specified, it will be filled with the current time.
+                format: date-time
+                type: string
+              renew:
+                description: Renew specifies if certificate objects should be renewed
+                  before revoking old certificates
+                type: boolean
+            type: object
+          status:
+            description: CertificateRevocationStatus is the status of the certificate
+              request.
+            properties:
+              message:
+                description: Message is the status or error message.
+                type: string
+              objects:
+                description: ObjectStatuses contains the statuses of the involved
+                  certificate objects
+                properties:
+                  failed:
+                    description: Failed is the list of certificate objects whose processing
+                      failed
+                    items:
+                      description: CertificateRef is the reference of the issuer by
+                        name.
+                      properties:
+                        name:
+                          description: Name is the name of the certificate in the
+                            same namespace.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the certificate
+                            CR.
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                  processing:
+                    description: Processing is the list of certificate objects to
+                      be processed
+                    items:
+                      description: CertificateRef is the reference of the issuer by
+                        name.
+                      properties:
+                        name:
+                          description: Name is the name of the certificate in the
+                            same namespace.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the certificate
+                            CR.
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                  renewed:
+                    description: Renewed is the list of certificate objects successfully
+                      renewed
+                    items:
+                      description: CertificateRef is the reference of the issuer by
+                        name.
+                      properties:
+                        name:
+                          description: Name is the name of the certificate in the
+                            same namespace.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the certificate
+                            CR.
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                  revoked:
+                    description: Revoked is the list of certificate objects successfully
+                      revoked (without renewal)
+                    items:
+                      description: CertificateRef is the reference of the issuer by
+                        name.
+                      properties:
+                        name:
+                          description: Name is the name of the certificate in the
+                            same namespace.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the certificate
+                            CR.
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the observed generation of the
+                  spec.
+                format: int64
+                type: integer
+              revocationApplied:
+                description: RevocationApplied is the timestamp when the revocation
+                  was completed
+                format: date-time
+                type: string
+              secrets:
+                description: SecretStatuses contains the statuses of the involved
+                  certificate secrets
+                properties:
+                  failed:
+                    description: Failed is the list of certificate secrets whose revocation
+                      failed
+                    items:
+                      description: CertificateSecretRef is a reference to a secret
+                        together with the serial number
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                        serialNumber:
+                          description: SerialNumber is the serial number of the certificate
+                          type: string
+                      required:
+                      - serialNumber
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  processing:
+                    description: Processing is the list of certificate secrets to
+                      be processed
+                    items:
+                      description: CertificateSecretRef is a reference to a secret
+                        together with the serial number
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                        serialNumber:
+                          description: SerialNumber is the serial number of the certificate
+                          type: string
+                      required:
+                      - serialNumber
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  revoked:
+                    description: Revoked is the list of certificate secrets successfully
+                      revoked
+                    items:
+                      description: CertificateSecretRef is a reference to a secret
+                        together with the serial number
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                        serialNumber:
+                          description: SerialNumber is the serial number of the certificate
+                          type: string
+                      required:
+                      - serialNumber
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+              state:
+                description: State is the certificate state.
+                type: string
+            required:
+            - state
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/integration/resourcemanager/health/crds/10-crd-cert.gardener.cloud_certificates.yaml
+++ b/test/integration/resourcemanager/health/crds/10-crd-cert.gardener.cloud_certificates.yaml
@@ -1,0 +1,362 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: certificates.cert.gardener.cloud
+spec:
+  group: cert.gardener.cloud
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+    - cert
+    singular: certificate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Subject domain name of certificate
+      jsonPath: .status.commonName
+      name: COMMON NAME
+      type: string
+    - description: Issuer name
+      jsonPath: .status.issuerRef.name
+      name: ISSUER
+      type: string
+    - description: Status of registration
+      jsonPath: .status.state
+      name: STATUS
+      type: string
+    - description: Expiration date (not valid anymore after this date)
+      jsonPath: .status.expirationDate
+      name: EXPIRATION_DATE
+      priority: 500
+      type: string
+    - description: Domains names in subject alternative names
+      jsonPath: .status.dnsNames
+      name: DNS_NAMES
+      priority: 2000
+      type: string
+    - description: object creation timestamp
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Certificate is the certificate CR.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec is the spec of the certificate to request.
+            properties:
+              commonName:
+                description: CommonName is the CN for the certificate (max. 64 chars).
+                maxLength: 64
+                type: string
+              csr:
+                description: CSR is the alternative way to provide CN,DNSNames and
+                  other information.
+                format: byte
+                type: string
+              dnsNames:
+                description: DNSNames are the optional additional domain names of
+                  the certificate.
+                items:
+                  type: string
+                type: array
+              ensureRenewedAfter:
+                description: EnsureRenewedAfter specifies a time stamp in the past.
+                  Renewing is only triggered if certificate notBefore date is before
+                  this date.
+                format: date-time
+                type: string
+              followCNAME:
+                description: FollowCNAME if true delegated domain for DNS01 challenge
+                  is used if CNAME record for DNS01 challange domain `_acme-challenge.<domain>`
+                  is set.
+                type: boolean
+              issuerRef:
+                description: IssuerRef is the reference of the issuer to use.
+                properties:
+                  name:
+                    description: Name is the name of the issuer (in the configured
+                      issuer namespace on default cluster or namespace on target cluster
+                      as given).
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the issuer, only needed
+                      if issuer is defined on target cluster
+                    type: string
+                required:
+                - name
+                type: object
+              keystores:
+                description: Keystores configures additional keystore output formats
+                  stored in the `secretName`/`secretRef` Secret resource.
+                properties:
+                  jks:
+                    description: JKS configures options for storing a JKS keystore
+                      in the `spec.secretName`/`spec.secretRef` Secret resource.
+                    properties:
+                      create:
+                        description: |-
+                          Create enables JKS keystore creation for the Certificate.
+                          If true, a file named `keystore.jks` will be created in the target
+                          Secret resource, encrypted using the password stored in `passwordSecretRef`.
+                          The keystore file will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: |-
+                          PasswordSecretRef is a reference to a key in a Secret resource
+                          containing the password used to encrypt the JKS keystore.
+                        properties:
+                          key:
+                            description: Key of the entry in the Secret resource's
+                              `data` field to be used.
+                            type: string
+                          secretName:
+                            description: SecretName of the secret resource being referred
+                              to in the same namespace.
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    type: object
+                  pkcs12:
+                    description: PKCS12 configures options for storing a PKCS12 keystore
+                      in the `spec.secretName`/`spec.secretRef` Secret resource.
+                    properties:
+                      create:
+                        description: |-
+                          Create enables PKCS12 keystore creation for the Certificate.
+                          If true, a file named `keystore.p12` will be created in the target
+                          Secret resource, encrypted using the password stored in `passwordSecretRef`.
+                          The keystore file will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: |-
+                          PasswordSecretRef is a reference to a key in a Secret resource
+                          containing the password used to encrypt the PKCS12 keystore.
+                        properties:
+                          key:
+                            description: Key of the entry in the Secret resource's
+                              `data` field to be used.
+                            type: string
+                          secretName:
+                            description: SecretName of the secret resource being referred
+                              to in the same namespace.
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    type: object
+                type: object
+              preferredChain:
+                description: 'PreferredChain allows to specify the preferred certificate
+                  chain: if the CA offers multiple certificate chains, prefer the
+                  chain with an issuer matching this Subject Common Name. If no match,
+                  the default offered chain will be used.'
+                type: string
+              renew:
+                description: Renew triggers a renewal if set to true
+                type: boolean
+              secretLabels:
+                additionalProperties:
+                  type: string
+                description: SecretLabels are labels to add to the certificate secret.
+                type: object
+              secretName:
+                description: SecretName is the name of the secret object to use for
+                  storing the certificate.
+                type: string
+              secretRef:
+                description: SecretRef is the reference of the secret object to use
+                  for storing the certificate.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+          status:
+            description: CertificateStatus is the status of the certificate request.
+            properties:
+              backoff:
+                description: BackOff contains the state to back off failed certificate
+                  requests
+                properties:
+                  observedGeneration:
+                    description: ObservedGeneration is the observed generation the
+                      BackOffState is assigned to
+                    format: int64
+                    type: integer
+                  recheckAfter:
+                    description: RetryAfter is the timestamp this cert request is
+                      not retried before.
+                    format: date-time
+                    type: string
+                  recheckInterval:
+                    description: RetryInterval is interval to wait for retrying.
+                    type: string
+                required:
+                - recheckAfter
+                - recheckInterval
+                type: object
+              commonName:
+                description: CommonName is the current CN.
+                type: string
+              conditions:
+                description: |-
+                  List of status conditions to indicate the status of certificates.
+                  Known condition types are `Ready`.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              dnsNames:
+                description: DNSNames are the current domain names.
+                items:
+                  type: string
+                type: array
+              expirationDate:
+                description: ExpirationDate shows the notAfter validity date.
+                type: string
+              issuerRef:
+                description: IssuerRef is the used issuer.
+                properties:
+                  cluster:
+                    description: |-
+                      Cluster is the cluster name of the issuer ('default' or 'target').
+                      optional because of backwards compatibility
+                    type: string
+                  name:
+                    description: Name is the name of the issuer.
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the issuer.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              lastPendingTimestamp:
+                description: LastPendingTimestamp contains the start timestamp of
+                  the last pending status.
+                format: date-time
+                type: string
+              message:
+                description: Message is the status or error message.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the observed generation of the
+                  spec.
+                format: int64
+                type: integer
+              state:
+                description: State is the certificate state.
+                type: string
+            required:
+            - state
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/integration/resourcemanager/health/crds/10-crd-cert.gardener.cloud_issuers.yaml
+++ b/test/integration/resourcemanager/health/crds/10-crd-cert.gardener.cloud_issuers.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: issuers.cert.gardener.cloud
+spec:
+  group: cert.gardener.cloud
+  names:
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    singular: issuer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: ACME Server
+      jsonPath: .spec.acme.server
+      name: SERVER
+      type: string
+    - description: ACME Registration email
+      jsonPath: .spec.acme.email
+      name: EMAIL
+      type: string
+    - description: Status of registration
+      jsonPath: .status.state
+      name: STATUS
+      type: string
+    - description: Issuer type
+      jsonPath: .status.type
+      name: TYPE
+      type: string
+    - description: object creation timestamp
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - description: included domains
+      jsonPath: .spec.acme.domains.include
+      name: INCLUDED_DOMAINS
+      priority: 2000
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Issuer is the issuer CR.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IssuerSpec is the spec of the issuer.
+            properties:
+              acme:
+                description: ACME is the ACME protocol specific spec.
+                properties:
+                  autoRegistration:
+                    description: AutoRegistration is the flag if automatic registration
+                      should be applied if needed.
+                    type: boolean
+                  domains:
+                    description: Domains optionally specifies domains allowed or forbidden
+                      for certificate requests
+                    properties:
+                      exclude:
+                        description: Exclude are domain names for which certificate
+                          requests are forbidden (including any subdomains)
+                        items:
+                          type: string
+                        type: array
+                      include:
+                        description: Include are domain names for which certificate
+                          requests are allowed (including any subdomains)
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  email:
+                    description: Email is the email address to use for user registration.
+                    type: string
+                  externalAccountBinding:
+                    description: ACMEExternalAccountBinding is a reference to a CA
+                      external account of the ACME server.
+                    properties:
+                      keyID:
+                        description: keyID is the ID of the CA key that the External
+                          Account is bound to.
+                        type: string
+                      keySecretRef:
+                        description: |-
+                          keySecretRef is the secret ref to the
+                          Secret which holds the symmetric MAC key of the External Account Binding with data key 'hmacKey'.
+                          The secret key stored in the Secret **must** be un-padded, base64 URL
+                          encoded data.
+                        properties:
+                          name:
+                            description: name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - keyID
+                    - keySecretRef
+                    type: object
+                  precheckNameservers:
+                    description: |-
+                      PrecheckNameservers overwrites the default precheck nameservers used for checking DNS propagation.
+                      Format `host` or `host:port`, e.g. "8.8.8.8" same as "8.8.8.8:53" or "google-public-dns-a.google.com:53".
+                    items:
+                      type: string
+                    type: array
+                  privateKeySecretRef:
+                    description: PrivateKeySecretRef is the secret ref to the ACME
+                      private key.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  server:
+                    description: Server is the URL of the ACME server.
+                    type: string
+                  skipDNSChallengeValidation:
+                    description: |-
+                      SkipDNSChallengeValidation marks that this issuer does not validate DNS challenges.
+                      In this case no DNS entries/records are created for a DNS Challenge and DNS propagation
+                      is not checked.
+                    type: boolean
+                required:
+                - email
+                - server
+                type: object
+              ca:
+                description: CA is the CA specific spec.
+                properties:
+                  privateKeySecretRef:
+                    description: PrivateKeySecretRef is the secret ref to the CA secret.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              requestsPerDayQuota:
+                description: RequestsPerDayQuota is the maximum number of certificate
+                  requests per days allowed for this issuer
+                type: integer
+            type: object
+          status:
+            description: IssuerStatus is the status of the issuer.
+            properties:
+              acme:
+                description: ACME is the ACME specific status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ca:
+                description: CA is the CA specific status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              message:
+                description: Message is the status or error message.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the observed generation of the
+                  spec.
+                format: int64
+                type: integer
+              requestsPerDayQuota:
+                description: RequestsPerDayQuota is the actual maximum number of certificate
+                  requests per days allowed for this issuer
+                type: integer
+              state:
+                description: State is either empty, 'Pending', 'Error', or 'Ready'.
+                type: string
+              type:
+                description: Type is the issuer type. Currently only 'acme' and 'ca'
+                  are supported.
+                type: string
+            required:
+            - state
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/integration/resourcemanager/health/crds/doc.go
+++ b/test/integration/resourcemanager/health/crds/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:generate ../../../../../hack/generate-crds.sh -p 10-crd- cert.gardener.cloud
+package crds
+
+import (
+	_ "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+)

--- a/test/integration/resourcemanager/health/health_suite_test.go
+++ b/test/integration/resourcemanager/health/health_suite_test.go
@@ -16,10 +16,12 @@ package health_test
 
 import (
 	"context"
+	"go/build"
 	"path/filepath"
 	"testing"
 	"time"
 
+	_ "github.com/gardener/cert-management/pkg/apis/cert/crds"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -67,6 +69,9 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName(testID)
 
+	certPkg, err := build.Import("github.com/gardener/cert-management/pkg/apis/cert/crds", "", build.FindOnly)
+	Expect(err).ToNot(HaveOccurred())
+
 	By("Start test environment")
 	testEnv = &envtest.Environment{
 		CRDInstallOptions: envtest.CRDInstallOptions{
@@ -74,12 +79,12 @@ var _ = BeforeSuite(func() {
 				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-resources.gardener.cloud_managedresources.yaml"),
 				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-monitoring.coreos.com_alertmanagers.yaml"),
 				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-monitoring.coreos.com_prometheuses.yaml"),
+				filepath.Join(certPkg.Dir, "cert.gardener.cloud_certificates.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,
 	}
 
-	var err error
 	restConfig, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(restConfig).NotTo(BeNil())

--- a/test/integration/resourcemanager/health/health_suite_test.go
+++ b/test/integration/resourcemanager/health/health_suite_test.go
@@ -16,12 +16,10 @@ package health_test
 
 import (
 	"context"
-	"go/build"
 	"path/filepath"
 	"testing"
 	"time"
 
-	_ "github.com/gardener/cert-management/pkg/apis/cert/crds"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,9 +67,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName(testID)
 
-	certPkg, err := build.Import("github.com/gardener/cert-management/pkg/apis/cert/crds", "", build.FindOnly)
-	Expect(err).ToNot(HaveOccurred())
-
 	By("Start test environment")
 	testEnv = &envtest.Environment{
 		CRDInstallOptions: envtest.CRDInstallOptions{
@@ -79,12 +74,13 @@ var _ = BeforeSuite(func() {
 				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-resources.gardener.cloud_managedresources.yaml"),
 				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-monitoring.coreos.com_alertmanagers.yaml"),
 				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-monitoring.coreos.com_prometheuses.yaml"),
-				filepath.Join(certPkg.Dir, "cert.gardener.cloud_certificates.yaml"),
+				filepath.Join("crds", "10-crd-cert.gardener.cloud_certificates.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,
 	}
 
+	var err error
 	restConfig, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(restConfig).NotTo(BeNil())

--- a/test/integration/resourcemanager/health/health_suite_test.go
+++ b/test/integration/resourcemanager/health/health_suite_test.go
@@ -75,6 +75,7 @@ var _ = BeforeSuite(func() {
 				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-monitoring.coreos.com_alertmanagers.yaml"),
 				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-monitoring.coreos.com_prometheuses.yaml"),
 				filepath.Join("crds", "10-crd-cert.gardener.cloud_certificates.yaml"),
+				filepath.Join("crds", "10-crd-cert.gardener.cloud_issuers.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,

--- a/test/integration/resourcemanager/health/health_test.go
+++ b/test/integration/resourcemanager/health/health_test.go
@@ -767,9 +767,8 @@ func generatePodTestResource(name string) *corev1.Pod {
 func generateDeploymentTestResource(name string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  testNamespace.Name,
-			Generation: 42,
+			Name:      name,
+			Namespace: testNamespace.Name,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr.To(int32(1)),
@@ -811,9 +810,8 @@ func generatePodForDeployment(deployment *appsv1.Deployment) *corev1.Pod {
 func generateStatefulSetTestResource(name string) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  testNamespace.Name,
-			Generation: 42,
+			Name:      name,
+			Namespace: testNamespace.Name,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: ptr.To(int32(1)),
@@ -836,9 +834,8 @@ func generateStatefulSetTestResource(name string) *appsv1.StatefulSet {
 func generateDaemonSetTestResource(name string) *appsv1.DaemonSet {
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  testNamespace.Name,
-			Generation: 42,
+			Name:      name,
+			Namespace: testNamespace.Name,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -860,9 +857,8 @@ func generateDaemonSetTestResource(name string) *appsv1.DaemonSet {
 func generatePrometheusTestResource(name string) *monitoringv1.Prometheus {
 	return &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  testNamespace.Name,
-			Generation: 42,
+			Name:      name,
+			Namespace: testNamespace.Name,
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
@@ -894,9 +890,8 @@ func generatePrometheusTestResource(name string) *monitoringv1.Prometheus {
 func generateAlertmanagerTestResource(name string) *monitoringv1.Alertmanager {
 	return &monitoringv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  testNamespace.Name,
-			Generation: 42,
+			Name:      name,
+			Namespace: testNamespace.Name,
 		},
 		Spec: monitoringv1.AlertmanagerSpec{
 			Replicas: ptr.To(int32(1)),

--- a/test/integration/resourcemanager/health/health_test.go
+++ b/test/integration/resourcemanager/health/health_test.go
@@ -15,6 +15,7 @@
 package health_test
 
 import (
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -375,6 +376,7 @@ var _ = Describe("Health controller tests", func() {
 				daemonSet    *appsv1.DaemonSet
 				prometheus   *monitoringv1.Prometheus
 				alertManager *monitoringv1.Alertmanager
+				cert         *certv1alpha1.Certificate
 			)
 
 			JustBeforeEach(func() {
@@ -412,6 +414,12 @@ var _ = Describe("Health controller tests", func() {
 				alertManager.Status = *alertManagerStatus
 				Expect(testClient.Status().Update(ctx, alertManager)).To(Succeed())
 
+				cert = generateCertificateTestResource(managedResource.Name)
+				certStatus := cert.Status.DeepCopy()
+				Expect(testClient.Create(ctx, cert)).To(Succeed())
+				cert.Status = *certStatus
+				Expect(testClient.Status().Update(ctx, cert)).To(Succeed())
+
 				DeferCleanup(func() {
 					By("Delete test resources")
 					Expect(testClient.Delete(ctx, pod)).To(Or(Succeed(), BeNotFoundError()))
@@ -420,6 +428,7 @@ var _ = Describe("Health controller tests", func() {
 					Expect(testClient.Delete(ctx, daemonSet)).To(Or(Succeed(), BeNotFoundError()))
 					Expect(testClient.Delete(ctx, prometheus)).To(Or(Succeed(), BeNotFoundError()))
 					Expect(testClient.Delete(ctx, alertManager)).To(Or(Succeed(), BeNotFoundError()))
+					Expect(testClient.Delete(ctx, cert)).To(Or(Succeed(), BeNotFoundError()))
 				})
 
 				By("Add resources to ManagedResource status")
@@ -463,6 +472,14 @@ var _ = Describe("Health controller tests", func() {
 							Kind:       "Alertmanager",
 							Namespace:  alertManager.Namespace,
 							Name:       alertManager.Name,
+						},
+					},
+					{
+						ObjectReference: corev1.ObjectReference{
+							APIVersion: "cert.gardener.cloud/v1alpha1",
+							Kind:       "Certificate",
+							Namespace:  cert.Namespace,
+							Name:       cert.Name,
 						},
 					},
 				}
@@ -634,6 +651,34 @@ var _ = Describe("Health controller tests", func() {
 				alertManager.Status.UpdatedReplicas--
 				Expect(testClient.Patch(ctx, alertManager, patch)).To(Succeed())
 				Expect(testClient.Status().Patch(ctx, alertManager, patch)).To(Succeed())
+
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					return managedResource.Status.Conditions
+				}).Should(
+					ContainCondition(OfType(resourcesv1alpha1.ResourcesProgressing), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("ResourcesRolledOut")),
+				)
+			})
+
+			It("sets Progressing to true as Certificate is not fully rolled out", func() {
+				patch := client.MergeFrom(cert.DeepCopy())
+				cert.Status.ObservedGeneration = cert.Generation - 1
+				Expect(testClient.Status().Patch(ctx, cert, patch)).To(Succeed())
+
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					return managedResource.Status.Conditions
+				}).Should(
+					ContainCondition(OfType(resourcesv1alpha1.ResourcesProgressing), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("CertificateProgressing")),
+				)
+			})
+
+			It("sets Progressing to false even if Certificate is not fully rolled out but skip-health-check annotation is present", func() {
+				patch := client.MergeFrom(cert.DeepCopy())
+				metav1.SetMetaDataAnnotation(&cert.ObjectMeta, resourcesv1alpha1.SkipHealthCheck, "true")
+				cert.Status.ObservedGeneration = cert.Generation - 1
+				Expect(testClient.Patch(ctx, cert, patch)).To(Succeed())
+				Expect(testClient.Status().Patch(ctx, cert, patch)).To(Succeed())
 
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
@@ -830,6 +875,30 @@ func generateAlertmanagerTestResource(name string) *monitoringv1.Alertmanager {
 					ObservedGeneration: 42,
 				},
 			},
+		},
+	}
+}
+
+func generateCertificateTestResource(name string) *certv1alpha1.Certificate {
+	return &certv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace.Name,
+		},
+		Spec: certv1alpha1.CertificateSpec{
+			DNSNames: []string{"foo.bar"},
+		},
+		Status: certv1alpha1.CertificateStatus{
+			State: "Ready",
+			Conditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             "True",
+					Reason:             "CertificateIssued",
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			ObservedGeneration: 42,
 		},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR extends health and progressing checks of GRM for `Certificate` and `Issuer` objects, originated from the [cert-management](https://github.com/gardener/cert-management/) component.

**Special notes for your reviewer**:
/cc @rfranzke @adenitiu @MartinWeindel

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-resource-manager` now considers the health and the progressing status for `Certificate` and `Issuer` resources (see [cert-management](https://github.com/gardener/cert-management/)) managed via `ManagedResource`s.
```
