### PR TITLE
Fix `logcheck` build

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,6 +83,13 @@
       "enabled": false
     },
     {
+      // Only patch level updates for logcheck. Minor and major versions must be in sync with golangci-lint.
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchFileNames": ["hack\/tools\/logcheck\/go\\.mod"],
+      "enabled": false
+    },
+    {
       // Update only patchlevels of major dependencies like kubernetes, controller-runtime and istio.
       // Minor and major upgrades most likely require manual adaptations of the code.
       "matchDatasources": ["go"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,9 +83,8 @@
       "enabled": false
     },
     {
-      // Only patch level updates for logcheck. Minor and major versions must be in sync with golangci-lint.
+      // Go versions must be in sync with golangci-lint.
       "matchDatasources": ["go"],
-      "matchUpdateTypes": ["major", "minor"],
       "matchFileNames": ["hack\/tools\/logcheck\/go\\.mod"],
       "enabled": false
     },

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -198,10 +198,10 @@ $(KUSTOMIZE): $(call tool_version_file,$(KUSTOMIZE),$(KUSTOMIZE_VERSION))
 
 ifeq ($(strip $(shell go list -m 2>/dev/null)),github.com/gardener/gardener)
 $(LOGCHECK): $(TOOLS_PKG_PATH)/logcheck/go.* $(shell find $(TOOLS_PKG_PATH)/logcheck -type f -name '*.go')
-	cd $(TOOLS_PKG_PATH)/logcheck; CGO_ENABLED=1 go build -o $(abspath $(LOGCHECK)) -buildmode=plugin ./plugin
+	cd $(TOOLS_PKG_PATH)/logcheck;GOTOOLCHAIN=auto CGO_ENABLED=1 go build -o $(abspath $(LOGCHECK)) -buildmode=plugin ./plugin
 else
 $(LOGCHECK): go.mod
-	CGO_ENABLED=1 go build -o $(LOGCHECK) -buildmode=plugin github.com/gardener/gardener/hack/tools/logcheck/plugin
+	GOTOOLCHAIN=auto CGO_ENABLED=1 go build -o $(LOGCHECK) -buildmode=plugin github.com/gardener/gardener/hack/tools/logcheck/plugin
 endif
 
 $(MOCKGEN): $(call tool_version_file,$(MOCKGEN),$(MOCKGEN_VERSION))

--- a/hack/tools/logcheck/go.mod
+++ b/hack/tools/logcheck/go.mod
@@ -1,6 +1,7 @@
 module github.com/gardener/gardener/hack/tools/logcheck
 
-go 1.22.1
+// Version must be kept in sync with Go version of https://github.com/golangci/golangci-lint.
+go 1.21
 
 // This is a separate go module to decouple the gardener codebase and production binaries from dependencies that are
 // only needed to build the logcheck tool


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue prevented running `make verify` locally.

**Which issue(s) this PR fixes**:
Fixes #9453

**Special notes for your reviewer**:
/cc @oliver-goetz, esp. for Renovate config changes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue was fixed that caused `make verify` to fail because of `logcheck` build issues.
```
