### PR TITLE
Parallelize orphaned node `Lease` deletion

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/garbage_collection.go
+++ b/pkg/gardenlet/controller/shoot/care/garbage_collection.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -117,7 +118,7 @@ func (g *GarbageCollection) deleteOrphanedNodeLeases(ctx context.Context, c clie
 		return err
 	}
 
-	var orphanedLeases []client.Object
+	var taskFns []flow.TaskFn
 
 	for _, l := range leaseList.Items {
 		if len(l.OwnerReferences) > 0 {
@@ -125,17 +126,21 @@ func (g *GarbageCollection) deleteOrphanedNodeLeases(ctx context.Context, c clie
 		}
 		lease := l.DeepCopy()
 
-		if err := c.Get(ctx, client.ObjectKey{Name: lease.Name}, &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "Node"}}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed getting node %s when checking for potential orphaned Lease %s: %w", lease.Name, client.ObjectKeyFromObject(lease), err)
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			if err := c.Get(ctx, client.ObjectKey{Name: lease.Name}, &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "Node"}}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed getting node %s when checking for potential orphaned Lease %s: %w", lease.Name, client.ObjectKeyFromObject(lease), err)
+				}
+
+				g.log.Info("Detected orphaned Lease object, cleaning it up", "nodeName", lease.Name, "lease", client.ObjectKeyFromObject(lease))
+				return kubernetesutils.DeleteObject(ctx, c, lease)
 			}
 
-			g.log.Info("Detected orphaned Lease object, cleaning it up", "nodeName", lease.Name, "lease", client.ObjectKeyFromObject(lease))
-			orphanedLeases = append(orphanedLeases, lease)
-		}
+			return nil
+		})
 	}
 
-	return kubernetesutils.DeleteObjects(ctx, c, orphanedLeases...)
+	return flow.ParallelN(100, taskFns...)(ctx)
 }
 
 // GardenerDeletionGracePeriod is the default grace period for Gardener's force deletion methods.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
We have seen clusters with way more than > 1.2k orphaned node `Lease`s due to https://github.com/kubernetes/kubernetes/issues/119660. https://github.com/gardener/gardener/pull/8817 was supposed to fix this. However, for such clusters the care controller can easily run into rate limiting:

```
{"level":"error","ts":"2024-03-09T15:27:14.772Z","msg":"Error during shoot garbage collection","controller":"shoot-care","namespace":"garden-local","name":"local","reconcileID":"26106ca2-31ac-491e-810d-708689eca6f2","error":"failed deleting orphaned node lease objects: failed getting node some-leasejt7z5 when checking for potential orphaned Lease kube-node-lease/some-leasejt7z5: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline","stacktrace":"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care.(*GarbageCollection).Collect.func2\n\tgithub.com/gardener/gardener/pkg/gardenlet/controller/shoot/care/garbage_collection.go:81"}
```

This is because it used to first collect all orphaned `Lease`s and only later started with their deletion. If there are too many such `Lease`s, the time might not be sufficient to get to the deletion step.

With this PR, read+delete is put into a parallizable function. This way, even if the care controller fails to delete all orphaned `Lease`s in one reconciliation, it will succeed to delete some of them, causing gradual decreases and eventual success of cleaning up all of them after a couple of reconciliations.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/8817

**Special notes for your reviewer**:
/cc @adenitiu 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue has been fixed which was causing scale-downs of `kube-controller-manager` and similar controllers due to prevented deletion of orphaned node `Lease`s.
```
