### PR TITLE
Describe howto access the shoot kubernetes apiserver via tailscale vpn

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@
 * [Admission Configuration for the `PodSecurity` Admission Plugin](usage/pod-security.md)
 * [Supported CPU Architectures for Shoot Worker Nodes](usage/shoot_supported_architectures.md)
 * [Workerless `Shoot`s](usage/shoot_workerless.md)
+* [Tailscale VPN for Kubernetes API Server access](usage/tailscale.md)
 
 ## [API Reference](api-reference/README.md)
 

--- a/docs/usage/images/tailscale.drawio.svg
+++ b/docs/usage/images/tailscale.drawio.svg
@@ -1,0 +1,259 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="672px" height="532px" viewBox="-0.5 -0.5 672 532" content="&lt;mxfile&gt;&lt;diagram id=&quot;qkV0hibk73dF067-kuox&quot; name=&quot;Page-1&quot;&gt;3VpLc+I4EP41HKFsGb+OCUlmD7NTTLG1OzkKW8GqGMsliwD59SsZ+SHLGBIMJOQSqy1L6q/7a3VLDKzJcvODwjT6m4QoHgAj3AyshwEApmm7/J+QbHcS1/V3ggXFoexUCWb4HUmhIaUrHKJM6cgIiRlOVWFAkgQFTJFBSsla7fZCYnXWFC6QJpgFMNal/+GQRYVejl+9+AvhRSSn9oBUeAmLzlKTLIIhWddE1uPAmlBC2O5puZmgWIBX4LL77mnP23JhFCXsmA/A7oM3GK+kbrNITA6MCUkYJaLvNIYJkstl2wKDdYQZmqUwEO01t/PAuo/YMuYtkz/CLN0h/4I3iE92/4YowxzCuxgvEi5nRHwhp+fv0GavCmYJDPcoRJaI0S3vIj8AlsRSOtPYle11zTS+lEU1q5RCKN1hUY5dIcYfJGjtAJLn12c2XT79+B0N5+/u0J1t74amo8GFQu5Bskkoi8iCJDB+rKR18LjmdPuHN4zRuGg+583y7YPQ3ihb23priijmiiAqhRk35CuakJjQfDGWkf+VbwofBmKADWZ/imXw5+faczWnaGxrjeaMO/WFzt1G5RCRFQ1kr7GkMqQLxDrg9dv9gaIYMvymTtm7bYGlUQYGAcoyLntdzRFNOA6iwSJKVouIP/07/dXqDz/hnAdGlTaSHQHHSaCp0WaJwzB3F4oy/A7n+XgC8pTghOXK2vcD+6GLWzIsyo+rYFQ3T4df72WiMTKcYo6jjSFHm4rlV0MNHYXTQ9NWRyAvLxn3kaYxyzWdwF2vL+6qzLUPMPcjJO2NXvY1mWT6OpNWLOIqcIdn+o7zPSnjHaCMPbad0yjTKyfGmk00O/CcJRWPq2V8FzBShzw3z5RkmGEioJ8Txshy7+5fsyJZsRgn3P+LjM3oMsfx2YFVRA4ZScyxnh1YLcmB00NuYGtYMojjTOSRo4DDcmpK1QM8HlCTJ9PS4fFa4PF6gMfT4BH75xCmOEOUa6Xhw/fTJBSa585xAK0ewAGuCo5ttmSW4EzOsz/zUSD7h3tUIlmvBMs45tWQiHoFXYOYrMKL4Gb5Km6gxalavQqMz5aRGxpy367QccDXK3Tc1l366GTpQ5VJVRSVuVRZnXQkVoNPJUvt6haHDT2mUO35r+fwZLr2B1RCNQPMbkFyjP5zYqCz5wYzNbeTfcYI+L6lmEG2vkTe1umvbRkIF5MUUSgSuGtvtI7T2Gj9a2+05vhyga3PAGXpAWpPAXKh0xL9gFFyWRzZ3kjgGHc699AYmb7vqgH8tMhRjGyq24KnDnDGuGKfxo76Vq7s5cbIP3ROcvIJ55np9gVPLPVdAG1SkvEAfxv825OClRu3ZTq90u/idNOPnJWTZlEu40BPw66+jV+9Xj7mOAsl4Z24E+SthCTCiUOYRTlsZi/Vimm4jRhnup8JcscHrs/Go5qd7BYzFbITty3tws5umH8Xd7VqRh/IawxkXLgs0g/47iY/uWAek+BVrEOMcQshFhxMcRzfMRVj9HMPZDUGbQxwvpgL+rvCVTOcj14DPT2d/xro1BJhj+0ax6damD+W55bhdhyGWEWtdinWuxrrywtgUdKot8BJfsbIs60MC9bdRjT41tfAvFn9vmbXvfqVkvX4Pw==&lt;/diagram&gt;&lt;diagram name=&quot;Big&quot; id=&quot;_MShD43h8jw513mkwRZf&quot;&gt;3Zldc6IwFIZ/jZd2IIDiZat23em20xl32u1lhCiZBsKGoNhfv4kGBZJ+7Lb4sb0pOcQDec6bk5PQcYZx8Y3BNLqlISIdYIVFxxl1AAC+2xf/pGW9tdg2GGwtC4ZDZdsbpvgFKaOlrDkOUVbryCklHKd1Y0CTBAW8ZoOM0VW925yS+lNTuECaYRpAolsfccijchi9wf7GBOFFpB7tAzXiGJad1UiyCIZ0VTE5444zZJTy7VVcDBGR9EouN5PfnuMWt3dXD083s/VojSZJd+vs+m9+shsCQwn/Wtdg63oJSa54TREK1Xj5uoTIaJ6ESDqyOs7VKsIcTVMYyLsroRthi3hMRMsWl0vEOBYBuCR4kQgbp7IDVC2C5mIMV+q5oisqGoF6Z5T2Dr0QLaIx4mwtfqe8dG1HhUsJ1rXdbXu1j37PV32iSuA9p6dUpxS32DnfUxUXCqwZsj8JeLEuwOAePAR594Zdf6ddu6dR/hzhtuDZXoNdybLCDngGdsC1Ps/O+MKuhu6RsmfEhO1OJCuN4zvkYJZuk8wcF5J2ayh9u47Sc4GG0qRCvy2QngbyOZ8JFkRDKPJcKi/zmFwGnLLKlP4BZ4jc0wxzTOVknlHOafzqnK+ApzknOEHDXZa3WoTv9Orw7b6uY8cAv9cWfD0B/ISYZJtVClhDSlmIE7iBCqwpYksp8BNVdv8DcNtStjm92horFIoaQDUp4xFd0ASS8d5aJSdgsPWvauNJ6vPCK5ujQul121rX1Csf9Q94xevSnAXojX6qDuGQLRB/a/zmcDFEhKKW9Zf7cmX3NWXjTOj4NNc316pLd1cHVKRrg0MmBt+YlbswxZk5C5wEx92ULxc3QwpojaNxDlgax2kkC3OZXMWkpdLBPYHJ5wsG80rXGmnvfcUCy1SRWa2l27OULGhMfd86tmTdL1q1rPqqBQ64bBnHBfRl6/XUd4Bl662XrIh4AVmIEiJe+ST12/UbW7Ojp1yvHf0eW77OOcjX0eSLCo6STGwgMmG/EH/nIWPP07fFh5VxuU8/492DcVz+B3XcP6aOzeXv/3ko0dw39weHO5QwK18/W5OnEolhCRQoeKMuVkwDgQQxA+wYh+FmrjCU4Rc427iSfFOKE74Zi3fV8UbSV85F9DYfDqTrTNTrzyIoREZ5lNBEepljQhqmtgLlNUpF0wFHzxAop7VAmc/uTr3ktk8v1+unFeMipVnONsdwBGbZaaJ0wOFQiub+m9bmXuXToDP+Aw==&lt;/diagram&gt;&lt;diagram name=&quot;Copy of Big&quot; id=&quot;blihjU-QDEaqAm3G6d1l&quot;&gt;3ZlLc5swEMc/jY/OgHj6mNhue0g7mbozaXuTQQbFAjFCxDifvpIRNlgkzgs/mkvQIi/ot3+ttGJgjZPyK4NZ/J2GiAyAEZYDazIAAPi2J/5Jy7qymCYYVZaI4VDZdoYZfkLKaChrgUOUtzpySgnHWdsY0DRFAW/ZIGN01e62oKT91AxGSDPMAkh06z0OeVwPwx3tbnxDOIrVo32gRpzAurMaSR7DkK4aJms6sMaMUl5dJeUYEUmv5hL+DMrlX+/eKaBv3xrp4qF4GFbOvrzlJ9shMJTyz3UNKtePkBSK1wyhUI2Xr2uIjBZpiKQjY2DdrGLM0SyDgby7EroRtpgnRLRMcfmIGMciANcER6mwcSo7QNUiaCHGcKOeK7qici9QB0ZpbtEL0SKaIM7W4nfKy9C0VLiUYG3TrtqrXfRdX/WJG4F3LFepTiku2jrfURUXCuwbIFsa5I8B7oud6eyhq1E20AGnAx2wjZ7Q2Rq6e8qWiAnbD5GrNI4HyME8q3LMApeSdm8ofbON0rGBhrJLhH5fIB0N5LKYCxZEQyjSXCYvi4RcB5yyxoy+hXNE7miOOaZyLs8p5zR5dso3wNOCE5yi8TbJGz3Ct9w2fNPTdWx1wHf7gu9q8H9BTPLNIgWMMaUsxCncQAXGDLFHKfAzVbb3CrhHVbanoUKh2AGoJmU8phFNIZnurE1wggVb/242/kh5Xjl1c1IquVatdUu88lHvoCtelxYsQC/086t+HLIIvejvmXAxRISiHttv9+nwfU3ZOBc6Ps/1zTba0t1uAxrSNcExE8OoMysPYYbz7ixwFhy3U75e3DpSwHE51qttcx8by425zK5i2lLp4Y7A9OM7hu6lrjfUzmHJAqNrS2b0xtq8SNGCvcnvGycXrV4GvG/lMtorFzj10mVar1y7Rqdcuky9LIsgC1FKxDufpYSH/l59dvq8a/cj4ZMr2LkIBetFHSo5SnNRSOTCfiX+LkPJjqOXx0dWsvtJSj6zMsL0Xqlk/6RK9jr3FP/n8cR+Be2NTnw8YepVnDyfSDvWQYGC722QFdNAIEGsA3aCw3AzWxjK8ROcb1xJvhnFKd+MxbkZOBPpq+AiepsvCNJ1LjbuSxEUIqM8SWkqvSwwIXumvgLlGIePOtyOQFm9BepC68Wzy/ZArxenZUbzgm0O5AjM8/NEaYHjoRTN3cetzb3GN0Jr+g8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="1" y="340" width="190" height="190" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 188px; height: 1px; padding-top: 347px; margin-left: 2px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Shoot Control Plane
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="96" y="359" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Shoot Control Plane
+                </text>
+            </switch>
+        </g>
+        <path d="M 116 70 L 116 77.5 Q 116 85 126 85 L 262.97 85 Q 272.97 85 272.97 95 L 272.99 115.76" fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 273 121.76 L 268.99 113.77 L 272.99 115.76 L 276.99 113.76 Z" fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 70px; margin-left: 207px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                access kubernetes through VPN
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="207" y="74" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    access kubernetes through VPN
+                </text>
+            </switch>
+        </g>
+        <path d="M 116 40 L 582.76 40" fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 588.76 40 L 580.76 44 L 582.76 40 L 580.76 36 Z" fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 40px; margin-left: 483px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                authenticate
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="483" y="44" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    authenticate
+                </text>
+            </switch>
+        </g>
+        <ellipse cx="101" cy="17.5" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 101 25 L 101 50 M 101 30 L 86 30 M 101 30 L 116 30 M 101 50 L 86 70 M 101 50 L 116 70" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="591" y="0" width="80" height="80" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 40px; margin-left: 592px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                tailscale.com
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="631" y="44" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    tailscale.com
+                </text>
+            </switch>
+        </g>
+        <rect x="41" y="380" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 410px; margin-left: 42px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                kube-apiserver
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="101" y="414" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    kube-apiserver
+                </text>
+            </switch>
+        </g>
+        <path d="M 231 160 C 175 160 161 220 205.8 232 C 161 258.4 211.4 316 247.8 292 C 273 340 357 340 385 292 C 441 292 441 244 406 220 C 441 172 385 124 336 148 C 301 112 245 112 231 160 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 278px; height: 1px; padding-top: 220px; margin-left: 162px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Tailnet
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="301" y="224" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Tailnet
+                </text>
+            </switch>
+        </g>
+        <rect x="391" y="340" width="190" height="190" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 188px; height: 1px; padding-top: 347px; margin-left: 392px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Shoot Control Plane
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="486" y="359" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Shoot Control Plane
+                </text>
+            </switch>
+        </g>
+        <path d="M 551 490.03 L 621.03 490.03 Q 631.03 490.03 631.03 480.03 L 631 88.24" fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 631 82.24 L 635 90.24 L 631 88.24 L 627 90.24 Z" fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 252px; margin-left: 628px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                authenticate
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="628" y="255" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    authenticate
+                </text>
+            </switch>
+        </g>
+        <rect x="431" y="460" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 490px; margin-left: 432px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                tailscale operator
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="491" y="494" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    tailscale operator
+                </text>
+            </switch>
+        </g>
+        <path d="M 431 410 L 169.24 410" fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 163.24 410 L 171.24 406 L 169.24 410 L 171.24 414 Z" fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 420px; margin-left: 311px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                points to
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="311" y="424" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    points to
+                </text>
+            </switch>
+        </g>
+        <path d="M 491.03 380 L 491.03 370.02 Q 491.03 360.03 481.03 360.03 L 325.03 360.03 Q 315.03 360.03 315.02 350.03 L 315.01 336.24" fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 315 330.24 L 319.01 338.23 L 315.01 336.24 L 311.01 338.24 Z" fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 370px; margin-left: 361px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                exposed
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="361" y="374" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    exposed
+                </text>
+            </switch>
+        </g>
+        <rect x="431" y="380" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 410px; margin-left: 432px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                kubernetes service
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="491" y="414" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    kubernetes service
+                </text>
+            </switch>
+        </g>
+        <path d="M 1 320 L 190.96 320.08" fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 330px; margin-left: 61px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                ACL block all
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="61" y="334" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    ACL block all
+                </text>
+            </switch>
+        </g>
+        <path d="M 101 70 L 101 371.76" fill="none" stroke="#ff0000" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 101 377.76 L 97 369.76 L 101 371.76 L 105 369.76 Z" fill="#ff0000" stroke="#ff0000" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 220px; margin-left: 95px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                access to kubernetes not possible
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="95" y="223" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    access to kubernetes not possible
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/usage/tailscale.md
+++ b/docs/usage/tailscale.md
@@ -1,0 +1,82 @@
+# Access the kubernetes apiserver from your tailnet
+
+If you would like to strengthen the security of your kubernetes cluster even further, this blog post explains how this can be achieved.
+
+The most common way to secure a kubernetes cluster which was created with gardener is to apply ACLs described [here](https://github.com/stackitcloud/gardener-extension-acl),
+or to use [ExposureClass](https://gardener.cloud/docs/gardener/exposureclasses/) which exposes the kubernetes apiserver in a cooporate network which is not exposed to the public internet.
+
+Managing the ACL extension becomes fairly difficult with the growing number of participants, especially in a dynamic environment and work from home scenarios.
+
+ExposureClass might be not possible because you do not have a cooporate network which is suitable for this purpose.
+
+But there is a solution which bridges the gap between these two approaches by the use of a mesh vpn based on the [WireGuard](https://www.wireguard.com/)
+
+## Tailscale
+
+Tailscale is a mesh vpn network which uses wireguard under the hood, but automates the key exchange procedure.
+Please consult the official [tailscale documentation](https://tailscale.com/kb/1151/what-is-tailscale) for a detailed explanation.
+
+## Target Architecture
+
+![architecture](images/tailscale.drawio.svg)
+
+### Installation
+
+In order to be able to access the kubernetes apiserver only from a tailscale vpn, we call it tailnet,
+
+1. Create a tailscale account, ensure [MagicDNS](https://tailscale.com/kb/1081/magicdns?q=magic) is enabled.
+2. Create a OAuth ClientID and Secret [OAuth](https://tailscale.com/kb/1236/kubernetes-operator#prerequisites), don't forget to create the tags mentioned there.
+3. Install the tailscale operator [Operator](https://tailscale.com/kb/1236/kubernetes-operator#installation).
+
+You can check if all went well after the operator installation by running `tailscale status`, the tailscale operator must be seen there:
+
+```bash
+# tailscale status
+...
+100.83.240.121  tailscale-operator   tagged-devices linux   -
+...
+```
+
+### Expose the kubernetes apiserver
+
+Now you are ready to expose the kubernetes apiserver in the tailnet by annotating the service which was created by gardener:
+
+```bash
+kubectl annotate -n default kubernetes tailscale.com/expose=true tailscale.com/hostname=kubernetes
+```
+
+It is required to `kubernetes` as the hostname, because this is part of the certificate common name of the kubernetes apiserver.
+
+After annotating the service, it will be exposed in the tailnet and can be shown with `tailscale status`:
+
+```bash
+# tailscale status
+...
+100.83.240.121  tailscale-operator   tagged-devices linux   -
+100.96.191.87   kubernetes           tagged-devices linux   idle, tx 19548 rx 71656
+...
+```
+
+### Modify the kubeconfig
+
+In order to access the cluster via the vpn, you must modify the kubeconfig to point to the kubernetes service exposed in the tailnet, by changing the `server` entry to `https://kubernetes`.
+
+```yaml
+---
+apiVersion: v1
+clusters:
+  - cluster:
+      certificate-authority-data: <base64 encoded secret>
+      server: https://kubernetes
+    name: my-cluster
+...
+```
+
+### Enable ACLs which blocks all IPs.
+
+Now you are ready to use your cluster from every device which is part of your tailnet. Therefore you can now block all access to the kubernetes apiserver with the ACL extension.
+
+## Further improvements
+
+Right now the tailscale operator can not be used if a installation of the open source coordination server [headscale](https://github.com/juanfont/headscale) should be used.
+This is currently not an easy task, because headscale does not implement all required API endpoints for the tailscale operator. The details can be found in this [Issue](https://github.com/juanfont/headscale/issues/1202).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:

If shoot cluster users want to completely close the kubernetes apiserver to access from the public internet, but allow access from a tailscale vpn, this document describe the required steps howto achieve this goal.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
