### PR TITLE
provider-local: Update machine-controller-manager-provider-local image

### DIFF
--- a/pkg/provider-local/imagevector/images.go
+++ b/pkg/provider-local/imagevector/images.go
@@ -11,8 +11,6 @@ const (
 	ImageNameLocalPathHelper = "local-path-helper"
 	// ImageNameLocalPathProvisioner is a constant for an image in the image vector with name 'local-path-provisioner'.
 	ImageNameLocalPathProvisioner = "local-path-provisioner"
-	// ImageNameMachineControllerManager is a constant for an image in the image vector with name 'machine-controller-manager'.
-	ImageNameMachineControllerManager = "machine-controller-manager"
 	// ImageNameMachineControllerManagerProviderLocal is a constant for an image in the image vector with name 'machine-controller-manager-provider-local'.
 	ImageNameMachineControllerManagerProviderLocal = "machine-controller-manager-provider-local"
 )

--- a/pkg/provider-local/imagevector/images.yaml
+++ b/pkg/provider-local/imagevector/images.yaml
@@ -1,8 +1,4 @@
 images:
-- name: machine-controller-manager
-  sourceRepository: github.com/gardener/machine-controller-manager
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager
-  tag: "v0.49.3"
 - name: machine-controller-manager-provider-local
   sourceRepository: github.com/gardener/machine-controller-manager-provider-local
   repository: ghcr.io/gardener/machine-controller-manager-provider-local

--- a/pkg/provider-local/imagevector/images.yaml
+++ b/pkg/provider-local/imagevector/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager-provider-local
   sourceRepository: github.com/gardener/machine-controller-manager-provider-local
   repository: ghcr.io/gardener/machine-controller-manager-provider-local
-  tag: sha-56e361b
+  tag: sha-aa28b3a
 - name: local-path-provisioner
   sourceRepository: github.com/kubernetes-sigs/kind/tree/main/images/local-path-provisioner
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kindest/local-path-provisioner


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates machine-controller-manager and machine-controller-manager-provider-local images after the merge of https://github.com/gardener/machine-controller-manager-provider-local/pull/36.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
