### PR TITLE
Enhance `shoot-care` controller with additional checks related to actions of `dependency-watchdog-prober`

### DIFF
--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
@@ -62,11 +62,6 @@ const (
 	configFileName                 = "dep-config.yaml"
 	dwdWeederDefaultLockObjectName = "dwd-weeder-leader-election"
 	dwdProberDefaultLockObjectName = "dwd-prober-leader-election"
-
-	// ManagedResourceDependencyWatchdogWeeder is the name of the dependency-watchdog-weeder managed resource.
-	ManagedResourceDependencyWatchdogWeeder = prefixDependencyWatchdog + "-weeder"
-	// ManagedResourceDependencyWatchdogProber is the name of the dependency-watchdog-prober managed resource.
-	ManagedResourceDependencyWatchdogProber = prefixDependencyWatchdog + "-prober"
 )
 
 // BootstrapperValues contains dependency-watchdog values.

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -445,7 +445,6 @@ func (h *Health) checkControlPlane(
 func CheckIfDependencyWatchdogProberScaledDownControllers(ctx context.Context, seedClient client.Client, shootNamespace string) ([]string, error) {
 	var scaledDownDeploymentNames []string
 
-	// Error is ignored since this function never returns an error
 	proberConfig, err := kubeapiserver.NewDependencyWatchdogProberConfiguration()
 	if err != nil {
 		return nil, fmt.Errorf("failed getting dependency-watchdog-prober config: %w", err)
@@ -795,7 +794,7 @@ func CheckNodeAgentLeases(nodeList *corev1.NodeList, leaseList *coordinationv1.L
 // an error will be returned. The motivation is that dependency-watchdog is starting to scale down controllers when 60%
 // of the Leases are expired.
 func CheckForExpiredNodeLeases(nodeList *corev1.NodeList, leaseList *coordinationv1.LeaseList, clock clock.Clock) error {
-	if len(leaseList.Items) == 0 {
+	if len(leaseList.Items) == 0 || len(nodeList.Items) == 0 {
 		return nil
 	}
 
@@ -814,7 +813,7 @@ func CheckForExpiredNodeLeases(nodeList *corev1.NodeList, leaseList *coordinatio
 	}
 
 	if expiredLeasesPercentage := 100 * expiredLeases / len(leaseList.Items); expiredLeasesPercentage >= 20 {
-		return fmt.Errorf("%d%% of all Leases in %s namespace are expired - dependency-watchdog-prober will start scaling down controllers if 60%% are reached", expiredLeasesPercentage, corev1.NamespaceNodeLease)
+		return fmt.Errorf("%d%% of all Leases in %s namespace are expired - dependency-watchdog-prober will start scaling down controllers when 60%% is reached", expiredLeasesPercentage, corev1.NamespaceNodeLease)
 	}
 
 	return nil

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -817,7 +817,7 @@ func CheckForExpiredNodeLeases(nodeList *corev1.NodeList, leaseList *coordinatio
 	}
 
 	if expiredLeasesPercentage := 100 * expiredLeases / len(leaseList.Items); expiredLeasesPercentage >= 20 {
-		return fmt.Errorf("%d%% of all Leases in %s namespace are expired - dependency-watchdog-prober will start scaling down controllers when 60%% is reached", expiredLeasesPercentage, corev1.NamespaceNodeLease)
+		return fmt.Errorf("%d%% of all Leases in %s namespace are expired - dependency-watchdog-prober might start scaling down controllers", expiredLeasesPercentage, corev1.NamespaceNodeLease)
 	}
 
 	return nil

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -146,6 +146,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			updatedConditions = NewHealthCheck(
 				log,
 				o.Shoot,
+				o.Seed,
 				r.SeedClientSet,
 				r.GardenClient,
 				initializeShootClients,

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -43,6 +43,7 @@ import (
 	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -522,6 +523,7 @@ func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {
 	return func(
 		_ logr.Logger,
 		_ *shootpkg.Shoot,
+		_ *seedpkg.Seed,
 		_ kubernetes.Interface,
 		_ client.Client,
 		_ ShootClientInit,

--- a/pkg/gardenlet/controller/shoot/care/types.go
+++ b/pkg/gardenlet/controller/shoot/care/types.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 )
 
@@ -41,6 +42,7 @@ type HealthCheck interface {
 type NewHealthCheckFunc func(
 	logger logr.Logger,
 	shoot *shoot.Shoot,
+	seed *seed.Seed,
 	seedClient kubernetes.Interface,
 	gardenClient client.Client,
 	shootClientInit ShootClientInit,
@@ -53,6 +55,7 @@ type NewHealthCheckFunc func(
 var defaultNewHealthCheck NewHealthCheckFunc = func(
 	log logr.Logger,
 	shoot *shoot.Shoot,
+	seed *seed.Seed,
 	seedClientSet kubernetes.Interface,
 	gardenClient client.Client,
 	shootClientInit ShootClientInit,
@@ -63,6 +66,7 @@ var defaultNewHealthCheck NewHealthCheckFunc = func(
 	return NewHealth(
 		log,
 		shoot,
+		seed,
 		seedClientSet,
 		gardenClient,
 		shootClientInit,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/9072, `dependency-watchdog-prober` considers `Lease` objects related to nodes in the `kube-node-lease` namespace. If at least 60% of them are expired, it starts scaling down controllers as defined in https://github.com/gardener/gardener/blob/8f03dfcaaddafe8b58e39592c907852e8f2cffac/pkg/component/kubernetes/apiserver/dependency_watchdog.go#L56-L101

This PR extends the `shoot-care` controller with two checks:

- `ControlPlaneHealthy` condition now checks if the relevant controllers have been scaled down to `0` replicas (previously, this wasn't visible at all). An example condition would look like this:
   ```yaml
   status:
     conditions:
     - lastTransitionTime: "2024-03-13T13:07:31Z"
       lastUpdateTime: "2024-03-13T13:06:31Z"
       message: 'The following deployments have been scaled down to 0 replicas (perhaps
         by dependency-watchdog-prober): kube-controller-manager, machine-controller-manager,
         cluster-autoscaler'
       reason: ControllersScaledDown
       status: "False"
       type: ControlPlaneHealthy
   ```
- `EveryNodeReady` condition now checks if the percentage of expired `Lease`s is 20% or higher (previously, this wasn't visible at all). An example condition would look like this:
   ```yaml
   status:
     conditions:
     - lastTransitionTime: "2024-03-13T14:52:17Z"
       lastUpdateTime: "2024-03-13T14:51:47Z"
       message: 90% of all Leases in kube-node-lease namespace are expired - dependency-watchdog-prober
         will start scaling down controllers if 60% are reached
       reason: TooManyExpiredNodeLeases
       status: "False"
       type: EveryNodeReady
   ```

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9072

**Special notes for your reviewer**:
/cc @ScheererJ @rishabh-11 @aaronfern 
FYI @BeckerMax @adenitiu @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `ControlPlaneHealthy` condition in `Shoot`s now reports an issue when `{kube,machine}-controller-manager` or `cluster-autoscaler` are scaled down to `0` replicas. The `EveryNodeReady` condition in `Shoot`s now reports an issue when at least `20%` of the `Lease`s related to nodes in the `kube-node-lease` namespace are expired.
```
