### PR TITLE
Improve `renovate` handling of `imagevector/images.yaml` updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,9 +58,15 @@
   "packageRules": [
     {
       // Group golang updates in one PR.
-      "groupName": "Update golang",
+      "groupName": "golang",
       "matchDatasources": ["docker", "go-version"],
       "matchPackagePatterns": ["golang"],
+    },
+    {
+      // Group istio image updates in one PR.
+      "groupName": "istio images",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["gcr\\.io\/istio-release\/.+"],
     },
     {
       // Only patch level updates for golang-test image. Minor and major versions are updated manually.
@@ -89,15 +95,39 @@
       "enabled": false
     },
     {
-      // Update only patchlevels container images of istio.
+      // Update only patchlevels container images of istio and cluster-autoscaler.
       // Minor and major upgrades most likely require manual adaptations of the code.
       "matchDatasources": ["docker", "github-releases"],
       "matchUpdateTypes": ["major", "minor"],
+      "matchFileNames": ["imagevector/**"],
       "matchPackagePatterns": [
-        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/gardener\/autoscaler\/cluster-autoscaler",
         "gardener\/autoscaler",
         "gcr\\.io\/istio-release\/.+",
-        "istio\/istio"
+      ],
+      "enabled": false
+    },
+    {
+      // Do not use docker for images from gardener registry except those which do not work with github-releases.
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["imagevector/**"],
+      "matchPackagePatterns": [
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/.+"
+      ],
+      "excludePackagePatterns": [
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/alpine",
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubernetesui\/.+",
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubesphere\/.+"
+      ],
+      "enabled": false
+    },
+    {
+      // Do not use github-releases for external dependencies except those we copy.
+      "matchDatasources": ["github-releases"],
+      "matchFileNames": ["imagevector/**"],
+      "excludePackagePatterns": [
+        "gardener\/.+",
+        "credativ\/.+",
+        "envoyproxy\/.+"
       ],
       "enabled": false
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,7 +95,7 @@
       "enabled": false
     },
     {
-      // Update only patchlevels container images of istio and cluster-autoscaler.
+      // Update only patch levels container images of istio and cluster-autoscaler.
       // Minor and major upgrades most likely require manual adaptations of the code.
       "matchDatasources": ["docker", "github-releases"],
       "matchUpdateTypes": ["major", "minor"],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR is a follow up to #9370 and improves the update of dependencies in `imagevector/images.yaml` file.
After #9370 `renovate` opens two PRs for each dependency update, one based on docker tag and another one based on github-releases.
This PR adapts the behavior and uses the update mechanism which works best for the particular case only.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
