### PR TITLE
Switch from `purpose` to `is_seed` for Seed alerts

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -68,8 +68,7 @@ spec:
       expr: |
         garden_shoot_condition{condition = "APIServerAvailable",
                               operation = "Reconcile",
-                              is_seed   = "true",
-                              purpose   = "infrastructure"}
+                              is_seed   = "true"}
         < 1
       for: 2m
       labels:
@@ -331,8 +330,7 @@ spec:
         max_over_time(
           garden_shoot_condition{condition       = "ControlPlaneHealthy",
                                  operation       = "Reconcile",
-                                 is_seed         = "false",
-                                 purpose         =~ "infrastructure",
+                                 is_seed         = "true",
                                  is_compliant    = "True",
                                  has_user_errors = "false"}[2m])
         == 0
@@ -368,8 +366,7 @@ spec:
         max_over_time(
           garden_shoot_condition{condition       = "SystemComponentsHealthy",
                                  operation       = "Reconcile",
-                                 is_seed         = "false",
-                                 purpose         =~ "infrastructure",
+                                 is_seed         = "true",
                                  is_compliant    = "True",
                                  has_user_errors = "false"}[2m])
         == 0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
When we introduced a new alert for Seed control-planes, we selected Shoots with `purpose: infrastructure` (which is only true for Seeds), but missed that the copy-pasted alert definition also had `is_seed="false"`.

This change removes `purpose: "infrastructure"` so identify Seeds and switches to `is_seed` instead. This is more direct (doesn't require knowledge about which Shoots may or may not have `purpose: "infrastructure"`) and removes a possibility to configure something that doesn't match any Shoot at all.

**Special notes for your reviewer**:
Thanks @rickardsjp and @vicwicker! 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed prometheus alerting rules for Seeds with unhealthy control-planes
```
