### PR TITLE
Streamline `WithServiceAccountIssuerHostname`

### DIFF
--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -165,17 +165,18 @@ func (b *Builder) WithDefaultDomains(defaultDomains []*gardenerutils.Domain) *Bu
 // Should be called before [Builder.Build].
 func (b *Builder) WithServiceAccountIssuerHostname(secret *corev1.Secret) *Builder {
 	b.serviceAccountIssuerHostname = func() (*string, error) {
-		if secret != nil {
-			if host, ok := secret.Data["hostname"]; ok {
-				hostname := string(host)
-				if strings.TrimSpace(hostname) == "" {
-					return nil, errors.New("service account issuer secret has an empty hostname key")
-				}
-				return &hostname, nil
-			}
+		if secret == nil {
+			return nil, nil
+		}
+		host, ok := secret.Data["hostname"]
+		if !ok {
 			return nil, errors.New("service account issuer secret is missing a hostname key")
 		}
-		return nil, nil
+		hostname := string(host)
+		if strings.TrimSpace(hostname) == "" {
+			return nil, errors.New("service account issuer secret has an empty hostname key")
+		}
+		return &hostname, nil
 	}
 	return b
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Streamline `WithServiceAccountIssuerHostname`

/cc @dimityrmirchev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
