### PR TITLE
Omit useless data from `OperatingSystemConfig` in `Secret`s reconciled by `gardener-node-agent`

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
@@ -31,14 +31,17 @@ func OperatingSystemConfigSecret(
 	*corev1.Secret,
 	error,
 ) {
+	// This OperatingSystemConfig object should only contain the data relevant for gardener-node-agent reconciliation to
+	// prevent undesired changes of the computed checksum of this object.
 	operatingSystemConfig := &extensionsv1alpha1.OperatingSystemConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        osc.Name,
-			Labels:      osc.Labels,
-			Annotations: osc.Annotations,
+		Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+			Units: osc.Spec.Units,
+			Files: osc.Spec.Files,
 		},
-		Spec:   osc.Spec,
-		Status: osc.Status,
+		Status: extensionsv1alpha1.OperatingSystemConfigStatus{
+			ExtensionUnits: osc.Status.ExtensionUnits,
+			ExtensionFiles: osc.Status.ExtensionFiles,
+		},
 	}
 
 	// The OperatingSystemConfig will be deployed to the shoot to get processed by gardener-node-agent. It doesn't

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
@@ -79,6 +80,14 @@ var _ = Describe("Secrets", func() {
 					ExtensionUnits: []extensionsv1alpha1.Unit{{
 						Name: "some-other-unit.service",
 					}},
+					ExtensionFiles: []extensionsv1alpha1.File{{
+						Path: "/some/other/path",
+					}},
+					DefaultStatus: extensionsv1alpha1.DefaultStatus{
+						LastOperation: &gardencorev1beta1.LastOperation{
+							LastUpdateTime: metav1.Now(),
+						},
+					},
 				},
 			}
 		})
@@ -91,7 +100,7 @@ var _ = Describe("Secrets", func() {
 					Name:      secretName,
 					Namespace: "kube-system",
 					Annotations: map[string]string{
-						"checksum/data-script": "b0a0d190d45f0d67d97bf30d7e45d9cbbaa86bbe99f34bc095a6fd172d1a18a2",
+						"checksum/data-script": "931abcfaf3fd3152748ec51b8f139a22a48a3ac6d8fff1c56a3aa2e07d2a39f1",
 					},
 					Labels: map[string]string{
 						"gardener.cloud/role":        "operating-system-config",
@@ -101,12 +110,7 @@ var _ = Describe("Secrets", func() {
 				Data: map[string][]byte{"osc.yaml": []byte(`apiVersion: extensions.gardener.cloud/v1alpha1
 kind: OperatingSystemConfig
 metadata:
-  annotations:
-    bar: foo
   creationTimestamp: null
-  labels:
-    foo: bar
-  name: osc-name
 spec:
   files:
   - content:
@@ -119,6 +123,9 @@ spec:
   units:
   - name: some-unit.service
 status:
+  extensionFiles:
+  - content: {}
+    path: /some/other/path
   extensionUnits:
   - name: some-other-unit.service
 `)},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Currently, each `Shoot` reconciliation causes recreation of the `ManagedResource` `Secret`s for `gardener-node-agent`:

```
$ k -n shoot--local--local get secret -l managed-resource=shoot-gardener-node-agent
NAME                                                       TYPE     DATA   AGE
managedresource-shoot-gardener-node-agent-local-98e659a0   Opaque   1      8m25s
managedresource-shoot-gardener-node-agent-rbac-2a486092    Opaque   7      47h

$ ./hack/usage/shoot-operation local garden-local
shoot.core.gardener.cloud/local annotated

$ k -n shoot--local--local get secret -l managed-resource=shoot-gardener-node-agent
NAME                                                       TYPE     DATA   AGE
managedresource-shoot-gardener-node-agent-local-2ce1d85f   Opaque   1      5s
managedresource-shoot-gardener-node-agent-rbac-2a486092    Opaque   7      47h
```

This causes the `Secret` in shoot clusters' `kube-system` namespaces to change, hence, causing a reconciliation (typically with jittered delay) of all `gardener-node-agent`s. However, such reconciliations do not apply any changes:

```
May 08 13:19:29 machine-shoot--local--local-local-5648f-vl9d9 gardener-node-agent[1219965]: {"level":"info","ts":"2024-05-08T13:19:29.362Z","msg":"Successfully applied operating system config","controller":"operatingsystemconfig","namespace":"kube-system","name":"gardener-node-agent-local-d0ffc","reconcileID":"271785bd-609f-4bc9-be3a-91c681db3d5c","changedFiles":0,"deletedFiles":0,"changedUnits":0,"deletedUnits":0}
```

When checking the difference of the `ManagedResource` `Secret`s, we only find irrelevant metadata changes:

<img width="1837" alt="image" src="https://github.com/gardener/gardener/assets/19169361/37b8b81a-883b-4239-b4af-e9f3c643bfa4" />

<img width="1837" alt="image" src="https://github.com/gardener/gardener/assets/19169361/d7387f4b-1d95-4b91-8a8f-9985065e1d04">

This PR simply omits irrelevant data from the `OperatingSystemConfig` to prevent such behaviour.

**Special notes for your reviewer**:
/cc @ScheererJ @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has has been fixed which caused unneeded `gardener-node-agent` reconciliations after each `Shoot` reconciliation even if the underlying `OperatingSystemConfig` did not contain relevant changes.
```
