### PR TITLE
Restore `etcd` with 1 replica and scale it up after `kapi` deployment for HA shoots

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -313,13 +313,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
 		scaleEtcdAfterRestore = g.Add(flow.Task{
-			Name:         "Scaling main and events etcd after restoration from backup",
+			Name:         "Scaling main and events etcd after kube-apiserver is ready",
 			Fn:           flow.TaskFn(botanist.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
 			SkipIf:       !v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo()) || !botanist.IsRestorePhase() || o.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Waiting until main and events etcd scaled up after restoration from backup",
+			Name:         "Waiting until main and events etcd scaled up after kube-apiserver is ready",
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsReady),
 			SkipIf:       !v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo()) || !botanist.IsRestorePhase() || o.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -315,13 +315,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		scaleEtcdAfterRestore = g.Add(flow.Task{
 			Name:         "Scaling main and events etcd after restoration from backup",
 			Fn:           flow.TaskFn(botanist.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
-			SkipIf:       !botanist.IsRestorePhase() || o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       !v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo()) || !botanist.IsRestorePhase() || o.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until main and events etcd scaled up after restoration from backup",
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsReady),
-			SkipIf:       !botanist.IsRestorePhase() || o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       !v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo()) || !botanist.IsRestorePhase() || o.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
With this PR during the `restore` phase of control plane migration of HA shoot clusters, the main and events `etcd`s will be deployed with only 1 replica (with all other settings required for multi-node etcd) initially. After the `etcd`s become ready, the `kube-apiserver` is deployed and after the `kube-apiserver` is ready we scale up the etcd replicas to 3.

Previously the `kube-apiserver` was deployed only after:
1. The main `etcd`  was created with 1 replica and restored
2. The main `etcd` was scaled to 3 replicas and they became ready
3. All 3 replicas of the events `etcd` became ready
This would lead to a 3 minute increase in downtime for HA shoot clusters compared to non-HA shoot clusters during control plane migration.

After talking with @ishan16696 it turns out that we do not have to wait for all 3 replicas of the `etcd`s to be up and running before deploying the kube-apiserver. So with this approach the extra 3 minutes of downtime are no-longer present. Note that now we also only wait for 1 replica of the events `etcd` to become ready before deploying the kube-apiserver, instead of waiting for all 3.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ishan16696
/cc @shafeeqes if we could get this in the `v1.91.0`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
During the `restore` phase of control plane migration of HA shoots, the shoot's `kube-apiserver` is deployed immediately after one replica is ready for each of the events and main `etcd`s. The event and main `etcd`s are scaled up to 3 replicas (the current default for HA shoots) after the `kube-apiserver` is deployed and ready. This should greatly reduce the downtime during control plane migration of HA shoots.
```
