### PR TITLE
Add main packages to skaffold `ko` dependencies

### DIFF
--- a/hack/check-skaffold-deps-for-binary.sh
+++ b/hack/check-skaffold-deps-for-binary.sh
@@ -63,13 +63,14 @@ echo "$skaffold_yaml" |\
   sort -f |\
   uniq > "$path_current_skaffold_dependencies"
 
+echo "cmd/$binary_name" > "$path_actual_dependencies"
 module_name=$(go list -m)
 module_prefix="$module_name/"
 go list -f '{{ join .Deps "\n" }}' "./cmd/$binary_name" |\
   grep "$module_prefix" |\
   sed "s@$module_prefix@@g" |\
   sort -f |\
-  uniq > "$path_actual_dependencies"
+  uniq >> "$path_actual_dependencies"
 
 # always add VERSION file
 echo "VERSION" >> "$path_actual_dependencies"

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -18,6 +18,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-operator
             - cmd/gardener-operator/app
             - cmd/gardener-operator/app/bootstrappers
             - cmd/utils
@@ -201,6 +202,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-resource-manager
             - cmd/gardener-resource-manager/app
             - cmd/gardener-resource-manager/app/bootstrappers
             - cmd/utils
@@ -299,6 +301,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-apiserver
             - cmd/gardener-apiserver/app
             - cmd/utils
             - pkg/api
@@ -475,6 +478,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-controller-manager
             - cmd/gardener-controller-manager/app
             - cmd/gardener-controller-manager/app/bootstrappers
             - cmd/utils
@@ -583,6 +587,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-scheduler
             - cmd/gardener-scheduler/app
             - cmd/utils
             - pkg/api/extensions
@@ -645,6 +650,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-admission-controller
             - cmd/gardener-admission-controller/app
             - cmd/utils
             - pkg/admissioncontroller/apis/config

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -34,6 +34,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-apiserver
             - cmd/gardener-apiserver/app
             - cmd/utils
             - pkg/api
@@ -210,6 +211,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-controller-manager
             - cmd/gardener-controller-manager/app
             - cmd/gardener-controller-manager/app/bootstrappers
             - cmd/utils
@@ -318,6 +320,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-scheduler
             - cmd/gardener-scheduler/app
             - cmd/utils
             - pkg/api/extensions
@@ -380,6 +383,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-admission-controller
             - cmd/gardener-admission-controller/app
             - cmd/utils
             - pkg/admissioncontroller/apis/config
@@ -553,6 +557,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-extension-provider-local
             - cmd/gardener-extension-provider-local/app
             - cmd/utils
             - extensions/pkg/apis/config
@@ -800,6 +805,7 @@ build:
         dependencies:
           paths:
             - charts
+            - cmd/gardenlet
             - cmd/gardenlet/app
             - cmd/gardenlet/app/bootstrappers
             - cmd/utils
@@ -1028,6 +1034,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-resource-manager
             - cmd/gardener-resource-manager/app
             - cmd/gardener-resource-manager/app/bootstrappers
             - cmd/utils
@@ -1126,6 +1133,7 @@ build:
       ko:
         dependencies:
           paths:
+            - cmd/gardener-node-agent
             - cmd/gardener-node-agent/app
             - cmd/gardener-node-agent/app/bootstrappers
             - cmd/utils


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Currently, changes to `main.go` in main packages, e.g. `cmd/gardener-apiserver/main.go` will not trigger a rebuild of the corresponding images when running `make gardener-up` (or other targets where the images are expected to be built).
This PR adds these main packages to the `build.artifacts.ko.dependencies.paths` array in `skaffold` configurations so that they can be properly tracked by the `ko` builder when building images.


__To reproduce this issue you could try to__:
1. Follow the guide in [getting startied locally](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md) to setup a local dev setup (make sure that you run `make gardener-up` at least once).
1. Make a change to any `main.go` file in the `./cmd/*/` directory (make sure that this is the only change).
2. Re-run `make gardener-up`
3. Observe that the images related to the change you made get picked up from cache, e.g:
```
Checking cache...
 - europe-docker.pkg.dev/gardener-project/releases/gardener/apiserver: Found. Tagging
 - europe-docker.pkg.dev/gardener-project/releases/gardener/controller-manager: Found. Tagging
 - europe-docker.pkg.dev/gardener-project/releases/gardener/scheduler: Found. Tagging
 - europe-docker.pkg.dev/gardener-project/releases/gardener/admission-controller: Found. Tagging
 - europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/provider-local: Found. Tagging
 - europe-docker.pkg.dev/gardener-project/releases/gardener/gardenlet: Found. Tagging
 - europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager: Found. Tagging
 - europe-docker.pkg.dev/gardener-project/releases/gardener/node-agent: Found. Tagging
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Images for local development should now be properly rebuilt, if changes are made only to files in the `main` packages under `./cmd/...` directories. 
```
