### PR TITLE
[GEP-19] [shoot-care] Check for `alertmanager-shoot` when Gardener `>= 1.90`

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -165,11 +165,15 @@ var _ = Describe("health check", func() {
 		})
 
 		It("should return expected statefulsets when alert manager is not wanted", func() {
-			Expect(ComputeRequiredMonitoringStatefulSets(false).UnsortedList()).To(ConsistOf(commonNames...))
+			Expect(ComputeRequiredMonitoringStatefulSets(false, semver.MustParse("1.90")).UnsortedList()).To(ConsistOf(commonNames...))
 		})
 
 		It("should return expected statefulsets when alert manager is wanted", func() {
-			Expect(ComputeRequiredMonitoringStatefulSets(true).UnsortedList()).To(ConsistOf(append(commonNames, "alertmanager")...))
+			Expect(ComputeRequiredMonitoringStatefulSets(true, semver.MustParse("1.89")).UnsortedList()).To(ConsistOf(append(commonNames, "alertmanager")...))
+		})
+
+		It("should return expected statefulsets when alert manager is wanted when reconciled by Gardener >= v1.90", func() {
+			Expect(ComputeRequiredMonitoringStatefulSets(true, semver.MustParse("1.90")).UnsortedList()).To(ConsistOf(append(commonNames, "alertmanager-shoot")...))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/9257 migrated the shoot Alertmanager to management of `prometheus-operator`. This changes the `StatefulSet` name from `alertmanager` to `alertmanager-shoot` which breaks the health check in shoot care controller.

Note that as part of https://github.com/gardener/gardener/pull/9313, the health checks will be improved to prevent such issues in the future.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9065
Follow-up of https://github.com/gardener/gardener/pull/9257

**Special notes for your reviewer**:
/cc @ary1992 @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which reported false negative health checks for the `ObservabilityComponentsHealthy` condition on `Shoot`s using Alertmanager if they have been reconciled with Gardener `>= 1.90`.
```
