### PR TITLE
[GEP-19] Fix the match expression in the alertmanager configuration

### DIFF
--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -264,7 +264,7 @@ var _ = Describe("Alertmanager", func() {
 					GroupInterval:  "5m",
 					RepeatInterval: "72h",
 					Receiver:       "dev-null",
-					Routes:         []apiextensionsv1.JSON{{Raw: []byte(`{"match_re":{"visibility":"^(all|operator)$"},"receiver":"email-kubernetes-ops"}`)}},
+					Routes:         []apiextensionsv1.JSON{{Raw: []byte(`{"matchers": [{"name": "visibility", "matchType": "=~", "value": "all|operator"}], "receiver": "email-kubernetes-ops"}`)}},
 				},
 				InhibitRules: []monitoringv1alpha1.InhibitRule{
 					{
@@ -568,7 +568,7 @@ var _ = Describe("Alertmanager", func() {
 				service.Annotations = map[string]string{"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":9093}]`}
 				alertManager.Labels["gardener.cloud/role"] = "monitoring"
 				alertManager.Spec.PodMetadata.Labels["gardener.cloud/role"] = "monitoring"
-				config.Spec.Route.Routes[0].Raw = []byte(`{"match_re":{"visibility":"^(all|owner)$"},"receiver":"email-kubernetes-ops"}`)
+				config.Spec.Route.Routes[0].Raw = []byte(`{"matchers": [{"name": "visibility", "matchType": "=~", "value": "all|owner"}], "receiver":"email-kubernetes-ops"}`)
 			})
 
 			It("should successfully deploy all resources", func() {

--- a/pkg/component/observability/monitoring/alertmanager/config.go
+++ b/pkg/component/observability/monitoring/alertmanager/config.go
@@ -62,7 +62,11 @@ func (a *alertManager) config() *monitoringv1alpha1.AlertmanagerConfig {
 				// Send alerts by default to nowhere
 				Receiver: "dev-null",
 				// email only for critical and blocker
-				Routes: []apiextensionsv1.JSON{{Raw: []byte(`{"match_re":{"visibility":"^(all|` + visibility + `)$"},"receiver":"` + emailReceiverName + `"}`)}},
+				Routes: []apiextensionsv1.JSON{{Raw: []byte(`
+				  {"matchers": [{"name": "visibility",
+				                 "matchType": "=~",
+				                 "value": "all|` + visibility + `"}],
+				   "receiver": "` + emailReceiverName + `"}`)}},
 			},
 			InhibitRules: []monitoringv1alpha1.InhibitRule{
 				// Apply inhibition if the alert name is the same.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area monitoring
/kind regression

**What this PR does / why we need it**:

The type of `AlertmanagerConfigSpec.Route.Routes` is intended to be a self referential type, ie. the type of `AlertmanagerConfigSpec.Route` itself.

Based on the comment here:

https://github.com/prometheus-operator/prometheus-operator/blob/07e4267d65e59adf503a352a08c6faead527540d/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go#L121-L129

there is a limitation in the CRD schema such that this type constraint can not be expressed and the generic JSON type is used instead for `AlertmanagerConfigSpec.Route.Routes`.

This means that the compiler can not help with checking the field names of `AlertmanagerConfigSpec.Route.Routes`.

It turns out that the old and deprecated Alertmanager configuration `match_re` that was migrated in #9159 does not exist on the `AlertmanagerConfigSpec` abstraction level. It is expected because it is a deprecated field and `matchers` should be used instead.

https://prometheus.io/docs/alerting/latest/configuration/#route

In the current implementation, the superfluous `match_re` field is not considered silently, so the resulting route does not have any match filter expressions. This means that although this is not the intended behavior, the impact was more forwarded alerts (which is better) and not fewer or no forwarded alerts at all.

This commit uses the `matchers` field with the name, matchType and value fields instead.

**Which issue(s) this PR fixes**:

Fixes an issue that the generated alertmanager configuration did not contain the intended match expression.

Part of #9065
Related to #9159, #9257, #9301 and #9384

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A configuration issue of the prometheus-operator managed alertmanager instances is fixed.
```
