### PR TITLE
Run gardenlet as `nonroot` user and group `65532`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ ENTRYPOINT ["/gardener-scheduler"]
 # gardenlet
 FROM distroless-static AS gardenlet
 COPY --from=builder /go/bin/gardenlet /gardenlet
-USER nonroot
 WORKDIR /
 ENTRYPOINT ["/gardenlet"]
 

--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -79,6 +79,9 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -981,6 +981,9 @@ func ComputeExpectedGardenletDeploymentSpec(
 				ServiceAccountName: "gardenlet",
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsNonRoot: ptr.To(true),
+					RunAsUser:    ptr.To[int64](65532),
+					RunAsGroup:   ptr.To[int64](65532),
+					FSGroup:      ptr.To[int64](65532),
 					SeccompProfile: &corev1.SeccompProfile{
 						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality
/kind bug enhancement

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/9640 `kubelet` validates that `gardenlet` runs with `non-root` user. This checks requires the uid to be set ([ref](https://github.com/kubernetes/kubernetes/blob/8a9031f9c9f803f86b427d96a1dddc45134858b9/pkg/kubelet/kuberuntime/security_context_others.go#L45-L52)). This PR sets `nonroot` user and group `65532` for the `kubelet` for consistency with the control plane components ([ref](https://github.com/gardener/gardener/pull/8690)) and to pass the `kubelet` validation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardenlet` now runs as `nonroot` user and group `65532`.
```
