### PR TITLE
Add renovate configuration for external imagevector container images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,6 +89,17 @@
       "enabled": false
     },
     {
+      // Update only patchlevels container images of istio.
+      // Minor and major upgrades most likely require manual adaptations of the code.
+      "matchDatasources": ["docker", "github-releases"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchPackagePatterns": [
+        "gcr\\.io\/istio-release\/.+",
+        "istio\/istio"
+      ],
+      "enabled": false
+    },
+    {
       // Ignore dependency updates from github.com/gardener because these PRs are created by pipeline jobs.
       "matchDatasources": ["go"],
       "matchPackagePatterns": ["github\\.com\/gardener\/.+"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -112,20 +112,6 @@
           "third_party/**"
       ],
       "enabled": false
-    },
-    {
-      // Ignore dependency updates from europe-docker.pkg.dev/gardener-project/releases/gardener/ because these PRs are created by pipeline jobs.
-      "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["europe-docker\\.pkg\\.dev\/gardener-project\/releases\/gardener\/.+"],
-      "matchFileNames": ["imagevector\/images\\.yaml"],
-      "enabled": false
-    },
-    {
-      // Ignore dependency updates from gardener/* because these PRs are created by pipeline jobs.
-      "matchDatasources": ["github-releases"],
-      "matchPackagePatterns": ["gardener\/.+"],
-      "matchFileNames": ["imagevector\/images\\.yaml"],
-      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -114,13 +114,6 @@
       "enabled": false
     },
     {
-      // Only patch level updates for container images in the imagevector. Minor and major versions are updated manually.
-      "matchDatasources": ["docker", "github-releases"],
-      "matchUpdateTypes": ["major", "minor"],
-      "matchFileNames": ["imagevector\/images\\.yaml"],
-      "enabled": false
-    },
-    {
       // Ignore dependency updates from europe-docker.pkg.dev/gardener-project/releases/gardener/ because these PRs are created by pipeline jobs.
       "matchDatasources": ["docker"],
       "matchPackagePatterns": ["europe-docker\\.pkg\\.dev\/gardener-project\/releases\/gardener\/.+"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,11 +40,18 @@
       "datasourceTemplate": "docker"
     },
     {
-      // Generic detection of container images in images.yaml.
+      // Generic detection of container images in images.yaml via container registry.
       "customType": "regex",
       "fileMatch": ["^imagevector\/images.yaml$"],
       "matchStrings": ["\\s+repository:\\s+(?<depName>.*?)\\n\\s+tag:\\s+[\"]?(?<currentValue>.*?)[\"]?\\n"],
       "datasourceTemplate": "docker"
+    },
+    {
+      // Generic detection of container images in images.yaml via github releases.
+      "customType": "regex",
+      "fileMatch": ["^imagevector\/images.yaml$"],
+      "matchStrings": ["\\s+sourceRepository:\\s+github.com\/(?<depName>.*?)\\n\\s+repository:\\s+.*\\n\\s+tag:\\s+[\"]?(?<currentValue>.*?)[\"]?\\n"],
+      "datasourceTemplate": "github-releases"
     }
   ],
   "separateMinorPatch": true,
@@ -108,7 +115,7 @@
     },
     {
       // Only patch level updates for container images in the imagevector. Minor and major versions are updated manually.
-      "matchDatasources": ["docker"],
+      "matchDatasources": ["docker", "github-releases"],
       "matchUpdateTypes": ["major", "minor"],
       "matchFileNames": ["imagevector\/images\\.yaml"],
       "enabled": false
@@ -117,6 +124,13 @@
       // Ignore dependency updates from europe-docker.pkg.dev/gardener-project/releases/gardener/ because these PRs are created by pipeline jobs.
       "matchDatasources": ["docker"],
       "matchPackagePatterns": ["europe-docker\\.pkg\\.dev\/gardener-project\/releases\/gardener\/.+"],
+      "matchFileNames": ["imagevector\/images\\.yaml"],
+      "enabled": false
+    },
+    {
+      // Ignore dependency updates from gardener/* because these PRs are created by pipeline jobs.
+      "matchDatasources": ["github-releases"],
+      "matchPackagePatterns": ["gardener\/.+"],
       "matchFileNames": ["imagevector\/images\\.yaml"],
       "enabled": false
     }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,6 +94,8 @@
       "matchDatasources": ["docker", "github-releases"],
       "matchUpdateTypes": ["major", "minor"],
       "matchPackagePatterns": [
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/gardener\/autoscaler\/cluster-autoscaler",
+        "gardener\/autoscaler",
         "gcr\\.io\/istio-release\/.+",
         "istio\/istio"
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,12 +100,6 @@
       "enabled": false
     },
     {
-      // Ignore dependency updates from github.com/gardener because these PRs are created by pipeline jobs.
-      "matchDatasources": ["go"],
-      "matchPackagePatterns": ["github\\.com\/gardener\/.+"],
-      "enabled": false
-    },
-    {
       // Ignore dependency updates from k8s.io/kube-openapi because it depends on k8s.io/apiserver.
       "matchDatasources": ["go"],
       "matchPackagePatterns": ["k8s\\.io\/kube-openapi"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,13 @@
       "fileMatch": ["^hack\/.+\\.sh$"],
       "matchStrings": ["--image[=| ][\"|']?(?<depName>.*?):(?<currentValue>.*?)[\"|']?\\s"],
       "datasourceTemplate": "docker"
+    },
+    {
+      // Generic detection of container images in images.yaml.
+      "customType": "regex",
+      "fileMatch": ["^imagevector\/images.yaml$"],
+      "matchStrings": ["\\s+repository:\\s+(?<depName>.*?)\\n\\s+tag:\\s+[\"]?(?<currentValue>.*?)[\"]?\\n"],
+      "datasourceTemplate": "docker"
     }
   ],
   "separateMinorPatch": true,
@@ -97,6 +104,20 @@
           "test/**",
           "third_party/**"
       ],
+      "enabled": false
+    },
+    {
+      // Only patch level updates for container images in the imagevector. Minor and major versions are updated manually.
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchFileNames": ["imagevector\/images\\.yaml"],
+      "enabled": false
+    },
+    {
+      // Ignore dependency updates from europe-docker.pkg.dev/gardener-project/releases/gardener/ because these PRs are created by pipeline jobs.
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["europe-docker\\.pkg\\.dev\/gardener-project\/releases\/gardener\/.+"],
+      "matchFileNames": ["imagevector\/images\\.yaml"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Add renovate configuration for external `imagevector` container images.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
The regular expression assumes that `repository` and `tag` are in lines following each other, which seems to be the normal way, but is not enforced in any way.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
