### PR TITLE
Fix istio-ingress dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/seed/istio/istio-ingress-gateway-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/seed/istio/istio-ingress-gateway-dashboard.json
@@ -791,7 +791,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(istio_tcp_received_bytes_total{pod=~\"$istio_proxy_pod\", namespace=~\"$istio_proxy_namespace\" }[$__rate_interval])) by (namespace)",
+          "expr": "sum(rate(istio_tcp_sent_bytes_total{pod=~\"$istio_proxy_pod\", namespace=~\"$istio_proxy_namespace\" }[$__rate_interval])) by (namespace)",
           "format": "time_series",
           "hide": false,
           "interval": "",

--- a/pkg/component/observability/plutono/dashboards/seed/istio/istio-ingress-gateway-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/seed/istio/istio-ingress-gateway-dashboard.json
@@ -172,7 +172,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(container_memory_working_set_bytes{pod=~\"$istio_proxy_pod\"}[$__rate_interval])",
+          "expr": "container_memory_working_set_bytes{pod=~\"$istio_proxy_pod\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -805,7 +805,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "TCP Send by Namespace",
+      "title": "TCP Sent by Namespace",
       "tooltip": {
         "shared": true,
         "sort": 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area monitoring
/kind bug

**What this PR does / why we need it**:
Fix istio-ingress dashboard.

The graph for sent tcp traffic used the incorrect metric.

Additionally, a typo was fixed and the memory graph is no longer a rate, which was rather confusing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Istio-ingress gateway dashboard now shows the correct sent tcp traffic metric and the correct memory usage.
```

/cc @DockToFuture @axel7born 