### PR TITLE
Fix shoot control plane federation regression (2)

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -92,6 +92,7 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 		obj.Spec.PodMonitorNamespaceSelector = nil
 		obj.Spec.ProbeNamespaceSelector = nil
 		obj.Spec.ScrapeConfigNamespaceSelector = nil
+		obj.Spec.RuleNamespaceSelector = nil
 	}
 
 	if p.values.Ingress != nil {

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -279,6 +279,7 @@ honor_labels: true`
 				obj.Spec.PodMonitorNamespaceSelector = nil
 				obj.Spec.ProbeNamespaceSelector = nil
 				obj.Spec.ScrapeConfigNamespaceSelector = nil
+				obj.Spec.RuleNamespaceSelector = nil
 			}
 
 			if alertmanagerName != "" {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

We missed to restrict the prometheusrules discovery to the namespace of prometheus in #9764, which fixes a regression of #9695.

**Which issue(s) this PR fixes**:

Without this fix, all the shoot control plane prometheus instances process all the recording rules of all the other Prometheus instances, such that the same (equivalent) recording rule is added up to 200 times.

**Special notes for your reviewer**:

cc @vicwicker @istvanballok @rfranzke
FYI @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
