### PR TITLE
[operator] Prevent crashing when no `Garden` exists

### DIFF
--- a/pkg/operator/controller/garden/care/add.go
+++ b/pkg/operator/controller/garden/care/add.go
@@ -91,11 +91,15 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 		return err
 	}
 
-	return c.Watch(
-		source.Kind(mgr.GetCache(), &resourcesv1alpha1.ManagedResource{}),
-		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), mapper.MapFunc(r.MapManagedResourceToGarden), mapper.UpdateWithNew, c.GetLogger()),
-		predicateutils.ManagedResourceConditionsChanged(),
-	)
+	r.registerManagedResourceWatchFunc = func() error {
+		return c.Watch(
+			source.Kind(mgr.GetCache(), &resourcesv1alpha1.ManagedResource{}),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), mapper.MapFunc(r.MapManagedResourceToGarden), mapper.UpdateWithNew, c.GetLogger()),
+			predicateutils.ManagedResourceConditionsChanged(),
+		)
+	}
+
+	return nil
 }
 
 // GardenPredicate is a predicate which returns 'true' for create events, and for update events in case the garden was


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
When you deploy `gardener-operator` without creating a `Garden` resource "fast enough", then it eventually crashes:

```
{"level":"error","ts":"2024-03-11T13:21:39.291Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:21:49.291Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:21:59.291Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:22:09.292Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:22:19.291Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:22:29.291Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:22:39.292Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:22:49.291Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:22:59.290Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:23:09.290Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:23:19.290Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:23:29.289Z","logger":"controller-runtime.source.EventHandler","msg":"if kind is a CRD, it should be installed before calling Start","kind":"ManagedResource.resources.gardener.cloud","error":"no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\tk8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56"}
{"level":"error","ts":"2024-03-11T13:23:29.390Z","msg":"Could not wait for Cache to sync","controller":"garden-care","error":"failed to wait for garden-care caches to sync: timed out waiting for cache to be synced for Kind *v1alpha1.ManagedResource","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:203\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:208\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:234\nsigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1\n\tsigs.k8s.io/controller-runtime@v0.17.2/pkg/manager/runnable_group.go:223"}
```

It can be easily reproduced by running `make kind-operator-up operator-up` without creating a `Garden` and waiting a few minutes.

This is annoying/confusing for users of `gardener-operator`. It is caused by the `ManagedResource` watch in the `garden-care` controller. This PR adapts the registration of said watch to happen only after a `Garden` has been created.

**Special notes for your reviewer**:
FYI @petersutter @holgerkoser 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
