### PR TITLE
[operator] Make `controllerregistrar` reconciler generic

### DIFF
--- a/pkg/operator/controller/controllerregistrar/reconciler.go
+++ b/pkg/operator/controller/controllerregistrar/reconciler.go
@@ -13,28 +13,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
-	"github.com/gardener/gardener/pkg/controller/networkpolicy"
-	"github.com/gardener/gardener/pkg/controller/vpaevictionrequirements"
-	"github.com/gardener/gardener/pkg/operator/apis/config"
 )
 
 // Reconciler adds the NetworkPolicy and VPAEvictionRequirements controllers to the manager.
 type Reconciler struct {
-	Manager                              manager.Manager
-	NetworkPolicyControllerConfiguration config.NetworkPolicyControllerConfiguration
-	VPAEvictionControllerConfiguration   config.VPAEvictionRequirementsControllerConfiguration
-
-	networkPolicyControllerAdded           bool
-	vpaEvictionRequirementsControllerAdded bool
+	Manager     manager.Manager
+	Controllers []Controller
 }
 
-// Reconcile performs the main reconciliation logic.
+// Controller contains a function for registering a controller.
+type Controller struct {
+	AddToManagerFunc func(context.Context, manager.Manager, *operatorv1alpha1.Garden) error
+	added            bool
+}
+
+// Reconcile performs the controller registration.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	if r.networkPolicyControllerAdded && r.vpaEvictionRequirementsControllerAdded {
+	if r.allControllersAdded() {
 		return reconcile.Result{}, nil
 	}
 
@@ -47,34 +45,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	if !r.networkPolicyControllerAdded {
-		if err := (&networkpolicy.Reconciler{
-			ConcurrentSyncs:              r.NetworkPolicyControllerConfiguration.ConcurrentSyncs,
-			AdditionalNamespaceSelectors: r.NetworkPolicyControllerConfiguration.AdditionalNamespaceSelectors,
-			RuntimeNetworks: networkpolicy.RuntimeNetworkConfig{
-				// gardener-operator only supports IPv4 single-stack networking in the runtime cluster for now.
-				IPFamilies: []gardencore.IPFamily{gardencore.IPFamilyIPv4},
-				Nodes:      garden.Spec.RuntimeCluster.Networking.Nodes,
-				Pods:       garden.Spec.RuntimeCluster.Networking.Pods,
-				Services:   garden.Spec.RuntimeCluster.Networking.Services,
-				BlockCIDRs: garden.Spec.RuntimeCluster.Networking.BlockCIDRs,
-			},
-		}).AddToManager(ctx, r.Manager, r.Manager); err != nil {
-			return reconcile.Result{}, err
+	for i, controller := range r.Controllers {
+		if !controller.added {
+			if err := controller.AddToManagerFunc(ctx, r.Manager, garden); err != nil {
+				return reconcile.Result{}, err
+			}
+			r.Controllers[i].added = true
 		}
-
-		r.networkPolicyControllerAdded = true
 	}
-
-	if !r.vpaEvictionRequirementsControllerAdded {
-		if err := (&vpaevictionrequirements.Reconciler{
-			ConcurrentSyncs: r.VPAEvictionControllerConfiguration.ConcurrentSyncs,
-		}).AddToManager(r.Manager, r.Manager); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		r.vpaEvictionRequirementsControllerAdded = true
-	}
-
 	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) allControllersAdded() bool {
+	for _, controller := range r.Controllers {
+		if !controller.added {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/operator/controller/controllerregistrar/reconciler.go
+++ b/pkg/operator/controller/controllerregistrar/reconciler.go
@@ -16,7 +16,7 @@ import (
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 )
 
-// Reconciler adds the NetworkPolicy and VPAEvictionRequirements controllers to the manager.
+// Reconciler adds the controllers to the manager.
 type Reconciler struct {
 	Manager     manager.Manager
 	Controllers []Controller


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR makes `gardener-operator`'s `controllerregistrar` controller generic so that it's easier to extend. For example, https://github.com/gardener/gardener/pull/8984 needed to make it register another controller, and this is was hard-coded into the reconciler. While this approach is fine, it will get easier after this PR in case we hit such case again in the future. After this PR, the only code that is needed is providing the `AddToManager` function when instantiating the reconciler.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
