### PR TITLE
Fix NodeNotHealthy alert with correct NodeNotReady taint

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -65,7 +65,7 @@ func CentralPrometheusRules() []*monitoringv1.PrometheusRule {
 						},
 						{
 							Alert: "NodeNotHealthy",
-							Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="deployment.machine.sapcloud.io/prefer-no-schedule", key!="ToBeDeletedByClusterAutoscaler", key!="` + v1beta1constants.LabelNodeCriticalComponent + `"}))[30m:]) > 9`),
+							Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!~"node.kubernetes.io/unschedulable|deployment.machine.sapcloud.io/prefer-no-schedule|ToBeDeletedByClusterAutoscaler|` + v1beta1constants.TaintNodeCriticalComponentsNotReady + `"}))[30m:]) > 9`),
 							For:   ptr.To(monitoringv1.Duration("0m")),
 							Labels: map[string]string{
 								"severity":   "warning",

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -57,7 +57,7 @@ var _ = Describe("PrometheusRules", func() {
 								},
 								{
 									Alert: "NodeNotHealthy",
-									Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="deployment.machine.sapcloud.io/prefer-no-schedule", key!="ToBeDeletedByClusterAutoscaler", key!="` + v1beta1constants.LabelNodeCriticalComponent + `"}))[30m:]) > 9`),
+									Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!~"node.kubernetes.io/unschedulable|deployment.machine.sapcloud.io/prefer-no-schedule|ToBeDeletedByClusterAutoscaler|` + v1beta1constants.TaintNodeCriticalComponentsNotReady + `"}))[30m:]) > 9`),
 									For:   ptr.To(monitoringv1.Duration("0m")),
 									Labels: map[string]string{
 										"severity":   "warning",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
This PR corrects the filtering query, as the current value[ v1beta1constants.LabelNodeCriticalComponent](https://github.com/gardener/gardener/blob/master/pkg/apis/core/v1beta1/constants/types_constants.go#L890) is wrong. The query was thought initially to handle `node.gardener.cloud/critical-components-not-ready` , hence the correct value should be [v1beta1constants.TaintNodeCriticalComponentsNotReady](https://github.com/gardener/gardener/blob/master/pkg/apis/core/v1beta1/constants/types_constants.go#L888C2-L888C37)

**Which issue(s) this PR fixes**:
False alerts of nodes being reported as not healthy.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Correct NodeNotHealthy filtering query to use `v1beta1constants.TaintNodeCriticalComponentsNotReady`
```
