### PR TITLE
Do not append reason to `lastMaintenance.description` if no feature gates or admission plugins are removed

### DIFF
--- a/docs/usage/shoot_versions.md
+++ b/docs/usage/shoot_versions.md
@@ -46,7 +46,7 @@ This information is programmatically available in the `CloudProfiles` of the Gar
 Due to its short early age, there is a higher probability of undiscovered issues and is therefore not yet recommended for production usage.
 A Shoot does not update (neither `auto-update` or `force-update`) to a `preview` version during the maintenance time.
 Also, `preview` versions are not considered for the defaulting to the highest available version when deliberately omitting the patch version during Shoot creation.
-Typically, after a fresh release of a new Kubernetes (e.g., v1.25.0) or Machine image version (e.g., suse-chost 15.4.20220818), the operator tags it as `preview` until he has gained sufficient experience and regards this version to be reliable.
+Typically, after a fresh release of a new Kubernetes (e.g., v1.25.0) or Machine image version (e.g., suse-chost 15.4.20220818), the operator tags it as `preview` until they have gained sufficient experience and regards this version to be reliable.
 After the operator has gained sufficient trust, the version can be manually promoted to `supported`.
 
 - **supported:** A `supported` version is the recommended version for new and existing Shoot clusters. This is the version that new Shoot clusters should use and existing clusters should update to.

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -880,6 +880,7 @@ func maintainFeatureGates(kubernetes *gardencorev1beta1.KubernetesConfig, versio
 	)
 
 	for fg, enabled := range kubernetes.FeatureGates {
+		// err should never be non-nil, because the feature gates are part of the existing spec and are already validated by the GAPI server
 		if supported, err := IsFeatureGateSupported(fg, version); err == nil && supported {
 			validFeatureGates[fg] = enabled
 		} else {
@@ -909,6 +910,7 @@ func maintainAdmissionPluginsForShoot(shoot *gardencorev1beta1.Shoot) []string {
 	if shoot.Spec.Kubernetes.KubeAPIServer != nil && shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins != nil {
 		validAdmissionPlugins := []gardencorev1beta1.AdmissionPlugin{}
 		for _, plugin := range shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
+			// err should never be non-nil, because the admission plugins are part of the existing spec and are already validated by the GAPI server
 			if supported, err := IsAdmissionPluginSupported(plugin.Name, shoot.Spec.Kubernetes.Version); err == nil && supported {
 				validAdmissionPlugins = append(validAdmissionPlugins, plugin)
 			} else {

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -889,8 +889,10 @@ func maintainFeatureGates(kubernetes *gardencorev1beta1.KubernetesConfig, versio
 
 	kubernetes.FeatureGates = validFeatureGates
 
-	slices.Sort(removedFeatureGates)
-	reasons = append(reasons, fmt.Sprintf("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", fieldPath, version, strings.Join(removedFeatureGates, ", ")))
+	if len(removedFeatureGates) > 0 {
+		slices.Sort(removedFeatureGates)
+		reasons = append(reasons, fmt.Sprintf("Removed feature gates from %q because they are not supported in Kubernetes version %q: %s", fieldPath, version, strings.Join(removedFeatureGates, ", ")))
+	}
 
 	return reasons
 }
@@ -916,8 +918,10 @@ func maintainAdmissionPluginsForShoot(shoot *gardencorev1beta1.Shoot) []string {
 
 		shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = validAdmissionPlugins
 
-		slices.Sort(removedAdmissionPlugins)
-		reasons = append(reasons, fmt.Sprintf("Removed admission plugins from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeAPIServer.admissionPlugins", shoot.Spec.Kubernetes.Version, strings.Join(removedAdmissionPlugins, ", ")))
+		if len(removedAdmissionPlugins) > 0 {
+			slices.Sort(removedAdmissionPlugins)
+			reasons = append(reasons, fmt.Sprintf("Removed admission plugins from %q because they are not supported in Kubernetes version %q: %s", "spec.kubernetes.kubeAPIServer.admissionPlugins", shoot.Spec.Kubernetes.Version, strings.Join(removedAdmissionPlugins, ", ")))
+		}
 	}
 
 	return reasons

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -1369,7 +1369,7 @@ var _ = Describe("Shoot Maintenance", func() {
 								},
 							},
 							{
-								Name: "cpu-worker-2",
+								Name: "cpu-worker-3",
 								Kubernetes: &gardencorev1beta1.WorkerKubernetes{
 									Kubelet: &gardencorev1beta1.KubeletConfig{
 										KubernetesConfig: gardencorev1beta1.KubernetesConfig{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Even if no feature gates are removed, maintenance reasons contain:
```
  lastMaintenance:
    description: 'All maintenance operations successful. Worker pool "local": Updated
      machine image "local" from "2.1.0" to "2.2.0". Reason: Automatic update of the
      machine image version is configured (image update strategy: major), Removed
      feature gates from "spec.provider.workers[0].kubernetes.kubelet.featureGates"
      because they are not supported in Kubernetes version "1.29.0": , Removed admission
      plugins from "spec.kubernetes.kubeAPIServer.admissionPlugins" because they are
      not supported in Kubernetes version "1.29.0": ''
```
This PR fixes this issue by appending to reasons only if something is removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing the Shoot `status.lastMaintenance.description` to contain "Removed feature gates from" or  "Removed admission plugins from" messages with zero entries is now fixed.
```
