### PR TITLE
Fix nil pointer when dashboard feature are already configured

### DIFF
--- a/pkg/component/gardener/dashboard/configmap.go
+++ b/pkg/component/gardener/dashboard/configmap.go
@@ -106,9 +106,9 @@ func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, e
 			cfg.Frontend = make(map[string]interface{})
 		}
 		if cfg.Frontend["features"] == nil {
-			cfg.Frontend["features"] = make(map[string]bool)
+			cfg.Frontend["features"] = make(map[string]interface{})
 		}
-		cfg.Frontend["features"].(map[string]bool)["terminalEnabled"] = true
+		cfg.Frontend["features"].(map[string]interface{})["terminalEnabled"] = true
 	}
 
 	if g.values.OIDC != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
```
panic: interface conversion: interface {} is map[string]interface {}, not map[string]bool

goroutine 1130 [running]:
github.com/gardener/gardener/pkg/component/gardener/dashboard.(*gardenerDashboard).configMap(0xc000e598c0, {0x33e19f8, 0xc000a48ae0})
	/go/src/github.com/gardener/gardener/pkg/component/gardener/dashboard/configmap.go:111 +0x1c14
github.com/gardener/gardener/pkg/component/gardener/dashboard.(*gardenerDashboard).Deploy(0xc000e598c0, {0x33e19f8, 0xc000a48ae0})
	/go/src/github.com/gardener/gardener/pkg/component/gardener/dashboard/dashboard.go:141 +0x3bb
```

This happens when `features` is already set in the provided frontend configmap.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9646

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
