### PR TITLE
Use existing constants for `controller-manager` and `scheduler`

### DIFF
--- a/pkg/component/gardener/controllermanager/controller_manager.go
+++ b/pkg/component/gardener/controllermanager/controller_manager.go
@@ -44,8 +44,6 @@ const (
 	ManagedResourceNameRuntime = "gardener-controller-manager-runtime"
 	// ManagedResourceNameVirtual is the name of the ManagedResource for the virtual resources.
 	ManagedResourceNameVirtual = "gardener-controller-manager-virtual"
-
-	roleName = "controller-manager"
 )
 
 // TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy or
@@ -179,6 +177,6 @@ func (g *gardenerControllerManager) WaitCleanup(ctx context.Context) error {
 func GetLabels() map[string]string {
 	return map[string]string{
 		v1beta1constants.LabelApp:  v1beta1constants.LabelGardener,
-		v1beta1constants.LabelRole: roleName,
+		v1beta1constants.LabelRole: v1beta1constants.LabelControllerManager,
 	}
 }

--- a/pkg/component/gardener/scheduler/scheduler.go
+++ b/pkg/component/gardener/scheduler/scheduler.go
@@ -43,8 +43,6 @@ const (
 	ManagedResourceNameRuntime = "gardener-scheduler-runtime"
 	// ManagedResourceNameVirtual is the name of the ManagedResource for the virtual resources.
 	ManagedResourceNameVirtual = "gardener-scheduler-virtual"
-
-	roleName = "scheduler"
 )
 
 // TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy or
@@ -176,6 +174,6 @@ func (g *gardenerScheduler) WaitCleanup(ctx context.Context) error {
 func GetLabels() map[string]string {
 	return map[string]string{
 		v1beta1constants.LabelApp:  v1beta1constants.LabelGardener,
-		v1beta1constants.LabelRole: roleName,
+		v1beta1constants.LabelRole: v1beta1constants.LabelScheduler,
 	}
 }

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -59,8 +59,6 @@ import (
 )
 
 const (
-	// LabelRole is a constant for the value of a label with key 'role'.
-	LabelRole = "controller-manager"
 	// ManagedResourceName is the name of the ManagedResource containing the resource specifications.
 	ManagedResourceName = "shoot-core-kube-controller-manager"
 
@@ -681,7 +679,7 @@ func (k *kubeControllerManager) emptyServiceMonitor() *monitoringv1.ServiceMonit
 func getLabels() map[string]string {
 	return map[string]string{
 		v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
-		v1beta1constants.LabelRole: LabelRole,
+		v1beta1constants.LabelRole: v1beta1constants.LabelControllerManager,
 	}
 }
 

--- a/pkg/component/kubernetes/controllermanager/waiter.go
+++ b/pkg/component/kubernetes/controllermanager/waiter.go
@@ -76,7 +76,7 @@ func (k *kubeControllerManager) WaitForControllerToBeActive(ctx context.Context)
 			client.InNamespace(k.namespace),
 			client.MatchingLabels(map[string]string{
 				v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
-				v1beta1constants.LabelRole: LabelRole,
+				v1beta1constants.LabelRole: v1beta1constants.LabelControllerManager,
 			}))
 		if err != nil {
 			return retry.SevereError(fmt.Errorf("could not check whether controller %s is active: %w", v1beta1constants.DeploymentNameKubeControllerManager, err))

--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -52,8 +52,6 @@ import (
 )
 
 const (
-	// LabelRole is a constant for the value of a label with key 'role'.
-	LabelRole = "scheduler"
 	// BinPackingSchedulerName is the scheduler name that is used when the "bin-packing"
 	// scheduling profile is configured.
 	BinPackingSchedulerName = "bin-packing-scheduler"
@@ -399,7 +397,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 func getLabels() map[string]string {
 	return map[string]string{
 		v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
-		v1beta1constants.LabelRole: LabelRole,
+		v1beta1constants.LabelRole: v1beta1constants.LabelScheduler,
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Nit: Use existing constants for `controller-manager` and `scheduler`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
