### PR TITLE
Fix race condition in istio zone migration.

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -624,6 +624,22 @@ func cleanupOrphanExposureClassHandlerResources(
 		}
 	}
 
+	// TODO(scheererj): Remove this after v1.95 has been released.
+	// Allow temporary creation of ingress gateway copy to easy migration
+	migrationTargetToSource := map[string]string{}
+	for _, label := range []string{"istio", v1beta1constants.LabelExposureClassHandlerName} {
+		namespaceList := &metav1.PartialObjectMetadataList{}
+		namespaceList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NamespaceList"))
+		if err := c.List(ctx, namespaceList, client.HasLabels{label}); err != nil {
+			return err
+		}
+		for _, ns := range namespaceList.Items {
+			if targetNamespace, ok := ns.Annotations["alpha.istio-ingress.gardener.cloud/migrate-to"]; ok && targetNamespace != "" {
+				migrationTargetToSource[targetNamespace] = ns.Name
+			}
+		}
+	}
+
 	// Remove zonal, orphaned istio exposure class namespaces
 	zonalExposureClassHandlerNamespaces := &corev1.NamespaceList{}
 	if err := c.List(ctx, zonalExposureClassHandlerNamespaces, client.MatchingLabelsSelector{
@@ -636,6 +652,9 @@ func cleanupOrphanExposureClassHandlerResources(
 	for _, namespace := range zonalExposureClassHandlerNamespaces.Items {
 		if ok, zone := sharedcomponent.IsZonalIstioExtension(namespace.Labels); ok {
 			if err := cleanupOrphanIstioNamespace(ctx, log, c, namespace, true, func() bool {
+				if migrationTargetToSource[namespace.Name] != "" {
+					return true
+				}
 				if !zoneSet.Has(zone) {
 					return false
 				}
@@ -662,7 +681,7 @@ func cleanupOrphanExposureClassHandlerResources(
 	for _, namespace := range zonalIstioNamespaces.Items {
 		if ok, zone := sharedcomponent.IsZonalIstioExtension(namespace.Labels); ok {
 			if err := cleanupOrphanIstioNamespace(ctx, log, c, namespace, false, func() bool {
-				return zoneSet.Has(zone)
+				return zoneSet.Has(zone) || migrationTargetToSource[namespace.Name] != ""
 			}); err != nil {
 				return err
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix race condition in istio zone migration.

The istio zone migration offers the possibility to migrate the shoot exposure to a consistent istio namespace pattern without causing disruption outside of the maintenance window for shoot cluster owners. Unfortunately, the cleanup of orphaned istio resources may interfere with the migration targets as it may detect the istio namespaces to refer to a none-existing zone and be empty. Therefore, the namespace may be cleaned up. As this happens directly before the creation in the seed reconcile flow the seed cluster may end up with temporarily having a deleted migration target namespace, which will be recreated again in the next seed reconcile flow.
This change safe-guards the migration by ensuring that the migration targets will be kept alive even if they do not see active usage.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The istio ingress gateway orphan namespace detection no longer interferes with the istio ingress gateway zone migration in case the target zone names are unknown and there is no active usage.
```
