### PR TITLE
[GEP-19] Slightly improve the formatting in the Gardener alerts

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -346,6 +346,7 @@ spec:
           The seed cluster: {{$labels.name}} has
           condition ControlPlaneHealthy == 0 for more than 30 minutes. Some Control Plane
           components of the seed may have an issue.
+
           {{with printf `ALERTS{alertstate       = 'firing',
                                 project          = '%s',
                                 shoot_name       = '%s',
@@ -354,9 +355,11 @@ spec:
                  | query
                  | sortByLabel "shoot_alertname"}}
           {{if .}}Currently firing alerts:
+
           {{end -}}
           {{range . -}}
           - {{.Labels.shoot_alertname}}
+
           {{end -}}
           {{end -}}
 
@@ -381,6 +384,7 @@ spec:
           The seed cluster: {{$labels.name}} has
           condition SystemComponentsHealthy == 0 for more than 30 minutes. Some
           components required by the seed may have an issue.
+
           {{with printf `ALERTS{alertstate       = 'firing',
                                 project          = '%s',
                                 shoot_name       = '%s',
@@ -389,8 +393,10 @@ spec:
                  | query
                  | sortByLabel "shoot_alertname"}}
           {{if .}}Currently firing alerts:
+
           {{end -}}
           {{range . -}}
           - {{.Labels.shoot_alertname}}
+
           {{end -}}
           {{end -}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

With #9543 there was an unintended change in the formatting of the alert descriptions.

The formatting of these multi line alert definitions in the yaml source code is tricky: we try to balance readability and proper alert descriptions, which means that we use the folded scalar yaml strings to be able to wrap lines, and also blank lines to add line breaks when needed.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9543

**Special notes for your reviewer**:

/cc @rfranzke @vicwicker

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
