### PR TITLE
🧹 Cleanup a few `TODOs`

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -249,7 +249,7 @@ func (a *actuator) reconcileControlPlane(
 			return false, fmt.Errorf("expected *webhook.Configs, got %T", value)
 		}
 
-		if err := extensionsshootwebhook.ReconcileWebhookConfig(ctx, a.client, cp.Namespace, a.webhookServerNamespace, a.providerName, ShootWebhooksResourceName, *webhookConfig, cluster, true); err != nil {
+		if err := extensionsshootwebhook.ReconcileWebhookConfig(ctx, a.client, cp.Namespace, ShootWebhooksResourceName, *webhookConfig, cluster, true); err != nil {
 			return false, fmt.Errorf("could not reconcile shoot webhooks: %w", err)
 		}
 	}

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/mock/gomock"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -367,8 +366,6 @@ webhooks:
 				c.EXPECT().Get(ctx, resourceKeyShootWebhooks, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errNotFound)
 				createdMRForShootWebhooks.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: createdMRSecretForShootWebhooks.Name}}
 				utilruntime.Must(references.InjectAnnotations(createdMRForShootWebhooks))
-				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "gardener-extension-" + providerName}})
-				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: webhookServerNamespace, Name: "ingress-from-all-shoots-kube-apiserver"}})
 				c.EXPECT().Create(ctx, createdMRForShootWebhooks).Return(nil)
 			}
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -67,7 +67,7 @@ func RestoreWithoutReconcile(
 	// Parse the worker state to a separate machineDeployment states and attach them to
 	// the corresponding machineDeployments which are to be deployed later
 	log.Info("Extracting machine state")
-	if err := addStateToMachineDeployment(ctx, log, gardenReader, cluster.Shoot, worker, wantedMachineDeployments); err != nil {
+	if err := addStateToMachineDeployment(ctx, log, gardenReader, cluster.Shoot, wantedMachineDeployments); err != nil {
 		return err
 	}
 
@@ -113,7 +113,6 @@ func addStateToMachineDeployment(
 	log logr.Logger,
 	gardenReader client.Reader,
 	shoot *gardencorev1beta1.Shoot,
-	worker *extensionsv1alpha1.Worker,
 	wantedMachineDeployments extensionsworkercontroller.MachineDeployments,
 ) error {
 	var state []byte
@@ -132,15 +131,6 @@ func addStateToMachineDeployment(
 		if err != nil {
 			return err
 		}
-	} else {
-		// TODO(rfranzke): Drop this code after Gardener v1.86 has been released.
-		log.Info("Fetching machine state from ShootState not possible since the machine state was not found, falling back to Worker's .status.state field", "shootState", client.ObjectKeyFromObject(shootState))
-		if worker.Status.State == nil || len(worker.Status.State.Raw) <= 0 {
-			log.Info("Worker's .status.state field is empty, no state to add")
-			return nil
-		}
-		log.Info("Fetching machine state from Worker's .status.state field succeeded")
-		state = worker.Status.State.Raw
 	}
 
 	if len(state) == 0 {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore_test.go
@@ -31,7 +31,6 @@ import (
 
 	extensionsworkercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
@@ -46,7 +45,6 @@ var _ = Describe("ActuatorRestore", func() {
 
 			shoot                    *gardencorev1beta1.Shoot
 			shootState               *gardencorev1beta1.ShootState
-			worker                   *extensionsv1alpha1.Worker
 			wantedMachineDeployments extensionsworkercontroller.MachineDeployments
 
 			stateDeployment1 = &shootstate.MachineDeploymentState{
@@ -72,7 +70,6 @@ var _ = Describe("ActuatorRestore", func() {
 
 			shoot = &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "foo"}}
 			shootState = &gardencorev1beta1.ShootState{ObjectMeta: metav1.ObjectMeta{Name: shoot.Name, Namespace: shoot.Namespace}}
-			worker = &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{Namespace: "shoot--foo--bar"}}
 			wantedMachineDeployments = []extensionsworkercontroller.MachineDeployment{
 				{Name: "deploy1"},
 				{Name: "deploy2"},
@@ -94,8 +91,8 @@ var _ = Describe("ActuatorRestore", func() {
 			Expect(fakeGardenClient.Create(ctx, shootState)).To(Succeed())
 		})
 
-		It("should do nothing because neither machine state exists in ShootState nor .status.state field is set", func() {
-			Expect(addStateToMachineDeployment(ctx, log, fakeGardenClient, shoot, worker, wantedMachineDeployments)).To(Succeed())
+		It("should do nothing because machine state does not exist in ShootState", func() {
+			Expect(addStateToMachineDeployment(ctx, log, fakeGardenClient, shoot, wantedMachineDeployments)).To(Succeed())
 
 			Expect(wantedMachineDeployments[0].State).To(BeNil())
 			Expect(wantedMachineDeployments[1].State).To(BeNil())
@@ -113,7 +110,7 @@ var _ = Describe("ActuatorRestore", func() {
 			}
 			Expect(fakeGardenClient.Patch(ctx, shootState, patch)).To(Succeed())
 
-			Expect(addStateToMachineDeployment(ctx, log, fakeGardenClient, shoot, worker, wantedMachineDeployments)).To(Succeed())
+			Expect(addStateToMachineDeployment(ctx, log, fakeGardenClient, shoot, wantedMachineDeployments)).To(Succeed())
 
 			Expect(wantedMachineDeployments[0].State).To(BeNil())
 			Expect(wantedMachineDeployments[1].State).To(BeNil())
@@ -131,17 +128,7 @@ var _ = Describe("ActuatorRestore", func() {
 			}
 			Expect(fakeGardenClient.Patch(ctx, shootState, patch)).To(Succeed())
 
-			Expect(addStateToMachineDeployment(ctx, log, fakeGardenClient, shoot, worker, wantedMachineDeployments)).To(Succeed())
-
-			Expect(wantedMachineDeployments[0].State).To(Equal(stateDeployment1))
-			Expect(wantedMachineDeployments[1].State).To(Equal(stateDeployment2))
-			Expect(wantedMachineDeployments[2].State).To(BeNil())
-		})
-
-		It("should fetch the state from the Worker's .status.state field when machine state does not exist in ShootState", func() {
-			worker.Status.State = &runtime.RawExtension{Raw: machineStateRaw}
-
-			Expect(addStateToMachineDeployment(ctx, log, fakeGardenClient, shoot, worker, wantedMachineDeployments)).To(Succeed())
+			Expect(addStateToMachineDeployment(ctx, log, fakeGardenClient, shoot, wantedMachineDeployments)).To(Succeed())
 
 			Expect(wantedMachineDeployments[0].State).To(Equal(stateDeployment1))
 			Expect(wantedMachineDeployments[1].State).To(Equal(stateDeployment2))

--- a/extensions/pkg/webhook/certificates/reconciler.go
+++ b/extensions/pkg/webhook/certificates/reconciler.go
@@ -203,7 +203,7 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		r.AtomicShootWebhookConfigs.Store(r.ShootWebhookConfigs.DeepCopy())
 
 		// reconcile all shoot webhook configs with the freshly created CA bundle
-		if err := extensionsshootwebhook.ReconcileWebhooksForAllNamespaces(ctx, r.client, r.Namespace, r.ComponentName, r.ShootWebhookManagedResourceName, r.ShootNamespaceSelector, *r.ShootWebhookConfigs); err != nil {
+		if err := extensionsshootwebhook.ReconcileWebhooksForAllNamespaces(ctx, r.client, r.ShootWebhookManagedResourceName, r.ShootNamespaceSelector, *r.ShootWebhookConfigs); err != nil {
 			return reconcile.Result{}, fmt.Errorf("error reconciling all shoot webhook configs: %w", err)
 		}
 

--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -362,7 +362,7 @@ func (c *AddToManagerConfig) reconcileSeedWebhookConfig(mgr manager.Manager, web
 func (c *AddToManagerConfig) reconcileShootWebhookConfigs(mgr manager.Manager, shootWebhookConfigs extensionswebhook.Configs) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		if shootWebhookConfigs.HasWebhookConfig() {
-			if err := extensionsshootwebhook.ReconcileWebhooksForAllNamespaces(ctx, mgr.GetClient(), c.Server.Namespace, c.extensionName, c.shootWebhookManagedResourceName, c.shootNamespaceSelector, shootWebhookConfigs); err != nil {
+			if err := extensionsshootwebhook.ReconcileWebhooksForAllNamespaces(ctx, mgr.GetClient(), c.shootWebhookManagedResourceName, c.shootNamespaceSelector, shootWebhookConfigs); err != nil {
 				return fmt.Errorf("error reconciling all shoot webhook configs: %w", err)
 			}
 		}

--- a/extensions/pkg/webhook/shoot/webhook_test.go
+++ b/extensions/pkg/webhook/shoot/webhook_test.go
@@ -50,7 +50,6 @@ var _ = Describe("Webhook", func() {
 		shootWebhookConfigRaw map[string][]byte
 
 		extensionName       = "provider-test"
-		extensionNamespace  = "extension-provider-test-12345"
 		managedResourceName = "extension-provider-test-shoot-webhooks"
 	)
 
@@ -91,7 +90,7 @@ webhooks:
 		})
 
 		It("should reconcile the shoot webhook config", func() {
-			Expect(ReconcileWebhookConfig(ctx, fakeClient, namespace, extensionNamespace, extensionName, managedResourceName, shootWebhookConfigs, cluster, true)).To(Succeed())
+			Expect(ReconcileWebhookConfig(ctx, fakeClient, namespace, managedResourceName, shootWebhookConfigs, cluster, true)).To(Succeed())
 			expectWebhookConfigReconciliation(ctx, fakeClient, namespace, managedResourceName, shootWebhookConfigRaw)
 		})
 	})
@@ -195,7 +194,7 @@ webhooks:
 			Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace3.Name, Name: managedResourceName}})).To(Succeed())
 			Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace4.Name, Name: managedResourceName}})).To(Succeed())
 
-			Expect(ReconcileWebhooksForAllNamespaces(ctx, fakeClient, extensionNamespace, extensionName, managedResourceName, shootNamespaceSelector, shootWebhookConfigs)).To(Succeed())
+			Expect(ReconcileWebhooksForAllNamespaces(ctx, fakeClient, managedResourceName, shootNamespaceSelector, shootWebhookConfigs)).To(Succeed())
 
 			expectNoWebhookConfigReconciliation(ctx, fakeClient, namespace1.Name, managedResourceName)
 			expectNoWebhookConfigReconciliation(ctx, fakeClient, namespace2.Name, managedResourceName)
@@ -208,7 +207,7 @@ webhooks:
 			Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace3.Name, Name: managedResourceName}})).To(Succeed())
 			Expect(fakeClient.Delete(ctx, cluster3)).To(Succeed())
 
-			err := ReconcileWebhooksForAllNamespaces(ctx, fakeClient, extensionNamespace, extensionName, managedResourceName, shootNamespaceSelector, shootWebhookConfigs)
+			err := ReconcileWebhooksForAllNamespaces(ctx, fakeClient, managedResourceName, shootNamespaceSelector, shootWebhookConfigs)
 
 			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
 			Expect(err.(*multierror.Error).Errors).To(ConsistOf(Equal(apierrors.NewNotFound(schema.GroupResource{Group: extensionsv1alpha1.SchemeGroupVersion.Group, Resource: "clusters"}, namespace3.Name))))
@@ -221,7 +220,7 @@ webhooks:
 			cluster4.Spec.Shoot = runtime.RawExtension{}
 			Expect(fakeClient.Patch(ctx, cluster4, patch)).To(Succeed())
 
-			err := ReconcileWebhooksForAllNamespaces(ctx, fakeClient, extensionNamespace, extensionName, managedResourceName, shootNamespaceSelector, shootWebhookConfigs)
+			err := ReconcileWebhooksForAllNamespaces(ctx, fakeClient, managedResourceName, shootNamespaceSelector, shootWebhookConfigs)
 
 			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
 			Expect(err.(*multierror.Error).Errors).To(ConsistOf(Equal(errors.New("no shoot found in cluster resource"))))

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 )
 
 const (
@@ -285,36 +284,10 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 
 // Restore uses the seed client and the ShootState to create the Worker resources and restore their state.
 func (w *worker) Restore(ctx context.Context, shootState *gardencorev1beta1.ShootState) error {
-	// gardenlet persists the machine state in the ShootState's `.spec.gardener[]` list with `type=machine-state`.
-	// In the future, the provider extension's Worker controller is expected to read the machine state directly from the
-	// ShootState resource in the garden cluster, and use it to recreate the actual machine.saploud.io/v1alpha1 objects.
-	// However: For backwards-compatibility, we have to make the machine state also available in the Worker object's
-	// `.status.state` field since older versions (< v1.81) of the generic `Worker` actuator's `Restore` function expect
-	// to find the state here, see https://github.com/gardener/gardener/blob/422e2bbedd23351383154bb733838a416f39f2b6/extensions/pkg/controller/worker/genericactuator/actuator_restore.go#L121C1-L141.
-	// TODO(rfranzke): Drop this code after Gardener v1.86 has been released.
-	var (
-		shootStateCopy = shootState.DeepCopy()
-		gardenerData   = v1beta1helper.GardenerResourceDataList(shootStateCopy.Spec.Gardener)
-	)
-
-	if machineState := gardenerData.Get(v1beta1constants.DataTypeMachineState); machineState != nil && machineState.Type == v1beta1constants.DataTypeMachineState {
-		machineStateDecompressed, err := shootstate.DecompressMachineState(machineState.Data.Raw)
-		if err != nil {
-			return err
-		}
-		extensionsData := v1beta1helper.ExtensionResourceStateList(shootStateCopy.Spec.Extensions)
-		extensionsData.Upsert(&gardencorev1beta1.ExtensionResourceState{
-			Kind:  extensionsv1alpha1.WorkerResource,
-			Name:  &w.worker.Name,
-			State: &runtime.RawExtension{Raw: machineStateDecompressed},
-		})
-		shootStateCopy.Spec.Extensions = extensionsData
-	}
-
 	return extensions.RestoreExtensionWithDeployFunction(
 		ctx,
 		w.client,
-		shootStateCopy,
+		shootState,
 		extensionsv1alpha1.WorkerResource,
 		w.deploy,
 	)

--- a/pkg/component/extensions/worker/worker_test.go
+++ b/pkg/component/extensions/worker/worker_test.go
@@ -717,17 +717,21 @@ var _ = Describe("Worker", func() {
 	})
 
 	Describe("#Restore", func() {
-		shootState := &gardencorev1beta1.ShootState{
-			Spec: gardencorev1beta1.ShootStateSpec{
-				Gardener: []gardencorev1beta1.GardenerResourceData{
-					{
-						Name: "machine-state",
-						Type: "machine-state",
-						Data: runtime.RawExtension{Raw: []byte(`{"state":"H4sIAAAAAAAAA6tWKs7PTVWyUiouSSxJVaoFACDAdOAQAAAA"}`)},
+		var shootState *gardencorev1beta1.ShootState
+
+		BeforeEach(func() {
+			shootState = &gardencorev1beta1.ShootState{
+				Spec: gardencorev1beta1.ShootStateSpec{
+					Extensions: []gardencorev1beta1.ExtensionResourceState{
+						{
+							Name:  &w.Name,
+							Kind:  extensionsv1alpha1.WorkerResource,
+							State: &runtime.RawExtension{Raw: []byte(`{"some":"state"}`)},
+						},
 					},
 				},
-			},
-		}
+			}
+		})
 
 		It("should properly restore the worker state if it exists", func() {
 			defer test.WithVars(

--- a/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -69,9 +69,6 @@ spec:
         networking.resources.gardener.cloud/to-all-istio-ingresses-istio-ingressgateway-tcp-9443: allowed
         networking.resources.gardener.cloud/to-garden-prometheus-cache-tcp-9090: allowed
         networking.resources.gardener.cloud/to-garden-alertmanager-seed-tcp-9093: allowed
-        # TODO(rfranzke): Remove this label after v1.91 has been released.
-        networking.resources.gardener.cloud/to-garden-prometheus-web-tcp-9090: allowed
-        networking.resources.gardener.cloud/to-garden-alertmanager-client-tcp-9093: allowed
         observability.gardener.cloud/app: "prometheus-shoot"
     spec:
       # used to talk to Seed's API server.

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -170,9 +170,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	metav1.SetMetaDataLabel(&node.ObjectMeta, v1beta1constants.LabelWorkerKubernetesVersion, r.Config.KubernetesVersion.String())
 	metav1.SetMetaDataAnnotation(&node.ObjectMeta, nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig, oscChecksum)
 
-	// TODO(rfranzke): Remove this after v1.90 has been released.
-	delete(node.Annotations, v1beta1constants.LabelWorkerKubernetesVersion)
-
 	return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, r.Client.Patch(ctx, node, patch)
 }
 

--- a/pkg/utils/gardener/shootstate/machines.go
+++ b/pkg/utils/gardener/shootstate/machines.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -44,32 +43,12 @@ type MachineState struct {
 	MachineDeployments map[string]*MachineDeploymentState `json:"machineDeployments,omitempty"`
 }
 
-func computeMachineState(ctx context.Context, seedClient client.Client, namespace, shootName string) (*MachineState, error) {
+func computeMachineState(ctx context.Context, seedClient client.Client, namespace string) (*MachineState, error) {
 	state := &MachineState{MachineDeployments: make(map[string]*MachineDeploymentState)}
 
 	machineDeployments := &machinev1alpha1.MachineDeploymentList{}
 	if err := seedClient.List(ctx, machineDeployments, client.InNamespace(namespace)); err != nil {
 		return nil, err
-	}
-
-	// If a provider extensions uses a version < v1.82 of the extensions library, then the Worker controller will have
-	// persisted the machine state to the `Worker`'s `.status.state` field and already shallow-deleted all machine
-	// objects before below code gets executed (i.e., before gardenlet can compute the machine state itself).
-	// In this case, let's get the data from the `Worker`'s `.status.state` field instead of trying to (re-)compute it
-	// (which will fail anyways).
-	// TODO(rfranzke): Remove this block after Gardener v1.86 has been released.
-	if len(machineDeployments.Items) == 0 {
-		worker := &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: namespace}}
-		if err := seedClient.Get(ctx, client.ObjectKeyFromObject(worker), worker); client.IgnoreNotFound(err) != nil {
-			return nil, fmt.Errorf("failed reading Worker object %s: %w", client.ObjectKeyFromObject(worker), err)
-		}
-
-		if worker.Status.State != nil && len(worker.Status.State.Raw) > 0 {
-			if err := json.Unmarshal(worker.Status.State.Raw, &state); err != nil {
-				return nil, fmt.Errorf("failed unmarshaling machine state from Worker's '.status.state' field: %w", err)
-			}
-			return state, nil
-		}
 	}
 
 	machineDeploymentToMachineSets, err := getMachineDeploymentToMachineSetsMap(ctx, seedClient, namespace)

--- a/pkg/utils/gardener/shootstate/shootstate_test.go
+++ b/pkg/utils/gardener/shootstate/shootstate_test.go
@@ -88,16 +88,14 @@ var _ = Describe("ShootState", func() {
 			var (
 				existingGardenerData   = []gardencorev1beta1.GardenerResourceData{{Name: "some-data"}}
 				existingExtensionsData = []gardencorev1beta1.ExtensionResourceState{{Name: ptr.To("some-data")}}
-				// TODO(rfranzke): Remove this `existingWorkerState` after Gardener v1.86 has been released.
-				existingWorkerState   = []gardencorev1beta1.ExtensionResourceState{{Kind: "Worker", Name: ptr.To("my-shoot")}}
-				existingResourcesData = []gardencorev1beta1.ResourceData{{Data: runtime.RawExtension{Raw: []byte("{}")}}}
-				expectedSpec          gardencorev1beta1.ShootStateSpec
+				existingResourcesData  = []gardencorev1beta1.ResourceData{{Data: runtime.RawExtension{Raw: []byte("{}")}}}
+				expectedSpec           gardencorev1beta1.ShootStateSpec
 			)
 
 			BeforeEach(func() {
 				By("Create ShootState with some data")
 				shootState.Spec.Gardener = append(shootState.Spec.Gardener, existingGardenerData...)
-				shootState.Spec.Extensions = append(shootState.Spec.Extensions, append(existingExtensionsData, existingWorkerState...)...)
+				shootState.Spec.Extensions = append(shootState.Spec.Extensions, existingExtensionsData...)
 				shootState.Spec.Resources = append(shootState.Spec.Resources, existingResourcesData...)
 				Expect(fakeGardenClient.Create(ctx, shootState)).To(Succeed())
 
@@ -203,12 +201,11 @@ var _ = Describe("ShootState", func() {
 							Purpose: ptr.To(""),
 							State:   &runtime.RawExtension{Raw: []byte(`{"name":"osc"}`)},
 						},
-						// TODO(rfranzke): Uncomment next lines after Gardener v1.86 has been released.
-						// {
-						// 	Kind:  "Worker",
-						// 	Name:  ptr.To("worker"),
-						// 	State: &runtime.RawExtension{Raw: []byte(`{"name":"worker"}`)},
-						// },
+						{
+							Kind:  "Worker",
+							Name:  ptr.To("worker"),
+							State: &runtime.RawExtension{Raw: []byte(`{"name":"worker"}`)},
+						},
 					},
 					Resources: []gardencorev1beta1.ResourceData{{
 						CrossVersionObjectReference: autoscalingv1.CrossVersionObjectReference{

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -296,7 +296,7 @@ var _ = Describe("Certificates tests", func() {
 
 				By("Prepare existing shoot webhook resources")
 				Expect(testClient.Create(ctx, cluster)).To(Succeed())
-				Expect(extensionsshootwebhook.ReconcileWebhookConfig(ctx, testClient, shootNamespace.Name, extensionNamespace.Name, extensionName, shootWebhookManagedResourceName, *shootWebhookConfig, &extensions.Cluster{Shoot: &gardencorev1beta1.Shoot{}}, true)).To(Succeed())
+				Expect(extensionsshootwebhook.ReconcileWebhookConfig(ctx, testClient, shootNamespace.Name, shootWebhookManagedResourceName, *shootWebhookConfig, &extensions.Cluster{Shoot: &gardencorev1beta1.Shoot{}}, true)).To(Succeed())
 
 				DeferCleanup(func() {
 					Expect(testClient.Delete(ctx, cluster)).To(Or(Succeed(), BeNotFoundError()))
@@ -501,7 +501,7 @@ var _ = Describe("Certificates tests", func() {
 			BeforeEach(func() {
 				By("Prepare existing shoot webhook resources")
 				Expect(testClient.Create(ctx, cluster)).To(Succeed())
-				Expect(extensionsshootwebhook.ReconcileWebhookConfig(ctx, testClient, shootNamespace.Name, extensionNamespace.Name, extensionName, shootWebhookManagedResourceName, *shootWebhookConfig, &extensions.Cluster{Shoot: &gardencorev1beta1.Shoot{}}, true)).To(Succeed())
+				Expect(extensionsshootwebhook.ReconcileWebhookConfig(ctx, testClient, shootNamespace.Name, shootWebhookManagedResourceName, *shootWebhookConfig, &extensions.Cluster{Shoot: &gardencorev1beta1.Shoot{}}, true)).To(Succeed())
 
 				DeferCleanup(func() {
 					Expect(testClient.Delete(ctx, cluster)).To(Or(Succeed(), BeNotFoundError()))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
- Drop backwards-compatibility code after eliminating the `Worker` state reconciler, introduced with https://github.com/gardener/gardener/pull/8559, released with `v1.82.0`
- Remove `NetworkPolicy` cleanup code, introduced with https://github.com/gardener/gardener/pull/8540, delayed with https://github.com/gardener/gardener/pull/9044, released with `v1.82.0`
- Drop backwards-compatibility code for machine state computation, introduced with https://github.com/gardener/gardener/pull/8673, released with `v1.83.0`
- Drop GNA's removal of worker Kubernetes version annotation, introduced with https://github.com/gardener/gardener/pull/9110, released with `v1.88.0`
- Remove legacy `NetworkPolicy` labels on shoot Prometheus pods, introduced with https://github.com/gardener/gardener/pull/9159 and https://github.com/gardener/gardener/pull/9159, released with `v1.88.0` and `v1.89.0`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
