### PR TITLE
Deprecate `shoot.spec.dns.providers` handling

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -4051,7 +4051,8 @@ kubeconfig that is handed out to end-users. This field is immutable.</p>
 <em>(Optional)</em>
 <p>Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 not a default domain is used.
-Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.</p>
+Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
+Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.</p>
 </td>
 </tr>
 </tbody>
@@ -4128,7 +4129,8 @@ DNSIncludeExclude
 <td>
 <em>(Optional)</em>
 <p>Domains contains information about which domains shall be included/excluded for this provider.
-Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.</p>
+Deprecated: This field is deprecated and will be removed in a future release.
+Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.</p>
 </td>
 </tr>
 <tr>
@@ -4141,7 +4143,8 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Primary indicates that this DNSProvider is used for shoot related domains.
-Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.</p>
+Deprecated: This field is deprecated and will be removed in a future release.
+Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.</p>
 </td>
 </tr>
 <tr>
@@ -4183,7 +4186,8 @@ DNSIncludeExclude
 <td>
 <em>(Optional)</em>
 <p>Zones contains information about which hosted zones shall be included/excluded for this provider.
-Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.</p>
+Deprecated: This field is deprecated and will be removed in a future release.
+Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -4050,7 +4050,8 @@ kubeconfig that is handed out to end-users. This field is immutable.</p>
 <td>
 <em>(Optional)</em>
 <p>Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
-not a default domain is used.</p>
+not a default domain is used.
+Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.</p>
 </td>
 </tr>
 </tbody>
@@ -4127,7 +4128,7 @@ DNSIncludeExclude
 <td>
 <em>(Optional)</em>
 <p>Domains contains information about which domains shall be included/excluded for this provider.
-Deprecated: This field is deprecated and will be removed in a future release.</p>
+Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.</p>
 </td>
 </tr>
 <tr>
@@ -4139,7 +4140,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Primary indicates that this DNSProvider is used for shoot related domains.</p>
+<p>Primary indicates that this DNSProvider is used for shoot related domains.
+Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.</p>
 </td>
 </tr>
 <tr>
@@ -4181,7 +4183,7 @@ DNSIncludeExclude
 <td>
 <em>(Optional)</em>
 <p>Zones contains information about which hosted zones shall be included/excluded for this provider.
-Deprecated: This field is deprecated and will be removed in a future release.</p>
+Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.</p>
 </td>
 </tr>
 </tbody>

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -314,10 +314,10 @@ spec:
     # When the shoot shall use a cluster domain no domain and no providers need to be provided - Gardener will
     # automatically compute a correct domain based on the default domains in the garden cluster.
     domain: crazy-botany.core.my-custom-domain.com
+    # Provider configuration required if custom shoot domain is configured.
   # providers:
   # - type: aws-route53
   #   secretName: my-custom-domain-secret
-  #   primary: true # `true` indicates that this provider is also used to manage the shoot domain `.spec.dns.domain`
   extensions:
   - type: foobar
   # providerConfig:

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -351,7 +351,8 @@ type DNS struct {
 	Domain *string
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.
-	// Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.
+	// Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
+	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.
 	Providers []DNSProvider
 }
 
@@ -360,10 +361,12 @@ type DNS struct {
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
 	// Domains contains information about which domains shall be included/excluded for this provider.
-	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
 	Domains *DNSIncludeExclude
 	// Primary indicates that this DNSProvider is used for shoot related domains.
-	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.
 	Primary *bool
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
@@ -374,7 +377,8 @@ type DNSProvider struct {
 	// this shoot.
 	Type *string
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
-	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
 	Zones *DNSIncludeExclude
 }
 

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -351,17 +351,19 @@ type DNS struct {
 	Domain *string
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.
+	// Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.
 	Providers []DNSProvider
 }
 
+// TODO(timuthy): Rework the 'DNSProvider' struct and deprecated fields in the scope of https://github.com/gardener/gardener/issues/9176.
+
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
-	// TODO(timuthy): Remove this field in the scope of https://github.com/gardener/gardener/issues/9176.
-
 	// Domains contains information about which domains shall be included/excluded for this provider.
-	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
 	Domains *DNSIncludeExclude
 	// Primary indicates that this DNSProvider is used for shoot related domains.
+	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.
 	Primary *bool
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
@@ -371,10 +373,8 @@ type DNSProvider struct {
 	// Type is the DNS provider type for the Shoot. Only relevant if not the default domain is used for
 	// this shoot.
 	Type *string
-	// TODO(timuthy): Remove this field in the scope of https://github.com/gardener/gardener/issues/9176.
-
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
-	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
 	Zones *DNSIncludeExclude
 }
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -687,7 +687,8 @@ message DNS {
 
   // Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
   // not a default domain is used.
-  // Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.
+  // Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
+  // Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +optional
@@ -708,12 +709,14 @@ message DNSIncludeExclude {
 // DNSProvider contains information about a DNS provider.
 message DNSProvider {
   // Domains contains information about which domains shall be included/excluded for this provider.
-  // Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
+  // Deprecated: This field is deprecated and will be removed in a future release.
+  // Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
   // +optional
   optional DNSIncludeExclude domains = 1;
 
   // Primary indicates that this DNSProvider is used for shoot related domains.
-  // Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.
+  // Deprecated: This field is deprecated and will be removed in a future release.
+  // Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.
   // +optional
   optional bool primary = 2;
 
@@ -729,7 +732,8 @@ message DNSProvider {
   optional string type = 4;
 
   // Zones contains information about which hosted zones shall be included/excluded for this provider.
-  // Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
+  // Deprecated: This field is deprecated and will be removed in a future release.
+  // Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
   // +optional
   optional DNSIncludeExclude zones = 5;
 }

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -687,6 +687,7 @@ message DNS {
 
   // Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
   // not a default domain is used.
+  // Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +optional
@@ -707,11 +708,12 @@ message DNSIncludeExclude {
 // DNSProvider contains information about a DNS provider.
 message DNSProvider {
   // Domains contains information about which domains shall be included/excluded for this provider.
-  // Deprecated: This field is deprecated and will be removed in a future release.
+  // Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
   // +optional
   optional DNSIncludeExclude domains = 1;
 
   // Primary indicates that this DNSProvider is used for shoot related domains.
+  // Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.
   // +optional
   optional bool primary = 2;
 
@@ -727,7 +729,7 @@ message DNSProvider {
   optional string type = 4;
 
   // Zones contains information about which hosted zones shall be included/excluded for this provider.
-  // Deprecated: This field is deprecated and will be removed in a future release.
+  // Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
   // +optional
   optional DNSIncludeExclude zones = 5;
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -432,7 +432,8 @@ type DNS struct {
 	Domain *string `json:"domain,omitempty" protobuf:"bytes,1,opt,name=domain"`
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.
-	// Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.
+	// Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
+	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +optional
@@ -444,11 +445,13 @@ type DNS struct {
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
 	// Domains contains information about which domains shall be included/excluded for this provider.
-	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
 	// +optional
 	Domains *DNSIncludeExclude `json:"domains,omitempty" protobuf:"bytes,1,opt,name=domains"`
 	// Primary indicates that this DNSProvider is used for shoot related domains.
-	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.
 	// +optional
 	Primary *bool `json:"primary,omitempty" protobuf:"varint,2,opt,name=primary"`
 	// SecretName is a name of a secret containing credentials for the stated domain and the
@@ -462,7 +465,8 @@ type DNSProvider struct {
 	Type *string `json:"type,omitempty" protobuf:"bytes,4,opt,name=type"`
 
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
-	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
 	// +optional
 	Zones *DNSIncludeExclude `json:"zones,omitempty" protobuf:"bytes,5,opt,name=zones"`
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -432,21 +432,23 @@ type DNS struct {
 	Domain *string `json:"domain,omitempty" protobuf:"bytes,1,opt,name=domain"`
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.
+	// Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +optional
 	Providers []DNSProvider `json:"providers,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=providers"`
 }
 
+// TODO(timuthy): Rework the 'DNSProvider' struct and deprecated fields in the scope of https://github.com/gardener/gardener/issues/9176.
+
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
-	// TODO(timuthy): Remove this field in the scope of https://github.com/gardener/gardener/issues/9176.
-
 	// Domains contains information about which domains shall be included/excluded for this provider.
-	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
 	// +optional
 	Domains *DNSIncludeExclude `json:"domains,omitempty" protobuf:"bytes,1,opt,name=domains"`
 	// Primary indicates that this DNSProvider is used for shoot related domains.
+	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.
 	// +optional
 	Primary *bool `json:"primary,omitempty" protobuf:"varint,2,opt,name=primary"`
 	// SecretName is a name of a secret containing credentials for the stated domain and the
@@ -458,10 +460,9 @@ type DNSProvider struct {
 	// Type is the DNS provider type.
 	// +optional
 	Type *string `json:"type,omitempty" protobuf:"bytes,4,opt,name=type"`
-	// TODO(timuthy): Remove this field in the scope of https://github.com/gardener/gardener/issues/9176.
 
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
-	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.
 	// +optional
 	Zones *DNSIncludeExclude `json:"zones,omitempty" protobuf:"bytes,5,opt,name=zones"`
 }

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2679,7 +2679,7 @@ func schema_pkg_apis_core_v1beta1_DNS(ref common.ReferenceCallback) common.OpenA
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if not a default domain is used. Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.",
+							Description: "Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if not a default domain is used. Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -2751,13 +2751,13 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"domains": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domains contains information about which domains shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.",
+							Description: "Domains contains information about which domains shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
 						},
 					},
 					"primary": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Primary indicates that this DNSProvider is used for shoot related domains. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.",
+							Description: "Primary indicates that this DNSProvider is used for shoot related domains. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -2778,7 +2778,7 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 					},
 					"zones": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Zones contains information about which hosted zones shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.",
+							Description: "Zones contains information about which hosted zones shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
 						},
 					},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2679,7 +2679,7 @@ func schema_pkg_apis_core_v1beta1_DNS(ref common.ReferenceCallback) common.OpenA
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if not a default domain is used.",
+							Description: "Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if not a default domain is used. Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config for additional providers.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -2751,13 +2751,13 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"domains": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domains contains information about which domains shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release.",
+							Description: "Domains contains information about which domains shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
 						},
 					},
 					"primary": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Primary indicates that this DNSProvider is used for shoot related domains.",
+							Description: "Primary indicates that this DNSProvider is used for shoot related domains. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional and non-primary providers.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -2778,7 +2778,7 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 					},
 					"zones": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Zones contains information about which hosted zones shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release.",
+							Description: "Zones contains information about which hosted zones shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config for additional configuration.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
 						},
 					},

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -512,7 +512,6 @@ func mutateAutoscalingReplicas(
 	}
 
 	// For compatibility reasons, only overwrite minReplicas if the current count is lower than the calculated count.
-	// TODO(timuthy): Reconsider if this should be removed in a future version.
 	if ptr.Deref(getMinReplicas(), 0) < *replicas {
 		log.Info("Mutating minReplicas", "minReplicas", replicas)
 		setMinReplicas(replicas)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cleanup
/kind api-change

**What this PR does / why we need it**:
This PRs adds deprecation notes about the DNS provider handling. See https://github.com/gardener/gardener/issues/9176 for more information.

**Which issue(s) this PR fixes**:
Part of #9176

**Special notes for your reviewer**:
/cc @MartinWeindel

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The specification of additional, non-primary DNS providers was deprecated and will be discontinued in a future release. If you need additional DNS providers for your shoot workload, please use the provider config for the respective DNS extension.
```
