### PR TITLE
Exclude kube-system namespace from seed VPA webhook

### DIFF
--- a/pkg/component/autoscaling/vpa/general.go
+++ b/pkg/component/autoscaling/vpa/general.go
@@ -210,11 +210,9 @@ func (v *vpa) reconcileGeneralMutatingWebhookConfiguration(mutatingWebhookConfig
 	if v.values.ClusterType == component.ClusterTypeSeed {
 		namespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{Key: "name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+				{Key: corev1.LabelMetadataName, Operator: metav1.LabelSelectorOpNotIn, Values: []string{metav1.NamespaceSystem}},
 			},
 		}
-	} else {
-		namespaceSelector = nil
 	}
 
 	mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1317,6 +1317,11 @@ var _ = Describe("VPA", func() {
 							Port:      ptr.To[int32](443),
 						},
 					}
+					mutatingWebhookConfiguration.Webhooks[0].NamespaceSelector = &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+						},
+					}
 
 					expectedObjects = append(expectedObjects,
 						clusterRoleGeneralActor,

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1319,7 +1319,7 @@ var _ = Describe("VPA", func() {
 					}
 					mutatingWebhookConfiguration.Webhooks[0].NamespaceSelector = &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{Key: "name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+							{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
 						},
 					}
 


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/kind improvement

**What this PR does / why we need it**:
Before this PR, Gardener uses the same mutating webhook for VPA on shoots and seeds. In result, seed VPA performs admission control to the seed's kube-system namespace. This has no benefits, as seed VPA has no targets in that namespace, and can only cause problems. Specifically, it fails a sanity check currently implemented by GKE and leads to GKE issuing warning messages.

This PR excludes the `kube-system` namespace from the seed VPA webhook.

**Release note**:
```other operator
The `kube-system` namespace is now excluded by the seed VPA webhook.
```
