### PR TITLE
Adds common label key to the observability applications

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -525,6 +525,9 @@ const (
 	// cluster which can be used to describe that this ClusterRole contains custom permissions for extensions.
 	LabelAuthorizationCustomExtensionsPermissions = "authorization.gardener.cloud/custom-extensions-permissions"
 
+	// LabelObservabilityApplication is a constant for a label key set to all observability applications in gardener exposing a public endpoint.
+	LabelObservabilityApplication = "observability.gardener.cloud/app"
+
 	// LabelApp is a constant for a label key.
 	LabelApp = "app"
 	// LabelRole is a constant for a label key.

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -306,7 +306,9 @@ func (v *vali) getHVPA() *hvpav1alpha1.Hvpa {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      valiName,
 				Namespace: v.namespace,
-				Labels:    getLabels(),
+				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+					v1beta1constants.LabelObservabilityApplication: valiName,
+				}),
 			},
 			Spec: hvpav1alpha1.HvpaSpec{
 				Replicas: ptr.To(v.values.Replicas),
@@ -627,7 +629,9 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: getLabels(),
+						Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+							v1beta1constants.LabelObservabilityApplication: valiName,
+						}),
 					},
 					Spec: corev1.PodSpec{
 						AutomountServiceAccountToken: ptr.To(false),

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -17,8 +17,6 @@ package vali_test
 import (
 	"context"
 	"fmt"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -41,11 +39,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/component/observability/logging/vali"
 	"github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -17,6 +17,8 @@ package vali_test
 import (
 	"context"
 	"fmt"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -1044,7 +1046,9 @@ func getHVPA(isRBACProxyEnabled bool) *hvpav1alpha1.Hvpa {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      valiName,
 			Namespace: namespace,
-			Labels:    getLabels(),
+			Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+				v1beta1constants.LabelObservabilityApplication: valiName,
+			}),
 		},
 		Spec: hvpav1alpha1.HvpaSpec{
 			Replicas: ptr.To(int32(1)),
@@ -1262,7 +1266,9 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: getLabels(),
+					Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+						v1beta1constants.LabelObservabilityApplication: valiName,
+					}),
 				},
 				Spec: corev1.PodSpec{
 					PriorityClassName:            priorityClassName,

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager.go
@@ -39,7 +39,7 @@ func (a *alertManager) alertManager(takeOverOldPV bool) *monitoringv1.Alertmanag
 					v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 					v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 					v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
-					v1beta1constants.LabelObservabilityApplication:       a.values.Name,
+					v1beta1constants.LabelObservabilityApplication:       a.name(),
 				}),
 			},
 			PriorityClassName: a.values.PriorityClassName,

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager.go
@@ -39,6 +39,7 @@ func (a *alertManager) alertManager(takeOverOldPV bool) *monitoringv1.Alertmanag
 					v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 					v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 					v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
+					v1beta1constants.LabelObservabilityApplication:       a.values.Name,
 				}),
 			},
 			PriorityClassName: a.values.PriorityClassName,

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -221,6 +221,7 @@ var _ = Describe("Alertmanager", func() {
 					"component":    "alertmanager",
 					"role":         "monitoring",
 					"alertmanager": name,
+					v1beta1constants.LabelObservabilityApplication: name,
 				},
 			},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Alertmanager", func() {
 						"networking.gardener.cloud/to-dns": "allowed",
 						"networking.gardener.cloud/to-public-networks":  "allowed",
 						"networking.gardener.cloud/to-private-networks": "allowed",
-						v1beta1constants.LabelObservabilityApplication:  name,
+						v1beta1constants.LabelObservabilityApplication:  "alertmanager-" + name,
 					},
 				},
 				PriorityClassName: priorityClassName,
@@ -221,7 +221,7 @@ var _ = Describe("Alertmanager", func() {
 					"component":    "alertmanager",
 					"role":         "monitoring",
 					"alertmanager": name,
-					v1beta1constants.LabelObservabilityApplication: name,
+					v1beta1constants.LabelObservabilityApplication: "alertmanager-" + name,
 				},
 			},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -181,6 +181,7 @@ var _ = Describe("Alertmanager", func() {
 						"networking.gardener.cloud/to-dns": "allowed",
 						"networking.gardener.cloud/to-public-networks":  "allowed",
 						"networking.gardener.cloud/to-private-networks": "allowed",
+						v1beta1constants.LabelObservabilityApplication:  name,
 					},
 				},
 				PriorityClassName: priorityClassName,

--- a/pkg/component/observability/monitoring/alertmanager/vpa.go
+++ b/pkg/component/observability/monitoring/alertmanager/vpa.go
@@ -34,7 +34,8 @@ func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 			Name:      a.name(),
 			Namespace: a.namespace,
 			Labels: utils.MergeStringMaps(a.getLabels(), map[string]string{
-				v1beta1constants.LabelObservabilityApplication: a.values.Name}),
+				v1beta1constants.LabelObservabilityApplication: a.name(),
+			}),
 		},
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{

--- a/pkg/component/observability/monitoring/alertmanager/vpa.go
+++ b/pkg/component/observability/monitoring/alertmanager/vpa.go
@@ -15,6 +15,8 @@
 package alertmanager
 
 import (
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,7 +32,8 @@ func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      a.name(),
 			Namespace: a.namespace,
-			Labels:    a.getLabels(),
+			Labels: utils.MergeStringMaps(a.getLabels(), map[string]string{
+				v1beta1constants.LabelObservabilityApplication: a.values.Name}),
 		},
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{

--- a/pkg/component/observability/monitoring/alertmanager/vpa.go
+++ b/pkg/component/observability/monitoring/alertmanager/vpa.go
@@ -15,14 +15,15 @@
 package alertmanager
 
 import (
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {

--- a/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: prometheus
     role: monitoring
+    observability.gardener.cloud/app: "prometheus"
 spec:
   targetRef:
     apiVersion: apps/v1
@@ -28,4 +29,3 @@ spec:
       controlledValues: RequestsOnly
     - containerName: prometheus-config-reloader
       mode: "Off"
-

--- a/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: prometheus
     role: monitoring
-    observability.gardener.cloud/app: "prometheus"
+    observability.gardener.cloud/app: "prometheus-shoot"
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -72,7 +72,7 @@ spec:
         # TODO(rfranzke): Remove this label after v1.91 has been released.
         networking.resources.gardener.cloud/to-garden-prometheus-web-tcp-9090: allowed
         networking.resources.gardener.cloud/to-garden-alertmanager-client-tcp-9093: allowed
-        observability.gardener.cloud/app: "prometheus"
+        observability.gardener.cloud/app: "prometheus-shoot"
     spec:
       # used to talk to Seed's API server.
       serviceAccountName: prometheus

--- a/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -72,6 +72,7 @@ spec:
         # TODO(rfranzke): Remove this label after v1.91 has been released.
         networking.resources.gardener.cloud/to-garden-prometheus-web-tcp-9090: allowed
         networking.resources.gardener.cloud/to-garden-alertmanager-client-tcp-9093: allowed
+        observability.gardener.cloud/app: "prometheus"
     spec:
       # used to talk to Seed's API server.
       serviceAccountName: prometheus

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -52,7 +52,7 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 						v1beta1constants.LabelNetworkPolicyToDNS:                                                         v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                                            v1beta1constants.LabelNetworkPolicyAllowed,
 						"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets: v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelObservabilityApplication:                                                   p.values.Name,
+						v1beta1constants.LabelObservabilityApplication:                                                   p.name(),
 					}, p.values.AdditionalPodLabels),
 				},
 				PriorityClassName: p.values.PriorityClassName,

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -52,6 +52,7 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 						v1beta1constants.LabelNetworkPolicyToDNS:                                                         v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                                            v1beta1constants.LabelNetworkPolicyAllowed,
 						"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets: v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelObservabilityApplication:                                                   p.values.Name,
 					}, p.values.AdditionalPodLabels),
 				},
 				PriorityClassName: p.values.PriorityClassName,

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -224,7 +224,7 @@ honor_labels: true`
 								"networking.gardener.cloud/to-dns": "allowed",
 								"networking.gardener.cloud/to-runtime-apiserver":                 "allowed",
 								"networking.resources.gardener.cloud/to-all-seed-scrape-targets": "allowed",
-								v1beta1constants.LabelObservabilityApplication:                   name,
+								v1beta1constants.LabelObservabilityApplication:                   "prometheus-" + name,
 							},
 						},
 						PriorityClassName: priorityClassName,
@@ -291,7 +291,7 @@ honor_labels: true`
 					"app":  "prometheus",
 					"role": "monitoring",
 					"name": name,
-					v1beta1constants.LabelObservabilityApplication: name,
+					v1beta1constants.LabelObservabilityApplication: "prometheus-" + name,
 				},
 			},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -291,6 +291,7 @@ honor_labels: true`
 					"app":  "prometheus",
 					"role": "monitoring",
 					"name": name,
+					v1beta1constants.LabelObservabilityApplication: name,
 				},
 			},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -224,6 +224,7 @@ honor_labels: true`
 								"networking.gardener.cloud/to-dns": "allowed",
 								"networking.gardener.cloud/to-runtime-apiserver":                 "allowed",
 								"networking.resources.gardener.cloud/to-all-seed-scrape-targets": "allowed",
+								v1beta1constants.LabelObservabilityApplication:                   name,
 							},
 						},
 						PriorityClassName: priorityClassName,

--- a/pkg/component/observability/monitoring/prometheus/vpa.go
+++ b/pkg/component/observability/monitoring/prometheus/vpa.go
@@ -35,7 +35,8 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 			Name:      p.name(),
 			Namespace: p.namespace,
 			Labels: utils.MergeStringMaps(p.getLabels(), map[string]string{
-				v1beta1constants.LabelObservabilityApplication: p.values.Name}),
+				v1beta1constants.LabelObservabilityApplication: p.name(),
+			}),
 		},
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{

--- a/pkg/component/observability/monitoring/prometheus/vpa.go
+++ b/pkg/component/observability/monitoring/prometheus/vpa.go
@@ -15,8 +15,6 @@
 package prometheus
 
 import (
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +22,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {

--- a/pkg/component/observability/monitoring/prometheus/vpa.go
+++ b/pkg/component/observability/monitoring/prometheus/vpa.go
@@ -15,6 +15,8 @@
 package prometheus
 
 import (
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,7 +33,8 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.name(),
 			Namespace: p.namespace,
-			Labels:    p.getLabels(),
+			Labels: utils.MergeStringMaps(p.getLabels(), map[string]string{
+				v1beta1constants.LabelObservabilityApplication: p.values.Name}),
 		},
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -814,6 +814,7 @@ func convertToCompactJSON(data map[string]string) (map[string]string, error) {
 
 func (p *plutono) getPodLabels() map[string]string {
 	labels := map[string]string{
+		v1beta1constants.LabelObservabilityApplication:                                      name,
 		v1beta1constants.LabelNetworkPolicyToDNS:                                            v1beta1constants.LabelNetworkPolicyAllowed,
 		gardenerutils.NetworkPolicyLabel(valiconstants.ServiceName, valiconstants.ValiPort): v1beta1constants.LabelNetworkPolicyAllowed,
 	}

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -826,6 +826,7 @@ func getLabels() map[string]string {
 
 func getPodLabels(values Values) map[string]string {
 	labels := map[string]string{
+		v1beta1constants.LabelObservabilityApplication:    "plutono",
 		v1beta1constants.LabelNetworkPolicyToDNS:          v1beta1constants.LabelNetworkPolicyAllowed,
 		gardenerutils.NetworkPolicyLabel("logging", 3100): v1beta1constants.LabelNetworkPolicyAllowed,
 	}


### PR DESCRIPTION
/area logging
/area monitoring
/kind enhancement

This PR adds `observability.gardener.cloud/app` label to the observability applications. The purpose of the label is to be used at the objectSelector in the `oidc-apps-controller` webhook definition. In this way we achieve explicit pod targeting by the mutating webhook. 

```other developer
Now the observability applications which are also targets of the authentication & authorization proxies share common label. 
```
