### PR TITLE
change ctr path in deploy-registry

### DIFF
--- a/example/provider-extensions/registry-seed/deploy-registry.sh
+++ b/example/provider-extensions/registry-seed/deploy-registry.sh
@@ -93,30 +93,30 @@ stringData:
     ExecStopPost=bash /var/opt/docker/stop-seed-registry-cache.sh\n
   start-seed-registry-cache.sh: |
     #!/usr/bin/env bash
-    if [[ "\$(/usr/bin/ctr task ls | grep seed-registry-cache | awk '{print \$3}')" == "RUNNING" ]]; then
+    if [[ "\$(ctr task ls | grep seed-registry-cache | awk '{print \$3}')" == "RUNNING" ]]; then
       echo "seed-registry-cache is already running"
       exit 0
     fi
-    if [[ "\$(/usr/bin/ctr container ls | grep seed-registry-cache | awk '{print \$1}')" == "seed-registry-cache" ]]; then
+    if [[ "\$(ctr container ls | grep seed-registry-cache | awk '{print \$1}')" == "seed-registry-cache" ]]; then
       echo "removing old seed-registry-cache container"
-      /usr/bin/ctr task kill seed-registry-cache
-      /usr/bin/ctr task rm seed-registry-cache
-      /usr/bin/ctr container rm seed-registry-cache
+      ctr task kill seed-registry-cache
+      ctr task rm seed-registry-cache
+      ctr container rm seed-registry-cache
     fi
-    if [[ "\$(/usr/bin/ctr snapshot ls | grep seed-registry-cache | awk '{print \$1}')" == "seed-registry-cache" ]]; then
+    if [[ "\$(ctr snapshot ls | grep seed-registry-cache | awk '{print \$1}')" == "seed-registry-cache" ]]; then
       echo "removing old seed-registry-cache snapshot"
-      /usr/bin/ctr snapshot rm seed-registry-cache
+      ctr snapshot rm seed-registry-cache
     fi
     echo "Pulling registry-cache image"
-    /usr/bin/ctr image pull ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev
+    ctr image pull ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev
     echo "Starting registry-cache"
-    /usr/bin/ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/docker/registry/config.yml,options=rbind:ro --net-host ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev seed-registry-cache
+    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/docker/registry/config.yml,options=rbind:ro --net-host ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev seed-registry-cache
   stop-seed-registry-cache.sh: |
     #!/usr/bin/env bash
     echo "stopping seed-registry-cache"
-    /usr/bin/ctr task kill seed-registry-cache
-    /usr/bin/ctr task rm seed-registry-cache
-    /usr/bin/ctr container rm seed-registry-cache
+    ctr task kill seed-registry-cache
+    ctr task rm seed-registry-cache
+    ctr container rm seed-registry-cache
 EOF
 
 echo "Creating pull secret in garden namespace"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

Changes the use of `ctr` from using it's full path to just the binary name. The reason is that some images may include `ctr` in `usr/sbin/ctr` instead of `/usr/bin/ctr`. There is no particular reason that we should assume the path of the binary in this case. By default both `/usr/bin` and `/usr/sbin` should be in the default `$PATH` used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
