### PR TITLE
Delete orphaned vali VPAs

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,7 +59,8 @@ func (g *garden) runMigrations(ctx context.Context, log logr.Logger, _ cluster.C
 		return err
 	}
 
-	return nil
+	log.Info("Deleting orphaned vali VPAs which used to be managed by the HVPA controller")
+	return deleteOrphanedValiVPAs(ctx, log, g.mgr.GetClient())
 }
 
 // TODO(aaronfern): Remove this code after v1.93 has been released.
@@ -376,4 +378,34 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 	}
 
 	return flow.Parallel(taskFns...)(ctx)
+}
+
+// TODO(plkokanov): Remove this code after a couple releases.
+// The refactoring done in https://github.com/gardener/gardener/pull/8061 incorrectly changed
+// the label used to select vali vpas by the corresponding vali hvpa from `role: vali-vpa` to
+// `role: valivpa`. This caused the hvpa controller to orphan the existing vpa objects with
+// the `role: vali-vpa` label and create new ones.
+// deleteOrphanedValiVPAs deletes the orphaned vali vpas with the `role vali-vpa` label.
+func deleteOrphanedValiVPAs(ctx context.Context, log logr.Logger, c client.Client) error {
+	var (
+		orphanedValiVPALabel = "vali-vpa"
+		orphanedVPAList      = &vpaautoscalingv1.VerticalPodAutoscalerList{}
+	)
+
+	if err := c.List(ctx, orphanedVPAList, client.MatchingLabels(map[string]string{v1beta1constants.LabelRole: orphanedValiVPALabel})); err != nil {
+		return fmt.Errorf("could not list orphaned vali VPAs with label '%s: %s': %w", v1beta1constants.LabelRole, orphanedValiVPALabel, err)
+	}
+
+	fns := make([]flow.TaskFn, 0, len(orphanedVPAList.Items))
+	for _, obj := range orphanedVPAList.Items {
+		fns = append(fns, func(ctx context.Context) error {
+			log.Info("Deleting orphaned vali VPA", "vpa", client.ObjectKeyFromObject(&obj))
+			if err := client.IgnoreNotFound(c.Delete(ctx, &obj)); err != nil {
+				return fmt.Errorf("could not delete orphaned vali VPA %q: %w", client.ObjectKeyFromObject(&obj).String(), err)
+			}
+			return nil
+		})
+	}
+
+	return flow.Parallel(fns...)(ctx)
 }

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -380,7 +380,7 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 	return flow.Parallel(taskFns...)(ctx)
 }
 
-// TODO(plkokanov): Remove this code after a couple releases.
+// TODO(plkokanov): Remove this code after gardener v1.96 has been released.
 // The refactoring done in https://github.com/gardener/gardener/pull/8061 incorrectly changed
 // the label used to select vali vpas by the corresponding vali hvpa from `role: vali-vpa` to
 // `role: valivpa`. This caused the hvpa controller to orphan the existing vpa objects with


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
This PR deletes orphaned vali VPAs that used to be managed by the corresponding vali HVPA with label `role: vali-vpa`. 

The vali deployment logic was refactored from helm chart into go components in https://github.com/gardener/gardener/pull/8061. This PR also incorrectly modified the selector and labels for the VPA managed by the vali HVPA from `role: vali-vpa` to `role: valivpa` (notice the missing dash). The change of the labels caused the hvpa controller to orphan the vpa with the `role: vali-vpa` label and create a new one with `role: valivpa` label. So until now there were two VPAs targeting the vali StatefulSets in `garden` namespace and each shoot control plane namespace.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added a cleanup function to `gardenlet` which is executed at startup and deletes orphaned VPAs with label `role: vali-vpa` that were previously managed by the HVPA deployed for `vali`.
```
