### PR TITLE
cmd: consistent error reporting while starting the app

### DIFF
--- a/cmd/gardener-admission-controller/main.go
+++ b/cmd/gardener-admission-controller/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-admission-controller/app"
@@ -27,10 +26,10 @@ import (
 
 func main() {
 	utils.DeduplicateWarnings()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-admission-controller/main.go
+++ b/cmd/gardener-admission-controller/main.go
@@ -15,20 +15,22 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-admission-controller/app"
 	"github.com/gardener/gardener/cmd/utils"
+	"github.com/gardener/gardener/pkg/logger"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		fmt.Println(err)
+		logf.Log.Error(err, "Error starting app")
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-admission-controller/main.go
+++ b/cmd/gardener-admission-controller/main.go
@@ -30,7 +30,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -71,12 +71,15 @@ import (
 	plugin "github.com/gardener/gardener/plugin/pkg"
 )
 
+// Name is the name of this component.
+const Name = "gardener-apiserver"
+
 // NewCommand creates a *cobra.Command object with default parameters.
 func NewCommand() *cobra.Command {
 	opts := NewOptions()
 
 	cmd := &cobra.Command{
-		Use:   "gardener-apiserver",
+		Use:   Name,
 		Short: "Launch the Gardener API server",
 		Long: `In essence, the Gardener is an extension API server along with a bundle
 of Kubernetes controllers which introduce new API objects in an existing Kubernetes

--- a/cmd/gardener-apiserver/main.go
+++ b/cmd/gardener-apiserver/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-apiserver/app"
@@ -30,10 +29,10 @@ func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
 	ctx := signals.SetupSignalHandler()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewCommand().ExecuteContext(ctx); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-apiserver/main.go
+++ b/cmd/gardener-apiserver/main.go
@@ -17,20 +17,23 @@ package main
 import (
 	"os"
 
-	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-apiserver/app"
 	"github.com/gardener/gardener/cmd/utils"
 	"github.com/gardener/gardener/pkg/apiserver/features"
+	"github.com/gardener/gardener/pkg/logger"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
-
 	ctx := signals.SetupSignalHandler()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+
 	if err := app.NewCommand().ExecuteContext(ctx); err != nil {
+		logf.Log.Error(err, "Error starting app")
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-apiserver/main.go
+++ b/cmd/gardener-apiserver/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"os"
 
+	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-apiserver/app"

--- a/cmd/gardener-apiserver/main.go
+++ b/cmd/gardener-apiserver/main.go
@@ -33,7 +33,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(ctx); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-controller-manager/main.go
+++ b/cmd/gardener-controller-manager/main.go
@@ -15,22 +15,24 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-controller-manager/app"
 	"github.com/gardener/gardener/cmd/utils"
 	"github.com/gardener/gardener/pkg/controllermanager/features"
+	"github.com/gardener/gardener/pkg/logger"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		fmt.Println(err)
+		logf.Log.Error(err, "Error starting app")
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-controller-manager/main.go
+++ b/cmd/gardener-controller-manager/main.go
@@ -32,7 +32,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-controller-manager/main.go
+++ b/cmd/gardener-controller-manager/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-controller-manager/app"
@@ -29,10 +28,10 @@ import (
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -68,6 +68,9 @@ import (
 
 var hostIP string
 
+// Name is the name of this component.
+const Name = local.Name + "-controller-manager"
+
 func init() {
 	addrs, err := net.InterfaceAddrs()
 	utilruntime.Must(err)
@@ -187,7 +190,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: fmt.Sprintf("%s-controller-manager", local.Name),
+		Use: Name,
 
 		RunE: func(_ *cobra.Command, _ []string) error {
 			seedName := os.Getenv("SEED_NAME")

--- a/cmd/gardener-extension-provider-local/main.go
+++ b/cmd/gardener-extension-provider-local/main.go
@@ -30,7 +30,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewControllerManagerCommand(signals.SetupSignalHandler()).Execute(); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-extension-provider-local/main.go
+++ b/cmd/gardener-extension-provider-local/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-extension-provider-local/app"
@@ -27,10 +26,10 @@ import (
 
 func main() {
 	utils.DeduplicateWarnings()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewControllerManagerCommand(signals.SetupSignalHandler()).Execute(); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-extension-provider-local/main.go
+++ b/cmd/gardener-extension-provider-local/main.go
@@ -27,11 +27,10 @@ import (
 
 func main() {
 	utils.DeduplicateWarnings()
-
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewControllerManagerCommand(signals.SetupSignalHandler()).Execute(); err != nil {
-		logf.Log.Error(err, "Error executing the main controller command")
+		logf.Log.Error(err, "Error starting app")
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-node-agent/main.go
+++ b/cmd/gardener-node-agent/main.go
@@ -15,22 +15,24 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-node-agent/app"
 	"github.com/gardener/gardener/cmd/utils"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/nodeagent/features"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		fmt.Println(err)
+		logf.Log.Error(err, "Error starting app")
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-node-agent/main.go
+++ b/cmd/gardener-node-agent/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-node-agent/app"
@@ -29,10 +28,10 @@ import (
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-node-agent/main.go
+++ b/cmd/gardener-node-agent/main.go
@@ -32,7 +32,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-operator/main.go
+++ b/cmd/gardener-operator/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-operator/app"
@@ -29,10 +28,10 @@ import (
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-operator/main.go
+++ b/cmd/gardener-operator/main.go
@@ -15,22 +15,24 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-operator/app"
 	"github.com/gardener/gardener/cmd/utils"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operator/features"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		fmt.Println(err)
+		logf.Log.Error(err, "Error starting app")
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-operator/main.go
+++ b/cmd/gardener-operator/main.go
@@ -32,7 +32,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-resource-manager/main.go
+++ b/cmd/gardener-resource-manager/main.go
@@ -15,20 +15,22 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-resource-manager/app"
 	"github.com/gardener/gardener/cmd/utils"
+	"github.com/gardener/gardener/pkg/logger"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		fmt.Println(err)
+		logf.Log.Error(err, "Error starting app")
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-resource-manager/main.go
+++ b/cmd/gardener-resource-manager/main.go
@@ -30,7 +30,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-resource-manager/main.go
+++ b/cmd/gardener-resource-manager/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-resource-manager/app"
@@ -27,10 +26,10 @@ import (
 
 func main() {
 	utils.DeduplicateWarnings()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-scheduler/main.go
+++ b/cmd/gardener-scheduler/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-scheduler/app"
@@ -29,10 +28,10 @@ import (
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-scheduler/main.go
+++ b/cmd/gardener-scheduler/main.go
@@ -15,22 +15,24 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-scheduler/app"
 	"github.com/gardener/gardener/cmd/utils"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/scheduler/features"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		fmt.Println(err)
+		logf.Log.Error(err, "Error starting app")
 		os.Exit(1)
 	}
 }

--- a/cmd/gardener-scheduler/main.go
+++ b/cmd/gardener-scheduler/main.go
@@ -32,7 +32,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardenlet/main.go
+++ b/cmd/gardenlet/main.go
@@ -15,18 +15,24 @@
 package main
 
 import (
+	"os"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardenlet/app"
 	"github.com/gardener/gardener/cmd/utils"
 	"github.com/gardener/gardener/pkg/gardenlet/features"
+	"github.com/gardener/gardener/pkg/logger"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		panic(err)
+		logf.Log.Error(err, "Error starting app")
+		os.Exit(1)
 	}
 }

--- a/cmd/gardenlet/main.go
+++ b/cmd/gardenlet/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardenlet/app"
@@ -29,10 +28,10 @@ import (
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+	log := logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON)
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app", "app", app.Name)
+		log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }

--- a/cmd/gardenlet/main.go
+++ b/cmd/gardenlet/main.go
@@ -32,7 +32,7 @@ func main() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		logf.Log.Error(err, "Error starting app")
+		logf.Log.Error(err, "Error starting app", "app", app.Name)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

Some apps are using `fmt.Println()`, others are `panic()`'ing, and we have third ones which are using `logf.Log.Error()`.

This commit makes all apps consistent in regards to error reporting and exiting.

**Which issue(s) this PR fixes**:

`NONE`

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
