### PR TITLE
Fix shoot control plane federation regression

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -112,6 +112,8 @@ type Values struct {
 	// DataMigration is a struct for migrating data from existing disks.
 	// TODO(rfranzke): Remove this after v1.97 has been released.
 	DataMigration monitoring.DataMigration
+	// RestrictToNamespace controls whether the Prometheus instance should only scrape its targets in its own namespace.
+	RestrictToNamespace bool
 }
 
 // CentralConfigs contains configuration for this Prometheus instance that is created together with it. This should

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -87,6 +87,13 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 		},
 	}
 
+	if p.values.RestrictToNamespace {
+		obj.Spec.ServiceMonitorNamespaceSelector = nil
+		obj.Spec.PodMonitorNamespaceSelector = nil
+		obj.Spec.ProbeNamespaceSelector = nil
+		obj.Spec.ScrapeConfigNamespaceSelector = nil
+	}
+
 	if p.values.Ingress != nil {
 		obj.Spec.ExternalURL = "https://" + p.values.Ingress.Host
 	}

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -97,13 +97,14 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 	}
 
 	values := prometheus.Values{
-		Name:              "shoot",
-		PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane100,
-		StorageCapacity:   resource.MustParse(b.Seed.GetValidVolumeSize("20Gi")),
-		ClusterType:       component.ClusterTypeShoot,
-		Replicas:          b.Shoot.GetReplicas(1),
-		Retention:         ptr.To(monitoringv1.Duration("30d")),
-		RetentionSize:     "15GB",
+		Name:                "shoot",
+		PriorityClassName:   v1beta1constants.PriorityClassNameShootControlPlane100,
+		StorageCapacity:     resource.MustParse(b.Seed.GetValidVolumeSize("20Gi")),
+		ClusterType:         component.ClusterTypeShoot,
+		Replicas:            b.Shoot.GetReplicas(1),
+		Retention:           ptr.To(monitoringv1.Duration("30d")),
+		RetentionSize:       "15GB",
+		RestrictToNamespace: true,
 		AdditionalPodLabels: map[string]string{
 			"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyScrapeTargets:  v1beta1constants.LabelNetworkPolicyAllowed,
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.GardenNamespace+"-prometheus-cache", 9090):  v1beta1constants.LabelNetworkPolicyAllowed,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Previously, since the introduction of the prometheus-operator-managed shoot control plane prometheus in #9695, prometheus-shoot instances were inadvertently able to federate metrics from the cache prometheus for other namespaces, i.e. other shoot control planes. Now, the relevant fields are set to nil for the shoot control plane prometheus, in accordance with [the prometheus-operator docs](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheus)

**Special notes for your reviewer**:
cc @vicwicker @istvanballok @rfranzke 
FYI @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
