### PR TITLE
Downgrade skaffold to v2.9.0

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -76,7 +76,7 @@ PROMTOOL_VERSION ?= 2.50.1
 # renovate: datasource=github-releases depName=protocolbuffers/protobuf
 PROTOC_VERSION ?= 25.3
 # renovate: datasource=github-releases depName=GoogleContainerTools/skaffold
-SKAFFOLD_VERSION ?= v2.10.1
+SKAFFOLD_VERSION ?= v2.9.0
 # renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VERSION ?= v4.41.1
 # renovate: datasource=github-releases depName=ironcore-dev/vgopath


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/9237 and the upgrade of `skaffold` to `v2.10.1` the local kind setup is not working as expected when changes are made to the codebase. This PR reverts the `skaffold` version.

To reproduce:
```bash
make kind-up
make gardener-up
```

Do a change to some code used in `gardenlet` (for example). Run `make gardener-up` again. I expect that the `gardenlet` image is rebuilt and deployed, but the output says

```logs
europe-docker.pkg.dev/gardener-project/releases/gardener/gardenlet: Found. Tagging
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @ialidzhikov 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The skaffold version is downgraded from v2.10.1 to v2.9.0 to fix an issue with skaffold not detecting code changes on `make gardener-up`.
```
