### PR TITLE
Unbundle `renovate` updates in `hack/tools.mk`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,11 +49,6 @@
       "matchPackagePatterns": ["golang"],
     },
     {
-      // Group tool updates in one PR.
-      "groupName": "Update tools",
-      "matchFileNames": ["hack\/tools\\.mk"]
-    },
-    {
       // Only patch level updates for golang-test image. Minor and major versions are updated manually.
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["major", "minor"],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR unbundles updates in `hack/tools.mk`. This way it is easier to skip single bad releases like skaffold in https://github.com/gardener/gardener/pull/9331.
For the initial update storm the bundling reduced the number of PRs, but now the tools are released independently anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
