### PR TITLE
[GEP-24] Sync service account public keys to Garden cluster

### DIFF
--- a/example/gardener-local/controlplane/service-account-issuer-secret.yaml
+++ b/example/gardener-local/controlplane/service-account-issuer-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: shoot-service-account-issuer
+  namespace: garden
+  labels:
+    gardener.cloud/role: shoot-service-account-issuer
+type: Opaque
+stringData:
+  hostname: discovery.local.gardener.cloud

--- a/example/provider-local/shoot.yaml
+++ b/example/provider-local/shoot.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds: "0"
     shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
+    authentication.gardener.cloud/issuer: "managed"
 spec:
   cloudProfileName: local
   secretBindingName: local # dummy, doesn't contain any credentials

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
@@ -357,15 +357,15 @@ func (h *Handler) admitSecret(ctx context.Context, seedName string, request admi
 			ok             bool
 		)
 		if shootName, ok = secret.Labels[v1beta1constants.LabelShootName]; !ok {
-			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %s is missing", v1beta1constants.LabelShootName))
+			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q is missing", v1beta1constants.LabelShootName))
 		}
 		if shootNamespace, ok = secret.Labels[v1beta1constants.LabelShootNamespace]; !ok {
-			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %s is missing", v1beta1constants.LabelShootNamespace))
+			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q is missing", v1beta1constants.LabelShootNamespace))
 		}
 		if publicKeyType, ok := secret.Labels[v1beta1constants.LabelPublicKeys]; !ok {
-			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %s is missing", v1beta1constants.LabelPublicKeys))
+			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q is missing", v1beta1constants.LabelPublicKeys))
 		} else if publicKeyType != v1beta1constants.LabelPublicKeysServiceAccount {
-			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %s value must be set to %s", v1beta1constants.LabelPublicKeys, v1beta1constants.LabelPublicKeysServiceAccount))
+			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q value must be set to %q", v1beta1constants.LabelPublicKeys, v1beta1constants.LabelPublicKeysServiceAccount))
 		}
 
 		shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: shootNamespace}}

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -1100,7 +1100,7 @@ var _ = Describe("handler", func() {
 								&corev1.Secret{},
 								&metav1.Status{
 									Code:    int32(http.StatusUnprocessableEntity),
-									Message: "label shoot.gardener.cloud/name is missing",
+									Message: `label "shoot.gardener.cloud/name" is missing`,
 								},
 							),
 							Entry(
@@ -1114,7 +1114,7 @@ var _ = Describe("handler", func() {
 								},
 								&metav1.Status{
 									Code:    int32(http.StatusUnprocessableEntity),
-									Message: "label shoot.gardener.cloud/namespace is missing",
+									Message: `label "shoot.gardener.cloud/namespace" is missing`,
 								},
 							),
 							Entry(
@@ -1129,7 +1129,7 @@ var _ = Describe("handler", func() {
 								},
 								&metav1.Status{
 									Code:    int32(http.StatusUnprocessableEntity),
-									Message: "label authentication.gardener.cloud/public-keys is missing",
+									Message: `label "authentication.gardener.cloud/public-keys" is missing`,
 								},
 							),
 							Entry(
@@ -1145,7 +1145,7 @@ var _ = Describe("handler", func() {
 								},
 								&metav1.Status{
 									Code:    int32(http.StatusUnprocessableEntity),
-									Message: "label authentication.gardener.cloud/public-keys value must be set to serviceaccount",
+									Message: `label "authentication.gardener.cloud/public-keys" value must be set to "serviceaccount"`,
 								},
 							),
 						)

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -1076,6 +1076,152 @@ var _ = Describe("handler", func() {
 						Describe("monitoring suffix", func() { testSuite(".monitoring") })
 					})
 
+					Context("managed shoot service account issuer secrets", func() {
+						BeforeEach(func() {
+							request.Namespace = "gardener-system-shoot-issuer"
+						})
+
+						DescribeTable("secret is missing labels",
+							func(secret *corev1.Secret, expectedResult *metav1.Status) {
+								data, err := runtime.Encode(encoder, secret)
+								Expect(err).NotTo(HaveOccurred())
+								request.Object.Raw = data
+
+								Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+									AdmissionResponse: admissionv1.AdmissionResponse{
+										Allowed: false,
+										Result:  expectedResult,
+									},
+								}))
+							},
+
+							Entry(
+								"missing shoot.gardener.cloud/name label",
+								&corev1.Secret{},
+								&metav1.Status{
+									Code:    int32(http.StatusUnprocessableEntity),
+									Message: "label shoot.gardener.cloud/name is missing",
+								},
+							),
+							Entry(
+								"missing shoot.gardener.cloud/namespace label",
+								&corev1.Secret{
+									ObjectMeta: metav1.ObjectMeta{
+										Labels: map[string]string{
+											"shoot.gardener.cloud/name": "foo",
+										},
+									},
+								},
+								&metav1.Status{
+									Code:    int32(http.StatusUnprocessableEntity),
+									Message: "label shoot.gardener.cloud/namespace is missing",
+								},
+							),
+							Entry(
+								"missing authentication.gardener.cloud/public-keys label",
+								&corev1.Secret{
+									ObjectMeta: metav1.ObjectMeta{
+										Labels: map[string]string{
+											"shoot.gardener.cloud/name":      "foo",
+											"shoot.gardener.cloud/namespace": "foo",
+										},
+									},
+								},
+								&metav1.Status{
+									Code:    int32(http.StatusUnprocessableEntity),
+									Message: "label authentication.gardener.cloud/public-keys is missing",
+								},
+							),
+							Entry(
+								"label authentication.gardener.cloud/public-keys has wrong value",
+								&corev1.Secret{
+									ObjectMeta: metav1.ObjectMeta{
+										Labels: map[string]string{
+											"shoot.gardener.cloud/name":                 "foo",
+											"shoot.gardener.cloud/namespace":            "foo",
+											"authentication.gardener.cloud/public-keys": "foo",
+										},
+									},
+								},
+								&metav1.Status{
+									Code:    int32(http.StatusUnprocessableEntity),
+									Message: "label authentication.gardener.cloud/public-keys value must be set to serviceaccount",
+								},
+							),
+						)
+
+						Context("secret is configured correctly", func() {
+							BeforeEach(func() {
+								secret := &corev1.Secret{
+									ObjectMeta: metav1.ObjectMeta{
+										Labels: map[string]string{
+											"shoot.gardener.cloud/name":                 name,
+											"shoot.gardener.cloud/namespace":            namespace,
+											"authentication.gardener.cloud/public-keys": "serviceaccount",
+										},
+									},
+								}
+								data, err := runtime.Encode(encoder, secret)
+								Expect(err).NotTo(HaveOccurred())
+								request.Object.Raw = data
+							})
+
+							It("should return an error because the related shoot was not found", func() {
+								mockCache.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).Return(apierrors.NewNotFound(schema.GroupResource{}, name))
+
+								Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+									AdmissionResponse: admissionv1.AdmissionResponse{
+										Allowed: false,
+										Result: &metav1.Status{
+											Code:    int32(http.StatusForbidden),
+											Message: fmt.Sprintf(" %q not found", name),
+										},
+									},
+								}))
+							})
+
+							It("should return an error because the related shoot could not be read", func() {
+								mockCache.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).Return(fakeErr)
+
+								Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+									AdmissionResponse: admissionv1.AdmissionResponse{
+										Allowed: false,
+										Result: &metav1.Status{
+											Code:    int32(http.StatusInternalServerError),
+											Message: fakeErr.Error(),
+										},
+									},
+								}))
+							})
+
+							It("should forbid because the related shoot does not belong to gardenlet's seed", func() {
+								mockCache.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+									(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SeedName: ptr.To("some-different-seed")}}).DeepCopyInto(obj)
+									return nil
+								})
+
+								Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+									AdmissionResponse: admissionv1.AdmissionResponse{
+										Allowed: false,
+										Result: &metav1.Status{
+											Code:    int32(http.StatusForbidden),
+											Message: fmt.Sprintf("object does not belong to seed %q", seedName),
+										},
+									},
+								}))
+							})
+
+							It("should allow because the related shoot does belong to gardenlet's seed", func() {
+								mockCache.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+									(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SeedName: &seedName}}).DeepCopyInto(obj)
+									return nil
+								})
+
+								Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+							})
+						})
+					})
+
 					Context("bootstrap token secret for managed seed", func() {
 						var (
 							secret      *corev1.Secret

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_shoot.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_shoot.go
@@ -18,23 +18,27 @@ import (
 	"context"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
-func (g *graph) setupShootWatch(_ context.Context, informer cache.Informer) error {
+func (g *graph) setupShootWatch(ctx context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			shoot, ok := obj.(*gardencorev1beta1.Shoot)
 			if !ok {
 				return
 			}
-			g.handleShootCreateOrUpdate(shoot)
+			g.handleShootCreateOrUpdate(ctx, shoot)
 		},
 
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -54,8 +58,9 @@ func (g *graph) setupShootWatch(_ context.Context, informer cache.Informer) erro
 				!apiequality.Semantic.DeepEqual(oldShoot.Spec.CloudProfileName, newShoot.Spec.CloudProfileName) ||
 				v1beta1helper.GetShootAuditPolicyConfigMapName(oldShoot.Spec.Kubernetes.KubeAPIServer) != v1beta1helper.GetShootAuditPolicyConfigMapName(newShoot.Spec.Kubernetes.KubeAPIServer) ||
 				!v1beta1helper.ShootDNSProviderSecretNamesEqual(oldShoot.Spec.DNS, newShoot.Spec.DNS) ||
-				!v1beta1helper.ShootResourceReferencesEqual(oldShoot.Spec.Resources, newShoot.Spec.Resources) {
-				g.handleShootCreateOrUpdate(newShoot)
+				!v1beta1helper.ShootResourceReferencesEqual(oldShoot.Spec.Resources, newShoot.Spec.Resources) ||
+				v1beta1helper.HasManagedIssuer(oldShoot) != v1beta1helper.HasManagedIssuer(newShoot) {
+				g.handleShootCreateOrUpdate(ctx, newShoot)
 			}
 		},
 
@@ -73,7 +78,7 @@ func (g *graph) setupShootWatch(_ context.Context, informer cache.Informer) erro
 	return err
 }
 
-func (g *graph) handleShootCreateOrUpdate(shoot *gardencorev1beta1.Shoot) {
+func (g *graph) handleShootCreateOrUpdate(ctx context.Context, shoot *gardencorev1beta1.Shoot) {
 	start := time.Now()
 	defer func() {
 		metricUpdateDuration.WithLabelValues("Shoot", "CreateOrUpdate").Observe(time.Since(start).Seconds())
@@ -175,6 +180,17 @@ func (g *graph) handleShootCreateOrUpdate(shoot *gardencorev1beta1.Shoot) {
 	// deleted as part of the gardenlet reconciliation and are bound to the lifetime of the shoot as well.
 	shootStateVertex := g.getOrCreateVertex(VertexTypeShootState, shoot.Namespace, shoot.Name)
 	g.addEdge(shootStateVertex, shootVertex)
+
+	if v1beta1helper.HasManagedIssuer(shoot) {
+		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: shoot.Namespace}}
+		if err := g.client.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err == nil {
+			if projectName, ok := namespace.Labels[v1beta1constants.ProjectName]; ok {
+				saPublicKeysSecretName := gardenerutils.ComputeManagedShootIssuerSecretName(projectName, shoot.UID)
+				saPublicKeysSecret := g.getOrCreateVertex(VertexTypeSecret, gardencorev1beta1.GardenerShootIssuerNamespace, saPublicKeysSecretName)
+				g.addEdge(saPublicKeysSecret, shootVertex)
+			}
+		}
+	}
 }
 
 func (g *graph) handleShootDelete(shoot *gardencorev1beta1.Shoot) {

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_shoot.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_shoot.go
@@ -186,8 +186,8 @@ func (g *graph) handleShootCreateOrUpdate(ctx context.Context, shoot *gardencore
 		if err := g.client.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err == nil {
 			if projectName, ok := namespace.Labels[v1beta1constants.ProjectName]; ok {
 				saPublicKeysSecretName := gardenerutils.ComputeManagedShootIssuerSecretName(projectName, shoot.UID)
-				saPublicKeysSecret := g.getOrCreateVertex(VertexTypeSecret, gardencorev1beta1.GardenerShootIssuerNamespace, saPublicKeysSecretName)
-				g.addEdge(saPublicKeysSecret, shootVertex)
+				saPublicKeysSecretVertex := g.getOrCreateVertex(VertexTypeSecret, gardencorev1beta1.GardenerShootIssuerNamespace, saPublicKeysSecretName)
+				g.addEdge(saPublicKeysSecretVertex, shootVertex)
 			}
 		}
 	}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
@@ -191,7 +191,7 @@ var _ = Describe("graph", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "shoot1",
 				Namespace: namespace1.Name,
-				UID:       "uid1",
+				UID:       "f486b21b-7cbe-4bde-9b83-bf8a55c7f075",
 				Annotations: map[string]string{
 					"authentication.gardener.cloud/issuer": "managed",
 				},

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -551,7 +551,7 @@ const (
 
 	// LabelPublicKeys is a constant for a label key that indicates that a resource contains public keys.
 	LabelPublicKeys = "authentication.gardener.cloud/public-keys"
-	// LabelPublicKeys is a constant for a label value that indicates that a resource contains service account public signing keys.
+	// LabelPublicKeysServiceAccount is a constant for a label value that indicates that a resource contains service account public signing keys.
 	LabelPublicKeysServiceAccount = "serviceaccount"
 
 	// LabelExposureClassHandlerName is the label key for exposure class handler names.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -544,9 +544,9 @@ const (
 	// LabelExtensionProjectRole is a constant for a label value for extension project roles
 	LabelExtensionProjectRole = "extension-project-role"
 
-	// LabelShootNamespace is a constant for a label key that indicates a relationstip to a shoot in the specified namespace.
+	// LabelShootNamespace is a constant for a label key that indicates a relationship to a shoot in the specified namespace.
 	LabelShootNamespace = "shoot.gardener.cloud/namespace"
-	// LabelShootName is a constant for a label key that indicates a relationstip to a shoot with the specified name.
+	// LabelShootName is a constant for a label key that indicates a relationship to a shoot with the specified name.
 	LabelShootName = "shoot.gardener.cloud/name"
 
 	// LabelPublicKeys is a constant for a label key that indicates that a resource contains public keys.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -551,7 +551,7 @@ const (
 
 	// LabelPublicKeys is a constant for a label key that indicates that a resource contains public keys.
 	LabelPublicKeys = "authentication.gardener.cloud/public-keys"
-	// LabelPublicKeysServiceAccount is a constant for a label value that indicates that a resource contains service account public signing keys.
+	// LabelPublicKeysServiceAccount is a constant for a label value that indicates that a resource contains service account public keys.
 	LabelPublicKeysServiceAccount = "serviceaccount"
 
 	// LabelExposureClassHandlerName is the label key for exposure class handler names.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -544,6 +544,16 @@ const (
 	// LabelExtensionProjectRole is a constant for a label value for extension project roles
 	LabelExtensionProjectRole = "extension-project-role"
 
+	// LabelShootNamespace is a constant for a label key that indicates a relationstip to a shoot in the specified namespace.
+	LabelShootNamespace = "shoot.gardener.cloud/namespace"
+	// LabelShootName is a constant for a label key that indicates a relationstip to a shoot with the specified name.
+	LabelShootName = "shoot.gardener.cloud/name"
+
+	// LabelPublicKeys is a constant for a label key that indicates that a resource contains public keys.
+	LabelPublicKeys = "authentication.gardener.cloud/public-keys"
+	// LabelPublicKeys is a constant for a label value that indicates that a resource contains service account public signing keys.
+	LabelPublicKeysServiceAccount = "serviceaccount"
+
 	// LabelExposureClassHandlerName is the label key for exposure class handler names.
 	LabelExposureClassHandlerName = "handler.exposureclass.gardener.cloud/name"
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -624,6 +624,11 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Fn:           botanist.Shoot.Components.ControlPlane.ResourceManager.Destroy,
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerDeleted),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Delete public service account signing keys from Garden cluster",
+			Fn:           botanist.DeletePublicServiceAccountKeys,
+			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerDeleted),
+		})
 
 		destroyControlPlaneExposure = g.Add(flow.Task{
 			Name: "Destroying shoot control plane exposure",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_force_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_force_delete.go
@@ -183,6 +183,11 @@ func (r *Reconciler) runForceDeleteShootFlow(ctx context.Context, log logr.Logge
 			Dependencies: flow.NewTaskIDs(syncPoint, waitUntilEtcdsDeleted, deleteKubernetesResources),
 		})
 		_ = g.Add(flow.Task{
+			Name:         "Delete public service account signing keys from Garden cluster",
+			Fn:           botanist.DeletePublicServiceAccountKeys,
+			Dependencies: flow.NewTaskIDs(syncPoint),
+		})
+		_ = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespace has been deleted",
 			Fn:           botanist.WaitUntilSeedNamespaceDeleted,
 			Dependencies: flow.NewTaskIDs(deleteNamespace),

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
@@ -1,0 +1,87 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
+// SyncPublicServiceAccountKeys retrieves the responses of /.well-known/openid-configuration and /openid/v1/jwks
+// from the shoot kube-apiserver and writes them in a secret in the gardener-system-shoot-issuer namespace in the Garden cluster.
+func (b *Botanist) SyncPublicServiceAccountKeys(ctx context.Context) error {
+	var (
+		client        = b.ShootClientSet.RESTClient()
+		retrieveBytes = func(ctx context.Context, client rest.Interface, relativePath string) ([]byte, error) {
+			request := client.Get()
+			request.RequestURI(relativePath)
+			return request.DoRaw(ctx)
+		}
+	)
+
+	// paths copied from https://github.com/kubernetes/kubernetes/blob/7ea3d0245a63fbbba698f1cb939831fe8143db3e/pkg/serviceaccount/openidmetadata.go#L34-L45
+	oidReqBytes, err := retrieveBytes(ctx, client, "/.well-known/openid-configuration")
+	if err != nil {
+		return err
+	}
+
+	jwksReqBytes, err := retrieveBytes(ctx, client, "/openid/v1/jwks")
+	if err != nil {
+		return err
+	}
+
+	secret := b.emptyPublicServiceAccountKeysSecret()
+	if _, err := controllerutil.CreateOrUpdate(ctx, b.GardenClient, secret, func() error {
+		secret.Labels = map[string]string{
+			v1beta1constants.ProjectName:         b.Garden.Project.Name,
+			v1beta1constants.LabelShootName:      b.Shoot.GetInfo().Name,
+			v1beta1constants.LabelShootNamespace: b.Shoot.GetInfo().Namespace,
+			v1beta1constants.LabelPublicKeys:     v1beta1constants.LabelPublicKeysServiceAccount,
+		}
+		secret.Data = map[string][]byte{
+			"openid-config": oidReqBytes,
+			"jwks":          jwksReqBytes,
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeletePublicServiceAccountKeys deletes the secret containing the public info
+// of the shoot's service account issuer from the gardener-system-shoot-issuer namespace in the Garden cluster.
+func (b *Botanist) DeletePublicServiceAccountKeys(ctx context.Context) error {
+	return client.IgnoreNotFound(b.GardenClient.Delete(ctx, b.emptyPublicServiceAccountKeysSecret()))
+}
+
+func (b *Botanist) emptyPublicServiceAccountKeysSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s--%s", b.Garden.Project.Name, b.Shoot.GetInfo().UID),
+			Namespace: gardencorev1beta1.GardenerShootIssuerNamespace,
+		},
+	}
+}

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
@@ -52,7 +52,7 @@ func (b *Botanist) SyncPublicServiceAccountKeys(ctx context.Context) error {
 	}
 
 	secret := b.emptyPublicServiceAccountKeysSecret()
-	if _, err := controllerutil.CreateOrUpdate(ctx, b.GardenClient, secret, func() error {
+	_, err = controllerutil.CreateOrUpdate(ctx, b.GardenClient, secret, func() error {
 		secret.Labels = map[string]string{
 			v1beta1constants.ProjectName:         b.Garden.Project.Name,
 			v1beta1constants.LabelShootName:      b.Shoot.GetInfo().Name,
@@ -64,11 +64,8 @@ func (b *Botanist) SyncPublicServiceAccountKeys(ctx context.Context) error {
 			"jwks":          jwksReqBytes,
 		}
 		return nil
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
+	return err
 }
 
 // DeletePublicServiceAccountKeys deletes the secret containing the public info

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
@@ -19,7 +19,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -32,21 +31,20 @@ import (
 // from the shoot kube-apiserver and writes them in a secret in the gardener-system-shoot-issuer namespace in the Garden cluster.
 func (b *Botanist) SyncPublicServiceAccountKeys(ctx context.Context) error {
 	var (
-		client        = b.ShootClientSet.RESTClient()
-		retrieveBytes = func(ctx context.Context, client rest.Interface, relativePath string) ([]byte, error) {
-			request := client.Get()
+		retrieveBytes = func(ctx context.Context, relativePath string) ([]byte, error) {
+			request := b.ShootClientSet.RESTClient().Get()
 			request.RequestURI(relativePath)
 			return request.DoRaw(ctx)
 		}
 	)
 
 	// paths copied from https://github.com/kubernetes/kubernetes/blob/7ea3d0245a63fbbba698f1cb939831fe8143db3e/pkg/serviceaccount/openidmetadata.go#L34-L45
-	oidReqBytes, err := retrieveBytes(ctx, client, "/.well-known/openid-configuration")
+	oidReqBytes, err := retrieveBytes(ctx, "/.well-known/openid-configuration")
 	if err != nil {
 		return err
 	}
 
-	jwksReqBytes, err := retrieveBytes(ctx, client, "/openid/v1/jwks")
+	jwksReqBytes, err := retrieveBytes(ctx, "/openid/v1/jwks")
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
@@ -16,7 +16,6 @@ package botanist
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +25,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // SyncPublicServiceAccountKeys retrieves the responses of /.well-known/openid-configuration and /openid/v1/jwks
@@ -80,7 +80,7 @@ func (b *Botanist) DeletePublicServiceAccountKeys(ctx context.Context) error {
 func (b *Botanist) emptyPublicServiceAccountKeysSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s--%s", b.Garden.Project.Name, b.Shoot.GetInfo().UID),
+			Name:      gardenerutils.ComputeManagedShootIssuerSecretName(b.Garden.Project.Name, b.Shoot.GetInfo().UID),
 			Namespace: gardencorev1beta1.GardenerShootIssuerNamespace,
 		},
 	}

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
@@ -1,0 +1,216 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	fakerest "k8s.io/client-go/rest/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/garden"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+)
+
+var _ = Describe("ServiceAccountKeys", func() {
+	var (
+		ctx = context.TODO()
+
+		shootName           = "foo"
+		shootNamespace      = "bar"
+		gardenClient        client.Client
+		shootClient         client.Client
+		shootClientSet      kubernetes.Interface
+		fakeShootRESTClient rest.Interface
+		botanist            *Botanist
+
+		expectedSecret *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		shootClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).Build()
+		fakeShootRESTClient = &fakerest.RESTClient{
+			NegotiatedSerializer: scheme.Codecs,
+			Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/.well-known/openid-configuration":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("well-known")))}, nil
+				case "/openid/v1/jwks":
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("jwks")))}, nil
+				default:
+					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
+				}
+			}),
+		}
+
+		shootClientSet = kubernetesfake.NewClientSetBuilder().WithClient(shootClient).WithRESTClient(fakeShootRESTClient).Build()
+
+		botanist = &Botanist{
+			Operation: &operation.Operation{
+				GardenClient:   gardenClient,
+				ShootClientSet: shootClientSet,
+				Shoot:          &shootpkg.Shoot{},
+				Garden: &garden.Garden{
+					Project: &gardencorev1beta1.Project{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "project-name",
+						},
+					},
+				},
+			},
+		}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+				UID:       "uid",
+			},
+		})
+		expectedSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "project-name--uid",
+				Namespace:       "gardener-system-shoot-issuer",
+				ResourceVersion: "1",
+				Labels: map[string]string{
+					"shoot.gardener.cloud/namespace":            "bar",
+					"authentication.gardener.cloud/public-keys": "serviceaccount",
+					"project.gardener.cloud/name":               "project-name",
+					"shoot.gardener.cloud/name":                 "foo",
+				},
+			},
+			Data: map[string][]byte{
+				"jwks":          []byte("jwks"),
+				"openid-config": []byte("well-known"),
+			},
+		}
+	})
+
+	Describe("#SyncPublicServiceAccountKeys", func() {
+		It("should sync public info", func() {
+			Expect(botanist.SyncPublicServiceAccountKeys(ctx)).To(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "project-name--uid",
+					Namespace: "gardener-system-shoot-issuer",
+				},
+			}
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			Expect(secret).To(Equal(expectedSecret))
+		})
+
+		It("should overwrite the public info", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "project-name--uid",
+					Namespace: "gardener-system-shoot-issuer",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Data: map[string][]byte{
+					"foo": []byte("bar"),
+				},
+			}
+			Expect(gardenClient.Create(ctx, secret))
+			Expect(botanist.SyncPublicServiceAccountKeys(ctx)).To(Succeed())
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			expectedSecret.ResourceVersion = "2"
+			Expect(secret).To(Equal(expectedSecret))
+		})
+
+		Context("error responses", func() {
+			It("should return bad request", func() {
+				fakeShootRESTClient = &fakerest.RESTClient{
+					NegotiatedSerializer: scheme.Codecs,
+					Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+						switch req.URL.Path {
+						case "/.well-known/openid-configuration":
+							return &http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(bytes.NewReader([]byte("bad")))}, nil
+						default:
+							return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
+						}
+					}),
+				}
+				shootClientSet = kubernetesfake.NewClientSetBuilder().WithClient(shootClient).WithRESTClient(fakeShootRESTClient).Build()
+				botanist.ShootClientSet = shootClientSet
+
+				err := botanist.SyncPublicServiceAccountKeys(ctx)
+				var statusError *apierrors.StatusError
+				Expect(errors.As(err, &statusError)).To(BeTrue())
+				Expect(statusError.Status().Code).To(Equal(int32(400)))
+				Expect(statusError.Status().Details.Causes[0].Message).To(Equal("bad"))
+			})
+
+			It("should return bad request", func() {
+				fakeShootRESTClient = &fakerest.RESTClient{
+					NegotiatedSerializer: scheme.Codecs,
+					Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+						switch req.URL.Path {
+						case "/.well-known/openid-configuration":
+							return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("good")))}, nil
+						case "/openid/v1/jwks":
+							return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(bytes.NewReader([]byte("bad")))}, nil
+						default:
+							return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(&bytes.Buffer{})}, nil
+						}
+					}),
+				}
+				shootClientSet = kubernetesfake.NewClientSetBuilder().WithClient(shootClient).WithRESTClient(fakeShootRESTClient).Build()
+				botanist.ShootClientSet = shootClientSet
+
+				err := botanist.SyncPublicServiceAccountKeys(ctx)
+				var statusError *apierrors.StatusError
+				Expect(errors.As(err, &statusError)).To(BeTrue())
+				Expect(statusError.Status().Code).To(Equal(int32(500)))
+				Expect(statusError.Status().Details.Causes[0].Message).To(Equal("bad"))
+			})
+		})
+	})
+
+	Describe("#DeletePublicServiceAccountKeys", func() {
+		It("should delete the public info", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "project-name--uid",
+					Namespace: "gardener-system-shoot-issuer",
+				},
+				Data: map[string][]byte{"foo": []byte("bar")},
+			}
+			Expect(gardenClient.Create(ctx, secret)).To(Succeed())
+			Expect(botanist.DeletePublicServiceAccountKeys(ctx)).To(Succeed())
+			err := gardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+})

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
@@ -142,7 +142,7 @@ var _ = Describe("ServiceAccountKeys", func() {
 					"foo": []byte("bar"),
 				},
 			}
-			Expect(gardenClient.Create(ctx, secret))
+			Expect(gardenClient.Create(ctx, secret)).To(Succeed())
 			Expect(botanist.SyncPublicServiceAccountKeys(ctx)).To(Succeed())
 			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			expectedSecret.ResourceVersion = "2"

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
@@ -172,7 +172,7 @@ var _ = Describe("ServiceAccountKeys", func() {
 				Expect(statusError.Status().Details.Causes[0].Message).To(Equal("bad"))
 			})
 
-			It("should return bad request", func() {
+			It("should return internal server error", func() {
 				fakeShootRESTClient = &fakerest.RESTClient{
 					NegotiatedSerializer: scheme.Codecs,
 					Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -281,7 +281,7 @@ func IsShootProjectInternalSecret(secretName string) (string, bool) {
 }
 
 // ComputeManagedShootIssuerSecretName returns the name that should be used for
-// storing the service account public signing keys of a shoot's kube-apiserver
+// storing the service account public keys of a shoot's kube-apiserver
 // in the gardener-system-shoot-issuer namespace in the Garden cluster.
 func ComputeManagedShootIssuerSecretName(projectName string, shootUID types.UID) string {
 	return fmt.Sprintf("%s--%s", projectName, shootUID)

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -284,7 +284,7 @@ func IsShootProjectInternalSecret(secretName string) (string, bool) {
 // storing the service account public keys of a shoot's kube-apiserver
 // in the gardener-system-shoot-issuer namespace in the Garden cluster.
 func ComputeManagedShootIssuerSecretName(projectName string, shootUID types.UID) string {
-	return fmt.Sprintf("%s--%s", projectName, shootUID)
+	return projectName + "--" + string(shootUID)
 }
 
 // IsShootProjectConfigMap checks if the given name matches the name of a shoot-related project config map. If no, it returns

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -277,6 +278,13 @@ func IsShootProjectInternalSecret(secretName string) (string, bool) {
 	}
 
 	return "", false
+}
+
+// ComputeManagedShootIssuerSecretName returns the name that should be used for
+// storing the service account public signing keys of a shoot's kube-apiserver
+// in the gardener-system-shoot-issuer namespace in the Garden cluster.
+func ComputeManagedShootIssuerSecretName(projectName string, shootUID types.UID) string {
+	return fmt.Sprintf("%s--%s", projectName, shootUID)
 }
 
 // IsShootProjectConfigMap checks if the given name matches the name of a shoot-related project config map. If no, it returns

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
@@ -398,6 +399,14 @@ var _ = Describe("Shoot", func() {
 		Entry("unrelated suffix", "foo.bar", "", false),
 		Entry("wrong suffix delimiter", "foo:kubeconfig", "", false),
 		Entry("ca-client suffix", "baz.ca-client", "baz", true),
+	)
+
+	DescribeTable("#ComputeManagedShootIssuerSecretName",
+		func(projectName string, shootUID types.UID, expectedName string) {
+			Expect(ComputeManagedShootIssuerSecretName(projectName, shootUID)).To(Equal(expectedName))
+		},
+		Entry("test one", "foo", types.UID("123"), "foo--123"),
+		Entry("test two", "bar", types.UID("4-5"), "bar--4-5"),
 	)
 
 	DescribeTable("#IsShootProjectConfigMap",

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -464,6 +464,12 @@ deploy:
               - apply
               - -f
               - example/gardener-local/controlplane/domain-secrets.yaml
+        - host:
+            command:
+              - kubectl
+              - apply
+              - -f
+              - example/gardener-local/controlplane/service-account-issuer-secret.yaml
     releases:
       - name: gardener-controlplane
         chartPath: charts/gardener/controlplane

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -68,6 +68,7 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 			Annotations: map[string]string{
 				v1beta1constants.AnnotationShootInfrastructureCleanupWaitPeriodSeconds: "0",
 				v1beta1constants.AnnotationShootCloudConfigExecutionMaxDelaySeconds:    "0",
+				v1beta1constants.AnnotationAuthenticationIssuer:                        v1beta1constants.AnnotationAuthenticationIssuerManaged,
 			},
 		},
 		Spec: gardencorev1beta1.ShootSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security usability
/kind enhancement

**What this PR does / why we need it**:
This PR enables the synchronization of the service account public keys of a shoot that has a managed issuer enabled into the Garden cluster. The PR follows GEP-24 with the exception that keys are stored in `secrets` instead of `configmaps`. The reason behind this decision is that `secrets` are generally treated with greater caution and is less likely that someone has edit permissions for them in comparison to `configmaps`. 

Part of https://github.com/gardener/gardener/issues/9157
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The gardenlet now synchronizes the service account public keys of shoot clusters that have managed issuer enabled. The public keys are stored in a dedicated `gardener-system-shoot-issuer` namespace in the Garden cluster.
```
