### PR TITLE
local-path provisioner with support for volume resizing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ kind2-up kind2-ha-single-zone-up: export ADDITIONAL_PARAMETERS = --skip-registry
 kind2-down: export ADDITIONAL_PARAMETERS = --keep-backupbuckets-dir
 kind-ha-multi-zone-up: export ADDITIONAL_PARAMETERS = --multi-zonal
 
-kind-up kind2-up kind-ha-single-zone-up kind2-ha-single-zone-up kind-ha-multi-zone-up: $(KIND) $(KUBECTL) $(HELM) $(YQ)
+kind-up kind2-up kind-ha-single-zone-up kind2-ha-single-zone-up kind-ha-multi-zone-up: $(KIND) $(KUBECTL) $(HELM) $(YQ) $(KUSTOMIZE)
 	./hack/kind-up.sh \
 		--cluster-name $(CLUSTER_NAME) \
 		--path-kubeconfig $(KIND_KUBECONFIG) \

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ kind-extensions-down: $(KIND)
 kind-extensions-clean:
 	./hack/kind-down.sh --cluster-name gardener-extensions --path-kubeconfig $(REPO_ROOT)/example/provider-extensions/garden/kubeconfig
 
-kind-operator-up: $(KIND) $(KUBECTL) $(HELM) $(YQ)
+kind-operator-up: $(KIND) $(KUBECTL) $(HELM) $(YQ) $(KUSTOMIZE)
 	./hack/kind-up.sh \
 		--cluster-name gardener-operator-local \
 		--path-kubeconfig $(REPO_ROOT)/example/gardener-local/kind/operator/kubeconfig \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ GARDENER_RELEASE_DOWNLOAD_PATH             := $(REPO_ROOT)/dev
 DEV_SETUP_WITH_LPP_RESIZE_SUPPORT          ?= false
 PRINT_HELP ?=
 
-
 ifneq ($(SEED_NAME),provider-extensions)
 	SEED_KUBECONFIG := $(REPO_ROOT)/example/provider-extensions/seed/kubeconfig-$(SEED_NAME)
 endif

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -248,7 +248,7 @@ _setup_kind_with_lpp_resize_support() {
 
     # The default manifests from rancher/local-path come with another
     # StorageClass, which we don't need, so make sure to remove it.
-    kubectl delete storageclass local-path
+    kubectl delete --ignore-not-found=true storageclass local-path
 
     cd "${_oldpwd}"
     rm -rf "${_workdir}"

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -245,6 +245,11 @@ _setup_kind_with_lpp_resize_support() {
         kustomize edit set image rancher/local-path-provisioner:master-head="${_local_latest_image}" && \
         kustomize build . | \
         kubectl apply -f -
+
+    # The default manifests from rancher/local-path come with another
+    # StorageClass, which we don't need, so make sure to remove it.
+    kubectl delete storageclass local-path
+
     cd "${_oldpwd}"
     rm -rf "${_workdir}"
 }

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -185,8 +185,9 @@ check_registry_cache_availability() {
 # [4]: https://github.com/kubernetes-sigs/kind/blob/main/pkg/cluster/internal/create/actions/installstorage/storage.go
 # [5]: https://kubernetes.io/docs/reference/instrumentation/metrics/
 _setup_kind_sc_default_volume_type() {
+    echo "Configuring default StorageClass for kind cluster ..."
     kubectl get storageclasses standard -o yaml | \
-        yq '.metadata.annotations.defaultVolumeType = "local"' | \
+        yq '.metadata.annotations.defaultVolumeType = "local" | .allowVolumeExpansion = true' | \
         kubectl apply -f -
 }
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -28,6 +28,8 @@ else
 TOOLS_PKG_PATH             := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools 2>/dev/null)
 endif
 
+SYSTEM_NAME                := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+SYSTEM_ARCH                := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
 CONTROLLER_GEN             := $(TOOLS_BIN_DIR)/controller-gen
 GEN_CRD_API_REFERENCE_DOCS := $(TOOLS_BIN_DIR)/gen-crd-api-reference-docs
@@ -43,6 +45,7 @@ HELM                       := $(TOOLS_BIN_DIR)/helm
 IMPORT_BOSS                := $(TOOLS_BIN_DIR)/import-boss
 KIND                       := $(TOOLS_BIN_DIR)/kind
 KUBECTL                    := $(TOOLS_BIN_DIR)/kubectl
+KUSTOMIZE                  := $(TOOLS_BIN_DIR)/kustomize
 LOGCHECK                   := $(TOOLS_BIN_DIR)/logcheck.so # plugin binary
 MOCKGEN                    := $(TOOLS_BIN_DIR)/mockgen
 OPENAPI_GEN                := $(TOOLS_BIN_DIR)/openapi-gen
@@ -71,6 +74,8 @@ HELM_VERSION ?= v3.14.3
 KIND_VERSION ?= v0.22.0
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.29.3
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
+KUSTOMIZE_VERSION ?= v5.3.0
 # renovate: datasource=github-releases depName=prometheus/prometheus
 PROMTOOL_VERSION ?= 2.50.1
 # renovate: datasource=github-releases depName=protocolbuffers/protobuf
@@ -184,6 +189,12 @@ $(KIND): $(call tool_version_file,$(KIND),$(KIND_VERSION))
 $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell uname -s | tr '[:upper:]' '[:lower:]')/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')/kubectl
 	chmod +x $(KUBECTL)
+
+$(KUSTOMIZE): $(call tool_version_file,$(KUSTOMIZE),$(KUSTOMIZE_VERSION))
+	curl -L -o - \
+		https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$(SYSTEM_NAME)_$(SYSTEM_ARCH).tar.gz | \
+	tar zxvf - -C $(TOOLS_BIN_DIR)
+	chmod +x $(KUSTOMIZE)
 
 ifeq ($(strip $(shell go list -m 2>/dev/null)),github.com/gardener/gardener)
 $(LOGCHECK): $(TOOLS_PKG_PATH)/logcheck/go.* $(shell find $(TOOLS_PKG_PATH)/logcheck -type f -name '*.go')

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -138,7 +138,7 @@ ifeq ($(shell if [ -d $(TOOLS_BIN_SOURCE_DIR) ]; then echo "found"; fi),found)
 endif
 
 .PHONY: create-tools-bin
-create-tools-bin: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GINKGO) $(GOIMPORTS) $(GOIMPORTSREVISER) $(GO_ADD_LICENSE) $(GO_APIDIFF) $(GO_VULN_CHECK) $(GO_TO_PROTOBUF) $(HELM) $(IMPORT_BOSS) $(KIND) $(KUBECTL) $(MOCKGEN) $(OPENAPI_GEN) $(PROMTOOL) $(PROTOC) $(PROTOC_GEN_GOGO) $(SETUP_ENVTEST) $(SKAFFOLD) $(YQ) $(VGOPATH)
+create-tools-bin: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GINKGO) $(GOIMPORTS) $(GOIMPORTSREVISER) $(GO_ADD_LICENSE) $(GO_APIDIFF) $(GO_VULN_CHECK) $(GO_TO_PROTOBUF) $(HELM) $(IMPORT_BOSS) $(KIND) $(KUBECTL) $(MOCKGEN) $(OPENAPI_GEN) $(PROMTOOL) $(PROTOC) $(PROTOC_GEN_GOGO) $(SETUP_ENVTEST) $(SKAFFOLD) $(YQ) $(VGOPATH) $(KUSTOMIZE)
 
 #########################################
 # Tools                                 #
@@ -183,18 +183,18 @@ $(IMPORT_BOSS): $(call tool_version_file,$(IMPORT_BOSS),$(CODE_GENERATOR_VERSION
 	go build -o $(IMPORT_BOSS) k8s.io/code-generator/cmd/import-boss
 
 $(KIND): $(call tool_version_file,$(KIND),$(KIND_VERSION))
-	curl -L -o $(KIND) https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+	curl -L -o $(KIND) https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(SYSTEM_NAME)-$(SYSTEM_ARCH)
 	chmod +x $(KIND)
 
 $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
-	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell uname -s | tr '[:upper:]' '[:lower:]')/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')/kubectl
+	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(SYSTEM_NAME)/$(SYSTEM_ARCH)/kubectl
 	chmod +x $(KUBECTL)
 
 $(KUSTOMIZE): $(call tool_version_file,$(KUSTOMIZE),$(KUSTOMIZE_VERSION))
 	curl -L -o - \
 		https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$(SYSTEM_NAME)_$(SYSTEM_ARCH).tar.gz | \
-	tar zxvf - -C $(TOOLS_BIN_DIR)
-	chmod +x $(KUSTOMIZE)
+	tar zxvf - -C $(abspath $(TOOLS_BIN_DIR))
+	touch $(KUSTOMIZE) && chmod +x $(KUSTOMIZE)
 
 ifeq ($(strip $(shell go list -m 2>/dev/null)),github.com/gardener/gardener)
 $(LOGCHECK): $(TOOLS_PKG_PATH)/logcheck/go.* $(shell find $(TOOLS_PKG_PATH)/logcheck -type f -name '*.go')
@@ -231,11 +231,11 @@ $(SETUP_ENVTEST): $(call tool_version_file,$(SETUP_ENVTEST),$(CONTROLLER_RUNTIME
 	go build -o $(SETUP_ENVTEST) sigs.k8s.io/controller-runtime/tools/setup-envtest
 
 $(SKAFFOLD): $(call tool_version_file,$(SKAFFOLD),$(SKAFFOLD_VERSION))
-	curl -Lo $(SKAFFOLD) https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+	curl -Lo $(SKAFFOLD) https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(SYSTEM_NAME)-$(SYSTEM_ARCH)
 	chmod +x $(SKAFFOLD)
 
 $(YQ): $(call tool_version_file,$(YQ),$(YQ_VERSION))
-	curl -L -o $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+	curl -L -o $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(SYSTEM_NAME)_$(SYSTEM_ARCH)
 	chmod +x $(YQ)
 
 $(VGOPATH): $(call tool_version_file,$(VGOPATH),$(VGOPATH_VERSION))

--- a/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml
+++ b/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml
@@ -4,6 +4,7 @@ metadata:
   name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+    defaultVolumeType: local
 provisioner: rancher.io/local-path
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml
+++ b/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml
@@ -8,4 +8,3 @@ metadata:
 provisioner: rancher.io/local-path
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
-allowVolumeExpansion: true

--- a/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml
+++ b/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml
@@ -8,3 +8,4 @@ metadata:
 provisioner: rancher.io/local-path
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area control-plane
/kind enhancement
/kind poc

**What this PR does / why we need it**:

This PR adds support for running the local dev environment with local-path provisioner which supports volume resizing.

The default `StorageClass` (named `standard`) in the local setup currently defaults to [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) (this is what `rancher.io/local-path` provisioner defaults to), and [hostPath does not expose metrics via kubelet](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/hostpath/host_path.go#L218). 

In order to expose the various `kubelet_volume_stats_*` metrics via kubelet in the local setup this PR also configures the default `StorageClass` to use [local volume](https://kubernetes.io/docs/concepts/storage/volumes/#local) instead of `hostPath`, since [localVolume exposes metrics](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/local/local.go#L496).

This configuration is done on the `StorageClass` object provided by `rancher/local-path` provisioner by configuring the `defaultVolumeType: local` setting. 

Additionally the `hack/kind-up.sh` script has been modified to support a new option called `--with-lpp-resize-support`, which when set to `true` will deploy and configure the local path provisioner with volume resize support. The [PVC resize support in rancher/local-path-provisioner](https://github.com/rancher/local-path-provisioner/pull/350) is currently under review and is scheduled for next release around May, 2024. Until this feature is merged we will use the the fork providing this feature, and later once merged into the upstream project we can drop the code from `kind-up.sh`.

Why is all this needed?

The end goal is to integrate PVC auto{scaler,resizer} into Gardener, which would allow PVCs to be auto-resized when they reach a certain threshold. The primary target during the first iteration of this integration are the observability components (`Vali`, `Plutono` and `Prometheus`), but later this could be leveraged by other PVCs as well.

In order to enable PVC auto-resizer we first need to start collecting metrics about the utilization of the PVCs. By enabling these metrics in the local dev setup we would be able to easily test the existing PVC auto-scalers and test their integration with Gardener.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4173

**Special notes for your reviewer**:

Running `make kind-up` will create a local `kind` cluster just like before, with the only exception that now the default `StorageClass` (named `standard`) will default to [local](https://kubernetes.io/docs/concepts/storage/volumes/#local) instead of [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath).

In order to create a local dev environment with local-path provisioner, which supports volume resizing execute this command instead.

``` shell
DEV_SETUP_WITH_LPP_RESIZE_SUPPORT=true make kind-up
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Local dev setup can now deploy a cluster with volume resize support.
```
