### PR TITLE
Enhance makefile tools binaries to be system and arch independent

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -24,7 +24,7 @@ cd /go/src/github.com/gardener/gardener
 git restore VERSION
 
 if [ $use_cache = yes ] ; then
-  make hack/tools/bin/golangci-lint
+  make hack/tools/bin/golangci-lint TOOLS_BIN_DIR=hack/tools/bin
 
   # list of all to-be-cached directories
   cache_dirs=(

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,7 @@
 !test/
 !third_party/
 !vendor/
-!.golangci.yaml
+!.golangci.yaml.in
 !go.mod
 !go.sum
 !Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ config.vmdk
 hack/tools/logcheck/pkg/logcheck/testdata/src/github.com/go-logr/logr
 hack/tools/logcheck/pkg/logcheck/testdata/src/sigs.k8s.io/controller-runtime/pkg/log
 
+.golangci.yaml
 # Virtual go & fuse
 .virtualgo
 .fuse_hidden*

--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -257,6 +257,6 @@ linters-settings:
         alias: applier
   custom:
     logcheck:
-      path: hack/tools/bin/logcheck.so
+      path: <<LOGCHECK_PLUGIN_PATH>>/logcheck.so
       description: Check structured logging calls to logr.Logger instances
       original-url: github.com/gardener/gardener/hack/tools/logcheck

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ SHELL=/usr/bin/env bash -o pipefail
 # Tools                                 #
 #########################################
 
+TOOLS_BIN_DIR ?= hack/tools/bin/$(go env GOOS)-$(go env GOARCH)
 TOOLS_DIR := hack/tools
 include hack/tools.mk
 
@@ -156,6 +157,7 @@ check-plutono-dashboards:
 
 .PHONY: check
 check: $(GO_ADD_LICENSE) $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(LOGCHECK) $(YQ) $(VGOPATH) logcheck-symlinks
+	@sed ./.golangci.yaml.in -e "s#<<LOGCHECK_PLUGIN_PATH>>#$(TOOLS_BIN_DIR)#g" > ./.golangci.yaml
 	@hack/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./test/...
 	@VGOPATH=$(VGOPATH) hack/check-imports.sh ./charts/... ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./test/... ./third_party/...
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -215,7 +215,7 @@ make test-integration
 If you want to run a specific set of integration tests, you can also execute them using `./hack/test-integration.sh` directly instead of using the `test-integration` rule. Prior to execution, the `PATH` environment variable needs to be set to also included the tools binary directory. For example:
 
 ```bash
-export PATH="$PWD/hack/tools/bin:$PATH"
+export PATH="$PWD/hack/tools/bin/$(go env GOOS)-$(go env GOARCH):$PATH"
 
 source ./hack/test-integration.env
 ./hack/test-integration.sh ./test/integration/resourcemanager/tokenrequestor

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -30,7 +30,7 @@ endif
 
 SYSTEM_NAME                := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 SYSTEM_ARCH                := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
+TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin/$(SYSTEM_NAME)-$(SYSTEM_ARCH)
 CONTROLLER_GEN             := $(TOOLS_BIN_DIR)/controller-gen
 GEN_CRD_API_REFERENCE_DOCS := $(TOOLS_BIN_DIR)/gen-crd-api-reference-docs
 GINKGO                     := $(TOOLS_BIN_DIR)/ginkgo
@@ -57,6 +57,8 @@ SETUP_ENVTEST              := $(TOOLS_BIN_DIR)/setup-envtest
 SKAFFOLD                   := $(TOOLS_BIN_DIR)/skaffold
 YQ                         := $(TOOLS_BIN_DIR)/yq
 VGOPATH                    := $(TOOLS_BIN_DIR)/vgopath
+
+$(shell mkdir -p $(TOOLS_BIN_DIR))
 
 # default tool versions
 # renovate: datasource=github-releases depName=golangci/golangci-lint

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -58,8 +58,6 @@ SKAFFOLD                   := $(TOOLS_BIN_DIR)/skaffold
 YQ                         := $(TOOLS_BIN_DIR)/yq
 VGOPATH                    := $(TOOLS_BIN_DIR)/vgopath
 
-$(shell mkdir -p $(TOOLS_BIN_DIR))
-
 # default tool versions
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.57.2
@@ -126,6 +124,7 @@ version_gomod = $(shell go list -mod=mod -f '{{ .Version }}' -m $(1))
 # This way, we can generically determine, which version was installed without calling each and every binary explicitly.
 $(TOOLS_BIN_DIR)/.version_%:
 	@version_file=$@; rm -f $${version_file%_*}*
+	@mkdir -p $(TOOLS_BIN_DIR)
 	@touch $@
 
 .PHONY: clean-tools-bin

--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -16,7 +16,7 @@ ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=$GOPROXY
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
-RUN make create-tools-bin
+RUN make create-tools-bin TOOLS_BIN_DIR=hack/tools/bin
 
 # golang-test
 FROM base AS golang-test


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Enhance makefile tools binaries to be system and arch independent

Sometimes, I am mounting the source code in a dev container and running various make commands from there, hence the system could differ (`linux` vs `darwin` and `arm64` vs `amd64`). This results in failure because darwin cannot run linux binaries and vise versa, to fix this I have to manually delete binaries one by one or the entire folder which is time consuming. By using dedicated folder for each system and arch, each target will get own set of binaries and the collision will be avoided.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The tools installed via the `tools.mk` make file are now by default installed in an OS and arch specific folder to allow running make targets from different platforms sharing the same source code.
The previous behavior can be achieved by setting the variable `TOOLS_BIN_DIR` to `hack/tools/bin` to any make target.
```
