### PR TITLE
Refine NodeNotHealthy prometheus alert

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -65,7 +65,7 @@ func CentralPrometheusRules() []*monitoringv1.PrometheusRule {
 						},
 						{
 							Alert: "NodeNotHealthy",
-							Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="ToBeDeletedByClusterAutoscaler", key!="` + v1beta1constants.LabelNodeCriticalComponent + `"}))[30m:]) > 5`),
+							Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="deployment.machine.sapcloud.io/prefer-no-schedule", key!="ToBeDeletedByClusterAutoscaler", key!="` + v1beta1constants.LabelNodeCriticalComponent + `"}))[30m:]) > 9`),
 							For:   ptr.To(monitoringv1.Duration("0m")),
 							Labels: map[string]string{
 								"severity":   "warning",
@@ -73,7 +73,7 @@ func CentralPrometheusRules() []*monitoringv1.PrometheusRule {
 								"visibility": "operator",
 							},
 							Annotations: map[string]string{
-								"description": "Node {{$labels.node}} in landscape {{$externalLabels.landscape}} was not healthy for five scrapes in the past 30 mins.",
+								"description": "Node {{$labels.node}} in landscape {{$externalLabels.landscape}} was not healthy for ten scrapes in the past 30 mins.",
 								"summary":     "A node is not healthy.",
 							},
 						},

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -57,7 +57,7 @@ var _ = Describe("PrometheusRules", func() {
 								},
 								{
 									Alert: "NodeNotHealthy",
-									Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="ToBeDeletedByClusterAutoscaler", key!="` + v1beta1constants.LabelNodeCriticalComponent + `"}))[30m:]) > 5`),
+									Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="deployment.machine.sapcloud.io/prefer-no-schedule", key!="ToBeDeletedByClusterAutoscaler", key!="` + v1beta1constants.LabelNodeCriticalComponent + `"}))[30m:]) > 9`),
 									For:   ptr.To(monitoringv1.Duration("0m")),
 									Labels: map[string]string{
 										"severity":   "warning",
@@ -65,7 +65,7 @@ var _ = Describe("PrometheusRules", func() {
 										"visibility": "operator",
 									},
 									Annotations: map[string]string{
-										"description": "Node {{$labels.node}} in landscape {{$externalLabels.landscape}} was not healthy for five scrapes in the past 30 mins.",
+										"description": "Node {{$labels.node}} in landscape {{$externalLabels.landscape}} was not healthy for ten scrapes in the past 30 mins.",
 										"summary":     "A node is not healthy.",
 									},
 								},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
During a rolling update, botanist maintains a [special taint ](https://github.com/gardener/gardener/blob/master/pkg/gardenlet/operation/botanist/worker.go#L180) on the nodes during rolling update `deployment.machine.sapcloud.io/prefer-no-schedule`. 
This PR enhances the current alert to disregard nodes with this taint, as this is not a valid usecase of nodes not being healthy.
Additionally, we increase the timespan to which we consider a node not being healthy, to 10 scrapes over a period of 30mins.

**Which issue(s) this PR fixes**:
Node not healthy false-positives.

**Special notes for your reviewer**:
/cc @rickardsjp 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NodeNotHealthy prometheus alert disregards nodes with `deployment.machine.sapcloud.io/prefer-no-schedule` taint
```
