### PR TITLE
[release-v1.91] Automated cherry pick of #9564: Use `x.y.0` versions of the Go Toolchain only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,7 +59,7 @@
     {
       // Group golang updates in one PR.
       "groupName": "golang",
-      "matchDatasources": ["docker", "go-version"],
+      "matchDatasources": ["docker"],
       "matchPackagePatterns": ["golang"],
     },
     {
@@ -80,6 +80,15 @@
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["major", "minor"],
       "matchPackagePatterns": ["kindest\/node"],
+      "enabled": false
+    },
+    {
+      // Do not update to patch versions of the Go Toolchain.
+      // Default golang images set the environment variable GOTOOLCHAIN=local
+      // and we don't want to enforce every (test-)image to be on the latest patch level.
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "matchPackagePatterns": ["go"],
       "enabled": false
     },
     {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener
 
-go 1.22.1
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
/kind enhancement
/area dev-productivity

Cherry pick of #9564 on release-v1.91.

#9564: Use `x.y.0` versions of the Go Toolchain only

**Release Notes:**
```other operator
NONE
```