### PR TITLE
Set ENV `GOTOOLCHAIN=auto` in `golang-test` image

### DIFF
--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -1,6 +1,7 @@
 # base
 ARG image
 FROM ${image} AS base
+ENV GOTOOLCHAIN=auto
 RUN echo "Installing Packages ..." \
 		&& apt-get update \
 		&& apt-get install -y --no-install-recommends \
@@ -13,7 +14,6 @@ RUN echo "Installing Packages ..." \
 FROM base as builder
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=$GOPROXY
-ENV GOTOOLCHAIN=auto
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
 RUN make create-tools-bin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR sets the ENV `GOTOOLCHAIN=auto` for `golang-test` image. By default it is `local` which prevents Go from downloading other Go toolchains.
This could cause errors similar to `go: go.mod requires go >= 1.22.1 (running go 1.22.0; GOTOOLCHAIN=local)`, 
when the `go` statement in `go.mod` does not not fit to the version of `golang`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
