### PR TITLE
docs: add missing `resources.gardener.cloud/class` label

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -439,6 +439,7 @@ metadata:
   namespace: garden
   labels:
     resources.gardener.cloud/purpose: token-requestor
+    resources.gardener.cloud/class: shoot
   annotations:
     serviceaccount.resources.gardener.cloud/name: virtual-garden-user
     serviceaccount.resources.gardener.cloud/namespace: kube-system


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
This PR adds a missing `resources.gardener.cloud/class` label to the `shoot-access-virtual-garden` `Secret`, so that the `token-requestor` will write the token into the `Secret`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
