### PR TITLE
Drop `Infrastructure Cleanup Wait Period` during shoot deletion

### DIFF
--- a/docs/usage/shoot_cleanup.md
+++ b/docs/usage/shoot_cleanup.md
@@ -22,15 +22,3 @@ It is possible to override the finalization grace periods via annotations on the
 
 ⚠️ If `"0"` is provided, then all resources are finalized immediately without waiting for any graceful deletion.
 Please be aware that this might lead to orphaned infrastructure artefacts.
-
-## Infrastructure Cleanup Wait Period
-
-After all above cleanup steps have been performed and the `Infrastructure` extension resource has been deleted, the gardenlet waits for a certain duration to allow controllers to properly cleanup infrastructure resources.
-
-By default, this duration is set to `5m`. Only after this time has passed, the shoot deletion flow continues with the entire tear-down of the remaining control plane components (including `kube-apiserver`s, etc.).
-
-It is also possible to override this wait period via an annotations on the `Shoot`:
-
-- `shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds`
-
-> ℹ️️ All provided period values larger than the above mentioned defaults are ignored.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -623,11 +623,6 @@ const (
 	// Kubernetes resources' step. Concretely, after the specified seconds, all the finalizers of the affected resources
 	// are forcefully removed.
 	AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds = "shoot.gardener.cloud/cleanup-kubernetes-resources-finalize-grace-period-seconds"
-	// AnnotationShootInfrastructureCleanupWaitPeriodSeconds is a key for an annotation on a Shoot
-	// resource that declares the wait period in seconds for infrastructure resources cleanup. Concretely,
-	// Gardener will wait for the specified time after the Infrastructure extension object has been deleted to allow
-	// controllers to gracefully cleanup everything (default behaviour is 300s).
-	AnnotationShootInfrastructureCleanupWaitPeriodSeconds = "shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds"
 	// AnnotationShootCloudConfigExecutionMaxDelaySeconds is a key for an annotation on a Shoot resource that declares
 	// the maximum delay in seconds when potentially updated cloud-config user data is executed on the worker nodes.
 	// Concretely, the gardener-node-agent systemd service running on all worker nodes will wait

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -68,9 +68,8 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				v1beta1constants.AnnotationShootInfrastructureCleanupWaitPeriodSeconds: "0",
-				v1beta1constants.AnnotationShootCloudConfigExecutionMaxDelaySeconds:    "0",
-				v1beta1constants.AnnotationAuthenticationIssuer:                        v1beta1constants.AnnotationAuthenticationIssuerManaged,
+				v1beta1constants.AnnotationShootCloudConfigExecutionMaxDelaySeconds: "0",
+				v1beta1constants.AnnotationAuthenticationIssuer:                     v1beta1constants.AnnotationAuthenticationIssuerManaged,
 			},
 		},
 		Spec: gardencorev1beta1.ShootSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind cleanup

**What this PR does / why we need it**:
There is a `Infrastructure Cleanup Wait Period` of 5 minutes from the times where service finalizers have not been enabled by default yet. This changed a long time ago. Thus, this PR removes the cleanup period.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Five minutes `Infrastructure Cleanup Wait Period` during shoot deletion was removed.
```
