### PR TITLE
Remove resource limits for the observability components

### DIFF
--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
@@ -240,9 +240,6 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 										corev1.ResourceCPU:    resource.MustParse("10m"),
 										corev1.ResourceMemory: resource.MustParse("25Mi"),
 									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("128Mi"),
-									},
 								},
 								Ports: []corev1.ContainerPort{
 									{

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
@@ -199,8 +199,6 @@ spec:
           name: probe
           protocol: TCP
         resources:
-          limits:
-            memory: 128Mi
           requests:
             cpu: 10m
             memory: 25Mi

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -251,9 +251,6 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 										corev1.ResourceCPU:    resource.MustParse("50m"),
 										corev1.ResourceMemory: resource.MustParse("50Mi"),
 									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("250Mi"),
-									},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -165,8 +165,6 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
         resources:
-          limits:
-            memory: 250Mi
           requests:
             cpu: 50m
             memory: 50Mi

--- a/pkg/component/observability/monitoring/prometheusoperator/deployment.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/deployment.go
@@ -55,7 +55,7 @@ func (p *prometheusOperator) deployment() *appsv1.Deployment {
 								"--config-reloader-cpu-request=10m",
 								"--config-reloader-cpu-limit=0",
 								"--config-reloader-memory-request=25Mi",
-								"--config-reloader-memory-limit=50Mi",
+								"--config-reloader-memory-limit=0",
 								"--enable-config-reloader-probes=false",
 							},
 							Env: []corev1.EnvVar{{

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -157,7 +157,7 @@ var _ = Describe("PrometheusOperator", func() {
 									"--config-reloader-cpu-request=10m",
 									"--config-reloader-cpu-limit=0",
 									"--config-reloader-memory-request=25Mi",
-									"--config-reloader-memory-limit=50Mi",
+									"--config-reloader-memory-limit=0",
 									"--enable-config-reloader-probes=false",
 								},
 								Env: []corev1.EnvVar{{

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -608,9 +608,6 @@ func (p *plutono) getDeployment(providerConfigMap, dataSourceConfigMap *corev1.C
 									corev1.ResourceCPU:    resource.MustParse("5m"),
 									corev1.ResourceMemory: resource.MustParse("45Mi"),
 								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("400Mi"),
-								},
 							},
 						},
 						{

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -353,9 +353,6 @@ metadata:
 												corev1.ResourceCPU:    resource.MustParse("5m"),
 												corev1.ResourceMemory: resource.MustParse("45Mi"),
 											},
-											Limits: corev1.ResourceList{
-												corev1.ResourceMemory: resource.MustParse("400Mi"),
-											},
 										},
 									},
 									{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Some time ago we decided to avoid using resource limits but somehow it was not consistently implemented for these components.

With this change the limits are removed for the observability components. Even if there is a momentary anomaly in the vertical pod autoscaling, the pod will be able to start and the autoscaler will correct the resource requests in the next iteration.

**Which issue(s) this PR fixes**:

The trigger for this change is a non self healing condition that we observed recently: when the vertical pod autoscaling has an anomaly (not understood) and it scales the resource requests of a pod to the lower bound recommendation instead of the target recommendation (e.g. 1m core and 2.6MB for the blackbox exporter), the limits are scaled proportionally (e.g. 13MB).

The problem is that such low memory limits do not manifest in OOM failures, but the container itself can not be started in the first place because the `runc` process is killed due to the out of memory condition on the cgroup. This manifests in a `RunContainerError` in the pod status and can not self heal.

    State:          Waiting
      Reason:       RunContainerError
    Last State:     Terminated
      Reason:       StartError
      Message:      failed to create containerd task:
                    failed to create shim task: context canceled: unknown

**Special notes for your reviewer**:

cc @vicwicker @rickardsjp 
fyi @dguendisch @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Resource limits are removed for the observability components
```
