### PR TITLE
[GEP-19] Remove the additional matcher from the Alertmanager config

### DIFF
--- a/pkg/component/observability/monitoring/alertmanager/alertmanager.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager.go
@@ -64,6 +64,7 @@ func (a *alertManager) alertManager(takeOverOldPV bool) *monitoringv1.Alertmanag
 			},
 			AlertmanagerConfigSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"alertmanager": a.values.Name}},
 			AlertmanagerConfigNamespaceSelector: &metav1.LabelSelector{},
+			AlertmanagerConfigMatcherStrategy:   monitoringv1.AlertmanagerConfigMatcherStrategy{Type: "None"},
 			LogLevel:                            "info",
 			ForceEnableClusterMode:              true,
 		},

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -206,6 +206,7 @@ var _ = Describe("Alertmanager", func() {
 				},
 				AlertmanagerConfigSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"alertmanager": name}},
 				AlertmanagerConfigNamespaceSelector: &metav1.LabelSelector{},
+				AlertmanagerConfigMatcherStrategy:   monitoringv1.AlertmanagerConfigMatcherStrategy{Type: "None"},
 				LogLevel:                            "info",
 				ForceEnableClusterMode:              true,
 				AlertmanagerConfiguration:           &monitoringv1.AlertmanagerConfiguration{Name: "alertmanager-" + name},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:

The default `AlertmanagerConfigMatcherStrategy` is `OnNamespace` and hence the prometheus operator injects a label matcher matching the namespace of the `AlertmanagerConfig` object for all its routes and inhibition rules.

This is not desired in our use cases (shoot, seed, garden alertmanagers).

This configuration option should be set to `None`: then the operator will not add any additional matchers other than the ones specified in the `AlertmanagerConfig`.

https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.AlertmanagerConfigMatcherStrategy



**Which issue(s) this PR fixes**:

Fixes an issue that the generated alertmanager configuration contained an unexpected route node with a matcher that in same cases prevented the expected processing of the alerts.

Part of #9065
Related to #9159, #9257 and #9301

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A configuration issue of the prometheus-operator managed alertmanager instances is fixed.
```
