### PR TITLE
[release-v1.90] [GEP-19] Add dedicated namespace label for PVCs in migration

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -395,6 +395,11 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
+	log.Info("Reconciling labels for PVC migrations")
+	if err := reconcileLabelsForPVCMigrations(ctx, log, g.mgr.GetClient()); err != nil {
+		return err
+	}
+
 	log.Info("Setting up shoot client map")
 	shootClientMap, err := clientmapbuilder.
 		NewShootClientMapBuilder().
@@ -687,6 +692,68 @@ func cleanupShootCoreManagedResource(ctx context.Context, seedClient client.Clie
 	}
 
 	return flow.Parallel(taskFns...)(ctx)
+}
+
+// TODO(rfranzke): Remove this code after gardener v1.92 has been released.
+func reconcileLabelsForPVCMigrations(ctx context.Context, log logr.Logger, seedClient client.Client) error {
+	labelMigrationPVCName := "disk-migration.monitoring.gardener.cloud/pvc-name"
+
+	persistentVolumeList := &corev1.PersistentVolumeList{}
+	if err := seedClient.List(ctx, persistentVolumeList, client.HasLabels{labelMigrationPVCName}); err != nil {
+		return fmt.Errorf("failed listing persistent volumes with label %s: %w", labelMigrationPVCName, err)
+	}
+
+	var (
+		persistentVolumeNamesWithoutClaimRef []string
+		taskFns                              []flow.TaskFn
+	)
+
+	for _, pv := range persistentVolumeList.Items {
+		persistentVolume := pv
+
+		labelValue := persistentVolume.Labels[labelMigrationPVCName]
+		if len(strings.Split(labelValue, "/")) == 2 {
+			continue
+		}
+
+		if persistentVolume.Status.Phase == corev1.VolumeReleased && persistentVolume.Spec.ClaimRef != nil {
+			// check if namespace is already gone - if yes, just clean them up
+			if err := seedClient.Get(ctx, client.ObjectKey{Name: persistentVolume.Spec.ClaimRef.Namespace}, &corev1.Namespace{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed checking if namespace %s still exists (due to PV %s): %w", persistentVolume.Spec.ClaimRef.Namespace, client.ObjectKeyFromObject(&persistentVolume), err)
+				}
+
+				taskFns = append(taskFns, func(ctx context.Context) error {
+					log.Info("Deleting orphaned persistent volume in migration", "persistentVolume", client.ObjectKeyFromObject(&persistentVolume))
+					return client.IgnoreNotFound(seedClient.Delete(ctx, &persistentVolume))
+				})
+				continue
+			}
+		} else if persistentVolume.Spec.ClaimRef == nil {
+			persistentVolumeNamesWithoutClaimRef = append(persistentVolumeNamesWithoutClaimRef, persistentVolume.Name)
+			continue
+		}
+
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			log.Info("Adding missing namespace to persistent volume in migration", "persistentVolume", client.ObjectKeyFromObject(&persistentVolume), "namespace", persistentVolume.Spec.ClaimRef.Namespace)
+			patch := client.MergeFrom(persistentVolume.DeepCopy())
+			metav1.SetMetaDataLabel(&persistentVolume.ObjectMeta, labelMigrationPVCName, persistentVolume.Spec.ClaimRef.Namespace+"/"+labelValue)
+			return seedClient.Patch(ctx, &persistentVolume, patch)
+		})
+	}
+
+	if err := flow.Parallel(taskFns...)(ctx); err != nil {
+		return err
+	}
+
+	if len(persistentVolumeNamesWithoutClaimRef) > 0 {
+		return fmt.Errorf("found persistent volumes with missing namespace in migration label and `.spec.claimRef=nil` - "+
+			"cannot automatically determine the namespace this PV originated from. "+
+			"A human operator needs to manually add the namespace and update the label to %s=<namespace>-<current-label-value>. "+
+			"The names of such PVs are: %+v", labelMigrationPVCName, persistentVolumeNamesWithoutClaimRef)
+	}
+
+	return nil
 }
 
 func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) error {

--- a/pkg/component/observability/monitoring/migration.go
+++ b/pkg/component/observability/monitoring/migration.go
@@ -36,7 +36,10 @@ import (
 
 // TODO(rfranzke): Remove this file after all Prometheis and AlertManagers have been migrated.
 
-const labelMigrationPVCName = "disk-migration.monitoring.gardener.cloud/pvc-name"
+const (
+	labelMigrationNamespace = "disk-migration.monitoring.gardener.cloud/namespace"
+	labelMigrationPVCName   = "disk-migration.monitoring.gardener.cloud/pvc-name"
+)
 
 // DataMigration is a struct for migrating data from existing disks.
 type DataMigration struct {
@@ -103,10 +106,10 @@ func (d *DataMigration) ExistingPVTakeOverPrerequisites(ctx context.Context, log
 
 	// PV was found, so let's label it so that we can find it in future invocations of this function (even after the old
 	// PVC has already been deleted).
-	labelId := pvcNameId(oldPVC.Namespace, oldPVC.Name)
-	log.Info("Adding PVC namespace and name to PV labels", "persistentVolume", client.ObjectKeyFromObject(pv), "label", labelMigrationPVCName, "value", labelId, "persistentVolumeClaim", client.ObjectKeyFromObject(oldPVC))
+	log.Info("Adding PVC namespace and name to PV labels", "persistentVolume", client.ObjectKeyFromObject(pv), "persistentVolumeClaim", client.ObjectKeyFromObject(oldPVC))
 	if err := d.patchPV(ctx, pv, func(_ *corev1.PersistentVolume) {
-		metav1.SetMetaDataLabel(&pv.ObjectMeta, labelMigrationPVCName, labelId)
+		metav1.SetMetaDataLabel(&pv.ObjectMeta, labelMigrationNamespace, d.Namespace)
+		metav1.SetMetaDataLabel(&pv.ObjectMeta, labelMigrationPVCName, d.PVCName)
 	}); err != nil {
 		return false, nil, nil, err
 	}
@@ -115,22 +118,20 @@ func (d *DataMigration) ExistingPVTakeOverPrerequisites(ctx context.Context, log
 }
 
 func (d *DataMigration) findPersistentVolumeByLabel(ctx context.Context, log logr.Logger) (*corev1.PersistentVolume, error) {
-	labelId := pvcNameId(d.Namespace, d.PVCName)
-
 	pvList := &corev1.PersistentVolumeList{}
-	if err := d.Client.List(ctx, pvList, client.MatchingLabels{labelMigrationPVCName: labelId}); err != nil {
+	if err := d.Client.List(ctx, pvList, client.MatchingLabels{labelMigrationNamespace: d.Namespace, labelMigrationPVCName: d.PVCName}); err != nil {
 		return nil, err
 	}
 
 	switch len(pvList.Items) {
 	case 0:
-		log.Info("Old PV not found via label, nothing to migrate", "label", labelMigrationPVCName, "value", labelId)
+		log.Info("Old PV not found via label, nothing to migrate", "namespaceName", d.Namespace, "pvcName", d.PVCName)
 		return nil, nil
 	case 1:
-		log.Info("Existing PV found via label", "persistentVolume", client.ObjectKeyFromObject(&pvList.Items[0]), "label", labelMigrationPVCName, "value", labelId)
+		log.Info("Existing PV found via label", "persistentVolume", client.ObjectKeyFromObject(&pvList.Items[0]), "namespaceName", d.Namespace, "pvcName", d.PVCName)
 		return &pvList.Items[0], nil
 	default:
-		return nil, fmt.Errorf("more than one PV found with label %s=%s", labelMigrationPVCName, labelId)
+		return nil, fmt.Errorf("more than one PV found with labels %s=%s and %s=%s", labelMigrationNamespace, d.Namespace, labelMigrationPVCName, d.PVCName)
 	}
 }
 
@@ -177,6 +178,7 @@ func (d *DataMigration) FinalizeExistingPVTakeOver(ctx context.Context, log logr
 	log.Info("Setting persistentVolumeReclaimPolicy to 'Delete' and removing migration label", "persistentVolume", client.ObjectKeyFromObject(pv))
 	if err := d.patchPV(ctx, pv, func(obj *corev1.PersistentVolume) {
 		obj.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimDelete
+		delete(pv.Labels, labelMigrationNamespace)
 		delete(pv.Labels, labelMigrationPVCName)
 	}); err != nil {
 		return err
@@ -363,8 +365,4 @@ func (d *DataMigration) waitForNewStatefulSetToBeRolledOut(ctx context.Context, 
 
 	log.Info("New StatefulSet is healthy now and no longer progressing", "statefulSet", client.ObjectKeyFromObject(statefulSet))
 	return nil
-}
-
-func pvcNameId(namespace, name string) string {
-	return namespace + "/" + name
 }


### PR DESCRIPTION
This is a manual cherry-pick of #9338 and https://github.com/gardener/gardener/pull/9344

/assign rfranzke

```bugfix user github.com/gardener/gardener #9341 @rfranzke
A bug has been fixed which prevented `Shoot`s using Alertmanager from getting stuck in reconciliation with error `last error: more than one PV found with label disk-migration.monitoring.gardener.cloud/pvc-name=alertmanager-db-alertmanager-0`.
```