### PR TITLE
FIx dependency-watchdog permissions

### DIFF
--- a/pkg/component/nodemanagement/dependencywatchdog/access_test.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/access_test.go
@@ -98,7 +98,7 @@ rules:
   - list
 `
 
-		ClusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+		clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
@@ -191,7 +191,7 @@ users:
 				"role__kube-node-lease__gardener.cloud_target_dependency-watchdog.yaml":        []byte(roleYAML),
 				"rolebinding__kube-node-lease__gardener.cloud_target_dependency-watchdog.yaml": []byte(roleBindingYAML),
 				"clusterrole____gardener.cloud_target_dependency-watchdog.yaml":                []byte(clusterRoleYAML),
-				"clusterrolebinding____gardener.cloud_target_dependency-watchdog.yaml":         []byte(ClusterRoleBindingYAML),
+				"clusterrolebinding____gardener.cloud_target_dependency-watchdog.yaml":         []byte(clusterRoleBindingYAML),
 			},
 			Immutable: ptr.To(true),
 		}

--- a/pkg/component/nodemanagement/dependencywatchdog/access_test.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/access_test.go
@@ -82,6 +82,36 @@ subjects:
   name: dependency-watchdog-probe
   namespace: kube-system
 `
+
+		clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: gardener.cloud:target:dependency-watchdog
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+`
+
+		ClusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: gardener.cloud:target:dependency-watchdog
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:target:dependency-watchdog
+subjects:
+- kind: ServiceAccount
+  name: dependency-watchdog-probe
+  namespace: kube-system
+`
 	)
 
 	BeforeEach(func() {
@@ -134,13 +164,13 @@ users:
 				Name:            "shoot-core-dependency-watchdog",
 				Namespace:       namespace,
 				Labels:          map[string]string{"origin": "gardener"},
-				Annotations:     map[string]string{"reference.resources.gardener.cloud/secret-2c6a3fae": "managedresource-shoot-core-dependency-watchdog-967328e8"},
+				Annotations:     map[string]string{"reference.resources.gardener.cloud/secret-03db818b": "managedresource-shoot-core-dependency-watchdog-31b5e010"},
 				ResourceVersion: "1",
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{
 					{
-						Name: "managedresource-shoot-core-dependency-watchdog-967328e8",
+						Name: "managedresource-shoot-core-dependency-watchdog-31b5e010",
 					},
 				},
 				InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
@@ -149,7 +179,7 @@ users:
 		}
 		expectedManagedResourceSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "managedresource-shoot-core-dependency-watchdog-967328e8",
+				Name:            "managedresource-shoot-core-dependency-watchdog-31b5e010",
 				Namespace:       namespace,
 				ResourceVersion: "1",
 				Labels: map[string]string{
@@ -160,6 +190,8 @@ users:
 			Data: map[string][]byte{
 				"role__kube-node-lease__gardener.cloud_target_dependency-watchdog.yaml":        []byte(roleYAML),
 				"rolebinding__kube-node-lease__gardener.cloud_target_dependency-watchdog.yaml": []byte(roleBindingYAML),
+				"clusterrole____gardener.cloud_target_dependency-watchdog.yaml":                []byte(clusterRoleYAML),
+				"clusterrolebinding____gardener.cloud_target_dependency-watchdog.yaml":         []byte(ClusterRoleBindingYAML),
 			},
 			Immutable: ptr.To(true),
 		}
@@ -183,7 +215,7 @@ users:
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(reconciledManagedResource), reconciledManagedResource)).To(Succeed())
 			Expect(reconciledManagedResource).To(DeepEqual(expectedManagedResource))
 
-			reconciledManagedResourceSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "managedresource-shoot-core-dependency-watchdog-967328e8", Namespace: namespace}}
+			reconciledManagedResourceSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "managedresource-shoot-core-dependency-watchdog-31b5e010", Namespace: namespace}}
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(reconciledManagedResourceSecret), reconciledManagedResourceSecret)).To(Succeed())
 			Expect(reconciledManagedResourceSecret).To(DeepEqual(expectedManagedResourceSecret))
 		})
@@ -195,7 +227,7 @@ users:
 			Expect(fakeClient.Create(ctx, reconciledInternalProbeSecret)).To(Succeed())
 			reconciledManagedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: "shoot-core-dependency-watchdog", Namespace: namespace}}
 			Expect(fakeClient.Create(ctx, reconciledManagedResource)).To(Succeed())
-			reconciledManagedResourceSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "managedresource-shoot-core-dependency-watchdog-967328e8", Namespace: namespace}}
+			reconciledManagedResourceSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "managedresource-shoot-core-dependency-watchdog-31b5e010", Namespace: namespace}}
 			Expect(fakeClient.Create(ctx, reconciledManagedResourceSecret)).To(Succeed())
 
 			Expect(access.Destroy(ctx)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area disaster-recovery ops-productivity quality 
/kind bug

**What this PR does / why we need it**:
FIx dependency-watchdog permissions

With https://github.com/gardener/gardener/pull/9454, dwd now reads the nodes, hence it needs permissions to get/list nodes.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix bug where dependency watchdog is missing permissions to read nodes in the shoot clusters.
```
