### PR TITLE
Prefer SNI hostname for dashboard API server URL

### DIFF
--- a/pkg/component/gardener/dashboard/config/config.go
+++ b/pkg/component/gardener/dashboard/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	LogFormat                              string                 `yaml:"logFormat"`
 	LogLevel                               string                 `yaml:"logLevel"`
 	APIServerURL                           string                 `yaml:"apiServerUrl"`
+	APIServerCAData                        *string                `yaml:"apiServerCaData,omitempty"`
 	MaxRequestBodySize                     string                 `yaml:"maxRequestBodySize"`
 	ExperimentalUseWatchCacheForListShoots string                 `yaml:"experimentalUseWatchCacheForListShoots"`
 	ReadinessProbe                         ReadinessProbe         `yaml:"readinessProbe"`

--- a/pkg/component/gardener/dashboard/configmaps.go
+++ b/pkg/component/gardener/dashboard/configmaps.go
@@ -61,7 +61,8 @@ func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, e
 			Port:               portServer,
 			LogFormat:          "text",
 			LogLevel:           g.values.LogLevel,
-			APIServerURL:       g.values.APIServerURL,
+			APIServerURL:       "https://" + g.values.APIServerURL,
+			APIServerCAData:    g.values.APIServerCABundle,
 			MaxRequestBodySize: "500kb",
 			// TODO: Remove this field once https://github.com/gardener/dashboard/issues/1788 is fixed
 			ExperimentalUseWatchCacheForListShoots: "yes",

--- a/pkg/component/gardener/dashboard/dashboard.go
+++ b/pkg/component/gardener/dashboard/dashboard.go
@@ -58,6 +58,8 @@ type Values struct {
 	LogLevel string
 	// APIServerURL is the URL of the API server of the virtual garden cluster.
 	APIServerURL string
+	// APIServerCABundle is the CA bundle of the API server of the virtual garden cluster.
+	APIServerCABundle *string
 	// EnableTokenLogin specifies whether token-based login is enabled.
 	EnableTokenLogin bool
 	// Ingress contains the ingress configuration.
@@ -104,6 +106,8 @@ type Interface interface {
 	component.DeployWaiter
 	// SetGardenTerminalSeedHost sets the terminal seed host field.
 	SetGardenTerminalSeedHost(string)
+	// SetAPIServerCABundle sets the API server CA bundle field.
+	SetAPIServerCABundle(*string)
 }
 
 // New creates a new instance of DeployWaiter for the gardener-dashboard.
@@ -256,6 +260,10 @@ func (g *gardenerDashboard) SetGardenTerminalSeedHost(host string) {
 	if g.values.Terminal != nil {
 		g.values.Terminal.GardenTerminalSeedHost = host
 	}
+}
+
+func (g *gardenerDashboard) SetAPIServerCABundle(bundle *string) {
+	g.values.APIServerCABundle = bundle
 }
 
 // GetLabels returns the labels for the gardener-dashboard.

--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -68,7 +68,7 @@ var _ = Describe("GardenerDashboard", func() {
 		namespace                  = "some-namespace"
 
 		image                 = "gardener-dashboard-image:latest"
-		apiServerURL          = "https://api.com"
+		apiServerURL          = "api.local.gardener.cloud"
 		logLevel              = "debug"
 		ingressValues         = IngressValues{Domains: []string{"first", "second"}}
 		enableTokenLogin      bool
@@ -211,7 +211,7 @@ var _ = Describe("GardenerDashboard", func() {
 			configRaw := `port: 8080
 logFormat: text
 logLevel: ` + logLevel + `
-apiServerUrl: ` + apiServerURL + `
+apiServerUrl: https://` + apiServerURL + `
 maxRequestBodySize: 500kb
 experimentalUseWatchCacheForListShoots: "yes"
 readinessProbe:

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1031,12 +1031,16 @@ func (r *Reconciler) newGardenerDashboard(garden *operatorv1alpha1.Garden, secre
 		Image:            image.String(),
 		LogLevel:         logger.InfoLevel,
 		RuntimeVersion:   r.RuntimeVersion,
-		APIServerURL:     "https://" + gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0]),
+		APIServerURL:     gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0]),
 		EnableTokenLogin: true,
 		Ingress: gardenerdashboard.IngressValues{
 			Domains:                garden.Spec.RuntimeCluster.Ingress.Domains,
 			WildcardCertSecretName: wildcardCertSecretName,
 		},
+	}
+
+	if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI != nil {
+		values.APIServerURL = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI.DomainPatterns[0]
 	}
 
 	if config := garden.Spec.VirtualCluster.Gardener.Dashboard; config != nil {

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	podsecurityadmissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -59,6 +60,7 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
 )
@@ -332,7 +334,7 @@ func (r *Reconciler) reconcile(
 		_ = g.Add(flow.Task{
 			Name: "Reconciling Gardener Dashboard",
 			Fn: func(ctx context.Context) error {
-				return r.deployGardenerDashboard(ctx, c.gardenerDashboard, garden.Spec.VirtualCluster.Gardener.Dashboard != nil, virtualClusterClient)
+				return r.deployGardenerDashboard(ctx, c.gardenerDashboard, garden, secretsManager, virtualClusterClient)
 			},
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerAPIServerReady, initializeVirtualClusterClient),
 		})
@@ -683,8 +685,8 @@ func (r *Reconciler) deployGardenPrometheus(ctx context.Context, log logr.Logger
 	return prometheus.Deploy(ctx)
 }
 
-func (r *Reconciler) deployGardenerDashboard(ctx context.Context, dashboard gardenerdashboard.Interface, enabled bool, virtualGardenClient client.Client) error {
-	if !enabled {
+func (r *Reconciler) deployGardenerDashboard(ctx context.Context, dashboard gardenerdashboard.Interface, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, virtualGardenClient client.Client) error {
+	if garden.Spec.VirtualCluster.Gardener.Dashboard == nil {
 		return component.OpDestroyAndWait(dashboard).Destroy(ctx)
 	}
 
@@ -708,6 +710,14 @@ func (r *Reconciler) deployGardenerDashboard(ctx context.Context, dashboard gard
 
 		dashboard.SetGardenTerminalSeedHost(seed.Name)
 		break
+	}
+
+	if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer == nil || garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI == nil {
+		caSecret, found := secretsManager.Get(v1beta1constants.SecretNameCACluster)
+		if !found {
+			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
+		}
+		dashboard.SetAPIServerCABundle(ptr.To(utils.EncodeBase64(caSecret.Data[secretsutils.DataKeyCertificateBundle])))
 	}
 
 	return component.OpWait(dashboard).Deploy(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Prefer SNI hostname for dashboard API server URL.
If no SNI is given, at least provide the CA bundle for the API server to prevent certificate verification issues.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9583

**Special notes for your reviewer**:
/cc @plkokanov @petersutter 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```