### PR TITLE
Remove graduated `APIServerFastRollout` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,8 +28,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` |        |
 | ShootForceDeletion                 | `false` | `Alpha` | `1.81` | `1.90` |
 | ShootForceDeletion                 | `true`  | `Beta`  | `1.91` |        |
-| APIServerFastRollout               | `true`  | `Beta`  | `1.82` | `1.89` |
-| APIServerFastRollout               | `true`  | `GA`    | `1.90` |        |
 | UseGardenerNodeAgent               | `false` | `Alpha` | `1.82` | `1.88` |
 | UseGardenerNodeAgent               | `true`  | `Beta`  | `1.89` |        |
 | UseGardenerNodeAgent               | `true`  | `GA`    | `1.90` |        |
@@ -139,15 +137,18 @@ The following tables are a summary of the feature gates that you can set on diff
 | ContainerdRegistryHostsDir                   | `false` | `Alpha`      | `1.77` | `1.85` |
 | ContainerdRegistryHostsDir                   | `true`  | `Beta`       | `1.86` | `1.86` |
 | ContainerdRegistryHostsDir                   | `true`  | `GA`         | `1.87` | `1.87` |
-| ContainerdRegistryHostsDir                   | `true`  | `Removed`    | `1.88` |        |
+| ContainerdRegistryHostsDir                   |         | `Removed`    | `1.88` |        |
 | WorkerlessShoots                             | `false` | `Alpha`      | `1.70` | `1.78` |
 | WorkerlessShoots                             | `true`  | `Beta`       | `1.79` | `1.85` |
 | WorkerlessShoots                             | `true`  | `GA`         | `1.86` |        |
-| WorkerlessShoots                             | `true`  | `Removed`    | `1.88` |        |
+| WorkerlessShoots                             |         | `Removed`    | `1.88` |        |
 | MachineControllerManagerDeployment           | `false` | `Alpha`      | `1.73` |        |
 | MachineControllerManagerDeployment           | `true`  | `Beta`       | `1.81` | `1.81` |
 | MachineControllerManagerDeployment           | `true`  | `GA`         | `1.82` | `1.91` |
-| MachineControllerManagerDeployment           | `true`  | `Removed`    | `1.92` |        |
+| MachineControllerManagerDeployment           |         | `Removed`    | `1.92` |        |
+| APIServerFastRollout                         | `true`  | `Beta`       | `1.82` | `1.89` |
+| APIServerFastRollout                         | `true`  | `GA`         | `1.90` | `1.91` |
+| APIServerFastRollout                         |         | `Removed`    | `1.92` |        |
 
 ## Using a Feature
 
@@ -194,5 +195,4 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | IPv6SingleStack                    | `gardener-apiserver`, `gardenlet` | Allows creating seed and shoot clusters with [IPv6 single-stack networking](../usage/ipv6.md) enabled in their spec ([GEP-21](../proposals/21-ipv6-singlestack-local.md)). If enabled in gardenlet, the default behavior is unchanged, but setting `ipFamilies=[IPv6]` in the `seedConfig` is allowed. Only if the `ipFamilies` setting is changed, gardenlet behaves differently. |
 | MutableShootSpecNetworkingNodes    | `gardener-apiserver`              | Allows updating the field `spec.networking.nodes`. The validity of the values has to be checked in the provider extensions. Only enable this feature gate when your system runs provider extensions which have implemented the validation.                                                                                                                                         |
 | ShootForceDeletion                 | `gardener-apiserver`              | Allows forceful deletion of Shoots by annotating them with the `confirmation.gardener.cloud/force-deletion` annotation.                                                                                                                                                                                                                                                            |
-| APIServerFastRollout               | `gardenlet`                       | Enables fast rollouts for Shoot kube-apiservers on the given Seed. When enabled, `maxSurge` for Shoot kube-apiserver deployments is set to 100%.                                                                                                                                                                                                                                   |
 | UseGardenerNodeAgent               | `gardenlet`                       | Enables the `gardener-node-agent` instead of the `cloud-config-downloader` for shoot worker nodes.                                                                                                                                                                                                                                                                                 |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -65,13 +65,6 @@ const (
 	// beta: v1.91.0
 	ShootForceDeletion featuregate.Feature = "ShootForceDeletion"
 
-	// APIServerFastRollout enables fast rollouts for Shoot kube-apiservers on the given Seed.
-	// When enabled, maxSurge for Shoot kube-apiserver deployments is set to 100%.
-	// owner: @oliver-goetz
-	// beta: v1.82.0
-	// GA: v1.90.0
-	APIServerFastRollout featuregate.Feature = "APIServerFastRollout"
-
 	// UseGardenerNodeAgent enables the `gardener-node-agent` instead of the `cloud-config-downloader` for shoot worker
 	// nodes.
 	// owner: @rfranzke @oliver-goetz
@@ -113,7 +106,6 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	IPv6SingleStack:                 {Default: false, PreRelease: featuregate.Alpha},
 	MutableShootSpecNetworkingNodes: {Default: false, PreRelease: featuregate.Alpha},
 	ShootForceDeletion:              {Default: true, PreRelease: featuregate.Beta},
-	APIServerFastRollout:            {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	UseGardenerNodeAgent:            {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 }
 

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -34,7 +34,6 @@ func GetFeatures() []featuregate.Feature {
 		features.DefaultSeccompProfile,
 		features.CoreDNSQueryRewriting,
 		features.IPv6SingleStack,
-		features.APIServerFastRollout,
 		features.UseGardenerNodeAgent,
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
Remove graduated `APIServerFastRollout` feature gate

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9214

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The graduated `APIServerFastRollout` feature gate has been dropped.
```
