### PR TITLE
Validation of DNSRecords: allow domain names starting with an underscore "_"

### DIFF
--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -58,8 +58,14 @@ func ValidateDNSRecordSpec(spec *extensionsv1alpha1.DNSRecordSpec, fldPath *fiel
 	}
 
 	// This will return FieldValueRequired for an empty spec.Name
-	// allow leading '_' as used for DNS challenges (e.g. Let's Encrypt)
-	allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath.Child("name"), strings.TrimPrefix(strings.TrimPrefix(spec.Name, "_"), "*."))...)
+	var nameToCheck string
+	if spec.RecordType == extensionsv1alpha1.DNSRecordTypeTXT {
+		// allow leading '_' as used for DNS challenges (e.g. Let's Encrypt)
+		nameToCheck = strings.TrimPrefix(spec.Name, "_")
+	} else {
+		nameToCheck = strings.TrimPrefix(spec.Name, "*.")
+	}
+	allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath.Child("name"), nameToCheck)...)
 
 	validRecordTypes := []string{string(extensionsv1alpha1.DNSRecordTypeA), string(extensionsv1alpha1.DNSRecordTypeAAAA), string(extensionsv1alpha1.DNSRecordTypeCNAME), string(extensionsv1alpha1.DNSRecordTypeTXT)}
 	if !slices.Contains(validRecordTypes, string(spec.RecordType)) {

--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -58,7 +58,8 @@ func ValidateDNSRecordSpec(spec *extensionsv1alpha1.DNSRecordSpec, fldPath *fiel
 	}
 
 	// This will return FieldValueRequired for an empty spec.Name
-	allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath.Child("name"), strings.TrimPrefix(spec.Name, "*."))...)
+	// allow leading '_' as used for DNS challenges (e.g. Let's Encrypt)
+	allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath.Child("name"), strings.TrimPrefix(strings.TrimPrefix(spec.Name, "_"), "*."))...)
 
 	validRecordTypes := []string{string(extensionsv1alpha1.DNSRecordTypeA), string(extensionsv1alpha1.DNSRecordTypeAAAA), string(extensionsv1alpha1.DNSRecordTypeCNAME), string(extensionsv1alpha1.DNSRecordTypeTXT)}
 	if !slices.Contains(validRecordTypes, string(spec.RecordType)) {

--- a/pkg/apis/extensions/validation/dnsrecord_test.go
+++ b/pkg/apis/extensions/validation/dnsrecord_test.go
@@ -204,6 +204,7 @@ var _ = Describe("DNSRecord validation tests", func() {
 
 		It("should allow domain names starting with '_' as used for DNS challenges", func() {
 			dns.Spec.Name = "_acme-challenge.test.example.com"
+			dns.Spec.RecordType = extensionsv1alpha1.DNSRecordTypeTXT
 			errorList := ValidateDNSRecord(dns)
 
 			Expect(errorList).To(BeEmpty())

--- a/pkg/apis/extensions/validation/dnsrecord_test.go
+++ b/pkg/apis/extensions/validation/dnsrecord_test.go
@@ -201,6 +201,13 @@ var _ = Describe("DNSRecord validation tests", func() {
 
 			Expect(errorList).To(BeEmpty())
 		})
+
+		It("should allow domain names starting with '_' as used for DNS challenges", func() {
+			dns.Spec.Name = "_acme-challenge.test.example.com"
+			errorList := ValidateDNSRecord(dns)
+
+			Expect(errorList).To(BeEmpty())
+		})
 	})
 
 	Describe("#ValidateDNSRecordUpdate", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The ACME protocol for requesting certificates (e.g. from Let's Encrypt) uses DNS challenges to validate that the client has control for the domain. The TXT records to be created are starting with `_acme-challenge.` which is not following the strict validation according to RFC 1123, but which is practically accepted by all DNS providers.
Therefore the validation now tolerates an underscore `_` at the beginning of the domain name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Validation of DNSRecords: allow domain names starting with an underscore "_"
```
