### PR TITLE
Deploy a service for the Node Problem Detector component

### DIFF
--- a/pkg/component/nodemanagement/nodeproblemdetector/logging.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/logging.go
@@ -36,11 +36,11 @@ func generateClusterFilters() []*fluentbitv1alpha2.ClusterFilter {
 	return []*fluentbitv1alpha2.ClusterFilter{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   deploymentName,
+				Name:   daemonSetName,
 				Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
 			},
 			Spec: fluentbitv1alpha2.FilterSpec{
-				Match: fmt.Sprintf("kubernetes.*%s*%s*", deploymentName, containerName),
+				Match: fmt.Sprintf("kubernetes.*%s*%s*", daemonSetName, containerName),
 				FilterItems: []fluentbitv1alpha2.FilterItem{
 					{
 						Parser: &fluentbitv1alpha2filter.Parser{

--- a/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
@@ -41,7 +41,6 @@ const (
 	// ManagedResourceName is the name of the ManagedResource containing the resource specifications.
 	ManagedResourceName                          = "shoot-core-node-problem-detector"
 	serviceAccountName                           = "node-problem-detector"
-	deploymentName                               = "node-problem-detector"
 	containerName                                = "node-problem-detector"
 	daemonSetName                                = "node-problem-detector"
 	clusterRoleName                              = "node-problem-detector"

--- a/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
@@ -35,6 +35,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
@@ -174,32 +175,26 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      daemonSetName,
 				Namespace: metav1.NamespaceSystem,
-				Labels: map[string]string{
-					"app.kubernetes.io/instance":    "shoot-core",
-					"app.kubernetes.io/name":        labelValue,
+				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 					managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
 					v1beta1constants.GardenRole:     v1beta1constants.GardenRoleSystemComponent,
-				},
+				}),
 			},
 			Spec: appsv1.DaemonSetSpec{
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						v1beta1constants.LabelApp:    labelValue,
-						"app.kubernetes.io/instance": "shoot-core",
-						"app.kubernetes.io/name":     labelValue,
-					},
+					MatchLabels: utils.MergeStringMaps(getLabels(), map[string]string{
+						v1beta1constants.LabelApp: labelValue,
+					}),
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
+						Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 							v1beta1constants.LabelApp:                           labelValue,
-							"app.kubernetes.io/instance":                        "shoot-core",
-							"app.kubernetes.io/name":                            labelValue,
 							v1beta1constants.GardenRole:                         v1beta1constants.GardenRoleSystemComponent,
 							v1beta1constants.LabelNetworkPolicyShootToAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
 							v1beta1constants.LabelNetworkPolicyToDNS:            v1beta1constants.LabelNetworkPolicyAllowed,
 							managedresources.LabelKeyOrigin:                     managedresources.LabelValueGardener,
-						},
+						}),
 					},
 					Spec: corev1.PodSpec{
 						DNSPolicy:                     corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
@@ -313,12 +308,10 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: metav1.NamespaceSystem,
-				Labels: map[string]string{
-					"app.kubernetes.io/instance": "shoot-core",
-					"app.kubernetes.io/name":     labelValue,
-					v1beta1constants.LabelApp:    labelValue,
-					v1beta1constants.GardenRole:  v1beta1constants.GardenRoleSystemComponent,
-				},
+				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+					v1beta1constants.LabelApp:   labelValue,
+					v1beta1constants.GardenRole: v1beta1constants.GardenRoleSystemComponent,
+				}),
 			},
 			Spec: corev1.ServiceSpec{
 				Selector: getLabels(),

--- a/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector_test.go
@@ -142,6 +142,29 @@ subjects:
   name: node-problem-detector
   namespace: kube-system
 `
+
+			serviceYAML = `apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: node-problem-detector
+    app.kubernetes.io/instance: shoot-core
+    app.kubernetes.io/name: node-problem-detector
+    gardener.cloud/role: system-component
+  name: node-problem-detector
+  namespace: kube-system
+spec:
+  ports:
+  - port: 20257
+    protocol: TCP
+    targetPort: 20257
+  selector:
+    app.kubernetes.io/instance: shoot-core
+    app.kubernetes.io/name: node-problem-detector
+status:
+  loadBalancer: {}
+`
 			hostPathFileOrCreate = corev1.HostPathFileOrCreate
 
 			daemonsetYAMLFor = func(apiserverHost string, vpaEnabled bool) string {
@@ -310,11 +333,12 @@ status: {}
 			Expect(string(managedResourceSecret.Data["serviceaccount__kube-system__node-problem-detector.yaml"])).To(Equal(serviceAccountYAML))
 			Expect(string(managedResourceSecret.Data["clusterrole____node-problem-detector.yaml"])).To(Equal(clusterRoleYAML))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____node-problem-detector.yaml"])).To(Equal(clusterRoleBindingYAML))
+			Expect(string(managedResourceSecret.Data["service__kube-system__node-problem-detector.yaml"])).To(Equal(serviceYAML))
 		})
 
 		Context("w/o apiserver host, w/o vpaEnabled", func() {
 			It("should successfully deploy all resources", func() {
-				Expect(managedResourceSecret.Data).To(HaveLen(4))
+				Expect(managedResourceSecret.Data).To(HaveLen(5))
 				Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor("", false)))
 			})
 		})
@@ -331,7 +355,7 @@ status: {}
 			})
 
 			It("should successfully deploy all resources", func() {
-				Expect(managedResourceSecret.Data).To(HaveLen(5))
+				Expect(managedResourceSecret.Data).To(HaveLen(6))
 				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__node-problem-detector.yaml"])).To(Equal(vpaYAML))
 				Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor(apiserverHost, vpaEnabled)))
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Deploy a service for the Node Problem Detector component to facilitate scraping the kube-system/node-problem-detector daemonset's endpoints by a Prometheus that is managed by shoot owners.

**Which issue(s) this PR fixes**:

Fixes #9481

**Special notes for your reviewer**:

cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A service is added for the shoot cluster's kube-system/node-problem-detector daemonset
```
