### PR TITLE
Add new Extension Lifecycle Strategy `AfterWorker`

### DIFF
--- a/cmd/gardener-extension-provider-local/app/options.go
+++ b/cmd/gardener-extension-provider-local/app/options.go
@@ -32,6 +32,7 @@ import (
 	dnsrecordcontroller "github.com/gardener/gardener/pkg/provider-local/controller/dnsrecord"
 	localextensionseedcontroller "github.com/gardener/gardener/pkg/provider-local/controller/extension/seed"
 	localextensionshootcontroller "github.com/gardener/gardener/pkg/provider-local/controller/extension/shoot"
+	localextensionshootafterworkercontroller "github.com/gardener/gardener/pkg/provider-local/controller/extension/shootafterworker"
 	healthcheckcontroller "github.com/gardener/gardener/pkg/provider-local/controller/healthcheck"
 	infrastructurecontroller "github.com/gardener/gardener/pkg/provider-local/controller/infrastructure"
 	ingresscontroller "github.com/gardener/gardener/pkg/provider-local/controller/ingress"
@@ -64,6 +65,7 @@ func ControllerSwitchOptions() *extensionscmdcontroller.SwitchOptions {
 		extensionscmdcontroller.Switch(extensionsheartbeatcontroller.ControllerName, extensionsheartbeatcontroller.AddToManager),
 		extensionscmdcontroller.Switch(localextensionseedcontroller.ControllerName, localextensionseedcontroller.AddToManager),
 		extensionscmdcontroller.Switch(localextensionshootcontroller.ControllerName, localextensionshootcontroller.AddToManager),
+		extensionscmdcontroller.Switch(localextensionshootafterworkercontroller.ControllerName, localextensionshootafterworkercontroller.AddToManager),
 		extensionscmdcontroller.Switch(networkpolicycontroller.ControllerName, networkpolicycontroller.AddToManager),
 	)
 }

--- a/docs/extensions/controllerregistration.md
+++ b/docs/extensions/controllerregistration.md
@@ -240,7 +240,7 @@ The `lifecycle` field tells Gardener when to perform a certain action on the `Ex
 - `delete: BeforeKubeAPIServer` means that the extension resource will be deleted before the `kube-apiserver` is destroyed during shoot deletion. This is the default behaviour if this value is not specified.
 - `migrate: BeforeKubeAPIServer` means that the extension resource will be migrated before the `kube-apiserver` is destroyed in the source cluster during [control plane migration](../operations/control_plane_migration.md). This is the default behaviour if this value is not specified. The restoration of the control plane follows the reconciliation control flow.
 
-The lifecycle value `AfterWorker` is only avaiable during `reconcile`. When specified, the extension resource will be reconciled after the workers are deployed. This is useful for extensions that want to deploy a workload in the shoot control plane and want to wait for the workload to run and get ready on a node. During shoot creation the extension will be reconciled before the first worker joins the cluster and extensions should be able to handle that.
+The lifecycle value `AfterWorker` is only avaiable during `reconcile`. When specified, the extension resource will be reconciled after the workers are deployed. This is useful for extensions that want to deploy a workload in the shoot control plane and want to wait for the workload to run and get ready on a node. During shoot creation the extension will start its reconciliation before the first workers have joined the cluster, they will become available at some later point.
 
 ### Deployment Configuration Options
 

--- a/docs/extensions/controllerregistration.md
+++ b/docs/extensions/controllerregistration.md
@@ -240,7 +240,7 @@ The `lifecycle` field tells Gardener when to perform a certain action on the `Ex
 - `delete: BeforeKubeAPIServer` means that the extension resource will be deleted before the `kube-apiserver` is destroyed during shoot deletion. This is the default behaviour if this value is not specified.
 - `migrate: BeforeKubeAPIServer` means that the extension resource will be migrated before the `kube-apiserver` is destroyed in the source cluster during [control plane migration](../operations/control_plane_migration.md). This is the default behaviour if this value is not specified. The restoration of the control plane follows the reconciliation control flow.
 
-The lifecycle value `AfterWorker` is only avaiable during `reconcile`. When specified, the extension resource will be reconciled after the workers are deployed. This is useful for extensions that want to deploy a workload in the shoot control plane and want to wait for the workload to run and get ready on a node. During shoot creation the extension will start its reconciliation before the first workers have joined the cluster, they will become available at some later point.
+The lifecycle value `AfterWorker` is only available during `reconcile`. When specified, the extension resource will be reconciled after the workers are deployed. This is useful for extensions that want to deploy a workload in the shoot control plane and want to wait for the workload to run and get ready on a node. During shoot creation the extension will start its reconciliation before the first workers have joined the cluster, they will become available at some later point.
 
 ### Deployment Configuration Options
 

--- a/docs/extensions/controllerregistration.md
+++ b/docs/extensions/controllerregistration.md
@@ -226,7 +226,7 @@ The `globallyEnabled=true` option specifies that the `Extension/foo` object shal
 The `reconcileTimeout` tells Gardener how long it should wait during its shoot reconciliation flow for the `Extension/foo`'s reconciliation to finish.
 
 #### `Extension` Lifecycle
-The `lifecycle` field tells Gardener when to perform a certain action on the `Extension` resource during the reconciliation flows. If omitted, then the default behaviour will be applied. Please find more information on the defaults in the explanation below. Possible values for each control flow are `AfterKubeAPIServer` and `BeforeKubeAPIServer`. Let's take the following configuration and explain it.
+The `lifecycle` field tells Gardener when to perform a certain action on the `Extension` resource during the reconciliation flows. If omitted, then the default behaviour will be applied. Please find more information on the defaults in the explanation below. Possible values for each control flow are `AfterKubeAPIServer`, `BeforeKubeAPIServer`, and `AfterWorker`. Let's take the following configuration and explain it.
 
 ```yaml
     ...
@@ -239,6 +239,8 @@ The `lifecycle` field tells Gardener when to perform a certain action on the `Ex
  - `reconcile: AfterKubeAPIServer` means that the extension resource will be reconciled after the successful reconciliation of the `kube-apiserver` during shoot reconciliation. This is also the default behaviour if this value is not specified. During shoot hibernation, the opposite rule is applied, meaning that in this case the reconciliation of the extension will happen before the `kube-apiserver` is scaled to 0 replicas. On the other hand, if the extension needs to be reconciled before the `kube-apiserver` and scaled down after it, then the value `BeforeKubeAPIServer` should be used.
 - `delete: BeforeKubeAPIServer` means that the extension resource will be deleted before the `kube-apiserver` is destroyed during shoot deletion. This is the default behaviour if this value is not specified.
 - `migrate: BeforeKubeAPIServer` means that the extension resource will be migrated before the `kube-apiserver` is destroyed in the source cluster during [control plane migration](../operations/control_plane_migration.md). This is the default behaviour if this value is not specified. The restoration of the control plane follows the reconciliation control flow.
+
+The lifecycle value `AfterWorker` is only avaiable during `reconcile`. When specified, the extension resource will be reconciled after the workers are deployed. This is useful for extensions that want to deploy a workload in the shoot control plane and want to wait for the workload to run and get ready on a node. During shoot creation the extension will be reconciled before the first worker joins the cluster and extensions should be able to handle that.
 
 ### Deployment Configuration Options
 

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -132,6 +132,9 @@ This controller reconciles `Extensions` of type `local-ext-seed`. It creates a s
 #### Extension Shoot
 This controller reconciles `Extensions` of type `local-ext-shoot`. It creates a single `serviceaccount` named `local-ext-shoot` in the `kube-system` namespace of the shoot. The extension is reconciled after the `kube-apiserver`. More on extension lifecycle strategies can be read [Registering Extension Controllers](controllerregistration.md#extension-lifecycle).
 
+#### Extension Shoot After Worker
+This controller reconciles `Extensions` of type `local-ext-shoot-after-worker`. It creates a `deployment` named `local-ext-shoot-after` in the `kube-system` namespace of the shoot. The extension is reconciled after the workers and waits until the deployment is ready. More on extension lifecycle strategies can be read [Registering Extension Controllers](controllerregistration.md#extension-lifecycle).
+
 #### Health Checks
 
 The health check controller leverages the [health check library](healthcheck-library.md) in order to:

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -133,7 +133,7 @@ This controller reconciles `Extensions` of type `local-ext-seed`. It creates a s
 This controller reconciles `Extensions` of type `local-ext-shoot`. It creates a single `serviceaccount` named `local-ext-shoot` in the `kube-system` namespace of the shoot. The extension is reconciled after the `kube-apiserver`. More on extension lifecycle strategies can be read [Registering Extension Controllers](controllerregistration.md#extension-lifecycle).
 
 #### Extension Shoot After Worker
-This controller reconciles `Extensions` of type `local-ext-shoot-after-worker`. It creates a `deployment` named `local-ext-shoot-after` in the `kube-system` namespace of the shoot. The extension is reconciled after the workers and waits until the deployment is ready. More on extension lifecycle strategies can be read [Registering Extension Controllers](controllerregistration.md#extension-lifecycle).
+This controller reconciles `Extensions` of type `local-ext-shoot-after-worker`. It creates a `deployment` named `local-ext-shoot-after-worker` in the `kube-system` namespace of the shoot. The extension is reconciled after the workers and waits until the deployment is ready. More on extension lifecycle strategies can be read [Registering Extension Controllers](controllerregistration.md#extension-lifecycle).
 
 #### Health Checks
 

--- a/example/provider-local/garden/base/kustomization.yaml
+++ b/example/provider-local/garden/base/kustomization.yaml
@@ -29,6 +29,13 @@ patches:
         kind: Extension
         type: local-ext-shoot
         workerlessSupported: true
+    - op: add
+      path: /spec/resources/-
+      value:
+        kind: Extension
+        type: local-ext-shoot-after-worker
+        lifecycle:
+          reconcile: AfterWorker
   target:
     group: core.gardener.cloud
     kind: ControllerRegistration

--- a/pkg/apis/core/types_controllerregistration.go
+++ b/pkg/apis/core/types_controllerregistration.go
@@ -121,6 +121,8 @@ const (
 	BeforeKubeAPIServer ControllerResourceLifecycleStrategy = "BeforeKubeAPIServer"
 	// AfterKubeAPIServer specifies that a resource should be handled after the kube-apiserver.
 	AfterKubeAPIServer ControllerResourceLifecycleStrategy = "AfterKubeAPIServer"
+	// AfterWorker specifies that a resource should be handled after workers. This is only available during reconcile.
+	AfterWorker ControllerResourceLifecycleStrategy = "AfterWorker"
 )
 
 // ControllerResourceLifecycle defines the lifecycle of a controller resource.

--- a/pkg/apis/core/v1beta1/types_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/types_controllerregistration.go
@@ -132,6 +132,8 @@ const (
 	BeforeKubeAPIServer ControllerResourceLifecycleStrategy = "BeforeKubeAPIServer"
 	// AfterKubeAPIServer specifies that a resource should be handled after the kube-apiserver.
 	AfterKubeAPIServer ControllerResourceLifecycleStrategy = "AfterKubeAPIServer"
+	// AfterWorker specifies that a resource should be handled after workers. This is only available during reconcile.
+	AfterWorker ControllerResourceLifecycleStrategy = "AfterWorker"
 )
 
 // ControllerResourceLifecycle defines the lifecycle of a controller resource.

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -41,6 +41,12 @@ var availableExtensionStrategies = sets.New(
 	string(core.AfterKubeAPIServer),
 )
 
+var availableExtensionStrategiesForReconcile = sets.New(
+	string(core.BeforeKubeAPIServer),
+	string(core.AfterKubeAPIServer),
+	string(core.AfterWorker),
+)
+
 // ValidateControllerRegistration validates a ControllerRegistration object.
 func ValidateControllerRegistration(controllerRegistration *core.ControllerRegistration) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -109,8 +115,8 @@ func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, f
 
 		if resource.Kind == extensionsv1alpha1.ExtensionResource && resource.Lifecycle != nil {
 			lifecyclePath := idxPath.Child("lifecycle")
-			if resource.Lifecycle.Reconcile != nil && !availableExtensionStrategies.Has(string(*resource.Lifecycle.Reconcile)) {
-				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("reconcile"), *resource.Lifecycle.Reconcile, sets.List(availableExtensionStrategies)))
+			if resource.Lifecycle.Reconcile != nil && !availableExtensionStrategiesForReconcile.Has(string(*resource.Lifecycle.Reconcile)) {
+				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("reconcile"), *resource.Lifecycle.Reconcile, sets.List(availableExtensionStrategiesForReconcile)))
 			}
 			if resource.Lifecycle.Delete != nil && !availableExtensionStrategies.Has(string(*resource.Lifecycle.Delete)) {
 				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("delete"), *resource.Lifecycle.Delete, sets.List(availableExtensionStrategies)))

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -41,9 +41,7 @@ var availableExtensionStrategies = sets.New(
 	string(core.AfterKubeAPIServer),
 )
 
-var availableExtensionStrategiesForReconcile = sets.New(
-	string(core.BeforeKubeAPIServer),
-	string(core.AfterKubeAPIServer),
+var availableExtensionStrategiesForReconcile = availableExtensionStrategies.Clone().Insert(
 	string(core.AfterWorker),
 )
 

--- a/pkg/component/extensions/extension/filters.go
+++ b/pkg/component/extensions/extension/filters.go
@@ -36,6 +36,13 @@ func deployAfterKubeAPIServer(e Extension) bool {
 	return *e.Lifecycle.Reconcile == gardencorev1beta1.AfterKubeAPIServer
 }
 
+func deployAfterWorker(e Extension) bool {
+	if e.Lifecycle == nil || e.Lifecycle.Reconcile == nil {
+		return false
+	}
+	return *e.Lifecycle.Reconcile == gardencorev1beta1.AfterWorker
+}
+
 func deleteBeforeKubeAPIServer(e Extension) bool {
 	if e.Lifecycle == nil || e.Lifecycle.Delete == nil {
 		return true

--- a/pkg/component/extensions/extension/mock/mocks.go
+++ b/pkg/component/extensions/extension/mock/mocks.go
@@ -69,6 +69,20 @@ func (mr *MockInterfaceMockRecorder) DeployAfterKubeAPIServer(arg0 any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployAfterKubeAPIServer", reflect.TypeOf((*MockInterface)(nil).DeployAfterKubeAPIServer), arg0)
 }
 
+// DeployAfterWorker mocks base method.
+func (m *MockInterface) DeployAfterWorker(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployAfterWorker", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeployAfterWorker indicates an expected call of DeployAfterWorker.
+func (mr *MockInterfaceMockRecorder) DeployAfterWorker(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployAfterWorker", reflect.TypeOf((*MockInterface)(nil).DeployAfterWorker), arg0)
+}
+
 // DeployBeforeKubeAPIServer mocks base method.
 func (m *MockInterface) DeployBeforeKubeAPIServer(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -167,6 +181,20 @@ func (mr *MockInterfaceMockRecorder) RestoreAfterKubeAPIServer(arg0, arg1 any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreAfterKubeAPIServer", reflect.TypeOf((*MockInterface)(nil).RestoreAfterKubeAPIServer), arg0, arg1)
 }
 
+// RestoreAfterWorker mocks base method.
+func (m *MockInterface) RestoreAfterWorker(arg0 context.Context, arg1 *v1beta1.ShootState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreAfterWorker", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestoreAfterWorker indicates an expected call of RestoreAfterWorker.
+func (mr *MockInterfaceMockRecorder) RestoreAfterWorker(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreAfterWorker", reflect.TypeOf((*MockInterface)(nil).RestoreAfterWorker), arg0, arg1)
+}
+
 // RestoreBeforeKubeAPIServer mocks base method.
 func (m *MockInterface) RestoreBeforeKubeAPIServer(arg0 context.Context, arg1 *v1beta1.ShootState) error {
 	m.ctrl.T.Helper()
@@ -193,6 +221,20 @@ func (m *MockInterface) WaitAfterKubeAPIServer(arg0 context.Context) error {
 func (mr *MockInterfaceMockRecorder) WaitAfterKubeAPIServer(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitAfterKubeAPIServer", reflect.TypeOf((*MockInterface)(nil).WaitAfterKubeAPIServer), arg0)
+}
+
+// WaitAfterWorker mocks base method.
+func (m *MockInterface) WaitAfterWorker(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitAfterWorker", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitAfterWorker indicates an expected call of WaitAfterWorker.
+func (mr *MockInterfaceMockRecorder) WaitAfterWorker(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitAfterWorker", reflect.TypeOf((*MockInterface)(nil).WaitAfterWorker), arg0)
 }
 
 // WaitBeforeKubeAPIServer mocks base method.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -748,6 +748,12 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployWorker),
 		})
+		deployExtensionResourcesAfterWorker = g.Add(flow.Task{
+			Name:         "Deploying extension resources after workers",
+			Fn:           flow.TaskFn(botanist.DeployExtensionsAfterWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
+		})
 		deployClusterAutoscaler = g.Add(flow.Task{
 			Name:         "Deploying cluster autoscaler",
 			Fn:           flow.TaskFn(botanist.DeployClusterAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -761,6 +767,12 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployWorker, waitUntilWorkerStatusUpdate, deployManagedResourceForCloudConfigExecutor, deployManagedResourceForGardenerNodeAgent),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Waiting until extension resources handled after workers are ready",
+			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitAfterWorker,
+			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterWorker),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Scaling down machine-controller-manager",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -751,7 +751,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployExtensionResourcesAfterWorker = g.Add(flow.Task{
 			Name:         "Deploying extension resources after workers",
 			Fn:           flow.TaskFn(botanist.DeployExtensionsAfterWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
 		})
 		deployClusterAutoscaler = g.Add(flow.Task{

--- a/pkg/gardenlet/operation/botanist/extension.go
+++ b/pkg/gardenlet/operation/botanist/extension.go
@@ -54,6 +54,15 @@ func (b *Botanist) DeployExtensionsAfterKubeAPIServer(ctx context.Context) error
 	return b.Shoot.Components.Extensions.Extension.DeployAfterKubeAPIServer(ctx)
 }
 
+// DeployExtensionsAfterWorker deploys the Extension custom resources and triggers the restore operation in case
+// the Shoot is in the restore phase of the control plane migration.
+func (b *Botanist) DeployExtensionsAfterWorker(ctx context.Context) error {
+	if b.IsRestorePhase() {
+		return b.Shoot.Components.Extensions.Extension.RestoreAfterWorker(ctx, b.Shoot.GetShootState())
+	}
+	return b.Shoot.Components.Extensions.Extension.DeployAfterWorker(ctx)
+}
+
 // DeployExtensionsBeforeKubeAPIServer deploys the Extension custom resources and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployExtensionsBeforeKubeAPIServer(ctx context.Context) error {

--- a/pkg/provider-local/controller/extension/shootafterworker/actuator.go
+++ b/pkg/provider-local/controller/extension/shootafterworker/actuator.go
@@ -1,0 +1,170 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	"github.com/gardener/gardener/extensions/pkg/controller/extension"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kubernetesclient "github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+const (
+	// ApplicationName is the name of the application.
+	ApplicationName string = "local-ext-shoot-after-worker"
+	// ManagedResourceNamesShoot is the name used to describe the managed shoot resources.
+	ManagedResourceNamesShoot string = ApplicationName
+	finalizer                 string = "extensions.gardener.cloud/local-ext-shoot-after-worker"
+)
+
+type actuator struct {
+	client client.Client
+}
+
+// NewActuator returns an actuator responsible for Extension resources.
+func NewActuator(mgr manager.Manager) extension.Actuator {
+	return &actuator{
+		client: mgr.GetClient(),
+	}
+}
+
+// Reconcile the extension resource.
+func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv1alpha1.Extension) error {
+	namespace := ex.Namespace
+
+	shootResources, err := getShootResources()
+	if err != nil {
+		return err
+	}
+
+	var (
+		injectedLabels       = map[string]string{v1beta1constants.ShootNoCleanup: "true"}
+		secretNameWithPrefix = true
+		keepObjects          = false
+	)
+
+	if err := managedresources.Create(
+		ctx,
+		a.client,
+		namespace,
+		ManagedResourceNamesShoot,
+		map[string]string{},
+		secretNameWithPrefix,
+		"",
+		shootResources,
+		&keepObjects,
+		injectedLabels,
+		nil,
+	); err != nil {
+		return err
+	}
+
+	cluster, err := extensionscontroller.GetCluster(ctx, a.client, ex.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if extensionscontroller.IsHibernationEnabled(cluster) {
+		return nil
+	}
+	return managedresources.WaitUntilHealthy(ctx, a.client, namespace, ManagedResourceNamesShoot)
+}
+
+// Delete the extension resource.
+func (a *actuator) Delete(ctx context.Context, _ logr.Logger, ex *extensionsv1alpha1.Extension) error {
+	namespace := ex.GetNamespace()
+	twoMinutes := 2 * time.Minute
+
+	timeoutShootCtx, cancelShootCtx := context.WithTimeout(ctx, twoMinutes)
+	defer cancelShootCtx()
+
+	if err := managedresources.DeleteForShoot(ctx, a.client, namespace, ManagedResourceNamesShoot); err != nil {
+		return err
+	}
+
+	return managedresources.WaitUntilDeleted(timeoutShootCtx, a.client, namespace, ManagedResourceNamesShoot)
+}
+
+// ForceDelete force deletes the extension resource.
+func (a *actuator) ForceDelete(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
+	return a.Delete(ctx, log, ex)
+}
+
+// Migrate the extension resource.
+func (a *actuator) Migrate(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
+	// Keep objects for shoot managed resources so that they are not deleted from the shoot during the migration
+	if err := managedresources.SetKeepObjects(ctx, a.client, ex.GetNamespace(), ManagedResourceNamesShoot, true); err != nil {
+		return err
+	}
+
+	return a.Delete(ctx, log, ex)
+}
+
+// Restore the extension resource.
+func (a *actuator) Restore(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
+	return a.Reconcile(ctx, log, ex)
+}
+
+func getShootResources() (map[string][]byte, error) {
+	shootRegistry := managedresources.NewRegistry(kubernetesclient.ShootScheme, kubernetesclient.ShootCodec, kubernetesclient.ShootSerializer)
+	labels := map[string]string{
+		"app.kubernetes.io/name": ApplicationName,
+	}
+	return shootRegistry.AddAllAndSerialize(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ApplicationName,
+				Namespace: metav1.NamespaceSystem,
+				Labels:    labels,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Replicas: ptr.To[int32](1),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  ApplicationName,
+							Image: "europe-docker.pkg.dev/gardener-project/releases/3rd/alpine:3.19.1",
+							Command: []string{
+								"/bin/sh",
+								"-c",
+								"sleep 3600",
+							},
+						}},
+						TerminationGracePeriodSeconds: ptr.To[int64](0),
+					},
+				},
+			},
+		},
+	)
+}

--- a/pkg/provider-local/controller/extension/shootafterworker/actuator.go
+++ b/pkg/provider-local/controller/extension/shootafterworker/actuator.go
@@ -1,4 +1,4 @@
-// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/provider-local/controller/extension/shootafterworker/add.go
+++ b/pkg/provider-local/controller/extension/shootafterworker/add.go
@@ -1,4 +1,4 @@
-// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/provider-local/controller/extension/shootafterworker/add.go
+++ b/pkg/provider-local/controller/extension/shootafterworker/add.go
@@ -1,0 +1,64 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/extensions/pkg/controller/extension"
+)
+
+const (
+	// Type is type of the extension.
+	Type string = "local-ext-shoot-after-worker"
+	// ControllerName is the name of the controller.
+	ControllerName = Type
+)
+
+var (
+	// DefaultAddOptions are the default AddOptions for AddToManager.
+	DefaultAddOptions = AddOptions{}
+)
+
+// AddOptions are options to apply when adding the extension controller to the manager.
+type AddOptions struct {
+	// Controller are the controller.Options.
+	Controller controller.Options
+	// IgnoreOperationAnnotation specifies whether to ignore the operation annotation or not.
+	IgnoreOperationAnnotation bool
+}
+
+// AddToManagerWithOptions adds a controller with the given Options to the given manager.
+// The opts.Reconciler is being set with a newly instantiated actuator.
+func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
+	return extension.Add(ctx, mgr, extension.AddArgs{
+		Actuator:          NewActuator(mgr),
+		ControllerOptions: opts.Controller,
+		Name:              ApplicationName,
+		FinalizerSuffix:   Type,
+		Resync:            60 * time.Minute,
+		Predicates:        extension.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
+		Type:              Type,
+	})
+}
+
+// AddToManager adds a controller with the default Options.
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -654,6 +654,7 @@ build:
             - pkg/provider-local/controller/dnsrecord
             - pkg/provider-local/controller/extension/seed
             - pkg/provider-local/controller/extension/shoot
+            - pkg/provider-local/controller/extension/shootafterworker
             - pkg/provider-local/controller/healthcheck
             - pkg/provider-local/controller/infrastructure
             - pkg/provider-local/controller/ingress

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -119,7 +119,8 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 	}
 
 	if ginkgo.Label("default").MatchesLabelFilter(ginkgo.GinkgoLabelFilter()) {
-		// TODO(maboehm) The extension is not available in the previous gardener
+		// TODO(maboehm): Add permanently to default shoot after v1.92
+		// The extension is not available in the previous gardener
 		// version (so during upgrade tests), so only set it for default tests.
 		shoot.Spec.Extensions = append(shoot.Spec.Extensions,
 			gardencorev1beta1.Extension{

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -62,7 +63,7 @@ func getShootControlPlane() *gardencorev1beta1.ControlPlane {
 
 // DefaultShoot returns a Shoot object with default values for the e2e tests.
 func DefaultShoot(name string) *gardencorev1beta1.Shoot {
-	return &gardencorev1beta1.Shoot{
+	shoot := &gardencorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
@@ -113,12 +114,20 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 				{
 					Type: "local-ext-shoot",
 				},
-				{
-					Type: "local-ext-shoot-after-worker",
-				},
 			},
 		},
 	}
+
+	if ginkgo.Label("default").MatchesLabelFilter(ginkgo.GinkgoLabelFilter()) {
+		// TODO(maboehm) The extension is not available in the previous gardener
+		// version (so during upgrade tests), so only set it for default tests.
+		shoot.Spec.Extensions = append(shoot.Spec.Extensions,
+			gardencorev1beta1.Extension{
+				Type: "local-ext-shoot-after-worker",
+			},
+		)
+	}
+	return shoot
 }
 
 // DefaultWorkerlessShoot returns a workerless Shoot object with default values for the e2e tests.

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -113,6 +113,9 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 				{
 					Type: "local-ext-shoot",
 				},
+				{
+					Type: "local-ext-shoot-after-worker",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Introduce new lifecycle strategy for the `reconcile` hook for extensions: `AfterWorker`.

Before https://github.com/gardener/gardener/pull/8232 any extensions that specified `AfterKubeAPIServer` were reconciled after the workers, so an extension could deploy a workload into the shoot and expect it to be scheduled and started on a node. This is for example used by [gardener-extension-shoot-flux](https://github.com/stackitcloud/gardener-extension-shoot-flux), which waits for the flux deployments to run.

This new field allows extensions again to be called only after worker are deployed, so eventually they will find running nodes for their workloads. I believe `AfterWorker` only makes sense during `reconcile`; during deletion the existing `BeforeKubeAPIServer` should suffice, and during migration workers are not really touched so a new strategy also makes no sense here.

**Which issue(s) this PR fixes**:
Fixes a behaviour change introduced in https://github.com/gardener/gardener/pull/8232 that some extensions relied on.

**Special notes for your reviewer**:

**Release note**:
```feature developer
A new extension lifecycle strategy `reconcile: AfterWorker` is now available for Extensions to use in their `ControllerRegistration`.
```
