### PR TITLE
Add disallowed transition to HA shoot control planes documentation

### DIFF
--- a/docs/usage/shoot_high_availability.md
+++ b/docs/usage/shoot_high_availability.md
@@ -50,7 +50,10 @@ If you already have a shoot cluster with non-HA control plane, then the followin
 
 **Disallowed Transitions**
 
-If you have already set-up an HA shoot control plane with `node` failure tolerance, then an upgrade to a `zone` failure tolerance is currently not supported, mainly because already existing volumes are bound to the zone they were created in originally.
+If you already have a shoot cluster with HA control plane, then the following transitions are not possible:
+* Upgrade of HA shoot control plane from `node` failure tolerance to `zone` failure tolerance is currently not supported, mainly because already existing volumes are bound to the zone they were created in originally.
+* Downgrade of HA shoot control plane with `zone` failure tolerance to `node` failure tolerance is currently not supported, mainly because of the same reason as above, that already existing volumes are bound to the respective zones they were created in originally.
+* Downgrade of HA shoot control plane with either `node` or `zone` failure tolerance, to a non-HA shoot control plane is currently not supported, mainly because [etcd-druid](https://github.com/gardener/etcd-druid) does not currently support scaling down of a multi-node etcd cluster to a single-node etcd cluster.
 
 ## Zone Outage Situation
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability documentation
/kind enhancement

**What this PR does / why we need it**:
Add information about disallowed transition from HA to non-HA shoot control plane, in HA shoot control planes documentation.

**Which issue(s) this PR fixes**:
Fixes #9356 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
