### PR TITLE
[GEP-19] Integrate long-term Prometheus deployment into `Garden` controller

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -269,7 +269,7 @@ This section highlights the most prominent fields:
 Its purpose is to provide an entrypoint for operators when debugging issues with components running in the garden cluster.
 It also serves as the top-level aggregator of metering across a Gardener landscape.
 
-If you would like to extend the configuration for this Garden Prometheus, you can create the [`prometheus-operator`'s custom resources](https://github.com/prometheus-operator/prometheus-operator?tab=readme-ov-file#customresourcedefinitions) and label them with `prometheus=garden`, for example:
+To extend the configuration of the Garden Prometheus, you can create the [`prometheus-operator`'s custom resources](https://github.com/prometheus-operator/prometheus-operator?tab=readme-ov-file#customresourcedefinitions) and label them with `prometheus=garden`, for example:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -295,10 +295,10 @@ spec:
 ###### Long-Term Prometheus
 
 `gardener-operator` deploys another Prometheus instance in the `garden` namespace (called "Long-Term Prometheus") which federates metrics from [Garden Prometheus](#garden-prometheus).
-Its purpose is to store those with a longer retention than Garden Prometheus would (it is not possible to define different retention periods for different metrics in Prometheus, hence, using another Prometheus instance is the only option).
-This Long-Term Prometheus also has an additional [Cortex](https://cortexmetrics.io/) sidecar container for caching some queries to process faster processing times.
+Its purpose is to store those with a longer retention than Garden Prometheus would. It is not possible to define different retention periods for different metrics in Prometheus, hence, using another Prometheus instance is the only option.
+This Long-term Prometheus also has an additional [Cortex](https://cortexmetrics.io/) sidecar container for caching some queries to achieve faster processing times.
 
-If you would like to extend the configuration for this Long-Term Prometheus, you can create the [`prometheus-operator`'s custom resources](https://github.com/prometheus-operator/prometheus-operator?tab=readme-ov-file#customresourcedefinitions) and label them with `prometheus=longterm`, for example:
+To extend the configuration of the Long-term Prometheus, you can create the [`prometheus-operator`'s custom resources](https://github.com/prometheus-operator/prometheus-operator?tab=readme-ov-file#customresourcedefinitions) and label them with `prometheus=longterm`, for example:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -159,8 +159,9 @@ The reconciler also manages a few observability-related components (more planned
 - `plutono`
 - `vali`
 - `prometheus-operator`
-- `alertmanager-garden` (read more [here](#observability))
-- `prometheus-garden` (read more [here](#observability))
+- `alertmanager-garden` (read more [here](#alertmanager))
+- `prometheus-garden` (read more [here](#garden-prometheus))
+- `prometheus-longterm` (read more [here](#long-term-prometheus))
 - `blackbox-exporter`
 
 It is also mandatory to provide an IPv4 CIDR for the service network of the virtual cluster via `.spec.virtualCluster.networking.services`.
@@ -277,6 +278,35 @@ metadata:
   labels:
     prometheus: garden
   name: garden-my-component
+  namespace: garden
+spec:
+  selector:
+    matchLabels:
+      app: my-component
+  endpoints:
+  - metricRelabelings:
+    - action: keep
+      regex: ^(metric1|metric2|...)$
+      sourceLabels:
+      - __name__
+    port: metrics
+```
+
+###### Long-Term Prometheus
+
+`gardener-operator` deploys another Prometheus instance in the `garden` namespace (called "Long-Term Prometheus") which federates metrics from [Garden Prometheus](#garden-prometheus).
+Its purpose is to store those with a longer retention than Garden Prometheus would (it is not possible to define different retention periods for different metrics in Prometheus, hence, using another Prometheus instance is the only option).
+This Long-Term Prometheus also has an additional [Cortex](https://cortexmetrics.io/) sidecar container for caching some queries to process faster processing times.
+
+If you would like to extend the configuration for this Long-Term Prometheus, you can create the [`prometheus-operator`'s custom resources](https://github.com/prometheus-operator/prometheus-operator?tab=readme-ov-file#customresourcedefinitions) and label them with `prometheus=longterm`, for example:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    prometheus: longterm
+  name: longterm-my-component
   namespace: garden
 spec:
   selector:

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -19,14 +19,14 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 
 ### `PriorityClass`es for Garden Control Plane Components
 
-| Name                              | Priority  | Associated Components (Examples)                                                                                                                                                              |
-|-----------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                                                                                                     |
-| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver`                                                                               |
-| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                                                                                                   |
-| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`                                                                                |
-| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`, `gardener-dashboard`                                                                |
-| `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `gardener-metrics-exporter`, `kube-state-metrics`, `plutono`, `vali`, `prometheus-operator`, `alertmanager-garden`, `prometheus-garden`, `blackbox-exporter` |
+| Name                              | Priority  | Associated Components (Examples)                                                                                                                                                                                     |
+|-----------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                                                                                                                            |
+| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver`                                                                                                      |
+| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                                                                                                                          |
+| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`                                                                                                       |
+| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`, `gardener-dashboard`                                                                                       |
+| `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `gardener-metrics-exporter`, `kube-state-metrics`, `plutono`, `vali`, `prometheus-operator`, `alertmanager-garden`, `prometheus-garden`, `blackbox-exporter`, `prometheus-longterm` |
 
 ## Seed Clusters
 

--- a/imagevector/images.go
+++ b/imagevector/images.go
@@ -27,6 +27,8 @@ const (
 	ImageNameConfigmapReloader = "configmap-reloader"
 	// ImageNameCoredns is a constant for an image in the image vector with name 'coredns'.
 	ImageNameCoredns = "coredns"
+	// ImageNameCortex is a constant for an image in the image vector with name 'cortex'.
+	ImageNameCortex = "cortex"
 	// ImageNameDependencyWatchdog is a constant for an image in the image vector with name 'dependency-watchdog'.
 	ImageNameDependencyWatchdog = "dependency-watchdog"
 	// ImageNameEtcdDruid is a constant for an image in the image vector with name 'etcd-druid'.

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -215,6 +215,22 @@ images:
     value:
     - type: 'githubTeam'
       teamname: 'gardener/monitoring-maintainers'
+- name: cortex
+  repository: quay.io/cortexproject/cortex
+  tag: v1.15.3
+  labels:
+  - name: gardener.cloud/cve-categorisation
+    value:
+      network_exposure: public
+      authentication_enforced: true
+      user_interaction: gardener-operator
+      confidentiality_requirement: high
+      integrity_requirement: high
+      availability_requirement: low
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/monitoring-maintainers'
 - name: kube-state-metrics
   sourceRepository: github.com/kubernetes/kube-state-metrics
   repository: registry.k8s.io/kube-state-metrics/kube-state-metrics

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -203,9 +203,6 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 	var cortexConfigMap *corev1.ConfigMap
 	if p.values.Cortex != nil {
 		cortexConfigMap = p.cortexConfigMap()
-		if err := registry.Add(cortexConfigMap); err != nil {
-			return err
-		}
 	}
 
 	resources, err := registry.AddAllAndSerialize(
@@ -213,6 +210,7 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		p.service(),
 		p.clusterRoleBinding(),
 		p.secretAdditionalScrapeConfigs(),
+		cortexConfigMap,
 		p.prometheus(takeOverExistingPV, cortexConfigMap),
 		p.vpa(),
 		p.podDisruptionBudget(),

--- a/pkg/component/observability/monitoring/prometheus/cortex.go
+++ b/pkg/component/observability/monitoring/prometheus/cortex.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	containerNameCortex = "cortex"
-	configMapNamePrefix = "cortex"
-	portCortex          = 9091
+	containerNameCortex   = "cortex"
+	cortexConfigNameInfix = "cortex"
+	portCortex            = 9091
 
 	dataKeyCortexConfig         = "config.yaml"
 	volumeNameCortexConfig      = "cortex-config"
@@ -77,7 +77,7 @@ func (p *prometheus) cortexVolume(configMapName string) corev1.Volume {
 func (p *prometheus) cortexConfigMap() *corev1.ConfigMap {
 	obj := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.name() + "-" + configMapNamePrefix,
+			Name:      p.name() + "-" + cortexConfigNameInfix,
 			Namespace: p.namespace,
 			Labels:    p.getLabels(),
 		},

--- a/pkg/component/observability/monitoring/prometheus/cortex.go
+++ b/pkg/component/observability/monitoring/prometheus/cortex.go
@@ -1,0 +1,111 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+const (
+	containerNameCortex = "cortex"
+	configMapNamePrefix = "cortex"
+	portCortex          = 9091
+
+	dataKeyCortexConfig         = "config.yaml"
+	volumeNameCortexConfig      = "cortex-config"
+	volumeMountPathCortexConfig = "/etc/cortex/config"
+
+	cortexTarget = "query-frontend"
+)
+
+func (p *prometheus) cortexContainer() corev1.Container {
+	return corev1.Container{
+		Name:            containerNameCortex,
+		Image:           p.values.Cortex.Image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Args: []string{
+			"-target=" + cortexTarget,
+			"-config.file=" + volumeMountPathCortexConfig + "/" + dataKeyCortexConfig,
+		},
+		Ports: []corev1.ContainerPort{{
+			Name:          "frontend",
+			ContainerPort: portCortex,
+			Protocol:      corev1.ProtocolTCP,
+		}},
+		SecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(true)},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("300Mi"),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      volumeNameCortexConfig,
+			MountPath: volumeMountPathCortexConfig,
+			ReadOnly:  true,
+		}},
+	}
+}
+
+func (p *prometheus) cortexVolume(configMapName string) corev1.Volume {
+	return corev1.Volume{
+		Name:         volumeNameCortexConfig,
+		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configMapName}}},
+	}
+}
+
+func (p *prometheus) cortexConfigMap() *corev1.ConfigMap {
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.name() + "-" + configMapNamePrefix,
+			Namespace: p.namespace,
+			Labels:    p.getLabels(),
+		},
+		Data: map[string]string{
+			dataKeyCortexConfig: `target: ` + cortexTarget + `
+auth_enabled: false
+http_prefix:
+api:
+  response_compression_enabled: true
+server:
+  http_listen_port: ` + strconv.Itoa(portCortex) + `
+frontend:
+  downstream_url: http://localhost:` + strconv.Itoa(port) + `
+  log_queries_longer_than: -1s
+query_range:
+  split_queries_by_interval: 24h
+  align_queries_with_step: true
+  cache_results: true
+  results_cache:
+    cache:
+      enable_fifocache: true
+      fifocache:
+        max_size_bytes: ` + p.values.StorageCapacity.String() + `
+        validity: ` + p.values.Cortex.CacheValidity.String() + `
+`,
+		},
+	}
+
+	utilruntime.Must(kubernetesutils.MakeUnique(obj))
+	return obj
+}

--- a/pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/recording.yaml
+++ b/pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/recording.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: recording
+spec:
+  groups:
+  - name: info
+    rules:
+    - record: iaas:info
+      expr: |
+        count by (iaas) (garden_shoot_info)
+
+    - record: project:info
+      expr: |
+        count by (project) (garden_shoot_info)
+
+    - record: purpose:info
+      expr: |
+        count by (purpose) (garden_shoot_condition)
+
+    - record: window:info
+      expr: |
+        count by (window) (probe_failure:run:time:total:percent)
+
+    - record: term:info
+      expr: |
+        count by (term) (probe_failure:run:time:total:percent)

--- a/pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/sla.yaml
+++ b/pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/sla.yaml
@@ -1,0 +1,212 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: sla
+spec:
+  groups:
+  - name: error_budget
+    rules:
+    # values:
+    #   1: the system was in a failed state for the observed scrape interval
+    #   0: the system was in a working state for the observed scrape interval
+    # note on min aggregation:
+    #   it is used to remove the instance and job labels; the instance vector
+    #   is expected to have a single item
+    # note on offset:
+    #   if the scrape duration fluctuates, data points with a long scrape duration
+    #   could be missing at the evaluation time; by using an offset of the scrape
+    #   interval, we can read the data points which arrived late and were dated back
+    - record: probe_failure
+      expr: |
+        min without(instance, job)
+          (garden_shoot_condition{operation = "Reconcile",
+                                  condition = "APIServerAvailable"}
+          offset 1m)
+        < bool 1
+
+    # if we don't trust a single failure, we can assert that in the preceeding
+    # minutes, there were at least n failures (n==1 is a NOOP)
+    - record: probe_failure:run
+      expr: |
+        probe_failure
+
+    # adds the day label with the index of the current day since 1970
+    - record: probe_failure:run:day
+      expr: |
+        probe_failure:run
+        + ignoring(day) group_right
+        count_values without() ("day",
+          floor(
+            timestamp(
+              probe_failure:run
+            ) / 60 / 60 / 24
+          )
+        ) * 0
+
+    # adds the week label with the index of the current week since 1970
+    - record: probe_failure:run:week
+      expr: |
+        probe_failure:run
+        + ignoring(week) group_right
+        count_values without() ("week",
+          floor(
+            (
+              timestamp(
+                probe_failure:run
+              ) - 4 * 24 * 60 * 60
+            ) / 60 / 60 / 24 / 7
+          )
+        ) * 0
+
+    # adds the week4 label with the index of the current "four week" since 1970
+    - record: probe_failure:run:week4
+      expr: |
+        probe_failure:run
+        + ignoring(week4) group_right
+        count_values without() ("week4",
+          floor(
+            (
+              timestamp(
+                probe_failure:run
+              ) - 4 * 24 * 60 * 60
+            ) / 60 / 60 / 24 / 7 / 4
+          )
+        ) * 0
+
+    # adds the year and month labels with the current year and month
+    - record: probe_failure:run:yearmonth
+      expr: |
+        probe_failure:run
+        + ignoring(year, month) group_right
+        count_values without() ("year",
+          year(timestamp(
+            count_values without() ("month",
+              month(timestamp(
+                probe_failure:run
+              ))
+            )
+          ))
+        ) * 0
+
+    # use the same metric name for the series above
+    - record: probe_failure:run:time
+      expr: |
+        label_replace(probe_failure:run, "window", "moving", "__name__", ".*") or
+        probe_failure:run:day or
+        probe_failure:run:week or
+        probe_failure:run:week4 or
+        probe_failure:run:yearmonth
+
+    # accumulate the probe failure seconds (hence multiplied by the evaluation_interval)
+    # due to the time labels, the accumulation is restarted in each time interval
+    # max_over_time could be used optionally to extend the default look back period
+    # of 5 minutes, e.g. in case a prometheus restart would take longer
+    # than 5 minutes
+    # the accumulation is started at 0 if there is no previous accumulated value
+    - record: probe_failure:run:time:total
+      expr: |
+        probe_failure:run:time * 30
+        +
+        (
+          max_over_time(
+            probe_failure:run:time:total[10m]
+          )
+          or
+          probe_failure:run:time * 0
+        )
+
+    # as percentage
+    - record: probe_failure:run:time:total:percent
+      labels:
+        window: fixed
+        term: day
+      expr: |
+        sum without(day) (
+          probe_failure:run:time:total{day!=""}
+        )
+        / 60 / 60 / 24
+
+    # as percentage
+    - record: probe_failure:run:time:total:percent
+      labels:
+        window: fixed
+        term: week
+      expr: |
+        sum without(week) (
+          probe_failure:run:time:total{week!=""}
+        )
+        / 60 / 60 / 24 / 7
+
+    # as percentage
+    - record: probe_failure:run:time:total:percent
+      labels:
+        window: fixed
+        term: week4
+      expr: |
+        sum without(week4) (
+          probe_failure:run:time:total{week4!=""}
+        )
+        / 60 / 60 / 24 / 7 / 4
+
+    # as percentage
+    - record: probe_failure:run:time:total:percent
+      labels:
+        window: fixed
+        term: year_month
+      expr: |
+        sum without(year, month) (
+          probe_failure:run:time:total{year!="", month!=""}
+        )
+        / 60 / 60 / 24
+        / days_in_month(timestamp(
+          sum without(year, month)
+            (probe_failure:run:time:total{year!="", month!=""})
+        ))
+
+    # moving day window percentage
+    - record: probe_failure:run:time:total:percent
+      labels:
+        term: day
+      expr: |
+        (
+          probe_failure:run:time:total{window="moving"}
+          -
+          (
+            probe_failure:run:time:total{window="moving"} offset 1d
+            or
+            probe_failure:run:time:total{window="moving"} * 0
+          )
+        )
+        / 60 / 60 / 24
+
+    # moving week window percentage
+    - record: probe_failure:run:time:total:percent
+      labels:
+        term: week
+      expr: |
+        (
+          probe_failure:run:time:total{window="moving"}
+          -
+          (
+            probe_failure:run:time:total{window="moving"} offset 1w
+            or
+            probe_failure:run:time:total{window="moving"} * 0
+          )
+        )
+        / 60 / 60 / 24 / 7
+
+    # moving week4 window percentage
+    - record: probe_failure:run:time:total:percent
+      labels:
+        term: week4
+      expr: |
+        (
+          probe_failure:run:time:total{window="moving"}
+          -
+          (
+            probe_failure:run:time:total{window="moving"} offset 4w
+            or
+            probe_failure:run:time:total{window="moving"} * 0
+          )
+        )
+        / 60 / 60 / 24 / 7 / 4

--- a/pkg/component/observability/monitoring/prometheus/longterm/longterm_suite_test.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/longterm_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package longterm_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLongTerm(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Observability Monitoring Prometheus LongTerm Suite")
+}

--- a/pkg/component/observability/monitoring/prometheus/longterm/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/prometheusrules.go
@@ -1,0 +1,51 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package longterm
+
+import (
+	_ "embed"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+var (
+	//go:embed assets/prometheusrules/recording.yaml
+	recordingYAML []byte
+	recording     *monitoringv1.PrometheusRule
+
+	//go:embed assets/prometheusrules/sla.yaml
+	slaYAML []byte
+	sla     *monitoringv1.PrometheusRule
+)
+
+func init() {
+	recording = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, recordingYAML, recording))
+
+	sla = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, slaYAML, sla))
+}
+
+// CentralPrometheusRules returns the central PrometheusRule resources for the long-term prometheus.
+func CentralPrometheusRules() []*monitoringv1.PrometheusRule {
+	return []*monitoringv1.PrometheusRule{
+		recording,
+		sla,
+	}
+}

--- a/pkg/component/observability/monitoring/prometheus/longterm/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/prometheusrules_test.go
@@ -1,0 +1,38 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package longterm
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = ginkgo.Describe("PrometheusRules", func() {
+	ginkgo.Describe("#CentralPrometheusRules", func() {
+		ginkgo.It("should return the expected objects", func() {
+			Expect(CentralPrometheusRules()).To(HaveExactElements(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("recording")}),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("sla")}),
+				})),
+			))
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
@@ -1,0 +1,81 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package longterm
+
+import (
+	_ "embed"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+)
+
+// CentralScrapeConfigs returns the central ScrapeConfig resources for the garden prometheus.
+func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
+	return []*monitoringv1alpha1.ScrapeConfig{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "prometheus"},
+			Spec: monitoringv1alpha1.ScrapeConfigSpec{
+				StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+					Targets: []monitoringv1alpha1.Target{"localhost:9090"},
+				}},
+				RelabelConfigs: []*monitoringv1.RelabelConfig{{
+					Action:      "replace",
+					Replacement: "prometheus",
+					TargetLabel: "job",
+				}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "cortex-frontend"},
+			Spec: monitoringv1alpha1.ScrapeConfigSpec{
+				StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+					Targets: []monitoringv1alpha1.Target{"localhost:9091"},
+				}},
+				RelabelConfigs: []*monitoringv1.RelabelConfig{{
+					Action:      "replace",
+					Replacement: "cortex-frontend",
+					TargetLabel: "job",
+				}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "prometheus-" + garden.Label},
+			Spec: monitoringv1alpha1.ScrapeConfigSpec{
+				HonorLabels:     ptr.To(true),
+				HonorTimestamps: ptr.To(true),
+				MetricsPath:     ptr.To("/federate"),
+				Params: map[string][]string{
+					"match[]": {
+						`{__name__="garden_shoot_info"}`,
+						`{__name__=~"garden_shoot_info:timestamp:this_month"}`,
+						`{__name__=~"metering:(cpu_requests|memory_requests|network|persistent_volume_claims|disk_usage_seconds|memory_usage_seconds).*:this_month"}`,
+						`{__name__="garden_shoot_node_info"}`,
+						`{__name__="garden_shoot_condition", condition="APIServerAvailable"}`,
+					},
+				},
+				StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: []monitoringv1alpha1.Target{"prometheus-" + garden.Label}}},
+				RelabelConfigs: []*monitoringv1.RelabelConfig{{
+					Action:      "replace",
+					Replacement: "prometheus-" + garden.Label,
+					TargetLabel: "job",
+				}},
+			},
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package longterm_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/longterm"
+)
+
+var _ = Describe("PrometheusRules", func() {
+	Describe("#CentralScrapeConfigs", func() {
+		It("should only contain the expected scrape configs", func() {
+			Expect(longterm.CentralScrapeConfigs()).To(HaveExactElements(
+				&monitoringv1alpha1.ScrapeConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "prometheus"},
+					Spec: monitoringv1alpha1.ScrapeConfigSpec{
+						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+							Targets: []monitoringv1alpha1.Target{"localhost:9090"},
+						}},
+						RelabelConfigs: []*monitoringv1.RelabelConfig{{
+							Action:      "replace",
+							Replacement: "prometheus",
+							TargetLabel: "job",
+						}},
+					},
+				},
+				&monitoringv1alpha1.ScrapeConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "cortex-frontend"},
+					Spec: monitoringv1alpha1.ScrapeConfigSpec{
+						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+							Targets: []monitoringv1alpha1.Target{"localhost:9091"},
+						}},
+						RelabelConfigs: []*monitoringv1.RelabelConfig{{
+							Action:      "replace",
+							Replacement: "cortex-frontend",
+							TargetLabel: "job",
+						}},
+					},
+				},
+				&monitoringv1alpha1.ScrapeConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "prometheus-garden"},
+					Spec: monitoringv1alpha1.ScrapeConfigSpec{
+						HonorLabels:     ptr.To(true),
+						HonorTimestamps: ptr.To(true),
+						MetricsPath:     ptr.To("/federate"),
+						Params: map[string][]string{
+							"match[]": {
+								`{__name__="garden_shoot_info"}`,
+								`{__name__=~"garden_shoot_info:timestamp:this_month"}`,
+								`{__name__=~"metering:(cpu_requests|memory_requests|network|persistent_volume_claims|disk_usage_seconds|memory_usage_seconds).*:this_month"}`,
+								`{__name__="garden_shoot_node_info"}`,
+								`{__name__="garden_shoot_condition", condition="APIServerAvailable"}`,
+							},
+						},
+						StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: []monitoringv1alpha1.Target{"prometheus-garden"}}},
+						RelabelConfigs: []*monitoringv1.RelabelConfig{{
+							Action:      "replace",
+							Replacement: "prometheus-garden",
+							TargetLabel: "job",
+						}},
+					},
+				},
+			))
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 )
 
-func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
+func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.ConfigMap) *monitoringv1.Prometheus {
 	obj := &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.values.Name,
@@ -137,6 +137,11 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 			Command:         []string{"/bin/sh", "-c"},
 			Args:            []string{arg},
 		})
+	}
+
+	if p.values.Cortex != nil {
+		obj.Spec.Containers = append(obj.Spec.Containers, p.cortexContainer())
+		obj.Spec.Volumes = append(obj.Spec.Volumes, p.cortexVolume(cortexConfigMap.Name))
 	}
 
 	return obj

--- a/pkg/component/observability/monitoring/prometheus/service.go
+++ b/pkg/component/observability/monitoring/prometheus/service.go
@@ -28,6 +28,11 @@ import (
 )
 
 func (p *prometheus) service() *corev1.Service {
+	var targetPort int32 = port
+	if p.values.Cortex != nil {
+		targetPort = portCortex
+	}
+
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.name(),
@@ -41,7 +46,7 @@ func (p *prometheus) service() *corev1.Service {
 				Name:       ServicePortName,
 				Port:       servicePort,
 				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt32(port),
+				TargetPort: intstr.FromInt32(targetPort),
 			}},
 		},
 	}

--- a/pkg/component/observability/plutono/dashboards/garden/global/container-runtime.json
+++ b/pkg/component/observability/plutono/dashboards/garden/global/container-runtime.json
@@ -24,7 +24,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "Shoots that are configured with listed runtimes",
       "fieldConfig": {
         "defaults": {},
@@ -139,7 +139,7 @@
       "type": "row"
     },
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "Shoots that are configured with listed runtimes",
       "fieldConfig": {
         "defaults": {
@@ -235,7 +235,7 @@
       "type": "row"
     },
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "Shoots that are configured with listed runtimes",
       "fieldConfig": {
         "defaults": {
@@ -334,7 +334,7 @@
       "type": "row"
     },
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "Shoots that are configured with listed runtimes",
       "fieldConfig": {
         "defaults": {
@@ -423,7 +423,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "availability-prometheus",
+        "datasource": "prometheus-longterm",
         "definition": "label_values(garden_shoot_node_info, cri)",
         "description": null,
         "error": null,

--- a/pkg/component/observability/plutono/dashboards/garden/global/shoot-sla-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden/global/shoot-sla-dashboard.json
@@ -20,7 +20,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -47,7 +47,7 @@
       "type": "text"
     },
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -107,7 +107,7 @@
       "type": "stat"
     },
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -167,7 +167,7 @@
       "type": "stat"
     },
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -232,7 +232,7 @@
       "type": "stat"
     },
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -334,7 +334,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -458,7 +458,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "",
       "fieldConfig": {
         "defaults": {

--- a/pkg/component/observability/plutono/dashboards/garden/global/shoot-sli-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden/global/shoot-sli-dashboard.json
@@ -36,7 +36,7 @@
       "type": "text"
     },
     {
-      "datasource": "availability-prometheus",
+      "datasource": "prometheus-longterm",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -101,7 +101,7 @@
       "id": 27,
       "panels": [
         {
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -311,7 +311,7 @@
           "type": "table"
         },
         {
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "description": "No data means that no shoot cluster exceeds the SLO",
           "fieldConfig": {
             "defaults": {
@@ -404,7 +404,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -546,7 +546,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -749,7 +749,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -945,7 +945,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -1142,7 +1142,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -1339,7 +1339,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -1536,7 +1536,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -1733,7 +1733,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -1930,7 +1930,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -2127,7 +2127,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -2324,7 +2324,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -2536,7 +2536,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -2754,7 +2754,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -2976,7 +2976,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -3198,7 +3198,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -3420,7 +3420,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -3642,7 +3642,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -3864,7 +3864,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -4086,7 +4086,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -4308,7 +4308,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "availability-prometheus",
+          "datasource": "prometheus-longterm",
           "decimals": 2,
           "description": "",
           "fieldConfig": {
@@ -4529,7 +4529,7 @@
           "text": ["All"],
           "value": ["$__all"]
         },
-        "datasource": "availability-prometheus",
+        "datasource": "prometheus-longterm",
         "definition": "label_values(probe_failure, iaas)",
         "error": null,
         "hide": 0,
@@ -4556,7 +4556,7 @@
           "text": ["All"],
           "value": ["$__all"]
         },
-        "datasource": "availability-prometheus",
+        "datasource": "prometheus-longterm",
         "definition": "label_values(probe_failure, purpose)",
         "error": null,
         "hide": 0,
@@ -4583,7 +4583,7 @@
           "text": ["All"],
           "value": ["$__all"]
         },
-        "datasource": "availability-prometheus",
+        "datasource": "prometheus-longterm",
         "definition": "label_values(probe_failure, project)",
         "error": null,
         "hide": 0,
@@ -4610,7 +4610,7 @@
           "text": "fixed",
           "value": "fixed"
         },
-        "datasource": "availability-prometheus",
+        "datasource": "prometheus-longterm",
         "definition": "label_values(probe_failure:run:time:total:percent, window)",
         "error": null,
         "hide": 0,
@@ -4648,7 +4648,7 @@
           "text": "day",
           "value": "day"
         },
-        "datasource": "availability-prometheus",
+        "datasource": "prometheus-longterm",
         "definition": "label_values(probe_failure:run:time:total:percent,term)",
         "error": null,
         "hide": 0,

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -351,10 +351,10 @@ datasources:
 `
 
 	if p.values.IsGardenCluster {
-		datasource += `- name: availability-prometheus
+		datasource += `- name: prometheus-longterm
   type: prometheus
   access: proxy
-  url: http://` + p.namespace + `-avail-prom:80
+  url: http://prometheus-longterm:80
   basicAuth: false
   isDefault: false
   jsonData:
@@ -821,8 +821,8 @@ func (p *plutono) getPodLabels() map[string]string {
 
 	if p.values.IsGardenCluster {
 		labels = utils.MergeStringMaps(labels, map[string]string{
-			gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
-			gardenerutils.NetworkPolicyLabel("garden-avail-prom", 9091): v1beta1constants.LabelNetworkPolicyAllowed,
+			gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090):   v1beta1constants.LabelNetworkPolicyAllowed,
+			gardenerutils.NetworkPolicyLabel("prometheus-longterm", 9091): v1beta1constants.LabelNetworkPolicyAllowed,
 		})
 
 		return labels

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -196,10 +196,10 @@ metadata:
         timeInterval: 1m
 `
 				if values.IsGardenCluster {
-					configMapData += `    - name: availability-prometheus
+					configMapData += `    - name: prometheus-longterm
       type: prometheus
       access: proxy
-      url: http://` + namespace + `-avail-prom:80
+      url: http://prometheus-longterm:80
       basicAuth: false
       isDefault: false
       jsonData:
@@ -241,7 +241,7 @@ metadata:
     resources.gardener.cloud/garbage-collectable-reference: "true"
 `
 				if values.IsGardenCluster {
-					configMap += `  name: plutono-datasources-b7111930
+					configMap += `  name: plutono-datasources-b320ffed
   namespace: some-namespace
 `
 					return configMap
@@ -268,7 +268,7 @@ metadata:
 				}
 				if values.IsGardenCluster {
 					providerConfigMap = "plutono-dashboard-providers-5be2bcda"
-					dataSourceConfigMap = "plutono-datasources-b7111930"
+					dataSourceConfigMap = "plutono-datasources-b320ffed"
 				}
 
 				deployment := &appsv1.Deployment{
@@ -599,7 +599,7 @@ status:
 
 				It("should successfully deploy all resources", func() {
 					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-dashboard-providers-5be2bcda.yaml"])).To(Equal(providerConfigMapYAMLFor(values)))
-					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-datasources-b7111930.yaml"])).To(Equal(dataSourceConfigMapYAMLFor(values)))
+					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-datasources-b320ffed.yaml"])).To(Equal(dataSourceConfigMapYAMLFor(values)))
 					plutonoDashboardsGardenConfigMap, err := getDashboardConfigMaps(ctx, c, namespace, "plutono-dashboards-garden-[^-]{8}")
 					Expect(err).ToNot(HaveOccurred())
 					plutonoDashboardsGlobalConfigMap, err := getDashboardConfigMaps(ctx, c, namespace, "plutono-dashboards-global-[^-]{8}")
@@ -833,8 +833,8 @@ func getPodLabels(values Values) map[string]string {
 
 	if values.IsGardenCluster {
 		labels = utils.MergeStringMaps(labels, map[string]string{
-			gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
-			gardenerutils.NetworkPolicyLabel("garden-avail-prom", 9091): v1beta1constants.LabelNetworkPolicyAllowed,
+			gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090):   v1beta1constants.LabelNetworkPolicyAllowed,
+			gardenerutils.NetworkPolicyLabel("prometheus-longterm", 9091): v1beta1constants.LabelNetworkPolicyAllowed,
 		})
 
 		return labels

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -79,6 +79,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/gardenermetricsexporter"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	gardenprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	longtermprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/longterm"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
 	"github.com/gardener/gardener/pkg/component/observability/plutono"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
@@ -1219,6 +1220,13 @@ func (r *Reconciler) newPrometheusLongTerm(log logr.Logger, garden *operatorv1al
 		VPAMaxAllowed: &corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("4"),
 			corev1.ResourceMemory: resource.MustParse("50G"),
+		},
+		AdditionalPodLabels: map[string]string{
+			gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
+		},
+		CentralConfigs: prometheus.CentralConfigs{
+			PrometheusRules: longtermprometheus.CentralPrometheusRules(),
+			ScrapeConfigs:   longtermprometheus.CentralScrapeConfigs(),
 		},
 		Ingress: &prometheus.IngressValues{
 			Host:                   "prometheus-longterm." + ingressDomain,

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1236,7 +1236,7 @@ func (r *Reconciler) newPrometheusLongTerm(log logr.Logger, garden *operatorv1al
 		},
 		Cortex: &prometheus.CortexValues{
 			Image:         imageCortex.String(),
-			CacheValidity: 168 * time.Hour,
+			CacheValidity: 7 * 24 * time.Hour, // 1 week
 		},
 		DataMigration: monitoring.DataMigration{
 			StatefulSetName: "availability-prometheus",

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1203,6 +1203,11 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 }
 
 func (r *Reconciler) newPrometheusLongTerm(log logr.Logger, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressDomain string, wildcardCertSecretName *string) (prometheus.Interface, error) {
+	imageCortex, err := imagevector.ImageVector().FindImage(imagevector.ImageNameCortex)
+	if err != nil {
+		return nil, err
+	}
+
 	return sharedcomponent.NewPrometheus(log, r.RuntimeClientSet.Client(), r.GardenNamespace, prometheus.Values{
 		Name:              "longterm",
 		PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem100,
@@ -1220,6 +1225,10 @@ func (r *Reconciler) newPrometheusLongTerm(log logr.Logger, garden *operatorv1al
 			SecretsManager:         secretsManager,
 			SigningCA:              operatorv1alpha1.SecretNameCARuntime,
 			WildcardCertSecretName: wildcardCertSecretName,
+		},
+		Cortex: &prometheus.CortexValues{
+			Image:         imageCortex.String(),
+			CacheValidity: 168 * time.Hour,
 		},
 		DataMigration: monitoring.DataMigration{
 			StatefulSetName: "availability-prometheus",

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -134,7 +134,8 @@ type components struct {
 	vali                          component.Deployer
 	prometheusOperator            component.DeployWaiter
 	alertManager                  alertmanager.Interface
-	prometheus                    prometheus.Interface
+	prometheusGarden              prometheus.Interface
+	prometheusLongTerm            prometheus.Interface
 	blackboxExporter              blackboxexporter.Interface
 }
 
@@ -285,7 +286,11 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.prometheus, err = r.newPrometheus(log, garden, secretsManager, garden.Spec.RuntimeCluster.Ingress.Domains[0], wildcardCertSecretName)
+	c.prometheusGarden, err = r.newPrometheusGarden(log, garden, secretsManager, garden.Spec.RuntimeCluster.Ingress.Domains[0], wildcardCertSecretName)
+	if err != nil {
+		return
+	}
+	c.prometheusLongTerm, err = r.newPrometheusLongTerm(log, garden, secretsManager, garden.Spec.RuntimeCluster.Ingress.Domains[0], wildcardCertSecretName)
 	if err != nil {
 		return
 	}
@@ -1154,7 +1159,7 @@ func (r *Reconciler) newAlertmanager(log logr.Logger, garden *operatorv1alpha1.G
 	})
 }
 
-func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressDomain string, wildcardCertSecretName *string) (prometheus.Interface, error) {
+func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressDomain string, wildcardCertSecretName *string) (prometheus.Interface, error) {
 	return sharedcomponent.NewPrometheus(log, r.RuntimeClientSet.Client(), r.GardenNamespace, prometheus.Values{
 		Name:              "garden",
 		PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem100,
@@ -1192,6 +1197,36 @@ func (r *Reconciler) newPrometheus(log logr.Logger, garden *operatorv1alpha1.Gar
 			PVCNames: []string{
 				"prometheus-db-garden-prometheus-0",
 				"prometheus-db-garden-prometheus-1",
+			},
+		},
+	})
+}
+
+func (r *Reconciler) newPrometheusLongTerm(log logr.Logger, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressDomain string, wildcardCertSecretName *string) (prometheus.Interface, error) {
+	return sharedcomponent.NewPrometheus(log, r.RuntimeClientSet.Client(), r.GardenNamespace, prometheus.Values{
+		Name:              "longterm",
+		PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem100,
+		StorageCapacity:   resource.MustParse(getValidVolumeSize(garden.Spec.RuntimeCluster.Volume, "100Gi")),
+		Replicas:          2,
+		RetentionSize:     "80GB",
+		ScrapeTimeout:     "50s", // This is intentionally smaller than the scrape interval of 1m.
+		RuntimeVersion:    r.RuntimeVersion,
+		VPAMaxAllowed: &corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4"),
+			corev1.ResourceMemory: resource.MustParse("50G"),
+		},
+		Ingress: &prometheus.IngressValues{
+			Host:                   "prometheus-longterm." + ingressDomain,
+			SecretsManager:         secretsManager,
+			SigningCA:              operatorv1alpha1.SecretNameCARuntime,
+			WildcardCertSecretName: wildcardCertSecretName,
+		},
+		DataMigration: monitoring.DataMigration{
+			StatefulSetName: "availability-prometheus",
+			OldSubPath:      ptr.To("/"),
+			PVCNames: []string{
+				"prometheus-availability-db-availability-prometheus-0",
+				"prometheus-availability-db-availability-prometheus-1",
 			},
 		},
 	})

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -79,10 +79,14 @@ func (r *Reconciler) delete(
 			Name: "Destroying Alertmanager",
 			Fn:   component.OpDestroyAndWait(c.alertManager).Destroy,
 		})
-		destroyPrometheus = g.Add(flow.Task{
-			Name: "Destroying Prometheus",
+		destroyPrometheusLongTerm = g.Add(flow.Task{
+			Name: "Destroying long-term Prometheus",
+			Fn:   component.OpDestroyAndWait(c.prometheusLongTerm).Destroy,
+		})
+		destroyPrometheusGarden = g.Add(flow.Task{
+			Name: "Destroying Garden Prometheus",
 			Fn: func(ctx context.Context) error {
-				return r.destroyGardenPrometheus(ctx, c.prometheus)
+				return r.destroyGardenPrometheus(ctx, c.prometheusGarden)
 			},
 		})
 		destroyBlackboxExporter = g.Add(flow.Task{
@@ -212,7 +216,7 @@ func (r *Reconciler) delete(
 		destroyPrometheusOperator = g.Add(flow.Task{
 			Name:         "Destroying prometheus-operator",
 			Fn:           component.OpDestroyAndWait(c.prometheusOperator).Destroy,
-			Dependencies: flow.NewTaskIDs(destroyAlertmanager, destroyPrometheus),
+			Dependencies: flow.NewTaskIDs(destroyAlertmanager, destroyPrometheusGarden, destroyPrometheusLongTerm),
 		})
 		destroyFluentOperatorCustomResources = g.Add(flow.Task{
 			Name:         "Destroying fluent-operator custom resources",

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -117,6 +117,7 @@ build:
             - pkg/component/observability/monitoring/prometheus/aggregate
             - pkg/component/observability/monitoring/prometheus/cache
             - pkg/component/observability/monitoring/prometheus/garden
+            - pkg/component/observability/monitoring/prometheus/longterm
             - pkg/component/observability/monitoring/prometheus/seed
             - pkg/component/observability/monitoring/prometheusoperator
             - pkg/component/observability/monitoring/utils

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -106,6 +106,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				healthyManagedResource("prometheus-operator"),
 				healthyManagedResource("alertmanager-garden"),
 				healthyManagedResource("prometheus-garden"),
+				healthyManagedResource("prometheus-longterm"),
 				healthyManagedResource("blackbox-exporter"),
 				healthyManagedResource("garden-system"),
 				healthyManagedResource("garden-system-virtual"),

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -723,6 +723,7 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-runtime")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-virtual")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-garden")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-longterm")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("blackbox-exporter")})}),
 		))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity monitoring
/kind enhancement

**What this PR does / why we need it**:
`gardener-operator` now deploys two Prometheus replicas into the `garden` namespace for long-term retention of some metrics (e.g., availability/SLI or metering data).

This also features a cortex frontend for caching purposes.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9065

**Special notes for your reviewer**:
/cc @ScheererJ 
FYI @istvanballok @vicwicker 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` now deploys two more Prometheus replicas into the `garden` namespace for storing long-term metrics. Read more about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#long-term-prometheus).
```
