### PR TITLE
Replace topology labels when `PersistentVolume` has no node affinity

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -344,10 +344,17 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 		taskFns = append(taskFns, func(ctx context.Context) error {
 			patch := client.MergeFrom(persistentVolume.DeepCopy())
 
-			delete(persistentVolume.Labels, corev1.LabelFailureDomainBetaRegion)
-			delete(persistentVolume.Labels, corev1.LabelFailureDomainBetaZone)
-
-			if persistentVolume.Spec.NodeAffinity != nil && persistentVolume.Spec.NodeAffinity.Required != nil {
+			if persistentVolume.Spec.NodeAffinity == nil {
+				// when PV is very old and has no node affinity, we just replace the topology labels
+				if v, ok := persistentVolume.Labels[corev1.LabelFailureDomainBetaRegion]; ok {
+					persistentVolume.Labels[corev1.LabelTopologyRegion] = v
+				}
+				if v, ok := persistentVolume.Labels[corev1.LabelFailureDomainBetaZone]; ok {
+					persistentVolume.Labels[corev1.LabelTopologyZone] = v
+				}
+			} else if persistentVolume.Spec.NodeAffinity.Required != nil {
+				// when PV has node affinity then we do not need the labels but just need to replace the topology keys
+				// in the node selector term match expressions
 				for i, term := range persistentVolume.Spec.NodeAffinity.Required.NodeSelectorTerms {
 					for j, expression := range term.MatchExpressions {
 						if expression.Key == corev1.LabelFailureDomainBetaRegion {
@@ -360,6 +367,11 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 					}
 				}
 			}
+
+			// either new topology labels were added above, or node affinity keys were adjusted
+			// in both cases, the old, deprecated topology labels are no longer needed and can be removed
+			delete(persistentVolume.Labels, corev1.LabelFailureDomainBetaRegion)
+			delete(persistentVolume.Labels, corev1.LabelFailureDomainBetaZone)
 
 			// prevent sending empty patches
 			if data, err := patch.Data(&persistentVolume); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Some `PersistentVolume`s created a very long time ago don't have any node affinity. They only use the topology labels.
Earlier, the migration code was always removing the topology labels, effectively rendering such `PersistentVolume`s unusable for pods since the `kube-scheduler` can no longer determine in which region/zone they live.

With this PR, we replace the topology labels with the new keys when the PV has no node affinity. We only remove them entirely when the PV has node affinity (in this case, the labels are not needed).

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9388

**Special notes for your reviewer**:
/cc @vpnachev @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused `PersistentVolume`s without `.spec.nodeAffinity` to become unusable in case they still had the old, deprecated topology labels.
```
