### PR TITLE
Test `AfterWorker` Lifecycle Strategy in Upgrade tests

### DIFF
--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -114,19 +113,11 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 				{
 					Type: "local-ext-shoot",
 				},
+				{
+					Type: "local-ext-shoot-after-worker",
+				},
 			},
 		},
-	}
-
-	if ginkgo.Label("default").MatchesLabelFilter(ginkgo.GinkgoLabelFilter()) {
-		// TODO(maboehm): Add permanently to default shoot after v1.92
-		// The extension is not available in the previous gardener
-		// version (so during upgrade tests), so only set it for default tests.
-		shoot.Spec.Extensions = append(shoot.Spec.Extensions,
-			gardencorev1beta1.Extension{
-				Type: "local-ext-shoot-after-worker",
-			},
-		)
 	}
 	return shoot
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
Adds the extensions `local-ext-shoot-after-worker` to all tests.
This was previously only added to default tests in #9472 because the upgrade tests failed, since the old gardener version did not know this extension. This should now work, because a new minor version was released.

**Special notes for your reviewer**:

**Release note**:
```other operator

```
