### PR TITLE
Reduce minAllowed values from kube-apiserver and kube-controller-manager

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -380,7 +380,7 @@ var _ = Describe("KubeAPIServer", func() {
 					{
 						ContainerName: "kube-apiserver",
 						MinAllowed: corev1.ResourceList{
-							"memory": resource.MustParse("400M"),
+							"memory": resource.MustParse("200M"),
 						},
 						MaxAllowed: corev1.ResourceList{
 							"cpu":    resource.MustParse("8"),

--- a/pkg/component/kubernetes/apiserver/hvpa.go
+++ b/pkg/component/kubernetes/apiserver/hvpa.go
@@ -63,7 +63,7 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 			{
 				ContainerName: ContainerNameKubeAPIServer,
 				MinAllowed: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("400M"),
+					corev1.ResourceMemory: resource.MustParse("200M"),
 				},
 				MaxAllowed: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("8"),

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -268,7 +268,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
 				ContainerName: containerName,
 				MinAllowed: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("100Mi"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 				MaxAllowed: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
@@ -281,7 +281,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
 				ContainerName: containerName,
 				MinAllowed: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("100Mi"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 				MaxAllowed: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -153,7 +153,7 @@ var _ = Describe("KubeControllerManager", func() {
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
 						ContainerName: "kube-controller-manager",
 						MinAllowed: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 						MaxAllowed: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("4"),
@@ -278,7 +278,7 @@ var _ = Describe("KubeControllerManager", func() {
 									ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
 										ContainerName: "kube-controller-manager",
 										MinAllowed: corev1.ResourceList{
-											corev1.ResourceMemory: resource.MustParse("100Mi"),
+											corev1.ResourceMemory: resource.MustParse("50Mi"),
 										},
 										MaxAllowed: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("4"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR reduces minAllowed (H)VPA minAllowed values from kube-apiserver and kube-controller-manager as suggested in https://github.com/gardener/gardener/issues/9562.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9562

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The kube-controller-manager's (H)VPA minAllowed memory is reduced from `100Mi` to `50Mi`. The kube-apiserver's HVPA minAllowed memory is reduced from `400M` to `200M`. 
```
