### PR TITLE
Add `NamespacedCloudProfileValidator` to admission doc

### DIFF
--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -190,4 +190,4 @@ Already existing `Shoot`s will not be affected by this admission plugin.
 _(enabled by default)_
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `NamespacedCloudProfile`s.
-It primarily validates if the referenced parent `CloudProfile` exits in the system. In addition, the admission controller ensures that the `NamespacedCloudProfile` only configures new machine types, and does not overwrite those from the parent `CloudProfile`.
+It primarily validates if the referenced parent `CloudProfile` exists in the system. In addition, the admission controller ensures that the `NamespacedCloudProfile` only configures new machine types, and does not overwrite those from the parent `CloudProfile`.

--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -184,3 +184,10 @@ _(disabled by default)_
 This admission controller reacts on `CREATE` operations for `Shoot`s.
 If enabled, it adds a set of common suffixes configured in its admission plugin configuration to the `Shoot` (`spec.systemComponents.coreDNS.rewriting.commonSuffixes`) (for more information, see [DNS Search Path Optimization](../usage/dns-search-path-optimization.md)).
 Already existing `Shoot`s will not be affected by this admission plugin.
+
+## `NamespacedCloudProfileValidator`
+
+_(enabled by default)_
+
+This admission controller reacts on `CREATE` and `UPDATE` operations for `NamespacedCloudProfile`s.
+It primarily validates if the referenced parent `CloudProfile` exits in the system. In addition, the admission controller ensures that the `NamespacedCloudProfile` only configures new machine types, and does not overwrite those from the parent `CloudProfile`.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Adds documentation in admission doc which was missed in https://github.com/gardener/gardener/pull/9440.

**Special notes for your reviewer**:
/cc @rfranzke @benedictweis 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
