### PR TITLE
Use `x.y.0` versions of the Go Toolchain only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,7 +59,7 @@
     {
       // Group golang updates in one PR.
       "groupName": "golang",
-      "matchDatasources": ["docker", "go-version"],
+      "matchDatasources": ["docker"],
       "matchPackagePatterns": ["golang"],
     },
     {
@@ -89,6 +89,15 @@
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["major", "minor"],
       "matchPackagePatterns": ["kindest\/node"],
+      "enabled": false
+    },
+    {
+      // Do not update to patch versions of the Go Toolchain.
+      // Default golang images set the environment variable GOTOOLCHAIN=local
+      // and we don't want to enforce every (test-)image to be on the latest patch level.
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "matchPackagePatterns": ["go"],
       "enabled": false
     },
     {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener
 
-go 1.22.2
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
There were several cases where tests in pipelines failed because not every test images had the most recent patch level of golang.
```
go: go.mod requires go >= 1.22.2 (running go 1.22.0; GOTOOLCHAIN=local)
```
In these cases logs similar to the line above could be found.

Relevant issue we would like to have fixed are usually in `golang` itself and not in its toolchain, so this PR pins it to `1.22.0` and disables patch updates for the `go` directive in `go.mod`. 
`golang` images are still updated. 

Other projects like [kubernetes](https://github.com/kubernetes/kubernetes/blob/9791f0d1f39f3f1e0796add7833c1059325d5098/go.mod#L9) and [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/20f3f4bed925a9b7e41388c993fb217e7821910f/go.mod#L3) are using the same approach.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
