### PR TITLE
Fix kube-apiserver service exposure after replacement of ingress resources with direct istio exposure.

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -116,10 +116,10 @@ func (b *Botanist) DefaultKubeAPIServerIngress() component.Deployer {
 			ServiceName: v1beta1constants.DeploymentNameKubeAPIServer,
 			Host:        b.ComputeKubeAPIServerHost(),
 			IstioIngressGatewayLabelsFunc: func() map[string]string {
-				return b.IstioLabels()
+				return b.DefaultIstioLabels()
 			},
 			IstioIngressGatewayNamespaceFunc: func() string {
-				return b.IstioNamespace()
+				return b.DefaultIstioNamespace()
 			},
 		})
 }

--- a/pkg/gardenlet/operation/istio_config.go
+++ b/pkg/gardenlet/operation/istio_config.go
@@ -33,7 +33,12 @@ func (o *Operation) IstioServiceName() string {
 
 // IstioNamespace is the currently used namespace of the istio ingress gateway, which is responsible for the shoot cluster.
 func (o *Operation) IstioNamespace() string {
-	return o.addZonePinningIfRequired(*o.sniConfig().Ingress.Namespace)
+	return o.addZonePinningIfRequired(o.DefaultIstioNamespace())
+}
+
+// DefaultIstioNamespace is the default namespace of the istio ingress gateway disregarding zonal affinities of the shoot cluster.
+func (o *Operation) DefaultIstioNamespace() string {
+	return *o.sniConfig().Ingress.Namespace
 }
 
 // IstioLoadBalancerAnnotations contain the annotation to be used for the istio ingress service load balancer.
@@ -53,7 +58,15 @@ func (o *Operation) IstioLoadBalancerAnnotations() map[string]string {
 
 // IstioLabels contain the labels to be used for the istio ingress gateway entities.
 func (o *Operation) IstioLabels() map[string]string {
-	zone := o.singleZoneIfPinned()
+	return o.istioLabels(o.singleZoneIfPinned())
+}
+
+// DefaultIstioLabels contain the labels to be used for the default istio ingress gateway entities disregarding zonal affinities.
+func (o *Operation) DefaultIstioLabels() map[string]string {
+	return o.istioLabels(nil)
+}
+
+func (o *Operation) istioLabels(zone *string) map[string]string {
 	if exposureClassHandler := o.exposureClassHandler(); exposureClassHandler != nil {
 		return sharedcomponent.GetIstioZoneLabels(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassHandler.SNI.Ingress.Labels, exposureClassHandler.Name), zone)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix kube-apiserver service exposure after replacement of ingress resources with direct istio exposure.

The DNS wildcard entry for ingress domains pointing to nginx in the past now points to the default istio ingress gateway. Therefore, all ingress resources need to be exposed using the default istio ingress gateway. For single-zonal shoot clusters, this was no longer the case after the ingress resource replacement with istio resources. This caused the dashboard terminal to fail for those cluster, but succeed for highly- available shoot clusters.
This change fixes this issue by switching to the default istio ingress gateway for ingress domains.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9300

**Special notes for your reviewer**:
None.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The ingress domain of kube-apiserver should work again for single-zonal shoot control planes.
```

/cc @plkokanov @petersutter 