### PR TITLE
[release-v1.89] Automated cherry pick of #9387: [GEP-19] Fix the match expression in the alertmanager configuration

### DIFF
--- a/pkg/component/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/monitoring/alertmanager/alertmanager_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Prometheus", func() {
 					GroupInterval:  "5m",
 					RepeatInterval: "72h",
 					Receiver:       "dev-null",
-					Routes:         []apiextensionsv1.JSON{{Raw: []byte(`{"match_re":{"visibility":"^(all|operator)$"},"receiver":"email-kubernetes-ops"}`)}},
+					Routes:         []apiextensionsv1.JSON{{Raw: []byte(`{"matchers": [{"name": "visibility", "matchType": "=~", "value": "all|operator"}], "receiver": "email-kubernetes-ops"}`)}},
 				},
 				InhibitRules: []monitoringv1alpha1.InhibitRule{
 					{

--- a/pkg/component/monitoring/alertmanager/config.go
+++ b/pkg/component/monitoring/alertmanager/config.go
@@ -49,7 +49,11 @@ func (a *alertManager) config() *monitoringv1alpha1.AlertmanagerConfig {
 				// Send alerts by default to nowhere
 				Receiver: "dev-null",
 				// email only for critical and blocker
-				Routes: []apiextensionsv1.JSON{{Raw: []byte(`{"match_re":{"visibility":"^(all|operator)$"},"receiver":"` + emailReceiverName + `"}`)}},
+				Routes: []apiextensionsv1.JSON{{Raw: []byte(`
+				  {"matchers": [{"name": "visibility",
+				                 "matchType": "=~",
+				                 "value": "all|operator"}],
+				   "receiver": "` + emailReceiverName + `"}`)}},
 			},
 			InhibitRules: []monitoringv1alpha1.InhibitRule{
 				// Apply inhibition if the alert name is the same.


### PR DESCRIPTION
/area monitoring
/kind regression

Cherry pick of #9387 on release-v1.89.

#9387: [GEP-19] Fix the match expression in the alertmanager configuration

**Release Notes:**
```bugfix operator
A configuration issue of the prometheus-operator managed alertmanager instances is fixed.
```