### PR TITLE
Only update network policy `allow-to-runtime-apiserver` after resolver has been synced

### DIFF
--- a/pkg/controller/networkpolicy/hostnameresolver/resolver.go
+++ b/pkg/controller/networkpolicy/hostnameresolver/resolver.go
@@ -58,6 +58,7 @@ type Provider interface {
 
 // HostResolver is used for getting endpoint subsets with resolved IPs.
 type HostResolver interface {
+	HasSynced() bool
 	Subset() []corev1.EndpointSubset
 }
 

--- a/pkg/controller/networkpolicy/hostnameresolver/resolver.go
+++ b/pkg/controller/networkpolicy/hostnameresolver/resolver.go
@@ -41,7 +41,7 @@ type resolver struct {
 	lookup lookup
 }
 
-type noOpResover struct{}
+type noOpResolver struct{}
 
 type lookup interface {
 	LookupHost(ctx context.Context, host string) (addrs []string, err error)
@@ -206,21 +206,21 @@ func CreateForCluster(restConfig *rest.Config, log logr.Logger) (Provider, error
 }
 
 // NewNoOpProvider returns a no-op Provider.
-func NewNoOpProvider() Provider { return &noOpResover{} }
+func NewNoOpProvider() Provider { return &noOpResolver{} }
 
 // HasSynced always returns true.
-func (*noOpResover) HasSynced() bool { return true }
+func (*noOpResolver) HasSynced() bool { return true }
 
 // Start does nothing.
-func (*noOpResover) Start(_ context.Context) error {
+func (*noOpResolver) Start(_ context.Context) error {
 	return nil
 }
 
 // Subset returns an empty slice.
-func (*noOpResover) Subset() []corev1.EndpointSubset { return []corev1.EndpointSubset{} }
+func (*noOpResolver) Subset() []corev1.EndpointSubset { return []corev1.EndpointSubset{} }
 
 // WithCallback does nothing.
-func (*noOpResover) WithCallback(_ func()) {}
+func (*noOpResolver) WithCallback(_ func()) {}
 
 func equal(a, b []string) bool {
 	if (a == nil) != (b == nil) {

--- a/pkg/controller/networkpolicy/hostnameresolver/resolver_test.go
+++ b/pkg/controller/networkpolicy/hostnameresolver/resolver_test.go
@@ -226,7 +226,7 @@ var _ = Describe("CreateForCluster", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(p).NotTo(BeNil())
 
-		_, ok := p.(*noOpResover)
-		Expect(ok).To(BeTrue(), "cast to noOpResover succeeds")
+		_, ok := p.(*noOpResolver)
+		Expect(ok).To(BeTrue(), "cast to noOpResolver succeeds")
 	})
 })

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -281,7 +281,7 @@ func (r *Reconciler) reconcileNetworkPolicyAllowToAPIServer(ctx context.Context,
 	}
 
 	if !r.Resolver.HasSynced() {
-		log.Info("resolver has not synced yet. Skipping update of NetworkPolicyAllowToAPIServer.")
+		log.Info("Resolver has not synced yet - skipping update of NetworkPolicy", "networkPolicyName", "allow-to-runtime-apiserver")
 		// The resolver triggers an event after it has been synced, which starts a new reconciliation.
 		// No need to raise an error here.
 		return nil

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -280,6 +280,13 @@ func (r *Reconciler) reconcileNetworkPolicyAllowToAPIServer(ctx context.Context,
 		return err
 	}
 
+	if !r.Resolver.HasSynced() {
+		log.Info("resolver has not synced yet. Skipping update of NetworkPolicyAllowToAPIServer.")
+		// The resolver triggers an event after it has been synced, which starts a new reconciliation.
+		// No need to raise an error here.
+		return nil
+	}
+
 	egressRules, err := helper.GetEgressRules(append(kubernetesEndpoints.Subsets, r.Resolver.Subset()...)...)
 	if err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The lookup of the IP address of the kube-apiserver via DNS from its external domain name can take some several seconds in rare situations due to network issues. In these cases, the  network policy `allow-to-runtime-apiserver` must not be updated until the resolver has resolved the domain name successfully. Especially on startup of the gardenlet, the first reconciliation of the network policy can occur too early.
A check is added to skip the update of the network policy in such situations.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Only update network policy `allow-to-runtime-apiserver` after resolver has been synced.
```
