### PR TITLE
Remove unsupported feature gates and admission plugins from the Shoot during force upgrades

### DIFF
--- a/pkg/component/nodemanagement/dependencywatchdog/access_test.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/access_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -144,7 +144,7 @@ users:
 					},
 				},
 				InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
-				KeepObjects:  pointer.Bool(false),
+				KeepObjects:  ptr.To(false),
 			},
 		}
 		expectedManagedResourceSecret = &corev1.Secret{
@@ -161,7 +161,7 @@ users:
 				"role__kube-node-lease__gardener.cloud_target_dependency-watchdog.yaml":        []byte(roleYAML),
 				"rolebinding__kube-node-lease__gardener.cloud_target_dependency-watchdog.yaml": []byte(roleBindingYAML),
 			},
-			Immutable: pointer.Bool(true),
+			Immutable: ptr.To(true),
 		}
 	})
 

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -160,7 +160,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 		operations = append(operations, reasons...)
 	}
 
-	if reasons := maintainAdmissionPlugins(maintainedShoot); len(reasons) > 0 {
+	if reasons := maintainAdmissionPluginsForShoot(maintainedShoot); len(reasons) > 0 {
 		operations = append(operations, reasons...)
 	}
 
@@ -893,7 +893,7 @@ func maintainFeatureGates(kubernetes *gardencorev1beta1.KubernetesConfig, versio
 // IsAdmissionPluginSupported is an alias for admissionpluginsvalidation.IsAdmissionPluginSupported. Exposed for testing purposes.
 var IsAdmissionPluginSupported = admissionpluginsvalidation.IsAdmissionPluginSupported
 
-func maintainAdmissionPlugins(shoot *gardencorev1beta1.Shoot) []string {
+func maintainAdmissionPluginsForShoot(shoot *gardencorev1beta1.Shoot) []string {
 	var (
 		reasons                 []string
 		removedAdmissionPlugins []string

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -1347,11 +1347,11 @@ var _ = Describe("Shoot Maintenance", func() {
 		It("should maintain feature gates", func() {
 			result := maintainFeatureGatesForShoot(shoot)
 			Expect(result).To(ConsistOf(
-				ContainSubstring("Feature gate %q is removed from %q, not supported in Kubernetes version %q", unsupportedfeatureGate1, "spec.kubernetes.kubeAPIServer.featureGates", "1.13.5"),
-				ContainSubstring("Feature gates: %s are removed from %q, not supported in Kubernetes version %q", fmt.Sprintf("%s, %s", unsupportedfeatureGate1, unsupportedfeatureGate2), "spec.kubernetes.kubeControllerManager.featureGates", "1.13.5"),
-				ContainSubstring("Feature gate %q is removed from %q, not supported in Kubernetes version %q", unsupportedfeatureGate1, "spec.kubernetes.kubeScheduler.featureGates", "1.13.5"),
-				ContainSubstring("Feature gate %q is removed from %q, not supported in Kubernetes version %q", unsupportedfeatureGate2, "spec.kubernetes.kubeProxy.featureGates", "1.13.5"),
-				ContainSubstring("Feature gate %q is removed from %q, not supported in Kubernetes version %q", unsupportedfeatureGate2, "spec.kubernetes.kubelet.featureGates", "1.13.5"),
+				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeAPIServer.featureGates", "1.13.5", unsupportedfeatureGate1),
+				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeControllerManager.featureGates", "1.13.5", fmt.Sprintf("%s, %s", unsupportedfeatureGate1, unsupportedfeatureGate2)),
+				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeScheduler.featureGates", "1.13.5", unsupportedfeatureGate1),
+				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeProxy.featureGates", "1.13.5", unsupportedfeatureGate2),
+				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubelet.featureGates", "1.13.5", unsupportedfeatureGate2),
 			))
 			Expect(shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates).To(Equal(map[string]bool{
 				supportedfeatureGate1: true,
@@ -1405,6 +1405,9 @@ var _ = Describe("Shoot Maintenance", func() {
 								{
 									Name: unsupportedAdmissionPlugin1,
 								},
+								{
+									Name: unsupportedAdmissionPlugin2,
+								},
 							},
 						},
 					},
@@ -1415,19 +1418,7 @@ var _ = Describe("Shoot Maintenance", func() {
 		It("should maintain admission plugins", func() {
 			result := maintainAdmissionPlugins(shoot)
 			Expect(result).To(ConsistOf(
-				ContainSubstring("Admission plugin %q is removed from %q, not supported in Kubernetes version %q", unsupportedAdmissionPlugin1, "spec.kubernetes.kubeAPIServer.admissionPlugins", "1.13.5"),
-			))
-			Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ConsistOf(
-				HaveField("Name", Equal(supportedAdmissionPlugin1)),
-				HaveField("Name", Equal(supportedAdmissionPlugin2)),
-			))
-		})
-
-		It("should maintain admission plugins - when there are more than one unsupported", func() {
-			shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = append(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins, gardencorev1beta1.AdmissionPlugin{Name: unsupportedAdmissionPlugin2})
-			result := maintainAdmissionPlugins(shoot)
-			Expect(result).To(ConsistOf(
-				ContainSubstring("Admission plugins: %s are removed from %q, not supported in Kubernetes version %q", fmt.Sprintf("%s, %s", unsupportedAdmissionPlugin1, unsupportedAdmissionPlugin2), "spec.kubernetes.kubeAPIServer.admissionPlugins", "1.13.5"),
+				ContainSubstring("Removed admission plugins from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeAPIServer.admissionPlugins", "1.13.5", fmt.Sprintf("%s, %s", unsupportedAdmissionPlugin1, unsupportedAdmissionPlugin2)),
 			))
 			Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ConsistOf(
 				HaveField("Name", Equal(supportedAdmissionPlugin1)),

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -15,6 +15,7 @@
 package maintenance
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -24,6 +25,10 @@ import (
 	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils/test"
+	admissionpluginsvalidation "github.com/gardener/gardener/pkg/utils/validation/admissionplugins"
+	featuresvalidation "github.com/gardener/gardener/pkg/utils/validation/features"
+	"github.com/gardener/gardener/pkg/utils/version"
 )
 
 var _ = Describe("Shoot Maintenance", func() {
@@ -1269,9 +1274,201 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(shoot.Spec.Provider.Workers[1].Maximum).To(Equal(int32(2)))
 		})
 	})
+
+	Describe("#MaintainFeatureGatesForShoot", func() {
+		var (
+			shoot                   *gardencorev1beta1.Shoot
+			supportedfeatureGate1   = "featureGate1"
+			supportedfeatureGate2   = "featureGate2"
+			unsupportedfeatureGate1 = "featureGate3"
+			unsupportedfeatureGate2 = "featureGate4"
+		)
+
+		BeforeEach(func() {
+			defer test.WithVar(
+				&IsFeatureGateSupported, isFeatureGateSupported,
+			)
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shoot",
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.13.5",
+						KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+							KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+								FeatureGates: map[string]bool{
+									supportedfeatureGate1:   true,
+									unsupportedfeatureGate1: true,
+									supportedfeatureGate2:   false,
+								},
+							},
+						},
+						KubeControllerManager: &gardencorev1beta1.KubeControllerManagerConfig{
+							KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+								FeatureGates: map[string]bool{
+									supportedfeatureGate1:   true,
+									unsupportedfeatureGate1: true,
+									unsupportedfeatureGate2: false,
+								},
+							},
+						},
+						KubeScheduler: &gardencorev1beta1.KubeSchedulerConfig{
+							KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+								FeatureGates: map[string]bool{
+									supportedfeatureGate2:   true,
+									unsupportedfeatureGate1: true,
+								},
+							},
+						},
+						KubeProxy: &gardencorev1beta1.KubeProxyConfig{
+							KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+								FeatureGates: map[string]bool{
+									supportedfeatureGate1:   true,
+									supportedfeatureGate2:   false,
+									unsupportedfeatureGate2: true,
+								},
+							},
+						},
+						Kubelet: &gardencorev1beta1.KubeletConfig{
+							KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+								FeatureGates: map[string]bool{
+									supportedfeatureGate1:   true,
+									unsupportedfeatureGate2: true,
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should maintain feature gates", func() {
+			result := maintainFeatureGatesForShoot(shoot)
+			Expect(result).To(ConsistOf(
+				ContainSubstring("Feature gate %q is removed from %q, not supported in Kubernetes version %q", unsupportedfeatureGate1, "spec.kubernetes.kubeAPIServer.featureGates", "1.13.5"),
+				ContainSubstring("Feature gates: %s are removed from %q, not supported in Kubernetes version %q", fmt.Sprintf("%s, %s", unsupportedfeatureGate1, unsupportedfeatureGate2), "spec.kubernetes.kubeControllerManager.featureGates", "1.13.5"),
+				ContainSubstring("Feature gate %q is removed from %q, not supported in Kubernetes version %q", unsupportedfeatureGate1, "spec.kubernetes.kubeScheduler.featureGates", "1.13.5"),
+				ContainSubstring("Feature gate %q is removed from %q, not supported in Kubernetes version %q", unsupportedfeatureGate2, "spec.kubernetes.kubeProxy.featureGates", "1.13.5"),
+				ContainSubstring("Feature gate %q is removed from %q, not supported in Kubernetes version %q", unsupportedfeatureGate2, "spec.kubernetes.kubelet.featureGates", "1.13.5"),
+			))
+			Expect(shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates).To(Equal(map[string]bool{
+				supportedfeatureGate1: true,
+				supportedfeatureGate2: false,
+			}))
+			Expect(shoot.Spec.Kubernetes.KubeControllerManager.FeatureGates).To(Equal(map[string]bool{
+				supportedfeatureGate1: true,
+			}))
+			Expect(shoot.Spec.Kubernetes.KubeScheduler.FeatureGates).To(Equal(map[string]bool{
+				supportedfeatureGate2: true,
+			}))
+			Expect(shoot.Spec.Kubernetes.KubeProxy.FeatureGates).To(Equal(map[string]bool{
+				supportedfeatureGate1: true,
+				supportedfeatureGate2: false,
+			}))
+			Expect(shoot.Spec.Kubernetes.Kubelet.FeatureGates).To(Equal(map[string]bool{
+				supportedfeatureGate1: true,
+			}))
+		})
+	})
+
+	Describe("#MaintainAdmissionPlugins", func() {
+		var (
+			shoot                       *gardencorev1beta1.Shoot
+			supportedAdmissionPlugin1   = "admissionPlugin1"
+			supportedAdmissionPlugin2   = "admissionPlugin2"
+			unsupportedAdmissionPlugin1 = "admissionPlugin3"
+			unsupportedAdmissionPlugin2 = "admissionPlugin4"
+		)
+
+		BeforeEach(func() {
+			defer test.WithVar(
+				&IsAdmissionPluginSupported, isAdmissionPluginSupported,
+			)
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shoot",
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.13.5",
+						KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+							AdmissionPlugins: []gardencorev1beta1.AdmissionPlugin{
+								{
+									Name: supportedAdmissionPlugin1,
+								},
+								{
+									Name: supportedAdmissionPlugin2,
+								},
+								{
+									Name: unsupportedAdmissionPlugin1,
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should maintain admission plugins", func() {
+			result := maintainAdmissionPlugins(shoot)
+			Expect(result).To(ConsistOf(
+				ContainSubstring("Admission plugin %q is removed from %q, not supported in Kubernetes version %q", unsupportedAdmissionPlugin1, "spec.kubernetes.kubeAPIServer.admissionPlugins", "1.13.5"),
+			))
+			Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ConsistOf(
+				HaveField("Name", Equal(supportedAdmissionPlugin1)),
+				HaveField("Name", Equal(supportedAdmissionPlugin2)),
+			))
+		})
+
+		It("should maintain admission plugins - when there are more than one unsupported", func() {
+			shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = append(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins, gardencorev1beta1.AdmissionPlugin{Name: unsupportedAdmissionPlugin2})
+			result := maintainAdmissionPlugins(shoot)
+			Expect(result).To(ConsistOf(
+				ContainSubstring("Admission plugins: %s are removed from %q, not supported in Kubernetes version %q", fmt.Sprintf("%s, %s", unsupportedAdmissionPlugin1, unsupportedAdmissionPlugin2), "spec.kubernetes.kubeAPIServer.admissionPlugins", "1.13.5"),
+			))
+			Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ConsistOf(
+				HaveField("Name", Equal(supportedAdmissionPlugin1)),
+				HaveField("Name", Equal(supportedAdmissionPlugin2)),
+			))
+		})
+	})
 })
 
 func assertWorkerMachineImageVersion(worker *gardencorev1beta1.Worker, imageName string, imageVersion string) {
 	ExpectWithOffset(1, worker.Machine.Image.Name).To(Equal(imageName))
 	ExpectWithOffset(1, *worker.Machine.Image.Version).To(Equal(imageVersion))
+}
+
+func isFeatureGateSupported(featureGate, v string) (bool, error) {
+	featureGateVersionRanges := map[string]*featuresvalidation.FeatureGateVersionRange{
+		"featureGate1": {VersionRange: version.VersionRange{}},
+		"featureGate2": {VersionRange: version.VersionRange{AddedInVersion: "1.12", RemovedInVersion: "1.14"}},
+		"featureGate3": {VersionRange: version.VersionRange{RemovedInVersion: "1.13"}},
+		"featureGate4": {VersionRange: version.VersionRange{AddedInVersion: "1.9", RemovedInVersion: "1.13"}},
+	}
+
+	vr := featureGateVersionRanges[featureGate]
+	if vr == nil {
+		return false, fmt.Errorf("unknown feature gate %s", featureGate)
+	}
+
+	return vr.Contains(v)
+}
+
+func isAdmissionPluginSupported(plugin, v string) (bool, error) {
+	admissionPluginsVersionRanges := map[string]*admissionpluginsvalidation.AdmissionPluginVersionRange{
+		"admissionPlugin1": {VersionRange: version.VersionRange{AddedInVersion: "1.12", RemovedInVersion: "1.14"}},
+		"admissionPlugin2": {VersionRange: version.VersionRange{}},
+		"admissionPlugin3": {VersionRange: version.VersionRange{RemovedInVersion: "1.13"}},
+		"admissionPlugin4": {VersionRange: version.VersionRange{AddedInVersion: "1.8", RemovedInVersion: "1.13"}},
+	}
+
+	vr := admissionPluginsVersionRanges[plugin]
+	if vr == nil {
+		return false, fmt.Errorf("unknown admission plugin %q", plugin)
+	}
+	return vr.Contains(v)
 }

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -1060,9 +1060,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			cloudProfile.Spec.Kubernetes.Versions[4].ExpirationDate = &expirationDateInThePast
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.1"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1078,9 +1078,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			// mark latest version 1.02 as preview
 			cloudProfile.Spec.Kubernetes.Versions[3].Classification = &previewClassification
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).To(Not(HaveOccurred()))
@@ -1092,9 +1092,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			cloudProfile.Spec.Kubernetes.Versions[3].ExpirationDate = &expirationDateInThePast
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.2"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1106,9 +1106,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			cloudProfile.Spec.Kubernetes.Versions[3].ExpirationDate = &expirationDateInThePast
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.2"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1127,9 +1127,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			cloudProfile.Spec.Kubernetes.Versions[1].ExpirationDate = &expirationDateInThePast
 			cloudProfile.Spec.Kubernetes.Versions[2].ExpirationDate = &expirationDateInThePast
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1145,9 +1145,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			cloudProfile.Spec.Kubernetes.Versions[3].ExpirationDate = &expirationDateInThePast
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.2"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).To(HaveOccurred())
@@ -1157,9 +1157,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = true
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.1"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1171,9 +1171,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			cloudProfile.Spec.Kubernetes.Versions[4].ExpirationDate = &expirationDateInTheFuture
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.1"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1185,9 +1185,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = true
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.0"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1199,9 +1199,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = true
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.2"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1213,9 +1213,9 @@ var _ = Describe("Shoot Maintenance", func() {
 			cloudProfile.Spec.Kubernetes.Versions[3].ExpirationDate = &expirationDateInThePast
 			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.1.2"}
 
-			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) error {
+			_, err := maintainKubernetesVersion(log, shoot.Spec.Kubernetes.Version, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion, cloudProfile, func(v string) (string, error) {
 				shoot.Spec.Kubernetes.Version = v
-				return nil
+				return v, nil
 			})
 
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -1340,6 +1340,36 @@ var _ = Describe("Shoot Maintenance", func() {
 							},
 						},
 					},
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{
+							{
+								Name: "cpu-worker-1",
+								Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+									Kubelet: &gardencorev1beta1.KubeletConfig{
+										KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+											FeatureGates: map[string]bool{
+												supportedfeatureGate1:   true,
+												unsupportedfeatureGate2: true,
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "cpu-worker-2",
+								Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+									Kubelet: &gardencorev1beta1.KubeletConfig{
+										KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+											FeatureGates: map[string]bool{
+												supportedfeatureGate2:   true,
+												unsupportedfeatureGate1: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			}
 		})
@@ -1352,6 +1382,8 @@ var _ = Describe("Shoot Maintenance", func() {
 				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeScheduler.featureGates", "1.13.5", unsupportedfeatureGate1),
 				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeProxy.featureGates", "1.13.5", unsupportedfeatureGate2),
 				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubelet.featureGates", "1.13.5", unsupportedfeatureGate2),
+				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.provider.workers[0].kubernetes.kubelet.featureGates", "1.13.5", unsupportedfeatureGate2),
+				ContainSubstring("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", "spec.provider.workers[1].kubernetes.kubelet.featureGates", "1.13.5", unsupportedfeatureGate1),
 			))
 			Expect(shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates).To(Equal(map[string]bool{
 				supportedfeatureGate1: true,
@@ -1369,6 +1401,12 @@ var _ = Describe("Shoot Maintenance", func() {
 			}))
 			Expect(shoot.Spec.Kubernetes.Kubelet.FeatureGates).To(Equal(map[string]bool{
 				supportedfeatureGate1: true,
+			}))
+			Expect(shoot.Spec.Provider.Workers[0].Kubernetes.Kubelet.FeatureGates).To(Equal(map[string]bool{
+				supportedfeatureGate1: true,
+			}))
+			Expect(shoot.Spec.Provider.Workers[1].Kubernetes.Kubelet.FeatureGates).To(Equal(map[string]bool{
+				supportedfeatureGate2: true,
 			}))
 		})
 	})

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -1416,7 +1416,7 @@ var _ = Describe("Shoot Maintenance", func() {
 		})
 
 		It("should maintain admission plugins", func() {
-			result := maintainAdmissionPlugins(shoot)
+			result := maintainAdmissionPluginsForShoot(shoot)
 			Expect(result).To(ConsistOf(
 				ContainSubstring("Removed admission plugins from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeAPIServer.admissionPlugins", "1.13.5", fmt.Sprintf("%s, %s", unsupportedAdmissionPlugin1, unsupportedAdmissionPlugin2)),
 			))

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
@@ -26,7 +26,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -111,7 +111,7 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			botanist.Config = &config.GardenletConfiguration{
 				SNI: &config.SNI{
 					Ingress: &config.SNIIngress{
-						Namespace: pointer.String("istio-ingress"),
+						Namespace: ptr.To("istio-ingress"),
 						Labels:    map[string]string{"istio": "ingressgateway"},
 					},
 				},

--- a/pkg/utils/gardener/secretsrotation/etcd_test.go
+++ b/pkg/utils/gardener/secretsrotation/etcd_test.go
@@ -371,7 +371,6 @@ var _ = Describe("ETCD", func() {
 			))
 		})
 	})
-
 })
 
 type fakeDiscoveryWithServerPreferredResources struct {

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -570,6 +570,8 @@ build:
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
             - pkg/utils/timewindow
+            - pkg/utils/validation/admissionplugins
+            - pkg/utils/validation/features
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
             - third_party/gopkg.in/yaml.v2

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -305,6 +305,8 @@ build:
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
             - pkg/utils/timewindow
+            - pkg/utils/validation/admissionplugins
+            - pkg/utils/validation/features
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
             - third_party/gopkg.in/yaml.v2

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -1365,7 +1365,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 				Eventually(func(g Gomega) string {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 					g.Expect(shoot.Status.LastMaintenance).NotTo(BeNil())
-					g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Worker pool \"cpu-worker1\": Updated Kubernetes version from \"0.0.5\" to \"0.1.5\". Reason: Kubernetes version expired - force update required"))
+					g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Worker pool \"cpu-worker1\": Updated Kubernetes version from \"0.0.5\" to \"0.1.1\". Reason: Kubernetes version expired - force update required"))
 					g.Expect(shoot.Status.LastMaintenance.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
 					g.Expect(shoot.Status.LastMaintenance.TriggeredTime).To(Equal(metav1.Time{Time: fakeClock.Now()}))
 					return *shoot.Spec.Provider.Workers[0].Kubernetes.Version
@@ -1446,7 +1446,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 				Eventually(func(g Gomega) string {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot127), shoot127)).To(Succeed())
 					g.Expect(shoot127.Status.LastMaintenance).NotTo(BeNil())
-					g.Expect(shoot127.Status.LastMaintenance.Description).To(ContainSubstring("Worker pool \"cpu-worker1\": Updated Kubernetes version from \"1.27.5\" to \"1.28.5\". Reason: Kubernetes version expired - force update required"))
+					g.Expect(shoot127.Status.LastMaintenance.Description).To(ContainSubstring("Worker pool \"cpu-worker1\": Updated Kubernetes version from \"1.27.5\" to \"1.28.1\". Reason: Kubernetes version expired - force update required"))
 					g.Expect(shoot127.Status.LastMaintenance.Description).To(ContainSubstring(" Removed feature gates from \"spec.provider.workers[0].kubernetes.kubelet.featureGates\" because they are not supported in Kubernetes version \"1.28.1\": AdvancedAuditing, CSIStorageCapacity"))
 					g.Expect(shoot127.Spec.Provider.Workers[0].Kubernetes.Kubelet.FeatureGates).To(Equal(map[string]bool{
 						supportedfeatureGate1: true,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
If the shoot contains feature gates or admission plugins which are supported in the current version, but when the maintenance controller tries to force upgrade the kubernetes version to the next minor version, they might no longer be supported.
This causes errors like:
```
Maintenance last triggered on: Feb 28, 2024 6:13 PM
Result: Failed
Last action: Maintenance failed
Failure reason: Updates to the Shoot failed to be applied: Shoot.core.gardener.cloud "shoot" is invalid: [spec.kubernetes.kubeAPIServer.featureGates.TTLAfterFinished: Forbidden: not supported in Kubernetes version 1.25.16, spec.kubernetes.kubeControllerManager.featureGates.TTLAfterFinished: Forbidden: not supported in Kubernetes version 1.25.16]
```

This PR enhances the maintenance controller to remove unsupported feature gates and admission plugins from the Shoot spec during force upgrade.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The Shoot maintenance controller now removes unsupported feature gates and admission plugins from the Shoot during force upgrades.
```
