### PR TITLE
Wait until extensions are deleted before deleting `Extension` resources

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -454,7 +454,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			SkipIf:       botanist.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerDeleted),
 		})
-		_ = g.Add(flow.Task{
+		waitUntilOperatingSystemConfigsAreDeleted = g.Add(flow.Task{
 			Name: "Waiting until all operating system config resources are deleted",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanup(ctx)
@@ -483,7 +483,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		deleteExtensionResourcesBeforeKubeAPIServer = g.Add(flow.Task{
 			Name:         "Deleting extension resources before kube-apiserver",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.Extension.DestroyBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(cleanKubernetesResources, waitUntilManagedResourcesDeleted),
+			Dependencies: flow.NewTaskIDs(cleanKubernetesResources, waitUntilOperatingSystemConfigsAreDeleted, waitUntilManagedResourcesDeleted),
 		})
 		waitUntilExtensionResourcesBeforeKubeAPIServerDeleted = g.Add(flow.Task{
 			Name:         "Waiting until extension resources that should be handled before kube-apiserver have been deleted",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
@@ -244,7 +244,7 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 		deleteExtensionsBeforeKubeAPIServer = g.Add(flow.Task{
 			Name:         "Deleting extensions before kube-apiserver",
 			Fn:           botanist.Shoot.Components.Extensions.Extension.DestroyBeforeKubeAPIServer,
-			Dependencies: flow.NewTaskIDs(waitUntilExtensionsBeforeKubeAPIServerMigrated),
+			Dependencies: flow.NewTaskIDs(waitUntilExtensionResourcesDeleted, waitUntilExtensionsBeforeKubeAPIServerMigrated),
 		})
 		waitUntilExtensionsBeforeKubeAPIServerDeleted = g.Add(flow.Task{
 			Name:         "Waiting until extensions that should be handled before kube-apiserver have been deleted",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR makes the `Deleting extensions before kube-apiserver` task depend on the `Deleting extension resources from the Shoot namespace` task. 
This is necessary because controllers that manage `Extension` resources that have the `migrate: BeforeKubeAPIServer` lifecycle could have a mutating webhook  for `OperatingSystemConfig`s. Without this dependency, if the `Extension` resource is removed before the `OperatingSystemConfig`s, it is likely for the mutating webhooks in these controllers to fail when the migrate flow tries to delete `OperatingSystemConfig`s as it tries to first annotate them with `confirmation.gardener.cloud/deletion=true`.

The `Deleting extension resources from the Shoot namespace` task includes the deletion of `OperatingSystemConfig`s.
The `Deleting extensions before kube-apiserver` task deletes all `Extension` resources.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
In the `migrate` flow of control plane migration the `Deleting extensions before kube-apiserver` task now depends on the `Waiting until extension resources have been deleted` task.
```
