### PR TITLE
Drop HVPA for the `vali` StatefulSet and use VPA instead 

### DIFF
--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -160,8 +160,6 @@ func (v *vali) Deploy(ctx context.Context) error {
 		}
 	}
 
-	resources = append(resources, v.getVPA())
-
 	var (
 		telegrafConfigMapName            string
 		genericTokenKubeconfigSecretName string
@@ -239,6 +237,7 @@ func (v *vali) Deploy(ctx context.Context) error {
 	resources = append(resources,
 		valiConfigMap,
 		v.getService(),
+		v.getVPA(),
 		v.getStatefulSet(valiConfigMap.Name, telegrafConfigMapName, genericTokenKubeconfigSecretName),
 	)
 
@@ -287,7 +286,9 @@ func (v *vali) getVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      valiName + "-vpa",
 			Namespace: v.namespace,
-			Labels:    getLabels(),
+			Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+				v1beta1constants.LabelObservabilityApplication: valiName,
+			}),
 		},
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -623,7 +623,7 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("5m"),
-										corev1.ResourceMemory: resource.MustParse("12Mi"),
+										corev1.ResourceMemory: resource.MustParse("15Mi"),
 									},
 									Limits: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("700Mi"),
@@ -690,7 +690,7 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("5m"),
-						corev1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
 					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("150Mi"),
@@ -723,7 +723,7 @@ wait
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("5m"),
-						corev1.ResourceMemory: resource.MustParse("35Mi"),
+						corev1.ResourceMemory: resource.MustParse("45Mi"),
 					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("350Mi"),

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -556,7 +556,7 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceCPU:    resource.MustParse("5m"),
 										corev1.ResourceMemory: resource.MustParse("12Mi"),
 									},
 									Limits: corev1.ResourceList{
@@ -623,7 +623,7 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceCPU:    resource.MustParse("5m"),
 						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 					Limits: corev1.ResourceList{

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -1144,7 +1144,7 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceCPU:    resource.MustParse("5m"),
 									corev1.ResourceMemory: resource.MustParse("12Mi"),
 								},
 								Limits: corev1.ResourceList{
@@ -1211,7 +1211,7 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceCPU:    resource.MustParse("5m"),
 						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 					Limits: corev1.ResourceList{

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -966,66 +966,60 @@ wait
 }
 
 func getVPA(isRBACProxyEnabled bool) *vpaautoscalingv1.VerticalPodAutoscaler {
-	var (
-		vpaUpdateMode      = vpaautoscalingv1.UpdateModeAuto
-		controlledValues   = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-		containerPolicyOff = vpaautoscalingv1.ContainerScalingModeOff
-
-		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      valiName + "-vpa",
-				Namespace: namespace,
-				Labels:    getLabels(),
+	vpa := &vpaautoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      valiName + "-vpa",
+			Namespace: namespace,
+			Labels:    getLabels(),
+		},
+		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscalingv1.CrossVersionObjectReference{
+				Kind:       "StatefulSet",
+				Name:       valiName,
+				APIVersion: appsv1.SchemeGroupVersion.String(),
 			},
-			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
-				TargetRef: &autoscalingv1.CrossVersionObjectReference{
-					Kind:       "StatefulSet",
-					Name:       valiName,
-					APIVersion: appsv1.SchemeGroupVersion.String(),
-				},
-				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-					UpdateMode: &vpaUpdateMode,
-				},
-				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-						{
-							ContainerName: valiName,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("200M"),
-							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("800m"),
-								corev1.ResourceMemory: resource.MustParse("3Gi"),
-							},
-							ControlledValues: &controlledValues,
+			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+				UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
+			},
+			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+					{
+						ContainerName: valiName,
+						MinAllowed: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("200M"),
 						},
-						{
-							ContainerName:    "curator",
-							Mode:             &containerPolicyOff,
-							ControlledValues: &controlledValues,
+						MaxAllowed: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("800m"),
+							corev1.ResourceMemory: resource.MustParse("3Gi"),
 						},
-						{
-							ContainerName:    "init-large-dir",
-							Mode:             &containerPolicyOff,
-							ControlledValues: &controlledValues,
-						},
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					},
+					{
+						ContainerName:    "curator",
+						Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					},
+					{
+						ContainerName:    "init-large-dir",
+						Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},
 				},
 			},
-		}
-	)
+		},
+	}
 
 	if isRBACProxyEnabled {
 		vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies,
 			vpaautoscalingv1.ContainerResourcePolicy{
 				ContainerName:    "kube-rbac-proxy",
-				Mode:             &containerPolicyOff,
-				ControlledValues: &controlledValues,
+				Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 			},
 			vpaautoscalingv1.ContainerResourcePolicy{
 				ContainerName:    "telegraf",
-				Mode:             &containerPolicyOff,
-				ControlledValues: &controlledValues,
+				Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 			},
 		)
 	}

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -970,7 +970,9 @@ func getVPA(isRBACProxyEnabled bool) *vpaautoscalingv1.VerticalPodAutoscaler {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      valiName + "-vpa",
 			Namespace: namespace,
-			Labels:    getLabels(),
+			Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+				v1beta1constants.LabelObservabilityApplication: valiName,
+			}),
 		},
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -1211,7 +1211,7 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("5m"),
-									corev1.ResourceMemory: resource.MustParse("12Mi"),
+									corev1.ResourceMemory: resource.MustParse("15Mi"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("700Mi"),
@@ -1278,7 +1278,7 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("5m"),
-						corev1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
 					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("150Mi"),
@@ -1320,7 +1320,7 @@ wait
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("5m"),
-						corev1.ResourceMemory: resource.MustParse("35Mi"),
+						corev1.ResourceMemory: resource.MustParse("45Mi"),
 					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("350Mi"),

--- a/pkg/component/shared/vali.go
+++ b/pkg/component/shared/vali.go
@@ -5,7 +5,6 @@
 package shared
 
 import (
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -26,8 +25,6 @@ func NewVali(
 	priorityClassName string,
 	storage *resource.Quantity,
 	ingressHost string,
-	hvpaEnabled bool,
-	maintenanceTimeWindow *hvpav1alpha1.MaintenanceTimeWindow,
 ) (
 	vali.Interface,
 	error,
@@ -64,8 +61,6 @@ func NewVali(
 		KubeRBACProxyImage:      kubeRBACProxyImage.String(),
 		TelegrafImage:           telegrafImage.String(),
 		Replicas:                replicas,
-		HVPAEnabled:             hvpaEnabled,
-		MaintenanceTimeWindow:   maintenanceTimeWindow,
 		ShootNodeLoggingEnabled: isShootNodeLoggingEnabled,
 		PriorityClassName:       priorityClassName,
 		Storage:                 storage,

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/logging/eventlogger"
 	"github.com/gardener/gardener/pkg/component/observability/logging/vali"
 	"github.com/gardener/gardener/pkg/component/shared"
-	"github.com/gardener/gardener/pkg/features"
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 )
@@ -89,11 +88,6 @@ func (b *Botanist) DefaultEventLogger() (component.Deployer, error) {
 
 // DefaultVali returns a deployer for Vali.
 func (b *Botanist) DefaultVali() (vali.Interface, error) {
-	hvpaEnabled := features.DefaultFeatureGate.Enabled(features.HVPA)
-	if b.ManagedSeed != nil {
-		hvpaEnabled = features.DefaultFeatureGate.Enabled(features.HVPAForShootedSeed)
-	}
-
 	return shared.NewVali(
 		b.SeedClientSet.Client(),
 		b.Shoot.SeedNamespace,
@@ -104,7 +98,5 @@ func (b *Botanist) DefaultVali() (vali.Interface, error) {
 		v1beta1constants.PriorityClassNameShootControlPlane100,
 		nil,
 		b.ComputeValiHost(),
-		hvpaEnabled,
-		nil,
 	)
 }

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -268,7 +268,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.vali, err = r.newVali(garden)
+	c.vali, err = r.newVali()
 	if err != nil {
 		return
 	}
@@ -1130,7 +1130,7 @@ func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) 
 	)
 }
 
-func (r *Reconciler) newVali(garden *operatorv1alpha1.Garden) (vali.Interface, error) {
+func (r *Reconciler) newVali() (vali.Interface, error) {
 	return sharedcomponent.NewVali(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
@@ -1141,11 +1141,6 @@ func (r *Reconciler) newVali(garden *operatorv1alpha1.Garden) (vali.Interface, e
 		v1beta1constants.PriorityClassNameGardenSystem100,
 		nil,
 		"",
-		hvpaEnabled(),
-		&hvpav1alpha1.MaintenanceTimeWindow{
-			Begin: garden.Spec.VirtualCluster.Maintenance.TimeWindow.Begin,
-			End:   garden.Spec.VirtualCluster.Maintenance.TimeWindow.End,
-		},
 	)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
As part of the topic to remove usages of HVPA where possible, this PR drops HVPA in favour of VPA for the `vali` statefulset.
Additionally it:
- Reduces `vali`'s `minAllowed` memory to `200M` 
- Reduces the  CPU requests of the `curator` `kube-rbac-proxy` and `telegraf` containers to `5m` as this is closer to the expected consumption 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Previously HVPA specified a scaleDown policy, which was added to stabilise the statefulset ref: https://github.com/gardener/gardener/pull/3482 and https://github.com/gardener/gardener/pull/3618 with the following settings:
```
ScaleDown: hvpav1alpha1.ScaleType{
	UpdatePolicy: hvpav1alpha1.UpdatePolicy{
		UpdateMode: ptr.To("MaintenanceWindow"),
	},
	StabilizationDuration: ptr.To("168h"),
	MinChange: hvpav1alpha1.ScaleParams{
		CPU: hvpav1alpha1.ChangeParams{
			Value:      ptr.To("200m"),
			Percentage: ptr.To[int32](80),
		},
		Memory: hvpav1alpha1.ChangeParams{
			Value:      ptr.To("500M"),
			Percentage: ptr.To[int32](80),
		},
	},
},
```
Meaning that scaleDown would only occur during maintenance time windows and the stabilisation duration was `168h` or 7 days. Additionally, there's a PR which disables all updates to the `vali` sts with a ValidatingWebhookConfiguration during testmachinery tests: https://github.com/gardener/gardener/pull/3594).
Thus, this is still a draft PR as I want to do a few more checks whether that stabilisation is still really required.

~We could wait for the `VPAEvictionRequirementsController` from https://github.com/gardener/gardener/pull/8984 or continue with the PR as it is and revert the change (as it is a small one) if vali turns out to be very unstable with VPA.~
Since #8984 is merged we could use this PR as is, and only add the necessary modifications if we see that vali is not stable.

~Later on, we will follow up with a second PR which puts the  `curator` `kube-rbac-proxy` and `telegraf` containers under VPA as well.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Replaced HVPA for the `vali` StatefulSet with VPA. Additionally, the `curator` `kube-rbac-proxy` and `telegraf` containers of the `vali` StatefulSet now specify CPU resource requests of `5m` each.
```
