### PR TITLE
Introduce `.spec.pools[].userDataSecretRef` to prevent inlining the entire user data

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4267,8 +4267,28 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>UserData is a base64-encoded string that contains the data that is sent to the provider&rsquo;s APIs
-when a new machine/VM that is part of this worker pool shall be spawned.</p>
+when a new machine/VM that is part of this worker pool shall be spawned.
+Either this or UserDataSecretRef must be provided.
+Deprecated: This field will be removed in future release.
+TODO(rfranzke): Remove this field after v1.100 has been released.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>userDataSecretRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider&rsquo;s APIs when
+a new machine/VM that is part of this worker pool shall be spawned.
+Either this or UserData must be provided.</p>
 </td>
 </tr>
 <tr>

--- a/docs/extensions/worker.md
+++ b/docs/extensions/worker.md
@@ -80,7 +80,9 @@ spec:
       worker.gardener.cloud/cri-name: containerd
       worker.gardener.cloud/pool: cpu-worker
       worker.gardener.cloud/system-components: "true"
-    userData: c29tZSBkYXRhIHRvIGJvb3RzdHJhcCB0aGUgVk0K
+    userDataSecretRef:
+      name: user-data-secret
+      key: cloud_config
     volume:
       size: 20Gi
       type: gp2
@@ -273,7 +275,7 @@ The `MachineDeployment`'s machine class reference (`.spec.template.spec.class.na
 However, all of this is only a convention that eases writing the controller, but you can do it completely differently if you desire - as long as you make sure that the described behaviours are implemented correctly.
 
 After the machine classes and machine deployments have been created, the machine-controller-manager will start talking to the provider's IaaS API and create the virtual machines.
-Gardener makes sure that the content of the `userData` field that is used to bootstrap the machines contains the required configuration for installation of the kubelet and registering the VM as worker node in the shoot cluster.
+Gardener makes sure that the content of the `Secret` referenced in the `userDataSecretRef` field that is used to bootstrap the machines contains the required configuration for installation of the kubelet and registering the VM as worker node in the shoot cluster.
 The `Worker` extension controller shall wait until all the created `MachineDeployment`s indicate healthiness/readiness before it ends the control loop.
 
 ## Does Gardener need some information that must be returned back?

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -279,8 +279,35 @@ spec:
                       description: |-
                         UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
                         when a new machine/VM that is part of this worker pool shall be spawned.
+                        Either this or UserDataSecretRef must be provided.
+                        Deprecated: This field will be removed in future release.
+                        TODO(rfranzke): Remove this field after v1.100 has been released.
                       format: byte
                       type: string
+                    userDataSecretRef:
+                      description: |-
+                        UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
+                        a new machine/VM that is part of this worker pool shall be spawned.
+                        Either this or UserData must be provided.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
                     volume:
                       description: Volume contains information about the root disks
                         that should be used for this worker pool.
@@ -314,7 +341,6 @@ spec:
                   - maximum
                   - minimum
                   - name
-                  - userData
                   type: object
                 type: array
               providerConfig:

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -165,6 +165,10 @@ var _ = Describe("Machines", func() {
 				p.UserData = []byte("new-data")
 			})
 
+			It("when changing user-data secret ref", func() {
+				p.UserDataSecretRef = &corev1.SecretKeySelector{}
+			})
+
 			It("when changing zones", func() {
 				p.Zones = []string{"1"}
 			})

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -132,7 +132,16 @@ type WorkerPool struct {
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty"`
 	// UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
 	// when a new machine/VM that is part of this worker pool shall be spawned.
-	UserData []byte `json:"userData"`
+	// Either this or UserDataSecretRef must be provided.
+	// Deprecated: This field will be removed in future release.
+	// TODO(rfranzke): Remove this field after v1.100 has been released.
+	// +optional
+	UserData []byte `json:"userData,omitempty"`
+	// UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
+	// a new machine/VM that is part of this worker pool shall be spawned.
+	// Either this or UserData must be provided.
+	// +optional
+	UserDataSecretRef *corev1.SecretKeySelector `json:"userDataSecretRef,omitempty"`
 	// Volume contains information about the root disks that should be used for this worker pool.
 	// +optional
 	Volume *Volume `json:"volume,omitempty"`

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1741,6 +1741,11 @@ func (in *WorkerPool) DeepCopyInto(out *WorkerPool) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.UserDataSecretRef != nil {
+		in, out := &in.UserDataSecretRef, &out.UserDataSecretRef
+		*out = new(v1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Volume != nil {
 		in, out := &in.Volume, &out.Volume
 		*out = new(Volume)

--- a/pkg/apis/extensions/validation/worker.go
+++ b/pkg/apis/extensions/validation/worker.go
@@ -83,8 +83,8 @@ func ValidateWorkerPools(pools []extensionsv1alpha1.WorkerPool, fldPath *field.P
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "field is required"))
 		}
 
-		if pool.UserData == nil {
-			allErrs = append(allErrs, field.Required(idxPath.Child("userData"), "field is required"))
+		if pool.UserData == nil && pool.UserDataSecretRef == nil {
+			allErrs = append(allErrs, field.Required(idxPath.Child("userData"), "either userData or userDataSecretRef must be provided"))
 		}
 
 		if pool.NodeTemplate != nil {

--- a/pkg/apis/extensions/validation/worker_test.go
+++ b/pkg/apis/extensions/validation/worker_test.go
@@ -117,6 +117,25 @@ var _ = Describe("Worker validation tests", func() {
 			}))))
 		})
 
+		It("should complain Worker resources without user data", func() {
+			workerCopy := worker.DeepCopy()
+
+			workerCopy.Spec.Pools[0].UserData = nil
+
+			Expect(ValidateWorker(workerCopy)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.pools[0].userData"),
+			}))))
+		})
+
+		It("should allow Worker resources with user data secret ref", func() {
+			workerCopy := worker.DeepCopy()
+
+			workerCopy.Spec.Pools[0].UserDataSecretRef = &corev1.SecretKeySelector{}
+
+			Expect(ValidateWorker(workerCopy)).To(BeEmpty())
+		})
+
 		It("should allow valid worker resources", func() {
 			errorList := ValidateWorker(worker)
 

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -281,8 +281,35 @@ spec:
                       description: |-
                         UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
                         when a new machine/VM that is part of this worker pool shall be spawned.
+                        Either this or UserDataSecretRef must be provided.
+                        Deprecated: This field will be removed in future release.
+                        TODO(rfranzke): Remove this field after v1.100 has been released.
                       format: byte
                       type: string
+                    userDataSecretRef:
+                      description: |-
+                        UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
+                        a new machine/VM that is part of this worker pool shall be spawned.
+                        Either this or UserData must be provided.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
                     volume:
                       description: Volume contains information about the root disks
                         that should be used for this worker pool.
@@ -316,7 +343,6 @@ spec:
                   - maximum
                   - minimum
                   - name
-                  - userData
                   type: object
                 type: array
               providerConfig:

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -182,7 +182,10 @@ type Data struct {
 	// Object is the plain OperatingSystemConfig object.
 	Object *extensionsv1alpha1.OperatingSystemConfig
 	// Content is the actual cloud-config user data.
+	// TODO(rfranzke): Remove this Content field after v1.100 is released.
 	Content string
+	// SecretName is the name of a secret storing the actual cloud-config user data.
+	SecretName *string
 	// Command is the command for reloading the cloud-config (in case a new version was downloaded).
 	Command *string
 	// Units is the list of systemd unit names.
@@ -252,11 +255,12 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 				}
 
 				data := Data{
-					Object:  osc,
-					Content: string(secret.Data[extensionsv1alpha1.OperatingSystemConfigSecretDataKey]),
-					Command: osc.Status.Command,
-					Units:   osc.Status.Units,
-					Files:   osc.Status.Files,
+					Object:     osc,
+					Content:    string(secret.Data[extensionsv1alpha1.OperatingSystemConfigSecretDataKey]),
+					SecretName: &secret.Name,
+					Command:    osc.Status.Command,
+					Units:      osc.Status.Units,
+					Files:      osc.Status.Files,
 				}
 
 				o.lock.Lock()

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -729,8 +729,9 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(defaultDepWaiter.WorkerNameToOperatingSystemConfigsMap()).To(Equal(map[string]*OperatingSystemConfigs{
 					worker1Name: {
 						Init: Data{
-							Content: "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
-							Command: ptr.To("foo-gardener-node-agent-" + worker1Name + "-77ac3-type1-init"),
+							Content:    "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
+							SecretName: ptr.To("cc-" + expected[0].Name),
+							Command:    ptr.To("foo-gardener-node-agent-" + worker1Name + "-77ac3-type1-init"),
 							Units: []string{
 								"bar-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
 								"baz-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
@@ -738,8 +739,9 @@ var _ = Describe("OperatingSystemConfig", func() {
 							Object: worker1OSCDownloader,
 						},
 						Original: Data{
-							Content: "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
-							Command: ptr.To("foo-gardener-node-agent-" + worker1Name + "-77ac3-type1-original"),
+							Content:    "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
+							SecretName: ptr.To("cc-" + expected[1].Name),
+							Command:    ptr.To("foo-gardener-node-agent-" + worker1Name + "-77ac3-type1-original"),
 							Units: []string{
 								"bar-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
 								"baz-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
@@ -749,8 +751,9 @@ var _ = Describe("OperatingSystemConfig", func() {
 					},
 					worker2Name: {
 						Init: Data{
-							Content: "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
-							Command: ptr.To("foo-gardener-node-agent-" + worker2Name + "-d9e53-type2-init"),
+							Content:    "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
+							SecretName: ptr.To("cc-" + expected[2].Name),
+							Command:    ptr.To("foo-gardener-node-agent-" + worker2Name + "-d9e53-type2-init"),
 							Units: []string{
 								"bar-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
 								"baz-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
@@ -758,8 +761,9 @@ var _ = Describe("OperatingSystemConfig", func() {
 							Object: worker2OSCDownloader,
 						},
 						Original: Data{
-							Content: "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",
-							Command: ptr.To("foo-gardener-node-agent-" + worker2Name + "-d9e53-type2-original"),
+							Content:    "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",
+							SecretName: ptr.To("cc-" + expected[3].Name),
+							Command:    ptr.To("foo-gardener-node-agent-" + worker2Name + "-d9e53-type2-original"),
 							Units: []string{
 								"bar-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",
 								"baz-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",

--- a/pkg/component/extensions/worker/worker_test.go
+++ b/pkg/component/extensions/worker/worker_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Worker", func() {
 		worker1MachineImageVersion            = "worker1machineimagev1"
 		worker1MCMSettings                    = &gardencorev1beta1.MachineControllerManagerSettings{}
 		worker1UserData                       = []byte("bootstrap-me")
+		worker1UserDataSecretName             = "user-data-secret-name-w1"
 		worker1VolumeName                     = "worker1volumename"
 		worker1VolumeType                     = "worker1volumetype"
 		worker1VolumeSize                     = "42Gi"
@@ -98,6 +99,7 @@ var _ = Describe("Worker", func() {
 		worker2MachineImageName          = "worker2machineimage"
 		worker2MachineImageVersion       = "worker2machineimagev1"
 		worker2UserData                  = []byte("bootstrap-me-now")
+		worker2UserDataSecretName        = "user-data-secret-name-w2"
 		worker2Arch                      = ptr.To("arm64")
 
 		machineTypes = []gardencorev1beta1.MachineType{
@@ -162,12 +164,14 @@ var _ = Describe("Worker", func() {
 			WorkerNameToOperatingSystemConfigsMap: map[string]*operatingsystemconfig.OperatingSystemConfigs{
 				worker1Name: {
 					Init: operatingsystemconfig.Data{
-						Content: string(worker1UserData),
+						Content:    string(worker1UserData),
+						SecretName: &worker1UserDataSecretName,
 					},
 				},
 				worker2Name: {
 					Init: operatingsystemconfig.Data{
-						Content: string(worker2UserData),
+						Content:    string(worker2UserData),
+						SecretName: &worker2UserDataSecretName,
 					},
 				},
 			},
@@ -282,8 +286,9 @@ var _ = Describe("Worker", func() {
 						Name:    worker1MachineImageName,
 						Version: worker1MachineImageVersion,
 					},
-					ProviderConfig: worker1ProviderConfig,
-					UserData:       worker1UserData,
+					ProviderConfig:    worker1ProviderConfig,
+					UserData:          worker1UserData,
+					UserDataSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker1UserDataSecretName}, Key: "cloud_config"},
 					Volume: &extensionsv1alpha1.Volume{
 						Name:      &worker1VolumeName,
 						Type:      &worker1VolumeType,
@@ -327,6 +332,7 @@ var _ = Describe("Worker", func() {
 					},
 					KubernetesVersion: &workerKubernetesVersion,
 					UserData:          worker2UserData,
+					UserDataSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker2UserDataSecretName}, Key: "cloud_config"},
 					NodeTemplate:      workerPool2NodeTemplate,
 					Architecture:      worker2Arch,
 					ClusterAutoscaler: emptyAutoscalerOptions,

--- a/pkg/provider-local/controller/worker/machine_images.go
+++ b/pkg/provider-local/controller/worker/machine_images.go
@@ -17,7 +17,7 @@ import (
 // UpdateMachineImagesStatus implements genericactuator.WorkerDelegate.
 func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	if w.machineImages == nil {
-		if err := w.generateMachineConfig(); err != nil {
+		if err := w.generateMachineConfig(ctx); err != nil {
 			return fmt.Errorf("unable to generate the machine config: %w", err)
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Creating a `Shoot` with > 80 worker pools leads to exceeds the etcd's max-request-bytes limit of `1.5MiB` due to the `Worker` resource. The culprit here is the `.spec.pools[].userData` field which inlines the user data for all pools. This can reduce the size by ~85% - 90%.

With this PR, the `extensions.gardener.cloud/v1alpha1.Worker` resource now has a new `.spec.pools[].userDataSecretRef` field which references a `Secret` containing the actual user data. the `.spec.pools[].userData` field is deprecated and will be removed in a future version. `Worker` extensions should fetch the user data from the secret and can use the `extensions/pkg/controller/worker.FetchUserData` helper function for it.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9545

**Special notes for your reviewer**:
/cc @ScheererJ @rickardsjp @hown3d

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The `extensions.gardener.cloud/v1alpha1.Worker` resource now has a new `.spec.pools[].userDataSecretRef` field which references a `Secret` containing the actual user data. the `.spec.pools[].userData` field is deprecated and will be removed in a future version. `Worker` extensions should fetch the user data from the secret and can use the `extensions/pkg/controller/worker.FetchUserData` helper function for it.
```
