### PR TITLE
Validate that containers run as `non-root`

### DIFF
--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -78,6 +78,7 @@ spec:
       automountServiceAccountToken: false
       {{- end }}
       securityContext:
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/pkg/component/kubernetes/dashboard/dashboard.go
+++ b/pkg/component/kubernetes/dashboard/dashboard.go
@@ -294,6 +294,7 @@ func (k *kubernetesDashboard) computeResourcesData() (map[string][]byte, error) 
 					},
 					Spec: corev1.PodSpec{
 						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot:       ptr.To(true),
 							RunAsUser:          ptr.To[int64](1001),
 							RunAsGroup:         ptr.To[int64](2001),
 							FSGroup:            ptr.To[int64](1),
@@ -421,6 +422,7 @@ func (k *kubernetesDashboard) computeResourcesData() (map[string][]byte, error) 
 								SecurityContext: &corev1.SecurityContext{
 									AllowPrivilegeEscalation: ptr.To(false),
 									ReadOnlyRootFilesystem:   ptr.To(true),
+									RunAsNonRoot:             ptr.To(true),
 									RunAsUser:                ptr.To[int64](1001),
 									RunAsGroup:               ptr.To[int64](2001),
 									SeccompProfile: &corev1.SeccompProfile{

--- a/pkg/component/kubernetes/dashboard/dashboard_test.go
+++ b/pkg/component/kubernetes/dashboard/dashboard_test.go
@@ -305,6 +305,7 @@ spec:
       securityContext:
         fsGroup: 1
         runAsGroup: 2001
+        runAsNonRoot: true
         runAsUser: 1001
         seccompProfile:
           type: RuntimeDefault
@@ -365,6 +366,7 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsGroup: 2001
+          runAsNonRoot: true
           runAsUser: 1001
           seccompProfile:
             type: RuntimeDefault

--- a/pkg/component/networking/nginxingress/nginxingress.go
+++ b/pkg/component/networking/nginxingress/nginxingress.go
@@ -454,8 +454,9 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 						PriorityClassName: n.values.PriorityClassName,
 						NodeSelector:      nodeSelector,
 						SecurityContext: &corev1.PodSecurityContext{
-							RunAsUser: ptr.To[int64](65534),
-							FSGroup:   ptr.To[int64](65534),
+							RunAsNonRoot: ptr.To(true),
+							RunAsUser:    ptr.To[int64](65534),
+							FSGroup:      ptr.To[int64](65534),
 						},
 						Containers: []corev1.Container{{
 							Name:            n.getName("Container", true),
@@ -526,6 +527,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 									Drop: []corev1.Capability{"ALL"},
 									Add:  []corev1.Capability{"NET_BIND_SERVICE", "SYS_CHROOT"},
 								},
+								RunAsNonRoot:             ptr.To(true),
 								RunAsUser:                ptr.To[int64](101),
 								AllowPrivilegeEscalation: ptr.To(true),
 								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined},

--- a/pkg/component/networking/nginxingress/nginxingress_test.go
+++ b/pkg/component/networking/nginxingress/nginxingress_test.go
@@ -468,6 +468,7 @@ spec:
       priorityClassName: gardener-system-600
       securityContext:
         fsGroup: 65534
+        runAsNonRoot: true
         runAsUser: 65534
       terminationGracePeriodSeconds: 60
 status: {}
@@ -573,6 +574,7 @@ spec:
             - SYS_CHROOT` + `
             drop:
             - ALL
+          runAsNonRoot: true
           runAsUser: 101
           seccompProfile:
             type: Unconfined
@@ -1040,6 +1042,7 @@ spec:
       priorityClassName: gardener-shoot-system-600
       securityContext:
         fsGroup: 65534
+        runAsNonRoot: true
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
@@ -1149,6 +1152,7 @@ spec:
             - SYS_CHROOT
             drop:
             - ALL
+          runAsNonRoot: true
           runAsUser: 101
           seccompProfile:
             type: Unconfined

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator.go
@@ -210,6 +210,12 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: serviceAccount.Name,
 						PriorityClassName:  f.values.PriorityClassName,
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: ptr.To(true),
+							RunAsUser:    ptr.To[int64](65532),
+							RunAsGroup:   ptr.To[int64](65532),
+							FSGroup:      ptr.To[int64](65532),
+						},
 						Containers: []corev1.Container{
 							{
 								Name:            name,

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
@@ -238,6 +238,12 @@ var _ = Describe("Fluent Operator", func() {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: serviceAccount.Name,
 						PriorityClassName:  priorityClassName,
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: ptr.To(true),
+							RunAsUser:    ptr.To[int64](65532),
+							RunAsGroup:   ptr.To[int64](65532),
+							FSGroup:      ptr.To[int64](65532),
+						},
 						Containers: []corev1.Container{{
 							Name:            name,
 							Image:           image,

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
@@ -224,6 +224,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 						ServiceAccountName: serviceAccount.Name,
 						PriorityClassName:  b.values.PriorityClassName,
 						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot:       ptr.To(true),
 							RunAsUser:          ptr.To[int64](65534),
 							FSGroup:            ptr.To[int64](65534),
 							SupplementalGroups: []int64{1},

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
@@ -232,6 +232,7 @@ spec:
       priorityClassName: ` + priorityClassName + `
       securityContext:
         fsGroup: 65534
+        runAsNonRoot: true
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault

--- a/pkg/component/observability/monitoring/metricsserver/metricsserver.go
+++ b/pkg/component/observability/monitoring/metricsserver/metricsserver.go
@@ -288,6 +288,7 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 					Spec: corev1.PodSpec{
 						PriorityClassName: "system-cluster-critical",
 						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot:       ptr.To(true),
 							RunAsUser:          ptr.To[int64](65534),
 							FSGroup:            ptr.To[int64](65534),
 							SupplementalGroups: []int64{1},

--- a/pkg/component/observability/monitoring/metricsserver/metricsserver_test.go
+++ b/pkg/component/observability/monitoring/metricsserver/metricsserver_test.go
@@ -279,6 +279,7 @@ spec:
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 65534
+        runAsNonRoot: true
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -978,6 +978,7 @@ func ComputeExpectedGardenletDeploymentSpec(
 				PriorityClassName:  v1beta1constants.PriorityClassNameSeedSystemCritical,
 				ServiceAccountName: "gardenlet",
 				SecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: ptr.To(true),
 					SeccompProfile: &corev1.SeccompProfile{
 						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the `securityContext` of pods that already run as `non-root` with the `runAsNonRoot` field set to `true`. This will force the `kubelet` to validate that the containers in a pod are started with a `non-root` user.

This PR also modifies `fluent-operator` to run as `nonroot` user & group `65532` (id of `nonroot` user in `distroless` images [ref](https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8)). Aiming to adhere to the principles of least privilege and reduce potential attack surface.

**Which issue(s) this PR fixes**:
Fixes #7157

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Containers, configured to run as `non-root`, are now validated to start with `non-root` user by the `kubelet`.
```
```other operator
The `fluent-operator` component now runs as `nonroot` user and group `65532`.
```
