### PR TITLE
Classify K8s dashboard test as `beta`

### DIFF
--- a/test/testmachinery/shoots/applications/shoot_app.go
+++ b/test/testmachinery/shoots/applications/shoot_app.go
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe("Shoot application testing", func() {
 		}, finalizationTimeout)
 	})
 
-	f.Default().Release().CIt("Dashboard should be available", func(ctx context.Context) {
+	f.Default().Beta().CIt("Dashboard should be available", func(ctx context.Context) {
 		shoot := f.Shoot
 		if !shoot.Spec.Addons.KubernetesDashboard.Enabled {
 			ginkgo.Fail("The test requires .spec.addons.kubernetesDashboard.enabled to be true")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
The K8s dashboard add-on is maintained on a best effort basis. There is only limited support and it is unsuitable for productive clusters. Therefore, it should not be part of the `release` tests as we've seen this test to be flakey (returning random 50x codes).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
K8s dashboard tests are classified as `beta`.
```
