### PR TITLE
docs: Add yq as a local setup prerequisite

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -97,7 +97,7 @@ brew install jq
 [yq](https://mikefarah.gitbook.io/yq) is a lightweight and portable command-line YAML processor. On macOS run
 
 ```bash
-brew install jq
+brew install yq
 ```
 
 ## Installing GNU Parallel

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -86,6 +86,16 @@ brew install iproute2mac
 
 ## Installing jq
 
+[jq](https://jqlang.github.io/jq/) is a lightweight and flexible command-line JSON processor. On macOS run
+
+```bash
+brew install jq
+```
+
+## Installing yq
+
+[yq](https://mikefarah.gitbook.io/yq) is a lightweight and portable command-line YAML processor. On macOS run
+
 ```bash
 brew install jq
 ```


### PR DESCRIPTION
/area documentation
/kind enhancement

**What this PR does / why we need it**:
When you're following the guide [Getting Started Locally](https://gardener.cloud/docs/gardener/deployment/getting_started_locally/) eventually you might use the script [./hack/usage/wait-for.sh](https://gardener.cloud/docs/gardener/deployment/getting_started_locally/#creating-a-shoot-cluster:~:text=ready%20by%20running%3A-,./hack/usage/wait%2Dfor.sh,-seed%20local%20GardenletReady).

This script uses `yq` to process YAML:
https://github.com/gardener/gardener/blob/73f6de66ebe95a398d57f382c344668fd763eb4b/hack/usage/wait-for.sh#L49-L60

If you followed the [Local Setup]() guide but haven't yet installed `yq` on your device you'll run into:
```shell
./hack/usage/wait-for.sh seed local GardenletReady SeedSystemComponentsHealthy ExtensionsRead
⏳ Checking conditions for seed/local...
./hack/usage/wait-for.sh: line 50: yq: command not found
error: the server doesn't have a resource type "seed"
```

**Which issue(s) this PR fixes**:
_n.a._

**Special notes for your reviewer**:
_n.a._

**Release note**:
```doc developer
Add `yq` as a local setup prerequisite.
```
