### PR TITLE
Fix `minAllowed` of VPA resource for `vpn-seed-server` containers.

### DIFF
--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -340,7 +340,7 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("100m"),
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceMemory: resource.MustParse("20Mi"),
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -531,7 +531,7 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("20m"),
-					corev1.ResourceMemory: resource.MustParse("100Mi"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("100Mi"),

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -460,7 +460,7 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("20m"),
-					corev1.ResourceMemory: resource.MustParse("20Mi"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("850M"),

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -763,14 +763,14 @@ func (v *vpnSeedServer) deployVPA(ctx context.Context) error {
 				{
 					ContainerName: DeploymentName,
 					MinAllowed: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("100Mi"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
 					},
 					ControlledValues: &controlledValues,
 				},
 				{
 					ContainerName: envoyProxyContainerName,
 					MinAllowed: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("20Mi"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
 					},
 					ControlledValues: &controlledValues,
 				},

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -374,7 +374,7 @@ var _ = Describe("VpnSeedServer", func() {
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("20m"),
-							corev1.ResourceMemory: resource.MustParse("20Mi"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("850M"),

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -171,7 +171,7 @@ var _ = Describe("VpnSeedServer", func() {
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("100Mi"),
+									corev1.ResourceMemory: resource.MustParse("20Mi"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -324,7 +324,7 @@ var _ = Describe("VpnSeedServer", func() {
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("20m"),
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -591,14 +591,14 @@ var _ = Describe("VpnSeedServer", func() {
 						{
 							ContainerName: DeploymentName,
 							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("100Mi"),
+								corev1.ResourceMemory: resource.MustParse("20Mi"),
 							},
 							ControlledValues: &controlledValues,
 						},
 						{
 							ContainerName: "envoy-proxy",
 							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("20Mi"),
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
 							},
 							ControlledValues: &controlledValues,
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area auto-scaling
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Fix `minAllowed` of VPA resource for `vpn-seed-server` containers.

Initially, the minimum allowed memory requests for the reverse vpn containers seem to have been mixed up. The container hosting OpenVPN never uses 20 MB of memory while the envoy proxy container regularly occupies 40 MB. Therefore, this change switches the minimum settings to reduce the amount of autoscaling required. Thereby it should stabilize the VPN connection.

In addition to that, the initial memory requests of OpenVPN container and its metrics exporter (only in HA scenario) are scaled down to be closer to their needs.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
As the highly-available VPN does not use envoy proxy there is not the same amount of autoscaling happening in the HA VPN. The additional container for metrics is not auto-scaled at all.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `vpn-seed-server` now has better minimum memory settings so that less auto-scaling should occur.
```
