### PR TITLE
Fix the `backup.gardener.cloud/created-by` annotation not being added on existing etcd-backup Secrets

### DIFF
--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -89,9 +89,9 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, log logr.Logger, 
 	}
 
 	etcdSecret := emptyEtcdBackupSecret(be.Name)
-	metav1.SetMetaDataAnnotation(&etcdSecret.ObjectMeta, AnnotationKeyCreatedByBackupEntry, be.Name)
 
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, a.client, etcdSecret, func() error {
+		metav1.SetMetaDataAnnotation(&etcdSecret.ObjectMeta, AnnotationKeyCreatedByBackupEntry, be.Name)
 		etcdSecret.Data = etcdSecretData
 		return nil
 	})

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -100,13 +100,13 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, log logr.Logger, 
 
 // Delete deletes the BackupEntry.
 func (a *actuator) Delete(ctx context.Context, log logr.Logger, be *extensionsv1alpha1.BackupEntry) error {
-	if err := a.deleteEtcdBackupSecret(ctx, be.Name); err != nil {
+	if err := a.deleteEtcdBackupSecret(ctx, log, be.Name); err != nil {
 		return err
 	}
 	return a.backupEntryDelegate.Delete(ctx, log, be)
 }
 
-func (a *actuator) deleteEtcdBackupSecret(ctx context.Context, backupEntryName string) error {
+func (a *actuator) deleteEtcdBackupSecret(ctx context.Context, log logr.Logger, backupEntryName string) error {
 	etcdSecret := emptyEtcdBackupSecret(backupEntryName)
 	if err := a.client.Get(ctx, client.ObjectKeyFromObject(etcdSecret), etcdSecret); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -117,9 +117,11 @@ func (a *actuator) deleteEtcdBackupSecret(ctx context.Context, backupEntryName s
 	}
 
 	if createdBy, ok := etcdSecret.Annotations[AnnotationKeyCreatedByBackupEntry]; ok && createdBy != backupEntryName {
+		log.Info("Skipping etcd-backup Secret deletion because it was not created by the currently deleting BackupEntry", "createdBy", createdBy)
 		return nil
 	}
 
+	log.Info("Deleting etcd-backup Secret")
 	return kubernetesutils.DeleteObject(ctx, a.client, etcdSecret)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/blob/6988da80bae6ba827d63535655f28885d91b0a23/extensions/pkg/controller/backupentry/genericactuator/actuator.go#L91-L97 the corresponding annotation will be set for new etcd-backup Secret but it won't be if the Secret already exists in the system.

We also added logs around the etcd-backup Secret deletion for debugging purposes as we faced another occurrences of https://github.com/gardener/gardener/issues/8675.

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener/issues/8675

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
extension library: An issue causing the `backup.gardener.cloud/created-by` annotation not being added on existing `etcd-backup` Secrets is now fixed.
```
