### PR TITLE
Add custom `matcher` for `ManagedResource`s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	go.uber.org/mock v0.4.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.21.0
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/text v0.14.0
 	golang.org/x/time v0.5.0
 	golang.org/x/tools v0.19.0
@@ -185,7 +186,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect

--- a/pkg/component/autoscaling/hvpa/hvpa_test.go
+++ b/pkg/component/autoscaling/hvpa/hvpa_test.go
@@ -40,12 +40,12 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/autoscaling/hvpa"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("HVPA", func() {
@@ -402,20 +402,20 @@ var _ = Describe("HVPA", func() {
 			Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 			Expect(managedResourceSecret.Data).To(HaveLen(10))
-			Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(serviceAccount)))
-			Expect(string(managedResourceSecret.Data["clusterrole____system_hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(clusterRole)))
-			Expect(string(managedResourceSecret.Data["clusterrolebinding____hvpa-controller-rolebinding.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
-			Expect(string(managedResourceSecret.Data["service__"+namespace+"__hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(service)))
-			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(deployment)))
-			Expect(string(managedResourceSecret.Data["role__"+namespace+"__hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(role)))
-			Expect(string(managedResourceSecret.Data["rolebinding__"+namespace+"__hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(roleBinding)))
-			Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__hvpa-controller-vpa.yaml"])).To(Equal(componenttest.Serialize(vpa)))
-			Expect(string(managedResourceSecret.Data["servicemonitor__"+namespace+"__cache-hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(serviceMonitor)))
+			Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(serviceAccount)))
+			Expect(string(managedResourceSecret.Data["clusterrole____system_hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
+			Expect(string(managedResourceSecret.Data["clusterrolebinding____hvpa-controller-rolebinding.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
+			Expect(string(managedResourceSecret.Data["service__"+namespace+"__hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(service)))
+			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(deployment)))
+			Expect(string(managedResourceSecret.Data["role__"+namespace+"__hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(role)))
+			Expect(string(managedResourceSecret.Data["rolebinding__"+namespace+"__hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(roleBinding)))
+			Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__hvpa-controller-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
+			Expect(string(managedResourceSecret.Data["servicemonitor__"+namespace+"__cache-hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(serviceMonitor)))
 		})
 
 		Context("Kubernetes versions < 1.26", func() {
 			It("should successfully deploy all resources", func() {
-				Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(false))))
+				Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(false))))
 			})
 		})
 
@@ -426,7 +426,7 @@ var _ = Describe("HVPA", func() {
 			})
 
 			It("should successfully deploy all resources", func() {
-				Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__hvpa-controller.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(true))))
+				Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__hvpa-controller.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
 			})
 		})
 	})

--- a/pkg/component/autoscaling/hvpa/hvpa_test.go
+++ b/pkg/component/autoscaling/hvpa/hvpa_test.go
@@ -50,7 +50,7 @@ import (
 
 var _ = Describe("HVPA", func() {
 	var (
-		ctx = context.TODO()
+		ctx = context.Background()
 
 		namespace         = "some-namespace"
 		image             = "some-image:some-tag"
@@ -61,9 +61,9 @@ var _ = Describe("HVPA", func() {
 			KubernetesVersion: semver.MustParse("1.25.5"),
 		}
 
-		c             client.Client
-		component     component.DeployWaiter
-		containObject func(object client.Object) types.GomegaMatcher
+		c         client.Client
+		component component.DeployWaiter
+		consistOf func(object ...client.Object) types.GomegaMatcher
 
 		managedResourceName   = "hvpa"
 		managedResource       *resourcesv1alpha1.ManagedResource
@@ -84,7 +84,7 @@ var _ = Describe("HVPA", func() {
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 		component = New(c, namespace, values)
-		containObject = NewManagedResourceObjectMatcher(c)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(c)
 
 		serviceAccount = &corev1.ServiceAccount{
 			TypeMeta: metav1.TypeMeta{
@@ -374,6 +374,8 @@ var _ = Describe("HVPA", func() {
 	})
 
 	Describe("#Deploy", func() {
+		var expectedObjects []client.Object
+
 		JustBeforeEach(func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
 
@@ -397,28 +399,30 @@ var _ = Describe("HVPA", func() {
 			}
 			utilruntime.Must(references.InjectAnnotations(expectedMr))
 			Expect(managedResource).To(DeepEqual(expectedMr))
+			expectedObjects = []client.Object{
+				serviceAccount,
+				clusterRole,
+				clusterRoleBinding,
+				service,
+				deployment,
+				role,
+				roleBinding,
+				vpa,
+				serviceMonitor,
+			}
 
 			managedResourceSecret.Name = managedResource.Spec.SecretRefs[0].Name
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
 			Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
-			Expect(managedResourceSecret.Data).To(HaveLen(10))
 
-			Expect(managedResource).To(containObject(serviceAccount))
-			Expect(managedResource).To(containObject(clusterRole))
-			Expect(managedResource).To(containObject(clusterRoleBinding))
-			Expect(managedResource).To(containObject(service))
-			Expect(managedResource).To(containObject(deployment))
-			Expect(managedResource).To(containObject(role))
-			Expect(managedResource).To(containObject(roleBinding))
-			Expect(managedResource).To(containObject(vpa))
-			Expect(managedResource).To(containObject(serviceMonitor))
 		})
 
 		Context("Kubernetes versions < 1.26", func() {
 			It("should successfully deploy all resources", func() {
-				Expect(managedResource).To(containObject(podDisruptionBudgetFor(false)))
+				expectedObjects = append(expectedObjects, podDisruptionBudgetFor(false))
+				Expect(managedResource).To(consistOf(expectedObjects...))
 			})
 		})
 
@@ -429,7 +433,8 @@ var _ = Describe("HVPA", func() {
 			})
 
 			It("should successfully deploy all resources", func() {
-				Expect(managedResource).To(containObject(podDisruptionBudgetFor(true)))
+				expectedObjects = append(expectedObjects, podDisruptionBudgetFor(true))
+				Expect(managedResource).To(consistOf(expectedObjects...))
 			})
 		})
 	})

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/autoscaling/vpa"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -55,6 +54,7 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("VPA", func() {
@@ -1253,11 +1253,11 @@ var _ = Describe("VPA", func() {
 					deploymentUpdater := deploymentUpdaterFor(true, nil, nil, nil, nil, nil)
 					adaptNetworkPolicyLabelsForClusterTypeSeed(deploymentUpdater.Spec.Template.Labels)
 
-					Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__vpa-updater.yaml"])).To(Equal(componenttest.Serialize(serviceAccountUpdater)))
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_evictioner.yaml"])).To(Equal(componenttest.Serialize(clusterRoleUpdater)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_evictioner.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingUpdater)))
-					Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-updater.yaml"])).To(Equal(componenttest.Serialize(deploymentUpdater)))
-					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__vpa-updater.yaml"])).To(Equal(componenttest.Serialize(vpaUpdater)))
+					Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__vpa-updater.yaml"])).To(Equal(testruntime.Serialize(serviceAccountUpdater)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_evictioner.yaml"])).To(Equal(testruntime.Serialize(clusterRoleUpdater)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_evictioner.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingUpdater)))
+					Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-updater.yaml"])).To(Equal(testruntime.Serialize(deploymentUpdater)))
+					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__vpa-updater.yaml"])).To(Equal(testruntime.Serialize(vpaUpdater)))
 
 					By("Verify vpa-recommender resources")
 					clusterRoleRecommenderMetricsReader.Name = replaceTargetSubstrings(clusterRoleRecommenderMetricsReader.Name)
@@ -1273,16 +1273,16 @@ var _ = Describe("VPA", func() {
 					deploymentRecommender := deploymentRecommenderFor(true, nil, nil, component.ClusterTypeSeed, nil)
 					adaptNetworkPolicyLabelsForClusterTypeSeed(deploymentRecommender.Spec.Template.Labels)
 
-					Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__vpa-recommender.yaml"])).To(Equal(componenttest.Serialize(serviceAccountRecommender)))
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_metrics-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleRecommenderMetricsReader)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_metrics-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingRecommenderMetricsReader)))
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_checkpoint-actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleRecommenderCheckpointActor)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_checkpoint-actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingRecommenderCheckpointActor)))
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_status-actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleRecommenderStatusActor)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_status-actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingRecommenderStatusActor)))
-					Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-recommender.yaml"])).To(Equal(componenttest.Serialize(deploymentRecommender)))
-					Expect(string(managedResourceSecret.Data["service__"+namespace+"__vpa-recommender.yaml"])).To(Equal(componenttest.Serialize(serviceRecommenderFor(component.ClusterTypeSeed))))
-					Expect(string(managedResourceSecret.Data["podmonitor__"+namespace+"__seed-vpa-recommender.yaml"])).To(Equal(componenttest.Serialize(podMonitorRecommender)))
+					Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__vpa-recommender.yaml"])).To(Equal(testruntime.Serialize(serviceAccountRecommender)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_metrics-reader.yaml"])).To(Equal(testruntime.Serialize(clusterRoleRecommenderMetricsReader)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_metrics-reader.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingRecommenderMetricsReader)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_checkpoint-actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleRecommenderCheckpointActor)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_checkpoint-actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingRecommenderCheckpointActor)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_status-actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleRecommenderStatusActor)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_status-actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingRecommenderStatusActor)))
+					Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-recommender.yaml"])).To(Equal(testruntime.Serialize(deploymentRecommender)))
+					Expect(string(managedResourceSecret.Data["service__"+namespace+"__vpa-recommender.yaml"])).To(Equal(testruntime.Serialize(serviceRecommenderFor(component.ClusterTypeSeed))))
+					Expect(string(managedResourceSecret.Data["podmonitor__"+namespace+"__seed-vpa-recommender.yaml"])).To(Equal(testruntime.Serialize(podMonitorRecommender)))
 					Expect(managedResourceSecret.Data).NotTo(HaveKey("verticalpodautoscaler__" + namespace + "__vpa-recommender.yaml"))
 
 					By("Verify vpa-admission-controller resources")
@@ -1293,12 +1293,12 @@ var _ = Describe("VPA", func() {
 					deploymentAdmissionController := deploymentAdmissionControllerFor(true)
 					adaptNetworkPolicyLabelsForClusterTypeSeed(deploymentAdmissionController.Spec.Template.Labels)
 
-					Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(componenttest.Serialize(serviceAccountAdmissionController)))
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_admission-controller.yaml"])).To(Equal(componenttest.Serialize(clusterRoleAdmissionController)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_admission-controller.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingAdmissionController)))
-					Expect(string(managedResourceSecret.Data["service__"+namespace+"__vpa-webhook.yaml"])).To(Equal(componenttest.Serialize(serviceAdmissionControllerFor(component.ClusterTypeSeed, false))))
-					Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(componenttest.Serialize(deploymentAdmissionController)))
-					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(componenttest.Serialize(vpaAdmissionController)))
+					Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(testruntime.Serialize(serviceAccountAdmissionController)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_admission-controller.yaml"])).To(Equal(testruntime.Serialize(clusterRoleAdmissionController)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_admission-controller.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingAdmissionController)))
+					Expect(string(managedResourceSecret.Data["service__"+namespace+"__vpa-webhook.yaml"])).To(Equal(testruntime.Serialize(serviceAdmissionControllerFor(component.ClusterTypeSeed, false))))
+					Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(testruntime.Serialize(deploymentAdmissionController)))
+					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(testruntime.Serialize(vpaAdmissionController)))
 
 					By("Verify general resources")
 					clusterRoleGeneralActor.Name = replaceTargetSubstrings(clusterRoleGeneralActor.Name)
@@ -1316,16 +1316,16 @@ var _ = Describe("VPA", func() {
 						},
 					}
 
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGeneralActor)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGeneralActor)))
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_target-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGeneralTargetReader)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_target-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGeneralTargetReader)))
-					Expect(string(managedResourceSecret.Data["mutatingwebhookconfiguration____zzz-vpa-webhook-config-source.yaml"])).To(Equal(componenttest.Serialize(mutatingWebhookConfiguration)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleGeneralActor)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingGeneralActor)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_target-reader.yaml"])).To(Equal(testruntime.Serialize(clusterRoleGeneralTargetReader)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_target-reader.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingGeneralTargetReader)))
+					Expect(string(managedResourceSecret.Data["mutatingwebhookconfiguration____zzz-vpa-webhook-config-source.yaml"])).To(Equal(testruntime.Serialize(mutatingWebhookConfiguration)))
 				})
 
 				Context("Kubernetes versions < 1.26", func() {
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetAdmissionController)))
+						Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetAdmissionController)))
 					})
 				})
 
@@ -1345,7 +1345,7 @@ var _ = Describe("VPA", func() {
 					It("should successfully deploy all resources", func() {
 						unhealthyPodEvictionPolicyAlwaysAllow := policyv1.AlwaysAllow
 						podDisruptionBudgetAdmissionController.Spec.UnhealthyPodEvictionPolicy = &unhealthyPodEvictionPolicyAlwaysAllow
-						Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetAdmissionController)))
+						Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__vpa-admission-controller.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetAdmissionController)))
 					})
 				})
 			})
@@ -1414,8 +1414,8 @@ var _ = Describe("VPA", func() {
 				)
 				adaptNetworkPolicyLabelsForClusterTypeSeed(deploymentRecommender.Spec.Template.Labels)
 
-				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-updater.yaml"])).To(Equal(componenttest.Serialize(deploymentUpdater)))
-				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-recommender.yaml"])).To(Equal(componenttest.Serialize(deploymentRecommender)))
+				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-updater.yaml"])).To(Equal(testruntime.Serialize(deploymentUpdater)))
+				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-recommender.yaml"])).To(Equal(testruntime.Serialize(deploymentRecommender)))
 				Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 			})
@@ -1469,8 +1469,8 @@ var _ = Describe("VPA", func() {
 					By("Verify vpa-updater application resources")
 					clusterRoleBindingUpdater.Subjects[0].Namespace = "kube-system"
 
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_evictioner.yaml"])).To(Equal(componenttest.Serialize(clusterRoleUpdater)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_evictioner.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingUpdater)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_evictioner.yaml"])).To(Equal(testruntime.Serialize(clusterRoleUpdater)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_evictioner.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingUpdater)))
 					Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
@@ -1495,10 +1495,10 @@ var _ = Describe("VPA", func() {
 					clusterRoleBindingRecommenderMetricsReader.Subjects[0].Namespace = "kube-system"
 					clusterRoleBindingRecommenderCheckpointActor.Subjects[0].Namespace = "kube-system"
 
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_metrics-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleRecommenderMetricsReader)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_metrics-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingRecommenderMetricsReader)))
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_checkpoint-actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleRecommenderCheckpointActor)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_checkpoint-actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingRecommenderCheckpointActor)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_metrics-reader.yaml"])).To(Equal(testruntime.Serialize(clusterRoleRecommenderMetricsReader)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_metrics-reader.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingRecommenderMetricsReader)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_checkpoint-actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleRecommenderCheckpointActor)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_checkpoint-actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingRecommenderCheckpointActor)))
 
 					By("Verify vpa-recommender runtime resources")
 					secret = &corev1.Secret{}
@@ -1526,8 +1526,8 @@ var _ = Describe("VPA", func() {
 					By("Verify vpa-admission-controller application resources")
 					clusterRoleBindingAdmissionController.Subjects[0].Namespace = "kube-system"
 
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_admission-controller.yaml"])).To(Equal(componenttest.Serialize(clusterRoleAdmissionController)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_admission-controller.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingAdmissionController)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_admission-controller.yaml"])).To(Equal(testruntime.Serialize(clusterRoleAdmissionController)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_admission-controller.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingAdmissionController)))
 
 					By("Verify vpa-admission-controller runtime resources")
 					secret = &corev1.Secret{}
@@ -1559,11 +1559,11 @@ var _ = Describe("VPA", func() {
 					clusterRoleBindingGeneralTargetReader.Subjects[1].Namespace = "kube-system"
 					clusterRoleBindingGeneralTargetReader.Subjects[2].Namespace = "kube-system"
 
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGeneralActor)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGeneralActor)))
-					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_target-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGeneralTargetReader)))
-					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_target-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGeneralTargetReader)))
-					Expect(string(managedResourceSecret.Data["mutatingwebhookconfiguration____zzz-vpa-webhook-config-target.yaml"])).To(Equal(componenttest.Serialize(mutatingWebhookConfiguration)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleGeneralActor)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_actor.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingGeneralActor)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_target-reader.yaml"])).To(Equal(testruntime.Serialize(clusterRoleGeneralTargetReader)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_target-reader.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingGeneralTargetReader)))
+					Expect(string(managedResourceSecret.Data["mutatingwebhookconfiguration____zzz-vpa-webhook-config-target.yaml"])).To(Equal(testruntime.Serialize(mutatingWebhookConfiguration)))
 					Expect(managedResourceSecret.Data).To(HaveKey("crd-verticalpodautoscalercheckpoints.yaml"))
 					Expect(managedResourceSecret.Data).To(HaveKey("crd-verticalpodautoscalers.yaml"))
 				})

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -42,15 +42,15 @@ import (
 
 var _ = Describe("Virtual", func() {
 	var (
-		ctx = context.TODO()
+		ctx = context.Background()
 
 		managedResourceName = "garden-system-virtual"
 		namespace           = "some-namespace"
 
-		c             client.Client
-		component     component.DeployWaiter
-		values        Values
-		containObject func(object client.Object) types.GomegaMatcher
+		c         client.Client
+		component component.DeployWaiter
+		values    Values
+		consistOf func(...client.Object) types.GomegaMatcher
 
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
@@ -84,7 +84,7 @@ var _ = Describe("Virtual", func() {
 		c = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
 		values = Values{}
 		component = New(c, namespace, values)
-		containObject = NewManagedResourceObjectMatcher(c)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(c)
 
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -633,30 +633,31 @@ var _ = Describe("Virtual", func() {
 		})
 
 		It("should successfully deploy the resources when seed authorizer is disabled", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(23))
-			Expect(managedResource).To(containObject(namespaceGarden))
-			Expect(managedResource).To(containObject(clusterRoleSeedBootstrapper))
-			Expect(managedResource).To(containObject(clusterRoleBindingSeedBootstrapper))
-			Expect(managedResource).To(containObject(clusterRoleSeeds))
-			Expect(managedResource).To(containObject(clusterRoleBindingSeeds))
-			Expect(managedResource).To(containObject(clusterRoleGardenerAdmin))
-			Expect(managedResource).To(containObject(clusterRoleBindingGardenerAdmin))
-			Expect(managedResource).To(containObject(clusterRoleGardenerAdminAggregated))
-			Expect(managedResource).To(containObject(clusterRoleGardenerViewer))
-			Expect(managedResource).To(containObject(clusterRoleGardenerViewerAggregated))
-			Expect(managedResource).To(containObject(clusterRoleReadGlobalResources))
-			Expect(managedResource).To(containObject(clusterRoleBindingReadGlobalResources))
-			Expect(managedResource).To(containObject(clusterRoleUserAuth))
-			Expect(managedResource).To(containObject(clusterRoleBindingUserAuth))
-			Expect(managedResource).To(containObject(clusterRoleProjectCreation))
-			Expect(managedResource).To(containObject(clusterRoleProjectMemberAggregated))
-			Expect(managedResource).To(containObject(clusterRoleProjectMember))
-			Expect(managedResource).To(containObject(clusterRoleProjectServiceAccountManagerAggregated))
-			Expect(managedResource).To(containObject(clusterRoleProjectServiceAccountManager))
-			Expect(managedResource).To(containObject(clusterRoleProjectViewerAggregated))
-			Expect(managedResource).To(containObject(clusterRoleProjectViewer))
-			Expect(managedResource).To(containObject(roleReadClusterIdentityConfigMap))
-			Expect(managedResource).To(containObject(roleBindingReadClusterIdentityConfigMap))
+			Expect(managedResource).To(consistOf(
+				namespaceGarden,
+				clusterRoleSeedBootstrapper,
+				clusterRoleBindingSeedBootstrapper,
+				clusterRoleSeeds,
+				clusterRoleBindingSeeds,
+				clusterRoleGardenerAdmin,
+				clusterRoleBindingGardenerAdmin,
+				clusterRoleGardenerAdminAggregated,
+				clusterRoleGardenerViewer,
+				clusterRoleGardenerViewerAggregated,
+				clusterRoleReadGlobalResources,
+				clusterRoleBindingReadGlobalResources,
+				clusterRoleUserAuth,
+				clusterRoleBindingUserAuth,
+				clusterRoleProjectCreation,
+				clusterRoleProjectMemberAggregated,
+				clusterRoleProjectMember,
+				clusterRoleProjectServiceAccountManagerAggregated,
+				clusterRoleProjectServiceAccountManager,
+				clusterRoleProjectViewerAggregated,
+				clusterRoleProjectViewer,
+				roleReadClusterIdentityConfigMap,
+				roleBindingReadClusterIdentityConfigMap,
+			))
 		})
 
 		Context("when seed authorizer is enabled", func() {

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -31,13 +31,13 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/garden/system/virtual"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("Virtual", func() {
@@ -632,29 +632,29 @@ var _ = Describe("Virtual", func() {
 
 		It("should successfully deploy the resources when seed authorizer is disabled", func() {
 			Expect(managedResourceSecret.Data).To(HaveLen(23))
-			Expect(string(managedResourceSecret.Data["namespace____garden.yaml"])).To(Equal(componenttest.Serialize(namespaceGarden)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_seed-bootstrapper.yaml"])).To(Equal(componenttest.Serialize(clusterRoleSeedBootstrapper)))
-			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_seed-bootstrapper.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingSeedBootstrapper)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_seeds.yaml"])).To(Equal(componenttest.Serialize(clusterRoleSeeds)))
-			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_seeds.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingSeeds)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_admin.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGardenerAdmin)))
-			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_admin.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGardenerAdmin)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_administrators.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGardenerAdminAggregated)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_viewer.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGardenerViewer)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_viewers.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGardenerViewerAggregated)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_read-global-resources.yaml"])).To(Equal(componenttest.Serialize(clusterRoleReadGlobalResources)))
-			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_read-global-resources.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingReadGlobalResources)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_user-auth.yaml"])).To(Equal(componenttest.Serialize(clusterRoleUserAuth)))
-			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_user-auth.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingUserAuth)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-creation.yaml"])).To(Equal(componenttest.Serialize(clusterRoleProjectCreation)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-member.yaml"])).To(Equal(componenttest.Serialize(clusterRoleProjectMemberAggregated)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-member-aggregation.yaml"])).To(Equal(componenttest.Serialize(clusterRoleProjectMember)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-serviceaccountmanager.yaml"])).To(Equal(componenttest.Serialize(clusterRoleProjectServiceAccountManagerAggregated)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-serviceaccountmanager-aggregation.yaml"])).To(Equal(componenttest.Serialize(clusterRoleProjectServiceAccountManager)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-viewer.yaml"])).To(Equal(componenttest.Serialize(clusterRoleProjectViewerAggregated)))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-viewer-aggregation.yaml"])).To(Equal(componenttest.Serialize(clusterRoleProjectViewer)))
-			Expect(string(managedResourceSecret.Data["role__kube-system__gardener.cloud_system_read-cluster-identity-configmap.yaml"])).To(Equal(componenttest.Serialize(roleReadClusterIdentityConfigMap)))
-			Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_system_read-cluster-identity-configmap.yaml"])).To(Equal(componenttest.Serialize(roleBindingReadClusterIdentityConfigMap)))
+			Expect(string(managedResourceSecret.Data["namespace____garden.yaml"])).To(Equal(testruntime.Serialize(namespaceGarden)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_seed-bootstrapper.yaml"])).To(Equal(testruntime.Serialize(clusterRoleSeedBootstrapper)))
+			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_seed-bootstrapper.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingSeedBootstrapper)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_seeds.yaml"])).To(Equal(testruntime.Serialize(clusterRoleSeeds)))
+			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_seeds.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingSeeds)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_admin.yaml"])).To(Equal(testruntime.Serialize(clusterRoleGardenerAdmin)))
+			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_admin.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingGardenerAdmin)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_administrators.yaml"])).To(Equal(testruntime.Serialize(clusterRoleGardenerAdminAggregated)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_viewer.yaml"])).To(Equal(testruntime.Serialize(clusterRoleGardenerViewer)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_viewers.yaml"])).To(Equal(testruntime.Serialize(clusterRoleGardenerViewerAggregated)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_read-global-resources.yaml"])).To(Equal(testruntime.Serialize(clusterRoleReadGlobalResources)))
+			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_read-global-resources.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingReadGlobalResources)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_user-auth.yaml"])).To(Equal(testruntime.Serialize(clusterRoleUserAuth)))
+			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_user-auth.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingUserAuth)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-creation.yaml"])).To(Equal(testruntime.Serialize(clusterRoleProjectCreation)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-member.yaml"])).To(Equal(testruntime.Serialize(clusterRoleProjectMemberAggregated)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-member-aggregation.yaml"])).To(Equal(testruntime.Serialize(clusterRoleProjectMember)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-serviceaccountmanager.yaml"])).To(Equal(testruntime.Serialize(clusterRoleProjectServiceAccountManagerAggregated)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-serviceaccountmanager-aggregation.yaml"])).To(Equal(testruntime.Serialize(clusterRoleProjectServiceAccountManager)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-viewer.yaml"])).To(Equal(testruntime.Serialize(clusterRoleProjectViewerAggregated)))
+			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_project-viewer-aggregation.yaml"])).To(Equal(testruntime.Serialize(clusterRoleProjectViewer)))
+			Expect(string(managedResourceSecret.Data["role__kube-system__gardener.cloud_system_read-cluster-identity-configmap.yaml"])).To(Equal(testruntime.Serialize(roleReadClusterIdentityConfigMap)))
+			Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_system_read-cluster-identity-configmap.yaml"])).To(Equal(testruntime.Serialize(roleBindingReadClusterIdentityConfigMap)))
 		})
 
 		Context("when seed authorizer is enabled", func() {

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -47,7 +47,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/gardener/admissioncontroller"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/logger"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -59,6 +58,7 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	"github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 const (
@@ -550,7 +550,7 @@ func configMap(namespace string, testValues Values) string {
 	}
 	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
 
-	return componenttest.Serialize(configMap)
+	return testruntime.Serialize(configMap)
 }
 
 func deployment(namespace, configSecretName, serverCertSecretName string, testValues Values) string {
@@ -705,7 +705,7 @@ func deployment(namespace, configSecretName, serverCertSecretName string, testVa
 
 	utilruntime.Must(references.InjectAnnotations(deployment))
 
-	return componenttest.Serialize(deployment)
+	return testruntime.Serialize(deployment)
 }
 
 func service(namespace string, testValues Values) string {
@@ -753,7 +753,7 @@ func service(namespace string, testValues Values) string {
 		}
 	}
 
-	return componenttest.Serialize(svc)
+	return testruntime.Serialize(svc)
 }
 
 func podDisruptionBudget(namespace string, k8sGreaterEqual126 bool) string {
@@ -776,13 +776,13 @@ func podDisruptionBudget(namespace string, k8sGreaterEqual126 bool) string {
 		pdb.Spec.UnhealthyPodEvictionPolicy = &unhealthyPodEvictionPolicyAlwatysAllow
 	}
 
-	return componenttest.Serialize(pdb)
+	return testruntime.Serialize(pdb)
 }
 
 func vpa(namespace string) string {
 	autoUpdateMode := vpaautoscalingv1.UpdateModeAuto
 
-	return componenttest.Serialize(&vpaautoscalingv1.VerticalPodAutoscaler{
+	return testruntime.Serialize(&vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gardener-admission-controller",
 			Namespace: namespace,
@@ -815,7 +815,7 @@ func vpa(namespace string) string {
 }
 
 func clusterRole() string {
-	return componenttest.Serialize(&rbacv1.ClusterRole{
+	return testruntime.Serialize(&rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "gardener.cloud:system:admission-controller",
 			Labels: map[string]string{
@@ -886,7 +886,7 @@ func clusterRole() string {
 }
 
 func clusterRoleBinding() string {
-	return componenttest.Serialize(&rbacv1.ClusterRoleBinding{
+	return testruntime.Serialize(&rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "gardener.cloud:admission-controller",
 			Labels: map[string]string{
@@ -1174,5 +1174,5 @@ func validatingWebhookConfiguration(namespace string, caBundle []byte, testValue
 		})
 	}
 
-	return componenttest.Serialize(webhookConfig)
+	return testruntime.Serialize(webhookConfig)
 }

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -57,8 +58,7 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
-	"github.com/gardener/gardener/pkg/utils/test/matchers"
-	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 const (
@@ -75,6 +75,7 @@ var _ = Describe("GardenerAdmissionController", func() {
 		fakeSecretManager secretsmanager.Interface
 		deployer          component.DeployWaiter
 		testValues        Values
+		containObject     func(object client.Object) types.GomegaMatcher
 
 		namespace = "some-namespace"
 	)
@@ -89,6 +90,7 @@ var _ = Describe("GardenerAdmissionController", func() {
 
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
 		fakeSecretManager = fakesecretsmanager.New(fakeClient, namespace)
+		containObject = NewManagedResourceObjectMatcher(fakeClient)
 
 		testValues = Values{}
 	})
@@ -137,7 +139,7 @@ var _ = Describe("GardenerAdmissionController", func() {
 		Context("with common values", func() {
 			It("should successfully deploy", func() {
 				Expect(deployer.Deploy(ctx)).To(Succeed())
-				verifyExpectations(ctx, fakeClient, fakeSecretManager, namespace, "4ef77c17", testValues, true)
+				verifyExpectations(ctx, fakeClient, containObject, fakeSecretManager, namespace, "4ef77c17", testValues, true)
 			})
 		})
 
@@ -148,7 +150,7 @@ var _ = Describe("GardenerAdmissionController", func() {
 
 			It("should successfully deploy", func() {
 				Expect(deployer.Deploy(ctx)).To(Succeed())
-				verifyExpectations(ctx, fakeClient, fakeSecretManager, namespace, "4ef77c17", testValues, true)
+				verifyExpectations(ctx, fakeClient, containObject, fakeSecretManager, namespace, "4ef77c17", testValues, true)
 			})
 		})
 
@@ -159,7 +161,7 @@ var _ = Describe("GardenerAdmissionController", func() {
 
 			It("should successfully deploy", func() {
 				Expect(deployer.Deploy(ctx)).To(Succeed())
-				verifyExpectations(ctx, fakeClient, fakeSecretManager, namespace, "4ef77c17", testValues, false)
+				verifyExpectations(ctx, fakeClient, containObject, fakeSecretManager, namespace, "4ef77c17", testValues, false)
 			})
 		})
 
@@ -171,7 +173,7 @@ var _ = Describe("GardenerAdmissionController", func() {
 
 			It("should successfully deploy", func() {
 				Expect(deployer.Deploy(ctx)).To(Succeed())
-				verifyExpectations(ctx, fakeClient, fakeSecretManager, namespace, "4ef77c17", testValues, true)
+				verifyExpectations(ctx, fakeClient, containObject, fakeSecretManager, namespace, "4ef77c17", testValues, true)
 			})
 		})
 
@@ -182,7 +184,7 @@ var _ = Describe("GardenerAdmissionController", func() {
 
 			It("should successfully deploy", func() {
 				Expect(deployer.Deploy(ctx)).To(Succeed())
-				verifyExpectations(ctx, fakeClient, fakeSecretManager, namespace, "6d282905", testValues, true)
+				verifyExpectations(ctx, fakeClient, containObject, fakeSecretManager, namespace, "6d282905", testValues, true)
 			})
 		})
 
@@ -193,7 +195,7 @@ var _ = Describe("GardenerAdmissionController", func() {
 
 			It("should successfully deploy", func() {
 				Expect(deployer.Deploy(ctx)).To(Succeed())
-				verifyExpectations(ctx, fakeClient, fakeSecretManager, namespace, "4ef77c17", testValues, true)
+				verifyExpectations(ctx, fakeClient, containObject, fakeSecretManager, namespace, "4ef77c17", testValues, true)
 			})
 		})
 	})
@@ -416,14 +418,14 @@ var _ = Describe("GardenerAdmissionController", func() {
 })
 
 func verifyResourcesGone(ctx context.Context, fakeClient client.Client, namespace string) {
-	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "managedresource-" + managedResourceNameRuntime}, &corev1.Secret{})).To(matchers.BeNotFoundError())
-	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: managedResourceNameRuntime}, &resourcesv1alpha1.ManagedResource{})).To(matchers.BeNotFoundError())
-	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "managedresource-" + managedResourceNameVirtual}, &corev1.Secret{})).To(matchers.BeNotFoundError())
-	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: managedResourceNameVirtual}, &resourcesv1alpha1.ManagedResource{})).To(matchers.BeNotFoundError())
-	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-access-gardener-admission-controller"}, &corev1.Secret{})).To(matchers.BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "managedresource-" + managedResourceNameRuntime}, &corev1.Secret{})).To(BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: managedResourceNameRuntime}, &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "managedresource-" + managedResourceNameVirtual}, &corev1.Secret{})).To(BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: managedResourceNameVirtual}, &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-access-gardener-admission-controller"}, &corev1.Secret{})).To(BeNotFoundError())
 }
 
-func verifyExpectations(ctx context.Context, fakeClient client.Client, fakeSecretManager secretsmanager.Interface, namespace, configMapChecksum string, testValues Values, k8sGreaterEqual126 bool) {
+func verifyExpectations(ctx context.Context, fakeClient client.Client, containObject func(object client.Object) types.GomegaMatcher, fakeSecretManager secretsmanager.Interface, namespace, configMapChecksum string, testValues Values, k8sGreaterEqual126 bool) {
 	By("Check Gardener Access Secret")
 	accessSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -468,11 +470,11 @@ func verifyExpectations(ctx context.Context, fakeClient client.Client, fakeSecre
 	}
 	Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(runtimeManagedResourceSecret), runtimeManagedResourceSecret)).To(Succeed())
 
-	Expect(string(runtimeManagedResourceSecret.Data["configmap__some-namespace__gardener-admission-controller-"+configMapChecksum+".yaml"])).To(Equal(configMap(namespace, testValues)), true)
-	Expect(string(runtimeManagedResourceSecret.Data["deployment__some-namespace__gardener-admission-controller.yaml"])).To(Equal(deployment(namespace, "gardener-admission-controller-"+configMapChecksum, serverCert.Name, testValues)), true)
-	Expect(string(runtimeManagedResourceSecret.Data["service__some-namespace__gardener-admission-controller.yaml"])).To(Equal(service(namespace, testValues)), true)
-	Expect(string(runtimeManagedResourceSecret.Data["verticalpodautoscaler__some-namespace__gardener-admission-controller.yaml"])).To(Equal(vpa(namespace)))
-	Expect(string(runtimeManagedResourceSecret.Data["poddisruptionbudget__some-namespace__gardener-admission-controller.yaml"])).To(Equal(podDisruptionBudget(namespace, k8sGreaterEqual126)))
+	Expect(runtimeMr).To(containObject(configMap(namespace, testValues)))
+	Expect(runtimeMr).To(containObject(deployment(namespace, "gardener-admission-controller-"+configMapChecksum, serverCert.Name, testValues)))
+	Expect(runtimeMr).To(containObject(service(namespace, testValues)))
+	Expect(runtimeMr).To(containObject(vpa(namespace)))
+	Expect(runtimeMr).To(containObject(podDisruptionBudget(namespace, k8sGreaterEqual126)))
 	Expect(runtimeManagedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 	Expect(runtimeManagedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
@@ -498,14 +500,14 @@ func verifyExpectations(ctx context.Context, fakeClient client.Client, fakeSecre
 	caGardener, ok := fakeSecretManager.Get("ca-gardener")
 	Expect(ok).To(BeTrue())
 
-	Expect(string(virtualManagedResourceSecret.Data["clusterrole____gardener.cloud_system_admission-controller.yaml"])).To(Equal(clusterRole()))
-	Expect(string(virtualManagedResourceSecret.Data["clusterrolebinding____gardener.cloud_admission-controller.yaml"])).To(Equal(clusterRoleBinding()))
-	Expect(string(virtualManagedResourceSecret.Data["validatingwebhookconfiguration____gardener-admission-controller.yaml"])).To(Equal(validatingWebhookConfiguration(namespace, caGardener.Data["bundle.crt"], testValues)), true)
+	Expect(virtualMr).To(containObject(clusterRole()))
+	Expect(virtualMr).To(containObject(clusterRoleBinding()))
+	Expect(virtualMr).To(containObject(validatingWebhookConfiguration(namespace, caGardener.Data["bundle.crt"], testValues)))
 	Expect(virtualManagedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 	Expect(virtualManagedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 }
 
-func configMap(namespace string, testValues Values) string {
+func configMap(namespace string, testValues Values) *corev1.ConfigMap {
 	admissionConfig := &admissioncontrollerv1alpha1.AdmissionControllerConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "admissioncontroller.config.gardener.cloud/v1alpha1",
@@ -550,10 +552,10 @@ func configMap(namespace string, testValues Values) string {
 	}
 	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
 
-	return testruntime.Serialize(configMap)
+	return configMap
 }
 
-func deployment(namespace, configSecretName, serverCertSecretName string, testValues Values) string {
+func deployment(namespace, configSecretName, serverCertSecretName string, testValues Values) *appsv1.Deployment {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gardener-admission-controller",
@@ -705,10 +707,10 @@ func deployment(namespace, configSecretName, serverCertSecretName string, testVa
 
 	utilruntime.Must(references.InjectAnnotations(deployment))
 
-	return testruntime.Serialize(deployment)
+	return deployment
 }
 
-func service(namespace string, testValues Values) string {
+func service(namespace string, testValues Values) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gardener-admission-controller",
@@ -753,10 +755,10 @@ func service(namespace string, testValues Values) string {
 		}
 	}
 
-	return testruntime.Serialize(svc)
+	return svc
 }
 
-func podDisruptionBudget(namespace string, k8sGreaterEqual126 bool) string {
+func podDisruptionBudget(namespace string, k8sGreaterEqual126 bool) *policyv1.PodDisruptionBudget {
 	var (
 		unhealthyPodEvictionPolicyAlwatysAllow = policyv1.AlwaysAllow
 		pdb                                    = &policyv1.PodDisruptionBudget{
@@ -776,13 +778,13 @@ func podDisruptionBudget(namespace string, k8sGreaterEqual126 bool) string {
 		pdb.Spec.UnhealthyPodEvictionPolicy = &unhealthyPodEvictionPolicyAlwatysAllow
 	}
 
-	return testruntime.Serialize(pdb)
+	return pdb
 }
 
-func vpa(namespace string) string {
+func vpa(namespace string) *vpaautoscalingv1.VerticalPodAutoscaler {
 	autoUpdateMode := vpaautoscalingv1.UpdateModeAuto
 
-	return testruntime.Serialize(&vpaautoscalingv1.VerticalPodAutoscaler{
+	return &vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gardener-admission-controller",
 			Namespace: namespace,
@@ -811,11 +813,11 @@ func vpa(namespace string) string {
 				},
 			},
 		},
-	})
+	}
 }
 
-func clusterRole() string {
-	return testruntime.Serialize(&rbacv1.ClusterRole{
+func clusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "gardener.cloud:system:admission-controller",
 			Labels: map[string]string{
@@ -882,11 +884,11 @@ func clusterRole() string {
 				Verbs: []string{"get", "list", "watch"},
 			},
 		},
-	})
+	}
 }
 
-func clusterRoleBinding() string {
-	return testruntime.Serialize(&rbacv1.ClusterRoleBinding{
+func clusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "gardener.cloud:admission-controller",
 			Labels: map[string]string{
@@ -904,10 +906,10 @@ func clusterRoleBinding() string {
 			Name:      "gardener-admission-controller",
 			Namespace: "kube-system",
 		}},
-	})
+	}
 }
 
-func validatingWebhookConfiguration(namespace string, caBundle []byte, testValues Values) string {
+func validatingWebhookConfiguration(namespace string, caBundle []byte, testValues Values) *admissionregistrationv1.ValidatingWebhookConfiguration {
 	var (
 		failurePolicyFail     = admissionregistrationv1.Fail
 		sideEffectsNone       = admissionregistrationv1.SideEffectClassNone
@@ -1174,5 +1176,5 @@ func validatingWebhookConfiguration(namespace string, caBundle []byte, testValue
 		})
 	}
 
-	return testruntime.Serialize(webhookConfig)
+	return webhookConfig
 }

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -42,7 +42,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/apiserver"
 	. "github.com/gardener/gardener/pkg/component/gardener/apiserver"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
@@ -54,6 +53,7 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("GardenerAPIServer", func() {
@@ -1423,22 +1423,22 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 
 					Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
 					Expect(managedResourceSecretRuntime.Data).To(HaveLen(4))
-					Expect(string(managedResourceSecretRuntime.Data["deployment__some-namespace__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(deployment)))
+					Expect(string(managedResourceSecretRuntime.Data["deployment__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(deployment)))
 					Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 					Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 					Expect(managedResourceSecretVirtual.Data).To(HaveLen(10))
-					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1beta1.core.gardener.cloud.yaml"])).To(Equal(componenttest.Serialize(apiServiceFor("core.gardener.cloud", "v1beta1"))))
-					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.seedmanagement.gardener.cloud.yaml"])).To(Equal(componenttest.Serialize(apiServiceFor("seedmanagement.gardener.cloud", "v1alpha1"))))
-					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.operations.gardener.cloud.yaml"])).To(Equal(componenttest.Serialize(apiServiceFor("operations.gardener.cloud", "v1alpha1"))))
-					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.settings.gardener.cloud.yaml"])).To(Equal(componenttest.Serialize(apiServiceFor("settings.gardener.cloud", "v1alpha1"))))
-					Expect(string(managedResourceSecretVirtual.Data["service__kube-system__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(serviceVirtual)))
-					Expect(string(managedResourceSecretVirtual.Data["endpoints__kube-system__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(endpoints)))
-					Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_system_apiserver.yaml"])).To(Equal(componenttest.Serialize(clusterRole)))
-					Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_system_apiserver.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
-					Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_apiserver_auth-delegator.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingAuthDelegation)))
-					Expect(string(managedResourceSecretVirtual.Data["rolebinding__kube-system__gardener.cloud_apiserver_auth-reader.yaml"])).To(Equal(componenttest.Serialize(roleBindingAuthReader)))
+					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1beta1.core.gardener.cloud.yaml"])).To(Equal(testruntime.Serialize(apiServiceFor("core.gardener.cloud", "v1beta1"))))
+					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.seedmanagement.gardener.cloud.yaml"])).To(Equal(testruntime.Serialize(apiServiceFor("seedmanagement.gardener.cloud", "v1alpha1"))))
+					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.operations.gardener.cloud.yaml"])).To(Equal(testruntime.Serialize(apiServiceFor("operations.gardener.cloud", "v1alpha1"))))
+					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.settings.gardener.cloud.yaml"])).To(Equal(testruntime.Serialize(apiServiceFor("settings.gardener.cloud", "v1alpha1"))))
+					Expect(string(managedResourceSecretVirtual.Data["service__kube-system__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(serviceVirtual)))
+					Expect(string(managedResourceSecretVirtual.Data["endpoints__kube-system__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(endpoints)))
+					Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_system_apiserver.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
+					Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_system_apiserver.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
+					Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_apiserver_auth-delegator.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingAuthDelegation)))
+					Expect(string(managedResourceSecretVirtual.Data["rolebinding__kube-system__gardener.cloud_apiserver_auth-reader.yaml"])).To(Equal(testruntime.Serialize(roleBindingAuthReader)))
 					Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 				})
@@ -1450,8 +1450,8 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					})
 
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(componenttest.Serialize(vpa)))
-						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(true))))
+						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
+						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
 					})
 				})
 
@@ -1462,9 +1462,9 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					})
 
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecretRuntime.Data["hvpa__some-namespace__gardener-apiserver-hvpa.yaml"])).To(Equal(componenttest.Serialize(hvpa)))
-						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(true))))
-						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(serviceRuntimeFor(true))))
+						Expect(string(managedResourceSecretRuntime.Data["hvpa__some-namespace__gardener-apiserver-hvpa.yaml"])).To(Equal(testruntime.Serialize(hvpa)))
+						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
+						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(serviceRuntimeFor(true))))
 					})
 				})
 
@@ -1475,9 +1475,9 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					})
 
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(componenttest.Serialize(vpa)))
-						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(false))))
-						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(serviceRuntimeFor(false))))
+						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
+						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(false))))
+						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(serviceRuntimeFor(false))))
 					})
 				})
 
@@ -1488,9 +1488,9 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					})
 
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(componenttest.Serialize(vpa)))
-						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(true))))
-						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(componenttest.Serialize(serviceRuntimeFor(false))))
+						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
+						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
+						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(serviceRuntimeFor(false))))
 					})
 				})
 			})

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -21,6 +21,7 @@ import (
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
@@ -53,7 +54,6 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("GardenerAPIServer", func() {
@@ -78,6 +78,7 @@ var _ = Describe("GardenerAPIServer", func() {
 		fakeSecretManager secretsmanager.Interface
 		values            Values
 		deployer          Interface
+		containObject     func(object client.Object) types.GomegaMatcher
 
 		fakeOps *retryfake.Ops
 
@@ -145,6 +146,7 @@ var _ = Describe("GardenerAPIServer", func() {
 			TopologyAwareRoutingEnabled: true,
 		}
 		deployer = New(fakeClient, namespace, fakeSecretManager, values)
+		containObject = NewManagedResourceObjectMatcher(fakeClient)
 
 		fakeOps = &retryfake.Ops{MaxAttempts: 2}
 		DeferCleanup(test.WithVars(
@@ -1423,22 +1425,22 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 
 					Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
 					Expect(managedResourceSecretRuntime.Data).To(HaveLen(4))
-					Expect(string(managedResourceSecretRuntime.Data["deployment__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(deployment)))
+					Expect(managedResourceRuntime).To(containObject(deployment))
 					Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 					Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 					Expect(managedResourceSecretVirtual.Data).To(HaveLen(10))
-					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1beta1.core.gardener.cloud.yaml"])).To(Equal(testruntime.Serialize(apiServiceFor("core.gardener.cloud", "v1beta1"))))
-					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.seedmanagement.gardener.cloud.yaml"])).To(Equal(testruntime.Serialize(apiServiceFor("seedmanagement.gardener.cloud", "v1alpha1"))))
-					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.operations.gardener.cloud.yaml"])).To(Equal(testruntime.Serialize(apiServiceFor("operations.gardener.cloud", "v1alpha1"))))
-					Expect(string(managedResourceSecretVirtual.Data["apiservice____v1alpha1.settings.gardener.cloud.yaml"])).To(Equal(testruntime.Serialize(apiServiceFor("settings.gardener.cloud", "v1alpha1"))))
-					Expect(string(managedResourceSecretVirtual.Data["service__kube-system__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(serviceVirtual)))
-					Expect(string(managedResourceSecretVirtual.Data["endpoints__kube-system__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(endpoints)))
-					Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_system_apiserver.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
-					Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_system_apiserver.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
-					Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_apiserver_auth-delegator.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingAuthDelegation)))
-					Expect(string(managedResourceSecretVirtual.Data["rolebinding__kube-system__gardener.cloud_apiserver_auth-reader.yaml"])).To(Equal(testruntime.Serialize(roleBindingAuthReader)))
+					Expect(managedResourceVirtual).To(containObject(apiServiceFor("core.gardener.cloud", "v1beta1")))
+					Expect(managedResourceVirtual).To(containObject(apiServiceFor("seedmanagement.gardener.cloud", "v1alpha1")))
+					Expect(managedResourceVirtual).To(containObject(apiServiceFor("operations.gardener.cloud", "v1alpha1")))
+					Expect(managedResourceVirtual).To(containObject(apiServiceFor("settings.gardener.cloud", "v1alpha1")))
+					Expect(managedResourceVirtual).To(containObject(serviceVirtual))
+					Expect(managedResourceVirtual).To(containObject(endpoints))
+					Expect(managedResourceVirtual).To(containObject(clusterRole))
+					Expect(managedResourceVirtual).To(containObject(clusterRoleBinding))
+					Expect(managedResourceVirtual).To(containObject(clusterRoleBindingAuthDelegation))
+					Expect(managedResourceVirtual).To(containObject(roleBindingAuthReader))
 					Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 				})
@@ -1450,8 +1452,8 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					})
 
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
-						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
+						Expect(managedResourceRuntime).To(containObject(vpa))
+						Expect(managedResourceRuntime).To(containObject(podDisruptionBudgetFor(true)))
 					})
 				})
 
@@ -1462,9 +1464,9 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					})
 
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecretRuntime.Data["hvpa__some-namespace__gardener-apiserver-hvpa.yaml"])).To(Equal(testruntime.Serialize(hvpa)))
-						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
-						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(serviceRuntimeFor(true))))
+						Expect(managedResourceRuntime).To(containObject(hvpa))
+						Expect(managedResourceRuntime).To(containObject(podDisruptionBudgetFor(true)))
+						Expect(managedResourceRuntime).To(containObject(serviceRuntimeFor(true)))
 					})
 				})
 
@@ -1475,9 +1477,9 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					})
 
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
-						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(false))))
-						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(serviceRuntimeFor(false))))
+						Expect(managedResourceRuntime).To(containObject(vpa))
+						Expect(managedResourceRuntime).To(containObject(podDisruptionBudgetFor(false)))
+						Expect(managedResourceRuntime).To(containObject(serviceRuntimeFor(false)))
 					})
 				})
 
@@ -1488,9 +1490,9 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					})
 
 					It("should successfully deploy all resources", func() {
-						Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-apiserver-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
-						Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
-						Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-apiserver.yaml"])).To(Equal(testruntime.Serialize(serviceRuntimeFor(false))))
+						Expect(managedResourceRuntime).To(containObject(vpa))
+						Expect(managedResourceRuntime).To(containObject(podDisruptionBudgetFor(true)))
+						Expect(managedResourceRuntime).To(containObject(serviceRuntimeFor(false)))
 					})
 				})
 			})

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -71,8 +71,8 @@ var _ = Describe("GardenerControllerManager", func() {
 		deployer          component.DeployWaiter
 		values            Values
 
-		fakeOps       *retryfake.Ops
-		containObject func(object client.Object) types.GomegaMatcher
+		fakeOps   *retryfake.Ops
+		consistOf func(...client.Object) types.GomegaMatcher
 
 		managedResourceRuntime       *resourcesv1alpha1.ManagedResource
 		managedResourceVirtual       *resourcesv1alpha1.ManagedResource
@@ -88,7 +88,7 @@ var _ = Describe("GardenerControllerManager", func() {
 	)
 
 	BeforeEach(func() {
-		ctx = context.TODO()
+		ctx = context.Background()
 
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
 		fakeSecretManager = fakesecretsmanager.New(fakeClient, namespace)
@@ -103,7 +103,7 @@ var _ = Describe("GardenerControllerManager", func() {
 			&retry.UntilTimeout, fakeOps.UntilTimeout,
 		))
 
-		containObject = NewManagedResourceObjectMatcher(fakeClient)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient)
 
 		managedResourceRuntime = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -257,6 +257,8 @@ var _ = Describe("GardenerControllerManager", func() {
 
 	Describe("#Deploy", func() {
 		Context("resources generation", func() {
+			var expectedRuntimeObjects []client.Object
+
 			BeforeEach(func() {
 				// test with typical values
 				values = Values{
@@ -315,6 +317,12 @@ var _ = Describe("GardenerControllerManager", func() {
 
 				managedResourceSecretRuntime.Name = managedResourceRuntime.Spec.SecretRefs[0].Name
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
+				expectedRuntimeObjects = []client.Object{
+					configMap(namespace, values),
+					serviceRuntime,
+					vpa,
+					deployment(namespace, "gardener-controller-manager-config-cff08f20", values),
+				}
 
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(Succeed())
 				expectedVirtualMr := &resourcesv1alpha1.ManagedResource{
@@ -337,23 +345,15 @@ var _ = Describe("GardenerControllerManager", func() {
 				}
 				utilruntime.Must(references.InjectAnnotations(expectedVirtualMr))
 				Expect(managedResourceVirtual).To(Equal(expectedVirtualMr))
+				Expect(managedResourceVirtual).To(consistOf(clusterRole, clusterRoleBinding))
 
 				managedResourceSecretVirtual.Name = expectedVirtualMr.Spec.SecretRefs[0].Name
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
-
 				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceSecretRuntime.Data).To(HaveLen(5))
-				Expect(managedResourceRuntime).To(containObject(configMap(namespace, values)))
-				Expect(managedResourceRuntime).To(containObject(serviceRuntime))
-				Expect(managedResourceRuntime).To(containObject(vpa))
-				Expect(managedResourceRuntime).To(containObject(deployment(namespace, "gardener-controller-manager-config-cff08f20", values)))
 				Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceSecretVirtual.Data).To(HaveLen(2))
-				Expect(managedResourceVirtual).To(containObject(clusterRole))
-				Expect(managedResourceVirtual).To(containObject(clusterRoleBinding))
 				Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
@@ -361,7 +361,8 @@ var _ = Describe("GardenerControllerManager", func() {
 
 			Context("Kubernetes version >= 1.26", func() {
 				It("should successfully deploy all resources", func() {
-					Expect(managedResourceRuntime).To(containObject(podDisruptionBudgetFor(true)))
+					expectedRuntimeObjects = append(expectedRuntimeObjects, podDisruptionBudgetFor(true))
+					Expect(managedResourceRuntime).To(consistOf(expectedRuntimeObjects...))
 					Expect(deployer.Deploy(ctx)).To(Succeed())
 				})
 			})
@@ -372,7 +373,8 @@ var _ = Describe("GardenerControllerManager", func() {
 				})
 
 				It("should successfully deploy all resources", func() {
-					Expect(managedResourceRuntime).To(containObject(podDisruptionBudgetFor(false)))
+					expectedRuntimeObjects = append(expectedRuntimeObjects, podDisruptionBudgetFor(false))
+					Expect(managedResourceRuntime).To(consistOf(expectedRuntimeObjects...))
 					Expect(deployer.Deploy(ctx)).To(Succeed())
 				})
 			})

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -42,7 +42,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/gardener/controllermanager"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
@@ -56,6 +55,7 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("GardenerControllerManager", func() {
@@ -341,16 +341,16 @@ var _ = Describe("GardenerControllerManager", func() {
 				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretRuntime.Data).To(HaveLen(5))
 				Expect(string(managedResourceSecretRuntime.Data["configmap__some-namespace__gardener-controller-manager-config-cff08f20.yaml"])).To(Equal(configMap(namespace, values)))
-				Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-controller-manager.yaml"])).To(Equal(componenttest.Serialize(serviceRuntime)))
-				Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-controller-manager-vpa.yaml"])).To(Equal(componenttest.Serialize(vpa)))
+				Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-controller-manager.yaml"])).To(Equal(testruntime.Serialize(serviceRuntime)))
+				Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-controller-manager-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
 				Expect(string(managedResourceSecretRuntime.Data["deployment__some-namespace__gardener-controller-manager.yaml"])).To(Equal(deployment(namespace, "gardener-controller-manager-config-cff08f20", values)))
 				Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretVirtual.Data).To(HaveLen(2))
-				Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_system_controller-manager.yaml"])).To(Equal(componenttest.Serialize(clusterRole)))
-				Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_system_controller-manager.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
+				Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_system_controller-manager.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
+				Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_system_controller-manager.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
 				Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
@@ -358,7 +358,7 @@ var _ = Describe("GardenerControllerManager", func() {
 
 			Context("Kubernetes version >= 1.26", func() {
 				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-controller-manager.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(true))))
+					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-controller-manager.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
 					Expect(deployer.Deploy(ctx)).To(Succeed())
 				})
 			})
@@ -369,7 +369,7 @@ var _ = Describe("GardenerControllerManager", func() {
 				})
 
 				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-controller-manager.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(false))))
+					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-controller-manager.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(false))))
 					Expect(deployer.Deploy(ctx)).To(Succeed())
 				})
 			})
@@ -770,7 +770,7 @@ func configMap(namespace string, testValues Values) string {
 	}
 	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
 
-	return componenttest.Serialize(configMap)
+	return testruntime.Serialize(configMap)
 }
 
 func deployment(namespace, configSecretName string, testValues Values) string {
@@ -911,5 +911,5 @@ func deployment(namespace, configSecretName string, testValues Values) string {
 
 	utilruntime.Must(references.InjectAnnotations(deployment))
 
-	return componenttest.Serialize(deployment)
+	return testruntime.Serialize(deployment)
 }

--- a/pkg/component/gardener/scheduler/scheduler_test.go
+++ b/pkg/component/gardener/scheduler/scheduler_test.go
@@ -42,7 +42,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/gardener/scheduler"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	schedulerv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
@@ -54,6 +53,7 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("GardenerScheduler", func() {
@@ -378,16 +378,16 @@ var _ = Describe("GardenerScheduler", func() {
 				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretRuntime.Data).To(HaveLen(5))
 				Expect(string(managedResourceSecretRuntime.Data["configmap__some-namespace__gardener-scheduler-config-3cf6616e.yaml"])).To(Equal(configMap(namespace, values)))
-				Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-scheduler.yaml"])).To(Equal(componenttest.Serialize(serviceRuntime)))
-				Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-scheduler-vpa.yaml"])).To(Equal(componenttest.Serialize(vpa)))
+				Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-scheduler.yaml"])).To(Equal(testruntime.Serialize(serviceRuntime)))
+				Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-scheduler-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
 				Expect(string(managedResourceSecretRuntime.Data["deployment__some-namespace__gardener-scheduler.yaml"])).To(Equal(deployment(namespace, "gardener-scheduler-config-3cf6616e", values)))
 				Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretVirtual.Data).To(HaveLen(2))
-				Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_system_scheduler.yaml"])).To(Equal(componenttest.Serialize(clusterRole)))
-				Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_system_scheduler.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
+				Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_system_scheduler.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
+				Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_system_scheduler.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
 				Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 			})
@@ -398,13 +398,13 @@ var _ = Describe("GardenerScheduler", func() {
 				})
 
 				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-scheduler.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(false))))
+					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-scheduler.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(false))))
 				})
 			})
 
 			Context("Kubernetes versions >= 1.26", func() {
 				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-scheduler.yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudgetFor(true))))
+					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-scheduler.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
 				})
 			})
 		})
@@ -775,7 +775,7 @@ func configMap(namespace string, testValues Values) string {
 	}
 	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
 
-	return componenttest.Serialize(configMap)
+	return testruntime.Serialize(configMap)
 }
 
 func deployment(namespace, configSecretName string, testValues Values) string {
@@ -916,5 +916,5 @@ func deployment(namespace, configSecretName string, testValues Values) string {
 
 	utilruntime.Must(references.InjectAnnotations(deployment))
 
-	return componenttest.Serialize(deployment)
+	return testruntime.Serialize(deployment)
 }

--- a/pkg/component/gardener/scheduler/scheduler_test.go
+++ b/pkg/component/gardener/scheduler/scheduler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	coordinationv1beta1 "k8s.io/api/coordination/v1beta1"
@@ -53,7 +54,6 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("GardenerScheduler", func() {
@@ -69,7 +69,8 @@ var _ = Describe("GardenerScheduler", func() {
 		deployer          component.DeployWaiter
 		values            Values
 
-		fakeOps *retryfake.Ops
+		fakeOps       *retryfake.Ops
+		containObject func(object client.Object) types.GomegaMatcher
 
 		managedResourceRuntime       *resourcesv1alpha1.ManagedResource
 		managedResourceVirtual       *resourcesv1alpha1.ManagedResource
@@ -99,6 +100,8 @@ var _ = Describe("GardenerScheduler", func() {
 			&retry.Until, fakeOps.Until,
 			&retry.UntilTimeout, fakeOps.UntilTimeout,
 		))
+
+		containObject = NewManagedResourceObjectMatcher(fakeClient)
 
 		managedResourceRuntime = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -377,17 +380,17 @@ var _ = Describe("GardenerScheduler", func() {
 
 				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretRuntime.Data).To(HaveLen(5))
-				Expect(string(managedResourceSecretRuntime.Data["configmap__some-namespace__gardener-scheduler-config-3cf6616e.yaml"])).To(Equal(configMap(namespace, values)))
-				Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-scheduler.yaml"])).To(Equal(testruntime.Serialize(serviceRuntime)))
-				Expect(string(managedResourceSecretRuntime.Data["verticalpodautoscaler__some-namespace__gardener-scheduler-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
-				Expect(string(managedResourceSecretRuntime.Data["deployment__some-namespace__gardener-scheduler.yaml"])).To(Equal(deployment(namespace, "gardener-scheduler-config-3cf6616e", values)))
+				Expect(managedResourceRuntime).To(containObject(configMap(namespace, values)))
+				Expect(managedResourceRuntime).To(containObject(serviceRuntime))
+				Expect(managedResourceRuntime).To(containObject(vpa))
+				Expect(managedResourceRuntime).To(containObject(deployment(namespace, "gardener-scheduler-config-3cf6616e", values)))
 				Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretVirtual.Data).To(HaveLen(2))
-				Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_system_scheduler.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
-				Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_system_scheduler.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
+				Expect(managedResourceVirtual).To(containObject(clusterRole))
+				Expect(managedResourceVirtual).To(containObject(clusterRoleBinding))
 				Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 			})
@@ -398,13 +401,13 @@ var _ = Describe("GardenerScheduler", func() {
 				})
 
 				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-scheduler.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(false))))
+					Expect(managedResourceRuntime).To(containObject(podDisruptionBudgetFor(false)))
 				})
 			})
 
 			Context("Kubernetes versions >= 1.26", func() {
 				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecretRuntime.Data["poddisruptionbudget__some-namespace__gardener-scheduler.yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudgetFor(true))))
+					Expect(managedResourceRuntime).To(containObject(podDisruptionBudgetFor(true)))
 				})
 			})
 		})
@@ -720,7 +723,7 @@ var (
 	}
 )
 
-func configMap(namespace string, testValues Values) string {
+func configMap(namespace string, testValues Values) *corev1.ConfigMap {
 	schedulerConfig := &schedulerv1alpha1.SchedulerConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "scheduler.config.gardener.cloud/v1alpha1",
@@ -775,10 +778,10 @@ func configMap(namespace string, testValues Values) string {
 	}
 	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
 
-	return testruntime.Serialize(configMap)
+	return configMap
 }
 
-func deployment(namespace, configSecretName string, testValues Values) string {
+func deployment(namespace, configSecretName string, testValues Values) *appsv1.Deployment {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gardener-scheduler",
@@ -916,5 +919,5 @@ func deployment(namespace, configSecretName string, testValues Values) string {
 
 	utilruntime.Must(references.InjectAnnotations(deployment))
 
-	return testruntime.Serialize(deployment)
+	return deployment
 }

--- a/pkg/component/observability/logging/eventlogger/event_logger_test.go
+++ b/pkg/component/observability/logging/eventlogger/event_logger_test.go
@@ -37,11 +37,11 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/logging/eventlogger"
-	"github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("EventLogger", func() {
@@ -325,8 +325,8 @@ var _ = Describe("EventLogger", func() {
 			Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-			Expect(string(managedResourceSecret.Data["clusterrole____event-logger.yaml"])).To(Equal(test.Serialize(clusterRoleForShoot())))
-			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_logging_event-logger.yaml"])).To(Equal(test.Serialize(clusterRoleBinding)))
+			Expect(string(managedResourceSecret.Data["clusterrole____event-logger.yaml"])).To(Equal(testruntime.Serialize(clusterRoleForShoot())))
+			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_logging_event-logger.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(eventLoggerServiceAccount), eventLoggerServiceAccount)).To(Succeed())
 			Expect(eventLoggerServiceAccount).To(DeepEqual(&corev1.ServiceAccount{

--- a/pkg/component/observability/logging/fluentoperator/fluent_bit_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluent_bit_test.go
@@ -40,6 +40,7 @@ import (
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("Fluent Bit", func() {
@@ -287,9 +288,9 @@ var _ = Describe("Fluent Bit", func() {
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____zz-modify-severity.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterparser____containerd-parser.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusteroutput____journald.yaml"))
-			Expect(string(customResourcesManagedResourceSecret.Data["servicemonitor__"+namespace+"__aggregate-fluent-bit.yaml"])).To(Equal(componenttest.Serialize(serviceMonitor)))
-			Expect(string(customResourcesManagedResourceSecret.Data["servicemonitor__"+namespace+"__aggregate-fluent-bit-output-plugin.yaml"])).To(Equal(componenttest.Serialize(serviceMonitorPlugin)))
-			Expect(string(customResourcesManagedResourceSecret.Data["prometheusrule__"+namespace+"__aggregate-fluent-bit.yaml"])).To(Equal(componenttest.Serialize(prometheusRule)))
+			Expect(string(customResourcesManagedResourceSecret.Data["servicemonitor__"+namespace+"__aggregate-fluent-bit.yaml"])).To(Equal(testruntime.Serialize(serviceMonitor)))
+			Expect(string(customResourcesManagedResourceSecret.Data["servicemonitor__"+namespace+"__aggregate-fluent-bit-output-plugin.yaml"])).To(Equal(testruntime.Serialize(serviceMonitorPlugin)))
+			Expect(string(customResourcesManagedResourceSecret.Data["prometheusrule__"+namespace+"__aggregate-fluent-bit.yaml"])).To(Equal(testruntime.Serialize(prometheusRule)))
 			componenttest.PrometheusRule(prometheusRule, "testdata/fluent-bit.prometheusrule.test.yaml")
 		})
 	})

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
@@ -37,12 +37,12 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("Fluent Operator", func() {
@@ -357,13 +357,13 @@ var _ = Describe("Fluent Operator", func() {
 			Expect(operatorManagedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(operatorManagedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-			Expect(string(operatorManagedResourceSecret.Data["serviceaccount__"+namespace+"__fluent-operator.yaml"])).To(Equal(componenttest.Serialize(serviceAccount)))
-			Expect(string(operatorManagedResourceSecret.Data["clusterrole____gardener.cloud_logging_fluent-operator.yaml"])).To(Equal(componenttest.Serialize(clusterRole)))
-			Expect(string(operatorManagedResourceSecret.Data["clusterrolebinding____fluent-operator.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
-			Expect(string(operatorManagedResourceSecret.Data["role__"+namespace+"__gardener.cloud_logging_fluent-operator.yaml"])).To(Equal(componenttest.Serialize(role)))
-			Expect(string(operatorManagedResourceSecret.Data["rolebinding__"+namespace+"__gardener.cloud_logging_fluent-operator.yaml"])).To(Equal(componenttest.Serialize(roleBinding)))
-			Expect(string(operatorManagedResourceSecret.Data["deployment__"+namespace+"__fluent-operator.yaml"])).To(Equal(componenttest.Serialize(deployment)))
-			Expect(string(operatorManagedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__fluent-operator.yaml"])).To(Equal(componenttest.Serialize(vpa)))
+			Expect(string(operatorManagedResourceSecret.Data["serviceaccount__"+namespace+"__fluent-operator.yaml"])).To(Equal(testruntime.Serialize(serviceAccount)))
+			Expect(string(operatorManagedResourceSecret.Data["clusterrole____gardener.cloud_logging_fluent-operator.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
+			Expect(string(operatorManagedResourceSecret.Data["clusterrolebinding____fluent-operator.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
+			Expect(string(operatorManagedResourceSecret.Data["role__"+namespace+"__gardener.cloud_logging_fluent-operator.yaml"])).To(Equal(testruntime.Serialize(role)))
+			Expect(string(operatorManagedResourceSecret.Data["rolebinding__"+namespace+"__gardener.cloud_logging_fluent-operator.yaml"])).To(Equal(testruntime.Serialize(roleBinding)))
+			Expect(string(operatorManagedResourceSecret.Data["deployment__"+namespace+"__fluent-operator.yaml"])).To(Equal(testruntime.Serialize(deployment)))
+			Expect(string(operatorManagedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__fluent-operator.yaml"])).To(Equal(testruntime.Serialize(vpa)))
 		})
 	})
 

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -50,6 +50,7 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -191,12 +192,12 @@ var _ = Describe("Vali", func() {
 			Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-			Expect(string(managedResourceSecret.Data["configmap__shoot--foo--bar__"+telegrafConfigMapName+".yaml"])).To(Equal(test.Serialize(getTelegrafConfigMap())))
-			Expect(string(managedResourceSecret.Data["configmap__shoot--foo--bar__"+valiConfigMapName+".yaml"])).To(Equal(test.Serialize(getValiConfigMap())))
-			Expect(string(managedResourceSecret.Data["hvpa__shoot--foo--bar__vali.yaml"])).To(Equal(test.Serialize(getHVPA(true))))
-			Expect(string(managedResourceSecret.Data["ingress__shoot--foo--bar__vali.yaml"])).To(Equal(test.Serialize(getIngress())))
-			Expect(string(managedResourceSecret.Data["service__shoot--foo--bar__logging.yaml"])).To(Equal(test.Serialize(getService(true, "shoot"))))
-			Expect(string(managedResourceSecret.Data["statefulset__shoot--foo--bar__vali.yaml"])).To(Equal(test.Serialize(getStatefulSet(true))))
+			Expect(string(managedResourceSecret.Data["configmap__shoot--foo--bar__"+telegrafConfigMapName+".yaml"])).To(Equal(testruntime.Serialize(getTelegrafConfigMap())))
+			Expect(string(managedResourceSecret.Data["configmap__shoot--foo--bar__"+valiConfigMapName+".yaml"])).To(Equal(testruntime.Serialize(getValiConfigMap())))
+			Expect(string(managedResourceSecret.Data["hvpa__shoot--foo--bar__vali.yaml"])).To(Equal(testruntime.Serialize(getHVPA(true))))
+			Expect(string(managedResourceSecret.Data["ingress__shoot--foo--bar__vali.yaml"])).To(Equal(testruntime.Serialize(getIngress())))
+			Expect(string(managedResourceSecret.Data["service__shoot--foo--bar__logging.yaml"])).To(Equal(testruntime.Serialize(getService(true, "shoot"))))
+			Expect(string(managedResourceSecret.Data["statefulset__shoot--foo--bar__vali.yaml"])).To(Equal(testruntime.Serialize(getStatefulSet(true))))
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceTarget), managedResourceTarget)).To(Succeed())
 			expectedTargetMr := &resourcesv1alpha1.ManagedResource{
@@ -224,9 +225,9 @@ var _ = Describe("Vali", func() {
 			Expect(managedResourceSecretTarget.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecretTarget.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-			Expect(string(managedResourceSecretTarget.Data["clusterrolebinding____gardener.cloud_logging_kube-rbac-proxy.yaml"])).To(Equal(test.Serialize(getKubeRBACProxyClusterRoleBinding())))
-			Expect(string(managedResourceSecretTarget.Data["clusterrole____gardener.cloud_logging_valitail.yaml"])).To(Equal(test.Serialize(getValitailClusterRole())))
-			Expect(string(managedResourceSecretTarget.Data["clusterrolebinding____gardener.cloud_logging_valitail.yaml"])).To(Equal(test.Serialize(getValitailClusterRoleBinding())))
+			Expect(string(managedResourceSecretTarget.Data["clusterrolebinding____gardener.cloud_logging_kube-rbac-proxy.yaml"])).To(Equal(testruntime.Serialize(getKubeRBACProxyClusterRoleBinding())))
+			Expect(string(managedResourceSecretTarget.Data["clusterrole____gardener.cloud_logging_valitail.yaml"])).To(Equal(testruntime.Serialize(getValitailClusterRole())))
+			Expect(string(managedResourceSecretTarget.Data["clusterrolebinding____gardener.cloud_logging_valitail.yaml"])).To(Equal(testruntime.Serialize(getValitailClusterRoleBinding())))
 		})
 
 		It("should successfully deploy all resources for seed", func() {
@@ -291,12 +292,12 @@ var _ = Describe("Vali", func() {
 			Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-			Expect(string(managedResourceSecret.Data["configmap__shoot--foo--bar__"+valiConfigMapName+".yaml"])).To(Equal(test.Serialize(getValiConfigMap())))
-			Expect(string(managedResourceSecret.Data["hvpa__shoot--foo--bar__vali.yaml"])).To(Equal(test.Serialize(getHVPA(false))))
-			Expect(string(managedResourceSecret.Data["service__shoot--foo--bar__logging.yaml"])).To(Equal(test.Serialize(getService(false, "seed"))))
-			Expect(string(managedResourceSecret.Data["statefulset__shoot--foo--bar__vali.yaml"])).To(Equal(test.Serialize(getStatefulSet(false))))
-			Expect(string(managedResourceSecret.Data["servicemonitor__shoot--foo--bar__aggregate-vali.yaml"])).To(Equal(test.Serialize(getServiceMonitor())))
-			Expect(string(managedResourceSecret.Data["prometheusrule__shoot--foo--bar__aggregate-vali.yaml"])).To(Equal(test.Serialize(getPrometheusRule())))
+			Expect(string(managedResourceSecret.Data["configmap__shoot--foo--bar__"+valiConfigMapName+".yaml"])).To(Equal(testruntime.Serialize(getValiConfigMap())))
+			Expect(string(managedResourceSecret.Data["hvpa__shoot--foo--bar__vali.yaml"])).To(Equal(testruntime.Serialize(getHVPA(false))))
+			Expect(string(managedResourceSecret.Data["service__shoot--foo--bar__logging.yaml"])).To(Equal(testruntime.Serialize(getService(false, "seed"))))
+			Expect(string(managedResourceSecret.Data["statefulset__shoot--foo--bar__vali.yaml"])).To(Equal(testruntime.Serialize(getStatefulSet(false))))
+			Expect(string(managedResourceSecret.Data["servicemonitor__shoot--foo--bar__aggregate-vali.yaml"])).To(Equal(testruntime.Serialize(getServiceMonitor())))
+			Expect(string(managedResourceSecret.Data["prometheusrule__shoot--foo--bar__aggregate-vali.yaml"])).To(Equal(testruntime.Serialize(getPrometheusRule())))
 			test.PrometheusRule(getPrometheusRule(), "testdata/aggregate-vali.prometheusrule.test.yaml")
 		})
 
@@ -347,11 +348,11 @@ var _ = Describe("Vali", func() {
 			Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-			Expect(string(managedResourceSecret.Data["configmap__shoot--foo--bar__"+valiConfigMapName+".yaml"])).To(Equal(test.Serialize(getValiConfigMap())))
-			Expect(string(managedResourceSecret.Data["service__shoot--foo--bar__logging.yaml"])).To(Equal(test.Serialize(getService(false, "seed"))))
-			Expect(string(managedResourceSecret.Data["statefulset__shoot--foo--bar__vali.yaml"])).To(Equal(test.Serialize(getStatefulSet(false))))
-			Expect(string(managedResourceSecret.Data["servicemonitor__shoot--foo--bar__aggregate-vali.yaml"])).To(Equal(test.Serialize(getServiceMonitor())))
-			Expect(string(managedResourceSecret.Data["prometheusrule__shoot--foo--bar__aggregate-vali.yaml"])).To(Equal(test.Serialize(getPrometheusRule())))
+			Expect(string(managedResourceSecret.Data["configmap__shoot--foo--bar__"+valiConfigMapName+".yaml"])).To(Equal(testruntime.Serialize(getValiConfigMap())))
+			Expect(string(managedResourceSecret.Data["service__shoot--foo--bar__logging.yaml"])).To(Equal(testruntime.Serialize(getService(false, "seed"))))
+			Expect(string(managedResourceSecret.Data["statefulset__shoot--foo--bar__vali.yaml"])).To(Equal(testruntime.Serialize(getStatefulSet(false))))
+			Expect(string(managedResourceSecret.Data["servicemonitor__shoot--foo--bar__aggregate-vali.yaml"])).To(Equal(testruntime.Serialize(getServiceMonitor())))
+			Expect(string(managedResourceSecret.Data["prometheusrule__shoot--foo--bar__aggregate-vali.yaml"])).To(Equal(testruntime.Serialize(getPrometheusRule())))
 		})
 	})
 

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -86,8 +86,8 @@ var _ = Describe("Alertmanager", func() {
 		deployer   component.DeployWaiter
 		values     Values
 
-		fakeOps       *retryfake.Ops
-		containObject func(object client.Object) types.GomegaMatcher
+		fakeOps   *retryfake.Ops
+		consistOf func(...client.Object) types.GomegaMatcher
 
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
@@ -123,7 +123,7 @@ var _ = Describe("Alertmanager", func() {
 			&retry.UntilTimeout, fakeOps.UntilTimeout,
 		))
 
-		containObject = NewManagedResourceObjectMatcher(fakeClient)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient)
 
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -450,13 +450,13 @@ var _ = Describe("Alertmanager", func() {
 
 		When("cluster type is 'seed'", func() {
 			It("should successfully deploy all resources", func() {
-				Expect(managedResourceSecret.Data).To(HaveLen(5))
-				Expect(managedResource).To(containObject(service))
-				Expect(managedResource).To(containObject(alertManager))
-				Expect(managedResource).To(containObject(vpa))
-				Expect(managedResource).To(containObject(config))
-				Expect(managedResource).To(containObject(smtpSecret))
-				Expect(managedResourceSecret.Data).NotTo(HaveKey("poddisruptionbudget__some-namespace__alertmanager-" + name + ".yaml"))
+				Expect(managedResource).To(consistOf(
+					service,
+					alertManager,
+					vpa,
+					config,
+					smtpSecret,
+				))
 			})
 
 			When("ingress is configured", func() {
@@ -471,14 +471,14 @@ var _ = Describe("Alertmanager", func() {
 				It("should successfully deploy all resources", func() {
 					alertManager.Spec.ExternalURL = "https://" + ingressHost
 
-					Expect(managedResourceSecret.Data).To(HaveLen(6))
-					Expect(managedResource).To(containObject(service))
-					Expect(managedResource).To(containObject(alertManager))
-					Expect(managedResource).To(containObject(vpa))
-					Expect(managedResource).To(containObject(config))
-					Expect(managedResource).To(containObject(smtpSecret))
-					Expect(managedResource).To(containObject(ingress))
-					Expect(managedResourceSecret.Data).NotTo(HaveKey("poddisruptionbudget__some-namespace__alertmanager-" + name + ".yaml"))
+					Expect(managedResource).To(consistOf(
+						service,
+						alertManager,
+						vpa,
+						config,
+						smtpSecret,
+						ingress,
+					))
 				})
 			})
 
@@ -492,12 +492,11 @@ var _ = Describe("Alertmanager", func() {
 
 					Expect(managedResourceSecret.Data).To(HaveLen(3))
 
-					Expect(managedResource).To(containObject(service))
-					Expect(managedResource).To(containObject(alertManager))
-					Expect(managedResource).To(containObject(vpa))
-					Expect(managedResourceSecret.Data).NotTo(HaveKey("alertmanagerconfig__some-namespace__alertmanager-" + name + ".yaml"))
-					Expect(managedResourceSecret.Data).NotTo(HaveKey("secret__some-namespace__alertmanager-" + name + "-smtp.yaml"))
-					Expect(managedResourceSecret.Data).NotTo(HaveKey("poddisruptionbudget__some-namespace__alertmanager-" + name + ".yaml"))
+					Expect(managedResource).To(consistOf(
+						service,
+						alertManager,
+						vpa,
+					))
 				})
 			})
 
@@ -532,13 +531,13 @@ var _ = Describe("Alertmanager", func() {
 				})
 
 				It("should successfully deploy all resources", func() {
-					Expect(managedResourceSecret.Data).To(HaveLen(5))
-
-					Expect(managedResource).To(containObject(service))
-					Expect(managedResource).To(containObject(alertManager))
-					Expect(managedResource).To(containObject(vpa))
-					Expect(managedResource).To(containObject(config))
-					Expect(managedResource).To(containObject(smtpSecret))
+					Expect(managedResource).To(consistOf(
+						service,
+						alertManager,
+						vpa,
+						config,
+						smtpSecret,
+					))
 				})
 			})
 
@@ -553,14 +552,14 @@ var _ = Describe("Alertmanager", func() {
 					alertManager.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-udp-9094"] = "allowed"
 					alertManager.Spec.Replicas = ptr.To(int32(2))
 
-					Expect(managedResourceSecret.Data).To(HaveLen(6))
-
-					Expect(managedResource).To(containObject(service))
-					Expect(managedResource).To(containObject(alertManager))
-					Expect(managedResource).To(containObject(vpa))
-					Expect(managedResource).To(containObject(config))
-					Expect(managedResource).To(containObject(smtpSecret))
-					Expect(managedResource).To(containObject(podDisruptionBudget))
+					Expect(managedResource).To(consistOf(
+						service,
+						alertManager,
+						vpa,
+						config,
+						smtpSecret,
+						podDisruptionBudget,
+					))
 				})
 			})
 		})
@@ -576,13 +575,13 @@ var _ = Describe("Alertmanager", func() {
 			})
 
 			It("should successfully deploy all resources", func() {
-				Expect(managedResourceSecret.Data).To(HaveLen(5))
-
-				Expect(managedResource).To(containObject(service))
-				Expect(managedResource).To(containObject(alertManager))
-				Expect(managedResource).To(containObject(vpa))
-				Expect(managedResource).To(containObject(config))
-				Expect(managedResource).To(containObject(smtpSecret))
+				Expect(managedResource).To(consistOf(
+					service,
+					alertManager,
+					vpa,
+					config,
+					smtpSecret,
+				))
 			})
 		})
 	})

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -42,13 +42,13 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/alertmanager"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("Alertmanager", func() {
@@ -448,12 +448,11 @@ var _ = Describe("Alertmanager", func() {
 		When("cluster type is 'seed'", func() {
 			It("should successfully deploy all resources", func() {
 				Expect(managedResourceSecret.Data).To(HaveLen(5))
-
-				Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(service)))
-				Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(componenttest.Serialize(alertManager)))
-				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(vpa)))
-				Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(config)))
-				Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(componenttest.Serialize(smtpSecret)))
+				Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(service)))
+				Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(testruntime.Serialize(alertManager)))
+				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(vpa)))
+				Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(config)))
+				Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(testruntime.Serialize(smtpSecret)))
 				Expect(managedResourceSecret.Data).NotTo(HaveKey("poddisruptionbudget__some-namespace__alertmanager-" + name + ".yaml"))
 			})
 
@@ -470,13 +469,12 @@ var _ = Describe("Alertmanager", func() {
 					alertManager.Spec.ExternalURL = "https://" + ingressHost
 
 					Expect(managedResourceSecret.Data).To(HaveLen(6))
-
-					Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(service)))
-					Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(componenttest.Serialize(alertManager)))
-					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(vpa)))
-					Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(config)))
-					Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(componenttest.Serialize(smtpSecret)))
-					Expect(string(managedResourceSecret.Data["ingress__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(ingress)))
+					Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(service)))
+					Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(testruntime.Serialize(alertManager)))
+					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(vpa)))
+					Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(config)))
+					Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(testruntime.Serialize(smtpSecret)))
+					Expect(string(managedResourceSecret.Data["ingress__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(ingress)))
 					Expect(managedResourceSecret.Data).NotTo(HaveKey("poddisruptionbudget__some-namespace__alertmanager-" + name + ".yaml"))
 				})
 			})
@@ -491,9 +489,9 @@ var _ = Describe("Alertmanager", func() {
 
 					Expect(managedResourceSecret.Data).To(HaveLen(3))
 
-					Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(service)))
-					Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(componenttest.Serialize(alertManager)))
-					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(vpa)))
+					Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(service)))
+					Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(testruntime.Serialize(alertManager)))
+					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(vpa)))
 					Expect(managedResourceSecret.Data).NotTo(HaveKey("alertmanagerconfig__some-namespace__alertmanager-" + name + ".yaml"))
 					Expect(managedResourceSecret.Data).NotTo(HaveKey("secret__some-namespace__alertmanager-" + name + "-smtp.yaml"))
 					Expect(managedResourceSecret.Data).NotTo(HaveKey("poddisruptionbudget__some-namespace__alertmanager-" + name + ".yaml"))
@@ -533,11 +531,11 @@ var _ = Describe("Alertmanager", func() {
 				It("should successfully deploy all resources", func() {
 					Expect(managedResourceSecret.Data).To(HaveLen(5))
 
-					Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(service)))
-					Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(componenttest.Serialize(alertManager)))
-					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(vpa)))
-					Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(config)))
-					Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(componenttest.Serialize(smtpSecret)))
+					Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(service)))
+					Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(testruntime.Serialize(alertManager)))
+					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(vpa)))
+					Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(config)))
+					Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(testruntime.Serialize(smtpSecret)))
 				})
 			})
 
@@ -554,12 +552,12 @@ var _ = Describe("Alertmanager", func() {
 
 					Expect(managedResourceSecret.Data).To(HaveLen(6))
 
-					Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(service)))
-					Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(componenttest.Serialize(alertManager)))
-					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(vpa)))
-					Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(config)))
-					Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(componenttest.Serialize(smtpSecret)))
-					Expect(string(managedResourceSecret.Data["poddisruptionbudget__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(podDisruptionBudget)))
+					Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(service)))
+					Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(testruntime.Serialize(alertManager)))
+					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(vpa)))
+					Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(config)))
+					Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(testruntime.Serialize(smtpSecret)))
+					Expect(string(managedResourceSecret.Data["poddisruptionbudget__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(podDisruptionBudget)))
 				})
 			})
 		})
@@ -577,11 +575,11 @@ var _ = Describe("Alertmanager", func() {
 			It("should successfully deploy all resources", func() {
 				Expect(managedResourceSecret.Data).To(HaveLen(5))
 
-				Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(service)))
-				Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(componenttest.Serialize(alertManager)))
-				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(vpa)))
-				Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(componenttest.Serialize(config)))
-				Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(componenttest.Serialize(smtpSecret)))
+				Expect(string(managedResourceSecret.Data["service__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(service)))
+				Expect(string(managedResourceSecret.Data["alertmanager__some-namespace__"+name+".yaml"])).To(Equal(testruntime.Serialize(alertManager)))
+				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(vpa)))
+				Expect(string(managedResourceSecret.Data["alertmanagerconfig__some-namespace__alertmanager-"+name+".yaml"])).To(Equal(testruntime.Serialize(config)))
+				Expect(string(managedResourceSecret.Data["secret__some-namespace__alertmanager-"+name+"-smtp.yaml"])).To(Equal(testruntime.Serialize(smtpSecret)))
 			})
 		})
 	})

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -35,7 +35,6 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/gardenermetricsexporter"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
@@ -45,6 +44,7 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("GardenerMetricsExporter", func() {
@@ -270,15 +270,15 @@ var _ = Describe("GardenerMetricsExporter", func() {
 
 				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretRuntime.Data).To(HaveLen(2))
-				Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-metrics-exporter.yaml"])).To(Equal(componenttest.Serialize(serviceRuntime)))
+				Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-metrics-exporter.yaml"])).To(Equal(testruntime.Serialize(serviceRuntime)))
 				Expect(string(managedResourceSecretRuntime.Data["deployment__some-namespace__gardener-metrics-exporter.yaml"])).To(Equal(deployment(namespace, values)))
 				Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretVirtual.Data).To(HaveLen(2))
-				Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_metrics-exporter.yaml"])).To(Equal(componenttest.Serialize(clusterRole)))
-				Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_metrics-exporter.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
+				Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_metrics-exporter.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
+				Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_metrics-exporter.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
 				Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 			})
@@ -725,5 +725,5 @@ func deployment(namespace string, testValues Values) string {
 
 	utilruntime.Must(references.InjectAnnotations(deployment))
 
-	return componenttest.Serialize(deployment)
+	return testruntime.Serialize(deployment)
 }

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/kubestatemetrics"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
@@ -49,6 +48,7 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("KubeStateMetrics", func() {
@@ -670,19 +670,19 @@ var _ = Describe("KubeStateMetrics", func() {
 				Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-				Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__kube-state-metrics.yaml"])).To(Equal(componenttest.Serialize(serviceAccount)))
-				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_monitoring_kube-state-metrics-seed.yaml"])).To(Equal(componenttest.Serialize(clusterRoleFor(component.ClusterTypeSeed))))
-				Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_monitoring_kube-state-metrics-seed.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingFor(component.ClusterTypeSeed))))
-				Expect(string(managedResourceSecret.Data["service__"+namespace+"__kube-state-metrics.yaml"])).To(Equal(componenttest.Serialize(serviceFor(component.ClusterTypeSeed))))
-				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__kube-state-metrics.yaml"])).To(Equal(componenttest.Serialize(deploymentFor(component.ClusterTypeSeed))))
-				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__kube-state-metrics-vpa.yaml"])).To(Equal(componenttest.Serialize(vpa)))
-				Expect(string(managedResourceSecret.Data["scrapeconfig__"+namespace+"__cache-kube-state-metrics.yaml"])).To(Equal(componenttest.Serialize(scrapeConfigCache)))
-				Expect(string(managedResourceSecret.Data["scrapeconfig__"+namespace+"__seed-kube-state-metrics.yaml"])).To(Equal(componenttest.Serialize(scrapeConfigSeed)))
+				Expect(string(managedResourceSecret.Data["serviceaccount__"+namespace+"__kube-state-metrics.yaml"])).To(Equal(testruntime.Serialize(serviceAccount)))
+				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_monitoring_kube-state-metrics-seed.yaml"])).To(Equal(testruntime.Serialize(clusterRoleFor(component.ClusterTypeSeed))))
+				Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_monitoring_kube-state-metrics-seed.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingFor(component.ClusterTypeSeed))))
+				Expect(string(managedResourceSecret.Data["service__"+namespace+"__kube-state-metrics.yaml"])).To(Equal(testruntime.Serialize(serviceFor(component.ClusterTypeSeed))))
+				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__kube-state-metrics.yaml"])).To(Equal(testruntime.Serialize(deploymentFor(component.ClusterTypeSeed))))
+				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__kube-state-metrics-vpa.yaml"])).To(Equal(testruntime.Serialize(vpa)))
+				Expect(string(managedResourceSecret.Data["scrapeconfig__"+namespace+"__cache-kube-state-metrics.yaml"])).To(Equal(testruntime.Serialize(scrapeConfigCache)))
+				Expect(string(managedResourceSecret.Data["scrapeconfig__"+namespace+"__seed-kube-state-metrics.yaml"])).To(Equal(testruntime.Serialize(scrapeConfigSeed)))
 			})
 
 			Context("Kubernetes versions >= 1.26", func() {
 				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__kube-state-metrics-pdb.yaml"])).To(Equal(componenttest.Serialize(pdbFor(true))))
+					Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__kube-state-metrics-pdb.yaml"])).To(Equal(testruntime.Serialize(pdbFor(true))))
 				})
 			})
 
@@ -698,7 +698,7 @@ var _ = Describe("KubeStateMetrics", func() {
 				})
 
 				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__kube-state-metrics-pdb.yaml"])).To(Equal(componenttest.Serialize(pdbFor(false))))
+					Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__kube-state-metrics-pdb.yaml"])).To(Equal(testruntime.Serialize(pdbFor(false))))
 				})
 			})
 		})
@@ -745,8 +745,8 @@ var _ = Describe("KubeStateMetrics", func() {
 				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 				Expect(managedResourceSecret.Data).To(HaveLen(2))
 
-				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_monitoring_kube-state-metrics.yaml"])).To(Equal(componenttest.Serialize(clusterRoleFor(component.ClusterTypeShoot))))
-				Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_monitoring_kube-state-metrics.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingFor(component.ClusterTypeShoot))))
+				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_monitoring_kube-state-metrics.yaml"])).To(Equal(testruntime.Serialize(clusterRoleFor(component.ClusterTypeShoot))))
+				Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_monitoring_kube-state-metrics.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBindingFor(component.ClusterTypeShoot))))
 
 				actualSecretShootAccess := &corev1.Secret{}
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(secretShootAccess), actualSecretShootAccess)).To(Succeed())

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -41,12 +41,12 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("Prometheus", func() {
@@ -504,27 +504,27 @@ honor_labels: true`
 
 			It("should successfully deploy all resources", func() {
 				Expect(managedResourceSecret.Data).To(HaveLen(11))
-				Expect(string(managedResourceSecret.Data["serviceaccount__some-namespace__prometheus-"+name+".yaml"])).To(Equal(componenttest.Serialize(serviceAccount)))
-				Expect(string(managedResourceSecret.Data["service__some-namespace__prometheus-"+name+".yaml"])).To(Equal(componenttest.Serialize(service)))
-				Expect(string(managedResourceSecret.Data["clusterrolebinding____prometheus-"+name+".yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
-				Expect(string(managedResourceSecret.Data["prometheus__some-namespace__"+name+".yaml"])).To(Equal(componenttest.Serialize(prometheusFor(""))))
-				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__prometheus-"+name+".yaml"])).To(Equal(componenttest.Serialize(vpa)))
+				Expect(string(managedResourceSecret.Data["serviceaccount__some-namespace__prometheus-"+name+".yaml"])).To(Equal(testruntime.Serialize(serviceAccount)))
+				Expect(string(managedResourceSecret.Data["service__some-namespace__prometheus-"+name+".yaml"])).To(Equal(testruntime.Serialize(service)))
+				Expect(string(managedResourceSecret.Data["clusterrolebinding____prometheus-"+name+".yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
+				Expect(string(managedResourceSecret.Data["prometheus__some-namespace__"+name+".yaml"])).To(Equal(testruntime.Serialize(prometheusFor(""))))
+				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__prometheus-"+name+".yaml"])).To(Equal(testruntime.Serialize(vpa)))
 
 				prometheusRule.Namespace = namespace
 				metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", name)
-				Expect(string(managedResourceSecret.Data["prometheusrule__some-namespace__"+name+"-rule.yaml"])).To(Equal(componenttest.Serialize(prometheusRule)))
+				Expect(string(managedResourceSecret.Data["prometheusrule__some-namespace__"+name+"-rule.yaml"])).To(Equal(testruntime.Serialize(prometheusRule)))
 
 				metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", name)
-				Expect(string(managedResourceSecret.Data["scrapeconfig__default__"+name+"-scrape.yaml"])).To(Equal(componenttest.Serialize(scrapeConfig)))
+				Expect(string(managedResourceSecret.Data["scrapeconfig__default__"+name+"-scrape.yaml"])).To(Equal(testruntime.Serialize(scrapeConfig)))
 
 				metav1.SetMetaDataLabel(&serviceMonitor.ObjectMeta, "prometheus", name)
-				Expect(string(managedResourceSecret.Data["servicemonitor__default__"+name+"-monitor.yaml"])).To(Equal(componenttest.Serialize(serviceMonitor)))
+				Expect(string(managedResourceSecret.Data["servicemonitor__default__"+name+"-monitor.yaml"])).To(Equal(testruntime.Serialize(serviceMonitor)))
 
 				metav1.SetMetaDataLabel(&podMonitor.ObjectMeta, "prometheus", name)
-				Expect(string(managedResourceSecret.Data["podmonitor__default__"+name+"-monitor.yaml"])).To(Equal(componenttest.Serialize(podMonitor)))
+				Expect(string(managedResourceSecret.Data["podmonitor__default__"+name+"-monitor.yaml"])).To(Equal(testruntime.Serialize(podMonitor)))
 
-				Expect(string(managedResourceSecret.Data["secret__some-namespace__prometheus-"+name+"-additional-scrape-configs.yaml"])).To(Equal(componenttest.Serialize(secretAdditionalScrapeConfigs)))
-				Expect(string(managedResourceSecret.Data["configmap__some-namespace__configmap.yaml"])).To(Equal(componenttest.Serialize(additionalConfigMap)))
+				Expect(string(managedResourceSecret.Data["secret__some-namespace__prometheus-"+name+"-additional-scrape-configs.yaml"])).To(Equal(testruntime.Serialize(secretAdditionalScrapeConfigs)))
+				Expect(string(managedResourceSecret.Data["configmap__some-namespace__configmap.yaml"])).To(Equal(testruntime.Serialize(additionalConfigMap)))
 			})
 
 			When("ingress is configured", func() {
@@ -540,7 +540,7 @@ honor_labels: true`
 				It("should successfully deploy all resources", func() {
 					Expect(managedResourceSecret.Data).To(HaveLen(12))
 
-					Expect(string(managedResourceSecret.Data["ingress__some-namespace__prometheus-"+name+".yaml"])).To(Equal(componenttest.Serialize(ingress)))
+					Expect(string(managedResourceSecret.Data["ingress__some-namespace__prometheus-"+name+".yaml"])).To(Equal(testruntime.Serialize(ingress)))
 				})
 			})
 
@@ -553,8 +553,8 @@ honor_labels: true`
 				It("should successfully deploy all resources", func() {
 					Expect(managedResourceSecret.Data).To(HaveLen(12))
 
-					Expect(string(managedResourceSecret.Data["prometheus__some-namespace__"+name+".yaml"])).To(Equal(componenttest.Serialize(prometheusFor(alertmanagerName))))
-					Expect(string(managedResourceSecret.Data["secret__some-namespace__prometheus-"+name+"-additional-alert-relabel-configs.yaml"])).To(Equal(componenttest.Serialize(secretAdditionalAlertRelabelConfigs)))
+					Expect(string(managedResourceSecret.Data["prometheus__some-namespace__"+name+".yaml"])).To(Equal(testruntime.Serialize(prometheusFor(alertmanagerName))))
+					Expect(string(managedResourceSecret.Data["secret__some-namespace__prometheus-"+name+"-additional-alert-relabel-configs.yaml"])).To(Equal(testruntime.Serialize(secretAdditionalAlertRelabelConfigs)))
 				})
 			})
 		})

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -60,8 +60,8 @@ var _ = Describe("PrometheusOperator", func() {
 		deployer   component.DeployWaiter
 		values     Values
 
-		fakeOps       *retryfake.Ops
-		containObject func(object client.Object) gomegatypes.GomegaMatcher
+		fakeOps   *retryfake.Ops
+		consistOf func(...client.Object) gomegatypes.GomegaMatcher
 
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
@@ -92,7 +92,7 @@ var _ = Describe("PrometheusOperator", func() {
 			&retry.UntilTimeout, fakeOps.UntilTimeout,
 		))
 
-		containObject = NewManagedResourceObjectMatcher(fakeClient)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient)
 
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -412,14 +412,15 @@ var _ = Describe("PrometheusOperator", func() {
 			})
 
 			It("should successfully deploy all resources", func() {
-				Expect(managedResourceSecret.Data).To(HaveLen(7))
-				Expect(managedResource).To(containObject(serviceAccount))
-				Expect(managedResource).To(containObject(service))
-				Expect(managedResource).To(containObject(deployment))
-				Expect(managedResource).To(containObject(vpa))
-				Expect(managedResource).To(containObject(clusterRole))
-				Expect(managedResource).To(containObject(clusterRoleBinding))
-				Expect(managedResource).To(containObject(clusterRolePrometheus))
+				Expect(managedResource).To(consistOf(
+					serviceAccount,
+					service,
+					deployment,
+					vpa,
+					clusterRole,
+					clusterRoleBinding,
+					clusterRolePrometheus,
+				))
 			})
 		})
 	})

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -37,12 +37,12 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
-	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 var _ = Describe("PrometheusOperator", func() {
@@ -410,13 +410,13 @@ var _ = Describe("PrometheusOperator", func() {
 
 			It("should successfully deploy all resources", func() {
 				Expect(managedResourceSecret.Data).To(HaveLen(7))
-				Expect(string(managedResourceSecret.Data["serviceaccount__some-namespace__prometheus-operator.yaml"])).To(Equal(componenttest.Serialize(serviceAccount)))
-				Expect(string(managedResourceSecret.Data["service__some-namespace__prometheus-operator.yaml"])).To(Equal(componenttest.Serialize(service)))
-				Expect(string(managedResourceSecret.Data["deployment__some-namespace__prometheus-operator.yaml"])).To(Equal(componenttest.Serialize(deployment)))
-				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__prometheus-operator.yaml"])).To(Equal(componenttest.Serialize(vpa)))
-				Expect(string(managedResourceSecret.Data["clusterrole____prometheus-operator.yaml"])).To(Equal(componenttest.Serialize(clusterRole)))
-				Expect(string(managedResourceSecret.Data["clusterrolebinding____prometheus-operator.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
-				Expect(string(managedResourceSecret.Data["clusterrole____prometheus.yaml"])).To(Equal(componenttest.Serialize(clusterRolePrometheus)))
+				Expect(string(managedResourceSecret.Data["serviceaccount__some-namespace__prometheus-operator.yaml"])).To(Equal(testruntime.Serialize(serviceAccount)))
+				Expect(string(managedResourceSecret.Data["service__some-namespace__prometheus-operator.yaml"])).To(Equal(testruntime.Serialize(service)))
+				Expect(string(managedResourceSecret.Data["deployment__some-namespace__prometheus-operator.yaml"])).To(Equal(testruntime.Serialize(deployment)))
+				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__some-namespace__prometheus-operator.yaml"])).To(Equal(testruntime.Serialize(vpa)))
+				Expect(string(managedResourceSecret.Data["clusterrole____prometheus-operator.yaml"])).To(Equal(testruntime.Serialize(clusterRole)))
+				Expect(string(managedResourceSecret.Data["clusterrolebinding____prometheus-operator.yaml"])).To(Equal(testruntime.Serialize(clusterRoleBinding)))
+				Expect(string(managedResourceSecret.Data["clusterrole____prometheus.yaml"])).To(Equal(testruntime.Serialize(clusterRolePrometheus)))
 			})
 		})
 	})

--- a/pkg/utils/test/matchers/managedresource.go
+++ b/pkg/utils/test/matchers/managedresource.go
@@ -20,36 +20,65 @@ import (
 	"strings"
 
 	"github.com/onsi/gomega/format"
+	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
-type managedResourceDataMatcher struct {
-	ctx         context.Context
-	cl          client.Client
-	expectedObj client.Object
+type managedResourceObjectsMatcher struct {
+	ctx                     context.Context
+	cl                      client.Client
+	expectedObjToSerialized map[client.Object]string
+	extraObjectsCheck       bool
 
-	expectedObjectSerialized string
-	actualObjectSerialized   string
-	secretNames              []string
+	extraObjects             []string
+	missingObjects           []string
+	mismatchExpectedToActual map[string]string
 }
 
-func (m *managedResourceDataMatcher) FailureMessage(_ interface{}) string {
-	if m.actualObjectSerialized != "" {
-		return format.Message(m.actualObjectSerialized, "to equal", m.expectedObjectSerialized)
+func (m *managedResourceObjectsMatcher) FailureMessage(actual interface{}) string {
+	return m.createMessage(actual, "not to be")
+}
+
+func (m *managedResourceObjectsMatcher) NegatedFailureMessage(actual interface{}) string {
+	return m.createMessage(actual, "to be")
+}
+
+func (m *managedResourceObjectsMatcher) createMessage(actual interface{}, addition string) string {
+	managedResource, ok := actual.(*resourcesv1alpha1.ManagedResource)
+	if !ok {
+		return fmt.Errorf("expected *resourcesv1alpha1.ManagedResource.  got:\n%s", format.Object(actual, 1)).Error()
 	}
-	return format.Message(m.expectedObjectSerialized, fmt.Sprintf("to be found in managed resource secrets %v", m.secretNames))
+
+	var message string
+
+	switch {
+	case len(m.mismatchExpectedToActual) > 0:
+		message = fmt.Sprintf("Expected for ManagedResource %s/%s the following object mismathes %s found:\n", managedResource.Namespace, managedResource.Name, addition)
+		for expected, actual := range m.mismatchExpectedToActual {
+			message += format.MessageWithDiff(actual, "to equal", expected)
+		}
+	case len(m.missingObjects) > 0:
+		message = fmt.Sprintf("Expected for ManagedResource %s/%s the following missing elements %s found:\n", managedResource.Namespace, managedResource.Name, addition)
+		for _, missingObject := range m.missingObjects {
+			message += format.IndentString(missingObject, 2)
+		}
+	case len(m.extraObjects) > 0:
+		message = fmt.Sprintf("Expected for ManagedResource %s/%s the following extra and unexpected elements %s found:\n", managedResource.Namespace, managedResource.Name, addition)
+		for _, extraObject := range m.extraObjects {
+			message += format.IndentString(extraObject, 2)
+		}
+	}
+
+	return message
 }
 
-func (m *managedResourceDataMatcher) NegatedFailureMessage(_ interface{}) string {
-	return format.Message(m.expectedObjectSerialized, fmt.Sprintf("not to be found in managed resource secrets %v", m.secretNames))
-}
-
-func (m *managedResourceDataMatcher) Match(actual interface{}) (bool, error) {
+func (m *managedResourceObjectsMatcher) Match(actual interface{}) (bool, error) {
 	if actual == nil {
 		return false, nil
 	}
@@ -59,18 +88,8 @@ func (m *managedResourceDataMatcher) Match(actual interface{}) (bool, error) {
 		return false, fmt.Errorf("expected *resourcesv1alpha1.ManagedResource.  got:\n%s", format.Object(actual, 1))
 	}
 
-	gvk, err := apiutil.GVKForObject(m.expectedObj, m.cl.Scheme())
-	if err != nil {
-		return false, fmt.Errorf("error when extracting object kind: %w", err)
-	}
-
-	dataKey := fmt.Sprintf(
-		"%s__%s__%s.yaml",
-		strings.ToLower(gvk.Kind),
-		m.expectedObj.GetNamespace(),
-		strings.ReplaceAll(m.expectedObj.GetName(), ":", "_"),
-	)
-
+	// Retrieve managed resource secrets.
+	var secrets = make([]*corev1.Secret, 0, len(managedResource.Spec.SecretRefs))
 	for _, secretRef := range managedResource.Spec.SecretRefs {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -82,21 +101,94 @@ func (m *managedResourceDataMatcher) Match(actual interface{}) (bool, error) {
 		if err := m.cl.Get(m.ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
 			return false, fmt.Errorf("error when retrieving managed resource secret: %w", err)
 		}
+		secrets = append(secrets, secret)
+	}
 
-		m.secretNames = append(m.secretNames, secretRef.Name)
+	dataKeyToExpected := make(map[string]string)
 
-		objData, ok := secret.Data[dataKey]
-		if !ok {
-			continue
+	// Compare expected and actual results.
+	for expectedObj, expectedObjSerialized := range m.expectedObjToSerialized {
+		gvk, err := apiutil.GVKForObject(expectedObj, m.cl.Scheme())
+		if err != nil {
+			return false, fmt.Errorf("error when extracting object kind: %w", err)
 		}
 
-		if string(objData) == m.expectedObjectSerialized {
-			return true, nil
-		} else {
-			m.actualObjectSerialized = string(objData)
+		dataKey := fmt.Sprintf(
+			"%s__%s__%s.yaml",
+			strings.ToLower(gvk.Kind),
+			expectedObj.GetNamespace(),
+			strings.ReplaceAll(expectedObj.GetName(), ":", "_"),
+		)
+		if _, ok := dataKeyToExpected[dataKey]; ok {
+			return false, fmt.Errorf("object is already specified for data key %s", dataKey)
+		}
+		dataKeyToExpected[dataKey] = expectedObjSerialized
+	}
+
+	dataKeys := sets.New(maps.Keys(dataKeyToExpected)...)
+
+	// Use early returns for the following checks to not overwhelm Gomega output.
+	m.mismatchExpectedToActual = findMismatchObjects(secrets, dataKeyToExpected)
+	if len(m.mismatchExpectedToActual) > 0 {
+		return false, nil
+	}
+
+	m.missingObjects = findMissingObjects(secrets, dataKeyToExpected)
+	if len(m.missingObjects) > 0 {
+		return false, nil
+	}
+
+	if m.extraObjectsCheck {
+		m.extraObjects = findExtraObjects(secrets, dataKeys)
+		if len(m.extraObjects) > 0 {
 			return false, nil
 		}
 	}
 
-	return false, nil
+	return true, nil
+}
+
+func findMismatchObjects(secrets []*corev1.Secret, keysToExpected map[string]string) map[string]string {
+	mismatches := make(map[string]string)
+
+	for _, secret := range secrets {
+		for dataKey, expected := range keysToExpected {
+			if actual, ok := secret.Data[dataKey]; ok && string(actual) != expected {
+				mismatches[expected] = string(actual)
+			}
+		}
+	}
+
+	return mismatches
+}
+
+func findMissingObjects(secrets []*corev1.Secret, keysToExpected map[string]string) []string {
+	var (
+		keysToBeFound  = sets.New(maps.Keys(keysToExpected)...)
+		missingObjects []string
+	)
+
+	for _, secret := range secrets {
+		keysToBeFound = keysToBeFound.Difference(sets.New(maps.Keys(secret.Data)...))
+	}
+
+	for notFoundKey := range keysToBeFound {
+		missingObjects = append(missingObjects, keysToExpected[notFoundKey])
+	}
+
+	return missingObjects
+}
+
+func findExtraObjects(secrets []*corev1.Secret, keys sets.Set[string]) []string {
+	var extraObjects []string
+
+	for _, secret := range secrets {
+		extraKeys := sets.New(maps.Keys(secret.Data)...).Difference(keys)
+
+		for extraKey := range extraKeys {
+			extraObjects = append(extraObjects, string(secret.Data[extraKey]))
+		}
+	}
+
+	return extraObjects
 }

--- a/pkg/utils/test/matchers/managedresource.go
+++ b/pkg/utils/test/matchers/managedresource.go
@@ -1,0 +1,101 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega/format"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+)
+
+type managedResourceDataMatcher struct {
+	cl          client.Client
+	expectedObj client.Object
+
+	expectedObjectSerialized string
+	actualObjectSerialized   string
+	secretNames              []string
+}
+
+func (m *managedResourceDataMatcher) FailureMessage(_ interface{}) (message string) {
+	if m.actualObjectSerialized != "" {
+		return format.Message(m.actualObjectSerialized, "to equal", m.expectedObjectSerialized)
+	}
+	return format.Message(m.expectedObjectSerialized, fmt.Sprintf("to be found in managed resource secrets %v", m.secretNames))
+}
+
+func (m *managedResourceDataMatcher) NegatedFailureMessage(_ interface{}) (message string) {
+	return format.Message(m.expectedObjectSerialized, fmt.Sprintf("not to be found in managed resource secrets %v", m.secretNames))
+}
+
+func (m *managedResourceDataMatcher) Match(actual interface{}) (bool, error) {
+	if actual == nil {
+		return false, nil
+	}
+
+	managedResource, ok := actual.(*resourcesv1alpha1.ManagedResource)
+	if !ok {
+		return false, fmt.Errorf("expected *resourcesv1alpha1.ManagedResource.  got:\n%s", format.Object(actual, 1))
+	}
+
+	gvk, err := apiutil.GVKForObject(m.expectedObj, m.cl.Scheme())
+	if err != nil {
+		return false, fmt.Errorf("error when extracting object kind: %s", err)
+	}
+
+	dataKey := fmt.Sprintf(
+		"%s__%s__%s.yaml",
+		strings.ToLower(gvk.Kind),
+		m.expectedObj.GetNamespace(),
+		strings.Replace(m.expectedObj.GetName(), ":", "_", -1),
+	)
+
+	for _, secretRef := range managedResource.Spec.SecretRefs {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretRef.Name,
+				Namespace: managedResource.Namespace,
+			},
+		}
+
+		if err := m.cl.Get(context.Background(), client.ObjectKeyFromObject(secret), secret); err != nil {
+			return false, fmt.Errorf("error when retrieving managed resource secret: %s", err)
+		}
+
+		m.secretNames = append(m.secretNames, secretRef.Name)
+
+		objData, ok := secret.Data[dataKey]
+		if !ok {
+			continue
+		}
+
+		if string(objData) == m.expectedObjectSerialized {
+			return true, nil
+		} else {
+			m.actualObjectSerialized = string(objData)
+			return false, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/utils/test/matchers/managedresource.go
+++ b/pkg/utils/test/matchers/managedresource.go
@@ -52,7 +52,7 @@ func (m *managedResourceObjectsMatcher) NegatedFailureMessage(actual interface{}
 func (m *managedResourceObjectsMatcher) createMessage(actual interface{}, addition string) string {
 	managedResource, ok := actual.(*resourcesv1alpha1.ManagedResource)
 	if !ok {
-		return fmt.Errorf("expected *resourcesv1alpha1.ManagedResource.  got:\n%s", format.Object(actual, 1)).Error()
+		return fmt.Sprintf("expected *resourcesv1alpha1.ManagedResource.  got:\n%s", format.Object(actual, 1))
 	}
 
 	var message string

--- a/pkg/utils/test/matchers/managedresource_test.go
+++ b/pkg/utils/test/matchers/managedresource_test.go
@@ -48,11 +48,11 @@ var _ = Describe("ManagedResource Object Matcher", func() {
 
 	Context("without managed resource", func() {
 		It("should not find an object", func() {
-			Expect(nil).ToNot(containsObject(&corev1.Secret{}))
+			Expect(nil).NotTo(containsObject(&corev1.Secret{}))
 		})
 	})
 
-	Context("with managed resource, without secret references", func() {
+	Context("with managed resource", func() {
 		var (
 			namespace       string
 			managedResource *resourcesv1alpha1.ManagedResource
@@ -67,7 +67,7 @@ var _ = Describe("ManagedResource Object Matcher", func() {
 			}
 		})
 
-		Context("With secrets references", func() {
+		Context("with secrets references", func() {
 			var (
 				ctx context.Context
 
@@ -158,7 +158,7 @@ var _ = Describe("ManagedResource Object Matcher", func() {
 
 		Context("without secret references", func() {
 			It("should not find an object", func() {
-				Expect(managedResource).ToNot(containsObject(&corev1.Secret{}))
+				Expect(managedResource).NotTo(containsObject(&corev1.Secret{}))
 			})
 		})
 	})

--- a/pkg/utils/test/matchers/managedresource_test.go
+++ b/pkg/utils/test/matchers/managedresource_test.go
@@ -112,7 +112,7 @@ var _ = Describe("ManagedResource Object Matcher", func() {
 						Namespace: namespace,
 					},
 					Data: map[string][]byte{
-						fmt.Sprintf("configmap__%s__%s.yaml", configMap.Namespace, configMap.Name): []byte(testruntime.Serialize(configMap)),
+						fmt.Sprintf("configmap__%s__%s.yaml", configMap.Namespace, configMap.Name): []byte(testruntime.Serialize(configMap, fakeClient.Scheme())),
 					},
 				}
 				managedResourceSecret2 = &corev1.Secret{
@@ -121,7 +121,7 @@ var _ = Describe("ManagedResource Object Matcher", func() {
 						Namespace: namespace,
 					},
 					Data: map[string][]byte{
-						fmt.Sprintf("deployment__%s__%s.yaml", deployment.Namespace, deployment.Name): []byte(testruntime.Serialize(deployment)),
+						fmt.Sprintf("deployment__%s__%s.yaml", deployment.Namespace, deployment.Name): []byte(testruntime.Serialize(deployment, fakeClient.Scheme())),
 					},
 				}
 				managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{

--- a/pkg/utils/test/matchers/managedresource_test.go
+++ b/pkg/utils/test/matchers/managedresource_test.go
@@ -1,0 +1,166 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gardener/etcd-druid/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
+)
+
+var _ = Describe("ManagedResource Object Matcher", func() {
+	var (
+		fakeClient     client.Client
+		containsObject func(client.Object) types.GomegaMatcher
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.Scheme).Build()
+		containsObject = NewManagedResourceObjectMatcher(fakeClient)
+	})
+
+	Context("without managed resource", func() {
+		It("should not find an object", func() {
+			Expect(nil).ToNot(containsObject(&corev1.Secret{}))
+		})
+	})
+
+	Context("with managed resource, without secret references", func() {
+		var (
+			namespace       string
+			managedResource *resourcesv1alpha1.ManagedResource
+		)
+
+		BeforeEach(func() {
+			namespace = "test-namespace"
+			managedResource = &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+				},
+			}
+		})
+
+		Context("With secrets references", func() {
+			var (
+				ctx context.Context
+
+				configMap                                      *corev1.ConfigMap
+				deployment                                     *appsv1.Deployment
+				managedResourceSecret1, managedResourceSecret2 *corev1.Secret
+			)
+
+			BeforeEach(func() {
+				ctx = context.Background()
+
+				configMap = &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "controller-config",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						"key": "value",
+					},
+				}
+				deployment = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "admission",
+						Namespace: "gardener",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: ptr.To(int32(2)),
+						Paused:   true,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "gardener"},
+								},
+							},
+						},
+					},
+				}
+
+				managedResourceSecret1 = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						fmt.Sprintf("configmap__%s__%s.yaml", configMap.Namespace, configMap.Name): []byte(testruntime.Serialize(configMap)),
+					},
+				}
+				managedResourceSecret2 = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret2",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						fmt.Sprintf("deployment__%s__%s.yaml", deployment.Namespace, deployment.Name): []byte(testruntime.Serialize(deployment)),
+					},
+				}
+				managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{
+					{Name: managedResourceSecret1.Name},
+					{Name: managedResourceSecret2.Name},
+				}
+
+				Expect(fakeClient.Create(ctx, managedResourceSecret1)).To(Succeed())
+				Expect(fakeClient.Create(ctx, managedResourceSecret2)).To(Succeed())
+			})
+
+			It("should only find contained resources", func() {
+				Expect(managedResource).To(containsObject(configMap))
+				Expect(managedResource).To(containsObject(deployment))
+
+				deploymentModified := deployment.DeepCopy()
+				deploymentModified.Spec.MinReadySeconds += 1
+				Expect(managedResource).NotTo(containsObject(deploymentModified))
+			})
+
+			It("should not find resources if data key does not match", func() {
+				objectKey := fmt.Sprintf("deployment__%s__%s.yaml", deployment.Namespace, deployment.Name)
+				objectData := managedResourceSecret2.Data[objectKey]
+				Expect(objectData).NotTo(BeEmpty())
+
+				patch := client.MergeFrom(managedResourceSecret2.DeepCopy())
+				delete(managedResourceSecret2.Data, objectKey)
+				managedResourceSecret2.Data[strings.Trim(objectKey, ".yaml")] = objectData
+				Expect(fakeClient.Patch(ctx, managedResourceSecret2, patch)).To(Succeed())
+
+				Expect(managedResource).NotTo(containsObject(deployment))
+			})
+		})
+
+		Context("without secret references", func() {
+			It("should not find an object", func() {
+				Expect(managedResource).ToNot(containsObject(&corev1.Secret{}))
+			})
+		})
+	})
+
+})

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -137,7 +137,7 @@ func NewManagedResourceObjectMatcher(cl client.Client) func(client.Object) types
 		return &managedResourceDataMatcher{
 			cl:                       cl,
 			expectedObj:              obj,
-			expectedObjectSerialized: testruntime.Serialize(obj),
+			expectedObjectSerialized: testruntime.Serialize(obj, cl.Scheme()),
 		}
 	}
 }

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -20,6 +20,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testruntime "github.com/gardener/gardener/pkg/utils/test/runtime"
 )
 
 func init() {
@@ -123,5 +126,18 @@ func BeInvalidError() types.GomegaMatcher {
 func ShareSameReferenceAs(expected interface{}) types.GomegaMatcher {
 	return &referenceMatcher{
 		expected: expected,
+	}
+}
+
+// NewManagedResourceObjectMatcher returns a function for a matcher that checks
+// if the given object is handled by the given managed resource.
+// It is expected that the data keys of referenced secret(s) follow the semantics of `managedresources.Registry`.
+func NewManagedResourceObjectMatcher(cl client.Client) func(client.Object) types.GomegaMatcher {
+	return func(obj client.Object) types.GomegaMatcher {
+		return &managedResourceDataMatcher{
+			cl:                       cl,
+			expectedObj:              obj,
+			expectedObjectSerialized: testruntime.Serialize(obj),
+		}
 	}
 }

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -15,6 +15,8 @@
 package matchers
 
 import (
+	"context"
+
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -135,6 +137,7 @@ func ShareSameReferenceAs(expected interface{}) types.GomegaMatcher {
 func NewManagedResourceObjectMatcher(cl client.Client) func(client.Object) types.GomegaMatcher {
 	return func(obj client.Object) types.GomegaMatcher {
 		return &managedResourceDataMatcher{
+			ctx:                      context.Background(),
 			cl:                       cl,
 			expectedObj:              obj,
 			expectedObjectSerialized: testruntime.Serialize(obj, cl.Scheme()),

--- a/pkg/utils/test/runtime/seralize.go
+++ b/pkg/utils/test/runtime/seralize.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package runtime
 
 import (
 	. "github.com/onsi/gomega"

--- a/pkg/utils/test/runtime/seralize.go
+++ b/pkg/utils/test/runtime/seralize.go
@@ -22,23 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	forkedyaml "github.com/gardener/gardener/third_party/gopkg.in/yaml.v2"
 )
 
 // Serialize serializes and encodes the passed object.
-func Serialize(obj client.Object) string {
-	testSchemeBuilder := runtime.NewSchemeBuilder(
-		kubernetes.AddGardenSchemeToScheme,
-		kubernetes.AddSeedSchemeToScheme,
-		kubernetes.AddShootSchemeToScheme,
-		operatorclient.AddRuntimeSchemeToScheme,
-		operatorclient.AddVirtualSchemeToScheme,
-	)
-	scheme := runtime.NewScheme()
-	ExpectWithOffset(1, testSchemeBuilder.AddToScheme(scheme)).To(Succeed())
-
+func Serialize(obj client.Object, scheme *runtime.Scheme) string {
 	var groupVersions []schema.GroupVersion
 	for k := range scheme.AllKnownTypes() {
 		groupVersions = append(groupVersions, k.GroupVersion())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR implements a custom Gomega matcher for `ManagedResource`s.
The matcher checks if expected objects are contained in the secret(s) referenced by the `ManagedResource`. A `consistOf` version is also in place.
Testing common scenarios becomes more efficient and concise (see 2429cf37a6d81752942fe1e39d24c56ea62d3040). Extensions and other dependent Gardener projects can re-use this matcher, as well.

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
New `consistOf` and `contain` Gomega matchers for `ManagedResource`s were added. Tests can concisely check for expected objects a `ManagedResource` is responsible for.
```
