### PR TITLE
[node-agent] Support restarting systemd units via annotation without `.service` suffix

### DIFF
--- a/pkg/nodeagent/controller/node/reconciler.go
+++ b/pkg/nodeagent/controller/node/reconciler.go
@@ -66,9 +66,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	var restartGardenerNodeAgent bool
 	for _, serviceName := range strings.Split(services, ",") {
+		if !strings.HasSuffix(serviceName, ".service") {
+			serviceName = serviceName + ".service"
+		}
 		// If the gardener-node-agent itself should be restarted, we have to first remove the annotation from the node.
 		// Otherwise, the annotation is never removed and it restarts itself indefinitely.
-		if strings.HasPrefix(serviceName, "gardener-node-agent") {
+		if serviceName == nodeagentv1alpha1.UnitName {
 			restartGardenerNodeAgent = true
 			continue
 		}

--- a/test/integration/nodeagent/node/node_test.go
+++ b/test/integration/nodeagent/node/node_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Node controller tests", func() {
 
 	It("should restart the systemd services specified in the restart annotation", func() {
 		By("Adding restart annotation to node")
-		svc1, svc2, svc3 := "gardener-node-agent", "foo", "bar"
+		svc1, svc2, svc3 := "gardener-node-agent", "foo.service", "bar"
 		metav1.SetMetaDataAnnotation(&node.ObjectMeta, "worker.gardener.cloud/restart-systemd-services", svc1+","+svc2+","+svc3)
 		Expect(testClient.Update(ctx, node)).To(Succeed())
 
@@ -106,7 +106,7 @@ var _ = Describe("Node controller tests", func() {
 			return fakeDBus.Actions
 		}).Should(ConsistOf(
 			fake.SystemdAction{Action: fake.ActionRestart, UnitNames: []string{svc2}},
-			fake.SystemdAction{Action: fake.ActionRestart, UnitNames: []string{svc3}},
+			fake.SystemdAction{Action: fake.ActionRestart, UnitNames: []string{svc3 + ".service"}},
 			fake.SystemdAction{Action: fake.ActionRestart, UnitNames: []string{svc1 + ".service"}},
 		))
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
`systemctl` allows restarting systemd units without `.service` suffix e.g. via `systemctl restart kubelet`.
This PR implements a similiar functionality in gardener-node-agent for restarting systemd units via node annotations e.g. via `kubectl annotate node <node-name> worker.gardener.cloud/restart-systemd-services=kubelet`.

According to the docs, this should be already the case ([ref](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_operations.md#restart-systemd-services-on-particular-worker-nodes)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @adenitiu @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Restarting systemd units by annotating the node now works without specifying the `.service` suffix in unit names.
```
