### PR TITLE
Don't do HVPA specific things for etcd when `VPAForETCD` is enabled

### DIFF
--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -852,7 +852,7 @@ func (e *etcd) Scale(ctx context.Context, replicas int32) error {
 		return err
 	}
 
-	if e.values.HVPAEnabled {
+	if e.values.HVPAEnabled && !e.values.VPAEnabled { // Skip this when VPA is enabled for etcd: there is no HVPA object anymore
 		// Keep the `hvpa.Spec.Hpa.Template.Spec.MaxReplicas` and `hvpa.Spec.Hpa.Template.Spec.MinReplicas`
 		// values consistent with the replica count of the etcd.
 		hvpa := e.emptyHVPA()
@@ -931,7 +931,7 @@ func (e *etcd) computeContainerResources(existingSts *appsv1.StatefulSet) (*core
 		}
 	)
 
-	if existingSts != nil && e.values.HVPAEnabled {
+	if existingSts != nil && e.values.HVPAEnabled && !e.values.VPAEnabled { // Skip this when VPA is enabled for etcd: we're not using HVPA for etcd in this case
 		for k := range existingSts.Spec.Template.Spec.Containers {
 			v := existingSts.Spec.Template.Spec.Containers[k]
 			switch v.Name {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
When the new featuregate `VPAForETCD` is enabled, Shoot deletion fails with 
```
Flow "Shoot cluster deletion" encountered task errors: [
task "Scaling up etcd main and event" failed: retry failed with context deadline exceeded, 
last error: Hvpa.autoscaling.k8s.io "etcd-main" not found] Operation will be retried.
```

because there are still paths in the `etcd` components which try to do HVPA specific things, although `VPAForETCD` disables HVPA usage for the `etcd` component.

This PR ensures we no longer do HVPA specific things for etcd when `VPAForETCD` is enabled, namely
* explicitly adjusting the HVPA resource during `#Scale()`
* explicitly copying over the currently set resources from an existing `etcd` StatefulSet into the newly created one


**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix an issue in the etcd component which caused Shoot deletion to fail when the `VPAForETCD` feature gate was enabled
```
