### PR TITLE
[release-v1.89] Automated cherry pick of #9536: Replace topology labels when `PersistentVolume` has no node affinity

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -580,10 +580,17 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 		taskFns = append(taskFns, func(ctx context.Context) error {
 			patch := client.MergeFrom(persistentVolume.DeepCopy())
 
-			delete(persistentVolume.Labels, corev1.LabelFailureDomainBetaRegion)
-			delete(persistentVolume.Labels, corev1.LabelFailureDomainBetaZone)
-
-			if persistentVolume.Spec.NodeAffinity != nil && persistentVolume.Spec.NodeAffinity.Required != nil {
+			if persistentVolume.Spec.NodeAffinity == nil {
+				// when PV is very old and has no node affinity, we just replace the topology labels
+				if v, ok := persistentVolume.Labels[corev1.LabelFailureDomainBetaRegion]; ok {
+					persistentVolume.Labels[corev1.LabelTopologyRegion] = v
+				}
+				if v, ok := persistentVolume.Labels[corev1.LabelFailureDomainBetaZone]; ok {
+					persistentVolume.Labels[corev1.LabelTopologyZone] = v
+				}
+			} else if persistentVolume.Spec.NodeAffinity.Required != nil {
+				// when PV has node affinity then we do not need the labels but just need to replace the topology keys
+				// in the node selector term match expressions
 				for i, term := range persistentVolume.Spec.NodeAffinity.Required.NodeSelectorTerms {
 					for j, expression := range term.MatchExpressions {
 						if expression.Key == corev1.LabelFailureDomainBetaRegion {
@@ -596,6 +603,11 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 					}
 				}
 			}
+
+			// either new topology labels were added above, or node affinity keys were adjusted
+			// in both cases, the old, deprecated topology labels are no longer needed and can be removed
+			delete(persistentVolume.Labels, corev1.LabelFailureDomainBetaRegion)
+			delete(persistentVolume.Labels, corev1.LabelFailureDomainBetaZone)
 
 			// prevent sending empty patches
 			if data, err := patch.Data(&persistentVolume); err != nil {


### PR DESCRIPTION
/kind bug
/area usability

Cherry pick of #9536 on release-v1.89.

#9536: Replace topology labels when `PersistentVolume` has no node affinity

**Release Notes:**
```bugfix operator
A bug has been fixed which caused `PersistentVolume`s without `.spec.nodeAffinity` to become unusable in case they still had the old, deprecated topology labels.
```