### PR TITLE
Add `rate` to istio mesh dashboard metrics

### DIFF
--- a/pkg/component/observability/plutono/dashboards/seed/istio/istio-mesh-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/seed/istio/istio-mesh-dashboard.json
@@ -79,15 +79,15 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(istio_tcp_received_bytes_total{destination_service=~\"$tcp_service\"})",
+          "expr": "sum(rate(istio_tcp_received_bytes_total{destination_service=~\"$tcp_service\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Received",
           "refId": "A"
         },
         {
-          "expr": "sum(istio_tcp_sent_bytes_total{destination_service=~\"$tcp_service\"})",
+          "expr": "sum(rate(istio_tcp_sent_bytes_total{destination_service=~\"$tcp_service\"}[$__rate_interval]))",
           "interval": "",
-          "legendFormat": "Send",
+          "legendFormat": "Sent",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR makes it so that `rate` is used when displaying the `istio_tcp_received_bytes_total` and `istio_tcp_sent_bytes_total` metrics in the Istio Mesh Dashboard in Plutono. These metrics are counters, so only using `sum` is not very helpful.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `Data Transfer` graph from the `Istio Mesh Dashboard` in the seed `plutono` now uses `rate` when displaying the `istio_tcp_received_bytes_total` and `istio_tcp_sent_bytes_total` metrics.
```
