### PR TITLE
Enable `gardener-operator` to reconcile shoot-specific `NetworkPolicy`s

### DIFF
--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -169,6 +169,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers

--- a/pkg/operator/client/scheme.go
+++ b/pkg/operator/client/scheme.go
@@ -32,6 +32,7 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	operationsinstall "github.com/gardener/gardener/pkg/apis/operations/install"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -66,6 +67,7 @@ var (
 		hvpav1alpha1.AddToScheme,
 		istionetworkingv1beta1.AddToScheme,
 		istionetworkingv1alpha3.AddToScheme,
+		extensionsv1alpha1.AddToScheme,
 		monitoringv1.AddToScheme,
 		monitoringv1beta1.AddToScheme,
 		monitoringv1alpha1.AddToScheme,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
When registering the runtime cluster (managed by `gardener-operator`) as seed, the `gardener-operator`'s `NetworkPolicy` controller is responsible for managing all `NetworkPolicy`s (including those for shoot namespaces). This is currently not possible because it fails with:

```
{"level":"error","ts":"2024-04-24T09:23:07.782Z","msg":"Reconciler error","controller":"networkpolicy","namespace":"","name":"shoot--garden--managedseed","reconcileID":"e79a922d-b748-47ff-94b0-e58153d2f58b","error":"failed to reconcile NetworkPolicy shoot--garden--managedseed/allow-to-private-networks: no kind is registered for the type v1alpha1.Cluster in scheme \"pkg/runtime/scheme.go:100\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:227"}
```

Fixes https://github.com/gardener/gardener/issues/8879

In a setup without `gardener-operator`, this controller is ran by `gardenlet`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardener-operator` is now capable of reconciling shoot cluster-specific `NetworkPolicy`s in case the garden cluster is a seed cluster at the same time.
```
