### PR TITLE
Don't depoy vali-specific ClusterOutputs when vali is disabled

### DIFF
--- a/pkg/component/observability/logging/fluentoperator/custom_resources.go
+++ b/pkg/component/observability/logging/fluentoperator/custom_resources.go
@@ -77,8 +77,8 @@ func (c *customResources) Deploy(ctx context.Context) error {
 		resources = append(resources, clusterParser)
 	}
 
-	for _, clusterParser := range c.values.Outputs {
-		resources = append(resources, clusterParser)
+	for _, clusterOutput := range c.values.Outputs {
+		resources = append(resources, clusterOutput)
 	}
 
 	serializedResources, err := registry.AddAllAndSerialize(resources...)

--- a/pkg/component/observability/logging/fluentoperator/fluent_bit.go
+++ b/pkg/component/observability/logging/fluentoperator/fluent_bit.go
@@ -46,6 +46,8 @@ type FluentBitValues struct {
 	Image string
 	// InitContainerImage is the fluent-bit init container image.
 	InitContainerImage string
+	// VailEnabled specifies whether vali is used and should be configured as a ClusterOutput.
+	ValiEnabled bool
 	// PriorityClass is the name of the priority class of the fluent-bit.
 	PriorityClass string
 }
@@ -284,10 +286,13 @@ end
 		configMap,
 		customresources.GetFluentBit(getFluentBitLabels(), v1beta1constants.DaemonSetNameFluentBit, f.namespace, f.values.Image, f.values.InitContainerImage, f.values.PriorityClass),
 		customresources.GetClusterFluentBitConfig(v1beta1constants.DaemonSetNameFluentBit, getCustomResourcesLabels()),
-		customresources.GetDefaultClusterOutput(getCustomResourcesLabels()),
 		serviceMonitor,
 		serviceMonitorPlugin,
 		prometheusRule,
+	}
+
+	if f.values.ValiEnabled {
+		resources = append(resources, customresources.GetDefaultClusterOutput(getCustomResourcesLabels()))
 	}
 
 	for _, clusterInput := range customresources.GetClusterInputs(getCustomResourcesLabels()) {

--- a/pkg/component/observability/logging/fluentoperator/fluent_bit_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluent_bit_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Fluent Bit", func() {
 		values            = FluentBitValues{
 			Image:              image,
 			InitContainerImage: image,
+			ValiEnabled:        true,
 			PriorityClass:      priorityClassName,
 		}
 
@@ -297,6 +298,17 @@ var _ = Describe("Fluent Bit", func() {
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterparser____containerd-parser.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusteroutput____journald.yaml"))
 			componenttest.PrometheusRule(prometheusRule, "testdata/fluent-bit.prometheusrule.test.yaml")
+		})
+
+		Context("with vali disabled", func() {
+			JustBeforeEach(func() {
+				values.ValiEnabled = false
+			})
+			It("should not deploy vali ClusterOutputs", func() {
+				Expect(component.Deploy(ctx)).To(Succeed())
+				Expect(customResourcesManagedResourceSecret.Data).NotTo(HaveKey("clusteroutput____journald.yaml"))
+			})
+
 		})
 	})
 

--- a/pkg/component/shared/fluent_bit.go
+++ b/pkg/component/shared/fluent_bit.go
@@ -27,6 +27,7 @@ func NewFluentBit(
 	c client.Client,
 	gardenNamespaceName string,
 	enabled bool,
+	valiEnabled bool,
 	priorityClassName string,
 ) (
 	deployer component.DeployWaiter,
@@ -48,6 +49,7 @@ func NewFluentBit(
 		fluentoperator.FluentBitValues{
 			Image:              fluentBitImage.String(),
 			InitContainerImage: fluentBitInitImage.String(),
+			ValiEnabled:        valiEnabled,
 			PriorityClass:      priorityClassName,
 		},
 	)

--- a/pkg/component/shared/fluent_operator_custom_resources.go
+++ b/pkg/component/shared/fluent_operator_custom_resources.go
@@ -38,6 +38,7 @@ func NewFluentOperatorCustomResources(
 		inputs  []*fluentbitv1alpha2.ClusterInput
 		filters []*fluentbitv1alpha2.ClusterFilter
 		parsers []*fluentbitv1alpha2.ClusterParser
+		outputs []*fluentbitv1alpha2.ClusterOutput
 	)
 
 	// Fetch component specific logging configurations
@@ -60,6 +61,10 @@ func NewFluentOperatorCustomResources(
 		}
 	}
 
+	if output != nil {
+		outputs = append(outputs, output)
+	}
+
 	deployer = fluentoperator.NewCustomResources(
 		c,
 		gardenNamespaceName,
@@ -68,7 +73,7 @@ func NewFluentOperatorCustomResources(
 			Inputs:  inputs,
 			Filters: filters,
 			Parsers: parsers,
-			Outputs: []*fluentbitv1alpha2.ClusterOutput{output},
+			Outputs: outputs,
 		},
 	)
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strings"
 
+	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
 	proberapi "github.com/gardener/dependency-watchdog/api/prober"
 	weederapi "github.com/gardener/dependency-watchdog/api/weeder"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -782,13 +783,18 @@ func (r *Reconciler) newFluentCustomResources(seedIsGarden bool) (deployer compo
 		centralLoggingConfigurations = append(centralLoggingConfigurations, eventlogger.CentralLoggingConfiguration)
 	}
 
+	var output *fluentbitv1alpha2.ClusterOutput
+	if gardenlethelper.IsValiEnabled(&r.Config) {
+		output = customresources.GetDynamicClusterOutput(map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource})
+	}
+
 	return sharedcomponent.NewFluentOperatorCustomResources(
 		r.SeedClientSet.Client(),
 		r.GardenNamespace,
 		gardenlethelper.IsLoggingEnabled(&r.Config),
 		"",
 		centralLoggingConfigurations,
-		customresources.GetDynamicClusterOutput(map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource}),
+		output,
 	)
 }
 
@@ -858,6 +864,7 @@ func (r *Reconciler) newFluentBit() (component.DeployWaiter, error) {
 		r.SeedClientSet.Client(),
 		r.GardenNamespace,
 		gardenlethelper.IsLoggingEnabled(&r.Config),
+		gardenlethelper.IsValiEnabled(&r.Config),
 		v1beta1constants.PriorityClassNameSeedSystem600,
 	)
 }

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1010,6 +1010,7 @@ func (r *Reconciler) newFluentBit() (component.DeployWaiter, error) {
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
 		true,
+		true,
 		v1beta1constants.PriorityClassNameGardenSystem100,
 	)
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind bug

**What this PR does / why we need it**:
Vali can be disabled in the `GardenletConfiguration` but this was not respected when creating the `ClusterOutput` resources that send logs to vali. They are not needed / cause errors when you bring your own Loki/Vali.

**Special notes for your reviewer**:
1. This change still always deploys them when using the Operator, because it looks like disabling vali is not an option there, correct?
2. When using your own Loki, the deployed fluentbit agents will likely be blocked from shipping their logs, since the network policy annotations are tailored for vali. I considered changing the labels [here](https://github.com/gardener/gardener/blob/master/pkg/component/observability/logging/fluentoperator/fluentoperator.go#L342) based on whether vali is enabled or not, but decided against it, because 
  a) changing this cannot be reconciled (fluentbit-operator does not handle changing the immutable label selectors field of the daemonset)
  b) This can easily be achieved by deploying your own `NetworkPolicy`

**Release note**:
```bugfix operator
When vali is disabled in the `GardenletConfiguration` its fluentbit `ClusterOutputs` are no longer deployed.
```
