### PR TITLE
Use `0755` permissions when `gardener-node-agent`'s OSC reconciler creates dirs

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -201,6 +201,7 @@ func (r *Reconciler) getNode(ctx context.Context) (*metav1.PartialObjectMetadata
 var (
 	etcSystemdSystem                   = path.Join("/", "etc", "systemd", "system")
 	defaultFilePermissions os.FileMode = 0600
+	defaultDirPermissions  os.FileMode = 0755
 )
 
 func (r *Reconciler) applyChangedFiles(ctx context.Context, log logr.Logger, files []extensionsv1alpha1.File) error {
@@ -218,7 +219,7 @@ func (r *Reconciler) applyChangedFiles(ctx context.Context, log logr.Logger, fil
 
 		switch {
 		case file.Content.Inline != nil:
-			if err := r.FS.MkdirAll(filepath.Dir(file.Path), fs.ModeDir); err != nil {
+			if err := r.FS.MkdirAll(filepath.Dir(file.Path), defaultDirPermissions); err != nil {
 				return fmt.Errorf("unable to create directory %q: %w", file.Path, err)
 			}
 
@@ -293,7 +294,7 @@ func (r *Reconciler) applyChangedUnits(ctx context.Context, log logr.Logger, uni
 				return fmt.Errorf("unable to delete systemd drop-in folder for unit %q: %w", unit.Name, err)
 			}
 		} else {
-			if err := r.FS.MkdirAll(dropInDirectory, fs.ModeDir); err != nil {
+			if err := r.FS.MkdirAll(dropInDirectory, defaultDirPermissions); err != nil {
 				return fmt.Errorf("unable to create drop-in directory %q for unit %q: %w", dropInDirectory, unit.Name, err)
 			}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:
This PR makes it so that the the operating system config reconciler of the `gardener-node-agent` creates directories with `0755 ` permissions instead of `0000` when it creates the files listed in the corresponding `OperatingSystemConfig` on the node. Having directories with `0000` permissions can be problematic for processes that do not have the `CAP_DAC_OVERRIDE` capability as they will not be able to traverse such directories and read/execute the files created by the `gardener-node-agent`. More information can be found in the #9424 issue.

**Which issue(s) this PR fixes**:
Fixes #9424 

**Special notes for your reviewer**:
Note that this does not affect directories that have already been created on existing nodes. However, this is not a problem as there aren't any currently running processes which do not have the `CAP_DAC_OVERRIDE` capability. The first such process is `rsyslog` on gardenlinux >= `1312`. The version of the `shoot-rsyslog-relp` extension which uses an OSC mutation and therefore the `gardener-node-agent` to configure `rsyslog` is still not released though.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The operating system config reconciler of the `gardener-node-agent` now creates directories with `0755` permissions when it creates files listed in the corresponding `OperatingSystemConfig` on the node. Previously these directories were created with no permissions.
```
