### PR TITLE
Fix example github `apiURL` in documentation

### DIFF
--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -223,7 +223,7 @@ spec:
     #   assetsConfigMapRef:
     #     name: gardener-dashboard-assets
     #   gitHub:
-    #     apiURL: https://github.com/api/v3/
+    #     apiURL: https://api.github.com
     #     organisation: kubernetes-dev
     #     repository: issues-dev
     #     secretRef:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
The example gitHub `apiURL` for the gardener dashboard is currently set to `https://github.com/api/v3/`. However, the correct public GitHub API endpoint is `https://api.github.com`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
For GitHub Enterprise Server, the API endpoint URL scheme is `http(s)://<em>HOSTNAME</em>/api/v3` ([ref](https://docs.github.com/en/enterprise-server@3.12/rest/enterprise-admin?apiVersion=2022-11-28#endpoint-urls)). The current example value was likely derived from this format. If the intention is to provide an example for GitHub Enterprise Server, the hostname should be updated to clarify that it is not referring to the public API endpoint.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
