### PR TITLE
[GEP-19] Integrate Prometheus and `blackbox-exporter` deployments into `Garden` controller

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -169,11 +169,11 @@ The controller maintains the `.status.lastOperation` which indicates the status 
 
 ###### Garden Prometheus
 
-`gardener-operator` deploys a Prometheus instance in the `garden` namespace (called "garden Prometheus") which fetches metrics and data from garden system components, cAdvisors, the virtual cluster control plane, and the Seeds' aggregate Prometheus instances.
+`gardener-operator` deploys a Prometheus instance in the `garden` namespace (called "Garden Prometheus") which fetches metrics and data from garden system components, cAdvisors, the virtual cluster control plane, and the Seeds' aggregate Prometheus instances.
 Its purpose is to provide an entrypoint for operators when debugging issues with components running in the garden cluster.
 It also serves as the top-level aggregator of metering across a Gardener landscape.
 
-If you would like to extend the configuration for this garden Prometheus, you can create the [`prometheus-operator`'s custom resources](https://github.com/prometheus-operator/prometheus-operator?tab=readme-ov-file#customresourcedefinitions) and label them with `prometheus=garden`, for example:
+If you would like to extend the configuration for this Garden Prometheus, you can create the [`prometheus-operator`'s custom resources](https://github.com/prometheus-operator/prometheus-operator?tab=readme-ov-file#customresourcedefinitions) and label them with `prometheus=garden`, for example:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -155,6 +155,7 @@ The reconciler also manages a few observability-related components (more planned
 - `prometheus-operator`
 - `alertmanager-garden` (read more [here](#observability))
 - `prometheus-garden` (read more [here](#observability))
+- `blackbox-exporter`
 
 It is also mandatory to provide an IPv4 CIDR for the service network of the virtual cluster via `.spec.virtualCluster.networking.services`.
 This range is used by the API server to compute the cluster IPs of `Service`s.

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -129,9 +129,12 @@ Instead, the [`TokenRequest` API](https://kubernetes.io/docs/reference/kubernete
 Third-party components that need to communicate with the virtual cluster can leverage the [`gardener-resource-manager`'s `TokenRequestor` controller](resource-manager.md#tokenrequestor-controller) and the generic kubeconfig, just like it works for `Shoot`s.
 Please note, that this functionality is restricted to the `garden` namespace. The current `Secret` name of the generic kubeconfig can be found in the annotations (key: `generic-token-kubeconfig.secret.gardener.cloud/name`) of the `Garden` resource.
 
-For the virtual cluster, it is essential to provide a DNS domain via `.spec.virtualCluster.dns.domains`.
-**The respective DNS record is not managed by `gardener-operator` and should be created manually. It should point to the load balancer IP of the `istio-ingressgateway` `Service` in namespace `virtual-garden-istio-ingress`.**
-The DNS domain is used for the `server` in the kubeconfig, and for configuring the `--external-hostname` flag of the API server.
+For the virtual cluster, it is essential to provide at least one DNS domain via `.spec.virtualCluster.dns.domains`.
+**The respective DNS records are not managed by `gardener-operator` and should be created manually.
+They should point to the load balancer IP of the `istio-ingressgateway` `Service` in namespace `virtual-garden-istio-ingress`.
+The DNS records must be prefixed with both `gardener.` and `api.` for all domains in `.spec.virtualCluster.dns.domains`.**
+
+The first DNS domain in this list is used for the `server` in the kubeconfig, and for configuring the `--external-hostname` flag of the API server.
 
 Apart from the control plane components of the virtual cluster, the reconcile also deploys the control plane components of Gardener.
 `gardener-apiserver` reuses the same ETCDs like the `virtual-garden-kube-apiserver`, so all data related to the "the garden cluster" is stored together and "isolated" from ETCD data related to the runtime cluster.

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -169,8 +169,9 @@ The controller maintains the `.status.lastOperation` which indicates the status 
 
 ###### Garden Prometheus
 
-`gardener-operator` deploys a Prometheus instance in the `garden` namespace (called "garden Prometheus") which fetches metrics and data from garden system components, cAdvisors, and the virtual cluster control plane.
+`gardener-operator` deploys a Prometheus instance in the `garden` namespace (called "garden Prometheus") which fetches metrics and data from garden system components, cAdvisors, the virtual cluster control plane, and the Seeds' aggregate Prometheus instances.
 Its purpose is to provide an entrypoint for operators when debugging issues with components running in the garden cluster.
+It also serves as the top-level aggregator of metering across a Gardener landscape.
 
 If you would like to extend the configuration for this garden Prometheus, you can create the [`prometheus-operator`'s custom resources](https://github.com/prometheus-operator/prometheus-operator?tab=readme-ov-file#customresourcedefinitions) and label them with `prometheus=garden`, for example:
 

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -19,14 +19,14 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 
 ### `PriorityClass`es for Garden Control Plane Components
 
-| Name                              | Priority  | Associated Components (Examples)                                                                                                                    |
-|-----------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                                                           |
-| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver`                                     |
-| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                                                         |
-| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`                                      |
-| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`                                            |
-| `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `gardener-metrics-exporter`, `kube-state-metrics`, `plutono`, `vali`, `prometheus-operator`, `alertmanager-garden` |
+| Name                              | Priority  | Associated Components (Examples)                                                                                                                                         |
+|-----------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                                                                                |
+| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver`                                                          |
+| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                                                                              |
+| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`                                                           |
+| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`                                                                 |
+| `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `gardener-metrics-exporter`, `kube-state-metrics`, `plutono`, `vali`, `prometheus-operator`, `alertmanager-garden`, `prometheus-garden` |
 
 ## Seed Clusters
 

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -19,14 +19,14 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 
 ### `PriorityClass`es for Garden Control Plane Components
 
-| Name                              | Priority  | Associated Components (Examples)                                                                                                                                         |
-|-----------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                                                                                |
-| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver`                                                          |
-| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                                                                              |
-| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`                                                           |
-| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`                                                                 |
-| `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `gardener-metrics-exporter`, `kube-state-metrics`, `plutono`, `vali`, `prometheus-operator`, `alertmanager-garden`, `prometheus-garden` |
+| Name                              | Priority  | Associated Components (Examples)                                                                                                                                                              |
+|-----------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                                                                                                     |
+| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver`                                                                               |
+| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                                                                                                   |
+| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`                                                                                |
+| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`                                                                                      |
+| `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `gardener-metrics-exporter`, `kube-state-metrics`, `plutono`, `vali`, `prometheus-operator`, `alertmanager-garden`, `prometheus-garden`, `blackbox-exporter` |
 
 ## Seed Clusters
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,9 @@ require (
 	github.com/onsi/gomega v1.32.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.73.1
+	github.com/prometheus/blackbox_exporter v0.24.0
 	github.com/prometheus/client_golang v1.18.0
+	github.com/prometheus/common v0.45.0
 	github.com/robfig/cron v1.2.0
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.0
@@ -47,6 +49,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	gonum.org/v1/gonum v0.15.0
 	google.golang.org/protobuf v1.33.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.4
 	istio.io/api v1.21.1
 	istio.io/client-go v1.21.1
@@ -83,6 +86,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -105,6 +109,8 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/go-kit/log v0.2.1 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/errors v0.20.4 // indirect
@@ -130,6 +136,7 @@ require (
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
@@ -137,6 +144,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+	github.com/miekg/dns v1.1.58 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -149,6 +157,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0 // indirect
@@ -156,8 +165,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
-	github.com/prometheus/common v0.45.0 // indirect
+	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -188,7 +196,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
-	golang.org/x/oauth2 v0.16.0 // indirect
+	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/term v0.19.0 // indirect
@@ -201,7 +209,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kms v0.29.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/ahmetb/gen-crd-api-reference-docs v0.3.0 h1:+XfOU14S4bGuwyvCijJwhhBIjYN+YXS18jrCY2EzJaY=
 github.com/ahmetb/gen-crd-api-reference-docs v0.3.0/go.mod h1:TdjdkYhlOifCQWPs1UdTma97kQQMozf5h26hTuG70u8=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -150,6 +152,10 @@ github.com/gardener/machine-controller-manager v0.52.0 h1:irhpamQ/QXixCXJpNKRL71
 github.com/gardener/machine-controller-manager v0.52.0/go.mod h1:6g5i/uRGugkRyIABZmDjvaiT8GLL7XRE9ziw4C/9nCo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
+github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -298,6 +304,8 @@ github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9q
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -336,6 +344,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
+github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
+github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
@@ -368,6 +378,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -407,11 +419,13 @@ github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.73.1 h1:VvIIWSQbvGaDgIeTrOintF/czS6UpLB086EUslAm7aI=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.73.1/go.mod h1:yJ3CawR/A5qEYFEeCOUVYLTwYxmacfHQhJS+b/2QiaM=
+github.com/prometheus/blackbox_exporter v0.24.0 h1:IttStBJcxgyIscyX5INsrIgLOhaADQF346kpf8PnO1g=
+github.com/prometheus/blackbox_exporter v0.24.0/go.mod h1:SfZtJPNWmR8SskeJMmggTpc/mFERPcSAKl7/REjnx/0=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
-github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=
+github.com/prometheus/client_model v0.6.0 h1:k1v3CzpSRUTrKMppY35TLwPvxHqBu0bYgxZzqGIgaos=
+github.com/prometheus/client_model v0.6.0/go.mod h1:NTQHnmxFpouOD0DpvP4XujX3CdOAGQPoaGhyTchlyt8=
 github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lneoxM=
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
@@ -604,8 +618,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.16.0 h1:aDkGMBSYxElaoP81NpoUoz2oo2R2wHdZpGToUxfyQrQ=
-golang.org/x/oauth2 v0.16.0/go.mod h1:hqZ+0LWXsiVoZpeld6jVt06P3adbS2Uu911W1SsJv2o=
+golang.org/x/oauth2 v0.18.0 h1:09qnuIAgzdx1XplqJvW6CQqMCtGZykZWcXzPMPUusvI=
+golang.org/x/oauth2 v0.18.0/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -778,6 +778,9 @@ const (
 
 	// IngressTLSCertificateValidity is the default validity for ingress TLS certificates.
 	IngressTLSCertificateValidity = 730 * 24 * time.Hour // ~2 years, see https://support.apple.com/en-us/HT210176
+	// IngressDomainPrefixPrometheusAggregate is the prefix of a domain exposing prometheus-aggregate in seed clusters.
+	IngressDomainPrefixPrometheusAggregate = "p-seed"
+
 	// VPNTunnel dictates that VPN is used as a tunnel between seed and shoot networks.
 	VPNTunnel string = "vpn-shoot"
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -491,6 +491,10 @@ const (
 	// which should be scraped by Prometheus.
 	// See https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#overwriting-the-pod-selector-label.
 	LabelNetworkPolicyScrapeTargets = "all-scrape-targets"
+	// LabelNetworkPolicyGardenScrapeTargets is a constant for pod selector label which can be used on Services for
+	// garden system components or extensions which should be scraped by Prometheus.
+	// See https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#overwriting-the-pod-selector-label.
+	LabelNetworkPolicyGardenScrapeTargets = "all-garden-scrape-targets"
 	// LabelNetworkPolicySeedScrapeTargets is a constant for pod selector label which can be used on Services for
 	// seed system components or extensions which should be scraped by Prometheus.
 	// See https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#overwriting-the-pod-selector-label.

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -270,8 +270,10 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		{Port: utils.IntStrPtrFromInt32(etcdconstants.PortBackupRestore), Protocol: ptr.To(corev1.ProtocolTCP)},
 	}
 	if e.values.NamePrefix != "" {
+		// etcd deployed for garden cluster
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(clientService, ports...))
 	} else {
+		// etcd deployed for shoot cluster
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(clientService, ports...))
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyNamespaceSelectors(clientService, metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: v1beta1constants.GardenNamespace}}))
 		metav1.SetMetaDataAnnotation(&clientService.ObjectMeta, resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias, v1beta1constants.LabelNetworkPolicyShootNamespaceAlias)
@@ -560,6 +562,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		}
 	}
 
+	// etcd deployed for garden cluster
 	if e.values.NamePrefix != "" {
 		serviceMonitor := e.emptyServiceMonitor()
 		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, serviceMonitor, func() error {

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -25,6 +25,7 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/go-logr/logr"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +44,8 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/etcd/constants"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/utils"
@@ -551,6 +554,106 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		}
 	}
 
+	if e.values.NamePrefix != "" {
+		serviceMonitor := e.emptyServiceMonitor()
+		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, serviceMonitor, func() error {
+			serviceMonitor.Labels = monitoringutils.Labels(garden.Label)
+			serviceMonitor.Spec = monitoringv1.ServiceMonitorSpec{
+				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+					"name":     "etcd",
+					"instance": e.etcd.Name,
+				}},
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						Port:   portNameClient,
+						Scheme: "https",
+						TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{
+							InsecureSkipVerify: true,
+							Cert: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: clientSecret.Name},
+								Key:                  secretsutils.DataKeyCertificate,
+							}},
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: clientSecret.Name},
+								Key:                  secretsutils.DataKeyPrivateKey,
+							},
+						}},
+						RelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_label_instance"},
+								TargetLabel:  "role",
+							},
+							{
+								Action:      "replace",
+								Replacement: e.values.NamePrefix + "etcd",
+								TargetLabel: "job",
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+							Action: "labeldrop",
+							Regex:  `^instance$`,
+						}},
+					},
+					{
+						Port:   portNameBackupRestore,
+						Scheme: "https",
+						TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{
+							InsecureSkipVerify: true,
+							Cert: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: clientSecret.Name},
+								Key:                  secretsutils.DataKeyCertificate,
+							}},
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: clientSecret.Name},
+								Key:                  secretsutils.DataKeyPrivateKey,
+							},
+						}},
+						RelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_label_instance"},
+								TargetLabel:  "role",
+							},
+
+							{
+								Action:      "replace",
+								Replacement: e.values.NamePrefix + "etcd-backup",
+								TargetLabel: "job",
+							},
+						},
+						MetricRelabelConfigs: append([]*monitoringv1.RelabelConfig{{
+							Action: "labeldrop",
+							Regex:  `^instance$`,
+						}}, monitoringutils.StandardMetricRelabelConfig(
+							"etcdbr_defragmentation_duration_seconds_.+",
+							"etcdbr_defragmentation_duration_seconds_count",
+							"etcdbr_defragmentation_duration_seconds_sum",
+							"etcdbr_network_received_bytes",
+							"etcdbr_network_transmitted_bytes",
+							"etcdbr_restoration_duration_seconds_.+",
+							"etcdbr_restoration_duration_seconds_count",
+							"etcdbr_restoration_duration_seconds_sum",
+							"etcdbr_snapshot_duration_seconds_.+",
+							"etcdbr_snapshot_duration_seconds_count",
+							"etcdbr_snapshot_duration_seconds_sum",
+							"etcdbr_snapshot_gc_total",
+							"etcdbr_snapshot_latest_revision",
+							"etcdbr_snapshot_latest_timestamp",
+							"etcdbr_snapshot_required",
+							"etcdbr_validation_duration_seconds_.+",
+							"etcdbr_validation_duration_seconds_count",
+							"etcdbr_validation_duration_seconds_sum",
+							"process_resident_memory_bytes",
+							"process_cpu_seconds_total",
+						)...),
+					},
+				},
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -561,6 +664,7 @@ func (e *etcd) Destroy(ctx context.Context) error {
 
 	return kubernetesutils.DeleteObjects(ctx, e.client,
 		e.emptyHVPA(),
+		e.emptyServiceMonitor(),
 		e.etcd,
 	)
 }
@@ -582,6 +686,10 @@ func GetLabels() map[string]string {
 
 func (e *etcd) emptyHVPA() *hvpav1alpha1.Hvpa {
 	return &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: e.etcd.Name, Namespace: e.namespace}}
+}
+
+func (e *etcd) emptyServiceMonitor() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{ObjectMeta: monitoringutils.ConfigObjectMeta(e.etcd.Name, e.namespace, garden.Label)}
 }
 
 func (e *etcd) Snapshot(ctx context.Context, httpClient rest.HTTPClient) error {

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -1618,6 +1618,10 @@ var _ = Describe("Etcd", func() {
 				)
 				etcdObj.Name = etcdName
 				etcdObj.Spec.VolumeClaimTemplate = ptr.To(testRole + "-virtual-garden-etcd")
+				etcdObj.Spec.Etcd.ClientService.Annotations["networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports"] = `[{"protocol":"TCP","port":2379},{"protocol":"TCP","port":8080}]`
+				delete(etcdObj.Spec.Etcd.ClientService.Annotations, "networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports")
+				delete(etcdObj.Spec.Etcd.ClientService.Annotations, "networking.resources.gardener.cloud/namespace-selectors")
+				delete(etcdObj.Spec.Etcd.ClientService.Annotations, "networking.resources.gardener.cloud/pod-label-selector-namespace-alias")
 
 				hvpaObj := hvpaFor(class, 1, updateMode)
 				hvpaObj.Name = hvpaName

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -78,6 +78,8 @@ var _ = Describe("Virtual", func() {
 		clusterRoleProjectViewerAggregated                *rbacv1.ClusterRole
 		roleReadClusterIdentityConfigMap                  *rbacv1.Role
 		roleBindingReadClusterIdentityConfigMap           *rbacv1.RoleBinding
+		clusterRoleMetricsScraper                         *rbacv1.ClusterRole
+		clusterRoleBindingMetricsScraper                  *rbacv1.ClusterRoleBinding
 	)
 
 	BeforeEach(func() {
@@ -597,6 +599,30 @@ var _ = Describe("Virtual", func() {
 				Name:     "system:authenticated",
 			}},
 		}
+		clusterRoleMetricsScraper = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.cloud:system:metrics-scraper",
+			},
+			Rules: []rbacv1.PolicyRule{{
+				NonResourceURLs: []string{"/metrics"},
+				Verbs:           []string{"get"},
+			}},
+		}
+		clusterRoleBindingMetricsScraper = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.cloud:system:metrics-scraper",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "gardener.cloud:system:metrics-scraper",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "prometheus-garden",
+				Namespace: "kube-system",
+			}},
+		}
 	})
 
 	Describe("#Deploy", func() {
@@ -657,6 +683,8 @@ var _ = Describe("Virtual", func() {
 				clusterRoleProjectViewer,
 				roleReadClusterIdentityConfigMap,
 				roleBindingReadClusterIdentityConfigMap,
+				clusterRoleMetricsScraper,
+				clusterRoleBindingMetricsScraper,
 			))
 		})
 

--- a/pkg/component/gardener/admissioncontroller/admission_controller.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller.go
@@ -120,6 +120,7 @@ func (a *gardenerAdmissionController) Deploy(ctx context.Context) error {
 		a.service(),
 		a.vpa(),
 		admissionConfigConfigMap,
+		a.serviceMonitor(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -723,7 +723,8 @@ func service(namespace string, testValues Values) *corev1.Service {
 				"role": "admission-controller",
 			},
 			Annotations: map[string]string{
-				"networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports": `[{"protocol":"TCP","port":2719}]`,
+				"networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports":       `[{"protocol":"TCP","port":2719}]`,
+				"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":2723}]`,
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/pkg/component/gardener/admissioncontroller/service.go
+++ b/pkg/component/gardener/admissioncontroller/service.go
@@ -26,6 +26,8 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
+const portNameMetrics = "metrics"
+
 func (a *gardenerAdmissionController) service() *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -44,7 +46,7 @@ func (a *gardenerAdmissionController) service() *corev1.Service {
 					TargetPort: intstr.FromInt32(serverPort),
 				},
 				{
-					Name:       "metrics",
+					Name:       portNameMetrics,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       int32(metricsPort),
 					TargetPort: intstr.FromInt32(metricsPort),

--- a/pkg/component/gardener/admissioncontroller/service.go
+++ b/pkg/component/gardener/admissioncontroller/service.go
@@ -60,6 +60,11 @@ func (a *gardenerAdmissionController) service() *corev1.Service {
 		Protocol: ptr.To(corev1.ProtocolTCP),
 	}))
 
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(svc, networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(metricsPort)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}))
+
 	gardenerutils.ReconcileTopologyAwareRoutingMetadata(svc, a.values.TopologyAwareRoutingEnabled, a.values.RuntimeVersion)
 
 	return svc

--- a/pkg/component/gardener/admissioncontroller/servicemonitor.go
+++ b/pkg/component/gardener/admissioncontroller/servicemonitor.go
@@ -1,0 +1,41 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admissioncontroller
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+func (a *gardenerAdmissionController) serviceMonitor() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: monitoringutils.ConfigObjectMeta(DeploymentName, a.namespace, garden.Label),
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: GetLabels()},
+			Endpoints: []monitoringv1.Endpoint{{
+				Port: portNameMetrics,
+				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+					"gardener_admission_controller_.+",
+					"rest_client_.+",
+					"controller_runtime_.+",
+					"go_.+",
+				),
+			}},
+		},
+	}
+}

--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -157,6 +157,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		g.verticalPodAutoscaler(),
 		g.hvpa(),
 		g.deployment(secretCAETCD, secretETCDClient, secretGenericTokenKubeconfig, secretServer, secretAdmissionKubeconfigs, secretETCDEncryptionConfiguration, secretAuditWebhookKubeconfig, secretVirtualGardenAccess, configMapAuditPolicy, configMapAdmissionConfigs),
+		g.serviceMonitor(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -215,7 +215,8 @@ var _ = Describe("GardenerAPIServer", func() {
 					Name:      "gardener-apiserver",
 					Namespace: namespace,
 					Annotations: map[string]string{
-						"networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports": `[{"protocol":"TCP","port":8443}]`,
+						"networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports":       `[{"protocol":"TCP","port":8443}]`,
+						"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8443}]`,
 					},
 					Labels: map[string]string{
 						"app":  "gardener",

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
@@ -119,6 +120,7 @@ var _ = Describe("GardenerAPIServer", func() {
 		clusterRoleBinding               *rbacv1.ClusterRoleBinding
 		clusterRoleBindingAuthDelegation *rbacv1.ClusterRoleBinding
 		roleBindingAuthReader            *rbacv1.RoleBinding
+		serviceMonitor                   *monitoringv1.ServiceMonitor
 	)
 
 	BeforeEach(func() {
@@ -752,6 +754,33 @@ var _ = Describe("GardenerAPIServer", func() {
 				Name:      "gardener-apiserver",
 				Namespace: "kube-system",
 			}},
+		}
+		serviceMonitor = &monitoringv1.ServiceMonitor{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "garden-gardener-apiserver",
+				Namespace: namespace,
+				Labels:    map[string]string{"prometheus": "garden"},
+			},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+					"app":  "gardener",
+					"role": "apiserver",
+				}},
+				Endpoints: []monitoringv1.Endpoint{{
+					TargetPort: ptr.To(intstr.FromInt32(8443)),
+					Scheme:     "https",
+					TLSConfig:  &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: true}},
+					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-garden"},
+						Key:                  "token",
+					}},
+					MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+						SourceLabels: []monitoringv1.LabelName{"__name__"},
+						Action:       "keep",
+						Regex:        `^(authentication_attempts|authenticated_user_requests|apiserver_admission_controller_admission_duration_seconds_.+|apiserver_admission_webhook_admission_duration_seconds_.+|apiserver_admission_step_admission_duration_seconds_.+|apiserver_admission_webhook_rejection_count|apiserver_audit_event_total|apiserver_audit_error_total|apiserver_audit_requests_rejected_total|apiserver_request_total|apiserver_storage_objects|apiserver_latency_seconds|apiserver_current_inflight_requests|apiserver_current_inqueue_requests|apiserver_response_sizes_.+|apiserver_request_duration_seconds_.+|apiserver_request_terminations_total|apiserver_storage_transformation_duration_seconds_.+|apiserver_storage_transformation_operations_total|apiserver_registered_watchers|apiserver_init_events_total|apiserver_watch_events_sizes_.+|apiserver_watch_events_total|etcd_db_total_size_in_bytes|etcd_request_duration_seconds_.+|watch_cache_capacity_increase_total|watch_cache_capacity_decrease_total|watch_cache_capacity|go_.+|apiserver_cache_list_.+|apiserver_storage_list_.+)$`,
+					}},
+				}},
+			},
 		}
 	})
 
@@ -1425,7 +1454,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					managedResourceSecretVirtual.Name = managedResourceVirtual.Spec.SecretRefs[0].Name
 					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
 
-					expectedRuntimeObjects = []client.Object{deployment}
+					expectedRuntimeObjects = []client.Object{deployment, serviceMonitor}
 					Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
 					Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))

--- a/pkg/component/gardener/apiserver/service.go
+++ b/pkg/component/gardener/apiserver/service.go
@@ -42,6 +42,11 @@ func (g *gardenerAPIServer) serviceRuntime() *corev1.Service {
 		Protocol: ptr.To(corev1.ProtocolTCP),
 	}))
 
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(port)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}))
+
 	return service
 }
 

--- a/pkg/component/gardener/apiserver/servicemonitor.go
+++ b/pkg/component/gardener/apiserver/servicemonitor.go
@@ -1,0 +1,78 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+func (g *gardenerAPIServer) serviceMonitor() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: monitoringutils.ConfigObjectMeta(DeploymentName, g.namespace, garden.Label),
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: GetLabels()},
+			Endpoints: []monitoringv1.Endpoint{{
+				TargetPort: ptr.To(intstr.FromInt32(port)),
+				Scheme:     "https",
+				TLSConfig:  &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: true}},
+				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: garden.AccessSecretName},
+					Key:                  resourcesv1alpha1.DataKeyToken,
+				}},
+				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+					"authentication_attempts",
+					"authenticated_user_requests",
+					"apiserver_admission_controller_admission_duration_seconds_.+",
+					"apiserver_admission_webhook_admission_duration_seconds_.+",
+					"apiserver_admission_step_admission_duration_seconds_.+",
+					"apiserver_admission_webhook_rejection_count",
+					"apiserver_audit_event_total",
+					"apiserver_audit_error_total",
+					"apiserver_audit_requests_rejected_total",
+					"apiserver_request_total",
+					"apiserver_storage_objects",
+					"apiserver_latency_seconds",
+					"apiserver_current_inflight_requests",
+					"apiserver_current_inqueue_requests",
+					"apiserver_response_sizes_.+",
+					"apiserver_request_duration_seconds_.+",
+					"apiserver_request_terminations_total",
+					"apiserver_storage_transformation_duration_seconds_.+",
+					"apiserver_storage_transformation_operations_total",
+					"apiserver_registered_watchers",
+					"apiserver_init_events_total",
+					"apiserver_watch_events_sizes_.+",
+					"apiserver_watch_events_total",
+					"etcd_db_total_size_in_bytes",
+					"etcd_request_duration_seconds_.+",
+					"watch_cache_capacity_increase_total",
+					"watch_cache_capacity_decrease_total",
+					"watch_cache_capacity",
+					"go_.+",
+					"apiserver_cache_list_.+",
+					"apiserver_storage_list_.+",
+				),
+			}},
+		},
+	}
+}

--- a/pkg/component/gardener/controllermanager/controller_manager.go
+++ b/pkg/component/gardener/controllermanager/controller_manager.go
@@ -110,6 +110,7 @@ func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 		g.service(),
 		g.verticalPodAutoscaler(),
 		g.deployment(secretGenericTokenKubeconfig.Name, virtualGardenAccessSecret.Secret.Name, controllerManagerConfigConfigMap.Name),
+		g.serviceMonitor(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -162,8 +162,9 @@ var _ = Describe("GardenerControllerManager", func() {
 		}
 		serviceRuntime = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gardener-controller-manager",
-				Namespace: namespace,
+				Name:        "gardener-controller-manager",
+				Namespace:   namespace,
+				Annotations: map[string]string{"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":2719}]`},
 				Labels: map[string]string{
 					"app":  "gardener",
 					"role": "controller-manager",

--- a/pkg/component/gardener/controllermanager/service.go
+++ b/pkg/component/gardener/controllermanager/service.go
@@ -20,7 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const serviceName = DeploymentName
+const (
+	serviceName     = DeploymentName
+	portNameMetrics = "metrics"
+)
 
 func (g *gardenerControllerManager) service() *corev1.Service {
 	service := &corev1.Service{
@@ -33,7 +36,7 @@ func (g *gardenerControllerManager) service() *corev1.Service {
 			Type:     corev1.ServiceTypeClusterIP,
 			Selector: GetLabels(),
 			Ports: []corev1.ServicePort{{
-				Name:       "metrics",
+				Name:       portNameMetrics,
 				Port:       int32(metricsPort),
 				Protocol:   corev1.ProtocolTCP,
 				TargetPort: intstr.FromInt32(metricsPort),

--- a/pkg/component/gardener/controllermanager/service.go
+++ b/pkg/component/gardener/controllermanager/service.go
@@ -16,8 +16,13 @@ package controllermanager
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 const (
@@ -43,6 +48,11 @@ func (g *gardenerControllerManager) service() *corev1.Service {
 			}},
 		},
 	}
+
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(metricsPort)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}))
 
 	return service
 }

--- a/pkg/component/gardener/controllermanager/servicemonitor.go
+++ b/pkg/component/gardener/controllermanager/servicemonitor.go
@@ -1,0 +1,41 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllermanager
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+func (g *gardenerControllerManager) serviceMonitor() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: monitoringutils.ConfigObjectMeta(DeploymentName, g.namespace, garden.Label),
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: GetLabels()},
+			Endpoints: []monitoringv1.Endpoint{{
+				Port: portNameMetrics,
+				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+					"rest_client_.+",
+					"controller_runtime_.+",
+					"workqueue_.+",
+					"go_.+",
+				),
+			}},
+		},
+	}
+}

--- a/pkg/component/gardener/scheduler/scheduler.go
+++ b/pkg/component/gardener/scheduler/scheduler.go
@@ -107,6 +107,7 @@ func (g *gardenerScheduler) Deploy(ctx context.Context) error {
 		g.service(),
 		g.verticalPodAutoscaler(),
 		g.deployment(secretGenericTokenKubeconfig.Name, virtualGardenAccessSecret.Secret.Name, schedulerConfigConfigMap.Name),
+		g.serviceMonitor(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardener/scheduler/scheduler_test.go
+++ b/pkg/component/gardener/scheduler/scheduler_test.go
@@ -160,8 +160,9 @@ var _ = Describe("GardenerScheduler", func() {
 		}
 		serviceRuntime = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gardener-scheduler",
-				Namespace: namespace,
+				Name:        "gardener-scheduler",
+				Namespace:   namespace,
+				Annotations: map[string]string{"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":19251}]`},
 				Labels: map[string]string{
 					"app":  "gardener",
 					"role": "scheduler",

--- a/pkg/component/gardener/scheduler/service.go
+++ b/pkg/component/gardener/scheduler/service.go
@@ -16,8 +16,13 @@ package scheduler
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 const (
@@ -43,6 +48,11 @@ func (g *gardenerScheduler) service() *corev1.Service {
 			}},
 		},
 	}
+
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(metricsPort)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}))
 
 	return service
 }

--- a/pkg/component/gardener/scheduler/service.go
+++ b/pkg/component/gardener/scheduler/service.go
@@ -20,7 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const serviceName = DeploymentName
+const (
+	serviceName     = DeploymentName
+	portNameMetrics = "metrics"
+)
 
 func (g *gardenerScheduler) service() *corev1.Service {
 	service := &corev1.Service{
@@ -33,7 +36,7 @@ func (g *gardenerScheduler) service() *corev1.Service {
 			Type:     corev1.ServiceTypeClusterIP,
 			Selector: GetLabels(),
 			Ports: []corev1.ServicePort{{
-				Name:       "metrics",
+				Name:       portNameMetrics,
 				Port:       int32(metricsPort),
 				Protocol:   corev1.ProtocolTCP,
 				TargetPort: intstr.FromInt32(metricsPort),

--- a/pkg/component/gardener/scheduler/servicemonitor.go
+++ b/pkg/component/gardener/scheduler/servicemonitor.go
@@ -1,0 +1,41 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+func (g *gardenerScheduler) serviceMonitor() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: monitoringutils.ConfigObjectMeta(DeploymentName, g.namespace, garden.Label),
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: GetLabels()},
+			Endpoints: []monitoringv1.Endpoint{{
+				Port: portNameMetrics,
+				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+					"rest_client_.+",
+					"controller_runtime_.+",
+					"workqueue_.+",
+					"go_.+",
+				),
+			}},
+		},
+	}
+}

--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -415,6 +415,12 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		}
 	}
 
+	if k.values.NamePrefix != "" {
+		if err := k.reconcileServiceMonitor(ctx, k.emptyServiceMonitor()); err != nil {
+			return err
+		}
+	}
+
 	if !k.values.IsWorkerless {
 		data, err := k.computeShootResourcesData()
 		if err != nil {
@@ -439,6 +445,7 @@ func (k *kubeAPIServer) Destroy(ctx context.Context) error {
 		k.emptyServiceAccount(),
 		k.emptyRoleHAVPN(),
 		k.emptyRoleBindingHAVPN(),
+		k.emptyServiceMonitor(),
 	)
 }
 

--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -415,6 +415,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		}
 	}
 
+	// apiserver deployed for garden cluster
 	if k.values.NamePrefix != "" {
 		if err := k.reconcileServiceMonitor(ctx, k.emptyServiceMonitor()); err != nil {
 			return err

--- a/pkg/component/kubernetes/apiserver/servicemonitor.go
+++ b/pkg/component/kubernetes/apiserver/servicemonitor.go
@@ -1,0 +1,87 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"context"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+	"github.com/gardener/gardener/pkg/controllerutils"
+)
+
+func (k *kubeAPIServer) emptyServiceMonitor() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{ObjectMeta: monitoringutils.ConfigObjectMeta(k.values.NamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, k.namespace, garden.Label)}
+}
+
+func (k *kubeAPIServer) reconcileServiceMonitor(ctx context.Context, serviceMonitor *monitoringv1.ServiceMonitor) error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client.Client(), serviceMonitor, func() error {
+		serviceMonitor.Labels = monitoringutils.Labels(garden.Label)
+		serviceMonitor.Spec = monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: getLabels()},
+			Endpoints: []monitoringv1.Endpoint{{
+				TargetPort: ptr.To(intstr.FromInt32(kubeapiserverconstants.Port)),
+				Scheme:     "https",
+				TLSConfig:  &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: true}},
+				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: garden.AccessSecretName},
+					Key:                  resourcesv1alpha1.DataKeyToken,
+				}},
+				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+					"authentication_attempts",
+					"authenticated_user_requests",
+					"apiserver_admission_controller_admission_duration_seconds_.+",
+					"apiserver_admission_webhook_admission_duration_seconds_.+",
+					"apiserver_admission_step_admission_duration_seconds_.+",
+					"apiserver_admission_webhook_rejection_count",
+					"apiserver_audit_event_total",
+					"apiserver_audit_error_total",
+					"apiserver_audit_requests_rejected_total",
+					"apiserver_request_total",
+					"apiserver_latency_seconds",
+					"apiserver_current_inflight_requests",
+					"apiserver_current_inqueue_requests",
+					"apiserver_response_sizes_.+",
+					"apiserver_request_duration_seconds_.+",
+					"apiserver_request_terminations_total",
+					"apiserver_storage_objects",
+					"apiserver_storage_transformation_duration_seconds_.+",
+					"apiserver_storage_transformation_operations_total",
+					"apiserver_registered_watchers",
+					"apiserver_init_events_total",
+					"apiserver_watch_events_sizes_.+",
+					"apiserver_watch_events_total",
+					"etcd_db_total_size_in_bytes",
+					"etcd_request_duration_seconds_.+",
+					"watch_cache_capacity_increase_total",
+					"watch_cache_capacity_decrease_total",
+					"watch_cache_capacity",
+					"go_.+",
+				),
+			}},
+		}
+		return nil
+	})
+	return err
+}

--- a/pkg/component/kubernetes/apiserverexposure/service_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/service_test.go
@@ -221,9 +221,9 @@ var _ = Describe("#Service", func() {
 				expected.Annotations = map[string]string{
 					"foo":                          "bar",
 					"networking.istio.io/exportTo": "*",
-					"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
-					"networking.resources.gardener.cloud/namespace-selectors":                   `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
-					"service.kubernetes.io/topology-aware-hints":                                "auto",
+					"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
+					"networking.resources.gardener.cloud/namespace-selectors":                          `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
+					"service.kubernetes.io/topology-aware-hints":                                       "auto",
 				}
 				expected.Labels = map[string]string{
 					"app": "kubernetes",
@@ -286,8 +286,8 @@ var _ = Describe("#Service", func() {
 
 func netpolAnnotations() map[string]string {
 	return map[string]string{
-		"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
-		"networking.resources.gardener.cloud/namespace-selectors":                   `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
+		"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
+		"networking.resources.gardener.cloud/namespace-selectors":                          `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
 	}
 }
 

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -308,8 +308,10 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		}
 
 		if k.values.NamePrefix != "" {
+			// controller-manager deployed for garden cluster
 			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, networkPolicyPort))
 		} else {
+			// controller-manager deployed for shoot cluster
 			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, networkPolicyPort))
 		}
 
@@ -584,6 +586,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		}
 	}
 
+	// controller-manager deployed for garden cluster
 	if k.values.NamePrefix != "" {
 		serviceMonitor := k.emptyServiceMonitor()
 		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.seedClient.Client(), serviceMonitor, func() error {

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -902,10 +902,21 @@ namespace: kube-system
 				)
 			})
 
+			It("should deploy the expected Service", func() {
+				Expect(kubeControllerManager.Deploy(ctx)).To(Succeed())
+
+				service.Name = "virtual-garden-kube-controller-manager"
+				service.Annotations = map[string]string{"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":10257}]`}
+
+				actualService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: namespace}}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(actualService), actualService)).To(Succeed())
+				Expect(actualService).To(DeepEqual(service))
+			})
+
 			It("should deploy the expected ServiceMonitor", func() {
 				Expect(kubeControllerManager.Deploy(ctx)).To(Succeed())
 
-				actualServiceMonitor := &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "garden-virtual-garden-kube-controller-manager", Namespace: namespace}}
+				actualServiceMonitor := &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: serviceMonitor.Name, Namespace: namespace}}
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(actualServiceMonitor), actualServiceMonitor)).To(Succeed())
 				Expect(actualServiceMonitor).To(DeepEqual(serviceMonitor))
 			})

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
@@ -181,8 +182,7 @@ var _ = Describe("KubeControllerManager", func() {
 			Type: corev1.SecretTypeOpaque,
 		}
 
-		pdbMaxUnavailable = intstr.FromInt32(1)
-		pdbFor            = func(runtimeKubernetesVersionGreaterEquals126 bool) *policyv1.PodDisruptionBudget {
+		pdbFor = func(runtimeKubernetesVersionGreaterEquals126 bool) *policyv1.PodDisruptionBudget {
 			pdb := &policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pdbName,
@@ -194,7 +194,7 @@ var _ = Describe("KubeControllerManager", func() {
 					ResourceVersion: "1",
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
-					MaxUnavailable: &pdbMaxUnavailable,
+					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app":  "kubernetes",
@@ -212,8 +212,7 @@ var _ = Describe("KubeControllerManager", func() {
 			return pdb
 		}
 
-		hvpaUpdateModeAuto = hvpav1alpha1.UpdateModeAuto
-		hvpaFor            = func(config *HVPAConfig) *hvpav1alpha1.Hvpa {
+		hvpaFor = func(config *HVPAConfig) *hvpav1alpha1.Hvpa {
 			scaleDownUpdateMode := config.ScaleDownUpdateMode
 			if scaleDownUpdateMode == nil {
 				scaleDownUpdateMode = ptr.To(hvpav1alpha1.UpdateModeAuto)
@@ -260,7 +259,7 @@ var _ = Describe("KubeControllerManager", func() {
 						Deploy: true,
 						ScaleUp: hvpav1alpha1.ScaleType{
 							UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-								UpdateMode: &hvpaUpdateModeAuto,
+								UpdateMode: ptr.To(hvpav1alpha1.UpdateModeAuto),
 							},
 						},
 						ScaleDown: hvpav1alpha1.ScaleType{
@@ -334,6 +333,36 @@ var _ = Describe("KubeControllerManager", func() {
 						Port:     10257,
 					},
 				},
+			},
+		}
+
+		serviceMonitor = &monitoringv1.ServiceMonitor{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "garden-virtual-garden-kube-controller-manager",
+				Namespace:       namespace,
+				Labels:          map[string]string{"prometheus": "garden"},
+				ResourceVersion: "1",
+			},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "kubernetes", "role": "controller-manager"}},
+				Endpoints: []monitoringv1.Endpoint{{
+					Port:      "metrics",
+					Scheme:    "https",
+					TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: true}},
+					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-garden"},
+						Key:                  "token",
+					}},
+					RelabelConfigs: []*monitoringv1.RelabelConfig{{
+						Action: "labelmap",
+						Regex:  `__meta_kubernetes_service_label_(.+)`,
+					}},
+					MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+						SourceLabels: []monitoringv1.LabelName{"__name__"},
+						Action:       "keep",
+						Regex:        `^(rest_client_requests_total|process_max_fds|process_open_fds)$`,
+					}},
+				}},
 			},
 		}
 
@@ -849,6 +878,38 @@ namespace: kube-system
 				"--controllers=*,bootstrapsigner,tokencleaner,-clusterrole-aggregation,-endpointslice,-endpointslicemirroring,-resource-claim-controller,-storage-version-gc",
 			),
 		)
+
+		Context("when name prefix is set", func() {
+			BeforeEach(func() {
+				values = Values{
+					RuntimeVersion:    runtimeKubernetesVersion,
+					TargetVersion:     semverVersion,
+					Image:             image,
+					Config:            &kcmConfig,
+					PriorityClassName: priorityClassName,
+					HVPAConfig:        hvpaConfigDisabled,
+					IsWorkerless:      isWorkerless,
+					PodNetwork:        podCIDR,
+					ServiceNetwork:    serviceCIDR,
+					NamePrefix:        "virtual-garden-",
+				}
+				kubeControllerManager = New(
+					testLogger,
+					fakeInterface,
+					namespace,
+					sm,
+					values,
+				)
+			})
+
+			It("should deploy the expected ServiceMonitor", func() {
+				Expect(kubeControllerManager.Deploy(ctx)).To(Succeed())
+
+				actualServiceMonitor := &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "garden-virtual-garden-kube-controller-manager", Namespace: namespace}}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(actualServiceMonitor), actualServiceMonitor)).To(Succeed())
+				Expect(actualServiceMonitor).To(DeepEqual(serviceMonitor))
+			})
+		})
 	})
 
 	Describe("#Destroy", func() {
@@ -858,6 +919,7 @@ namespace: kube-system
 			vpa := &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: vpaName, Namespace: namespace}}
 			hvpa := &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: namespace}}
 			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace}}
+			serviceMonitor := &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "garden-kube-controller-manager", Namespace: namespace}}
 			pdb := &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: pdbName, Namespace: namespace}}
 			deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-controller-manager", Namespace: namespace}}
 			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace}}
@@ -866,6 +928,7 @@ namespace: kube-system
 			Expect(c.Create(ctx, vpa)).To(Succeed())
 			Expect(c.Create(ctx, hvpa)).To(Succeed())
 			Expect(c.Create(ctx, service)).To(Succeed())
+			Expect(c.Create(ctx, serviceMonitor)).To(Succeed())
 			Expect(c.Create(ctx, deploy)).To(Succeed())
 			Expect(c.Create(ctx, pdb)).To(Succeed())
 			Expect(c.Create(ctx, secret)).To(Succeed())
@@ -885,6 +948,7 @@ namespace: kube-system
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(vpa), vpa)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(hvpa), hvpa)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(service), service)).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(serviceMonitor), serviceMonitor)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(pdb), pdb)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(BeNotFoundError())

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -148,8 +148,9 @@ var _ = Describe("Alertmanager", func() {
 					"alertmanager": name,
 				},
 				Annotations: map[string]string{
-					"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":9093}]`,
-					"networking.resources.gardener.cloud/namespace-selectors":                        `[{"matchLabels":{"gardener.cloud/role":"shoot"}}]`,
+					"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":9093}]`,
+					"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports":   `[{"protocol":"TCP","port":9093}]`,
+					"networking.resources.gardener.cloud/namespace-selectors":                          `[{"matchLabels":{"gardener.cloud/role":"shoot"}}]`,
 				},
 			},
 			Spec: corev1.ServiceSpec{

--- a/pkg/component/observability/monitoring/alertmanager/component.go
+++ b/pkg/component/observability/monitoring/alertmanager/component.go
@@ -41,9 +41,9 @@ const (
 // Interface contains functions for an alertmanager deployer.
 type Interface interface {
 	component.DeployWaiter
-	// SetIngressAuthSecret sets the ingress auth secret name.
+	// SetIngressAuthSecret sets the ingress authentication secret name.
 	SetIngressAuthSecret(*corev1.Secret)
-	// SetIngressWildcardCertSecret sets the ingress wildcard cert secret name.
+	// SetIngressWildcardCertSecret sets the ingress wildcard certificate secret name.
 	SetIngressWildcardCertSecret(*corev1.Secret)
 }
 

--- a/pkg/component/observability/monitoring/alertmanager/component.go
+++ b/pkg/component/observability/monitoring/alertmanager/component.go
@@ -205,9 +205,14 @@ func (a *alertManager) name() string {
 }
 
 func (a *alertManager) getLabels() map[string]string {
+	return GetLabels(a.values.Name)
+}
+
+// GetLabels returns the labels for the given name.
+func GetLabels(name string) map[string]string {
 	return map[string]string{
 		"component":                "alertmanager",
 		v1beta1constants.LabelRole: v1beta1constants.LabelMonitoring,
-		"alertmanager":             a.values.Name,
+		"alertmanager":             name,
 	}
 }

--- a/pkg/component/observability/monitoring/alertmanager/service.go
+++ b/pkg/component/observability/monitoring/alertmanager/service.go
@@ -18,12 +18,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
-	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -44,21 +44,21 @@ func (a *alertManager) service() *corev1.Service {
 		},
 	}
 
+	networkPolicyPort := networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(port)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}
+
 	switch a.values.ClusterType {
 	case component.ClusterTypeSeed:
-		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, networkingv1.NetworkPolicyPort{
-			Port:     utils.IntStrPtrFromInt32(port),
-			Protocol: ptr.To(corev1.ProtocolTCP),
-		}))
+		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, networkPolicyPort))
+		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, networkPolicyPort))
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyNamespaceSelectors(service, metav1.LabelSelector{MatchLabels: map[string]string{
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot,
 		}}))
 
 	case component.ClusterTypeShoot:
-		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, networkingv1.NetworkPolicyPort{
-			Port:     utils.IntStrPtrFromInt32(port),
-			Protocol: ptr.To(corev1.ProtocolTCP),
-		}))
+		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, networkPolicyPort))
 	}
 
 	return service

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
@@ -219,7 +219,9 @@ spec:
 			if clusterType == component.ClusterTypeSeed {
 				out += `
         - mountPath: /var/run/secrets/blackbox_exporter/cluster-access
-          name: cluster-access`
+          name: cluster-access
+        - mountPath: /var/run/secrets/blackbox_exporter/gardener-ca
+          name: gardener-ca`
 			}
 
 			out += `
@@ -258,7 +260,10 @@ spec:
               - key: token
                 path: token
               name: shoot-access-prometheus-garden
-              optional: false`
+              optional: false
+      - name: gardener-ca
+        secret:
+          secretName: ca-gardener`
 			}
 
 			out += `
@@ -416,6 +421,7 @@ status: {}
 
 			By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
 			Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: namespace}})).To(Succeed())
+			Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-gardener", Namespace: namespace}})).To(Succeed())
 		})
 
 		Describe("#Deploy", func() {

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
@@ -1,0 +1,68 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden
+
+import (
+	"time"
+
+	blackboxexporterconfig "github.com/prometheus/blackbox_exporter/config"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+)
+
+const (
+	http2xxModuleName              = "http_2xx"
+	httpAPIServerModuleName        = "http_apiserver"
+	httpAPIServerRootCAsModuleName = "http_apiserver_root_cas"
+)
+
+// Config returns the blackbox-exporter config for the garden use-case.
+func Config() blackboxexporterconfig.Config {
+	var (
+		defaultModuleConfig = func() blackboxexporterconfig.Module {
+			return blackboxexporterconfig.Module{
+				Prober:  "http",
+				Timeout: 10 * time.Second,
+				HTTP: blackboxexporterconfig.HTTPProbe{
+					Headers: map[string]string{
+						"Accept":          "*/*",
+						"Accept-Language": "en-US",
+					},
+					IPProtocol: "ipv4",
+				},
+			}
+		}
+
+		http2xxModule              = defaultModuleConfig()
+		httpAPIServerModule        = defaultModuleConfig()
+		httpAPIServerRootCAsModule = defaultModuleConfig()
+
+		pathCABundle = blackboxexporter.VolumeMountPathClusterAccess + "/" + secretsutils.DataKeyCertificateBundle
+		pathToken    = blackboxexporter.VolumeMountPathClusterAccess + "/" + resourcesv1alpha1.DataKeyToken
+	)
+
+	http2xxModule.HTTP.HTTPClientConfig.TLSConfig.InsecureSkipVerify = true
+	httpAPIServerModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathCABundle
+	httpAPIServerModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
+	httpAPIServerRootCAsModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
+
+	return blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
+		http2xxModuleName:              http2xxModule,
+		httpAPIServerModuleName:        httpAPIServerModule,
+		httpAPIServerRootCAsModuleName: httpAPIServerRootCAsModule,
+	}}
+}

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	http2xxModuleName              = "http_2xx"
-	httpAPIServerModuleName        = "http_apiserver"
-	httpAPIServerRootCAsModuleName = "http_apiserver_root_cas"
+	httpGardenerAPIServerModuleName    = "http_gardener_apiserver"
+	httpKubeAPIServerModuleName        = "http_kube_apiserver"
+	httpKubeAPIServerRootCAsModuleName = "http_kube_apiserver_root_cas"
 )
 
 // Config returns the blackbox-exporter config for the garden use-case.
@@ -47,22 +47,23 @@ func Config() blackboxexporterconfig.Config {
 			}
 		}
 
-		http2xxModule              = defaultModuleConfig()
-		httpAPIServerModule        = defaultModuleConfig()
-		httpAPIServerRootCAsModule = defaultModuleConfig()
+		httpGardenerAPIServerModule    = defaultModuleConfig()
+		httpKubeAPIServerModule        = defaultModuleConfig()
+		httpKubeAPIServerRootCAsModule = defaultModuleConfig()
 
-		pathCABundle = blackboxexporter.VolumeMountPathClusterAccess + "/" + secretsutils.DataKeyCertificateBundle
-		pathToken    = blackboxexporter.VolumeMountPathClusterAccess + "/" + resourcesv1alpha1.DataKeyToken
+		pathGardenerAPIServerCABundle = blackboxexporter.VolumeMountPathGardenerCA + "/" + secretsutils.DataKeyCertificateBundle
+		pathKubeAPIServerCABundle     = blackboxexporter.VolumeMountPathClusterAccess + "/" + secretsutils.DataKeyCertificateBundle
+		pathToken                     = blackboxexporter.VolumeMountPathClusterAccess + "/" + resourcesv1alpha1.DataKeyToken
 	)
 
-	http2xxModule.HTTP.HTTPClientConfig.TLSConfig.InsecureSkipVerify = true
-	httpAPIServerModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathCABundle
-	httpAPIServerModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
-	httpAPIServerRootCAsModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
+	httpGardenerAPIServerModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathGardenerAPIServerCABundle
+	httpKubeAPIServerModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathKubeAPIServerCABundle
+	httpKubeAPIServerModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
+	httpKubeAPIServerRootCAsModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
 
 	return blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
-		http2xxModuleName:              http2xxModule,
-		httpAPIServerModuleName:        httpAPIServerModule,
-		httpAPIServerRootCAsModuleName: httpAPIServerRootCAsModule,
+		httpGardenerAPIServerModuleName:    httpGardenerAPIServerModule,
+		httpKubeAPIServerModuleName:        httpKubeAPIServerModule,
+		httpKubeAPIServerRootCAsModuleName: httpKubeAPIServerRootCAsModule,
 	}}
 }

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Config", func() {
 	Describe("#Config", func() {
 		It("should return the expected config for the garden's blackbox-exporter", func() {
 			Expect(Config()).To(Equal(blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
-				"http_2xx": {
+				"http_gardener_apiserver": {
 					Prober:  "http",
 					Timeout: 10 * time.Second,
 					HTTP: blackboxexporterconfig.HTTPProbe{
@@ -38,12 +38,12 @@ var _ = Describe("Config", func() {
 							"Accept-Language": "en-US",
 						},
 						HTTPClientConfig: prometheuscommonconfig.HTTPClientConfig{
-							TLSConfig: prometheuscommonconfig.TLSConfig{InsecureSkipVerify: true},
+							TLSConfig: prometheuscommonconfig.TLSConfig{CAFile: "/var/run/secrets/blackbox_exporter/gardener-ca/bundle.crt"},
 						},
 						IPProtocol: "ipv4",
 					},
 				},
-				"http_apiserver": {
+				"http_kube_apiserver": {
 					Prober:  "http",
 					Timeout: 10 * time.Second,
 					HTTP: blackboxexporterconfig.HTTPProbe{
@@ -58,7 +58,7 @@ var _ = Describe("Config", func() {
 						IPProtocol: "ipv4",
 					},
 				},
-				"http_apiserver_root_cas": {
+				"http_kube_apiserver_root_cas": {
 					Prober:  "http",
 					Timeout: 10 * time.Second,
 					HTTP: blackboxexporterconfig.HTTPProbe{

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config_test.go
@@ -1,0 +1,78 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	blackboxexporterconfig "github.com/prometheus/blackbox_exporter/config"
+	prometheuscommonconfig "github.com/prometheus/common/config"
+
+	. "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/garden"
+)
+
+var _ = Describe("Config", func() {
+	Describe("#Config", func() {
+		It("should return the expected config for the garden's blackbox-exporter", func() {
+			Expect(Config()).To(Equal(blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
+				"http_2xx": {
+					Prober:  "http",
+					Timeout: 10 * time.Second,
+					HTTP: blackboxexporterconfig.HTTPProbe{
+						Headers: map[string]string{
+							"Accept":          "*/*",
+							"Accept-Language": "en-US",
+						},
+						HTTPClientConfig: prometheuscommonconfig.HTTPClientConfig{
+							TLSConfig: prometheuscommonconfig.TLSConfig{InsecureSkipVerify: true},
+						},
+						IPProtocol: "ipv4",
+					},
+				},
+				"http_apiserver": {
+					Prober:  "http",
+					Timeout: 10 * time.Second,
+					HTTP: blackboxexporterconfig.HTTPProbe{
+						Headers: map[string]string{
+							"Accept":          "*/*",
+							"Accept-Language": "en-US",
+						},
+						HTTPClientConfig: prometheuscommonconfig.HTTPClientConfig{
+							TLSConfig:       prometheuscommonconfig.TLSConfig{CAFile: "/var/run/secrets/blackbox_exporter/cluster-access/bundle.crt"},
+							BearerTokenFile: "/var/run/secrets/blackbox_exporter/cluster-access/token",
+						},
+						IPProtocol: "ipv4",
+					},
+				},
+				"http_apiserver_root_cas": {
+					Prober:  "http",
+					Timeout: 10 * time.Second,
+					HTTP: blackboxexporterconfig.HTTPProbe{
+						Headers: map[string]string{
+							"Accept":          "*/*",
+							"Accept-Language": "en-US",
+						},
+						HTTPClientConfig: prometheuscommonconfig.HTTPClientConfig{
+							BearerTokenFile: "/var/run/secrets/blackbox_exporter/cluster-access/token",
+						},
+						IPProtocol: "ipv4",
+					},
+				},
+			}}))
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/garden_suite_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/garden_suite_test.go
@@ -12,23 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package garden_test
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
 
-	"github.com/gardener/gardener/imagevector"
-	"github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter"
-	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-// NewBlackboxExporter creates a new blackbox-exporter deployer.
-func NewBlackboxExporter(c client.Client, secretsManager secretsmanager.Interface, namespace string, values blackboxexporter.Values) (blackboxexporter.Interface, error) {
-	image, err := imagevector.ImageVector().FindImage(imagevector.ImageNameBlackboxExporter)
-	if err != nil {
-		return nil, err
-	}
-	values.Image = image.String()
-
-	return blackboxexporter.New(c, secretsManager, namespace, values), nil
+func TestGarden(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Observability Monitoring BlackboxExporter Garden Suite")
 }

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/scrapeconfig.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/scrapeconfig.go
@@ -75,8 +75,8 @@ func ScrapeConfig(namespace string, kubeAPIServerTargets []monitoringv1alpha1.Ta
 	}
 
 	var (
-		gardenerAPIServerScrapeConfig = defaultScrapeConfig("gardener-apiserver", http2xxModuleName, []monitoringv1alpha1.Target{"https://gardener-apiserver.garden.svc/healthz"})
-		kubeAPIServerScrapeConfig     = defaultScrapeConfig("apiserver", httpAPIServerModuleName, kubeAPIServerTargets)
+		gardenerAPIServerScrapeConfig = defaultScrapeConfig("gardener-apiserver", httpGardenerAPIServerModuleName, []monitoringv1alpha1.Target{"https://gardener-apiserver.garden.svc/healthz"})
+		kubeAPIServerScrapeConfig     = defaultScrapeConfig("apiserver", httpKubeAPIServerModuleName, kubeAPIServerTargets)
 	)
 
 	kubeAPIServerScrapeConfig.Spec.RelabelConfigs = append([]*monitoringv1.RelabelConfig{{
@@ -84,7 +84,7 @@ func ScrapeConfig(namespace string, kubeAPIServerTargets []monitoringv1alpha1.Ta
 		Separator:    ptr.To(";"),
 		Regex:        `https://api\..*`,
 		TargetLabel:  "__param_module",
-		Replacement:  httpAPIServerRootCAsModuleName,
+		Replacement:  httpKubeAPIServerRootCAsModuleName,
 		Action:       "replace",
 	}}, kubeAPIServerScrapeConfig.Spec.RelabelConfigs...)
 

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/scrapeconfig.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/scrapeconfig.go
@@ -1,0 +1,92 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"k8s.io/utils/ptr"
+
+	gardenprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+// ScrapeConfig returns the scrape configs related to the blackbox-exporter for the garden use-case.
+func ScrapeConfig(namespace string, kubeAPIServerTargets []monitoringv1alpha1.Target) []*monitoringv1alpha1.ScrapeConfig {
+	defaultScrapeConfig := func(name, module string, targets []monitoringv1alpha1.Target) *monitoringv1alpha1.ScrapeConfig {
+		return &monitoringv1alpha1.ScrapeConfig{
+			ObjectMeta: monitoringutils.ConfigObjectMeta("blackbox-"+name, namespace, gardenprometheus.Label),
+			Spec: monitoringv1alpha1.ScrapeConfigSpec{
+				Params:      map[string][]string{"module": {module}},
+				MetricsPath: ptr.To("/probe"),
+				StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+					Targets: targets,
+					Labels:  map[monitoringv1.LabelName]string{"purpose": "availability"},
+				}},
+				RelabelConfigs: []*monitoringv1.RelabelConfig{
+					{
+						SourceLabels: []monitoringv1.LabelName{"__address__"},
+						Separator:    ptr.To(";"),
+						Regex:        `(.*)`,
+						TargetLabel:  "__param_target",
+						Replacement:  `$1`,
+						Action:       "replace",
+					},
+					{
+						SourceLabels: []monitoringv1.LabelName{"__param_target"},
+						Separator:    ptr.To(";"),
+						Regex:        `(.*)`,
+						TargetLabel:  "instance",
+						Replacement:  `$1`,
+						Action:       "replace",
+					},
+					{
+						Separator:   ptr.To(";"),
+						Regex:       `(.*)`,
+						TargetLabel: "__address__",
+						Replacement: "blackbox-exporter:9115",
+						Action:      "replace",
+					},
+					{
+						Action:      "replace",
+						Replacement: "blackbox-" + name,
+						TargetLabel: "job",
+					},
+				},
+				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+					"probe_success",
+					"probe_http_status_code",
+					"probe_http_duration_seconds",
+				),
+			},
+		}
+	}
+
+	var (
+		gardenerAPIServerScrapeConfig = defaultScrapeConfig("gardener-apiserver", http2xxModuleName, []monitoringv1alpha1.Target{"https://gardener-apiserver.garden.svc/healthz"})
+		kubeAPIServerScrapeConfig     = defaultScrapeConfig("apiserver", httpAPIServerModuleName, kubeAPIServerTargets)
+	)
+
+	kubeAPIServerScrapeConfig.Spec.RelabelConfigs = append([]*monitoringv1.RelabelConfig{{
+		SourceLabels: []monitoringv1.LabelName{"__address__"},
+		Separator:    ptr.To(";"),
+		Regex:        `https://api\..*`,
+		TargetLabel:  "__param_module",
+		Replacement:  httpAPIServerRootCAsModuleName,
+		Action:       "replace",
+	}}, kubeAPIServerScrapeConfig.Spec.RelabelConfigs...)
+
+	return []*monitoringv1alpha1.ScrapeConfig{gardenerAPIServerScrapeConfig, kubeAPIServerScrapeConfig}
+}

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/scrapeconfig_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/scrapeconfig_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ScrapeConfig", func() {
 						Labels:    map[string]string{"prometheus": "garden"},
 					},
 					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						Params:      map[string][]string{"module": {"http_2xx"}},
+						Params:      map[string][]string{"module": {"http_gardener_apiserver"}},
 						MetricsPath: ptr.To("/probe"),
 						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
 							Targets: []monitoringv1alpha1.Target{"https://gardener-apiserver.garden.svc/healthz"},
@@ -91,7 +91,7 @@ var _ = Describe("ScrapeConfig", func() {
 						Labels:    map[string]string{"prometheus": "garden"},
 					},
 					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						Params:      map[string][]string{"module": {"http_apiserver"}},
+						Params:      map[string][]string{"module": {"http_kube_apiserver"}},
 						MetricsPath: ptr.To("/probe"),
 						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
 							Targets: kubeAPIServerTargets,
@@ -103,7 +103,7 @@ var _ = Describe("ScrapeConfig", func() {
 								Separator:    ptr.To(";"),
 								Regex:        `https://api\..*`,
 								TargetLabel:  "__param_module",
-								Replacement:  "http_apiserver_root_cas",
+								Replacement:  "http_kube_apiserver_root_cas",
 								Action:       "replace",
 							},
 							{

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/scrapeconfig_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/scrapeconfig_test.go
@@ -1,0 +1,148 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/garden"
+)
+
+var _ = Describe("ScrapeConfig", func() {
+	Describe("#ScrapeConfig", func() {
+		var (
+			namespace            = "namespace"
+			kubeAPIServerTargets = []monitoringv1alpha1.Target{"target1", "target2"}
+		)
+
+		It("should compute the scrape config for {gardener,kube}-apiserver", func() {
+			Expect(ScrapeConfig(namespace, kubeAPIServerTargets)).To(ContainElements(
+				&monitoringv1alpha1.ScrapeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "garden-blackbox-gardener-apiserver",
+						Namespace: namespace,
+						Labels:    map[string]string{"prometheus": "garden"},
+					},
+					Spec: monitoringv1alpha1.ScrapeConfigSpec{
+						Params:      map[string][]string{"module": {"http_2xx"}},
+						MetricsPath: ptr.To("/probe"),
+						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+							Targets: []monitoringv1alpha1.Target{"https://gardener-apiserver.garden.svc/healthz"},
+							Labels:  map[monitoringv1.LabelName]string{"purpose": "availability"},
+						}},
+						RelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__address__"},
+								Separator:    ptr.To(";"),
+								Regex:        `(.*)`,
+								TargetLabel:  "__param_target",
+								Replacement:  `$1`,
+								Action:       "replace",
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__param_target"},
+								Separator:    ptr.To(";"),
+								Regex:        `(.*)`,
+								TargetLabel:  "instance",
+								Replacement:  `$1`,
+								Action:       "replace",
+							},
+							{
+								Separator:   ptr.To(";"),
+								Regex:       `(.*)`,
+								TargetLabel: "__address__",
+								Replacement: "blackbox-exporter:9115",
+								Action:      "replace",
+							},
+							{
+								Action:      "replace",
+								Replacement: "blackbox-gardener-apiserver",
+								TargetLabel: "job",
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+							SourceLabels: []monitoringv1.LabelName{"__name__"},
+							Action:       "keep",
+							Regex:        `^(probe_success|probe_http_status_code|probe_http_duration_seconds)$`,
+						}},
+					},
+				},
+				&monitoringv1alpha1.ScrapeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "garden-blackbox-apiserver",
+						Namespace: namespace,
+						Labels:    map[string]string{"prometheus": "garden"},
+					},
+					Spec: monitoringv1alpha1.ScrapeConfigSpec{
+						Params:      map[string][]string{"module": {"http_apiserver"}},
+						MetricsPath: ptr.To("/probe"),
+						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+							Targets: kubeAPIServerTargets,
+							Labels:  map[monitoringv1.LabelName]string{"purpose": "availability"},
+						}},
+						RelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__address__"},
+								Separator:    ptr.To(";"),
+								Regex:        `https://api\..*`,
+								TargetLabel:  "__param_module",
+								Replacement:  "http_apiserver_root_cas",
+								Action:       "replace",
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__address__"},
+								Separator:    ptr.To(";"),
+								Regex:        `(.*)`,
+								TargetLabel:  "__param_target",
+								Replacement:  `$1`,
+								Action:       "replace",
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__param_target"},
+								Separator:    ptr.To(";"),
+								Regex:        `(.*)`,
+								TargetLabel:  "instance",
+								Replacement:  `$1`,
+								Action:       "replace",
+							},
+							{
+								Separator:   ptr.To(";"),
+								Regex:       `(.*)`,
+								TargetLabel: "__address__",
+								Replacement: "blackbox-exporter:9115",
+								Action:      "replace",
+							},
+							{
+								Action:      "replace",
+								Replacement: "blackbox-apiserver",
+								TargetLabel: "job",
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+							SourceLabels: []monitoringv1.LabelName{"__name__"},
+							Action:       "keep",
+							Regex:        `^(probe_success|probe_http_status_code|probe_http_duration_seconds)$`,
+						}},
+					},
+				},
+			))
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/blackboxexporter/monitoring_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/monitoring_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Monitoring", func() {
 	var component component.MonitoringComponent
 
 	BeforeEach(func() {
-		component = New(nil, "", Values{})
+		component = New(nil, nil, "", Values{})
 	})
 
 	It("should successfully test the scrape config", func() {

--- a/pkg/component/observability/monitoring/blackboxexporter/shoot/config.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/shoot/config.go
@@ -1,0 +1,43 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"time"
+
+	blackboxexporterconfig "github.com/prometheus/blackbox_exporter/config"
+	prometheuscommonconfig "github.com/prometheus/common/config"
+)
+
+// Config returns the blackbox-exporter config for the shoot use-case.
+func Config() blackboxexporterconfig.Config {
+	return blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
+		"http_kubernetes_service": {
+			Prober:  "http",
+			Timeout: 10 * time.Second,
+			HTTP: blackboxexporterconfig.HTTPProbe{
+				Headers: map[string]string{
+					"Accept":          "*/*",
+					"Accept-Language": "en-US",
+				},
+				HTTPClientConfig: prometheuscommonconfig.HTTPClientConfig{
+					TLSConfig:       prometheuscommonconfig.TLSConfig{CAFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+					BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+				},
+				IPProtocol: "ipv4",
+			},
+		},
+	}}
+}

--- a/pkg/component/observability/monitoring/blackboxexporter/shoot/config_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/shoot/config_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	blackboxexporterconfig "github.com/prometheus/blackbox_exporter/config"
+	prometheuscommonconfig "github.com/prometheus/common/config"
+
+	. "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/shoot"
+)
+
+var _ = Describe("Config", func() {
+	Describe("#Config", func() {
+		It("should return the expected config for the shoot's blackbox-exporter", func() {
+			Expect(Config()).To(Equal(blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
+				"http_kubernetes_service": {
+					Prober:  "http",
+					Timeout: 10 * time.Second,
+					HTTP: blackboxexporterconfig.HTTPProbe{
+						Headers: map[string]string{
+							"Accept":          "*/*",
+							"Accept-Language": "en-US",
+						},
+						HTTPClientConfig: prometheuscommonconfig.HTTPClientConfig{
+							TLSConfig:       prometheuscommonconfig.TLSConfig{CAFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						},
+						IPProtocol: "ipv4",
+					},
+				},
+			}}))
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/blackboxexporter/shoot/shoot_suite_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/shoot/shoot_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Observability Monitoring BlackboxExporter Shoot Suite")
+}

--- a/pkg/component/observability/monitoring/component.go
+++ b/pkg/component/observability/monitoring/component.go
@@ -36,7 +36,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
-	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/utils"
@@ -202,9 +201,9 @@ func (m *monitoring) Deploy(ctx context.Context) error {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCD)
 	}
 
-	etcdClientSecret, found := m.secretsManager.Get(etcd.SecretNameClient)
+	etcdClientSecret, found := m.secretsManager.Get("etcd-client")
 	if !found {
-		return fmt.Errorf("secret %q not found", etcd.SecretNameClient)
+		return fmt.Errorf("secret %q not found", "etcd-client")
 	}
 
 	var (

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter.go
@@ -94,6 +94,7 @@ func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error {
 	runtimeResources, err := runtimeRegistry.AddAllAndSerialize(
 		g.deployment(secretGenericTokenKubeconfig.Name, virtualGardenAccessSecret.Secret.Name),
 		g.service(),
+		g.serviceMonitor(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -69,6 +70,7 @@ var _ = Describe("GardenerMetricsExporter", func() {
 		managedResourceSecretVirtual *corev1.Secret
 
 		serviceRuntime *corev1.Service
+		serviceMonitor *monitoringv1.ServiceMonitor
 
 		clusterRole        *rbacv1.ClusterRole
 		clusterRoleBinding *rbacv1.ClusterRoleBinding
@@ -133,6 +135,24 @@ var _ = Describe("GardenerMetricsExporter", func() {
 					Port:       2718,
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromInt32(2718),
+				}},
+			},
+		}
+		serviceMonitor = &monitoringv1.ServiceMonitor{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "garden-gardener-metrics-exporter",
+				Namespace: namespace,
+				Labels:    map[string]string{"prometheus": "garden"},
+			},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "gardener", "role": "metrics-exporter"}},
+				Endpoints: []monitoringv1.Endpoint{{
+					TargetPort: ptr.To(intstr.FromInt32(2718)),
+					MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+						SourceLabels: []monitoringv1.LabelName{"__name__"},
+						Action:       "keep",
+						Regex:        `^(garden_projects_status|garden_users_total|garden_shoot_info|garden_shoot_condition|garden_shoot_node_info|garden_shoot_operation_states|garden_shoot_node_max_total|garden_shoot_node_min_total|garden_shoot_response_duration_milliseconds|garden_shoot_operations_total|garden_shoots_hibernation_enabled_total|garden_shoots_hibernation_schedule_total|garden_shoot_hibernated|garden_shoots_custom_addon_kubedashboard_total|garden_shoots_custom_addon_nginxingress_total|garden_shoots_custom_apiserver_auditpolicy_total|garden_shoots_custom_apiserver_basicauth_total|garden_shoots_custom_apiserver_featuregates_total|garden_shoots_custom_apiserver_oidcconfig_total|garden_shoots_custom_extensions_total|garden_shoots_custom_kcm_horizontalpodautoscale_total|garden_shoots_custom_kcm_nodecidrmasksize_total|garden_shoots_custom_kubelet_podpidlimit_total|garden_shoots_custom_network_customdomain_total|garden_shoots_custom_privileged_containers_total|garden_shoots_custom_proxy_mode_total|garden_shoots_custom_worker_annotations_total|garden_shoots_custom_worker_multiplepools_total|garden_shoots_custom_worker_multizones_total|garden_shoots_custom_worker_taints_total|garden_seed_info|garden_seed_condition|garden_seed_capacity|garden_seed_usage)$`,
+					}},
 				}},
 			},
 		}
@@ -242,7 +262,11 @@ var _ = Describe("GardenerMetricsExporter", func() {
 				}
 				utilruntime.Must(references.InjectAnnotations(expectedRuntimeMr))
 				Expect(managedResourceRuntime).To(Equal(expectedRuntimeMr))
-				Expect(managedResourceRuntime).To(consistOf(serviceRuntime, deployment(namespace, values)))
+				Expect(managedResourceRuntime).To(consistOf(
+					serviceRuntime,
+					deployment(namespace, values),
+					serviceMonitor,
+				))
 
 				managedResourceSecretRuntime.Name = managedResourceRuntime.Spec.SecretRefs[0].Name
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -117,8 +117,9 @@ var _ = Describe("GardenerMetricsExporter", func() {
 		}
 		serviceRuntime = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gardener-metrics-exporter",
-				Namespace: namespace,
+				Name:        "gardener-metrics-exporter",
+				Namespace:   namespace,
+				Annotations: map[string]string{"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":2718}]`},
 				Labels: map[string]string{
 					"app":  "gardener",
 					"role": "metrics-exporter",

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/service.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/service.go
@@ -16,12 +16,17 @@ package gardenermetricsexporter
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 func (g *gardenerMetricsExporter) service() *corev1.Service {
-	return &corev1.Service{
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: g.namespace,
@@ -40,4 +45,11 @@ func (g *gardenerMetricsExporter) service() *corev1.Service {
 			},
 		},
 	}
+
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(probePort)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}))
+
+	return service
 }

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/servicemonitor.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/servicemonitor.go
@@ -1,0 +1,73 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenermetricsexporter
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+func (g *gardenerMetricsExporter) serviceMonitor() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: monitoringutils.ConfigObjectMeta(deploymentName, g.namespace, garden.Label),
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: GetLabels()},
+			Endpoints: []monitoringv1.Endpoint{{
+				TargetPort: ptr.To(intstr.FromInt32(probePort)),
+				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+					"garden_projects_status",
+					"garden_users_total",
+					"garden_shoot_info",
+					"garden_shoot_condition",
+					"garden_shoot_node_info",
+					"garden_shoot_operation_states",
+					"garden_shoot_node_max_total",
+					"garden_shoot_node_min_total",
+					"garden_shoot_response_duration_milliseconds",
+					"garden_shoot_operations_total",
+					"garden_shoots_hibernation_enabled_total",
+					"garden_shoots_hibernation_schedule_total",
+					"garden_shoot_hibernated",
+					"garden_shoots_custom_addon_kubedashboard_total",
+					"garden_shoots_custom_addon_nginxingress_total",
+					"garden_shoots_custom_apiserver_auditpolicy_total",
+					"garden_shoots_custom_apiserver_basicauth_total",
+					"garden_shoots_custom_apiserver_featuregates_total",
+					"garden_shoots_custom_apiserver_oidcconfig_total",
+					"garden_shoots_custom_extensions_total",
+					"garden_shoots_custom_kcm_horizontalpodautoscale_total",
+					"garden_shoots_custom_kcm_nodecidrmasksize_total",
+					"garden_shoots_custom_kubelet_podpidlimit_total",
+					"garden_shoots_custom_network_customdomain_total",
+					"garden_shoots_custom_privileged_containers_total",
+					"garden_shoots_custom_proxy_mode_total",
+					"garden_shoots_custom_worker_annotations_total",
+					"garden_shoots_custom_worker_multiplepools_total",
+					"garden_shoots_custom_worker_multizones_total",
+					"garden_shoots_custom_worker_taints_total",
+					"garden_seed_info",
+					"garden_seed_condition",
+					"garden_seed_capacity",
+					"garden_seed_usage",
+				),
+			}},
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -195,7 +195,10 @@ var _ = Describe("KubeStateMetrics", func() {
 			}
 
 			if clusterType == component.ClusterTypeSeed {
-				obj.Annotations = map[string]string{"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8080}]`}
+				obj.Annotations = map[string]string{
+					"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8080}]`,
+					"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports":   `[{"protocol":"TCP","port":8080}]`,
+				}
 			}
 			if clusterType == component.ClusterTypeShoot {
 				obj.Annotations = map[string]string{"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8080}]`}

--- a/pkg/component/observability/monitoring/kubestatemetrics/resources.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/resources.go
@@ -184,6 +184,7 @@ func (k *kubeStateMetrics) reconcileService(service *corev1.Service) {
 
 	switch k.values.ClusterType {
 	case component.ClusterTypeSeed:
+		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, metricsPort))
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, metricsPort))
 	case component.ClusterTypeShoot:
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, metricsPort))

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -50,9 +50,9 @@ const (
 // Interface contains functions for a Prometheus deployer.
 type Interface interface {
 	component.DeployWaiter
-	// SetIngressAuthSecret sets the ingress auth secret name.
+	// SetIngressAuthSecret sets the ingress authentication secret name.
 	SetIngressAuthSecret(*corev1.Secret)
-	// SetIngressWildcardCertSecret sets the ingress wildcard cert secret name.
+	// SetIngressWildcardCertSecret sets the ingress wildcard certificate secret name.
 	SetIngressWildcardCertSecret(*corev1.Secret)
 	// SetCentralScrapeConfigs sets the central scrape configs.
 	SetCentralScrapeConfigs([]*monitoringv1alpha1.ScrapeConfig)

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -69,6 +69,8 @@ type Values struct {
 	RuntimeVersion *semver.Version
 	// VPAMinAllowed defines the resource list for the minAllowed field for the prometheus container resource policy.
 	VPAMinAllowed *corev1.ResourceList
+	// VPAMaxAllowed defines the resource list for the maxAllowed field for the prometheus container resource policy.
+	VPAMaxAllowed *corev1.ResourceList
 	// ExternalLabels is the set of external labels for the Prometheus configuration.
 	ExternalLabels map[string]string
 	// AdditionalPodLabels is a map containing additional labels for the created pods.

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -58,10 +59,14 @@ type Values struct {
 	PriorityClassName string
 	// StorageCapacity is the storage capacity of Prometheus.
 	StorageCapacity resource.Quantity
+	// Replicas is the number of replicas.
+	Replicas int32
 	// Retention is the duration for the data retention.
 	Retention *monitoringv1.Duration
 	// RetentionSize is the size for the data retention.
 	RetentionSize monitoringv1.ByteSize
+	// RuntimeVersion is the Kubernetes version of the runtime cluster.
+	RuntimeVersion *semver.Version
 	// VPAMinAllowed defines the resource list for the minAllowed field for the prometheus container resource policy.
 	VPAMinAllowed *corev1.ResourceList
 	// ExternalLabels is the set of external labels for the Prometheus configuration.
@@ -174,6 +179,7 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		p.secretAdditionalScrapeConfigs(),
 		p.prometheus(takeOverExistingPV),
 		p.vpa(),
+		p.podDisruptionBudget(),
 		ingress,
 	)
 	if err != nil {

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -54,6 +54,8 @@ type Interface interface {
 	SetIngressAuthSecret(*corev1.Secret)
 	// SetIngressWildcardCertSecret sets the ingress wildcard cert secret name.
 	SetIngressWildcardCertSecret(*corev1.Secret)
+	// SetCentralScrapeConfigs sets the central scrape configs.
+	SetCentralScrapeConfigs([]*monitoringv1alpha1.ScrapeConfig)
 }
 
 // Values contains configuration values for the prometheus resources.
@@ -258,6 +260,10 @@ func (p *prometheus) SetIngressWildcardCertSecret(secret *corev1.Secret) {
 	if p.values.Ingress != nil && secret != nil {
 		p.values.Ingress.WildcardCertSecretName = &secret.Name
 	}
+}
+
+func (p *prometheus) SetCentralScrapeConfigs(configs []*monitoringv1alpha1.ScrapeConfig) {
+	p.values.CentralConfigs.ScrapeConfigs = configs
 }
 
 func (p *prometheus) name() string {

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -76,6 +76,8 @@ type Values struct {
 	RetentionSize monitoringv1.ByteSize
 	// RuntimeVersion is the Kubernetes version of the runtime cluster.
 	RuntimeVersion *semver.Version
+	// ScrapeTimeout is the timeout duration when scraping targets.
+	ScrapeTimeout monitoringv1.Duration
 	// VPAMinAllowed defines the resource list for the minAllowed field for the prometheus container resource policy.
 	VPAMinAllowed *corev1.ResourceList
 	// VPAMaxAllowed defines the resource list for the maxAllowed field for the prometheus container resource policy.

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -121,6 +121,9 @@ type IngressValues struct {
 	// SecretsManager is the secrets manager used for generating the TLS certificate if no wildcard certificate is
 	// provided.
 	SecretsManager secretsmanager.Interface
+	// SigningCA is the name of the CA that should be used the sign a self-signed server certificate. Only needed when
+	// no wildcard certificate secret is provided.
+	SigningCA string
 	// WildcardCertSecretName is name of a secret containing the wildcard TLS certificate which is issued for the
 	// ingress domain. If not provided, a self-signed server certificate will be created.
 	WildcardCertSecretName *string

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/auditlog.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/auditlog.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: auditlog
+spec:
+  groups:
+  - name: auditlog
+    rules:
+
+    - alert: TooManyAuditlogFailures
+      expr: |
+        ( sum by (job) (
+              rate(
+                apiserver_audit_error_total{plugin="webhook"}[5m]
+              )
+          )
+          /
+          sum by (job) (
+              rate(
+                apiserver_audit_event_total[5m]
+              )
+          )
+        ) > 0.02
+      for: 10m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: >-
+          The {{$labels.job}} server in landscape {{$externalLabels.landscape}}
+          has too many failed attempts to log audit events.
+        description: >
+          The API server's cumulative failure rate in logging audit events is
+          greater than 2%.

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/auditlog.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/auditlog.yaml
@@ -6,7 +6,6 @@ spec:
   groups:
   - name: auditlog
     rules:
-
     - alert: TooManyAuditlogFailures
       expr: |
         ( sum by (job) (

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
@@ -6,7 +6,6 @@ spec:
   groups:
   - name: etcd
     rules:
-
     - alert: EtcdMainDown
       expr: |
         sum(

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
@@ -1,0 +1,240 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd
+spec:
+  groups:
+  - name: etcd
+    rules:
+
+    - alert: EtcdMainDown
+      expr: |
+        sum(
+          up{job  = "virtual-garden-etcd",
+            role = "main"}
+        ) < 2
+      for: 5m
+      labels:
+        severity: critical
+        topology: garden
+        service: VirtualGardenEtcd
+        role: main
+      annotations:
+        summary: >-
+          Virtual garden etcd main cluster is down in landscape
+          {{$externalLabels.landscape}}.
+        description: >
+          Virtual garden etcd main cluster is unavailable or cannot be scraped due to possible quorum loss. As
+          long as etcd main is down the virtual garden cluster is unreachable.
+
+    - alert: EtcdEventsDown
+      expr: |
+        sum(
+          up{job  = "virtual-garden-etcd",
+            role = "events"}
+        ) < 2
+      for: 15m
+      labels:
+        severity: info
+        topology: garden
+        service: VirtualGardenEtcd
+        role: events
+      annotations:
+        summary: >-
+          Virtual garden etcd events cluster is down in landscape
+          {{$externalLabels.landscape}}.
+        description: >
+          Virtual garden etcd events cluster is unavailable or cannot be scraped due to possible quorum loss.
+          Cluster events cannot be collected.
+
+    - alert: EtcdMainNoLeader
+      expr: |
+        sum(
+          etcd_server_has_leader{job  = "virtual-garden-etcd",
+                                role = "main"}
+        )
+        <
+        count(
+          etcd_server_has_leader{job  = "virtual-garden-etcd",
+                                role = "main"}
+        )
+      for: 10m
+      labels:
+        severity: critical
+        topology: garden
+        service: VirtualGardenEtcd
+        role: main
+      annotations:
+        summary: >-
+          Virtual garden etcd main has no leader in landscape
+          {{$externalLabels.landscape}}.
+        description: >
+          Virtual garden etcd main has no leader. Possible network partition in the etcd cluster.
+
+    - alert: EtcdEventsNoLeader
+      expr: |
+        sum(
+          etcd_server_has_leader{job  = "virtual-garden-etcd",
+                                role = "events"}
+        )
+        <
+        count(
+          etcd_server_has_leader{job  = "virtual-garden-etcd",
+                                role = "events"}
+        )
+      for: 15m
+      labels:
+        severity: info
+        topology: garden
+        service: VirtualGardenEtcd
+        role: events
+      annotations:
+        summary: >-
+          Virtual garden etcd events has no leader in landscape
+          {{$externalLabels.landscape}}.
+        description: >
+          Virtual garden etcd events has no leader. Possible network partition in the etcd cluster.
+
+    - alert: EtcdHighNumberOfFailedProposals
+      expr: |
+        increase(
+          etcd_server_proposals_failed_total{job="virtual-garden-etcd"}[1h]
+        ) > 80
+      labels:
+        severity: info
+        topology: garden
+        service: VirtualGardenEtcd
+      annotations:
+        summary: >-
+          High number of failed virtual garden etcd {{$labels.role}} proposals in
+          landscape {{$externalLabels.landscape}}.
+        description: >
+          Virtual garden etcd {{$labels.role}} has seen {{$value}} proposal
+          failures within the last hour.
+
+    - record: virtual_garden:apiserver_storage_objects:max_by_resource
+      expr: |
+        max by (resource) (
+            apiserver_storage_objects
+        )
+
+    - alert: EtcdDbSizeLimitApproaching
+      expr: |
+        ( etcd_mvcc_db_total_size_in_bytes{job="virtual-garden-etcd"}
+          > bool 4294967296
+        )
+        +
+        ( etcd_mvcc_db_total_size_in_bytes{job="virtual-garden-etcd"}
+          <= bool 8589900000
+        )
+        == 2 # between 4GB and 8GB
+      labels:
+        severity: warning
+        topology: garden
+        service: VirtualGardenEtcd
+      annotations:
+        summary: >-
+          Virtual garden etcd {{$labels.role}} DB size is approaching its current
+          practical limit in landscape {{$externalLabels.landscape}}.
+        description: >
+          Virtual garden etcd {{$labels.role}} DB size is approaching its current
+          practical limit of 8GB. Etcd quota might need to be increased.
+
+    - alert: EtcdDbSizeLimitCrossed
+      expr: |
+        etcd_mvcc_db_total_size_in_bytes{job="virtual-garden-etcd"}
+        > 8589900000 # above 8GB
+      labels:
+        severity: critical
+        topology: garden
+        service: VirtualGardenEtcd
+      annotations:
+        summary: >-
+          Virtual garden etcd {{$labels.role}} DB size has crossed its current
+          practical limit in landscape {{$externalLabels.landscape}}.
+        description: >
+          Virtual garden etcd {{$labels.role}} DB size has crossed its current
+          practical limit of 8GB. Etcd quota must be increased to allow updates.
+
+    - alert: EtcdDeltaBackupFailed
+      expr: |
+        (( time()
+          -
+          etcdbr_snapshot_latest_timestamp{job  = "virtual-garden-etcd-backup",
+                                          kind = "Incr",
+                                          role = "main"}
+          > bool 900
+        )
+        +
+        ( etcdbr_snapshot_required{kind = "Incr",
+                                  role = "main"}
+          >= bool 1
+        )
+        == 2
+        )
+        +
+        on(pod,role)
+        group_left 0 *
+        ( etcd_server_is_leader{job = "virtual-garden-etcd-backup", role = "main"}
+        == 1
+        )
+      for: 15m
+      labels:
+        severity: critical
+        topology: garden
+        service: VirtualGardenEtcd
+      annotations:
+        summary: >-
+          Virtual garden etcd delta snapshot failure in landscape
+          {{$externalLabels.landscape}}.
+        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
+
+    - alert: EtcdFullBackupFailed
+      expr: |
+        (( time()
+          -
+          etcdbr_snapshot_latest_timestamp{job  = "virtual-garden-etcd-backup",
+                                          kind = "Full",
+                                          role = "main"}
+          > bool 86400
+        )
+        +
+        ( etcdbr_snapshot_required{kind = "Full",
+                                  role = "main"}
+          >= bool 1
+        )
+        == 2
+        )
+        +
+        on(pod,role)
+        group_left 0 *
+        ( etcd_server_is_leader{job="virtual-garden-etcd-backup",role="main"}
+        == 1
+        )
+      for: 15m
+      labels:
+        severity: critical
+        topology: garden
+        service: VirtualGardenEtcd
+      annotations:
+        summary: >-
+          Virtual garden etcd full snapshot failure in landscape
+          {{$externalLabels.landscape}}.
+        description: No full snapshot taken in the past day taken by backup-restore leader.
+
+    - alert: EtcdRestorationFailed
+      expr: |
+        rate(
+          etcdbr_restoration_duration_seconds_count{job       = "virtual-garden-etcd-backup",
+                                                    role      = "main",
+                                                    succeeded = "false"}[2m]
+        )
+        > 0
+      for: 1m
+      labels:
+        service: VirtualGardenEtcd
+        severity: critical
+      annotations:
+        summary: Virtual garden etcd data restoration failure.
+        description: >
+          Virtual garden etcd data restoration was triggered, but has failed.

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/garden.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/garden.yaml
@@ -1,0 +1,135 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: garden
+spec:
+  groups:
+  - name: garden
+    rules:
+
+    - alert: ApiServerDown
+      expr: |
+        probe_success{job     = "blackbox-apiserver",
+                      purpose = "availability"}
+        == 0
+      for: 2m
+      labels:
+        severity: critical
+        topology: garden
+        service: apiserver
+      annotations:
+        summary: ApiServer is Down in landscape {{$externalLabels.landscape}}
+        description: >
+          The http health probe to the Api Server failed for at least 2 minutes
+          (instance is {{$labels.instance}}).
+
+          (Status code is
+          {{printf `probe_http_status_code{job      = "blackbox-apiserver"
+          ,                                purpose  = "availability"
+          ,                                instance = "%s"}`
+          $labels.instance | query | first | value}}).
+
+    - alert: GardenerApiServerDown
+      expr: |
+        probe_success{job     = "blackbox-gardener-apiserver",
+                      purpose = "availability"}
+        == 0
+      for: 2m
+      labels:
+        severity: critical
+        topology: garden
+        service: gardener-apiserver
+      annotations:
+        summary: >-
+          Gardener ApiServer is Down in landscape {{$externalLabels.landscape}}
+        description: >
+          The http health probe to the Gardener Api Server failed for at least 2
+          minutes (instance is {{$labels.instance}}).
+
+          (Status code is
+          {{printf `probe_http_status_code{job      = "blackbox-gardener-apiserver"
+          ,                                purpose  = "availability"
+          ,                                instance = "%s"}`
+          $labels.instance
+          | query | first | value}}).
+
+    - alert: ProjectStuckInDeletion
+      expr: |
+          avg(garden_projects_status{phase="Terminating"}) without (instance)
+          and
+          avg(garden_projects_status{phase="Terminating"} offset 1w) without (instance)
+      for: 5m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: Project {{$labels.name}} stuck in {{$labels.phase}} phase in landscape {{$externalLabels.landscape}}
+        description: Project {{$labels.name}} has been stuck in {{$labels.phase}} phase for 1 week. Please investigate.
+
+    - alert: GardenerControllerManagerDown
+      expr: |
+        absent( up{job = "gardener-controller-manager"} == 1 )
+      for: 10m
+      labels:
+        severity: critical
+        topology: garden
+        service: gardener-controller-manager
+      annotations:
+        summary: >-
+          Gardener Controller Manager is Down in landscape
+          {{$externalLabels.landscape}}
+        description: >
+          Scraping the /metrics endpoint of the Gardener Controller Manager
+          failed for at least 10 minutes.
+
+    - alert: GardenerMetricsExporterDown
+      expr: |
+        absent(
+          up{job="gardener-metrics-exporter"}
+          == 1
+        )
+      for: 15m
+      labels:
+        severity: critical
+        topology: garden
+      annotations:
+        summary: >-
+          The gardener-metrics-exporter is down in landscape:
+          {{$externalLabels.landscape}}.
+        description: >
+          The gardener-metrics-exporter is down. Alert conditions for the
+          gardenlets, shoots, and seeds cannot be detected. Metering will also not
+          work because there are no metrics.
+
+    - alert: MissingGardenMetrics
+      expr: |
+        scrape_samples_scraped{job="gardener-metrics-exporter"}
+        == 0
+      for: 15m
+      labels:
+        severity: critical
+        topology: garden
+      annotations:
+        summary: >-
+          The gardener-metrics-exporter is not exposing metrics in landscape:
+          {{$externalLabels.landscape}}
+        description: >
+          The gardener-metrics-exporter is not exposing any metrics. Alert
+          conditions for the gardenlets, shoots, and seeds cannot be detected.
+          Metering will also not work because there are no metrics.
+
+    - alert: PodFrequentlyRestarting
+      expr: |
+        increase(
+          kube_pod_container_status_restarts_total[1h]
+        ) > 5
+      for: 10m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: Pod is restarting frequently
+        description: >
+          Pod {{$labels.namespace}}/{{$labels.pod}} in landscape
+          {{$externalLabels.landscape}} was restarted more than 5 times within the
+          last hour. The pod is running on the garden cluster.

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/garden.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/garden.yaml
@@ -6,7 +6,6 @@ spec:
   groups:
   - name: garden
     rules:
-
     - alert: ApiServerDown
       expr: |
         probe_success{job     = "blackbox-apiserver",

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/metering-meta.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/metering-meta.yaml
@@ -19,7 +19,7 @@ spec:
         *
           0
 
-  # garden_shoot_info :this_month
+  # garden_shoot_info:this_month
 
     - record: garden_shoot_info:this_month
       expr: |2

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/metering-meta.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/metering-meta.yaml
@@ -1,0 +1,544 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: metering-meta
+spec:
+  groups:
+  - name: metering.rules.meta
+    interval: 60s
+    rules:
+
+  # - _year_month2
+
+    - record: _year_month2
+      expr: |2
+          count_values without () (
+            "year",
+            year(timestamp(count_values without () ("month", month(timestamp(vector(0))))))
+          )
+        *
+          0
+
+  # garden_shoot_info :this_month
+
+    - record: garden_shoot_info:this_month
+      expr: |2
+          (garden_shoot_info + on () group_left (year, month) _year_month2)
+        or
+          last_over_time(garden_shoot_info:this_month[30m]) + on (year, month) group_left () _year_month2
+
+  # _timestamp
+
+    - record: _timestamp
+      expr: |
+        count_values without () ("timestamp", round(timestamp(vector(0)))) * 0
+
+  # garden_shoot_info:timestamp
+
+    - record: garden_shoot_info:timestamp
+      expr: |2
+          (
+              last_over_time(garden_shoot_info:timestamp[30m])
+            or ignoring (timestamp)
+              garden_shoot_info + on () group_left (timestamp) _timestamp
+          )
+        and ignoring (timestamp)
+          garden_shoot_info
+
+  # garden_shoot_info :timestamp :this_month
+
+    - record: garden_shoot_info:timestamp:this_month
+      expr: |2
+          (garden_shoot_info:timestamp + on () group_left (year, month) _year_month2)
+        or
+          last_over_time(garden_shoot_info:timestamp:this_month[30m]) + on (year, month) group_left () _year_month2
+
+  # - metering :cpu_requests             :sum_by_namespace :meta
+  # - metering :cpu_usage                :sum_by_namespace :meta
+  # - metering :memory_requests          :sum_by_namespace :meta
+  # - metering :memory_usage             :sum_by_namespace :meta
+  # - metering :network_receive          :sum_by_namespace :meta
+  # - metering :network_transmit         :sum_by_namespace :meta
+  # - metering :persistent_volume_claims :sum_by_namespace :meta
+  # - metering :persistent_volume_usage  :sum_by_namespace :meta
+  # - metering :working_set_memory       :sum_by_namespace :meta
+
+    - record: metering:cpu_requests:sum_by_namespace:meta
+      expr: |2
+          metering:cpu_requests:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+    - record: metering:cpu_usage:sum_by_namespace:meta
+      expr: |2
+          metering:cpu_usage:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+    - record: metering:memory_requests:sum_by_namespace:meta
+      expr: |2
+          metering:memory_requests:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+    - record: metering:memory_usage:sum_by_namespace:meta
+      expr: |2
+          metering:memory_usage:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+    - record: metering:network_receive:sum_by_namespace:meta
+      expr: |2
+          metering:network_receive:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+    - record: metering:network_transmit:sum_by_namespace:meta
+      expr: |2
+          metering:network_transmit:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+    - record: metering:persistent_volume_claims:sum_by_namespace:meta
+      expr: |2
+          metering:persistent_volume_claims:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+    - record: metering:persistent_volume_usage:sum_by_namespace:meta
+      expr: |2
+          metering:persistent_volume_usage:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+    - record: metering:working_set_memory:sum_by_namespace:meta
+      expr: |2
+          metering:working_set_memory:sum_by_namespace{shoot_uid!=""}
+        + on (shoot_uid, seed) group_left (project, name, failure_tolerance, version, cost_object, cost_object_owner, iaas, region, seed_iaas, seed_region, is_seed, timestamp)
+          garden_shoot_info:timestamp
+
+  # - metering   :memory_usage_seconds   :meta
+  # - metering   :disk_usage_seconds     :meta
+  # - metering   :memory_usage_seconds   :meta      :this_month
+  # - metering   :disk_usage_seconds     :meta      :this_month
+
+    - record: metering:memory_usage_seconds:meta
+      expr: |2
+          (metering:working_set_memory:sum_by_namespace:meta > bool 0) * 60
+        +
+          (last_over_time(metering:memory_usage_seconds:meta[30m]) or metering:working_set_memory:sum_by_namespace:meta * 0)
+
+    - record: metering:disk_usage_seconds:meta
+      expr: |2
+          (metering:persistent_volume_claims:sum_by_namespace:meta > bool 0) * 60
+        +
+          (
+              last_over_time(metering:disk_usage_seconds:meta[30m])
+            or
+              metering:persistent_volume_claims:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:memory_usage_seconds:meta:this_month
+      expr: |2
+          metering:memory_usage_seconds:meta
+        or
+            last_over_time(metering:memory_usage_seconds:meta:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:disk_usage_seconds:meta:this_month
+      expr: |2
+          metering:disk_usage_seconds:meta
+        or
+            last_over_time(metering:disk_usage_seconds:meta:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+  # - metering  :persistent_volume_claims   :sum_by_namespace   :meta   :sum_over_time
+  # - metering  :persistent_volume_claims   :sum_by_namespace   :meta   :avg_over_time
+  # - metering  :persistent_volume_claims   :sum_by_namespace   :meta   :avg_over_time   :this_month
+
+    - record: metering:persistent_volume_claims:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:persistent_volume_claims:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:persistent_volume_claims:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:persistent_volume_claims:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:persistent_volume_claims:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:disk_usage_seconds:meta != 0)
+
+    - record: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+  # - metering  :cpu_usage                 :sum_by_namespace           :meta            :sum_over_time
+  # - metering  :cpu_usage                 :sum_by_namespace           :meta            :avg_over_time
+  # - metering  :cpu_usage                 :sum_by_namespace           :meta            :avg_over_time             :this_month
+  # - metering  :cpu_requests              :sum_by_namespace           :meta            :sum_over_time
+  # - metering  :cpu_requests              :sum_by_namespace           :meta            :avg_over_time
+  # - metering  :cpu_requests              :sum_by_namespace           :meta            :avg_over_time             :this_month
+  # - metering  :memory_usage              :sum_by_namespace           :meta            :sum_over_time
+  # - metering  :memory_usage              :sum_by_namespace           :meta            :avg_over_time
+  # - metering  :memory_usage              :sum_by_namespace           :meta            :avg_over_time             :this_month
+  # - metering  :working_set_memory        :sum_by_namespace           :meta            :sum_over_time
+  # - metering  :working_set_memory        :sum_by_namespace           :meta            :avg_over_time
+  # - metering  :working_set_memory        :sum_by_namespace           :meta            :avg_over_time             :this_month
+  # - metering  :memory_requests           :sum_by_namespace           :meta            :sum_over_time
+  # - metering  :memory_requests           :sum_by_namespace           :meta            :avg_over_time
+  # - metering  :memory_requests           :sum_by_namespace           :meta            :avg_over_time             :this_month
+  # - metering  :network_transmit          :sum_by_namespace           :meta            :sum_over_time
+  # - metering  :network_transmit          :sum_by_namespace           :meta            :avg_over_time
+  # - metering  :network_transmit          :sum_by_namespace           :meta            :avg_over_time             :this_month
+  # - metering  :network_receive           :sum_by_namespace           :meta            :sum_over_time
+  # - metering  :network_receive           :sum_by_namespace           :meta            :avg_over_time
+  # - metering  :network_receive           :sum_by_namespace           :meta            :avg_over_time             :this_month
+  # - metering  :persistent_volume_usage   :sum_by_namespace           :meta            :sum_over_time
+  # - metering  :persistent_volume_usage   :sum_by_namespace           :meta            :avg_over_time
+  # - metering  :persistent_volume_usage   :sum_by_namespace           :meta            :avg_over_time             :this_month
+
+    - record: metering:cpu_usage:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:cpu_usage:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:cpu_usage:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:cpu_usage:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:cpu_usage:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:cpu_usage:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds:meta != 0)
+
+    - record: metering:cpu_usage:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:cpu_usage:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:cpu_usage:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:cpu_requests:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:cpu_requests:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:cpu_requests:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:cpu_requests:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:cpu_requests:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:cpu_requests:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds:meta != 0)
+
+    - record: metering:cpu_requests:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:cpu_requests:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:cpu_requests:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:memory_usage:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:memory_usage:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:memory_usage:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:memory_usage:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:memory_usage:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:memory_usage:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds:meta != 0)
+
+    - record: metering:memory_usage:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:memory_usage:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:memory_usage:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:working_set_memory:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:working_set_memory:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:working_set_memory:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:working_set_memory:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:working_set_memory:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:working_set_memory:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds:meta != 0)
+
+    - record: metering:working_set_memory:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:working_set_memory:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:working_set_memory:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:memory_requests:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:memory_requests:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:memory_requests:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:memory_requests:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:memory_requests:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:memory_requests:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds:meta != 0)
+
+    - record: metering:memory_requests:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:memory_requests:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:memory_requests:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:network_transmit:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:network_transmit:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:network_transmit:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:network_transmit:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:network_transmit:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:network_transmit:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds:meta != 0)
+
+    - record: metering:network_transmit:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:network_transmit:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:network_transmit:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:network_receive:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:network_receive:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:network_receive:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:network_receive:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:network_receive:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:network_receive:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds:meta != 0)
+
+    - record: metering:network_receive:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:network_receive:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:network_receive:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:persistent_volume_usage:sum_by_namespace:meta:sum_over_time
+      expr: |2
+          metering:persistent_volume_usage:sum_by_namespace:meta
+        +
+          (
+              last_over_time(metering:persistent_volume_usage:sum_by_namespace:meta:sum_over_time[30m])
+            or
+              metering:persistent_volume_usage:sum_by_namespace:meta * 0
+          )
+
+    - record: metering:persistent_volume_usage:sum_by_namespace:meta:avg_over_time
+      expr: |2
+          metering:persistent_volume_usage:sum_by_namespace:meta:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds:meta != 0)
+
+    - record: metering:persistent_volume_usage:sum_by_namespace:meta:avg_over_time:this_month
+      expr: |2
+          metering:persistent_volume_usage:sum_by_namespace:meta:avg_over_time
+        or
+            last_over_time(metering:persistent_volume_usage:sum_by_namespace:meta:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+  # - metering  :node_capacity             :sum_by_instance_type   :sum_over_time
+  # - metering  :node_capacity             :sum_by_instance_type   :count_over_time
+  # - metering  :node_capacity             :sum_by_instance_type   :count_over_time :this_month
+  # - metering  :node_capacity             :sum_by_instance_type   :avg_over_time
+  # - metering  :node_capacity             :sum_by_instance_type   :avg_over_time   :this_month
+
+    - record: metering:node_capacity:sum_by_instance_type:sum_over_time
+      expr: |2
+          metering:node_capacity:sum_by_instance_type
+        +
+          (
+              last_over_time(metering:node_capacity:sum_by_instance_type:sum_over_time[30m])
+            or
+              metering:node_capacity:sum_by_instance_type * 0
+          )
+
+    - record: metering:node_capacity:sum_by_instance_type:count_over_time
+      expr: |2
+          1 + metering:node_capacity:sum_by_instance_type * 0
+        +
+          (
+              last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time[30m])
+            or
+              metering:node_capacity:sum_by_instance_type * 0
+          )
+
+    - record: metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+      expr: |2
+          metering:node_capacity:sum_by_instance_type:count_over_time
+        or
+            last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:node_capacity:sum_by_instance_type:avg_over_time
+      expr: |2
+          metering:node_capacity:sum_by_instance_type:sum_over_time
+        /
+          metering:node_capacity:sum_by_instance_type:count_over_time
+
+    - record: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+      expr: |2
+          metering:node_capacity:sum_by_instance_type:avg_over_time
+        or
+            last_over_time(metering:node_capacity:sum_by_instance_type:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+  # - metering  :node_cp_usage             :sum_by_instance_type   :sum_over_time
+  # - metering  :node_cp_usage             :sum_by_instance_type   :count_over_time
+  # - metering  :node_cp_usage             :sum_by_instance_type   :count_over_time :this_month
+  # - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time
+  # - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time   :this_month
+
+    - record: metering:node_cp_usage:sum_by_instance_type:sum_over_time
+      expr: |2
+          metering:node_cp_usage:sum_by_instance_type
+        +
+          (
+              last_over_time(metering:node_cp_usage:sum_by_instance_type:sum_over_time[30m])
+            or
+              metering:node_cp_usage:sum_by_instance_type * 0
+          )
+
+    - record: metering:node_cp_usage:sum_by_instance_type:count_over_time
+      expr: |2
+          1 + metering:node_cp_usage:sum_by_instance_type * 0
+        +
+          (
+              last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time[30m])
+            or
+              metering:node_cp_usage:sum_by_instance_type * 0
+          )
+
+    - record: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+      expr: |2
+          metering:node_cp_usage:sum_by_instance_type:count_over_time
+        or
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:node_cp_usage:sum_by_instance_type:avg_over_time
+      expr: |2
+          metering:node_cp_usage:sum_by_instance_type:sum_over_time
+        /
+          metering:node_cp_usage:sum_by_instance_type:count_over_time
+
+    - record: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+      expr: |2
+          metering:node_cp_usage:sum_by_instance_type:avg_over_time
+        or
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+  # - metering  :node_cp_requests             :sum_by_instance_type   :sum_over_time
+  # - metering  :node_cp_requests             :sum_by_instance_type   :count_over_time
+  # - metering  :node_cp_requests             :sum_by_instance_type   :count_over_time :this_month
+  # - metering  :node_cp_requests             :sum_by_instance_type   :avg_over_time
+  # - metering  :node_cp_requests             :sum_by_instance_type   :avg_over_time   :this_month
+
+    - record: metering:node_cp_requests:sum_by_instance_type:sum_over_time
+      expr: |2
+          metering:node_cp_requests:sum_by_instance_type
+        +
+          (
+              last_over_time(metering:node_cp_requests:sum_by_instance_type:sum_over_time[30m])
+            or
+              metering:node_cp_requests:sum_by_instance_type * 0
+          )
+
+    - record: metering:node_cp_requests:sum_by_instance_type:count_over_time
+      expr: |2
+          1 + metering:node_cp_requests:sum_by_instance_type * 0
+        +
+          (
+              last_over_time(metering:node_cp_requests:sum_by_instance_type:count_over_time[30m])
+            or
+              metering:node_cp_requests:sum_by_instance_type * 0
+          )
+
+    - record: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month
+      expr: |2
+          metering:node_cp_requests:sum_by_instance_type:count_over_time
+        or
+            last_over_time(metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2
+
+    - record: metering:node_cp_requests:sum_by_instance_type:avg_over_time
+      expr: |2
+          metering:node_cp_requests:sum_by_instance_type:sum_over_time
+        /
+          metering:node_cp_requests:sum_by_instance_type:count_over_time
+
+    - record: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month
+      expr: |2
+          metering:node_cp_requests:sum_by_instance_type:avg_over_time
+        or
+            last_over_time(metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month[30m])
+          + on (year, month) group_left ()
+            _year_month2

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/recording.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/recording.yaml
@@ -1,0 +1,41 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: recording
+spec:
+  groups:
+  - name: recording.rules
+    rules:
+    ### API latency ###
+    - record: apiserver_latency_seconds:quantile
+      expr: |
+        histogram_quantile(
+          0.99,
+          rate(
+            apiserver_request_duration_seconds_bucket[5m]
+          )
+        )
+      labels:
+        quantile: "0.99"
+
+    - record: apiserver_latency_seconds:quantile
+      expr: |
+        histogram_quantile(
+          0.9,
+          rate(
+            apiserver_request_duration_seconds_bucket[5m]
+          )
+        )
+      labels:
+        quantile: "0.9"
+
+    - record: apiserver_latency_seconds:quantile
+      expr: |
+        histogram_quantile(
+          0.5,
+          rate(
+            apiserver_request_duration_seconds_bucket[5m]
+          )
+        )
+      labels:
+        quantile: "0.5"

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -6,7 +6,6 @@ spec:
   groups:
   - name: seed
     rules:
-
     - alert: PodFrequentlyRestarting
       expr: |
         seed:kube_pod_container_status_restarts_total:max_by_namespace > 5

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -1,0 +1,397 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: seed
+spec:
+  groups:
+  - name: seed
+    rules:
+
+    - alert: PodFrequentlyRestarting
+      expr: |
+        seed:kube_pod_container_status_restarts_total:max_by_namespace > 5
+      for: 10m
+      labels:
+        severity: info
+        topology: garden
+      annotations:
+        summary: Some container is restarting frequently
+        description: >
+          Some container in namespace {{$labels.namespace}} in seed
+          {{$labels.seed}} in landscape {{$externalLabels.landscape}} was
+          restarted more than 5 times within the last hour.
+
+    - alert: PersistentVolumeSizeMismatch
+      expr: round((seed:persistentvolume:inconsistent_size > 0.05) * 10000) / 100
+      for: 5m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: There is a persistent volume with a size mismatch
+        description: |
+          Landscape: {{$externalLabels.landscape}}
+          Seed: {{$labels.seed}}
+          Namespace:  {{$labels.namespace}}
+          PersistentVolumeClaim:  {{$labels.persistentvolumeclaim}}
+          Size difference: {{$value}}%
+
+    - alert: GardenletDown
+      expr: |
+        min_over_time(garden_seed_condition{condition = "GardenletReady"}[5m])
+        == 0
+      for: 10m
+      labels:
+        severity: critical
+        topology: seed
+        service: gardenlet
+      annotations:
+        summary: Gardenlet Down in landscape {{$externalLabels.landscape}}
+        description: The Gardenlet in seed {{$labels.name}} is down.
+
+    - alert: GardenletUnknown
+      expr: |
+        min_over_time(garden_seed_condition{condition = "GardenletReady"}[5m])
+        == -1
+      for: 10m
+      labels:
+        severity: critical
+        topology: seed
+        service: gardenlet
+      annotations:
+        summary: >-
+          Gardenlet Unknown Status in landscape {{$externalLabels.landscape}}
+        description: >
+          The Gardenlet in seed {{$labels.name}} has been in an in unknown state
+          for over 10 minutes.
+
+    - alert: SeedAPIServerUnavailable
+      expr: |
+        garden_shoot_condition{condition = "APIServerAvailable",
+                              operation = "Reconcile",
+                              is_seed   = "true",
+                              purpose   = "infrastructure"}
+        < 1
+      for: 2m
+      labels:
+        severity: critical
+        topology: shoot
+      annotations:
+        summary: API Server Unavailable
+        description: >
+          The seed cluster: {{$labels.project}}/{{$labels.name}} has the
+          condition APIServerAvailable < 1.
+
+    - alert: ApproachingSeedCapacity
+      expr: |
+        # number of shoots
+        sum by(iaas, region) (
+          sum by (iaas,region,name) (
+            garden_seed_usage{protected="false",resource="shoot",visible="true"})
+            +
+            # Only count usage of seeds that also have a capacity
+            (sum by (iaas,region, name) (
+              garden_seed_capacity{protected="false",visible="true"}
+            ) * 0
+          )
+        )
+        >
+        # total regional seed capacity
+        sum by (iaas,region) (
+          garden_seed_capacity{protected = "false",
+                              visible   = "true"}
+        ) * 0.98
+        # hysteresis: alert as long as the value is above 90%
+        or
+        (
+          sum by(iaas, region) (
+            sum by (iaas,region,name) (
+              garden_seed_usage{protected="false",resource="shoot",visible="true"})
+              +
+              # Only count usage of seeds that also have a capacity
+              (sum by (iaas,region, name) (
+                garden_seed_capacity{protected="false",visible="true"}
+              ) * 0
+            )
+          )
+          >
+          # total regional seed capacity
+          sum by (iaas,region) (
+            garden_seed_capacity{protected = "false",
+                                visible   = "true"}
+          ) * 0.90
+          and
+          count by(iaas,region) (
+            ALERTS{alertname  = "ApproachingSeedCapacity",
+                  alertstate = "firing"}
+          )
+        )
+      for: 10m
+      labels:
+        severity: critical
+        topology: garden
+      annotations:
+        summary: >-
+          {{$externalLabels.landscape}}: {{$labels.region}} in {{$labels.iaas}} is
+          approaching capacity
+        description: >
+          {{$labels.region}} in {{$labels.iaas}} has crossed the 98% capacity threshold.
+          The alert will stop firing when the seed usage drops below 90%.
+
+          There are currently {{$value}} shoots hosted in this region.
+          Current usage is
+          {{range
+                  printf `
+                    round(
+                          sum by (iaas, region) (
+                              sum by (iaas, region, name) (garden_seed_usage{protected="false",resource="shoot",visible="true"})
+                            +
+                              0 * sum by (iaas, region, name) (garden_seed_capacity{protected="false",visible="true"})
+                          )
+                        / ignoring (resource)
+                          sum by (iaas, region) (
+                            garden_seed_capacity{iaas="%s",protected="false",region="%s",visible="true"}
+                          )
+                      *
+                        100,
+                      0.01
+                    )
+                  ` $labels.iaas $labels.region
+                  | query -}}
+            {{- . | value -}}%
+          {{- end}}.
+
+          Current distribution of shoots:
+          {{range
+          printf `sum by (name) (garden_seed_usage{resource  = "shoot"
+          ,                                        protected = "false"
+          ,                                        visible   = "true"
+          ,                                        region    = "%s"
+          ,                                        iaas      = "%s"})`
+          $labels.region $labels.iaas
+          | query}}
+          {{. | label "name"}} = {{. | value}},
+          {{end}}
+
+          Visible non-protected seeds:
+          {{range
+          printf `count by (name) (garden_seed_info{protected = "false"
+          ,                                         visible   = "true"
+          ,                                         region    = "%s"
+          ,                                         iaas      = "%s"})`
+          $labels.region $labels.iaas
+          | query}}
+          {{. | label "name"}},
+          {{end}}
+
+    - alert: ApproachingSeedCapacity
+      expr: |
+        # number of shoots
+        sum by(iaas, region) (
+          sum by (iaas,region,name) (
+            garden_seed_usage{protected="false",resource="shoot",visible="true"})
+            +
+            # Only count usage of seeds that also have a capacity
+            (sum by (iaas,region, name) (
+              garden_seed_capacity{protected="false",visible="true"}
+            ) * 0
+          )
+        )
+        >
+        # total regional seed capacity
+        sum by (iaas,region) (
+          garden_seed_capacity{protected = "false",
+                              visible   = "true"}
+        ) * 0.90
+        # hysteresis: alert as long as the value is above 85%
+        or
+        (
+          sum by(iaas, region) (
+            sum by (iaas,region,name) (
+              garden_seed_usage{protected="false",resource="shoot",visible="true"})
+              +
+              # Only count usage of seeds that also have a capacity
+              (sum by (iaas,region, name) (
+                garden_seed_capacity{protected="false",visible="true"}
+              ) * 0
+            )
+          )
+          >
+          # total regional seed capacity
+          sum by (iaas,region) (
+            garden_seed_capacity{protected = "false",
+                                visible   = "true"}
+          ) * 0.85
+          and
+          count by(iaas,region) (
+            ALERTS{alertname  = "ApproachingSeedCapacity",
+                  alertstate = "firing"}
+          )
+        )
+      for: 10m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: >-
+          {{$externalLabels.landscape}}: {{$labels.region}} in {{$labels.iaas}} is
+          approaching capacity
+        description: >
+          {{$labels.region}} in {{$labels.iaas}} has crossed the 90% capacity threshold.
+          The alert will stop firing when the seed usage drops below 85%.
+
+          There are currently {{$value}} shoots hosted in this region.
+          Current usage is
+          {{range
+                  printf `
+                    round(
+                          sum by (iaas, region) (
+                              sum by (iaas, region, name) (garden_seed_usage{protected="false",resource="shoot",visible="true"})
+                            +
+                              0 * sum by (iaas, region, name) (garden_seed_capacity{protected="false",visible="true"})
+                          )
+                        / ignoring (resource)
+                          sum by (iaas, region) (
+                            garden_seed_capacity{iaas="%s",protected="false",region="%s",visible="true"}
+                          )
+                      *
+                        100,
+                      0.01
+                    )
+                  ` $labels.iaas $labels.region
+                  | query -}}
+            {{- . | value -}}%
+          {{- end}}.
+
+          Current distribution of shoots:
+          {{range
+          printf `sum by (name) (garden_seed_usage{resource  = "shoot"
+          ,                                        protected = "false"
+          ,                                        visible   = "true"
+          ,                                        region    = "%s"
+          ,                                        iaas      = "%s"})`
+          $labels.region $labels.iaas
+          | query}}
+          {{. | label "name"}} = {{. | value}},
+          {{end}}
+
+          Visible non-protected seeds:
+          {{range
+          printf `count by (name) (garden_seed_info{protected = "false"
+          ,                                         visible   = "true"
+          ,                                         region    = "%s"
+          ,                                         iaas      = "%s"})`
+          $labels.region $labels.iaas
+          | query}}
+          {{. | label "name"}},
+          {{end}}
+
+    - alert: SeedFederationFailure
+      expr: up{job="prometheus-aggregate", instance!~".*\\.(cc|cp-mgr).*"} == 0
+      for: 5m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: Seed federation failure
+        description: |
+          Federating from the prometheus-aggregate instance {{$labels.instance}} failed.
+          Please check the error message in the `prometheus-garden` in the garden runtime cluster.
+          Port-forward to `prometheus-garden-0` in the `garden` namespace and open:
+          http://localhost:9090/targets?search={{$labels.instance}}
+
+    - alert: SeedPodStuckInPending
+      expr: |
+        ALERTS{alertname="PodStuckInPending",alertstate="firing"}
+      for: 10m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: A pod is stuck in Pending state for more than 10 minutes.
+        description: >
+          The pod {{$labels.pod}} in namespace {{$labels.namespace}} in seed
+          {{$labels.seed}} in landscape {{$externalLabels.landscape}} is
+          stuck in Pending state for more than 10 minutes.
+
+    - alert: SeedNodeNotHealthy
+      expr: |
+        ALERTS{alertname="NodeNotHealthy",alertstate="firing"}
+      for: 0m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary:  A node was reported not healthy for 5 scrapes in the past 30 minutes.
+        description: >
+          Node {{$labels.node}} in landscape
+          {{$externalLabels.landscape}} was not healthy for five scrapes in the past 30 minutes.
+
+    - alert: SeedControlPlaneUnhealthy
+      expr: |
+        max_over_time(
+          garden_shoot_condition{condition       = "ControlPlaneHealthy",
+                                 operation       = "Reconcile",
+                                 is_seed         = "false",
+                                 purpose         =~ "infrastructure",
+                                 is_compliant    = "True",
+                                 has_user_errors = "false"}[2m])
+        == 0
+      for: 30m
+      labels:
+        severity: critical
+        topology: garden
+      annotations:
+        summary: Seed ControlPlane Components Unhealthy
+        description: >
+          The seed cluster: {{$labels.name}} has
+          condition ControlPlaneHealthy == 0 for more than 30 minutes. Some Control Plane
+          components of the seed may have an issue.
+          {{with printf `ALERTS{alertstate       = 'firing',
+                                project          = '%s',
+                                shoot_name       = '%s',
+                                severity         =~'critical|blocker',
+                                shoot_alertname != ''}` $labels.project $labels.name
+                 | query
+                 | sortByLabel "shoot_alertname"}}
+          {{if .}}Currently firing alerts:
+          {{end -}}
+          {{range . -}}
+          - {{.Labels.shoot_alertname}}
+          {{end -}}
+          {{end -}}
+
+    - alert: SeedSystemComponentsUnhealthy
+      expr: |
+        max_over_time(
+          garden_shoot_condition{condition       = "SystemComponentsHealthy",
+                                 operation       = "Reconcile",
+                                 is_seed         = "false",
+                                 purpose         =~ "infrastructure",
+                                 is_compliant    = "True",
+                                 has_user_errors = "false"}[2m])
+        == 0
+      for: 30m
+      labels:
+        severity: critical
+        topology: garden
+        mute_on_weekends: "true"
+      annotations:
+        summary: Seed System Components Unhealthy
+        description: >
+          The seed cluster: {{$labels.name}} has
+          condition SystemComponentsHealthy == 0 for more than 30 minutes. Some
+          components required by the seed may have an issue.
+          {{with printf `ALERTS{alertstate       = 'firing',
+                                project          = '%s',
+                                shoot_name       = '%s',
+                                severity         =~'critical|blocker',
+                                shoot_alertname != ''}` $labels.project $labels.name
+                 | query
+                 | sortByLabel "shoot_alertname"}}
+          {{if .}}Currently firing alerts:
+          {{end -}}
+          {{range . -}}
+          - {{.Labels.shoot_alertname}}
+          {{end -}}
+          {{end -}}

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
@@ -6,7 +6,6 @@ spec:
   groups:
   - name: shoot
     rules:
-
     - alert: ShootOutageOverall
       expr: |
         count (

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
@@ -1,0 +1,114 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: shoot
+spec:
+  groups:
+  - name: shoot
+    rules:
+
+    - alert: ShootOutageOverall
+      expr: |
+        count (
+          garden_shoot_condition{condition =  "APIServerAvailable",
+                                operation =  "Reconcile",
+                                is_seed   =  "false",
+                                purpose   =~ "production"}
+          == 0
+        )
+        /
+        count (
+          garden_shoot_condition{condition =  "APIServerAvailable",
+                                operation =  "Reconcile",
+                                is_seed   =  "false",
+                                purpose   =~ "production"}
+        )
+        > 0.10
+      for: 10m
+      labels:
+        severity: critical
+        topology: garden
+      annotations:
+        summary: >-
+          Over 10% of productive shoots are unavailable on the 
+          {{$externalLabels.landscape}} landscape.
+        description: >
+          Over 10% of the shoots have the condition APIServerAvailable false.
+          (
+          {{`count(
+          garden_shoot_condition{condition =  "APIServerAvailable"
+          ,                      operation =  "Reconcile"
+          ,                      is_seed   =  "false"
+          ,                      purpose   =~ "production"}
+          == 0)`
+          | query | first | value}}
+          out of
+          {{`count(
+          garden_shoot_condition{condition =  "APIServerAvailable"
+          ,                      operation =  "Reconcile"
+          ,                      is_seed   =  "false"
+          ,                      purpose   =~ "production"})`
+          | query | first | value}}
+          )
+
+    - alert: ShootOutageByIaas
+      expr: |
+        count by (iaas) (
+          garden_shoot_condition{condition =  "APIServerAvailable",
+                                operation =  "Reconcile",
+                                is_seed   =  "false",
+                                purpose   =~ "production"}
+          == 0
+        )
+        /
+        count by (iaas) (
+          garden_shoot_condition{condition =  "APIServerAvailable",
+                                operation =  "Reconcile",
+                                is_seed   =  "false",
+                                purpose   =~ "production"}
+        )
+        > 0.10
+      for: 10m
+      labels:
+        severity: critical
+        topology: garden
+      annotations:
+        summary: >-
+          Over 10% of productive {{$labels.iaas}} shoots are unavailable on the 
+          {{$externalLabels.landscape}} landscape.
+        description: >
+          Over 10% of {{$labels.iaas}} shoots have the condition
+          APIServerAvailable == 0.
+          (
+          {{printf `count(
+          garden_shoot_condition{iaas      =  "%s"
+          ,                      condition =  "APIServerAvailable"
+          ,                      operation =  "Reconcile"
+          ,                      is_seed   =  "false"
+          ,                      purpose   =~ "production"}
+          == 0)`
+          $labels.iaas
+          | query | first | value}}
+          out of
+          {{printf `count(
+          garden_shoot_condition{iaas      =  "%s"
+          ,                      condition =  "APIServerAvailable"
+          ,                      operation =  "Reconcile"
+          ,                      is_seed   =  "false"
+          ,                      purpose   =~ "production"})`
+          $labels.iaas
+          | query | first | value}}
+          )
+
+
+    - alert: NodeFilesystemAlmostOutOfFiles
+      expr: shoot:node_filesystem_files_free:percent{project="garden"} < 5
+      for: 10m
+      labels:
+        severity: critical
+        topology: seed
+      annotations:
+        summary: Node filesystem has less than 5% inodes left.
+        description: >
+          The seed cluster: {{$labels.project}}/{{$labels.name}} has a filesystem mounted at {{ $labels.mountpoint }}
+          on node {{ $labels.node }} that has only {{ printf "%.2f" $value }}% available inodes left.

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/scrapeconfigs/cadvisor.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/scrapeconfigs/cadvisor.yaml
@@ -1,0 +1,30 @@
+job_name: cadvisor
+honor_labels: false
+scheme: https
+
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+kubernetes_sd_configs:
+- role: node
+
+relabel_configs:
+- source_labels: [__meta_kubernetes_node_address_InternalIP]
+  target_label: instance
+- action: labelmap
+  regex: __meta_kubernetes_node_label_(.+)
+- target_label: __address__
+  replacement: kubernetes.default.svc
+- source_labels: [__meta_kubernetes_node_name]
+  regex: (.+)
+  target_label: __metrics_path__
+  replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+metric_relabel_configs:
+- source_labels: [ namespace ]
+  regex: garden
+  action: keep
+- source_labels: [ __name__ ]
+  regex: ^(container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_writes_bytes_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
+  action: keep

--- a/pkg/component/observability/monitoring/prometheus/garden/constants.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/constants.go
@@ -1,0 +1,28 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden
+
+import (
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+const (
+	// Label is a constant for the label of the garden prometheus instance.
+	Label = "garden"
+	// ServiceAccountName is the name of the service account in the virtual garden cluster.
+	ServiceAccountName = "prometheus-" + Label
+	// AccessSecretName is the name of the secret containing a token for accessing the virtual garden cluster.
+	AccessSecretName = gardenerutils.SecretNamePrefixShootAccess + ServiceAccountName
+)

--- a/pkg/component/observability/monitoring/prometheus/garden/garden_suite_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/garden_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGarden(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Observability Monitoring Prometheus Garden Suite")
+}

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
@@ -1,0 +1,91 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden
+
+import (
+	_ "embed"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+var (
+	//go:embed assets/prometheusrules/auditlog.yaml
+	auditLogYAML []byte
+	auditLog     *monitoringv1.PrometheusRule
+
+	//go:embed assets/prometheusrules/etcd.yaml
+	etcdYAML []byte
+	etcd     *monitoringv1.PrometheusRule
+
+	//go:embed assets/prometheusrules/garden.yaml
+	gardenYAML []byte
+	garden     *monitoringv1.PrometheusRule
+
+	//go:embed assets/prometheusrules/metering-meta.yaml
+	meteringYAML []byte
+	metering     *monitoringv1.PrometheusRule
+
+	//go:embed assets/prometheusrules/recording.yaml
+	recordingYAML []byte
+	recording     *monitoringv1.PrometheusRule
+
+	//go:embed assets/prometheusrules/seed.yaml
+	seedYAML []byte
+	seed     *monitoringv1.PrometheusRule
+
+	//go:embed assets/prometheusrules/shoot.yaml
+	shootYAML []byte
+	shoot     *monitoringv1.PrometheusRule
+)
+
+func init() {
+	auditLog = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, auditLogYAML, auditLog))
+
+	etcd = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, etcdYAML, etcd))
+
+	garden = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, gardenYAML, garden))
+
+	metering = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, meteringYAML, metering))
+
+	recording = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, recordingYAML, recording))
+
+	seed = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, seedYAML, seed))
+
+	shoot = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, shootYAML, shoot))
+}
+
+// CentralPrometheusRules returns the central PrometheusRule resources for the garden prometheus.
+func CentralPrometheusRules() []*monitoringv1.PrometheusRule {
+	return []*monitoringv1.PrometheusRule{
+		auditLog,
+		etcd,
+		garden,
+		metering,
+		recording,
+		seed,
+		shoot,
+	}
+}

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules_test.go
@@ -1,0 +1,62 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	"github.com/gardener/gardener/pkg/component/test"
+)
+
+var _ = ginkgo.Describe("PrometheusRules", func() {
+	ginkgo.Describe("#CentralPrometheusRules", func() {
+		ginkgo.It("should return the expected objects", func() {
+			Expect(CentralPrometheusRules()).To(HaveExactElements(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("auditlog")}),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd")}),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden")}),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("metering-meta")}),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("recording")}),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("seed")}),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("shoot")}),
+				})),
+			))
+
+			test.PrometheusRule(metering, "testdata/metering-meta.prometheusrule.test.yaml")
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -55,8 +55,7 @@ func CentralScrapeConfigs(prometheusAggregateTargets []monitoringv1alpha1.Target
 		},
 	}}
 
-	if globalMonitoringSecret != nil {
-		// if len(prometheusAggregateTargets) > 0 && globalMonitoringSecret != nil {
+	if len(prometheusAggregateTargets) > 0 && globalMonitoringSecret != nil {
 		out = append(out, &monitoringv1alpha1.ScrapeConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "prometheus-" + aggregate.Label},
 			Spec: monitoringv1alpha1.ScrapeConfigSpec{

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -16,6 +16,16 @@ package garden
 
 import (
 	_ "embed"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/aggregate"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
 //go:embed assets/scrapeconfigs/cadvisor.yaml
@@ -24,4 +34,70 @@ var cAdvisor string
 // AdditionalScrapeConfigs returns the additional scrape configs for the garden prometheus.
 func AdditionalScrapeConfigs() []string {
 	return []string{cAdvisor}
+}
+
+// CentralScrapeConfigs returns the central ScrapeConfig resources for the garden prometheus.
+func CentralScrapeConfigs(prometheusAggregateTargets []monitoringv1alpha1.Target, globalMonitoringSecret *corev1.Secret) []*monitoringv1alpha1.ScrapeConfig {
+	out := []*monitoringv1alpha1.ScrapeConfig{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prometheus",
+		},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+				Targets: []monitoringv1alpha1.Target{"localhost:9090"},
+			}},
+			RelabelConfigs: []*monitoringv1.RelabelConfig{{
+				Action:      "replace",
+				Replacement: "prometheus-garden",
+				TargetLabel: "job",
+			}},
+			MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig("prometheus_(.+)"),
+		},
+	}}
+
+	if globalMonitoringSecret != nil {
+		// if len(prometheusAggregateTargets) > 0 && globalMonitoringSecret != nil {
+		out = append(out, &monitoringv1alpha1.ScrapeConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prometheus-" + aggregate.Label},
+			Spec: monitoringv1alpha1.ScrapeConfigSpec{
+				HonorLabels:     ptr.To(true),
+				HonorTimestamps: ptr.To(false),
+				MetricsPath:     ptr.To("/federate"),
+				Scheme:          ptr.To("HTTPS"),
+				Params: map[string][]string{
+					"match[]": {
+						`{__name__=~"seed:(.+):count"}`,
+						`{__name__=~"seed:(.+):sum"}`,
+						`{__name__=~"seed:(.+):sum_cp"}`,
+						`{__name__=~"seed:(.+):sum_by_pod",namespace=~"extension-(.+)"}`,
+						`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_storage_objects:sum_by_resource",__name__!="shoot:apiserver_watch_duration:quantile"}`,
+						`{__name__="ALERTS"}`,
+						`{__name__="shoot:availability"}`,
+						`{__name__="prometheus_tsdb_lowest_timestamp"}`,
+						`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,
+						`{__name__="seed:persistentvolume:inconsistent_size"}`,
+						`{__name__="seed:kube_pod_container_status_restarts_total:max_by_namespace"}`,
+						`{__name__=~"metering:.+:(sum_by_namespace|sum_by_instance_type)"}`,
+					},
+				},
+				TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: true},
+				BasicAuth: &monitoringv1.BasicAuth{
+					Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: secretsutils.DataKeyUserName},
+					Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: secretsutils.DataKeyPassword},
+				},
+				StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: prometheusAggregateTargets}},
+				RelabelConfigs: []*monitoringv1.RelabelConfig{{
+					Action:      "replace",
+					Replacement: "prometheus-" + aggregate.Label,
+					TargetLabel: "job",
+				}},
+				MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+					SourceLabels: []monitoringv1.LabelName{"alertname"},
+					TargetLabel:  "shoot_alertname",
+				}},
+			},
+		})
+	}
+
+	return out
 }

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -1,0 +1,27 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden
+
+import (
+	_ "embed"
+)
+
+//go:embed assets/scrapeconfigs/cadvisor.yaml
+var cAdvisor string
+
+// AdditionalScrapeConfigs returns the additional scrape configs for the garden prometheus.
+func AdditionalScrapeConfigs() []string {
+	return []string{cAdvisor}
+}

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
@@ -1,0 +1,62 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+)
+
+var _ = Describe("PrometheusRules", func() {
+	Describe("#AdditionalScrapeConfigs", func() {
+		It("should return the expected objects", func() {
+			Expect(garden.AdditionalScrapeConfigs()).To(HaveExactElements(
+				`job_name: cadvisor
+honor_labels: false
+scheme: https
+
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+kubernetes_sd_configs:
+- role: node
+
+relabel_configs:
+- source_labels: [__meta_kubernetes_node_address_InternalIP]
+  target_label: instance
+- action: labelmap
+  regex: __meta_kubernetes_node_label_(.+)
+- target_label: __address__
+  replacement: kubernetes.default.svc
+- source_labels: [__meta_kubernetes_node_name]
+  regex: (.+)
+  target_label: __metrics_path__
+  replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+metric_relabel_configs:
+- source_labels: [ namespace ]
+  regex: garden
+  action: keep
+- source_labels: [ __name__ ]
+  regex: ^(container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_writes_bytes_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
+  action: keep
+`,
+			))
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
@@ -66,26 +66,30 @@ metric_relabel_configs:
 	})
 
 	Describe("#CentralScrapeConfigs", func() {
+		var (
+			scrapeConfigPrometheus = &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "prometheus"},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+						Targets: []monitoringv1alpha1.Target{"localhost:9090"},
+					}},
+					RelabelConfigs: []*monitoringv1.RelabelConfig{{
+						Action:      "replace",
+						Replacement: "prometheus-garden",
+						TargetLabel: "job",
+					}},
+					MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+						SourceLabels: []monitoringv1.LabelName{"__name__"},
+						Action:       "keep",
+						Regex:        `^(prometheus_(.+))$`,
+					}},
+				},
+			}
+		)
+
 		When("no global monitoring secret provided", func() {
 			It("should only contain the prometheus-garden scrape config", func() {
-				Expect(garden.CentralScrapeConfigs(nil, nil)).To(HaveExactElements(&monitoringv1alpha1.ScrapeConfig{
-					ObjectMeta: metav1.ObjectMeta{Name: "prometheus"},
-					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
-							Targets: []monitoringv1alpha1.Target{"localhost:9090"},
-						}},
-						RelabelConfigs: []*monitoringv1.RelabelConfig{{
-							Action:      "replace",
-							Replacement: "prometheus-garden",
-							TargetLabel: "job",
-						}},
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
-							SourceLabels: []monitoringv1.LabelName{"__name__"},
-							Action:       "keep",
-							Regex:        `^(prometheus_(.+))$`,
-						}},
-					},
-				}))
+				Expect(garden.CentralScrapeConfigs(nil, nil)).To(HaveExactElements(scrapeConfigPrometheus))
 			})
 		})
 
@@ -95,47 +99,56 @@ metric_relabel_configs:
 				globalMonitoringSecret     = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "global-monitoring-secret"}}
 			)
 
+			When("there are no aggregate targets", func() {
+				It("should only contain the prometheus-garden scrape config", func() {
+					Expect(garden.CentralScrapeConfigs(nil, globalMonitoringSecret)).To(HaveExactElements(scrapeConfigPrometheus))
+				})
+			})
+
 			It("should also contain the aggregate prometheus scrape config", func() {
-				Expect(garden.CentralScrapeConfigs(prometheusAggregateTargets, globalMonitoringSecret)).To(ContainElement(&monitoringv1alpha1.ScrapeConfig{
-					ObjectMeta: metav1.ObjectMeta{Name: "prometheus-aggregate"},
-					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						HonorLabels:     ptr.To(true),
-						HonorTimestamps: ptr.To(false),
-						MetricsPath:     ptr.To("/federate"),
-						Scheme:          ptr.To("HTTPS"),
-						Params: map[string][]string{
-							"match[]": {
-								`{__name__=~"seed:(.+):count"}`,
-								`{__name__=~"seed:(.+):sum"}`,
-								`{__name__=~"seed:(.+):sum_cp"}`,
-								`{__name__=~"seed:(.+):sum_by_pod",namespace=~"extension-(.+)"}`,
-								`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_storage_objects:sum_by_resource",__name__!="shoot:apiserver_watch_duration:quantile"}`,
-								`{__name__="ALERTS"}`,
-								`{__name__="shoot:availability"}`,
-								`{__name__="prometheus_tsdb_lowest_timestamp"}`,
-								`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,
-								`{__name__="seed:persistentvolume:inconsistent_size"}`,
-								`{__name__="seed:kube_pod_container_status_restarts_total:max_by_namespace"}`,
-								`{__name__=~"metering:.+:(sum_by_namespace|sum_by_instance_type)"}`,
+				Expect(garden.CentralScrapeConfigs(prometheusAggregateTargets, globalMonitoringSecret)).To(HaveExactElements(
+					scrapeConfigPrometheus,
+					&monitoringv1alpha1.ScrapeConfig{
+						ObjectMeta: metav1.ObjectMeta{Name: "prometheus-aggregate"},
+						Spec: monitoringv1alpha1.ScrapeConfigSpec{
+							HonorLabels:     ptr.To(true),
+							HonorTimestamps: ptr.To(false),
+							MetricsPath:     ptr.To("/federate"),
+							Scheme:          ptr.To("HTTPS"),
+							Params: map[string][]string{
+								"match[]": {
+									`{__name__=~"seed:(.+):count"}`,
+									`{__name__=~"seed:(.+):sum"}`,
+									`{__name__=~"seed:(.+):sum_cp"}`,
+									`{__name__=~"seed:(.+):sum_by_pod",namespace=~"extension-(.+)"}`,
+									`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_storage_objects:sum_by_resource",__name__!="shoot:apiserver_watch_duration:quantile"}`,
+									`{__name__="ALERTS"}`,
+									`{__name__="shoot:availability"}`,
+									`{__name__="prometheus_tsdb_lowest_timestamp"}`,
+									`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,
+									`{__name__="seed:persistentvolume:inconsistent_size"}`,
+									`{__name__="seed:kube_pod_container_status_restarts_total:max_by_namespace"}`,
+									`{__name__=~"metering:.+:(sum_by_namespace|sum_by_instance_type)"}`,
+								},
 							},
+							TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: true},
+							BasicAuth: &monitoringv1.BasicAuth{
+								Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: "username"},
+								Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: "password"},
+							},
+							StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: prometheusAggregateTargets}},
+							RelabelConfigs: []*monitoringv1.RelabelConfig{{
+								Action:      "replace",
+								Replacement: "prometheus-aggregate",
+								TargetLabel: "job",
+							}},
+							MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+								SourceLabels: []monitoringv1.LabelName{"alertname"},
+								TargetLabel:  "shoot_alertname",
+							}},
 						},
-						TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: true},
-						BasicAuth: &monitoringv1.BasicAuth{
-							Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: "username"},
-							Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: "password"},
-						},
-						StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: prometheusAggregateTargets}},
-						RelabelConfigs: []*monitoringv1.RelabelConfig{{
-							Action:      "replace",
-							Replacement: "prometheus-aggregate",
-							TargetLabel: "job",
-						}},
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
-							SourceLabels: []monitoringv1.LabelName{"alertname"},
-							TargetLabel:  "shoot_alertname",
-						}},
 					},
-				}))
+				))
 			})
 		})
 	})

--- a/pkg/component/observability/monitoring/prometheus/garden/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/servicemonitors.go
@@ -1,0 +1,57 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden
+
+import (
+	_ "embed"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/alertmanager"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+// CentralServiceMonitors returns the central ServiceMonitor resources for the garden prometheus.
+func CentralServiceMonitors() []*monitoringv1.ServiceMonitor {
+	return []*monitoringv1.ServiceMonitor{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-garden"},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Selector: metav1.LabelSelector{MatchLabels: alertmanager.GetLabels("garden")},
+				Endpoints: []monitoringv1.Endpoint{{
+					Port: alertmanager.PortNameMetrics,
+					MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+						"alertmanager_alerts",
+						"alertmanager_alerts_received_total",
+						"alertmanager_build_info",
+						"alertmanager_cluster_health_score",
+						"alertmanager_cluster_members",
+						"alertmanager_cluster_peers_joined_total",
+						"alertmanager_config_hash",
+						"alertmanager_config_last_reload_success_timestamp_seconds",
+						"alertmanager_notifications_failed_total",
+						"alertmanager_notifications_total",
+						"alertmanager_peer_position",
+						"alertmanager_silences",
+						"process_cpu_seconds_total",
+						"process_resident_memory_bytes",
+						"process_start_time_seconds",
+					),
+				}},
+			},
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/prometheus/garden/servicemonitors_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/servicemonitors_test.go
@@ -1,0 +1,49 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+)
+
+var _ = Describe("ServiceMonitors", func() {
+	Describe("#CentralServiceMonitors", func() {
+		It("should return the expected objects", func() {
+			Expect(garden.CentralServiceMonitors()).To(HaveExactElements(&monitoringv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-garden"},
+				Spec: monitoringv1.ServiceMonitorSpec{
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+						"component":    "alertmanager",
+						"role":         "monitoring",
+						"alertmanager": "garden",
+					}},
+					Endpoints: []monitoringv1.Endpoint{{
+						Port: "metrics",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{{
+							SourceLabels: []monitoringv1.LabelName{"__name__"},
+							Action:       "keep",
+							Regex:        `^(alertmanager_alerts|alertmanager_alerts_received_total|alertmanager_build_info|alertmanager_cluster_health_score|alertmanager_cluster_members|alertmanager_cluster_peers_joined_total|alertmanager_config_hash|alertmanager_config_last_reload_success_timestamp_seconds|alertmanager_notifications_failed_total|alertmanager_notifications_total|alertmanager_peer_position|alertmanager_silences|process_cpu_seconds_total|process_resident_memory_bytes|process_start_time_seconds)$`,
+						}},
+					}},
+				},
+			}))
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/metering-meta.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/metering-meta.prometheusrule.test.yaml
@@ -1,0 +1,455 @@
+rule_files:
+- metering-meta.prometheusrule.yaml
+
+tests:
+
+# metering:*:sum_by_namespace:meta merge in meta data from the garden_shoot_info metrics
+- name: metering:cpu_requests:sum_by_namespace:meta
+  input_series:
+  - series: garden_shoot_info{
+                cost_object       = "0101010xxx",
+                cost_object_owner = "user@example.com",
+                failure_tolerance = "zone",
+                iaas              = "shoot-iaas",
+                is_seed           = "true",
+                name              = "some-shoot",
+                project           = "garden",
+                region            = "shoot-region",
+                seed              = "some-seed",
+                seed_iaas         = "seed-iaas",
+                seed_region       = "seed-region",
+                shoot_uid         = "6fe5a58a-f98e-4cf3-9fbd-197d5bcb2a78",
+                timestamp         = "0",
+                version           = "1.26.7"}
+    values: 0
+  - series: metering:cpu_requests:sum_by_namespace{
+                seed      = "some-seed",
+                shoot_uid = "6fe5a58a-f98e-4cf3-9fbd-197d5bcb2a78"}
+
+    values: 42
+
+  promql_expr_test:
+  - expr: metering:cpu_requests:sum_by_namespace:meta
+    exp_samples:
+    - labels: metering:cpu_requests:sum_by_namespace:meta{
+                cost_object       = "0101010xxx",
+                cost_object_owner = "user@example.com",
+                failure_tolerance = "zone",
+                iaas              = "shoot-iaas",
+                is_seed           = "true",
+                name              = "some-shoot",
+                project           = "garden",
+                region            = "shoot-region",
+                seed              = "some-seed",
+                seed_iaas         = "seed-iaas",
+                seed_region       = "seed-region",
+                shoot_uid         = "6fe5a58a-f98e-4cf3-9fbd-197d5bcb2a78",
+                timestamp         = "0",
+                version           = "1.26.7"}
+      value: 42
+
+# _year_month2 contains the year and month labels of the evaluation time.
+- name: _year_month2
+  promql_expr_test:
+  - expr: _year_month2
+    exp_samples:
+    - labels: _year_month2{
+                  year  = "1970",
+                  month = "1"}
+      value: 0
+
+# metering:memory_usage_seconds:meta
+# metering:memory_usage_seconds:meta:this_month
+- name: metering:memory_usage_seconds*
+  interval: 1m
+  input_series:
+  - series: metering:working_set_memory:sum_by_namespace:meta{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:working_set_memory:sum_by_namespace:meta{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:working_set_memory:sum_by_namespace:meta{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:memory_usage_seconds:meta
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:memory_usage_seconds:meta{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:memory_usage_seconds:meta{type="data gaps", year="1970", month="1"}
+      value: 900
+  - expr: metering:memory_usage_seconds:meta:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:memory_usage_seconds:meta:this_month{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:memory_usage_seconds:meta:this_month{type="data gaps", year="1970", month="1"}
+      value: 900
+    - labels: metering:memory_usage_seconds:meta:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1800
+
+# metering:disk_usage_seconds:meta
+# metering:disk_usage_seconds:meta:this_month
+- name: metering:disk_usage_seconds:meta*
+  interval: 1m
+  input_series:
+  - series: metering:persistent_volume_claims:sum_by_namespace:meta{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:persistent_volume_claims:sum_by_namespace:meta{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:persistent_volume_claims:sum_by_namespace:meta{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:disk_usage_seconds:meta
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:disk_usage_seconds:meta{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:disk_usage_seconds:meta{type="data gaps", year="1970", month="1"}
+      value: 900
+  - expr: metering:disk_usage_seconds:meta:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:disk_usage_seconds:meta:this_month{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:disk_usage_seconds:meta:this_month{type="data gaps", year="1970", month="1"}
+      value: 900
+    - labels: metering:disk_usage_seconds:meta:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1800
+
+# metering:persistent_volume_claims:sum_by_namespace:meta:sum_over_time
+# metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time
+# metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time:this_month
+- name: metering:persistent_volume_claims:sum_by_namespace:meta:*
+  interval: 1m
+  input_series:
+  - series: metering:persistent_volume_claims:sum_by_namespace:meta{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:persistent_volume_claims:sum_by_namespace:meta{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:persistent_volume_claims:sum_by_namespace:meta{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:persistent_volume_claims:sum_by_namespace:meta:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:meta:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:persistent_volume_claims:sum_by_namespace:meta:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 1
+  - expr: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:meta:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:cpu_usage:sum_by_namespace:meta:sum_over_time
+# metering:cpu_usage:sum_by_namespace:meta:avg_over_time
+# metering:cpu_usage:sum_by_namespace:meta:avg_over_time:this_month
+- name: metering:cpu_usage:sum_by_namespace:meta:*
+  interval: 1m
+  input_series:
+  - series: metering:cpu_usage:sum_by_namespace:meta{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:memory_usage_seconds:meta{type="complete", year="1970", month="1"}
+    values: 60+60x60
+  - series: metering:cpu_usage:sum_by_namespace:meta{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:working_set_memory:sum_by_namespace:meta{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 1x13 stale _x4 1
+  - series: metering:cpu_usage:sum_by_namespace:meta{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  - series: metering:working_set_memory:sum_by_namespace:meta{type="no longer existing", year="1970", month="1"}
+    values: 1+0x9 stale _x29
+  - series: metering:cpu_usage:sum_by_namespace:meta{type="avg calculation bug", year="1970", month="1"}
+    values: 1x60
+  - series: metering:working_set_memory:sum_by_namespace:meta{type="avg calculation bug", year="1970", month="1"}
+    values: 1x58 stale
+  promql_expr_test:
+  - expr: metering:cpu_usage:sum_by_namespace:meta:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:meta:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:cpu_usage:sum_by_namespace:meta:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+    - labels: metering:cpu_usage:sum_by_namespace:meta:sum_over_time{type="avg calculation bug", year="1970", month="1"}
+      value: 60
+  - expr: metering:cpu_usage:sum_by_namespace:meta:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:meta:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:meta:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+  - expr: metering:cpu_usage:sum_by_namespace:meta:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:meta:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:meta:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:cpu_usage:sum_by_namespace:meta:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:meta:avg_over_time:this_month{type="avg calculation bug", year="1970", month="1"}
+      value: 1
+
+# The remaining recording rules are similar
+
+# garden_shoot_info :this_month
+- name: garden_shoot_info:this_month
+  interval: 59s
+  input_series:
+  - series: garden_shoot_info{name="one", year="1970", month="1"}
+    values: 0x10
+  - series: garden_shoot_info:this_month{name="two", year="1970", month="1"}
+    values: 0 stale
+  - series: garden_shoot_info:this_month{name="three", year="1969", month="12"}
+    values: 0 stale
+  promql_expr_test:
+  - expr: garden_shoot_info:this_month
+    eval_time: 10m
+    exp_samples:
+    - labels: garden_shoot_info:this_month{
+                  name  = "one",
+                  year  = "1970",
+                  month = "1"}
+      value: 0
+    - labels: garden_shoot_info:this_month{
+                  name  = "two",
+                  year  = "1970",
+                  month = "1"}
+      value: 0
+
+# garden_shoot_info :timestamp
+- name: garden_shoot_info:timestamp
+  interval: 1m
+  input_series:
+  - series: garden_shoot_info{name="one"}
+    values: 0x20
+  - series: garden_shoot_info{name="two"}
+    values: _ 0x10
+  - series: garden_shoot_info{name="three"}
+    values: _ _ 0x10
+  promql_expr_test:
+  - expr: garden_shoot_info:timestamp
+    eval_time: 10m
+    exp_samples:
+    - labels: garden_shoot_info:timestamp{
+                  name      = "one",
+                  timestamp = "0"}
+      value: 0
+    - labels: garden_shoot_info:timestamp{
+                  name      = "two",
+                  timestamp = "60"}
+      value: 0
+    - labels: garden_shoot_info:timestamp{
+                  name      = "three",
+                  timestamp = "120"}
+      value: 0
+  - expr: garden_shoot_info:timestamp
+    eval_time: 20m
+    exp_samples:
+    - labels: garden_shoot_info:timestamp{
+                  name      = "one",
+                  timestamp = "0"}
+      value: 0
+  - expr: garden_shoot_info:timestamp:this_month
+    eval_time: 20m
+    exp_samples:
+    - labels: garden_shoot_info:timestamp:this_month{
+                  name      = "one",
+                  timestamp = "0",
+                  year      = "1970",
+                  month     = "1"}
+      value: 0
+    - labels: garden_shoot_info:timestamp:this_month{
+                  name      = "two",
+                  timestamp = "60",
+                  year      = "1970",
+                  month     = "1"}
+      value: 0
+    - labels: garden_shoot_info:timestamp:this_month{
+                  name      = "three",
+                  timestamp = "120",
+                  year      = "1970",
+                  month     = "1"}
+      value: 0
+
+# metering:node_capacity:sum_by_instance_type:sum_over_time
+# metering:node_capacity:sum_by_instance_type:count_over_time
+# metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+# metering:node_capacity:sum_by_instance_type:avg_over_time
+# metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+- name: metering:node_capacity:sum_by_instance_type:*
+  interval: 1m
+  input_series:
+  - series: metering:node_capacity:sum_by_instance_type{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:node_capacity:sum_by_instance_type{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:node_capacity:sum_by_instance_type{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:node_capacity:sum_by_instance_type:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:node_capacity:sum_by_instance_type:count_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time{type="data gaps", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_capacity:sum_by_instance_type:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+
+  - expr: metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 30
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:node_cp_usage:sum_by_instance_type:sum_over_time
+# metering:node_cp_usage:sum_by_instance_type:count_over_time
+# metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+# metering:node_cp_usage:sum_by_instance_type:avg_over_time
+# metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+- name: metering:node_cp_usage:sum_by_instance_type:*
+  interval: 1m
+  input_series:
+  - series: metering:node_cp_usage:sum_by_instance_type{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:node_cp_usage:sum_by_instance_type{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:node_cp_usage:sum_by_instance_type{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:node_cp_usage:sum_by_instance_type:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:node_cp_usage:sum_by_instance_type:count_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time{type="data gaps", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_usage:sum_by_instance_type:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+
+  - expr: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 30
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:node_cp_requests:sum_by_instance_type:sum_over_time
+# metering:node_cp_requests:sum_by_instance_type:count_over_time
+# metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month
+# metering:node_cp_requests:sum_by_instance_type:avg_over_time
+# metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month
+- name: metering:node_cp_requests:sum_by_instance_type:*
+  interval: 1m
+  input_series:
+  - series: metering:node_cp_requests:sum_by_instance_type{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:node_cp_requests:sum_by_instance_type{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:node_cp_requests:sum_by_instance_type{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:node_cp_requests:sum_by_instance_type:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_requests:sum_by_instance_type:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:node_cp_requests:sum_by_instance_type:count_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time{type="data gaps", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_requests:sum_by_instance_type:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+
+  - expr: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 30
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1

--- a/pkg/component/observability/monitoring/prometheus/ingress.go
+++ b/pkg/component/observability/monitoring/prometheus/ingress.go
@@ -41,7 +41,7 @@ func (p *prometheus) ingress(ctx context.Context) (*networkingv1.Ingress, error)
 			CertType:                    secretsutils.ServerCert,
 			Validity:                    ptr.To(v1beta1constants.IngressTLSCertificateValidity),
 			SkipPublishingCACertificate: true,
-		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCASeed))
+		}, secretsmanager.SignedByCA(p.values.Ingress.SigningCA))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/component/observability/monitoring/prometheus/poddisruptionbudget.go
+++ b/pkg/component/observability/monitoring/prometheus/poddisruptionbudget.go
@@ -1,0 +1,45 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+func (p *prometheus) podDisruptionBudget() *policyv1.PodDisruptionBudget {
+	if p.values.Replicas <= 1 || p.values.RuntimeVersion == nil {
+		return nil
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.name(),
+			Namespace: p.namespace,
+			Labels:    p.getLabels(),
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MaxUnavailable: utils.IntStrPtrFromInt32(1),
+			Selector:       &metav1.LabelSelector{MatchLabels: p.getLabels()},
+		},
+	}
+
+	kubernetesutils.SetAlwaysAllowEviction(pdb, p.values.RuntimeVersion)
+
+	return pdb
+}

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -50,10 +50,9 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 
 				PodMetadata: &monitoringv1.EmbeddedObjectMetadata{
 					Labels: utils.MergeStringMaps(map[string]string{
-						v1beta1constants.LabelNetworkPolicyToDNS:                                                         v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                                            v1beta1constants.LabelNetworkPolicyAllowed,
-						"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets: v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelObservabilityApplication:                                                   p.name(),
+						v1beta1constants.LabelNetworkPolicyToDNS:              v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelObservabilityApplication:        p.name(),
 					}, p.values.AdditionalPodLabels),
 				},
 				PriorityClassName: p.values.PriorityClassName,

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -56,7 +56,7 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 					}, p.values.AdditionalPodLabels),
 				},
 				PriorityClassName: p.values.PriorityClassName,
-				Replicas:          ptr.To[int32](1),
+				Replicas:          &p.values.Replicas,
 				Shards:            ptr.To[int32](1),
 				Image:             &p.values.Image,
 				ImagePullPolicy:   corev1.PullIfNotPresent,

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -94,6 +94,10 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 		},
 	}
 
+	if p.values.Ingress != nil {
+		obj.Spec.ExternalURL = "https://" + p.values.Ingress.Host
+	}
+
 	if p.values.Retention != nil {
 		obj.Spec.Retention = *p.values.Retention
 	}

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -40,6 +40,7 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 			EvaluationInterval: "1m",
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				ScrapeInterval: "1m",
+				ScrapeTimeout:  p.values.ScrapeTimeout,
 				ReloadStrategy: ptr.To(monitoringv1.HTTPReloadStrategyType),
 				ExternalLabels: p.values.ExternalLabels,
 				AdditionalScrapeConfigs: &corev1.SecretKeySelector{

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -540,9 +540,29 @@ honor_labels: true`
 				})
 
 				It("should successfully deploy all resources", func() {
-					Expect(managedResourceSecret.Data).To(HaveLen(12))
+					prometheusObj := prometheusFor("")
+					prometheusObj.Spec.ExternalURL = "https://" + ingressHost
 
-					Expect(managedResource).To(contain(ingress))
+					prometheusRule.Namespace = namespace
+					metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", name)
+					metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", name)
+					metav1.SetMetaDataLabel(&serviceMonitor.ObjectMeta, "prometheus", name)
+					metav1.SetMetaDataLabel(&podMonitor.ObjectMeta, "prometheus", name)
+
+					Expect(managedResource).To(consistOf(
+						serviceAccount,
+						service,
+						clusterRoleBinding,
+						prometheusObj,
+						vpa,
+						prometheusRule,
+						scrapeConfig,
+						serviceMonitor,
+						podMonitor,
+						secretAdditionalScrapeConfigs,
+						additionalConfigMap,
+						ingress,
+					))
 				})
 			})
 

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -670,6 +670,37 @@ honor_labels: true`
 					))
 				})
 			})
+
+			When("scrape timeout is configured", func() {
+				BeforeEach(func() {
+					values.ScrapeTimeout = "10s"
+				})
+
+				It("should successfully deploy all resources", func() {
+					prometheusObj := prometheusFor("")
+					prometheusObj.Spec.ScrapeTimeout = "10s"
+
+					prometheusRule.Namespace = namespace
+					metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", name)
+					metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", name)
+					metav1.SetMetaDataLabel(&serviceMonitor.ObjectMeta, "prometheus", name)
+					metav1.SetMetaDataLabel(&podMonitor.ObjectMeta, "prometheus", name)
+
+					Expect(managedResource).To(contain(
+						serviceAccount,
+						service,
+						clusterRoleBinding,
+						prometheusObj,
+						vpa,
+						prometheusRule,
+						scrapeConfig,
+						serviceMonitor,
+						podMonitor,
+						secretAdditionalScrapeConfigs,
+						additionalConfigMap,
+					))
+				})
+			})
 		})
 	})
 

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -232,9 +232,8 @@ honor_labels: true`
 							Labels: map[string]string{
 								"foo":                              "bar",
 								"networking.gardener.cloud/to-dns": "allowed",
-								"networking.gardener.cloud/to-runtime-apiserver":                 "allowed",
-								"networking.resources.gardener.cloud/to-all-seed-scrape-targets": "allowed",
-								v1beta1constants.LabelObservabilityApplication:                   "prometheus-" + name,
+								"networking.gardener.cloud/to-runtime-apiserver": "allowed",
+								v1beta1constants.LabelObservabilityApplication:   "prometheus-" + name,
 							},
 						},
 						PriorityClassName: priorityClassName,

--- a/pkg/component/observability/monitoring/prometheus/vpa.go
+++ b/pkg/component/observability/monitoring/prometheus/vpa.go
@@ -54,10 +54,10 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 						MinAllowed: ptr.Deref(p.values.VPAMinAllowed, corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1000M"),
 						}),
-						MaxAllowed: corev1.ResourceList{
+						MaxAllowed: ptr.Deref(p.values.VPAMaxAllowed, corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("4"),
 							corev1.ResourceMemory: resource.MustParse("28G"),
-						},
+						}),
 						ControlledValues: &controlledValuesRequestsOnly,
 					},
 					{

--- a/pkg/component/observability/plutono/dashboards/garden/garden/garden-alertmanager-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden/garden/garden-alertmanager-dashboard.json
@@ -81,7 +81,7 @@
       "pluginVersion": "7.3.1",
       "targets": [
         {
-          "expr": "count(up{job=\"gardener-alertmanager\"})",
+          "expr": "count(up{job=\"alertmanager-garden\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1972,7 +1972,7 @@
           "value": ["$__all"]
         },
         "datasource": "$datasource",
-        "definition": "label_values(up{job=\"gardener-alertmanager\"},instance)",
+        "definition": "label_values(up{job=\"alertmanager-garden\"},instance)",
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -1980,7 +1980,7 @@
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{job=\"gardener-alertmanager\"},instance)",
+        "query": "label_values(up{job=\"alertmanager-garden\"},instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -317,15 +317,14 @@ providers:
 }
 
 func (p *plutono) getDataSource() string {
-	url := "http://prometheus-web:80"
-	maxLine := "1000"
+	prometheusSuffix, maxLine := "web", "1000"
 	if p.values.IsGardenCluster {
-		url = "http://" + p.namespace + "-prometheus:80"
-		maxLine = "5000"
+		prometheusSuffix, maxLine = "garden", "5000"
 	} else if p.values.ClusterType == component.ClusterTypeSeed {
-		url = "http://prometheus-aggregate:80"
-		maxLine = "5000"
+		prometheusSuffix, maxLine = "aggregate", "5000"
 	}
+
+	url := "http://prometheus-" + prometheusSuffix + ":80"
 
 	datasource := `apiVersion: 1
 
@@ -822,7 +821,7 @@ func (p *plutono) getPodLabels() map[string]string {
 
 	if p.values.IsGardenCluster {
 		labels = utils.MergeStringMaps(labels, map[string]string{
-			gardenerutils.NetworkPolicyLabel("garden-prometheus", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
+			gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
 			gardenerutils.NetworkPolicyLabel("garden-avail-prom", 9091): v1beta1constants.LabelNetworkPolicyAllowed,
 		})
 

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -166,7 +166,7 @@ metadata:
 				url := "http://prometheus-web:80"
 				maxLine := "1000"
 				if values.IsGardenCluster {
-					url = "http://" + namespace + "-prometheus:80"
+					url = "http://prometheus-garden:80"
 					maxLine = "5000"
 				} else if values.ClusterType == comp.ClusterTypeSeed {
 					url = "http://prometheus-aggregate:80"
@@ -241,7 +241,7 @@ metadata:
     resources.gardener.cloud/garbage-collectable-reference: "true"
 `
 				if values.IsGardenCluster {
-					configMap += `  name: plutono-datasources-ff212e8b
+					configMap += `  name: plutono-datasources-b7111930
   namespace: some-namespace
 `
 					return configMap
@@ -268,7 +268,7 @@ metadata:
 				}
 				if values.IsGardenCluster {
 					providerConfigMap = "plutono-dashboard-providers-5be2bcda"
-					dataSourceConfigMap = "plutono-datasources-ff212e8b"
+					dataSourceConfigMap = "plutono-datasources-b7111930"
 				}
 
 				deployment := &appsv1.Deployment{
@@ -599,7 +599,7 @@ status:
 
 				It("should successfully deploy all resources", func() {
 					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-dashboard-providers-5be2bcda.yaml"])).To(Equal(providerConfigMapYAMLFor(values)))
-					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-datasources-ff212e8b.yaml"])).To(Equal(dataSourceConfigMapYAMLFor(values)))
+					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-datasources-b7111930.yaml"])).To(Equal(dataSourceConfigMapYAMLFor(values)))
 					plutonoDashboardsGardenConfigMap, err := getDashboardConfigMaps(ctx, c, namespace, "plutono-dashboards-garden-[^-]{8}")
 					Expect(err).ToNot(HaveOccurred())
 					plutonoDashboardsGlobalConfigMap, err := getDashboardConfigMaps(ctx, c, namespace, "plutono-dashboards-global-[^-]{8}")
@@ -833,7 +833,7 @@ func getPodLabels(values Values) map[string]string {
 
 	if values.IsGardenCluster {
 		labels = utils.MergeStringMaps(labels, map[string]string{
-			gardenerutils.NetworkPolicyLabel("garden-prometheus", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
+			gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
 			gardenerutils.NetworkPolicyLabel("garden-avail-prom", 9091): v1beta1constants.LabelNetworkPolicyAllowed,
 		})
 

--- a/pkg/component/shared/blackboxexporter.go
+++ b/pkg/component/shared/blackboxexporter.go
@@ -1,0 +1,33 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/imagevector"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter"
+)
+
+// NewBlackboxExporter creates a new blackbox-exporter deployer.
+func NewBlackboxExporter(c client.Client, namespace string, values blackboxexporter.Values) (blackboxexporter.Interface, error) {
+	image, err := imagevector.ImageVector().FindImage(imagevector.ImageNameBlackboxExporter)
+	if err != nil {
+		return nil, err
+	}
+	values.Image = image.String()
+
+	return blackboxexporter.New(c, namespace, values), nil
+}

--- a/pkg/component/shared/prometheus.go
+++ b/pkg/component/shared/prometheus.go
@@ -20,12 +20,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
-	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 )
 
 // NewPrometheus creates a new prometheus deployer.
-func NewPrometheus(log logr.Logger, c client.Client, namespace string, values prometheus.Values) (component.DeployWaiter, error) {
+func NewPrometheus(log logr.Logger, c client.Client, namespace string, values prometheus.Values) (prometheus.Interface, error) {
 	imagePrometheus, err := imagevector.ImageVector().FindImage(imagevector.ImageNamePrometheus)
 	if err != nil {
 		return nil, err

--- a/pkg/component/shared/prometheus.go
+++ b/pkg/component/shared/prometheus.go
@@ -1,0 +1,60 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/imagevector"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
+)
+
+// NewPrometheus creates a new prometheus deployer.
+func NewPrometheus(log logr.Logger, c client.Client, namespace string, values prometheus.Values) (component.DeployWaiter, error) {
+	imagePrometheus, err := imagevector.ImageVector().FindImage(imagevector.ImageNamePrometheus)
+	if err != nil {
+		return nil, err
+	}
+
+	values.Image = imagePrometheus.String()
+	values.Version = ptr.Deref(imagePrometheus.Version, "v0.0.0")
+
+	// TODO(rfranzke): Remove this block after all Prometheis have been migrated.
+	{
+		imageAlpine, err := imagevector.ImageVector().FindImage(imagevector.ImageNameAlpine)
+		if err != nil {
+			return nil, err
+		}
+
+		values.DataMigration.Client = c
+		values.DataMigration.Namespace = namespace
+		values.DataMigration.StorageCapacity = values.StorageCapacity
+		values.DataMigration.ImageAlpine = imageAlpine.String()
+		if values.DataMigration.StatefulSetName == "" {
+			values.DataMigration.StatefulSetName = "prometheus"
+		}
+		if values.DataMigration.FullName == "" {
+			values.DataMigration.FullName = "prometheus-" + values.Name
+		}
+		if values.DataMigration.PVCNames == nil {
+			values.DataMigration.PVCNames = []string{"prometheus-db-" + values.DataMigration.StatefulSetName + "-0"}
+		}
+	}
+
+	return prometheus.New(log, c, namespace, values), nil
+}

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -694,7 +694,7 @@ func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed,
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.LabelNetworkPolicyShootNamespaceAlias+"-prometheus-web", 9090):                                                       v1beta1constants.LabelNetworkPolicyAllowed,
 		},
 		Ingress: &prometheus.IngressValues{
-			Host:           seed.GetIngressFQDN("p-seed"),
+			Host:           seed.GetIngressFQDN(v1beta1constants.IngressDomainPrefixPrometheusAggregate),
 			SecretsManager: secretsManager,
 			SigningCA:      v1beta1constants.SecretNameCASeed,
 		},

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -688,6 +688,7 @@ func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed,
 		Ingress: &prometheus.IngressValues{
 			Host:           seed.GetIngressFQDN("p-seed"),
 			SecretsManager: secretsManager,
+			SigningCA:      v1beta1constants.SecretNameCASeed,
 		},
 	}
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -635,6 +635,9 @@ func (r *Reconciler) newCachePrometheus(log logr.Logger, seed *seedpkg.Seed) (co
 		Replicas:          1,
 		Retention:         ptr.To(monitoringv1.Duration("1d")),
 		RetentionSize:     "5GB",
+		AdditionalPodLabels: map[string]string{
+			"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets: v1beta1constants.LabelNetworkPolicyAllowed,
+		},
 		CentralConfigs: prometheus.CentralConfigs{
 			AdditionalScrapeConfigs: cacheprometheus.AdditionalScrapeConfigs(),
 			ServiceMonitors:         cacheprometheus.CentralServiceMonitors(),
@@ -656,6 +659,7 @@ func (r *Reconciler) newSeedPrometheus(log logr.Logger, seed *seedpkg.Seed) (com
 		RetentionSize:     "85GB",
 		VPAMinAllowed:     &corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("400Mi")},
 		AdditionalPodLabels: map[string]string{
+			"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets:            v1beta1constants.LabelNetworkPolicyAllowed,
 			"networking.resources.gardener.cloud/to-extensions-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets: v1beta1constants.LabelNetworkPolicyAllowed,
 			// TODO: For whatever reasons, the seed-prometheus also scrapes vpa-recommenders in all shoot namespaces.
 			//  Conceptionally, this is wrong and should be improved (seed-prometheus should only scrape
@@ -689,6 +693,7 @@ func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed,
 			ServiceMonitors: aggregateprometheus.CentralServiceMonitors(),
 		},
 		AdditionalPodLabels: map[string]string{
+			"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets:                                                                       v1beta1constants.LabelNetworkPolicyAllowed,
 			"networking.resources.gardener.cloud/to-" + v1beta1constants.IstioSystemNamespace + "-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets:                         v1beta1constants.LabelNetworkPolicyAllowed,
 			"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyIstioIngressNamespaceAlias + "-" + v1beta1constants.LabelNetworkPolicySeedScrapeTargets: v1beta1constants.LabelNetworkPolicyAllowed,
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.LabelNetworkPolicyShootNamespaceAlias+"-prometheus-web", 9090):                                                       v1beta1constants.LabelNetworkPolicyAllowed,

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -188,18 +188,8 @@ func (r *Reconciler) runReconcileSeedFlow(
 	}
 
 	log.Info("Replicating global monitoring secret to garden namespace in seed", "secret", client.ObjectKeyFromObject(globalMonitoringSecretGarden))
-	globalMonitoringSecretSeed := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "seed-" + globalMonitoringSecretGarden.Name, Namespace: r.GardenNamespace}}
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClientSet.Client(), globalMonitoringSecretSeed, func() error {
-		globalMonitoringSecretSeed.Type = globalMonitoringSecretGarden.Type
-		globalMonitoringSecretSeed.Data = globalMonitoringSecretGarden.Data
-		globalMonitoringSecretSeed.Immutable = globalMonitoringSecretGarden.Immutable
-
-		if _, ok := globalMonitoringSecretSeed.Data[secretsutils.DataKeySHA1Auth]; !ok {
-			globalMonitoringSecretSeed.Data[secretsutils.DataKeySHA1Auth] = utils.CreateSHA1Secret(globalMonitoringSecretGarden.Data[secretsutils.DataKeyUserName], globalMonitoringSecretGarden.Data[secretsutils.DataKeyPassword])
-		}
-
-		return nil
-	}); err != nil {
+	globalMonitoringSecretSeed, err := gardenerutils.ReplicateGlobalMonitoringSecret(ctx, r.SeedClientSet.Client(), "seed-", r.GardenNamespace, globalMonitoringSecretGarden)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/gardenlet/operation/botanist/blackboxexporter.go
+++ b/pkg/gardenlet/operation/botanist/blackboxexporter.go
@@ -28,6 +28,7 @@ import (
 func (b *Botanist) DefaultBlackboxExporter() (blackboxexporter.Interface, error) {
 	return sharedcomponent.NewBlackboxExporter(
 		b.SeedClientSet.Client(),
+		b.SecretsManager,
 		b.Shoot.SeedNamespace,
 		blackboxexporter.Values{
 			ClusterType:       component.ClusterTypeShoot,

--- a/pkg/operator/client/scheme.go
+++ b/pkg/operator/client/scheme.go
@@ -69,10 +69,22 @@ var (
 		monitoringv1.AddToScheme,
 		monitoringv1beta1.AddToScheme,
 		monitoringv1alpha1.AddToScheme,
+		func(scheme *runtime.Scheme) error {
+			apiextensionsinstall.Install(scheme)
+			return nil
+		},
 	)
 	virtualSchemeBuilder = runtime.NewSchemeBuilder(
 		kubernetesscheme.AddToScheme,
 		apiregistrationv1.AddToScheme,
+		func(scheme *runtime.Scheme) error {
+			apiextensionsinstall.Install(scheme)
+			gardencoreinstall.Install(scheme)
+			seedmanagementinstall.Install(scheme)
+			settingsinstall.Install(scheme)
+			operationsinstall.Install(scheme)
+			return nil
+		},
 	)
 
 	// AddRuntimeSchemeToScheme adds all object kinds used in the runtime cluster into the given scheme.
@@ -83,12 +95,5 @@ var (
 
 func init() {
 	utilruntime.Must(AddRuntimeSchemeToScheme(RuntimeScheme))
-	apiextensionsinstall.Install(RuntimeScheme)
-
 	utilruntime.Must(AddVirtualSchemeToScheme(VirtualScheme))
-	apiextensionsinstall.Install(VirtualScheme)
-	gardencoreinstall.Install(VirtualScheme)
-	seedmanagementinstall.Install(VirtualScheme)
-	settingsinstall.Install(VirtualScheme)
-	operationsinstall.Install(VirtualScheme)
 }

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1092,7 +1092,9 @@ func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Gar
 		Replicas:          2,
 		Retention:         ptr.To(monitoringv1.Duration("10d")),
 		RetentionSize:     "190GB",
+		ScrapeTimeout:     "50s",
 		RuntimeVersion:    r.RuntimeVersion,
+		ExternalLabels:    map[string]string{"landscape": garden.Spec.VirtualCluster.Gardener.ClusterIdentity},
 		VPAMaxAllowed: &corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("4"),
 			corev1.ResourceMemory: resource.MustParse("50G"),

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1104,7 +1104,7 @@ func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Gar
 		Replicas:          2,
 		Retention:         ptr.To(monitoringv1.Duration("10d")),
 		RetentionSize:     "190GB",
-		ScrapeTimeout:     "50s",
+		ScrapeTimeout:     "50s", // This is intentionally smaller than the scrape interval of 1m.
 		RuntimeVersion:    r.RuntimeVersion,
 		ExternalLabels:    map[string]string{"landscape": garden.Spec.VirtualCluster.Gardener.ClusterIdentity},
 		VPAMaxAllowed: &corev1.ResourceList{
@@ -1157,8 +1157,8 @@ func (r *Reconciler) newBlackboxExporter(garden *operatorv1alpha1.Garden, secret
 			KubernetesVersion: r.RuntimeVersion,
 			PodLabels: map[string]string{
 				v1beta1constants.LabelNetworkPolicyToPublicNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
-				"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyIstioIngressNamespaceAlias + "-" + v1beta1constants.DefaultSNIIngressServiceName: v1beta1constants.LabelNetworkPolicyAllowed,
-				gardenerutils.NetworkPolicyLabel(gardenerapiserver.DeploymentName, 8443):                                                                                        v1beta1constants.LabelNetworkPolicyAllowed,
+				gardenerutils.NetworkPolicyLabel(v1beta1constants.LabelNetworkPolicyIstioIngressNamespaceAlias+"-"+v1beta1constants.DefaultSNIIngressServiceName, 9443): v1beta1constants.LabelNetworkPolicyAllowed,
+				gardenerutils.NetworkPolicyLabel(gardenerapiserver.DeploymentName, 8443):                                                                                v1beta1constants.LabelNetworkPolicyAllowed,
 			},
 			PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem100,
 			Config:            gardenblackboxexporter.Config(),

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1111,6 +1111,9 @@ func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Gar
 			corev1.ResourceCPU:    resource.MustParse("4"),
 			corev1.ResourceMemory: resource.MustParse("50G"),
 		},
+		AdditionalPodLabels: map[string]string{
+			"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyGardenScrapeTargets: v1beta1constants.LabelNetworkPolicyAllowed,
+		},
 		CentralConfigs: prometheus.CentralConfigs{
 			AdditionalScrapeConfigs: gardenprometheus.AdditionalScrapeConfigs(),
 			PrometheusRules:         gardenprometheus.CentralPrometheusRules(),

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -73,6 +73,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/alertmanager"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/gardenermetricsexporter"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
+	gardenprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
 	"github.com/gardener/gardener/pkg/component/observability/plutono"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
@@ -1098,6 +1099,10 @@ func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Gar
 		VPAMaxAllowed: &corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("4"),
 			corev1.ResourceMemory: resource.MustParse("50G"),
+		},
+		CentralConfigs: prometheus.CentralConfigs{
+			AdditionalScrapeConfigs: gardenprometheus.AdditionalScrapeConfigs(),
+			ServiceMonitors:         gardenprometheus.CentralServiceMonitors(),
 		},
 		Alerting: &prometheus.AlertingValues{AlertmanagerName: "alertmanager-garden"},
 		Ingress: &prometheus.IngressValues{

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1102,6 +1102,7 @@ func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Gar
 		},
 		CentralConfigs: prometheus.CentralConfigs{
 			AdditionalScrapeConfigs: gardenprometheus.AdditionalScrapeConfigs(),
+			PrometheusRules:         gardenprometheus.CentralPrometheusRules(),
 			ServiceMonitors:         gardenprometheus.CentralServiceMonitors(),
 		},
 		Alerting: &prometheus.AlertingValues{AlertmanagerName: "alertmanager-garden"},

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1156,7 +1156,9 @@ func (r *Reconciler) newBlackboxExporter(garden *operatorv1alpha1.Garden, secret
 			VPAEnabled:        true,
 			KubernetesVersion: r.RuntimeVersion,
 			PodLabels: map[string]string{
-				gardenerutils.NetworkPolicyLabel(gardenerapiserver.DeploymentName, 8443): v1beta1constants.LabelNetworkPolicyAllowed,
+				v1beta1constants.LabelNetworkPolicyToPublicNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
+				"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyIstioIngressNamespaceAlias + "-" + v1beta1constants.DefaultSNIIngressServiceName: v1beta1constants.LabelNetworkPolicyAllowed,
+				gardenerutils.NetworkPolicyLabel(gardenerapiserver.DeploymentName, 8443):                                                                                        v1beta1constants.LabelNetworkPolicyAllowed,
 			},
 			PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem100,
 			Config:            gardenblackboxexporter.Config(),

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -85,6 +85,10 @@ func (r *Reconciler) delete(
 				return kubernetesutils.DeleteObject(ctx, r.RuntimeClientSet.Client(), gardenerutils.NewShootAccessSecret(gardenprometheus.AccessSecretName, r.GardenNamespace).Secret)
 			},
 		})
+		destroyBlackboxExporter = g.Add(flow.Task{
+			Name: "Destroying blackbox-exporter",
+			Fn:   component.OpDestroyAndWait(c.blackboxExporter).Destroy,
+		})
 
 		destroyGardenerScheduler = g.Add(flow.Task{
 			Name: "Destroying Gardener Scheduler",
@@ -236,6 +240,7 @@ func (r *Reconciler) delete(
 			destroyFluentOperator,
 			destroyVali,
 			destroyPrometheusOperator,
+			destroyBlackboxExporter,
 		)
 
 		destroyRuntimeSystemResources = g.Add(flow.Task{

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -73,6 +73,10 @@ func (r *Reconciler) delete(
 			Name: "Destroying Alertmanager",
 			Fn:   component.OpDestroyAndWait(c.alertManager).Destroy,
 		})
+		destroyPrometheus = g.Add(flow.Task{
+			Name: "Destroying Prometheus",
+			Fn:   component.OpDestroyAndWait(c.prometheus).Destroy,
+		})
 
 		destroyGardenerScheduler = g.Add(flow.Task{
 			Name: "Destroying Gardener Scheduler",
@@ -191,7 +195,7 @@ func (r *Reconciler) delete(
 		destroyPrometheusOperator = g.Add(flow.Task{
 			Name:         "Destroying prometheus-operator",
 			Fn:           component.OpDestroyAndWait(c.prometheusOperator).Destroy,
-			Dependencies: flow.NewTaskIDs(destroyAlertmanager),
+			Dependencies: flow.NewTaskIDs(destroyAlertmanager, destroyPrometheus),
 		})
 		destroyFluentOperatorCustomResources = g.Add(flow.Task{
 			Name:         "Destroying fluent-operator custom resources",

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -31,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	gardenprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
@@ -79,10 +82,7 @@ func (r *Reconciler) delete(
 		destroyPrometheus = g.Add(flow.Task{
 			Name: "Destroying Prometheus",
 			Fn: func(ctx context.Context) error {
-				if err := component.OpDestroyAndWait(c.prometheus).Destroy(ctx); err != nil {
-					return err
-				}
-				return kubernetesutils.DeleteObject(ctx, r.RuntimeClientSet.Client(), gardenerutils.NewShootAccessSecret(gardenprometheus.AccessSecretName, r.GardenNamespace).Secret)
+				return r.destroyGardenPrometheus(ctx, c.prometheus)
 			},
 		})
 		destroyBlackboxExporter = g.Add(flow.Task{
@@ -332,4 +332,16 @@ func (r *Reconciler) checkIfManagedResourcesExist() func(context.Context) error 
 			Cause:        errors.New("at least one ManagedResource still exists"),
 		}
 	}
+}
+
+func (r *Reconciler) destroyGardenPrometheus(ctx context.Context, prometheus prometheus.Interface) error {
+	if err := component.OpDestroyAndWait(prometheus).Destroy(ctx); err != nil {
+		return err
+	}
+
+	if err := kubernetesutils.DeleteObject(ctx, r.RuntimeClientSet.Client(), gardenerutils.NewShootAccessSecret(gardenprometheus.AccessSecretName, r.GardenNamespace).Secret); err != nil {
+		return err
+	}
+
+	return r.RuntimeClientSet.Client().DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(r.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenerPurpose: gardenerutils.LabelPurposeGlobalMonitoringSecret})
 }

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -446,6 +446,11 @@ func (r *Reconciler) reconcile(
 			},
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD, waitUntilGardenerAPIServerReady, initializeVirtualClusterClient),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying blackbox-exporter",
+			Fn:           c.blackboxExporter.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilKubeAPIServerIsReady),
+		})
 
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Kube State Metrics",

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -439,7 +439,7 @@ func (r *Reconciler) reconcile(
 			},
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD),
 		})
-		_ = g.Add(flow.Task{
+		deployPrometheus = g.Add(flow.Task{
 			Name: "Deploying Prometheus",
 			Fn: func(ctx context.Context) error {
 				return r.deployGardenPrometheus(ctx, log, secretsManager, c.prometheus, virtualClusterClient)
@@ -449,7 +449,7 @@ func (r *Reconciler) reconcile(
 		_ = g.Add(flow.Task{
 			Name:         "Deploying blackbox-exporter",
 			Fn:           c.blackboxExporter.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilKubeAPIServerIsReady),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilKubeAPIServerIsReady, deployPrometheus),
 		})
 
 		_ = g.Add(flow.Task{

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,6 +139,7 @@ func (r *Reconciler) reconcile(
 				return r.generateObservabilityIngressPassword(ctx, secretsManager)
 			},
 		})
+
 		deployEtcdCRD = g.Add(flow.Task{
 			Name: "Deploying ETCD-related custom resource definitions",
 			Fn:   c.etcdCRD.Deploy,
@@ -163,6 +165,7 @@ func (r *Reconciler) reconcile(
 			Name: "Deploying custom resource definitions for prometheus-operator",
 			Fn:   c.prometheusCRD.Deploy,
 		})
+
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name:         "Deploying and waiting for gardener-resource-manager to be healthy",
 			Fn:           component.OpWait(c.gardenerResourceManager).Deploy,
@@ -198,49 +201,6 @@ func (r *Reconciler) reconcile(
 			Fn:           component.OpWait(c.istio).Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
-		deployFluentOperator = g.Add(flow.Task{
-			Name:         "Deploying fluent-operator",
-			Fn:           c.fluentOperator.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
-		})
-		deployFluentOperatorCustomResources = g.Add(flow.Task{
-			Name:         "Deploying fluent-operator CustomResources",
-			Fn:           c.fluentOperatorCustomResources.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
-		})
-		deployFluentBit = g.Add(flow.Task{
-			Name:         "Deploying fluent-bit",
-			Fn:           c.fluentBit.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
-		})
-		deployVali = g.Add(flow.Task{
-			Name:         "Deploying Vali",
-			Fn:           c.vali.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
-		})
-		deployPrometheusOperator = g.Add(flow.Task{
-			Name:         "Deploying prometheus-operator",
-			Fn:           c.prometheusOperator.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD),
-		})
-		deployAlertmanager = g.Add(flow.Task{
-			Name: "Deploying Alertmanager",
-			Fn: func(ctx context.Context) error {
-				credentialsSecret, found := secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
-				if !found {
-					return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
-				}
-
-				c.alertManager.SetIngressAuthSecret(credentialsSecret)
-				return c.alertManager.Deploy(ctx)
-			},
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD),
-		})
-		deployPrometheus = g.Add(flow.Task{
-			Name:         "Deploying Prometheus",
-			Fn:           r.deployGardenPrometheus(secretsManager, c.prometheus),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD),
-		})
 		syncPointSystemComponents = flow.NewTaskIDs(
 			generateGenericTokenKubeconfig,
 			generateObservabilityIngressPassword,
@@ -252,13 +212,6 @@ func (r *Reconciler) reconcile(
 			deployEtcdDruid,
 			deployIstio,
 			deployNginxIngressController,
-			deployFluentOperator,
-			deployFluentOperatorCustomResources,
-			deployFluentBit,
-			deployVali,
-			deployPrometheusOperator,
-			deployAlertmanager,
-			deployPrometheus,
 		)
 
 		deployEtcds = g.Add(flow.Task{
@@ -448,6 +401,53 @@ func (r *Reconciler) reconcile(
 		})
 
 		_ = g.Add(flow.Task{
+			Name:         "Deploying fluent-operator",
+			Fn:           c.fluentOperator.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying fluent-operator CustomResources",
+			Fn:           c.fluentOperatorCustomResources.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying fluent-bit",
+			Fn:           c.fluentBit.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying Vali",
+			Fn:           c.vali.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
+		})
+
+		_ = g.Add(flow.Task{
+			Name:         "Deploying prometheus-operator",
+			Fn:           c.prometheusOperator.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying Alertmanager",
+			Fn: func(ctx context.Context) error {
+				credentialsSecret, found := secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
+				if !found {
+					return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
+				}
+
+				c.alertManager.SetIngressAuthSecret(credentialsSecret)
+				return c.alertManager.Deploy(ctx)
+			},
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying Prometheus",
+			Fn: func(ctx context.Context) error {
+				return r.deployGardenPrometheus(ctx, log, secretsManager, c.prometheus, virtualClusterClient)
+			},
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD, waitUntilGardenerAPIServerReady, initializeVirtualClusterClient),
+		})
+
+		_ = g.Add(flow.Task{
 			Name:         "Deploying Kube State Metrics",
 			Fn:           c.kubeStateMetrics.Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilKubeAPIServerIsReady),
@@ -615,20 +615,54 @@ func (r *Reconciler) deployGardenerAPIServerFunc(garden *operatorv1alpha1.Garden
 	}
 }
 
-func (r *Reconciler) deployGardenPrometheus(secretsManager secretsmanager.Interface, prometheus prometheus.Interface) flow.TaskFn {
-	return func(ctx context.Context) error {
-		if err := gardenerutils.NewShootAccessSecret(gardenprometheus.AccessSecretName, r.GardenNamespace).Reconcile(ctx, r.RuntimeClientSet.Client()); err != nil {
-			return fmt.Errorf("failed reconciling access secret for garden prometheus: %w", err)
-		}
-
-		credentialsSecret, found := secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
-		if !found {
-			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
-		}
-
-		prometheus.SetIngressAuthSecret(credentialsSecret)
-		return prometheus.Deploy(ctx)
+func (r *Reconciler) deployGardenPrometheus(ctx context.Context, log logr.Logger, secretsManager secretsmanager.Interface, prometheus prometheus.Interface, virtualGardenClient client.Client) error {
+	if err := gardenerutils.NewShootAccessSecret(gardenprometheus.AccessSecretName, r.GardenNamespace).Reconcile(ctx, r.RuntimeClientSet.Client()); err != nil {
+		return fmt.Errorf("failed reconciling access secret for garden prometheus: %w", err)
 	}
+
+	// fetch auth secret for ingress
+	credentialsSecret, found := secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
+	if !found {
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
+	}
+	prometheus.SetIngressAuthSecret(credentialsSecret)
+
+	// fetch global monitoring secret for prometheus-aggregate scrape config
+	secretList := &corev1.SecretList{}
+	if err := virtualGardenClient.List(ctx, secretList, client.InNamespace(r.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleGlobalMonitoring}); err != nil {
+		return fmt.Errorf("failed listing secrets in virtual garden for looking up global monitoring secret: %w", err)
+	}
+
+	var (
+		globalMonitoringSecretRuntime *corev1.Secret
+		err                           error
+	)
+
+	if len(secretList.Items) > 0 {
+		globalMonitoringSecret := &secretList.Items[0]
+
+		log.Info("Replicating global monitoring secret to garden namespace in runtime cluster", "secret", client.ObjectKeyFromObject(globalMonitoringSecret))
+		globalMonitoringSecretRuntime, err = gardenerutils.ReplicateGlobalMonitoringSecret(ctx, r.RuntimeClientSet.Client(), "global-", r.GardenNamespace, globalMonitoringSecret)
+		if err != nil {
+			return err
+		}
+	}
+
+	// fetch ingress urls for prometheus-aggregate scrape config
+	seedList := &gardencorev1beta1.SeedList{}
+	if err := virtualGardenClient.List(ctx, seedList); err != nil {
+		return fmt.Errorf("failed listing secrets in virtual garden: %w", err)
+	}
+
+	var prometheusAggregateTargets []monitoringv1alpha1.Target
+	for _, seed := range seedList.Items {
+		if seed.Spec.Ingress != nil {
+			prometheusAggregateTargets = append(prometheusAggregateTargets, monitoringv1alpha1.Target(v1beta1constants.IngressDomainPrefixPrometheusAggregate+"."+seed.Spec.Ingress.Domain))
+		}
+	}
+
+	prometheus.SetCentralScrapeConfigs(gardenprometheus.CentralScrapeConfigs(prometheusAggregateTargets, globalMonitoringSecretRuntime))
+	return prometheus.Deploy(ctx)
 }
 
 func getKubernetesResourcesForEncryption(garden *operatorv1alpha1.Garden) []string {

--- a/pkg/utils/gardener/networkpolicy.go
+++ b/pkg/utils/gardener/networkpolicy.go
@@ -32,6 +32,12 @@ func InjectNetworkPolicyAnnotationsForScrapeTargets(service *corev1.Service, por
 	return injectNetworkPolicyAnnotationsForScrapeTargets(service, v1beta1constants.LabelNetworkPolicyScrapeTargets, ports...)
 }
 
+// InjectNetworkPolicyAnnotationsForGardenScrapeTargets injects the provided ports into the
+// `networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports` annotation of the given service.
+func InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service *corev1.Service, ports ...networkingv1.NetworkPolicyPort) error {
+	return injectNetworkPolicyAnnotationsForScrapeTargets(service, v1beta1constants.LabelNetworkPolicyGardenScrapeTargets, ports...)
+}
+
 // InjectNetworkPolicyAnnotationsForSeedScrapeTargets injects the provided ports into the
 // `networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports` annotation of the given service.
 func InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service *corev1.Service, ports ...networkingv1.NetworkPolicyPort) error {

--- a/pkg/utils/gardener/networkpolicy_test.go
+++ b/pkg/utils/gardener/networkpolicy_test.go
@@ -43,6 +43,22 @@ var _ = Describe("NetworkPolicy", func() {
 		})
 	})
 
+	Describe("#InjectNetworkPolicyAnnotationsForGardenScrapeTargets", func() {
+		It("should inject the annotations", func() {
+			obj := &corev1.Service{}
+
+			Expect(InjectNetworkPolicyAnnotationsForGardenScrapeTargets(
+				obj,
+				networkingv1.NetworkPolicyPort{Port: utils.IntStrPtrFromInt32(1234), Protocol: ptr.To(corev1.ProtocolTCP)},
+				networkingv1.NetworkPolicyPort{Port: utils.IntStrPtrFromString("foo"), Protocol: ptr.To(corev1.ProtocolUDP)},
+			)).Should(Succeed())
+
+			Expect(obj.Annotations).To(And(
+				HaveKeyWithValue("networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports", `[{"protocol":"TCP","port":1234},{"protocol":"UDP","port":"foo"}]`),
+			))
+		})
+	})
+
 	Describe("#InjectNetworkPolicyAnnotationsForSeedScrapeTargets", func() {
 		It("should inject the annotations", func() {
 			obj := &corev1.Service{}

--- a/pkg/utils/gardener/secrets_test.go
+++ b/pkg/utils/gardener/secrets_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Secrets", func() {
 
 		It("should replicate the secret", func() {
 			assertions := func(secret *corev1.Secret) {
+				Expect(secret.Labels).To(HaveKeyWithValue("gardener.cloud/purpose", "global-monitoring-secret-replica"))
 				Expect(secret.Type).To(Equal(globalMonitoringSecret.Type))
 				Expect(secret.Immutable).To(Equal(globalMonitoringSecret.Immutable))
 				for k, v := range globalMonitoringSecret.Data {

--- a/pkg/utils/gardener/secrets_test.go
+++ b/pkg/utils/gardener/secrets_test.go
@@ -1,0 +1,74 @@
+// Copyright 202$ SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardener_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+var _ = Describe("Secrets", func() {
+	Describe("ReplicateGlobalMonitoringSecret", func() {
+		var (
+			ctx        = context.Background()
+			fakeClient client.Client
+
+			prefix                 = "prefix"
+			namespace              = "namespace"
+			globalMonitoringSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "global-monitoring-secret",
+					Namespace:   "foo",
+					Labels:      map[string]string{"bar": "baz"},
+					Annotations: map[string]string{"baz": "foo"},
+				},
+				Type:      corev1.SecretTypeOpaque,
+				Immutable: ptr.To(false),
+				Data:      map[string][]byte{"username": []byte("bar"), "password": []byte("baz")},
+			}
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().Build()
+		})
+
+		It("should replicate the secret", func() {
+			assertions := func(secret *corev1.Secret) {
+				Expect(secret.Type).To(Equal(globalMonitoringSecret.Type))
+				Expect(secret.Immutable).To(Equal(globalMonitoringSecret.Immutable))
+				for k, v := range globalMonitoringSecret.Data {
+					Expect(secret.Data).To(HaveKeyWithValue(k, v), "have key "+k+" with value "+string(v))
+				}
+				Expect(secret.Data).To(HaveKeyWithValue("auth", []byte("bar:{SHA}u+lgol6jEdIdQGaek98gA7qbkKI=")))
+			}
+
+			secret, err := ReplicateGlobalMonitoringSecret(ctx, fakeClient, prefix, namespace, globalMonitoringSecret)
+			Expect(err).NotTo(HaveOccurred())
+			assertions(secret)
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			assertions(secret)
+		})
+	})
+})

--- a/pkg/utils/test/matchers/managedresource.go
+++ b/pkg/utils/test/matchers/managedresource.go
@@ -59,7 +59,7 @@ func (m *managedResourceObjectsMatcher) createMessage(actual interface{}, additi
 
 	switch {
 	case len(m.mismatchExpectedToActual) > 0:
-		message = fmt.Sprintf("Expected for ManagedResource %s/%s the following object mismathes %s found:\n", managedResource.Namespace, managedResource.Name, addition)
+		message = fmt.Sprintf("Expected for ManagedResource %s/%s the following object mismatches %s found:\n", managedResource.Namespace, managedResource.Name, addition)
 		for expected, actual := range m.mismatchExpectedToActual {
 			message += format.MessageWithDiff(actual, "to equal", expected)
 		}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -106,11 +106,14 @@ build:
             - pkg/component/observability/logging/vali/constants
             - pkg/component/observability/monitoring
             - pkg/component/observability/monitoring/alertmanager
+            - pkg/component/observability/monitoring/blackboxexporter
+            - pkg/component/observability/monitoring/blackboxexporter/garden
             - pkg/component/observability/monitoring/gardenermetricsexporter
             - pkg/component/observability/monitoring/kubestatemetrics
             - pkg/component/observability/monitoring/prometheus
             - pkg/component/observability/monitoring/prometheus/aggregate
             - pkg/component/observability/monitoring/prometheus/cache
+            - pkg/component/observability/monitoring/prometheus/garden
             - pkg/component/observability/monitoring/prometheus/seed
             - pkg/component/observability/monitoring/prometheusoperator
             - pkg/component/observability/monitoring/utils

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -918,12 +918,14 @@ build:
             - pkg/component/observability/monitoring
             - pkg/component/observability/monitoring/alertmanager
             - pkg/component/observability/monitoring/blackboxexporter
+            - pkg/component/observability/monitoring/blackboxexporter/shoot
             - pkg/component/observability/monitoring/kubestatemetrics
             - pkg/component/observability/monitoring/metricsserver
             - pkg/component/observability/monitoring/nodeexporter
             - pkg/component/observability/monitoring/prometheus
             - pkg/component/observability/monitoring/prometheus/aggregate
             - pkg/component/observability/monitoring/prometheus/cache
+            - pkg/component/observability/monitoring/prometheus/garden
             - pkg/component/observability/monitoring/prometheus/seed
             - pkg/component/observability/monitoring/prometheusoperator
             - pkg/component/observability/monitoring/utils

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -106,6 +106,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				healthyManagedResource("prometheus-operator"),
 				healthyManagedResource("alertmanager-garden"),
 				healthyManagedResource("prometheus-garden"),
+				healthyManagedResource("blackbox-exporter"),
 				healthyManagedResource("garden-system"),
 				healthyManagedResource("garden-system-virtual"),
 				healthyManagedResource("gardener-apiserver-runtime"),

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -105,6 +105,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				healthyManagedResource("plutono"),
 				healthyManagedResource("prometheus-operator"),
 				healthyManagedResource("alertmanager-garden"),
+				healthyManagedResource("prometheus-garden"),
 				healthyManagedResource("garden-system"),
 				healthyManagedResource("garden-system-virtual"),
 				healthyManagedResource("gardener-apiserver-runtime"),

--- a/test/integration/operator/garden/garden/garden_suite_test.go
+++ b/test/integration/operator/garden/garden/garden_suite_test.go
@@ -66,6 +66,7 @@ var _ = BeforeSuite(func() {
 		CRDInstallOptions: envtest.CRDInstallOptions{
 			Paths: []string{
 				filepath.Join("..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
+				filepath.Join("testdata", "crd-seeds.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -427,9 +427,9 @@ var _ = Describe("Garden controller tests", func() {
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(service), service)).To(Succeed())
 			return service.Annotations
 		}).Should(Equal(utils.MergeStringMaps(loadBalancerServiceAnnotations, map[string]string{
-			"networking.istio.io/exportTo":                                              "*",
-			"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
-			"networking.resources.gardener.cloud/namespace-selectors":                   `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
+			"networking.istio.io/exportTo": "*",
+			"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
+			"networking.resources.gardener.cloud/namespace-selectors":                          `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
 		})))
 
 		// The garden controller waits for the Etcd resources to be healthy, but etcd-druid is not really running in

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -720,6 +720,7 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-runtime")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-virtual")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-garden")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("blackbox-exporter")})}),
 		))
 
 		By("Wait for last operation state to be set to Succeeded")

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -715,6 +715,7 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-runtime")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-virtual")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-garden")})}),
 		))
 
 		By("Wait for last operation state to be set to Succeeded")

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -123,8 +123,12 @@ var _ = Describe("Garden controller tests", func() {
 		mapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
 		Expect(err).NotTo(HaveOccurred())
 
+		scheme := runtime.NewScheme()
+		Expect(operatorclient.AddRuntimeSchemeToScheme(scheme)).To(Succeed())
+		Expect(operatorclient.AddVirtualSchemeToScheme(scheme)).To(Succeed())
+
 		mgr, err := manager.New(restConfig, manager.Options{
-			Scheme:  operatorclient.RuntimeScheme,
+			Scheme:  scheme,
 			Metrics: metricsserver.Options{BindAddress: "0"},
 			Cache: cache.Options{
 				Mapper: mapper,

--- a/test/integration/operator/garden/garden/testdata/crd-seeds.yaml
+++ b/test/integration/operator/garden/garden/testdata/crd-seeds.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: seeds.core.gardener.cloud
+spec:
+  scope: Cluster
+  names:
+    kind: Seed
+    listKind: SeedList
+    plural: seeds
+    singular: seed
+  group: core.gardener.cloud
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity monitoring
/kind enhancement

**What this PR does / why we need it**:
`gardener-operator` now deploys two Prometheus replicas into the `garden` namespace. Read more about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#observability).

In addition, a `blackbox-exporter` will be deployed for API server probes. The existing `blackboxexporter` component was made reusable.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9065

**Special notes for your reviewer**:
/cc @oliver-goetz @ScheererJ 
FYI @istvanballok @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` now deploys two Prometheus replicas into the `garden` namespace. Read more about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#observability).
```
