### PR TITLE
Prevent generation of new `managedresource-shoot-core-system-*` `Secret`s on each `Shoot` reconciliation

### DIFF
--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -439,6 +439,9 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 
 			apiGroupToReadableResourcesNames[apiGroup] = append(apiGroupToReadableResourcesNames[apiGroup], resource.Name)
 		}
+
+		// Sort keys to get a stable order of the RBAC rules when iterating.
+		slices.Sort(apiGroupToReadableResourcesNames[apiGroup])
 	}
 
 	// Sort keys to get a stable order of the RBAC rules when iterating.

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -515,8 +515,8 @@ rules:
 - apiGroups:
   - bar
   resources:
-  - foo
   - baz
+  - foo
   verbs:
   - get
   - list


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Today, each `Shoot` reconciliation produces a new `managedresource-shoot-core-system-*` `Secret`:

```
$ ./hack/usage/shoot-operation local garden-local
shoot.core.gardener.cloud/local annotated

$ k -n shoot--local--local get secret | grep system
managedresource-shoot-core-system-2b594673                       Opaque              53     25h
managedresource-shoot-core-system-33fb4949                       Opaque              53     33s

$ ./hack/usage/shoot-operation local garden-local
shoot.core.gardener.cloud/local annotated

$ k -n shoot--local--local get secret | grep system
managedresource-shoot-core-system-2b594673                       Opaque              53     25h
managedresource-shoot-core-system-33fb4949                       Opaque              53     57s
managedresource-shoot-core-system-9b96838c                       Opaque              53     7s
```

This is because the `clusterrole____gardener.cloud_system_read-only.yaml` key differs each time, for example:

<img width="1837" alt="Screenshot 2024-05-07 at 17 05 25" src="https://github.com/gardener/gardener/assets/19169361/12fba4b0-25f8-4644-be68-d9ed29a9d5ba">

We already sort the rules by API groups
https://github.com/gardener/gardener/blob/5dc8374094ee44c23bcda6541eae405156bfa930/pkg/component/shoot/system/system.go#L444-L449
but not the resources inside. This is added by this PR.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/8870

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused regeneration of `managedresource-shoot-core-system-*` `Secret`s on each `Shoot` reconciliation.
```
