### PR TITLE
[GEP-19] Support Prometheus PVC migration w/o subpath

### DIFF
--- a/pkg/component/observability/monitoring/migration.go
+++ b/pkg/component/observability/monitoring/migration.go
@@ -52,6 +52,10 @@ type DataMigration struct {
 	StorageCapacity resource.Quantity
 	// FullName is the full name of the component (e.g., prometheus-<name> or alertmanager-<name>).
 	FullName string
+	// OldSubPath is the subpath of the database on the old persistent volume. prometheus-operator assumes a subpath
+	// `prometheus-db`, hence, if it was different before, it needs to be migrated.
+	// If this field is not specified, the old subpath is assumed to be `prometheus-`.
+	OldSubPath *string
 
 	// ImageAlpine defines the container image of alpine.
 	ImageAlpine string

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1130,6 +1130,7 @@ func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Gar
 		},
 		DataMigration: monitoring.DataMigration{
 			StatefulSetName: "garden-prometheus",
+			OldSubPath:      ptr.To("/"),
 			PVCNames: []string{
 				"prometheus-db-garden-prometheus-0",
 				"prometheus-db-garden-prometheus-1",

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1140,12 +1140,12 @@ func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Gar
 }
 
 func (r *Reconciler) newBlackboxExporter(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) (blackboxexporter.Interface, error) {
-	kubeAPIServerTargets := []monitoringv1alpha1.Target{monitoringv1alpha1.Target(gardenerDNSNamePrefix + garden.Spec.VirtualCluster.DNS.Domains[0])}
+	kubeAPIServerTargets := []monitoringv1alpha1.Target{monitoringv1alpha1.Target("https://" + gardenerDNSNamePrefix + garden.Spec.VirtualCluster.DNS.Domains[0] + "/healthz")}
 
 	if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI != nil {
 		for _, domainPattern := range garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI.DomainPatterns {
 			if !strings.Contains(domainPattern, "*") {
-				kubeAPIServerTargets = append(kubeAPIServerTargets, monitoringv1alpha1.Target(domainPattern))
+				kubeAPIServerTargets = append(kubeAPIServerTargets, monitoringv1alpha1.Target("https://"+domainPattern+"/healthz"))
 			}
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Some existing Prometheus instances might be deployed w/o `subPath` for their databases, but the current migration code does not support this scenario yet.
With this PR, it's possible to specify the old sub path and facilitate migration.

**Which issue(s) this PR fixes**:
Follow-up of #9543 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
