### PR TITLE
[node-agent] Delete leftover `*.tmp` files from failed copy attempts

### DIFF
--- a/pkg/nodeagent/files/files.go
+++ b/pkg/nodeagent/files/files.go
@@ -47,7 +47,7 @@ func Copy(fs afero.Afero, source, destination string, permissions os.FileMode) e
 		return fmt.Errorf("error creating temp directory: %w", err)
 	}
 
-	defer func() { runtime.HandleError(fs.Remove(tempDir)) }()
+	defer func() { runtime.HandleError(fs.RemoveAll(tempDir)) }()
 
 	tmpFilePath := filepath.Join(tempDir, filepath.Base(destination))
 

--- a/pkg/nodeagent/files/files_test.go
+++ b/pkg/nodeagent/files/files_test.go
@@ -199,6 +199,21 @@ var _ = Describe("Files", func() {
 			})
 
 			runTests()
+
+			It("should work if a tmp file from a previous run still exists", func() {
+				createFile(fakeFS, destinationFile+".tmp", content, permissions)
+				createFile(fakeFS, sourceFile, content, permissions)
+				Expect(Move(fakeFS, sourceFile, destinationFile)).To(Succeed())
+				checkFile(fakeFS, destinationFile, content, permissions)
+				checkFileNotFound(fakeFS, sourceFile)
+				checkFileNotFound(fakeFS, destinationFile+".tmp")
+			})
+
+			It("should not delete if there .tmp file exists and is a directory", func() {
+				Expect(fakeFS.Mkdir(destinationFile, permissions)).To(Succeed())
+				createFile(fakeFS, sourceFile, content, permissions)
+				Expect(Move(fakeFS, sourceFile, destinationFile)).To(MatchError(ContainSubstring("exists but is not a regular file")))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This is a follow up to PR to #9609. 
If a previous file copy attempt failed `gardener-node-agent` now deletes leftover `*.tmp` files instead of returning an error. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke @MichaelEischer 

I did not introduce a special handling for symlinks at the the `destination`.
`copyAndSync` copies into new files only.
In `Copy` and `Move` the final step is always `fs.Rename(xyz, destination)`. If there is a symlink it will be overwritten with a file. GNA does not create symlinks. Thus, if there is one it was created by someone else. We don't check for files created by someone else either, so we can do the same for symlinks.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
If a previous file copy attempt failed `gardener-node-agent` now deletes leftover `*.tmp` files instead of returning an error. 
```
