### PR TITLE
Drop graduated `MachineControllerManagerDeployment` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,9 +26,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | CoreDNSQueryRewriting              | `false` | `Alpha` | `1.55` |        |
 | IPv6SingleStack                    | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` |        |
-| MachineControllerManagerDeployment | `false` | `Alpha` | `1.73` |        |
-| MachineControllerManagerDeployment | `true`  | `Beta`  | `1.81` | `1.81` |
-| MachineControllerManagerDeployment | `true`  | `GA`    | `1.82` |        |
 | ShootForceDeletion                 | `false` | `Alpha` | `1.81` | `1.90` |
 | ShootForceDeletion                 | `true`  | `Beta`  | `1.91` |        |
 | APIServerFastRollout               | `true`  | `Beta`  | `1.82` | `1.89` |
@@ -147,6 +144,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | WorkerlessShoots                             | `true`  | `Beta`       | `1.79` | `1.85` |
 | WorkerlessShoots                             | `true`  | `GA`         | `1.86` |        |
 | WorkerlessShoots                             | `true`  | `Removed`    | `1.88` |        |
+| MachineControllerManagerDeployment           | `false` | `Alpha`      | `1.73` |        |
+| MachineControllerManagerDeployment           | `true`  | `Beta`       | `1.81` | `1.81` |
+| MachineControllerManagerDeployment           | `true`  | `GA`         | `1.82` | `1.91` |
+| MachineControllerManagerDeployment           | `true`  | `Removed`    | `1.92` |        |
 
 ## Using a Feature
 
@@ -192,7 +193,6 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | CoreDNSQueryRewriting              | `gardenlet`                       | Enables automatic DNS query rewriting in shoot cluster's CoreDNS to shortcut name resolution of fully qualified in-cluster and out-of-cluster names, which follow a user-defined pattern. Details can be found in [DNS Search Path Optimization](../usage/dns-search-path-optimization.md).                                                                                        |
 | IPv6SingleStack                    | `gardener-apiserver`, `gardenlet` | Allows creating seed and shoot clusters with [IPv6 single-stack networking](../usage/ipv6.md) enabled in their spec ([GEP-21](../proposals/21-ipv6-singlestack-local.md)). If enabled in gardenlet, the default behavior is unchanged, but setting `ipFamilies=[IPv6]` in the `seedConfig` is allowed. Only if the `ipFamilies` setting is changed, gardenlet behaves differently. |
 | MutableShootSpecNetworkingNodes    | `gardener-apiserver`              | Allows updating the field `spec.networking.nodes`. The validity of the values has to be checked in the provider extensions. Only enable this feature gate when your system runs provider extensions which have implemented the validation.                                                                                                                                         |
-| MachineControllerManagerDeployment | `gardenlet`                       | Enables Gardener to take over the deployment of the machine-controller-manager. If enabled, all registered provider extensions must support injecting the provider-specific MCM sidecar container into the deployment via the `controlplane` webhook.                                                                                                                              |
 | ShootForceDeletion                 | `gardener-apiserver`              | Allows forceful deletion of Shoots by annotating them with the `confirmation.gardener.cloud/force-deletion` annotation.                                                                                                                                                                                                                                                            |
 | APIServerFastRollout               | `gardenlet`                       | Enables fast rollouts for Shoot kube-apiservers on the given Seed. When enabled, `maxSurge` for Shoot kube-apiserver deployments is set to 100%.                                                                                                                                                                                                                                   |
 | UseGardenerNodeAgent               | `gardenlet`                       | Enables the `gardener-node-agent` instead of the `cloud-config-downloader` for shoot worker nodes.                                                                                                                                                                                                                                                                                 |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -65,17 +65,6 @@ const (
 	// beta: v1.91.0
 	ShootForceDeletion featuregate.Feature = "ShootForceDeletion"
 
-	// MachineControllerManagerDeployment enables Gardener to take over the deployment of the
-	// machine-controller-manager. If enabled, all registered provider extensions must support injecting the
-	// provider-specific MCM provider sidecar container into the deployment via the `controlplane` webhook.
-	// owner: @rfranzke @JensAc @mreiger
-	// alpha: v1.73.0
-	// beta: v1.81.0
-	// GA: v1.82.0
-	// TODO(scheererj): Do not remove this feature gate before v1.90 to give extensions enough time to adopt v1.83.
-	// Otherwise, extensions might end up believing they need to manage MCM again when the feature gate is removed.
-	MachineControllerManagerDeployment featuregate.Feature = "MachineControllerManagerDeployment"
-
 	// APIServerFastRollout enables fast rollouts for Shoot kube-apiservers on the given Seed.
 	// When enabled, maxSurge for Shoot kube-apiserver deployments is set to 100%.
 	// owner: @oliver-goetz
@@ -117,16 +106,15 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 
 // AllFeatureGates is the list of all feature gates.
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	HVPA:                               {Default: false, PreRelease: featuregate.Alpha},
-	HVPAForShootedSeed:                 {Default: false, PreRelease: featuregate.Alpha},
-	DefaultSeccompProfile:              {Default: false, PreRelease: featuregate.Alpha},
-	CoreDNSQueryRewriting:              {Default: false, PreRelease: featuregate.Alpha},
-	IPv6SingleStack:                    {Default: false, PreRelease: featuregate.Alpha},
-	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
-	ShootForceDeletion:                 {Default: true, PreRelease: featuregate.Beta},
-	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	APIServerFastRollout:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	UseGardenerNodeAgent:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	HVPA:                            {Default: false, PreRelease: featuregate.Alpha},
+	HVPAForShootedSeed:              {Default: false, PreRelease: featuregate.Alpha},
+	DefaultSeccompProfile:           {Default: false, PreRelease: featuregate.Alpha},
+	CoreDNSQueryRewriting:           {Default: false, PreRelease: featuregate.Alpha},
+	IPv6SingleStack:                 {Default: false, PreRelease: featuregate.Alpha},
+	MutableShootSpecNetworkingNodes: {Default: false, PreRelease: featuregate.Alpha},
+	ShootForceDeletion:              {Default: true, PreRelease: featuregate.Beta},
+	APIServerFastRollout:            {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	UseGardenerNodeAgent:            {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -34,7 +34,6 @@ func GetFeatures() []featuregate.Feature {
 		features.DefaultSeccompProfile,
 		features.CoreDNSQueryRewriting,
 		features.IPv6SingleStack,
-		features.MachineControllerManagerDeployment,
 		features.APIServerFastRollout,
 		features.UseGardenerNodeAgent,
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
Drop graduated `MachineControllerManagerDeployment` feature gate.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Please note that was attempted already in the past (see #8691), but was reverted at the time with #8708. Meanwhile, the provider extensions for alicloud, aws, azure, gcp and openstack have adopted the corresponding gardener/gardener release since at least a month.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Graduated `MachineControllerManagerDeployment` feature gate was removed.
```

/hold until release branch for v1.91 is created