### PR TITLE
Improve API discovery for generating read-only `ClusterRole` for `shoots/viewerkubeconfig` subresource

### DIFF
--- a/pkg/gardenlet/operation/botanist/shootsystem.go
+++ b/pkg/gardenlet/operation/botanist/shootsystem.go
@@ -50,7 +50,7 @@ func (b *Botanist) DefaultShootSystem() shootsystem.Interface {
 
 // DeployShootSystem deploys the shoot system resources.
 func (b *Botanist) DeployShootSystem(ctx context.Context) error {
-	_, apiResourceList, err := b.ShootClientSet.Kubernetes().Discovery().ServerGroupsAndResources()
+	apiResourceList, err := b.ShootClientSet.Kubernetes().Discovery().ServerPreferredResources()
 	if err != nil {
 		return fmt.Errorf("failed to discover the API: %w", err)
 	}

--- a/pkg/gardenlet/operation/botanist/shootsystem_test.go
+++ b/pkg/gardenlet/operation/botanist/shootsystem_test.go
@@ -22,10 +22,10 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/testing"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 
 	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/client/kubernetes/test"
 	mockshootsystem "github.com/gardener/gardener/pkg/component/shoot/system/mock"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
@@ -75,8 +75,8 @@ var _ = Describe("ShootSystem", func() {
 		BeforeEach(func() {
 			shootSystem = mockshootsystem.NewMockInterface(ctrl)
 
-			fakeKubernetes := fake.NewSimpleClientset()
-			fakeKubernetes.Fake = testing.Fake{Resources: apiResourceList}
+			fakeDiscoveryClient := &fakeDiscoveryWithServerPreferredResources{apiResourceList: apiResourceList}
+			fakeKubernetes := test.NewClientSetWithDiscovery(nil, fakeDiscoveryClient)
 			botanist.ShootClientSet = kubernetesfake.NewClientSetBuilder().WithKubernetes(fakeKubernetes).Build()
 
 			botanist.Shoot = &shootpkg.Shoot{
@@ -101,3 +101,13 @@ var _ = Describe("ShootSystem", func() {
 		})
 	})
 })
+
+type fakeDiscoveryWithServerPreferredResources struct {
+	*fakediscovery.FakeDiscovery
+
+	apiResourceList []*metav1.APIResourceList
+}
+
+func (f *fakeDiscoveryWithServerPreferredResources) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return f.apiResourceList, nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
In `Shoot`s that have registered the `custom.metrics.k8s.io` API group, the previous way of discovering the API lead to overloaded `ClusterRole`s (sometimes more than 18k entries), which also leads to hitting the `1 MB` limit of the respective `ManagedResource` `Secret`.

With this PR

- we use `ServerPreferredResources()` instead of `ServerGroupsAndResources()` (similar to what `kubectl api-resources` does) - this effectively skips subresources (or, more generally, resources containing a `/`) - which should be good enough for our "read only" purposes
- we continue despite facing discovery failures for some groups (e.g., end-users could have created `APIService`s which are not `Available`, hence not discoverable) which sometimes leaded to stuck `Shoot` reconciliation

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/8870 (https://github.com/gardener/gardener/pull/8870/commits/eb601cc4d5b41d3bad75cbd70bb19cccd3716212)

**Special notes for your reviewer**:
/cc @ScheererJ @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue has been fixed which caused `Shoot` reconciliation to get stuck because the API discovery used to generate the read-only `ClusterRole` for `shoots/viewerkubeconfig` subresource failed.
```
