### PR TITLE
[GEP-19] Ensure legacy resource cleanup for shoot Alertmanager is executed

### DIFF
--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -75,7 +75,20 @@ func (b *Botanist) DeployAlertManager(ctx context.Context) error {
 	b.Operation.Shoot.Components.Monitoring.Alertmanager.SetIngressAuthSecret(ingressAuthSecret)
 	b.Operation.Shoot.Components.Monitoring.Alertmanager.SetIngressWildcardCertSecret(b.ControlPlaneWildcardCert)
 
-	return b.Shoot.Components.Monitoring.Alertmanager.Deploy(ctx)
+	if err := b.Shoot.Components.Monitoring.Alertmanager.Deploy(ctx); err != nil {
+		return err
+	}
+
+	// TODO(rfranzke): Remove this after v1.93 has been released.
+	return kubernetesutils.DeleteObjects(ctx, b.SeedClientSet.Client(),
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager", Namespace: b.Shoot.SeedNamespace}},
+		&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager", Namespace: b.Shoot.SeedNamespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-client", Namespace: b.Shoot.SeedNamespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager", Namespace: b.Shoot.SeedNamespace}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-basic-auth", Namespace: b.Shoot.SeedNamespace}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-config", Namespace: b.Shoot.SeedNamespace}},
+		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-db-alertmanager-0", Namespace: b.Shoot.SeedNamespace}},
+	)
 }
 
 // MigrateAlertManager migrate the shoot alert manager to prometheus-operator.
@@ -89,19 +102,7 @@ func (b *Botanist) MigrateAlertManager(ctx context.Context) error {
 		return fmt.Errorf("failed reading old Alertmanager StatefulSet %s: %w", client.ObjectKeyFromObject(oldStatefulSet), err)
 	}
 
-	if err := b.DeployAlertManager(ctx); err != nil {
-		return err
-	}
-
-	return kubernetesutils.DeleteObjects(ctx, b.SeedClientSet.Client(),
-		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager", Namespace: b.Shoot.SeedNamespace}},
-		&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager", Namespace: b.Shoot.SeedNamespace}},
-		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-client", Namespace: b.Shoot.SeedNamespace}},
-		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager", Namespace: b.Shoot.SeedNamespace}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-basic-auth", Namespace: b.Shoot.SeedNamespace}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-config", Namespace: b.Shoot.SeedNamespace}},
-		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-db-alertmanager-0", Namespace: b.Shoot.SeedNamespace}},
-	)
+	return b.DeployAlertManager(ctx)
 }
 
 // DefaultMonitoring creates a new monitoring component.

--- a/pkg/gardenlet/operation/botanist/monitoring_test.go
+++ b/pkg/gardenlet/operation/botanist/monitoring_test.go
@@ -27,6 +27,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	mockalertmanager "github.com/gardener/gardener/pkg/component/observability/monitoring/alertmanager/mock"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
@@ -62,6 +63,7 @@ var _ = Describe("Monitoring", func() {
 		botanist = &Botanist{
 			Operation: &operation.Operation{
 				SecretsManager: fakeSecretManager,
+				SeedClientSet:  kubernetesfake.NewClientSetBuilder().WithClient(fakeSeedClient).Build(),
 				Shoot: &shootpkg.Shoot{
 					SeedNamespace: seedNamespace,
 					Purpose:       gardencorev1beta1.ShootPurposeProduction,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
The `MigrateAlertmanager` function will only cleanup the legacy resources when the old `StatefulSet` exists. However, the `DeployAlertmanager` function running before the `DeleteObjects` function is already deleting the old `StatefulSet`. If it fails in between for whatever reason, causing the whole flow to be executed again (from the start), the `MigrateAlertmanager` function will do nothing. Effectively, all old resources are never cleaned up and leak.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9257

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug operator
A bug has been fixed which prevented the legacy resource cleanup for the shoot Alertmanager.
```
