### PR TITLE
extensions lib: Drop the `EnsureKubeAPIServerService` func from the controlplane `Ensurer`

### DIFF
--- a/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
@@ -20,8 +20,7 @@ import (
 	v1alpha10 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
-	v10 "k8s.io/api/core/v1"
-	v11 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	v10 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	v1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
@@ -146,20 +145,6 @@ func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerDeployment(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerDeployment), arg0, arg1, arg2, arg3)
 }
 
-// EnsureKubeAPIServerService mocks base method.
-func (m *MockEnsurer) EnsureKubeAPIServerService(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *v10.Service) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeAPIServerService", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnsureKubeAPIServerService indicates an expected call of EnsureKubeAPIServerService.
-func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerService(arg0, arg1, arg2, arg3 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerService", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerService), arg0, arg1, arg2, arg3)
-}
-
 // EnsureKubeControllerManagerDeployment mocks base method.
 func (m *MockEnsurer) EnsureKubeControllerManagerDeployment(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *v1.Deployment) error {
 	m.ctrl.T.Helper()
@@ -260,7 +245,7 @@ func (mr *MockEnsurerMockRecorder) EnsureMachineControllerManagerDeployment(arg0
 }
 
 // EnsureMachineControllerManagerVPA mocks base method.
-func (m *MockEnsurer) EnsureMachineControllerManagerVPA(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *v11.VerticalPodAutoscaler) error {
+func (m *MockEnsurer) EnsureMachineControllerManagerVPA(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *v10.VerticalPodAutoscaler) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureMachineControllerManagerVPA", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -172,21 +172,6 @@ var _ = Describe("Mutator", func() {
 			Expect(err).To(Not(HaveOccurred()))
 		},
 			Entry(
-				"EnsureKubeAPIServerService with a kube-apiserver service",
-				func() {
-					newObj = &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
-					ensurer.EXPECT().EnsureKubeAPIServerService(context.TODO(), gomock.Any(), newObj, oldObj).Return(nil)
-				},
-			),
-			Entry(
-				"EnsureKubeAPIServerService with a kube-apiserver service and existing service",
-				func() {
-					newObj = &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
-					oldObj = newObj.DeepCopyObject().(client.Object)
-					ensurer.EXPECT().EnsureKubeAPIServerService(context.TODO(), gomock.Any(), newObj, oldObj).Return(nil)
-				},
-			),
-			Entry(
 				"EnsureKubeAPIServerDeployment with a kube-apiserver deployment",
 				func() {
 					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/coreos/go-systemd/v22/unit"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
@@ -23,11 +22,6 @@ import (
 type NoopEnsurer struct{}
 
 var _ Ensurer = &NoopEnsurer{}
-
-// EnsureKubeAPIServerService ensures that the kube-apiserver service conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeAPIServerService(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *corev1.Service) error {
-	return nil
-}
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *NoopEnsurer) EnsureKubeAPIServerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind cleanup

**What this PR does / why we need it**:
See the motivation in https://github.com/gardener/gardener/issues/9755

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/9755

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The `github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator.Ensurer#EnsureKubeAPIServerService` func is removed. This func was used before the introduction of `ManagedIstio`/`APIServerSNI` (when the kube-apiserver Service was of type LoadBalancer) to set cloud provider specific annotations to the Service. However, after `ManagedIstio`/`APIServerSNI` are unconditionally enabled (the kube-apiserver Service is of type ClusterIP) this func is no longer used. Nowadays, istio-ingressgateway Service annotations can be provided via the Seed spec.
```

```breaking dependency
With the removal of the `github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator.Ensurer#EnsureKubeAPIServerService` func, the provider extensions using the `genericmutator.Ensurer` no longer need to mutate Services and should no longer mutate Services to prevent no-op webhook invocations.
```
