### PR TITLE
[GEP-23] Federate resource utilization metrics for the kube-apiserver container

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -69,6 +69,7 @@ func CentralScrapeConfigs(prometheusAggregateTargets []monitoringv1alpha1.Target
 						`{__name__=~"seed:(.+):sum"}`,
 						`{__name__=~"seed:(.+):sum_cp"}`,
 						`{__name__=~"seed:(.+):sum_by_pod",namespace=~"extension-(.+)"}`,
+						`{__name__=~"seed:(.+):sum_by_container",__name__!="seed:kube_pod_container_status_restarts_total:sum_by_container",container="kube-apiserver"}`,
 						`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_storage_objects:sum_by_resource",__name__!="shoot:apiserver_watch_duration:quantile"}`,
 						`{__name__="ALERTS"}`,
 						`{__name__="shoot:availability"}`,

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
@@ -121,6 +121,7 @@ metric_relabel_configs:
 									`{__name__=~"seed:(.+):sum"}`,
 									`{__name__=~"seed:(.+):sum_cp"}`,
 									`{__name__=~"seed:(.+):sum_by_pod",namespace=~"extension-(.+)"}`,
+									`{__name__=~"seed:(.+):sum_by_container",__name__!="seed:kube_pod_container_status_restarts_total:sum_by_container",container="kube-apiserver"}`,
 									`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_storage_objects:sum_by_resource",__name__!="shoot:apiserver_watch_duration:quantile"}`,
 									`{__name__="ALERTS"}`,
 									`{__name__="shoot:availability"}`,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR federates the following recording rules for the `kube-apiserver` container only:
```
seed:container_cpu_usage_seconds_total:sum_by_container
seed:container_cpu_cfs_throttled_seconds_total:sum_by_container
seed:container_cpu_cfs_throttled_periods_total:sum_by_container
seed:container_memory_working_set_bytes:sum_by_container
seed:kube_pod_container_resource_requests_cpu_cores:sum_by_container
seed:kube_pod_container_resource_requests_memory_bytes:sum_by_container
seed:kube_pod_container_resource_limits_cpu_cores:sum_by_container
seed:kube_pod_container_resource_limits_memory_bytes:sum_by_container
seed:hvpa_status_applied_vpa_recommendation_target:sum_by_container
```

See all of the recording rules in https://github.com/gardener/gardener/blob/ed35517d533b2ee9e283168c699a23ef90a67f14/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/recording-rules.rules.yaml.

The motivation for this PR is to build a dashboard in garden/plutono for the kube-apiserver utilization.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8259

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Resource utilization metrics for the kube-apiserver container are now federated in the runtime/prometheus.
```
