### PR TITLE
Replace all occurences of interface{} whith any

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -256,6 +256,10 @@ linters-settings:
         alias: shootdnsrewriting
       - pkg: github.com/gardener/gardener/plugin/pkg/shoot/oidc
         alias: applier
+  gofmt:
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
   custom:
     logcheck:
       path: <<LOGCHECK_PLUGIN_PATH>>/logcheck.so

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -69,7 +69,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.ControllerManagerConf
 	// This is like importing the automaxprocs package for its init func (it will in turn call maxprocs.Set).
 	// Here we pass a custom logger, so that the result of the library gets logged to the same logger we use for the
 	// component itself.
-	if _, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...interface{}) {
+	if _, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...any) {
 		log.Info(fmt.Sprintf(s, i...)) //nolint:logcheck
 	})); err != nil {
 		log.Error(err, "Failed to set GOMAXPROCS")

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -39,17 +39,17 @@ import (
 // ValuesProvider provides values for the 2 charts applied by this actuator.
 type ValuesProvider interface {
 	// GetConfigChartValues returns the values for the config chart applied by this actuator.
-	GetConfigChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]interface{}, error)
+	GetConfigChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]any, error)
 	// GetControlPlaneChartValues returns the values for the control plane chart applied by this actuator.
-	GetControlPlaneChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, secretsReader secretsmanager.Reader, checksums map[string]string, scaledDown bool) (map[string]interface{}, error)
+	GetControlPlaneChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, secretsReader secretsmanager.Reader, checksums map[string]string, scaledDown bool) (map[string]any, error)
 	// GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by this actuator.
-	GetControlPlaneShootChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, secretsReader secretsmanager.Reader, checksums map[string]string) (map[string]interface{}, error)
+	GetControlPlaneShootChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, secretsReader secretsmanager.Reader, checksums map[string]string) (map[string]any, error)
 	// GetControlPlaneShootCRDsChartValues returns the values for the control plane shoot CRDs chart applied by this actuator.
-	GetControlPlaneShootCRDsChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]interface{}, error)
+	GetControlPlaneShootCRDsChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]any, error)
 	// GetStorageClassesChartValues returns the values for the storage classes chart applied by this actuator.
-	GetStorageClassesChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]interface{}, error)
+	GetStorageClassesChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]any, error)
 	// GetControlPlaneExposureChartValues returns the values for the control plane exposure chart applied by this actuator.
-	GetControlPlaneExposureChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, secretsReader secretsmanager.Reader, checksums map[string]string) (map[string]interface{}, error)
+	GetControlPlaneExposureChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, secretsReader secretsmanager.Reader, checksums map[string]string) (map[string]any, error)
 }
 
 // NewActuator creates a new Actuator that acts upon and updates the status of ControlPlane resources.

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -160,27 +160,27 @@ var _ = Describe("Actuator", func() {
 			"lb-readvertiser":          "d640460979ef9e3ff08ffeff15486a0c8ed6222be4c4f9ce1e10a7dd62b967a6",
 		}
 
-		configChartValues = map[string]interface{}{
+		configChartValues = map[string]any{
 			"cloudProviderConfig": `[Global]`,
 		}
 
-		controlPlaneChartValues = map[string]interface{}{
+		controlPlaneChartValues = map[string]any{
 			"clusterName": namespace,
 		}
 
-		controlPlaneShootChartValues = map[string]interface{}{
+		controlPlaneShootChartValues = map[string]any{
 			"foo": "bar",
 		}
 
-		controlPlaneShootCRDsChartValues = map[string]interface{}{
+		controlPlaneShootCRDsChartValues = map[string]any{
 			"foo": "bar",
 		}
 
-		storageClassesChartValues = map[string]interface{}{
+		storageClassesChartValues = map[string]any{
 			"foo": "bar",
 		}
 
-		controlPlaneExposureChartValues = map[string]interface{}{
+		controlPlaneExposureChartValues = map[string]any{
 			"replicas": 1,
 		}
 
@@ -724,7 +724,7 @@ webhooks:
 	)
 })
 
-func clientGet(result client.Object) interface{} {
+func clientGet(result client.Object) any {
 	return func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 		switch obj.(type) {
 		case *corev1.Secret:
@@ -787,7 +787,7 @@ func getSecretsConfigsExposure(namespace string) []extensionssecretsmanager.Secr
 }
 
 var (
-	objectIdentifier = Identifier(func(obj interface{}) string {
+	objectIdentifier = Identifier(func(obj any) string {
 		switch o := obj.(type) {
 		case corev1.Secret:
 			return o.GetName()

--- a/extensions/pkg/controller/controlplane/genericactuator/noopvaluesprovider.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/noopvaluesprovider.go
@@ -18,31 +18,31 @@ type NoopValuesProvider struct{}
 var _ ValuesProvider = NoopValuesProvider{}
 
 // GetConfigChartValues returns the values for the config chart applied by this actuator.
-func (vp NoopValuesProvider) GetConfigChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error) {
+func (vp NoopValuesProvider) GetConfigChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]any, error) {
 	return nil, nil
 }
 
 // GetControlPlaneChartValues returns the values for the control plane chart applied by this actuator.
-func (vp NoopValuesProvider) GetControlPlaneChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, secretsmanager.Reader, map[string]string, bool) (map[string]interface{}, error) {
+func (vp NoopValuesProvider) GetControlPlaneChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, secretsmanager.Reader, map[string]string, bool) (map[string]any, error) {
 	return nil, nil
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by this actuator.
-func (vp NoopValuesProvider) GetControlPlaneShootChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, secretsmanager.Reader, map[string]string) (map[string]interface{}, error) {
+func (vp NoopValuesProvider) GetControlPlaneShootChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, secretsmanager.Reader, map[string]string) (map[string]any, error) {
 	return nil, nil
 }
 
 // GetControlPlaneShootCRDsChartValues returns the values for the control plane shoot CRDs chart applied by this actuator.
-func (vp NoopValuesProvider) GetControlPlaneShootCRDsChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error) {
+func (vp NoopValuesProvider) GetControlPlaneShootCRDsChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]any, error) {
 	return nil, nil
 }
 
 // GetStorageClassesChartValues returns the values for the storage classes chart applied by this actuator.
-func (vp NoopValuesProvider) GetStorageClassesChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error) {
+func (vp NoopValuesProvider) GetStorageClassesChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]any, error) {
 	return nil, nil
 }
 
 // GetControlPlaneExposureChartValues returns the values for the control plane exposure chart applied by this actuator.
-func (vp NoopValuesProvider) GetControlPlaneExposureChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, secretsmanager.Reader, map[string]string) (map[string]interface{}, error) {
+func (vp NoopValuesProvider) GetControlPlaneExposureChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, secretsmanager.Reader, map[string]string) (map[string]any, error) {
 	return nil, nil
 }

--- a/extensions/pkg/controller/healthcheck/inject.go
+++ b/extensions/pkg/controller/healthcheck/inject.go
@@ -21,7 +21,7 @@ type SeedClient interface {
 }
 
 // ShootClientInto will set the shoot client on i if i implements ShootClient.
-func ShootClientInto(client client.Client, i interface{}) bool {
+func ShootClientInto(client client.Client, i any) bool {
 	if s, ok := i.(ShootClient); ok {
 		s.InjectShootClient(client)
 		return true
@@ -30,7 +30,7 @@ func ShootClientInto(client client.Client, i interface{}) bool {
 }
 
 // SeedClientInto will set the seed client on i if i implements SeedClient.
-func SeedClientInto(client client.Client, i interface{}) bool {
+func SeedClientInto(client client.Client, i any) bool {
 	if s, ok := i.(SeedClient); ok {
 		s.InjectSeedClient(client)
 		return true

--- a/extensions/pkg/terraformer/raw_state.go
+++ b/extensions/pkg/terraformer/raw_state.go
@@ -34,7 +34,7 @@ func (t *terraformer) GetRawState(ctx context.Context) (*RawState, error) {
 }
 
 // UnmarshalRawState transform passed rawState to RawState struct. It tries to decode the state
-func UnmarshalRawState(rawState interface{}) (*RawState, error) {
+func UnmarshalRawState(rawState any) (*RawState, error) {
 	var rawData []byte
 
 	switch v := rawState.(type) {

--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -32,8 +32,8 @@ type terraformStateV3 struct {
 }
 
 type outputState struct {
-	Type  string      `json:"type"`
-	Value interface{} `json:"value"`
+	Type  string `json:"type"`
+	Value any    `json:"value"`
 }
 
 type terraformStateV4 struct {

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -486,7 +486,7 @@ var _ = Describe("terraformer", func() {
 		)
 
 		It("should return err when state version is not supported", func() {
-			state := map[string]interface{}{
+			state := map[string]any{
 				"version": 1,
 			}
 			stateJSON, err := json.Marshal(state)
@@ -509,11 +509,11 @@ var _ = Describe("terraformer", func() {
 		})
 
 		It("should get state v3 output variables", func() {
-			state := map[string]interface{}{
+			state := map[string]any{
 				"version": 3,
-				"modules": []map[string]interface{}{
+				"modules": []map[string]any{
 					{
-						"outputs": map[string]interface{}{
+						"outputs": map[string]any{
 							"variableV3": map[string]string{
 								"value": "valueV3",
 							},
@@ -544,9 +544,9 @@ var _ = Describe("terraformer", func() {
 		})
 
 		It("should get state v4 output variables", func() {
-			state := map[string]interface{}{
+			state := map[string]any{
 				"version": 4,
-				"outputs": map[string]interface{}{
+				"outputs": map[string]any{
 					"variableV4": map[string]string{
 						"value": "valueV4",
 					},

--- a/extensions/pkg/util/secret/manager/manager_test.go
+++ b/extensions/pkg/util/secret/manager/manager_test.go
@@ -348,7 +348,7 @@ func createOldCASecrets(c client.Client, cluster *extensionscontroller.Cluster, 
 }
 
 func consistOfConfigs(configs ...SecretConfigWithOptions) gomegatypes.GomegaMatcher {
-	elements := make([]interface{}, 0, len(configs))
+	elements := make([]any, 0, len(configs))
 	for _, config := range configs {
 		elements = append(elements, config)
 	}
@@ -356,7 +356,7 @@ func consistOfConfigs(configs ...SecretConfigWithOptions) gomegatypes.GomegaMatc
 }
 
 var (
-	objectIdentifier = Identifier(func(obj interface{}) string {
+	objectIdentifier = Identifier(func(obj any) string {
 		switch o := obj.(type) {
 		case corev1.Secret:
 			return o.GetName()

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -594,7 +594,7 @@ func checkProvisionOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystem
 	ExpectWithOffset(1, customFile).To(Not(BeNil()))
 }
 
-func clientGet(result client.Object) interface{} {
+func clientGet(result client.Object) any {
 	return func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 		switch obj.(type) {
 		case *extensionsv1alpha1.Cluster:

--- a/extensions/pkg/webhook/controlplane/test/matchers.go
+++ b/extensions/pkg/webhook/controlplane/test/matchers.go
@@ -29,7 +29,7 @@ type containElementWithPrefixContainingMatcher struct {
 	prefix, value, sep string
 }
 
-func (m *containElementWithPrefixContainingMatcher) Match(actual interface{}) (success bool, err error) {
+func (m *containElementWithPrefixContainingMatcher) Match(actual any) (success bool, err error) {
 	items, ok := actual.([]string)
 	if !ok {
 		return false, fmt.Errorf("ContainElementWithPrefixContaining matcher expects []string")
@@ -42,10 +42,10 @@ func (m *containElementWithPrefixContainingMatcher) Match(actual interface{}) (s
 	return slices.Index(values, m.value) >= 0, nil
 }
 
-func (m *containElementWithPrefixContainingMatcher) FailureMessage(actual interface{}) (message string) {
+func (m *containElementWithPrefixContainingMatcher) FailureMessage(actual any) (message string) {
 	return fmt.Sprintf("Expected\n\t%#v\nto contain an element with prefix '%s' containing '%s'", actual, m.prefix, m.value)
 }
 
-func (m *containElementWithPrefixContainingMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (m *containElementWithPrefixContainingMatcher) NegatedFailureMessage(actual any) (message string) {
 	return fmt.Sprintf("Expected\n\t%#v\nnot to contain an element with prefix '%s' containing '%s'", actual, m.prefix, m.value)
 }

--- a/extensions/pkg/webhook/handler_test.go
+++ b/extensions/pkg/webhook/handler_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Handler", func() {
 					{
 						Operation: "add",
 						Path:      "/metadata/annotations",
-						Value:     map[string]interface{}{"foo": "bar"},
+						Value:     map[string]any{"foo": "bar"},
 					},
 				},
 				AdmissionResponse: admissionv1.AdmissionResponse{

--- a/hack/tools/logcheck/pkg/logcheck/logcheck.go
+++ b/hack/tools/logcheck/pkg/logcheck/logcheck.go
@@ -27,7 +27,7 @@ var Analyzer = &analysis.Analyzer{
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	// find the logger type, so that we can later on check, if a given receiver is actually a logr.Logger instance
 	loggerType, err := findLogrLoggerType(pass)
 	if err != nil {

--- a/hack/tools/logcheck/pkg/logcheck/testdata/src/use-logr/use_logr.go
+++ b/hack/tools/logcheck/pkg/logcheck/testdata/src/use-logr/use_logr.go
@@ -18,14 +18,14 @@ import (
 type notLogr struct {
 }
 
-func (n notLogr) Enabled() bool                                             { return false }
-func (n notLogr) Info(msg string, keysAndValues ...interface{})             {}
-func (n notLogr) Error(err error, msg string, keysAndValues ...interface{}) {}
-func (n notLogr) WithValues(keysAndValues ...interface{}) logr.Logger       { return logr.Logger{} }
+func (n notLogr) Enabled() bool                                     { return false }
+func (n notLogr) Info(msg string, keysAndValues ...any)             {}
+func (n notLogr) Error(err error, msg string, keysAndValues ...any) {}
+func (n notLogr) WithValues(keysAndValues ...any) logr.Logger       { return logr.Logger{} }
 
-func Info(msg string, keysAndValues ...interface{})             {}
-func Error(err error, msg string, keysAndValues ...interface{}) {}
-func WithValues(keysAndValues ...interface{}) logr.Logger       { return logr.Logger{} }
+func Info(msg string, keysAndValues ...any)             {}
+func Error(err error, msg string, keysAndValues ...any) {}
+func WithValues(keysAndValues ...any) logr.Logger       { return logr.Logger{} }
 
 // begin test cases
 

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/debug.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/debug.go
@@ -149,7 +149,7 @@ func separate(withNewBeginning bool) string {
 	return result
 }
 
-func indent(level int, format string, a ...interface{}) string {
+func indent(level int, format string, a ...any) string {
 	return fmt.Sprintf("| "+strings.Repeat("&nbsp;&nbsp;", level)+format+"<br />", a...)
 }
 

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_backupbucket.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_backupbucket.go
@@ -17,7 +17,7 @@ import (
 
 func (g *graph) setupBackupBucketWatch(_ context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			backupBucket, ok := obj.(*gardencorev1beta1.BackupBucket)
 			if !ok {
 				return
@@ -25,7 +25,7 @@ func (g *graph) setupBackupBucketWatch(_ context.Context, informer cache.Informe
 			g.handleBackupBucketCreateOrUpdate(backupBucket)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldBackupBucket, ok := oldObj.(*gardencorev1beta1.BackupBucket)
 			if !ok {
 				return
@@ -43,7 +43,7 @@ func (g *graph) setupBackupBucketWatch(_ context.Context, informer cache.Informe
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_backupentry.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_backupentry.go
@@ -18,7 +18,7 @@ import (
 
 func (g *graph) setupBackupEntryWatch(_ context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			backupEntry, ok := obj.(*gardencorev1beta1.BackupEntry)
 			if !ok {
 				return
@@ -26,7 +26,7 @@ func (g *graph) setupBackupEntryWatch(_ context.Context, informer cache.Informer
 			g.handleBackupEntryCreateOrUpdate(backupEntry)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldBackupEntry, ok := oldObj.(*gardencorev1beta1.BackupEntry)
 			if !ok {
 				return
@@ -45,7 +45,7 @@ func (g *graph) setupBackupEntryWatch(_ context.Context, informer cache.Informer
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_bastion.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_bastion.go
@@ -17,7 +17,7 @@ import (
 
 func (g *graph) setupBastionWatch(_ context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			bastion, ok := obj.(*operationsv1alpha1.Bastion)
 			if !ok {
 				return
@@ -25,7 +25,7 @@ func (g *graph) setupBastionWatch(_ context.Context, informer cache.Informer) er
 			g.handleBastionCreateOrUpdate(bastion)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldBastion, ok := oldObj.(*operationsv1alpha1.Bastion)
 			if !ok {
 				return
@@ -41,7 +41,7 @@ func (g *graph) setupBastionWatch(_ context.Context, informer cache.Informer) er
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_certificatesigningrequest.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_certificatesigningrequest.go
@@ -19,14 +19,14 @@ import (
 
 func (g *graph) setupCertificateSigningRequestWatch(_ context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			if csrV1, ok := obj.(*certificatesv1.CertificateSigningRequest); ok {
 				g.handleCertificateSigningRequestCreate(csrV1.Name, csrV1.Spec.Request, csrV1.Spec.Usages)
 				return
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_controllerinstallation.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_controllerinstallation.go
@@ -16,7 +16,7 @@ import (
 
 func (g *graph) setupControllerInstallationWatch(_ context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			controllerInstallation, ok := obj.(*gardencorev1beta1.ControllerInstallation)
 			if !ok {
 				return
@@ -24,7 +24,7 @@ func (g *graph) setupControllerInstallationWatch(_ context.Context, informer cac
 			g.handleControllerInstallationCreateOrUpdate(controllerInstallation)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldControllerInstallation, ok := oldObj.(*gardencorev1beta1.ControllerInstallation)
 			if !ok {
 				return
@@ -51,7 +51,7 @@ func (g *graph) setupControllerInstallationWatch(_ context.Context, informer cac
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
@@ -24,7 +24,7 @@ import (
 
 func (g *graph) setupManagedSeedWatch(ctx context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			managedSeed, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
 			if !ok {
 				return
@@ -32,7 +32,7 @@ func (g *graph) setupManagedSeedWatch(ctx context.Context, informer cache.Inform
 			g.handleManagedSeedCreateOrUpdate(ctx, managedSeed)
 		},
 
-		UpdateFunc: func(_, newObj interface{}) {
+		UpdateFunc: func(_, newObj any) {
 			newManagedSeed, ok := newObj.(*seedmanagementv1alpha1.ManagedSeed)
 			if !ok {
 				return
@@ -40,7 +40,7 @@ func (g *graph) setupManagedSeedWatch(ctx context.Context, informer cache.Inform
 			g.handleManagedSeedCreateOrUpdate(ctx, newManagedSeed)
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_project.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_project.go
@@ -17,7 +17,7 @@ import (
 
 func (g *graph) setupProjectWatch(_ context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			project, ok := obj.(*gardencorev1beta1.Project)
 			if !ok {
 				return
@@ -25,7 +25,7 @@ func (g *graph) setupProjectWatch(_ context.Context, informer cache.Informer) er
 			g.handleProjectCreateOrUpdate(project)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldProject, ok := oldObj.(*gardencorev1beta1.Project)
 			if !ok {
 				return
@@ -41,7 +41,7 @@ func (g *graph) setupProjectWatch(_ context.Context, informer cache.Informer) er
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_secretbinding.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_secretbinding.go
@@ -17,7 +17,7 @@ import (
 
 func (g *graph) setupSecretBindingWatch(_ context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			secretBinding, ok := obj.(*gardencorev1beta1.SecretBinding)
 			if !ok {
 				return
@@ -25,7 +25,7 @@ func (g *graph) setupSecretBindingWatch(_ context.Context, informer cache.Inform
 			g.handleSecretBindingCreateOrUpdate(secretBinding)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldSecretBinding, ok := oldObj.(*gardencorev1beta1.SecretBinding)
 			if !ok {
 				return
@@ -41,7 +41,7 @@ func (g *graph) setupSecretBindingWatch(_ context.Context, informer cache.Inform
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_seed.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_seed.go
@@ -22,7 +22,7 @@ import (
 
 func (g *graph) setupSeedWatch(ctx context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			seed, ok := obj.(*gardencorev1beta1.Seed)
 			if !ok {
 				return
@@ -31,7 +31,7 @@ func (g *graph) setupSeedWatch(ctx context.Context, informer cache.Informer) err
 			g.handleManagedSeedIfSeedBelongsToIt(ctx, seed.Name)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldSeed, ok := oldObj.(*gardencorev1beta1.Seed)
 			if !ok {
 				return
@@ -59,7 +59,7 @@ func (g *graph) setupSeedWatch(ctx context.Context, informer cache.Informer) err
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_serviceaccount.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_serviceaccount.go
@@ -19,7 +19,7 @@ import (
 
 func (g *graph) setupServiceAccountWatch(_ context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			serviceAccount, ok := obj.(*corev1.ServiceAccount)
 			if !ok {
 				return
@@ -32,7 +32,7 @@ func (g *graph) setupServiceAccountWatch(_ context.Context, informer cache.Infor
 			g.handleServiceAccountCreateOrUpdate(serviceAccount)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldServiceAccount, ok := oldObj.(*corev1.ServiceAccount)
 			if !ok {
 				return
@@ -48,7 +48,7 @@ func (g *graph) setupServiceAccountWatch(_ context.Context, informer cache.Infor
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_shoot.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_shoot.go
@@ -23,7 +23,7 @@ import (
 
 func (g *graph) setupShootWatch(ctx context.Context, informer cache.Informer) error {
 	_, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			shoot, ok := obj.(*gardencorev1beta1.Shoot)
 			if !ok {
 				return
@@ -31,7 +31,7 @@ func (g *graph) setupShootWatch(ctx context.Context, informer cache.Informer) er
 			g.handleShootCreateOrUpdate(ctx, shoot)
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldShoot, ok := oldObj.(*gardencorev1beta1.Shoot)
 			if !ok {
 				return
@@ -54,7 +54,7 @@ func (g *graph) setupShootWatch(ctx context.Context, informer cache.Informer) er
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}

--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -49,7 +49,7 @@ type unstructuredStatusAccessor struct {
 	*unstructured.Unstructured
 }
 
-func nestedString(obj map[string]interface{}, fields ...string) string {
+func nestedString(obj map[string]any, fields ...string) string {
 	v, ok, err := unstructured.NestedString(obj, fields...)
 	if err != nil || !ok {
 		return ""
@@ -57,7 +57,7 @@ func nestedString(obj map[string]interface{}, fields ...string) string {
 	return v
 }
 
-func nestedInt64(obj map[string]interface{}, fields ...string) int64 {
+func nestedInt64(obj map[string]any, fields ...string) int64 {
 	v, ok, err := unstructured.NestedInt64(obj, fields...)
 	if err != nil || !ok {
 		return 0
@@ -65,7 +65,7 @@ func nestedInt64(obj map[string]interface{}, fields ...string) int64 {
 	return v
 }
 
-func nestedStringReference(obj map[string]interface{}, fields ...string) *string {
+func nestedStringReference(obj map[string]any, fields ...string) *string {
 	v, ok, err := unstructured.NestedString(obj, fields...)
 	if err != nil || !ok {
 		return nil
@@ -74,13 +74,13 @@ func nestedStringReference(obj map[string]interface{}, fields ...string) *string
 	return &v
 }
 
-func nestedRawExtension(obj map[string]interface{}, fields ...string) *runtime.RawExtension {
+func nestedRawExtension(obj map[string]any, fields ...string) *runtime.RawExtension {
 	val, ok, err := unstructured.NestedFieldNoCopy(obj, fields...)
 	if err != nil || !ok {
 		return nil
 	}
 
-	data, ok := val.(map[string]interface{})
+	data, ok := val.(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -131,7 +131,7 @@ func (u unstructuredStatusAccessor) GetLastOperation() *gardencorev1beta1.LastOp
 	}
 
 	lastOperation := &gardencorev1beta1.LastOperation{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), lastOperation); err != nil {
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]any), lastOperation); err != nil {
 		return nil
 	}
 	return lastOperation
@@ -157,7 +157,7 @@ func (u unstructuredStatusAccessor) GetLastError() *gardencorev1beta1.LastError 
 	}
 
 	lastError := &gardencorev1beta1.LastError{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), lastError); err != nil {
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]any), lastError); err != nil {
 		return nil
 	}
 	return lastError
@@ -194,7 +194,7 @@ func (u unstructuredStatusAccessor) GetState() *runtime.RawExtension {
 		return nil
 	}
 	raw := &runtime.RawExtension{}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), raw)
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]any), raw)
 	if err != nil {
 		return nil
 	}
@@ -221,9 +221,9 @@ func (u unstructuredStatusAccessor) GetConditions() []gardencorev1beta1.Conditio
 	}
 
 	var conditions []gardencorev1beta1.Condition
-	interfaceConditionSlice := val.([]interface{})
+	interfaceConditionSlice := val.([]any)
 	for _, interfaceCondition := range interfaceConditionSlice {
-		unstructuredCondition := interfaceCondition.(map[string]interface{})
+		unstructuredCondition := interfaceCondition.(map[string]any)
 		condition := &gardencorev1beta1.Condition{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredCondition, condition); err != nil {
 			return nil
@@ -235,7 +235,7 @@ func (u unstructuredStatusAccessor) GetConditions() []gardencorev1beta1.Conditio
 
 // SetConditions implements Status.
 func (u unstructuredStatusAccessor) SetConditions(conditions []gardencorev1beta1.Condition) {
-	var interfaceSlice = make([]interface{}, len(conditions))
+	var interfaceSlice = make([]any, len(conditions))
 	for i, d := range conditions {
 		unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&d)
 		if err != nil {
@@ -256,9 +256,9 @@ func (u unstructuredStatusAccessor) GetResources() []gardencorev1beta1.NamedReso
 		return nil
 	}
 	var resources []gardencorev1beta1.NamedResourceReference
-	interfaceResourceSlice := val.([]interface{})
+	interfaceResourceSlice := val.([]any)
 	for _, interfaceResource := range interfaceResourceSlice {
-		unstructuredResource := interfaceResource.(map[string]interface{})
+		unstructuredResource := interfaceResource.(map[string]any)
 		resource := &gardencorev1beta1.NamedResourceReference{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredResource, resource); err != nil {
 			return nil
@@ -270,7 +270,7 @@ func (u unstructuredStatusAccessor) GetResources() []gardencorev1beta1.NamedReso
 
 // SetResources implements Status.
 func (u unstructuredStatusAccessor) SetResources(namedResourceReference []gardencorev1beta1.NamedResourceReference) {
-	var interfaceSlice = make([]interface{}, len(namedResourceReference))
+	var interfaceSlice = make([]any, len(namedResourceReference))
 	for i, d := range namedResourceReference {
 		unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&d)
 		if err != nil {

--- a/pkg/apis/core/validation/internalsecret.go
+++ b/pkg/apis/core/validation/internalsecret.go
@@ -54,7 +54,7 @@ func ValidateInternalSecret(secret *core.InternalSecret) field.ErrorList {
 		}
 
 		// make sure that the content is well-formed json.
-		if err := json.Unmarshal(dockercfgBytes, &map[string]interface{}{}); err != nil {
+		if err := json.Unmarshal(dockercfgBytes, &map[string]any{}); err != nil {
 			allErrs = append(allErrs, field.Invalid(dataPath.Key(corev1.DockerConfigKey), "<secret contents redacted>", err.Error()))
 		}
 	case corev1.SecretTypeDockerConfigJson:
@@ -65,7 +65,7 @@ func ValidateInternalSecret(secret *core.InternalSecret) field.ErrorList {
 		}
 
 		// make sure that the content is well-formed json.
-		if err := json.Unmarshal(dockerConfigJSONBytes, &map[string]interface{}{}); err != nil {
+		if err := json.Unmarshal(dockerConfigJSONBytes, &map[string]any{}); err != nil {
 			allErrs = append(allErrs, field.Invalid(dataPath.Key(corev1.DockerConfigJsonKey), "<secret contents redacted>", err.Error()))
 		}
 	case corev1.SecretTypeBasicAuth:

--- a/pkg/apis/operations/v1alpha1/conversions.go
+++ b/pkg/apis/operations/v1alpha1/conversions.go
@@ -30,25 +30,25 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 
 	// Add non-generated conversion functions
 
-	if err := scheme.AddConversionFunc((*Bastion)(nil), (*operations.Bastion)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := scheme.AddConversionFunc((*Bastion)(nil), (*operations.Bastion)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_Bastion_To_operations_Bastion(a.(*Bastion), b.(*operations.Bastion), scope)
 	}); err != nil {
 		return err
 	}
 
-	if err := scheme.AddConversionFunc((*BastionSpec)(nil), (*operations.BastionSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := scheme.AddConversionFunc((*BastionSpec)(nil), (*operations.BastionSpec)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_BastionSpec_To_operations_BastionSpec(a.(*BastionSpec), b.(*operations.BastionSpec), scope)
 	}); err != nil {
 		return err
 	}
 
-	if err := scheme.AddConversionFunc((*operations.Bastion)(nil), (*Bastion)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := scheme.AddConversionFunc((*operations.Bastion)(nil), (*Bastion)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_operations_Bastion_To_v1alpha1_Bastion(a.(*operations.Bastion), b.(*Bastion), scope)
 	}); err != nil {
 		return err
 	}
 
-	if err := scheme.AddConversionFunc((*operations.BastionSpec)(nil), (*BastionSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := scheme.AddConversionFunc((*operations.BastionSpec)(nil), (*BastionSpec)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_operations_BastionSpec_To_v1alpha1_BastionSpec(a.(*operations.BastionSpec), b.(*BastionSpec), scope)
 	}); err != nil {
 		return err

--- a/pkg/apiserver/registry/core/backupbucket/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/backupbucket/storage/tableconvertor.go
@@ -54,10 +54,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			backupBucket = obj.(*core.BackupBucket)
-			cells        = []interface{}{}
+			cells        = []any{}
 		)
 
 		cells = append(cells, backupBucket.Name)

--- a/pkg/apiserver/registry/core/backupentry/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/backupentry/storage/tableconvertor.go
@@ -54,10 +54,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			backupEntry = obj.(*core.BackupEntry)
-			cells       = []interface{}{}
+			cells       = []any{}
 		)
 
 		cells = append(cells, backupEntry.Name)

--- a/pkg/apiserver/registry/core/backupentry/strategy.go
+++ b/pkg/apiserver/registry/core/backupentry/strategy.go
@@ -179,7 +179,7 @@ func MatchBackupEntry(label labels.Selector, field fields.Selector) storage.Sele
 }
 
 // SeedNameIndexFunc returns spec.seedName of given BackupEntry.
-func SeedNameIndexFunc(obj interface{}) ([]string, error) {
+func SeedNameIndexFunc(obj any) ([]string, error) {
 	backupEntry, ok := obj.(*core.BackupEntry)
 	if !ok {
 		return nil, fmt.Errorf("expected *core.BackupEntry but got %T", obj)
@@ -196,7 +196,7 @@ func getSeedName(backupEntry *core.BackupEntry) string {
 }
 
 // BucketNameIndexFunc returns spec.BucketName of given BackupEntry.
-func BucketNameIndexFunc(obj interface{}) ([]string, error) {
+func BucketNameIndexFunc(obj any) ([]string, error) {
 	backupEntry, ok := obj.(*core.BackupEntry)
 	if !ok {
 		return nil, fmt.Errorf("expected *core.BackupEntry but got %T", obj)

--- a/pkg/apiserver/registry/core/cloudprofile/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/cloudprofile/storage/tableconvertor.go
@@ -51,10 +51,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			cloudProfile = obj.(*core.CloudProfile)
-			cells        = []interface{}{}
+			cells        = []any{}
 		)
 
 		cells = append(cells, cloudProfile.Name)

--- a/pkg/apiserver/registry/core/controllerdeployment/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/controllerdeployment/storage/tableconvertor.go
@@ -50,10 +50,10 @@ func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtim
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			obj   = o.(*core.ControllerDeployment)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, obj.Name)

--- a/pkg/apiserver/registry/core/controllerinstallation/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/controllerinstallation/storage/tableconvertor.go
@@ -57,10 +57,10 @@ func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtim
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			obj   = o.(*core.ControllerInstallation)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, obj.Name)

--- a/pkg/apiserver/registry/core/controllerinstallation/strategy.go
+++ b/pkg/apiserver/registry/core/controllerinstallation/strategy.go
@@ -146,7 +146,7 @@ func MatchControllerInstallation(label labels.Selector, field fields.Selector) s
 }
 
 // SeedRefNameIndexFunc returns spec.seedRef.name of given ControllerInstallation.
-func SeedRefNameIndexFunc(obj interface{}) ([]string, error) {
+func SeedRefNameIndexFunc(obj any) ([]string, error) {
 	controllerInstallation, ok := obj.(*core.ControllerInstallation)
 	if !ok {
 		return nil, fmt.Errorf("expected *core.ControllerInstallation but got %T", obj)
@@ -156,7 +156,7 @@ func SeedRefNameIndexFunc(obj interface{}) ([]string, error) {
 }
 
 // RegistrationRefNameIndexFunc returns spec.registrationRef.name of given ControllerInstallation.
-func RegistrationRefNameIndexFunc(obj interface{}) ([]string, error) {
+func RegistrationRefNameIndexFunc(obj any) ([]string, error) {
 	controllerInstallation, ok := obj.(*core.ControllerInstallation)
 	if !ok {
 		return nil, fmt.Errorf("expected *core.ControllerInstallation but got %T", obj)

--- a/pkg/apiserver/registry/core/controllerregistration/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/controllerregistration/storage/tableconvertor.go
@@ -53,10 +53,10 @@ func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtim
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			obj       = o.(*core.ControllerRegistration)
-			cells     = []interface{}{}
+			cells     = []any{}
 			resources = make([]string, 0, len(obj.Spec.Resources))
 		)
 

--- a/pkg/apiserver/registry/core/exposureclass/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/exposureclass/storage/tableconvertor.go
@@ -51,10 +51,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			exposureClass = obj.(*core.ExposureClass)
-			cells         = []interface{}{}
+			cells         = []any{}
 		)
 		cells = append(cells, exposureClass.Name)
 		cells = append(cells, exposureClass.Handler)

--- a/pkg/apiserver/registry/core/internalsecret/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/internalsecret/storage/tableconvertor.go
@@ -52,10 +52,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			secret = obj.(*core.InternalSecret)
-			cells  = []interface{}{}
+			cells  = []any{}
 		)
 
 		cells = append(cells, secret.Name, string(secret.Type), int64(len(secret.Data)), metatable.ConvertToHumanReadableDateType(secret.CreationTimestamp))

--- a/pkg/apiserver/registry/core/namespacedcloudprofile/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/namespacedcloudprofile/storage/tableconvertor.go
@@ -52,10 +52,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			namespacedCloudProfile = obj.(*core.NamespacedCloudProfile)
-			cells                  = []interface{}{}
+			cells                  = []any{}
 		)
 
 		cells = append(cells, namespacedCloudProfile.Name)

--- a/pkg/apiserver/registry/core/project/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/project/storage/tableconvertor.go
@@ -54,10 +54,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			project = obj.(*core.Project)
-			cells   = []interface{}{}
+			cells   = []any{}
 		)
 
 		cells = append(cells, project.Name)

--- a/pkg/apiserver/registry/core/quota/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/quota/storage/tableconvertor.go
@@ -53,10 +53,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			quota = obj.(*core.Quota)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, quota.Name)

--- a/pkg/apiserver/registry/core/secretbinding/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/secretbinding/storage/tableconvertor.go
@@ -52,10 +52,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			sb    = obj.(*core.SecretBinding)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, sb.Name)

--- a/pkg/apiserver/registry/core/seed/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/seed/storage/tableconvertor.go
@@ -58,10 +58,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			seed  = obj.(*core.Seed)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		gardenletReadyCondition := helper.GetCondition(seed.Status.Conditions, core.SeedGardenletReady)

--- a/pkg/apiserver/registry/core/shoot/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/shoot/storage/tableconvertor.go
@@ -69,10 +69,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			shoot = obj.(*core.Shoot)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, shoot.Name)

--- a/pkg/apiserver/registry/core/shootstate/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/shootstate/storage/tableconvertor.go
@@ -52,10 +52,10 @@ func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtim
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			obj   = o.(*core.ShootState)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, obj.Name)

--- a/pkg/apiserver/registry/operations/bastion/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/operations/bastion/storage/tableconvertor.go
@@ -58,10 +58,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			bastion = obj.(*operations.Bastion)
-			cells   = []interface{}{}
+			cells   = []any{}
 		)
 
 		ingress := bastion.Status.Ingress

--- a/pkg/apiserver/registry/security/credentialsbinding/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/security/credentialsbinding/storage/tableconvertor.go
@@ -54,10 +54,10 @@ func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtim
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			obj   = o.(*security.CredentialsBinding)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, obj.Name)

--- a/pkg/apiserver/registry/seedmanagement/managedseed/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseed/storage/tableconvertor.go
@@ -56,10 +56,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			managedSeed = obj.(*seedmanagement.ManagedSeed)
-			cells       = []interface{}{}
+			cells       = []any{}
 		)
 
 		seedRegisteredCondition := helper.GetCondition(managedSeed.Status.Conditions, seedmanagement.ManagedSeedSeedRegistered)

--- a/pkg/apiserver/registry/seedmanagement/managedseedset/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseedset/storage/tableconvertor.go
@@ -53,10 +53,10 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			managedSeedSet = obj.(*seedmanagement.ManagedSeedSet)
-			cells          = []interface{}{}
+			cells          = []any{}
 		)
 
 		pending := ""

--- a/pkg/apiserver/registry/settings/clusteropenidconnectpreset/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/settings/clusteropenidconnectpreset/storage/tableconvertor.go
@@ -53,10 +53,10 @@ func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtim
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			obj   = o.(*settings.ClusterOpenIDConnectPreset)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, obj.Name)

--- a/pkg/apiserver/registry/settings/openidconnectpreset/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/settings/openidconnectpreset/storage/tableconvertor.go
@@ -52,10 +52,10 @@ func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtim
 		}
 	}
 
-	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
+	table.Rows, err = metatable.MetaToTableRow(o, func(o runtime.Object, _ metav1.Object, _, _ string) ([]any, error) {
 		var (
 			obj   = o.(*settings.OpenIDConnectPreset)
-			cells = []interface{}{}
+			cells = []any{}
 		)
 
 		cells = append(cells, obj.Name)

--- a/pkg/chartrenderer/default.go
+++ b/pkg/chartrenderer/default.go
@@ -66,7 +66,7 @@ func NewWithServerVersion(serverVersion *version.Info) Interface {
 
 // RenderArchive loads the chart from the given location <chartPath> and calls the renderRelease() function
 // to convert it into a ChartRelease object.
-func (r *chartRenderer) RenderArchive(archive []byte, releaseName, namespace string, values interface{}) (*RenderedChart, error) {
+func (r *chartRenderer) RenderArchive(archive []byte, releaseName, namespace string, values any) (*RenderedChart, error) {
 	chart, err := helmloader.LoadArchive(bytes.NewReader(archive))
 	if err != nil {
 		return nil, fmt.Errorf("can't load chart from archive: %s", err)
@@ -76,7 +76,7 @@ func (r *chartRenderer) RenderArchive(archive []byte, releaseName, namespace str
 
 // RenderEmbeddedFS loads the chart from the given embed.FS and calls the renderRelease() function
 // to convert it into a ChartRelease object.
-func (r *chartRenderer) RenderEmbeddedFS(embeddedFS embed.FS, chartPath, releaseName, namespace string, values interface{}) (*RenderedChart, error) {
+func (r *chartRenderer) RenderEmbeddedFS(embeddedFS embed.FS, chartPath, releaseName, namespace string, values any) (*RenderedChart, error) {
 	chart, err := loadEmbeddedFS(embeddedFS, chartPath)
 	if err != nil {
 		return nil, fmt.Errorf("can't load chart %q from embedded file system: %w", chartPath, err)
@@ -84,7 +84,7 @@ func (r *chartRenderer) RenderEmbeddedFS(embeddedFS embed.FS, chartPath, release
 	return r.renderRelease(chart, releaseName, namespace, values)
 }
 
-func (r *chartRenderer) renderRelease(chart *helmchart.Chart, releaseName, namespace string, values interface{}) (*RenderedChart, error) {
+func (r *chartRenderer) renderRelease(chart *helmchart.Chart, releaseName, namespace string, values any) (*RenderedChart, error) {
 	parsedValues, err := json.Marshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse values for chart %s: %w", chart.Metadata.Name, err)

--- a/pkg/chartrenderer/renderer.go
+++ b/pkg/chartrenderer/renderer.go
@@ -12,8 +12,8 @@ import (
 
 // Interface is an interface for rendering Helm Charts from path, name, namespace and values.
 type Interface interface {
-	RenderEmbeddedFS(embeddedFS embed.FS, chartPath, releaseName, namespace string, values interface{}) (*RenderedChart, error)
-	RenderArchive(archive []byte, releaseName, namespace string, values interface{}) (*RenderedChart, error)
+	RenderEmbeddedFS(embeddedFS embed.FS, chartPath, releaseName, namespace string, values any) (*RenderedChart, error)
+	RenderArchive(archive []byte, releaseName, namespace string, values any) (*RenderedChart, error)
 }
 
 // RenderedChart holds a map of rendered templates file with template file name as key and

--- a/pkg/client/kubernetes/applier.go
+++ b/pkg/client/kubernetes/applier.go
@@ -139,7 +139,7 @@ var (
 
 			annotations, found, _ := unstructured.NestedMap(oldObj.Object, "metadata", "annotations")
 			if found {
-				mergedAnnotations := make(map[string]interface{})
+				mergedAnnotations := make(map[string]any)
 				for key, value := range annotations {
 					annotation := key
 					annotationValue := value.(string)
@@ -174,15 +174,15 @@ var (
 					break
 				}
 
-				ports := make([]interface{}, 0, len(newPorts))
+				ports := make([]any, 0, len(newPorts))
 				for _, newPort := range newPorts {
-					np := newPort.(map[string]interface{})
+					np := newPort.(map[string]any)
 					npName, _, _ := unstructured.NestedString(np, "name")
 					npPort, _ := nestedFloat64OrInt64(np, "port")
 					nodePort, ok := nestedFloat64OrInt64(np, "nodePort")
 
 					for _, oldPortObj := range oldPorts {
-						op := oldPortObj.(map[string]interface{})
+						op := oldPortObj.(map[string]any)
 						opName, _, _ := unstructured.NestedString(op, "name")
 						opPort, _ := nestedFloat64OrInt64(op, "port")
 
@@ -247,7 +247,7 @@ var (
 	})
 )
 
-func nestedFloat64OrInt64(obj map[string]interface{}, fields ...string) (int64, bool) {
+func nestedFloat64OrInt64(obj map[string]any, fields ...string) (int64, bool) {
 	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
 	if !found || err != nil {
 		return 0, found
@@ -285,7 +285,7 @@ func (a *defaultApplier) mergeObjects(newObj, oldObj *unstructured.Unstructured,
 	newObj.SetResourceVersion(oldObj.GetResourceVersion())
 
 	// We do not want to overwrite the Finalizers.
-	newObj.Object["metadata"].(map[string]interface{})["finalizers"] = oldObj.Object["metadata"].(map[string]interface{})["finalizers"]
+	newObj.Object["metadata"].(map[string]any)["finalizers"] = oldObj.Object["metadata"].(map[string]any)["finalizers"]
 
 	if merge, ok := mergeFuncs[newObj.GroupVersionKind().GroupKind()]; ok {
 		merge(newObj, oldObj)
@@ -385,7 +385,7 @@ type manifestReader struct {
 func (m *manifestReader) Read() (*unstructured.Unstructured, error) {
 	// loop for skipping empty yaml objects
 	for {
-		var data map[string]interface{}
+		var data map[string]any
 
 		err := m.decoder.Decode(&data)
 		if err == io.EOF {

--- a/pkg/client/kubernetes/chartapplier.go
+++ b/pkg/client/kubernetes/chartapplier.go
@@ -99,7 +99,7 @@ func (c *chartApplier) DeleteFromEmbeddedFS(ctx context.Context, embeddedFS embe
 	return c.DeleteManifest(ctx, manifestReader, deleteManifestOpts...)
 }
 
-func (c *chartApplier) newManifestReader(embeddedFS embed.FS, chartPath, namespace, name string, values interface{}) (UnstructuredReader, error) {
+func (c *chartApplier) newManifestReader(embeddedFS embed.FS, chartPath, namespace, name string, values any) (UnstructuredReader, error) {
 	var (
 		release *chartrenderer.RenderedChart
 		err     error

--- a/pkg/client/kubernetes/chartoptions.go
+++ b/pkg/client/kubernetes/chartoptions.go
@@ -17,7 +17,7 @@ type ApplyOption interface {
 // ApplyOptions contains options for apply requests
 type ApplyOptions struct {
 	// Values to pass to chart.
-	Values interface{}
+	Values any
 
 	// Additional MergeFunctions.
 	MergeFuncs MergeFuncs
@@ -28,10 +28,10 @@ type ApplyOptions struct {
 }
 
 // Values applies values to ApplyOptions or DeleteOptions.
-var Values = func(values interface{}) ValueOption { return &withValue{values} }
+var Values = func(values any) ValueOption { return &withValue{values} }
 
 type withValue struct {
-	values interface{}
+	values any
 }
 
 func (v withValue) MutateApplyOptions(opts *ApplyOptions) {
@@ -85,7 +85,7 @@ type DeleteOption interface {
 // DeleteOptions contains options for delete requests
 type DeleteOptions struct {
 	// Values to pass to chart.
-	Values interface{}
+	Values any
 
 	// Forces the namespace for chart objects when applying the chart, this is because sometimes native chart
 	// objects do not come with a Release.Namespace option and leave the namespace field empty

--- a/pkg/client/kubernetes/test/options_matchers.go
+++ b/pkg/client/kubernetes/test/options_matchers.go
@@ -24,7 +24,7 @@ import (
 //		kubernetes.WithClientOptions(clientOptions),
 //		kubernetes.WithDisabledCachedClient(),
 //	))
-func ConsistOfConfigFuncs(fns ...interface{}) gomegatypes.GomegaMatcher {
+func ConsistOfConfigFuncs(fns ...any) gomegatypes.GomegaMatcher {
 	var matchers []gomegatypes.GomegaMatcher
 
 	for _, fn := range fns {
@@ -39,17 +39,17 @@ func ConsistOfConfigFuncs(fns ...interface{}) gomegatypes.GomegaMatcher {
 // e.g.:
 //
 //	Expect(fn).Should(MatchConfigFunc(WithClientConnectionOptions(clientConnectionConfig)))
-func MatchConfigFunc(fn interface{}) gomegatypes.GomegaMatcher {
+func MatchConfigFunc(fn any) gomegatypes.GomegaMatcher {
 	return &configFuncMatcher{expected: fn}
 }
 
 type configFuncMatcher struct {
-	expected interface{}
+	expected any
 
 	expectedConfig, actualConfig *kubernetes.Config
 }
 
-func (m *configFuncMatcher) Match(actual interface{}) (success bool, err error) {
+func (m *configFuncMatcher) Match(actual any) (success bool, err error) {
 	if m.expected == nil {
 		return false, fmt.Errorf("Refusing to compare <nil> to <nil>.\nBe explicit and use BeNil() instead.  This is to avoid mistakes where both sides of an assertion are erroneously uninitialized.") //nolint:revive
 	}
@@ -78,7 +78,7 @@ func (m *configFuncMatcher) Match(actual interface{}) (success bool, err error) 
 	return reflect.DeepEqual(m.expectedConfig, m.actualConfig), nil
 }
 
-func (m *configFuncMatcher) FailureMessage(actual interface{}) (message string) {
+func (m *configFuncMatcher) FailureMessage(actual any) (message string) {
 	if m.actualConfig == nil || m.expectedConfig == nil {
 		return format.Message(actual, "to produce an equal config to the one produced by", m.expected)
 	}
@@ -86,7 +86,7 @@ func (m *configFuncMatcher) FailureMessage(actual interface{}) (message string) 
 	return format.MessageWithDiff(fmt.Sprintf("%+v", m.actualConfig), "to produce an equal config to the one produced by", fmt.Sprintf("%+v", m.expectedConfig))
 }
 
-func (m *configFuncMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (m *configFuncMatcher) NegatedFailureMessage(actual any) (message string) {
 	if m.actualConfig == nil || m.expectedConfig == nil {
 		return format.Message(actual, "to not produce an equal config to the one produced by", m.expected)
 	}

--- a/pkg/client/seedmanagement/applyconfiguration/utils.go
+++ b/pkg/client/seedmanagement/applyconfiguration/utils.go
@@ -14,7 +14,7 @@ import (
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no
 // apply configuration type exists for the given GroupVersionKind.
-func ForKind(kind schema.GroupVersionKind) interface{} {
+func ForKind(kind schema.GroupVersionKind) any {
 	switch kind {
 	// Group=seedmanagement.gardener.cloud, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithKind("Gardenlet"):

--- a/pkg/client/settings/applyconfiguration/utils.go
+++ b/pkg/client/settings/applyconfiguration/utils.go
@@ -14,7 +14,7 @@ import (
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no
 // apply configuration type exists for the given GroupVersionKind.
-func ForKind(kind schema.GroupVersionKind) interface{} {
+func ForKind(kind schema.GroupVersionKind) any {
 	switch kind {
 	// Group=settings.gardener.cloud, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithKind("ClusterOpenIDConnectPreset"):

--- a/pkg/component/apiserver/admission.go
+++ b/pkg/component/apiserver/admission.go
@@ -166,7 +166,7 @@ kind: WebhookAdmissionConfiguration`, webhookadmissionv1.SchemeGroupVersion.Stri
 			}
 		}
 
-		config := map[string]interface{}{}
+		config := map[string]any{}
 		if err := yaml.Unmarshal(plugin.Config.Raw, &config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal plugin configuration for %s: %w", plugin.Name, err)
 		}
@@ -174,7 +174,7 @@ kind: WebhookAdmissionConfiguration`, webhookadmissionv1.SchemeGroupVersion.Stri
 			return nil, fmt.Errorf(`expected "imagePolicy" key in configuration but it does not exist`)
 		}
 
-		config["imagePolicy"].(map[string]interface{})["kubeConfigFile"] = kubeconfigFilePath
+		config["imagePolicy"].(map[string]any)["kubeConfigFile"] = kubeconfigFilePath
 		return yaml.Marshal(config)
 
 	default:

--- a/pkg/component/autoscaling/clusterautoscaler/monitoring.go
+++ b/pkg/component/autoscaling/clusterautoscaler/monitoring.go
@@ -121,7 +121,7 @@ func init() {
 func (c *clusterAutoscaler) ScrapeConfigs() ([]string, error) {
 	var scrapeConfig bytes.Buffer
 
-	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{"namespace": c.namespace}); err != nil {
+	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]any{"namespace": c.namespace}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/etcd/etcd/monitoring.go
+++ b/pkg/component/etcd/etcd/monitoring.go
@@ -397,7 +397,7 @@ func init() {
 
 // ScrapeConfigs returns the scrape configurations for Prometheus.
 func (e *etcd) ScrapeConfigs() ([]string, error) {
-	values := map[string]interface{}{
+	values := map[string]any{
 		"namespace": e.namespace,
 		"role":      e.values.Role,
 	}
@@ -439,7 +439,7 @@ func (e *etcd) AlertingRules() (map[string]string, error) {
 		etcdReplicas = *e.values.Replicas
 	}
 
-	if err := monitoringAlertingRulesTemplate.Execute(&alertingRules, map[string]interface{}{
+	if err := monitoringAlertingRulesTemplate.Execute(&alertingRules, map[string]any{
 		"role":               e.values.Role,
 		"Role":               cases.Title(language.English).String(e.values.Role),
 		"class":              e.values.Class,

--- a/pkg/component/extensions/extension/extension_test.go
+++ b/pkg/component/extensions/extension/extension_test.go
@@ -42,7 +42,7 @@ func (e *errorClient) Delete(_ context.Context, _ client.Object, _ ...client.Del
 }
 
 var (
-	objectIdentifier = Identifier(func(obj interface{}) string {
+	objectIdentifier = Identifier(func(obj any) string {
 		switch o := obj.(type) {
 		case extensionsv1alpha1.Extension:
 			return o.GetName()

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -122,7 +122,7 @@ func init() {
 
 func generateInitScript(nodeAgentImage string) ([]byte, error) {
 	var initScript bytes.Buffer
-	if err := initScriptTpl.Execute(&initScript, map[string]interface{}{
+	if err := initScriptTpl.Execute(&initScript, map[string]any{
 		"image":           nodeAgentImage,
 		"binaryDirectory": nodeagentv1alpha1.BinaryDir,
 		"configFile":      nodeagentv1alpha1.ConfigFilePath,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
@@ -55,7 +55,7 @@ func (initializer) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []
 	)
 
 	var script bytes.Buffer
-	if err := tplInitializer.Execute(&script, map[string]interface{}{
+	if err := tplInitializer.Execute(&script, map[string]any{
 		"binaryPath":          extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
 		"pauseContainerImage": ctx.Images[imagevector.ImageNamePauseContainer],
 	}); err != nil {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser/component.go
@@ -60,7 +60,7 @@ func (component) Name() string {
 
 func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 	var script bytes.Buffer
-	if err := tpl.Execute(&script, map[string]interface{}{
+	if err := tpl.Execute(&script, map[string]any{
 		"pathPublicSSHKey":      pathPublicSSHKey,
 		"pathAuthorizedSSHKeys": pathAuthorizedSSHKeys,
 	}); err != nil {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -117,7 +117,7 @@ WantedBy=multi-user.target`),
 
 func updateLocalCACertificatesScriptFile() (extensionsv1alpha1.File, error) {
 	var script bytes.Buffer
-	if err := tplUpdateLocalCaCertificates.Execute(&script, map[string]interface{}{
+	if err := tplUpdateLocalCaCertificates.Execute(&script, map[string]any{
 		"pathLocalSSLCerts": pathLocalSSLCerts,
 	}); err != nil {
 		return extensionsv1alpha1.File{}, err

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -45,7 +45,7 @@ func getValitailConfigurationFile(ctx components.Context) (extensionsv1alpha1.Fi
 	}
 
 	var config bytes.Buffer
-	if err := tplValitail.Execute(&config, map[string]interface{}{
+	if err := tplValitail.Execute(&config, map[string]any{
 		"clientURL":         "https://" + ctx.ValiIngress + "/vali/api/v1/push",
 		"pathCACert":        PathCACert,
 		"valiIngress":       ctx.ValiIngress,

--- a/pkg/component/gardener/dashboard/config/config.go
+++ b/pkg/component/gardener/dashboard/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	Terminal                               *Terminal              `yaml:"terminal,omitempty"`
 	OIDC                                   *OIDC                  `yaml:"oidc,omitempty"`
 	GitHub                                 *GitHub                `yaml:"gitHub,omitempty"`
-	Frontend                               map[string]interface{} `yaml:"frontend,omitempty"`
+	Frontend                               map[string]any         `yaml:"frontend,omitempty"`
 }
 
 // ReadinessProbe is the readiness probe configuration.

--- a/pkg/component/gardener/dashboard/config/login_config.go
+++ b/pkg/component/gardener/dashboard/config/login_config.go
@@ -6,8 +6,8 @@ package config
 
 // LoginConfig is the dashboard login config structure.
 type LoginConfig struct {
-	LoginTypes     []string               `json:"loginTypes"`
-	LandingPageURL string                 `json:"landingPageUrl,omitempty"`
-	Branding       map[string]interface{} `json:"branding,omitempty"`
-	Themes         map[string]interface{} `json:"themes,omitempty"`
+	LoginTypes     []string       `json:"loginTypes"`
+	LandingPageURL string         `json:"landingPageUrl,omitempty"`
+	Branding       map[string]any `json:"branding,omitempty"`
+	Themes         map[string]any `json:"themes,omitempty"`
 }

--- a/pkg/component/gardener/dashboard/configmap.go
+++ b/pkg/component/gardener/dashboard/configmap.go
@@ -33,14 +33,14 @@ const (
 )
 
 func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, error) {
-	var frontendConfig map[string]interface{}
+	var frontendConfig map[string]any
 	if g.values.FrontendConfigMapName != nil {
 		frontendConfigMap := &corev1.ConfigMap{}
 		if err := g.client.Get(ctx, client.ObjectKey{Name: *g.values.FrontendConfigMapName, Namespace: g.namespace}, frontendConfigMap); err != nil {
 			return nil, err
 		}
 
-		frontendConfig = make(map[string]interface{})
+		frontendConfig = make(map[string]any)
 		if err := yaml.Unmarshal([]byte(frontendConfigMap.Data[dataKeyFrontendConfig]), &frontendConfig); err != nil {
 			return nil, err
 		}
@@ -69,10 +69,10 @@ func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, e
 			loginCfg.LandingPageURL = v.(string)
 		}
 		if v, ok := frontendConfig["branding"]; ok {
-			loginCfg.Branding = v.(map[string]interface{})
+			loginCfg.Branding = v.(map[string]any)
 		}
 		if v, ok := frontendConfig["themes"]; ok {
-			loginCfg.Themes = v.(map[string]interface{})
+			loginCfg.Themes = v.(map[string]any)
 		}
 	}
 
@@ -103,12 +103,12 @@ func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, e
 		}
 
 		if cfg.Frontend == nil {
-			cfg.Frontend = make(map[string]interface{})
+			cfg.Frontend = make(map[string]any)
 		}
 		if cfg.Frontend["features"] == nil {
-			cfg.Frontend["features"] = make(map[string]interface{})
+			cfg.Frontend["features"] = make(map[string]any)
 		}
-		cfg.Frontend["features"].(map[string]interface{})["terminalEnabled"] = true
+		cfg.Frontend["features"].(map[string]any)["terminalEnabled"] = true
 	}
 
 	if g.values.OIDC != nil {

--- a/pkg/component/gardener/resourcemanager/monitoring.go
+++ b/pkg/component/gardener/resourcemanager/monitoring.go
@@ -52,7 +52,7 @@ func init() {
 func (r *resourceManager) ScrapeConfigs() ([]string, error) {
 	var scrapeConfig bytes.Buffer
 
-	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{"namespace": r.namespace, "namePrefix": r.values.NamePrefix}); err != nil {
+	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]any{"namespace": r.namespace, "namePrefix": r.values.NamePrefix}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/kubernetes/apiserver/monitoring.go
+++ b/pkg/component/kubernetes/apiserver/monitoring.go
@@ -285,7 +285,7 @@ func init() {
 func (k *kubeAPIServer) ScrapeConfigs() ([]string, error) {
 	var scrapeConfig bytes.Buffer
 
-	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{"namespace": k.namespace}); err != nil {
+	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]any{"namespace": k.namespace}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/kubernetes/controllermanager/monitoring.go
+++ b/pkg/component/kubernetes/controllermanager/monitoring.go
@@ -87,7 +87,7 @@ func init() {
 func (k *kubeControllerManager) ScrapeConfigs() ([]string, error) {
 	var scrapeConfig bytes.Buffer
 
-	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{"namespace": k.namespace}); err != nil {
+	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]any{"namespace": k.namespace}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/kubernetes/scheduler/monitoring.go
+++ b/pkg/component/kubernetes/scheduler/monitoring.go
@@ -132,7 +132,7 @@ func init() {
 func (k *kubeScheduler) ScrapeConfigs() ([]string, error) {
 	var scrapeConfig bytes.Buffer
 
-	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{"namespace": k.namespace}); err != nil {
+	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]any{"namespace": k.namespace}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy.go
@@ -141,7 +141,7 @@ func (a *apiserverProxy) SetAdvertiseIPAddress(advertiseIPAddress string) {
 
 func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 	var envoyYAML bytes.Buffer
-	if err := tplEnvoy.Execute(&envoyYAML, map[string]interface{}{
+	if err := tplEnvoy.Execute(&envoyYAML, map[string]any{
 		"advertiseIPAddress":  a.values.advertiseIPAddress,
 		"dnsLookupFamily":     a.values.DNSLookupFamily,
 		"adminPort":           adminPort,

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -51,7 +51,7 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 	renderedChart := &chartrenderer.RenderedChart{}
 
 	for _, istioIngressGateway := range i.values.IngressGateway {
-		values := map[string]interface{}{
+		values := map[string]any{
 			"trustDomain":           istioIngressGateway.TrustDomain,
 			"labels":                istioIngressGateway.Labels,
 			"networkPolicyLabels":   istioIngressGateway.NetworkPolicyLabels,
@@ -66,7 +66,7 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 			"loadBalancerIP":        istioIngressGateway.LoadBalancerIP,
 			"serviceName":           v1beta1constants.DefaultSNIIngressServiceName,
 			"proxyProtocolEnabled":  istioIngressGateway.ProxyProtocolEnabled,
-			"vpn": map[string]interface{}{
+			"vpn": map[string]any{
 				"enabled": istioIngressGateway.VPNEnabled,
 			},
 			"enforceSpreadAcrossHosts": istioIngressGateway.EnforceSpreadAcrossHosts,

--- a/pkg/component/networking/istio/istiod.go
+++ b/pkg/component/networking/istio/istiod.go
@@ -283,16 +283,16 @@ func (i *istiod) GetValues() Values {
 }
 
 func (i *istiod) generateIstiodChart() (*chartrenderer.RenderedChart, error) {
-	return i.chartRenderer.RenderEmbeddedFS(chartIstiod, chartPathIstiod, releaseName, i.values.Istiod.Namespace, map[string]interface{}{
+	return i.chartRenderer.RenderEmbeddedFS(chartIstiod, chartPathIstiod, releaseName, i.values.Istiod.Namespace, map[string]any{
 		"serviceName":       IstiodServiceName,
 		"trustDomain":       i.values.Istiod.TrustDomain,
 		"labels":            getIstiodLabels(),
 		"deployNamespace":   false,
 		"priorityClassName": i.values.Istiod.PriorityClassName,
-		"ports": map[string]interface{}{
+		"ports": map[string]any{
 			"https": PortWebhookServer,
 		},
-		"portsNames": map[string]interface{}{
+		"portsNames": map[string]any{
 			"metrics": istiodServicePortNameMetrics,
 		},
 		"image":     i.values.Istiod.Image,

--- a/pkg/component/networking/vpn/seedserver/monitoring.go
+++ b/pkg/component/networking/vpn/seedserver/monitoring.go
@@ -204,7 +204,7 @@ func (v *vpnSeedServer) ScrapeConfigs() ([]string, error) {
 	if v.values.HighAvailabilityEnabled {
 		scrapeTemplate = monitoringScrapeConfigTemplateHA
 	}
-	if err := scrapeTemplate.Execute(&scrapeConfig, map[string]interface{}{"namespace": v.namespace}); err != nil {
+	if err := scrapeTemplate.Execute(&scrapeConfig, map[string]any{"namespace": v.namespace}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/nodemanagement/machinecontrollermanager/monitoring.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/monitoring.go
@@ -220,7 +220,7 @@ func init() {
 func (m *machineControllerManager) ScrapeConfigs() ([]string, error) {
 	var scrapeConfig bytes.Buffer
 
-	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{"namespace": m.namespace}); err != nil {
+	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]any{"namespace": m.namespace}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/observability/logging/vali/monitoring.go
+++ b/pkg/component/observability/logging/vali/monitoring.go
@@ -149,11 +149,11 @@ func init() {
 func (v *vali) ScrapeConfigs() ([]string, error) {
 	var scrapeConfigVali, scrapeConfigValiTelegraf bytes.Buffer
 
-	if err := monitoringScrapeConfigValiTemplate.Execute(&scrapeConfigVali, map[string]interface{}{"namespace": v.namespace}); err != nil {
+	if err := monitoringScrapeConfigValiTemplate.Execute(&scrapeConfigVali, map[string]any{"namespace": v.namespace}); err != nil {
 		return nil, err
 	}
 
-	if err := monitoringScrapeConfigValiTelegrafTemplate.Execute(&scrapeConfigValiTelegraf, map[string]interface{}{"namespace": v.namespace}); err != nil {
+	if err := monitoringScrapeConfigValiTelegrafTemplate.Execute(&scrapeConfigValiTelegraf, map[string]any{"namespace": v.namespace}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -464,12 +464,12 @@ func (v *vali) getValiConfigMap() *corev1.ConfigMap {
 
 func (v *vali) getTelegrafConfigMap() (*corev1.ConfigMap, error) {
 	var telegrafConfig bytes.Buffer
-	if err := telegrafConfigTemplate.Execute(&telegrafConfig, map[string]interface{}{"ListenPort": telegrafServicePort}); err != nil {
+	if err := telegrafConfigTemplate.Execute(&telegrafConfig, map[string]any{"ListenPort": telegrafServicePort}); err != nil {
 		return nil, fmt.Errorf("failed to render telegraf configuration: %w", err)
 	}
 
 	var telegrafStartScript bytes.Buffer
-	if err := telegrafStartScriptTemplate.Execute(&telegrafStartScript, map[string]interface{}{"KubeRBACProxyPort": kubeRBACProxyPort}); err != nil {
+	if err := telegrafStartScriptTemplate.Execute(&telegrafStartScript, map[string]any{"KubeRBACProxyPort": kubeRBACProxyPort}); err != nil {
 		return nil, fmt.Errorf("failed to render telegraf start script: %w", err)
 	}
 

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -348,7 +348,7 @@ var _ = Describe("Vali", func() {
 				*sts = scaledToZeroValiStatefulset
 				return nil
 			}
-			funcPatchTo200GiStorage = func(_ context.Context, pvc *corev1.PersistentVolumeClaim, _ client.Patch, _ ...interface{}) error {
+			funcPatchTo200GiStorage = func(_ context.Context, pvc *corev1.PersistentVolumeClaim, _ client.Patch, _ ...any) error {
 				if pvc.Spec.Resources.Requests.Storage().Cmp(resource.MustParse("200Gi")) != 0 {
 					return fmt.Errorf("expect 200Gi found %v", *pvc.Spec.Resources.Requests.Storage())
 				}

--- a/pkg/component/observability/monitoring/kubestatemetrics/monitoring.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/monitoring.go
@@ -315,7 +315,7 @@ func (k *kubeStateMetrics) ScrapeConfigs() ([]string, error) {
 		return []string{}, nil
 	}
 
-	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{
+	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]any{
 		"jobName":          monitoringPrometheusJobName,
 		"serviceNamespace": k.namespace,
 		"allowedMetrics":   shootMonitoringAllowedMetrics,

--- a/pkg/component/observability/monitoring/prometheus/shoot/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/prometheusrules_test.go
@@ -16,7 +16,7 @@ var _ = ginkgo.Describe("PrometheusRules", func() {
 	ginkgo.Describe("#CentralPrometheusRules", func() {
 		ginkgo.DescribeTable("return the expected objects",
 			func(isWorkerless, wantsAlertmanager bool, expectedRuleNames []string) {
-				var matchers []interface{}
+				var matchers []any
 
 				for _, ruleName := range expectedRuleNames {
 					matchers = append(matchers, PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -382,7 +382,7 @@ type secretMatcher struct {
 	bootstrapKubeconfigName *string
 }
 
-func (m *secretMatcher) Matches(x interface{}) bool {
+func (m *secretMatcher) Matches(x any) bool {
 	req, ok := x.(resourcemanager.Secrets)
 	if !ok {
 		return false

--- a/pkg/component/test/monitoringcomponent.go
+++ b/pkg/component/test/monitoringcomponent.go
@@ -20,7 +20,7 @@ func ScrapeConfigs(c component.MonitoringComponent, expectedScrapeConfigs ...str
 	scrapeConfigs, err := c.ScrapeConfigs()
 	Expect(err).NotTo(HaveOccurred())
 
-	matchers := make([]interface{}, 0, len(expectedScrapeConfigs))
+	matchers := make([]any, 0, len(expectedScrapeConfigs))
 	for _, sc := range expectedScrapeConfigs {
 		matchers = append(matchers, Equal(sc))
 	}

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
@@ -469,7 +469,7 @@ func deployNeededInstallation(
 
 		if controllerDeployment != nil {
 			// Add all fields that are relevant for the hash calculation as `ControllerDeployment`s don't have a `spec` field.
-			hashFields := map[string]interface{}{
+			hashFields := map[string]any{
 				"type":           controllerDeployment.Type,
 				"providerConfig": controllerDeployment.ProviderConfig,
 			}
@@ -532,8 +532,8 @@ func deleteUnneededInstallations(
 	return nil
 }
 
-func convertObjToMap(in interface{}) (map[string]interface{}, error) {
-	var out map[string]interface{}
+func convertObjToMap(in any) (map[string]any, error) {
+	var out map[string]any
 
 	data, err := json.Marshal(in)
 	if err != nil {

--- a/pkg/controllermanager/controller/managedseedset/actuator.go
+++ b/pkg/controllermanager/controller/managedseedset/actuator.go
@@ -342,11 +342,11 @@ func (a *actuator) deleteReplica(
 	return nil
 }
 
-func (a *actuator) infoEventf(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, reason, fmt string, args ...interface{}) {
+func (a *actuator) infoEventf(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, reason, fmt string, args ...any) {
 	a.recorder.Eventf(managedSeedSet, corev1.EventTypeNormal, reason, fmt, args...)
 }
 
-func (a *actuator) errorEventf(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, reason, fmt string, args ...interface{}) {
+func (a *actuator) errorEventf(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, reason, fmt string, args ...any) {
 	a.recorder.Eventf(managedSeedSet, corev1.EventTypeWarning, reason, fmt, args...)
 }
 

--- a/pkg/controllermanager/controller/managedseedset/actuator_test.go
+++ b/pkg/controllermanager/controller/managedseedset/actuator_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Actuator", func() {
 
 	Context("not scaling in or out", func() {
 		DescribeTable("#Reconcile",
-			func(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, setupReplicas func(), status *seedmanagementv1alpha1.ManagedSeedSetStatus, reason, fmt string, args ...interface{}) {
+			func(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, setupReplicas func(), status *seedmanagementv1alpha1.ManagedSeedSetStatus, reason, fmt string, args ...any) {
 				setupReplicas()
 				rg.EXPECT().GetReplicas(ctx, managedSeedSet).Return([]Replica{r0}, nil)
 
@@ -273,7 +273,7 @@ var _ = Describe("Actuator", func() {
 
 	Context("scaling out", func() {
 		DescribeTable("#Reconcile",
-			func(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, setupReplicas func(), status *seedmanagementv1alpha1.ManagedSeedSetStatus, reason, fmt string, args ...interface{}) {
+			func(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, setupReplicas func(), status *seedmanagementv1alpha1.ManagedSeedSetStatus, reason, fmt string, args ...any) {
 				setupReplicas()
 				rg.EXPECT().GetReplicas(ctx, managedSeedSet).Return([]Replica{r0}, nil)
 				recorder.EXPECT().Eventf(managedSeedSet, corev1.EventTypeNormal, reason, fmt, args)
@@ -404,7 +404,7 @@ var _ = Describe("Actuator", func() {
 
 	Context("scaling in", func() {
 		DescribeTable("#Reconcile",
-			func(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, setupReplicas func(), status *seedmanagementv1alpha1.ManagedSeedSetStatus, success bool, reason, fmt string, args ...interface{}) {
+			func(managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet, setupReplicas func(), status *seedmanagementv1alpha1.ManagedSeedSetStatus, success bool, reason, fmt string, args ...any) {
 				setupReplicas()
 				rg.EXPECT().GetReplicas(ctx, managedSeedSet).Return([]Replica{r0}, nil)
 				if success {

--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -127,7 +127,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, nil
 	}
 
-	var gardenletOfflineSince interface{} = "Unknown"
+	var gardenletOfflineSince any = "Unknown"
 	if conditionGardenletReady != nil {
 		gardenletOfflineSince = conditionGardenletReady.LastTransitionTime.UTC()
 	}

--- a/pkg/controllerutils/associations.go
+++ b/pkg/controllerutils/associations.go
@@ -19,7 +19,7 @@ import (
 
 // DetermineShootsAssociatedTo gets a <shootLister> to determine the Shoots resources which are associated
 // to given <obj> (either a CloudProfile, Seed, Secretbinding a or a ExposureClass object).
-func DetermineShootsAssociatedTo(ctx context.Context, gardenClient client.Reader, obj interface{}) ([]string, error) {
+func DetermineShootsAssociatedTo(ctx context.Context, gardenClient client.Reader, obj any) ([]string, error) {
 	shootList := &gardencorev1beta1.ShootList{}
 	if err := gardenClient.List(ctx, shootList); err != nil {
 		return nil, err

--- a/pkg/gardenlet/bootstrap/bootstrap_test.go
+++ b/pkg/gardenlet/bootstrap/bootstrap_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Bootstrap", func() {
 		})
 
 		It("should not return an error", func() {
-			defer test.WithVar(&certificate.DigestedName, func(interface{}, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
+			defer test.WithVar(&certificate.DigestedName, func(any, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
 				return approvedCSR.Name, nil
 			})()
 
@@ -198,7 +198,7 @@ var _ = Describe("Bootstrap", func() {
 		})
 
 		It("should return an error - the CSR got denied", func() {
-			defer test.WithVar(&certificate.DigestedName, func(interface{}, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
+			defer test.WithVar(&certificate.DigestedName, func(any, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
 				return deniedCSR.Name, nil
 			})()
 
@@ -216,7 +216,7 @@ var _ = Describe("Bootstrap", func() {
 		})
 
 		It("should return an error - the CSR failed", func() {
-			defer test.WithVar(&certificate.DigestedName, func(interface{}, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
+			defer test.WithVar(&certificate.DigestedName, func(any, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
 				return failedCSR.Name, nil
 			})()
 

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Certificates", func() {
 		})
 
 		It("should not return an error", func() {
-			defer test.WithVar(&DigestedName, func(interface{}, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
+			defer test.WithVar(&DigestedName, func(any, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
 				return approvedCSR.Name, nil
 			})()
 
@@ -169,7 +169,7 @@ var _ = Describe("Certificates", func() {
 		})
 
 		It("should return an error - CSR is denied", func() {
-			defer test.WithVar(&DigestedName, func(interface{}, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
+			defer test.WithVar(&DigestedName, func(any, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
 				return deniedCSR.Name, nil
 			})()
 
@@ -184,7 +184,7 @@ var _ = Describe("Certificates", func() {
 		})
 
 		It("should return an error - CSR is failed", func() {
-			defer test.WithVar(&DigestedName, func(interface{}, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
+			defer test.WithVar(&DigestedName, func(any, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
 				return failedCSR.Name, nil
 			})()
 
@@ -199,7 +199,7 @@ var _ = Describe("Certificates", func() {
 		})
 
 		It("should return an error - the CN of the x509 cert to be rotated is not set", func() {
-			defer test.WithVar(&DigestedName, func(interface{}, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
+			defer test.WithVar(&DigestedName, func(any, *pkix.Name, []certificatesv1.KeyUsage) (string, error) {
 				return deniedCSR.Name, nil
 			})()
 

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -152,7 +152,7 @@ func CreateGardenletKubeconfigWithToken(config *rest.Config, token string) ([]by
 // regenerate every loop and we include usages which are not contained in the
 // CSR. This needs to be kept up to date as we add new fields to the node
 // certificates and with ensureCompatible.
-func DigestedName(publicKey interface{}, subject *pkix.Name, usages []certificatesv1.KeyUsage) (string, error) {
+func DigestedName(publicKey any, subject *pkix.Name, usages []certificatesv1.KeyUsage) (string, error) {
 	hash := sha512.New512_256()
 
 	// Here we make sure two different inputs can't write the same stream

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -154,7 +154,7 @@ func (r *Reconciler) reconcile(
 		// chart is a Helm chart tarball.
 		Chart []byte `json:"chart,omitempty"`
 		// Values is a map of values for the given chart.
-		Values map[string]interface{} `json:"values,omitempty"`
+		Values map[string]any `json:"values,omitempty"`
 	}
 
 	if err := json.Unmarshal(providerConfig.Raw, &helmDeployment); err != nil {
@@ -212,14 +212,14 @@ func (r *Reconciler) reconcile(
 	}
 
 	// Mix-in some standard values for garden and seed.
-	gardenerValues := map[string]interface{}{
-		"gardener": map[string]interface{}{
+	gardenerValues := map[string]any{
+		"gardener": map[string]any{
 			"version": r.Identity.Version,
-			"garden": map[string]interface{}{
+			"garden": map[string]any{
 				"clusterIdentity":             r.GardenClusterIdentity,
 				"genericKubeconfigSecretName": genericGardenKubeconfigSecretName,
 			},
-			"seed": map[string]interface{}{
+			"seed": map[string]any{
 				"name":            seed.Name,
 				"clusterIdentity": *seed.Status.ClusterIdentity,
 				"annotations":     seed.Annotations,
@@ -236,7 +236,7 @@ func (r *Reconciler) reconcile(
 				"blockCIDRs":      seed.Spec.Networks.BlockCIDRs,
 				"spec":            seed.Spec,
 			},
-			"gardenlet": map[string]interface{}{
+			"gardenlet": map[string]any{
 				"featureGates": featureToEnabled,
 			},
 		},

--- a/pkg/gardenlet/controller/managedseed/actuator.go
+++ b/pkg/gardenlet/controller/managedseed/actuator.go
@@ -583,7 +583,7 @@ func (a *actuator) prepareGardenletChartValues(
 	bootstrap seedmanagementv1alpha1.Bootstrap,
 	mergeWithParent bool,
 	shoot *gardencorev1beta1.Shoot,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	// Merge gardenlet deployment with parent values
 	deployment, err := a.vp.MergeGardenletDeployment(managedSeed.Spec.Gardenlet.Deployment, shoot)
 	if err != nil {

--- a/pkg/gardenlet/controller/managedseed/actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/actuator_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Actuator", func() {
 
 		mergedDeployment      *seedmanagementv1alpha1.GardenletDeployment
 		mergedGardenletConfig *gardenletv1alpha1.GardenletConfiguration
-		gardenletChartValues  map[string]interface{}
+		gardenletChartValues  map[string]any
 	)
 
 	BeforeEach(func() {
@@ -436,10 +436,10 @@ var _ = Describe("Actuator", func() {
 		}
 
 		expectGetGardenletChartValues = func(withBootstrap bool) {
-			gardenletChartValues = map[string]interface{}{"foo": "bar"}
+			gardenletChartValues = map[string]any{"foo": "bar"}
 
 			vh.EXPECT().GetGardenletChartValues(mergedDeployment, gomock.AssignableToTypeOf(&gardenletv1alpha1.GardenletConfiguration{}), gomock.AssignableToTypeOf("")).DoAndReturn(
-				func(_ *seedmanagementv1alpha1.GardenletDeployment, gc *gardenletv1alpha1.GardenletConfiguration, _ string) (map[string]interface{}, error) {
+				func(_ *seedmanagementv1alpha1.GardenletDeployment, gc *gardenletv1alpha1.GardenletConfiguration, _ string) (map[string]any, error) {
 					if withBootstrap {
 						Expect(gc.GardenClientConnection.Kubeconfig).To(Equal(""))
 						Expect(gc.GardenClientConnection.KubeconfigSecret).To(Equal(&corev1.SecretReference{

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart.go
@@ -15,11 +15,11 @@ import (
 
 type gardenlet struct {
 	kubernetes.ChartApplier
-	values map[string]interface{}
+	values map[string]any
 }
 
 // NewGardenletChartApplier can be used to deploy the Gardenlet chart.
-func NewGardenletChartApplier(applier kubernetes.ChartApplier, values map[string]interface{}) component.Deployer {
+func NewGardenletChartApplier(applier kubernetes.ChartApplier, values map[string]any) component.Deployer {
 	return &gardenlet{
 		ChartApplier: applier,
 		values:       values,

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -123,9 +123,9 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 
 			mockChartApplier := mock.NewMockChartApplier(ctrl)
 
-			mockChartApplier.EXPECT().DeleteFromEmbeddedFS(ctx, charts.ChartGardenlet, charts.ChartPathGardenlet, "garden", "gardenlet", kubernetes.Values(map[string]interface{}{}))
+			mockChartApplier.EXPECT().DeleteFromEmbeddedFS(ctx, charts.ChartGardenlet, charts.ChartPathGardenlet, "garden", "gardenlet", kubernetes.Values(map[string]any{}))
 
-			deployer = NewGardenletChartApplier(mockChartApplier, map[string]interface{}{})
+			deployer = NewGardenletChartApplier(mockChartApplier, map[string]any{})
 			Expect(deployer.Destroy(ctx)).ToNot(HaveOccurred(), "Destroy Gardenlet resources succeeds")
 		})
 	})
@@ -145,20 +145,20 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 			cmAndSecretNameToUniqueName map[string]string,
 			k8sGreaterEqual126 bool,
 		) {
-			gardenletValues := map[string]interface{}{
+			gardenletValues := map[string]any{
 				"enabled": true,
 			}
 
-			componentConfigValues := map[string]interface{}{}
+			componentConfigValues := map[string]any{}
 
 			if gardenClientConnectionKubeconfig != nil {
-				componentConfigValues["gardenClientConnection"] = map[string]interface{}{
+				componentConfigValues["gardenClientConnection"] = map[string]any{
 					"kubeconfig": *gardenClientConnectionKubeconfig,
 				}
 			}
 
 			if seedClientConnectionKubeconfig != nil {
-				componentConfigValues["seedClientConnection"] = map[string]interface{}{
+				componentConfigValues["seedClientConnection"] = map[string]any{
 					"kubeconfig": *seedClientConnectionKubeconfig,
 				}
 			}
@@ -166,13 +166,13 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 			// bootstrap configurations are tested in one test-case
 			usesTLSBootstrapping := bootstrapKubeconfigContent != nil && bootstrapKubeconfig != nil && bootstrapKubeconfigSecret != nil
 			if usesTLSBootstrapping {
-				componentConfigValues["gardenClientConnection"] = map[string]interface{}{
-					"bootstrapKubeconfig": map[string]interface{}{
+				componentConfigValues["gardenClientConnection"] = map[string]any{
+					"bootstrapKubeconfig": map[string]any{
 						"name":       bootstrapKubeconfig.Name,
 						"namespace":  bootstrapKubeconfig.Namespace,
 						"kubeconfig": *bootstrapKubeconfigContent,
 					},
-					"kubeconfigSecret": map[string]interface{}{
+					"kubeconfigSecret": map[string]any{
 						"name":      bootstrapKubeconfigSecret.Name,
 						"namespace": bootstrapKubeconfigSecret.Namespace,
 					},

--- a/pkg/gardenlet/controller/managedseed/valueshelper.go
+++ b/pkg/gardenlet/controller/managedseed/valueshelper.go
@@ -30,7 +30,7 @@ type ValuesHelper interface {
 	// MergeGardenletConfiguration merges the given GardenletConfiguration with the parent GardenletConfiguration.
 	MergeGardenletConfiguration(config *gardenletv1alpha1.GardenletConfiguration) (*gardenletv1alpha1.GardenletConfiguration, error)
 	// GetGardenletChartValues computes the values to be used when applying the gardenlet chart.
-	GetGardenletChartValues(*seedmanagementv1alpha1.GardenletDeployment, *gardenletv1alpha1.GardenletConfiguration, string) (map[string]interface{}, error)
+	GetGardenletChartValues(*seedmanagementv1alpha1.GardenletDeployment, *gardenletv1alpha1.GardenletConfiguration, string) (map[string]any, error)
 }
 
 // valuesHelper is a concrete implementation of ValuesHelper
@@ -124,7 +124,7 @@ func (vp *valuesHelper) GetGardenletChartValues(
 	deployment *seedmanagementv1alpha1.GardenletDeployment,
 	config *gardenletv1alpha1.GardenletConfiguration,
 	bootstrapKubeconfig string,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	var err error
 
 	// Get deployment values
@@ -150,7 +150,7 @@ func (vp *valuesHelper) GetGardenletChartValues(
 }
 
 // getGardenletDeploymentValues computes and returns the gardenlet deployment values from the given GardenletDeployment.
-func (vp *valuesHelper) getGardenletDeploymentValues(deployment *seedmanagementv1alpha1.GardenletDeployment) (map[string]interface{}, error) {
+func (vp *valuesHelper) getGardenletDeploymentValues(deployment *seedmanagementv1alpha1.GardenletDeployment) (map[string]any, error) {
 	// Convert deployment object to values
 	deploymentValues, err := utils.ToValuesMap(deployment)
 	if err != nil {
@@ -183,7 +183,7 @@ func (vp *valuesHelper) getGardenletDeploymentValues(deployment *seedmanagementv
 }
 
 // getGardenletConfigurationValues computes and returns the gardenlet configuration values from the given GardenletConfiguration.
-func (vp *valuesHelper) getGardenletConfigurationValues(config *gardenletv1alpha1.GardenletConfiguration, bootstrapKubeconfig string) (map[string]interface{}, error) {
+func (vp *valuesHelper) getGardenletConfigurationValues(config *gardenletv1alpha1.GardenletConfiguration, bootstrapKubeconfig string) (map[string]any, error) {
 	// Convert configuration object to values
 	configValues, err := utils.ToValuesMap(config)
 	if err != nil {

--- a/pkg/gardenlet/controller/managedseed/valueshelper_test.go
+++ b/pkg/gardenlet/controller/managedseed/valueshelper_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ValuesHelper", func() {
 		mergedDeployment      *seedmanagementv1alpha1.GardenletDeployment
 		mergedGardenletConfig func(bool) *gardenletv1alpha1.GardenletConfiguration
 
-		gardenletChartValues func(bool, string, int32, map[string]interface{}) map[string]interface{}
+		gardenletChartValues func(bool, string, int32, map[string]any) map[string]any
 	)
 
 	BeforeEach(func() {
@@ -213,58 +213,58 @@ var _ = Describe("ValuesHelper", func() {
 			}
 		}
 
-		gardenletChartValues = func(withBootstrap bool, bk string, replicaCount int32, additionalValues map[string]interface{}) map[string]interface{} {
+		gardenletChartValues = func(withBootstrap bool, bk string, replicaCount int32, additionalValues map[string]any) map[string]any {
 			var kubeconfig string
 			if !withBootstrap {
 				kubeconfig = "garden kubeconfig"
 			}
 
-			result := map[string]interface{}{
+			result := map[string]any{
 				"replicaCount":         float64(replicaCount),
 				"revisionHistoryLimit": float64(1),
-				"image": map[string]interface{}{
+				"image": map[string]any{
 					"repository": "europe-docker.pkg.dev/gardener-project/releases/gardener/gardenlet",
 					"tag":        "v0.0.0-master+$Format:%H$",
 					"pullPolicy": "IfNotPresent",
 				},
-				"podAnnotations": map[string]interface{}{
+				"podAnnotations": map[string]any{
 					"foo": "bar",
 				},
 				"vpa":                            true,
 				"imageVectorOverwrite":           "image vector overwrite",
 				"componentImageVectorOverwrites": "component image vector overwrites",
-				"config": map[string]interface{}{
+				"config": map[string]any{
 					"apiVersion": "gardenlet.config.gardener.cloud/v1alpha1",
 					"kind":       "GardenletConfiguration",
-					"gardenClientConnection": map[string]interface{}{
+					"gardenClientConnection": map[string]any{
 						"kubeconfig":         kubeconfig,
 						"acceptContentTypes": "application/json",
 						"contentType":        "application/json",
 						"qps":                float64(100),
 						"burst":              float64(130),
 					},
-					"seedClientConnection": map[string]interface{}{
+					"seedClientConnection": map[string]any{
 						"kubeconfig":         "",
 						"acceptContentTypes": "application/json",
 						"contentType":        "application/json",
 						"qps":                float64(100),
 						"burst":              float64(130),
 					},
-					"server": map[string]interface{}{
-						"healthProbes": map[string]interface{}{
+					"server": map[string]any{
+						"healthProbes": map[string]any{
 							"bindAddress": "0.0.0.0",
 							"port":        float64(2728),
 						},
-						"metrics": map[string]interface{}{
+						"metrics": map[string]any{
 							"bindAddress": "0.0.0.0",
 							"port":        float64(2729),
 						},
 					},
-					"featureGates": map[string]interface{}{
+					"featureGates": map[string]any{
 						"FooFeature": false,
 						"BarFeature": true,
 					},
-					"logging": map[string]interface{}{
+					"logging": map[string]any{
 						"enabled": true,
 					},
 					"logLevel":  "",
@@ -273,12 +273,12 @@ var _ = Describe("ValuesHelper", func() {
 			}
 
 			if withBootstrap {
-				bootstrapKubeconfig := map[string]interface{}{
+				bootstrapKubeconfig := map[string]any{
 					"name":       "gardenlet-kubeconfig-bootstrap",
 					"namespace":  v1beta1constants.GardenNamespace,
 					"kubeconfig": bk,
 				}
-				kubeconfigSecret := map[string]interface{}{
+				kubeconfigSecret := map[string]any{
 					"name":      "gardenlet-kubeconfig",
 					"namespace": v1beta1constants.GardenNamespace,
 				}

--- a/pkg/gardenlet/controller/seed/seed/nginxingress.go
+++ b/pkg/gardenlet/controller/seed/seed/nginxingress.go
@@ -69,13 +69,13 @@ func getDNSProviderSecretData(ctx context.Context, gardenClient client.Client, s
 
 func getConfig(seed *gardencorev1beta1.Seed) (map[string]string, error) {
 	var (
-		defaultConfig = map[string]interface{}{
+		defaultConfig = map[string]any{
 			"server-name-hash-bucket-size": "256",
 			"use-proxy-protocol":           "false",
 			"worker-processes":             "2",
 			"allow-snippet-annotations":    "true",
 		}
-		providerConfig = map[string]interface{}{}
+		providerConfig = map[string]any{}
 	)
 	if seed.Spec.Ingress != nil && seed.Spec.Ingress.Controller.ProviderConfig != nil {
 		if err := json.Unmarshal(seed.Spec.Ingress.Controller.ProviderConfig.Raw, &providerConfig); err != nil {

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -82,7 +82,7 @@ var _ = Describe("health check", func() {
 
 	Describe("#ComputeRequiredControlPlaneDeployments", func() {
 		var (
-			workerlessDepoymentNames = []interface{}{
+			workerlessDepoymentNames = []any{
 				"gardener-resource-manager",
 				"kube-apiserver",
 				"kube-controller-manager",
@@ -90,7 +90,7 @@ var _ = Describe("health check", func() {
 			commonDeploymentNames = append(workerlessDepoymentNames, "kube-scheduler", "machine-controller-manager")
 		)
 
-		tests := func(shoot *gardencorev1beta1.Shoot, names []interface{}, isWorkerless bool) {
+		tests := func(shoot *gardencorev1beta1.Shoot, names []any, isWorkerless bool) {
 			It("should return expected deployments for shoot", func() {
 				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shoot)
 

--- a/pkg/gardenlet/controller/shoot/care/webhook_remediation.go
+++ b/pkg/gardenlet/controller/shoot/care/webhook_remediation.go
@@ -276,7 +276,7 @@ func (r *remediator) failurePolicy() *admissionregistrationv1.FailurePolicyType 
 	return &ignore
 }
 
-func (r *remediator) reportf(fieldName string, messageFmt string, args ...interface{}) {
+func (r *remediator) reportf(fieldName string, messageFmt string, args ...any) {
 	r.log.Info("Remediating", "fieldName", fieldName)
 	*r.remediations = append(*r.remediations, fmt.Sprintf("%s of webhook %q was %s", fieldName, r.webhookName, fmt.Sprintf(messageFmt, args...)))
 }

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -574,7 +574,7 @@ type secretMatcher struct {
 	bootstrapKubeconfigName *string
 }
 
-func (m *secretMatcher) Matches(x interface{}) bool {
+func (m *secretMatcher) Matches(x any) bool {
 	req, ok := x.(resourcemanager.Secrets)
 	if !ok {
 		return false

--- a/pkg/gardenlet/operation/botanist/resources_test.go
+++ b/pkg/gardenlet/operation/botanist/resources_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Resources", func() {
 
 			var (
 				decoder    = yaml.NewYAMLOrJSONDecoder(bytes.NewReader(managedResourceSecret.Data["referenced-resources"]), 1024)
-				decodedObj map[string]interface{}
+				decodedObj map[string]any
 			)
 
 			var i = 0

--- a/pkg/gardenlet/operation/botanist/worker_test.go
+++ b/pkg/gardenlet/operation/botanist/worker_test.go
@@ -536,7 +536,7 @@ var _ = Describe("Worker", func() {
 	})
 })
 
-func clientGet(managedResource *resourcesv1alpha1.ManagedResource) interface{} {
+func clientGet(managedResource *resourcesv1alpha1.ManagedResource) any {
 	return func(_ context.Context, _ client.ObjectKey, mr *resourcesv1alpha1.ManagedResource, _ ...client.GetOption) error {
 		*mr = *managedResource
 		return nil

--- a/pkg/nodeagent/bootstrap/kubelet_data_volume.go
+++ b/pkg/nodeagent/bootstrap/kubelet_data_volume.go
@@ -37,7 +37,7 @@ func init() {
 func formatKubeletDataDevice(log logr.Logger, fs afero.Afero, kubeletDataVolumeSize int64) error {
 	log.Info("Rendering script")
 	var formatKubeletDataVolumeScript bytes.Buffer
-	if err := formatKubeletDataVolumeTpl.Execute(&formatKubeletDataVolumeScript, map[string]interface{}{"kubeletDataVolumeSize": kubeletDataVolumeSize}); err != nil {
+	if err := formatKubeletDataVolumeTpl.Execute(&formatKubeletDataVolumeScript, map[string]any{"kubeletDataVolumeSize": kubeletDataVolumeSize}); err != nil {
 		return fmt.Errorf("failed rendering script: %w", err)
 	}
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -890,14 +890,14 @@ func (r *Reconciler) newPlutono(secretsManager secretsmanager.Interface, ingress
 
 func getNginxIngressConfig(garden *operatorv1alpha1.Garden) (map[string]string, error) {
 	var (
-		defaultConfig = map[string]interface{}{
+		defaultConfig = map[string]any{
 			"enable-vts-status":            "false",
 			"server-name-hash-bucket-size": "256",
 			"use-proxy-protocol":           "false",
 			"worker-processes":             "2",
 			"allow-snippet-annotations":    "false",
 		}
-		providerConfig = map[string]interface{}{}
+		providerConfig = map[string]any{}
 	)
 
 	if garden.Spec.RuntimeCluster.Ingress.Controller.ProviderConfig != nil {

--- a/pkg/provider-local/controller/controlplane/valuesprovider.go
+++ b/pkg/provider-local/controller/controlplane/valuesprovider.go
@@ -102,6 +102,6 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 	_ *extensionscontroller.Cluster,
 	_ secretsmanager.Reader,
 	_ map[string]string,
-) (map[string]interface{}, error) {
-	return map[string]interface{}{}, nil
+) (map[string]any, error) {
+	return map[string]any{}, nil
 }

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -42,7 +42,7 @@ func merge(origin string, desired, current *unstructured.Unstructured, forceOver
 	// keep metadata information of old object to avoid unnecessary update calls
 	if oldMetadataInterface, ok := oldObject.Object["metadata"]; ok {
 		// cast to map to be able to check if metadata is empty
-		if oldMetadataMap, ok := oldMetadataInterface.(map[string]interface{}); ok {
+		if oldMetadataMap, ok := oldMetadataInterface.(map[string]any); ok {
 			if len(oldMetadataMap) > 0 {
 				newObject.Object["metadata"] = oldMetadataMap
 			}
@@ -81,10 +81,10 @@ func merge(origin string, desired, current *unstructured.Unstructured, forceOver
 	newObject.SetAnnotations(ann)
 
 	// keep status of old object if it is set and not empty
-	var oldStatus map[string]interface{}
+	var oldStatus map[string]any
 	if oldStatusInterface, containsStatus := oldObject.Object["status"]; containsStatus {
 		// cast to map to be able to check if status is empty
-		if oldStatusMap, ok := oldStatusInterface.(map[string]interface{}); ok {
+		if oldStatusMap, ok := oldStatusInterface.(map[string]any); ok {
 			oldStatus = oldStatusMap
 		}
 	}

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -192,10 +192,10 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should keep current .status if it is not empty", func() {
-			current.Object["status"] = map[string]interface{}{
+			current.Object["status"] = map[string]any{
 				"podIP": "1.1.1.1",
 			}
-			desired.Object["status"] = map[string]interface{}{
+			desired.Object["status"] = map[string]any{
 				"podIP": "2.2.2.2",
 			}
 
@@ -206,18 +206,18 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should discard .status if current .status is empty", func() {
-			desired.Object["status"] = map[string]interface{}{
+			desired.Object["status"] = map[string]any{
 				"podIP": "2.2.2.2",
 			}
 
-			current.Object["status"] = map[string]interface{}{}
+			current.Object["status"] = map[string]any{}
 
 			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(BeNil())
 		})
 
 		It("should discard .status if current .status is not set", func() {
-			desired.Object["status"] = map[string]interface{}{
+			desired.Object["status"] = map[string]any{
 				"podIP": "2.2.2.2",
 			}
 

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -178,7 +178,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 			value := secret.Data[secretKey]
 			var (
 				decoder    = yaml.NewYAMLOrJSONDecoder(bytes.NewReader(value), 1024)
-				decodedObj map[string]interface{}
+				decodedObj map[string]any
 			)
 
 			for indexInFile := 0; true; indexInFile++ {
@@ -952,9 +952,9 @@ func injectLabelsIntoVolumeClaimTemplate(obj *unstructured.Unstructured, labels 
 	}
 
 	for i, t := range volumeClaimTemplates {
-		template, ok := t.(map[string]interface{})
+		template, ok := t.(map[string]any)
 		if !ok {
-			return fmt.Errorf("failed to inject labels into .spec.volumeClaimTemplates[%d], is not a map[string]interface{}", i)
+			return fmt.Errorf("failed to inject labels into .spec.volumeClaimTemplates[%d], is not a map[string]any", i)
 		}
 
 		templateLabels, _, err := unstructured.NestedStringMap(template, "metadata", "labels")
@@ -970,12 +970,12 @@ func injectLabelsIntoVolumeClaimTemplate(obj *unstructured.Unstructured, labels 
 	return unstructured.SetNestedSlice(obj.Object, volumeClaimTemplates, "spec", "volumeClaimTemplates")
 }
 
-func mergeLabels(existingLabels, newLabels map[string]string) map[string]interface{} {
+func mergeLabels(existingLabels, newLabels map[string]string) map[string]any {
 	if existingLabels == nil {
 		return stringMapToInterfaceMap(newLabels)
 	}
 
-	labels := make(map[string]interface{}, len(existingLabels)+len(newLabels))
+	labels := make(map[string]any, len(existingLabels)+len(newLabels))
 	for k, v := range existingLabels {
 		labels[k] = v
 	}
@@ -985,8 +985,8 @@ func mergeLabels(existingLabels, newLabels map[string]string) map[string]interfa
 	return labels
 }
 
-func stringMapToInterfaceMap(in map[string]string) map[string]interface{} {
-	m := make(map[string]interface{}, len(in))
+func stringMapToInterfaceMap(in map[string]string) map[string]any {
+	m := make(map[string]any, len(in))
 	for k, v := range in {
 		m[k] = v
 	}

--- a/pkg/resourcemanager/controller/managedresource/reconciler_test.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Controller", func() {
 		)
 
 		BeforeEach(func() {
-			obj = &unstructured.Unstructured{Object: map[string]interface{}{}}
+			obj = &unstructured.Unstructured{Object: map[string]any{}}
 			expected = obj.DeepCopy()
 		})
 
@@ -50,12 +50,12 @@ var _ = Describe("Controller", func() {
 			}
 
 			// add .spec.template to object
-			Expect(unstructured.SetNestedMap(obj.Object, map[string]interface{}{
-				"template": map[string]interface{}{},
+			Expect(unstructured.SetNestedMap(obj.Object, map[string]any{
+				"template": map[string]any{},
 			}, "spec")).To(Succeed())
 
 			expected = obj.DeepCopy()
-			Expect(unstructured.SetNestedMap(expected.Object, map[string]interface{}{
+			Expect(unstructured.SetNestedMap(expected.Object, map[string]any{
 				"inject": "me",
 			}, "spec", "template", "metadata", "labels")).To(Succeed())
 			expected.SetLabels(labels)
@@ -70,10 +70,10 @@ var _ = Describe("Controller", func() {
 			}
 
 			// add .spec.volumeClaimTemplates to object
-			Expect(unstructured.SetNestedMap(obj.Object, map[string]interface{}{
-				"volumeClaimTemplates": []interface{}{
-					map[string]interface{}{
-						"metadata": map[string]interface{}{
+			Expect(unstructured.SetNestedMap(obj.Object, map[string]any{
+				"volumeClaimTemplates": []any{
+					map[string]any{
+						"metadata": map[string]any{
 							"name": "volume-claim-name",
 						},
 					},
@@ -81,12 +81,12 @@ var _ = Describe("Controller", func() {
 			}, "spec")).To(Succeed())
 
 			expected = obj.DeepCopy()
-			Expect(unstructured.SetNestedMap(expected.Object, map[string]interface{}{
-				"volumeClaimTemplates": []interface{}{
-					map[string]interface{}{
-						"metadata": map[string]interface{}{
+			Expect(unstructured.SetNestedMap(expected.Object, map[string]any{
+				"volumeClaimTemplates": []any{
+					map[string]any{
+						"metadata": map[string]any{
 							"name": "volume-claim-name",
-							"labels": map[string]interface{}{
+							"labels": map[string]any{
 								"inject": "me",
 							},
 						},

--- a/pkg/resourcemanager/controller/managedresource/sort_test.go
+++ b/pkg/resourcemanager/controller/managedresource/sort_test.go
@@ -106,10 +106,10 @@ var _ = Describe("Sorter", func() {
 				objBase = []object{
 					{
 						obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
+							Object: map[string]any{
 								"apiVersion": "v1",
 								"kind":       "ConfigMap",
-								"metadata": map[string]interface{}{
+								"metadata": map[string]any{
 									"name":      "foo",
 									"namespace": "bar",
 								},
@@ -118,10 +118,10 @@ var _ = Describe("Sorter", func() {
 					},
 					{
 						obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
+							Object: map[string]any{
 								"apiVersion": "apps/v1",
 								"kind":       "Deployment",
-								"metadata": map[string]interface{}{
+								"metadata": map[string]any{
 									"name":      "nginx",
 									"namespace": "web",
 								},
@@ -152,10 +152,10 @@ var _ = Describe("Sorter", func() {
 				objBase = []object{
 					{
 						obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
+							Object: map[string]any{
 								"apiVersion": "v1",
 								"kind":       "ConfigMap",
-								"metadata": map[string]interface{}{
+								"metadata": map[string]any{
 									"name":      "foo",
 									"namespace": "bar",
 								},
@@ -164,10 +164,10 @@ var _ = Describe("Sorter", func() {
 					},
 					{
 						obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
+							Object: map[string]any{
 								"apiVersion": "v1",
 								"kind":       "ConfigMap",
-								"metadata": map[string]interface{}{
+								"metadata": map[string]any{
 									"name":      "foo1",
 									"namespace": "bar",
 								},

--- a/pkg/resourcemanager/webhook/crddeletionprotection/handler_test.go
+++ b/pkg/resourcemanager/webhook/crddeletionprotection/handler_test.go
@@ -322,18 +322,18 @@ var _ = Describe("handler", func() {
 	})
 })
 
-func expectAllowed(response admission.Response, reason gomegatypes.GomegaMatcher, optionalDescription ...interface{}) {
+func expectAllowed(response admission.Response, reason gomegatypes.GomegaMatcher, optionalDescription ...any) {
 	Expect(response.Allowed).To(BeTrue(), optionalDescription...)
 	Expect(response.Result.Message).To(reason, optionalDescription...)
 }
 
-func expectDenied(response admission.Response, reason gomegatypes.GomegaMatcher, optionalDescription ...interface{}) {
+func expectDenied(response admission.Response, reason gomegatypes.GomegaMatcher, optionalDescription ...any) {
 	Expect(response.Allowed).To(BeFalse(), optionalDescription...)
 	Expect(response.Result.Code).To(BeEquivalentTo(http.StatusForbidden), optionalDescription...)
 	Expect(response.Result.Message).To(reason, optionalDescription...)
 }
 
-func expectErrored(response admission.Response, code, err gomegatypes.GomegaMatcher, optionalDescription ...interface{}) {
+func expectErrored(response admission.Response, code, err gomegatypes.GomegaMatcher, optionalDescription ...any) {
 	Expect(response.Allowed).To(BeFalse(), optionalDescription...)
 	Expect(response.Result.Code).To(code, optionalDescription...)
 	Expect(response.Result.Message).To(err, optionalDescription...)

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -108,7 +108,7 @@ func (r *Reconciler) reportFailedScheduling(ctx context.Context, log logr.Logger
 	}
 }
 
-func (r *Reconciler) reportEvent(shoot *gardencorev1beta1.Shoot, eventType string, eventReason, messageFmt string, args ...interface{}) {
+func (r *Reconciler) reportEvent(shoot *gardencorev1beta1.Shoot, eventType string, eventReason, messageFmt string, args ...any) {
 	r.Recorder.Eventf(shoot, eventType, eventReason, messageFmt, args...)
 }
 

--- a/pkg/utils/chart/chart.go
+++ b/pkg/utils/chart/chart.go
@@ -22,10 +22,10 @@ import (
 type Interface interface {
 	// Apply applies this chart in the given namespace using the given ChartApplier. Before applying the chart,
 	// it collects its values, injecting images and merging the given values as needed.
-	Apply(context.Context, kubernetesclient.ChartApplier, string, imagevector.ImageVector, string, string, map[string]interface{}) error
+	Apply(context.Context, kubernetesclient.ChartApplier, string, imagevector.ImageVector, string, string, map[string]any) error
 	// Render renders this chart in the given namespace using the given chartRenderer. Before rendering the chart,
 	// it collects its values, injecting images and merging the given values as needed.
-	Render(chartrenderer.Interface, string, imagevector.ImageVector, string, string, map[string]interface{}) (string, []byte, error)
+	Render(chartrenderer.Interface, string, imagevector.ImageVector, string, string, map[string]any) (string, []byte, error)
 	// Delete deletes this chart's objects from the given namespace.
 	Delete(context.Context, client.Client, string) error
 }
@@ -54,7 +54,7 @@ func (c *Chart) Apply(
 	namespace string,
 	imageVector imagevector.ImageVector,
 	runtimeVersion, targetVersion string,
-	additionalValues map[string]interface{},
+	additionalValues map[string]any,
 ) error {
 	// Get values with injected images
 	values, err := c.injectImages(imageVector, runtimeVersion, targetVersion)
@@ -77,7 +77,7 @@ func (c *Chart) Render(
 	namespace string,
 	imageVector imagevector.ImageVector,
 	runtimeVersion, targetVersion string,
-	additionalValues map[string]interface{},
+	additionalValues map[string]any,
 ) (
 	string,
 	[]byte,
@@ -104,11 +104,11 @@ func (c *Chart) injectImages(
 	imageVector imagevector.ImageVector,
 	runtimeVersion, targetVersion string,
 ) (
-	map[string]interface{},
+	map[string]any,
 	error,
 ) {
 	// Inject images
-	values := make(map[string]interface{})
+	values := make(map[string]any)
 	var err error
 	if len(c.Images) > 0 {
 		values, err = InjectImages(values, imageVector, c.Images, imagevector.RuntimeVersion(runtimeVersion), imagevector.TargetVersion(targetVersion))
@@ -170,7 +170,7 @@ func objectKey(namespace, name string) client.ObjectKey {
 
 // InjectImages finds the images with the given names and opts, makes a shallow copy of the given
 // Values and injects a name to image string mapping at the `images` key of that map and returns it.
-func InjectImages(values map[string]interface{}, v imagevector.ImageVector, names []string, opts ...imagevector.FindOptionFunc) (map[string]interface{}, error) {
+func InjectImages(values map[string]any, v imagevector.ImageVector, names []string, opts ...imagevector.FindOptionFunc) (map[string]any, error) {
 	images, err := imagevector.FindImages(v, names, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/chart/chart_test.go
+++ b/pkg/utils/chart/chart_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Chart", func() {
 	Describe("#InjectImages", func() {
 		It("should find the images and inject the image as value map at the 'images' key into a shallow copy", func() {
 			var (
-				values map[string]interface{}
+				values map[string]any
 				img1   = &imagevector.ImageSource{
 					Name:       "img1",
 					Repository: "repo1",
@@ -37,8 +37,8 @@ var _ = Describe("Chart", func() {
 
 			injected, err := InjectImages(values, v, []string{img1.Name, img2.Name})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(injected).To(Equal(map[string]interface{}{
-				"images": map[string]interface{}{
+			Expect(injected).To(Equal(map[string]any{
+				"images": map[string]any{
 					img1.Name: img1.ToImage(nil).String(),
 					img2.Name: img2.ToImage(nil).String(),
 				},

--- a/pkg/utils/checksums.go
+++ b/pkg/utils/checksums.go
@@ -42,7 +42,7 @@ func ComputeConfigMapChecksum(data map[string]string) string {
 }
 
 // ComputeChecksum computes a SHA256 checksum for the given data.
-func ComputeChecksum(data interface{}) string {
+func ComputeChecksum(data any) string {
 	jsonString, err := json.Marshal(data)
 	if err != nil {
 		return ""

--- a/pkg/utils/encoding.go
+++ b/pkg/utils/encoding.go
@@ -142,8 +142,8 @@ func ComputeSHA256Hex(in []byte) string {
 	return hex.EncodeToString(SHA256(in))
 }
 
-// HashForMap creates a hash value for a map of type map[string]interface{} and returns it.
-func HashForMap(m map[string]interface{}) string {
+// HashForMap creates a hash value for a map of type map[string]any and returns it.
+func HashForMap(m map[string]any) string {
 	var hash string
 	keys := make([]string, 0, len(m))
 
@@ -165,9 +165,9 @@ func HashForMap(m map[string]interface{}) string {
 			for _, val := range v {
 				hash += ComputeSHA256Hex([]byte(val))
 			}
-		case map[string]interface{}:
+		case map[string]any:
 			hash += HashForMap(v)
-		case []map[string]interface{}:
+		case []map[string]any:
 			for _, val := range v {
 				hash += HashForMap(val)
 			}

--- a/pkg/utils/imagevector/imagevector.go
+++ b/pkg/utils/imagevector/imagevector.go
@@ -404,8 +404,8 @@ func (i *Image) String() string {
 }
 
 // ImageMapToValues transforms the given image name to image mapping into chart Values.
-func ImageMapToValues(m map[string]*Image) map[string]interface{} {
-	out := make(map[string]interface{}, len(m))
+func ImageMapToValues(m map[string]*Image) map[string]any {
+	out := make(map[string]any, len(m))
 	for k, v := range m {
 		out[k] = v.String()
 	}

--- a/pkg/utils/imagevector/imagevector_test.go
+++ b/pkg/utils/imagevector/imagevector_test.go
@@ -736,7 +736,7 @@ images:
 				}
 			)
 
-			Expect(ImageMapToValues(imageMap)).To(Equal(map[string]interface{}{
+			Expect(ImageMapToValues(imageMap)).To(Equal(map[string]any{
 				image1Key: image1Name + ":" + image1Tag,
 				image2Key: image2Repository,
 			}))

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -807,11 +807,11 @@ var _ = Describe("kubernetes", func() {
 				podTemplatehashKey: rs3PodTemplateHash,
 			}
 
-			rsListOptions = []interface{}{
+			rsListOptions = []any{
 				client.InNamespace(namespace),
 				client.MatchingLabels(labels),
 			}
-			podListOptions []interface{}
+			podListOptions []any
 
 			deployment = &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/kubernetes/unstructured/object_test.go
+++ b/pkg/utils/kubernetes/unstructured/object_test.go
@@ -14,19 +14,19 @@ import (
 var _ = Describe("Object", func() {
 	Describe("#FilterMetadata", func() {
 		It("should remove the fields", func() {
-			content := map[string]interface{}{
+			content := map[string]any{
 				"foo": "",
 				"bar": "",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"foo": "",
 					"bar": "",
 				},
 			}
 
-			Expect(FilterMetadata(content, "foo", "bar")).To(Equal(map[string]interface{}{
+			Expect(FilterMetadata(content, "foo", "bar")).To(Equal(map[string]any{
 				"foo":      "",
 				"bar":      "",
-				"metadata": map[string]interface{}{},
+				"metadata": map[string]any{},
 			}))
 		})
 	})

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -387,7 +387,7 @@ func SetKeepObjects(ctx context.Context, c client.Writer, namespace, name string
 
 // RenderChartAndCreate renders a chart and creates a ManagedResource for the gardener-resource-manager
 // out of the results.
-func RenderChartAndCreate(ctx context.Context, namespace string, name string, secretNameWithPrefix bool, client client.Client, chartRenderer chartrenderer.Interface, chart chart.Interface, values map[string]interface{}, imageVector imagevector.ImageVector, chartNamespace string, version string, withNoCleanupLabel bool, forceOverwriteAnnotations bool) error {
+func RenderChartAndCreate(ctx context.Context, namespace string, name string, secretNameWithPrefix bool, client client.Client, chartRenderer chartrenderer.Interface, chart chart.Interface, values map[string]any, imageVector imagevector.ImageVector, chartNamespace string, version string, withNoCleanupLabel bool, forceOverwriteAnnotations bool) error {
 	chartName, data, err := chart.Render(chartRenderer, chartNamespace, imageVector, version, version, values)
 	if err != nil {
 		return fmt.Errorf("could not render chart: %w", err)

--- a/pkg/utils/managedresources/registry.go
+++ b/pkg/utils/managedresources/registry.go
@@ -105,7 +105,7 @@ func (r *Registry) Add(objs ...client.Object) error {
 		// or the issue is resolved upstream in yaml.v2
 		// Please see https://github.com/go-yaml/yaml/pull/736
 		if r.isYAMLSerializer {
-			var anyObj interface{}
+			var anyObj any
 			if err := forkedyaml.Unmarshal(serializationYAML, &anyObj); err != nil {
 				return err
 			}

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -18,17 +18,17 @@ import (
 
 // MergeMaps takes two maps <a>, <b> and merges them. If <b> defines a value with a key
 // already existing in the <a> map, the <a> value for that key will be overwritten.
-func MergeMaps(a, b map[string]interface{}) map[string]interface{} {
-	var values = make(map[string]interface{}, len(b))
+func MergeMaps(a, b map[string]any) map[string]any {
+	var values = make(map[string]any, len(b))
 
 	for i, v := range b {
 		existing, ok := a[i]
 		values[i] = v
 
 		switch elem := v.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			if ok {
-				if extMap, ok := existing.(map[string]interface{}); ok {
+				if extMap, ok := existing.(map[string]any); ok {
 					values[i] = MergeMaps(extMap, elem)
 				}
 			}
@@ -119,8 +119,8 @@ func Indent(str string, spaces int) string {
 }
 
 // ShallowCopyMapStringInterface creates a shallow copy of the given map.
-func ShallowCopyMapStringInterface(values map[string]interface{}) map[string]interface{} {
-	copiedValues := make(map[string]interface{}, len(values))
+func ShallowCopyMapStringInterface(values map[string]any) map[string]any {
+	copiedValues := make(map[string]any, len(values))
 	for k, v := range values {
 		copiedValues[k] = v
 	}
@@ -136,8 +136,8 @@ func IifString(condition bool, onTrue, onFalse string) string {
 	return onFalse
 }
 
-// InterfaceMapToStringMap translates map[string]interface{} to map[string]string.
-func InterfaceMapToStringMap(in map[string]interface{}) map[string]string {
+// InterfaceMapToStringMap translates map[string]any to map[string]string.
+func InterfaceMapToStringMap(in map[string]any) map[string]string {
 	m := make(map[string]string, len(in))
 	for k, v := range in {
 		m[k] = fmt.Sprint(v)

--- a/pkg/utils/miscellaneous_test.go
+++ b/pkg/utils/miscellaneous_test.go
@@ -96,7 +96,7 @@ baz`, spaces)).To(Equal(`foo
 
 	Describe("#ShallowCopyMapStringInterface", func() {
 		It("should create a shallow copy of the map", func() {
-			v := map[string]interface{}{"foo": nil, "bar": map[string]interface{}{"baz": nil}}
+			v := map[string]any{"foo": nil, "bar": map[string]any{"baz": nil}}
 
 			c := ShallowCopyMapStringInterface(v)
 
@@ -105,8 +105,8 @@ baz`, spaces)).To(Equal(`foo
 			c["foo"] = 1
 			Expect(v["foo"]).To(BeNil())
 
-			c["bar"].(map[string]interface{})["baz"] = "bang"
-			Expect(v["bar"].(map[string]interface{})["baz"]).To(Equal("bang"))
+			c["bar"].(map[string]any)["baz"] = "bang"
+			Expect(v["bar"].(map[string]any)["baz"]).To(Equal("bang"))
 		})
 	})
 
@@ -119,7 +119,7 @@ baz`, spaces)).To(Equal(`foo
 	)
 
 	Describe("#InterfaceMapToStringMap", func() {
-		input := map[string]interface{}{
+		input := map[string]any{
 			"foo":   nil,
 			"age":   32,
 			"alive": true,

--- a/pkg/utils/test/gomock.go
+++ b/pkg/utils/test/gomock.go
@@ -21,7 +21,7 @@ type objectKeyMatcher struct {
 	key client.ObjectKey
 }
 
-func (o *objectKeyMatcher) Matches(actual interface{}) bool {
+func (o *objectKeyMatcher) Matches(actual any) bool {
 	if actual == nil {
 		return false
 	}

--- a/pkg/utils/test/matchers/deep.go
+++ b/pkg/utils/test/matchers/deep.go
@@ -21,11 +21,11 @@ This is to avoid mistakes where both sides of an assertion are erroneously unini
 
 type deepMatcher struct {
 	name      string
-	expected  interface{}
-	compareFn func(a1, a2 interface{}) bool
+	expected  any
+	compareFn func(a1, a2 any) bool
 }
 
-func newDeepDerivativeMatcher(expected interface{}) gomegatypes.GomegaMatcher {
+func newDeepDerivativeMatcher(expected any) gomegatypes.GomegaMatcher {
 	return &deepMatcher{
 		name:      "deep derivative equal",
 		expected:  expected,
@@ -33,7 +33,7 @@ func newDeepDerivativeMatcher(expected interface{}) gomegatypes.GomegaMatcher {
 	}
 }
 
-func newDeepEqualMatcher(expected interface{}) gomegatypes.GomegaMatcher {
+func newDeepEqualMatcher(expected any) gomegatypes.GomegaMatcher {
 	return &deepMatcher{
 		name:      "deep equal",
 		expected:  expected,
@@ -41,7 +41,7 @@ func newDeepEqualMatcher(expected interface{}) gomegatypes.GomegaMatcher {
 	}
 }
 
-func (m *deepMatcher) Match(actual interface{}) (success bool, err error) {
+func (m *deepMatcher) Match(actual any) (success bool, err error) {
 	if actual == nil && m.expected == nil {
 		return false, errors.New(deepMatcherNilError)
 	}
@@ -49,15 +49,15 @@ func (m *deepMatcher) Match(actual interface{}) (success bool, err error) {
 	return m.compareFn(m.expected, actual), nil
 }
 
-func (m *deepMatcher) FailureMessage(actual interface{}) (message string) {
+func (m *deepMatcher) FailureMessage(actual any) (message string) {
 	return m.failureMessage(actual, "to")
 }
 
-func (m *deepMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (m *deepMatcher) NegatedFailureMessage(actual any) (message string) {
 	return m.failureMessage(actual, "not to")
 }
 
-func (m *deepMatcher) failureMessage(actual interface{}, messagePrefix string) (message string) {
+func (m *deepMatcher) failureMessage(actual any, messagePrefix string) (message string) {
 	var (
 		actualYAML, actualErr     = yaml.Marshal(actual)
 		expectedYAML, expectedErr = yaml.Marshal(m.expected)

--- a/pkg/utils/test/matchers/fields.go
+++ b/pkg/utils/test/matchers/fields.go
@@ -20,7 +20,7 @@ func HaveFields(fields gstruct.Fields) types.GomegaMatcher {
 // Actual must be an array, slice or map.  For maps, ConsistOfFields matches against the map's values.
 // Actual's elements must be pointers.
 func ConsistOfFields(fields ...gstruct.Fields) types.GomegaMatcher {
-	var m []interface{}
+	var m []any
 	for _, f := range fields {
 		m = append(m, HaveFields(f))
 	}

--- a/pkg/utils/test/matchers/kubernetes_errors.go
+++ b/pkg/utils/test/matchers/kubernetes_errors.go
@@ -15,7 +15,7 @@ type kubernetesErrors struct {
 	message   string
 }
 
-func (k *kubernetesErrors) Match(actual interface{}) (success bool, err error) {
+func (k *kubernetesErrors) Match(actual any) (success bool, err error) {
 	// is purely nil?
 	if actual == nil {
 		return false, nil
@@ -29,9 +29,9 @@ func (k *kubernetesErrors) Match(actual interface{}) (success bool, err error) {
 	return k.checkFunc(actualErr), nil
 }
 
-func (k *kubernetesErrors) FailureMessage(actual interface{}) (message string) {
+func (k *kubernetesErrors) FailureMessage(actual any) (message string) {
 	return format.Message(actual, fmt.Sprintf("to be %s error", k.message))
 }
-func (k *kubernetesErrors) NegatedFailureMessage(actual interface{}) (message string) {
+func (k *kubernetesErrors) NegatedFailureMessage(actual any) (message string) {
 	return format.Message(actual, fmt.Sprintf("to not be %s error", k.message))
 }

--- a/pkg/utils/test/matchers/managedresource.go
+++ b/pkg/utils/test/matchers/managedresource.go
@@ -31,15 +31,15 @@ type managedResourceObjectsMatcher struct {
 	mismatchExpectedToActual map[string]string
 }
 
-func (m *managedResourceObjectsMatcher) FailureMessage(actual interface{}) string {
+func (m *managedResourceObjectsMatcher) FailureMessage(actual any) string {
 	return m.createMessage(actual, "not to be")
 }
 
-func (m *managedResourceObjectsMatcher) NegatedFailureMessage(actual interface{}) string {
+func (m *managedResourceObjectsMatcher) NegatedFailureMessage(actual any) string {
 	return m.createMessage(actual, "to be")
 }
 
-func (m *managedResourceObjectsMatcher) createMessage(actual interface{}, addition string) string {
+func (m *managedResourceObjectsMatcher) createMessage(actual any, addition string) string {
 	managedResource, ok := actual.(*resourcesv1alpha1.ManagedResource)
 	if !ok {
 		return fmt.Sprintf("expected *resourcesv1alpha1.ManagedResource.  got:\n%s", format.Object(actual, 1))
@@ -68,7 +68,7 @@ func (m *managedResourceObjectsMatcher) createMessage(actual interface{}, additi
 	return message
 }
 
-func (m *managedResourceObjectsMatcher) Match(actual interface{}) (bool, error) {
+func (m *managedResourceObjectsMatcher) Match(actual any) (bool, error) {
 	if actual == nil {
 		return false, nil
 	}

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -29,14 +29,14 @@ func init() {
 
 // DeepEqual returns a Gomega matcher which checks whether the expected object is deeply equal with the object it is
 // being compared against.
-func DeepEqual(expected interface{}) types.GomegaMatcher {
+func DeepEqual(expected any) types.GomegaMatcher {
 	return newDeepEqualMatcher(expected)
 }
 
 // DeepDerivativeEqual is similar to DeepEqual except that unset fields in actual are
 // ignored (not compared). This allows us to focus on the fields that matter to
 // the semantic comparison.
-func DeepDerivativeEqual(expected interface{}) types.GomegaMatcher {
+func DeepDerivativeEqual(expected any) types.GomegaMatcher {
 	return newDeepDerivativeMatcher(expected)
 }
 
@@ -115,7 +115,7 @@ func BeInvalidError() types.GomegaMatcher {
 // ShareSameReferenceAs checks if objects shares the same underlying reference as the passed object.
 // This can be used to check if maps or slices have the same underlying data store.
 // Only objects that work for 'reflect.ValueOf(x).Pointer' can be compared.
-func ShareSameReferenceAs(expected interface{}) types.GomegaMatcher {
+func ShareSameReferenceAs(expected any) types.GomegaMatcher {
 	return &referenceMatcher{
 		expected: expected,
 	}

--- a/pkg/utils/test/matchers/reference.go
+++ b/pkg/utils/test/matchers/reference.go
@@ -11,23 +11,23 @@ import (
 )
 
 type referenceMatcher struct {
-	expected interface{}
+	expected any
 }
 
-func (r *referenceMatcher) Match(actual interface{}) (success bool, err error) {
-	return func(expected, actual interface{}) bool {
+func (r *referenceMatcher) Match(actual any) (success bool, err error) {
+	return func(expected, actual any) bool {
 		return reflect.ValueOf(expected).Pointer() == reflect.ValueOf(actual).Pointer()
 	}(r.expected, actual), nil
 }
 
-func (r *referenceMatcher) FailureMessage(actual interface{}) (message string) {
+func (r *referenceMatcher) FailureMessage(actual any) (message string) {
 	return r.failureMessage(actual, "")
 }
 
-func (r *referenceMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (r *referenceMatcher) NegatedFailureMessage(actual any) (message string) {
 	return r.failureMessage(actual, " not")
 }
 
-func (r *referenceMatcher) failureMessage(actual interface{}, messagePrefix string) (message string) {
+func (r *referenceMatcher) failureMessage(actual any, messagePrefix string) (message string) {
 	return format.Message(actual, "to"+messagePrefix+" share reference with the compared object")
 }

--- a/pkg/utils/test/matchers/reference_test.go
+++ b/pkg/utils/test/matchers/reference_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("Reference Matcher", func() {
-	test := func(actual, expected interface{}) {
+	test := func(actual, expected any) {
 		It("should be true if objects share the same reference", func() {
 			sameRef := actual
 

--- a/pkg/utils/test/runtime/seralize.go
+++ b/pkg/utils/test/runtime/seralize.go
@@ -32,7 +32,7 @@ func Serialize(obj client.Object, scheme *runtime.Scheme) string {
 
 	// Keep this in sync with pkg/utils/managedresources/registry.go
 	// See https://github.com/gardener/gardener/pull/8312
-	var anyObj interface{}
+	var anyObj any
 	Expect(forkedyaml.Unmarshal(serializationYAML, &anyObj)).To(Succeed())
 
 	serBytes, err := forkedyaml.Marshal(anyObj)

--- a/pkg/utils/test/test.go
+++ b/pkg/utils/test/test.go
@@ -30,7 +30,7 @@ import (
 //
 //	v := "foo"
 //	DeferCleanup(WithVar(&v, "bar"))
-func WithVar(dst, src interface{}) func() {
+func WithVar(dst, src any) func() {
 	dstValue := reflect.ValueOf(dst)
 	if dstValue.Type().Kind() != reflect.Ptr {
 		ginkgo.Fail(fmt.Sprintf("destination value %T is not a pointer", dst))
@@ -58,7 +58,7 @@ func WithVar(dst, src interface{}) func() {
 // Example usage:
 //
 //	DeferCleanup(WithVars(&v, "foo", &x, "bar"))
-func WithVars(dstsAndSrcs ...interface{}) func() {
+func WithVars(dstsAndSrcs ...any) func() {
 	if len(dstsAndSrcs)%2 != 0 {
 		ginkgo.Fail(fmt.Sprintf("dsts and srcs are not of equal length: %v", dstsAndSrcs))
 	}
@@ -177,7 +177,7 @@ func WithTempFile(dir, pattern string, content []byte, fileName *string) func() 
 }
 
 // EXPECTPatch is a helper function for a GoMock call expecting a patch with the mock client.
-func EXPECTPatch(ctx interface{}, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...interface{}) *gomock.Call {
+func EXPECTPatch(ctx any, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...any) *gomock.Call {
 	var expectedPatch client.Patch
 
 	switch patchType {
@@ -191,7 +191,7 @@ func EXPECTPatch(ctx interface{}, c *mockclient.MockClient, expectedObj, mergeFr
 }
 
 // EXPECTStatusPatch is a helper function for a GoMock call expecting a status patch with the mock client.
-func EXPECTStatusPatch(ctx interface{}, c *mockclient.MockStatusWriter, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...interface{}) *gomock.Call {
+func EXPECTStatusPatch(ctx any, c *mockclient.MockStatusWriter, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...any) *gomock.Call {
 	var expectedPatch client.Patch
 
 	switch patchType {
@@ -206,7 +206,7 @@ func EXPECTStatusPatch(ctx interface{}, c *mockclient.MockStatusWriter, expected
 
 // EXPECTPatchWithOptimisticLock is a helper function for a GoMock call with the mock client
 // expecting a merge patch with optimistic lock.
-func EXPECTPatchWithOptimisticLock(ctx interface{}, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...interface{}) *gomock.Call {
+func EXPECTPatchWithOptimisticLock(ctx any, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...any) *gomock.Call {
 	var expectedPatch client.Patch
 
 	switch patchType {
@@ -219,12 +219,12 @@ func EXPECTPatchWithOptimisticLock(ctx interface{}, c *mockclient.MockClient, ex
 	return expectPatch(ctx, c, expectedObj, expectedPatch, rets...)
 }
 
-func expectPatch(ctx interface{}, c *mockclient.MockClient, expectedObj client.Object, expectedPatch client.Patch, rets ...interface{}) *gomock.Call {
+func expectPatch(ctx any, c *mockclient.MockClient, expectedObj client.Object, expectedPatch client.Patch, rets ...any) *gomock.Call {
 	expectedData, expectedErr := expectedPatch.Data(expectedObj)
 	Expect(expectedErr).NotTo(HaveOccurred())
 
 	if rets == nil {
-		rets = []interface{}{nil}
+		rets = []any{nil}
 	}
 
 	// match object key here, but verify contents only inside DoAndReturn.
@@ -248,12 +248,12 @@ func expectPatch(ctx interface{}, c *mockclient.MockClient, expectedObj client.O
 		Return(rets...)
 }
 
-func expectStatusPatch(ctx interface{}, c *mockclient.MockStatusWriter, expectedObj client.Object, expectedPatch client.Patch, rets ...interface{}) *gomock.Call {
+func expectStatusPatch(ctx any, c *mockclient.MockStatusWriter, expectedObj client.Object, expectedPatch client.Patch, rets ...any) *gomock.Call {
 	expectedData, expectedErr := expectedPatch.Data(expectedObj)
 	Expect(expectedErr).NotTo(HaveOccurred())
 
 	if rets == nil {
-		rets = []interface{}{nil}
+		rets = []any{nil}
 	}
 
 	// match object key here, but verify contents only inside DoAndReturn.
@@ -279,7 +279,7 @@ func expectStatusPatch(ctx interface{}, c *mockclient.MockStatusWriter, expected
 
 // CEventually is like gomega.Eventually but with a context.Context. When it has a deadline then the gomega.Eventually
 // call with be configured with a the respective timeout.
-func CEventually(ctx context.Context, actual interface{}) AsyncAssertion {
+func CEventually(ctx context.Context, actual any) AsyncAssertion {
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return Eventually(actual)

--- a/pkg/utils/values.go
+++ b/pkg/utils/values.go
@@ -24,8 +24,8 @@ type Options struct {
 // ToValuesMap converts the given value v to a values map, by first marshalling it to JSON,
 // and then unmarshalling the result from JSON into a values map.
 // If v cannot be marshalled to JSON, or if the result cannot be unmarshalled into a values map, an error is returned.
-func ToValuesMap(v interface{}) (map[string]interface{}, error) {
-	var m map[string]interface{}
+func ToValuesMap(v any) (map[string]any, error) {
+	var m map[string]any
 	if err := convert(v, &m); err != nil {
 		return nil, err
 	}
@@ -35,8 +35,8 @@ func ToValuesMap(v interface{}) (map[string]interface{}, error) {
 // ToValuesMapWithOptions converts the given value v to a values map, by first marshalling it to JSON,
 // and then unmarshalling the result from JSON into a values map.
 // If v cannot be marshalled to JSON, or if the result cannot be unmarshalled into a values map, an error is returned.
-func ToValuesMapWithOptions(v interface{}, opt Options) (map[string]interface{}, error) {
-	var m map[string]interface{}
+func ToValuesMapWithOptions(v any, opt Options) (map[string]any, error) {
+	var m map[string]any
 	if err := convert(v, &m); err != nil {
 		return nil, err
 	}
@@ -53,8 +53,8 @@ func hasOptions(opt Options) bool {
 	return opt.LowerCaseKeys || opt.RemoveZeroEntries
 }
 
-// applyOptions recursively ensures that the keys in a map[string]interface{} are lower-case
-func (opt *Options) applyOptions(input map[string]interface{}) map[string]interface{} {
+// applyOptions recursively ensures that the keys in a map[string]any are lower-case
+func (opt *Options) applyOptions(input map[string]any) map[string]any {
 	if input == nil {
 		return nil
 	}
@@ -63,7 +63,7 @@ func (opt *Options) applyOptions(input map[string]interface{}) map[string]interf
 		return input
 	}
 
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	for key, value := range input {
 		if value == nil {
 			continue
@@ -79,9 +79,9 @@ func (opt *Options) applyOptions(input map[string]interface{}) map[string]interf
 			key = string(unicode.ToLower(r)) + key[n:]
 		}
 
-		if m, ok := value.(map[string]interface{}); ok {
+		if m, ok := value.(map[string]any); ok {
 			value = opt.applyOptions(m)
-		} else if m, ok := value.([]interface{}); ok {
+		} else if m, ok := value.([]any); ok {
 			value = opt.sliceToValues(m)
 		}
 
@@ -90,10 +90,10 @@ func (opt *Options) applyOptions(input map[string]interface{}) map[string]interf
 	return result
 }
 
-func (opt *Options) sliceToValues(input []interface{}) []interface{} {
-	var result = make([]interface{}, len(input))
+func (opt *Options) sliceToValues(input []any) []any {
+	var result = make([]any, len(input))
 	for index, v2 := range input {
-		if m2, ok := v2.(map[string]interface{}); ok {
+		if m2, ok := v2.(map[string]any); ok {
 			result[index] = opt.applyOptions(m2)
 			continue
 		}
@@ -105,14 +105,14 @@ func (opt *Options) sliceToValues(input []interface{}) []interface{} {
 // FromValuesMap converts the given values map values to the given value v, by first marshalling it to JSON,
 // and then unmarshalling the result from JSON into v.
 // If values cannot be marshalled to JSON, or if the result cannot be unmarshalled into v, an error is returned.
-func FromValuesMap(values map[string]interface{}, v interface{}) error {
+func FromValuesMap(values map[string]any, v any) error {
 	return convert(values, v)
 }
 
 // InitValuesMap returns the given values map if it is non-nil, or a newly allocated values map if it is nil.
-func InitValuesMap(values map[string]interface{}) map[string]interface{} {
+func InitValuesMap(values map[string]any) map[string]any {
 	if values == nil {
-		values = make(map[string]interface{})
+		values = make(map[string]any)
 	}
 	return values
 }
@@ -122,7 +122,7 @@ func InitValuesMap(values map[string]interface{}) map[string]interface{} {
 // If such an element does not exist, it returns nil.
 // All keys must be of type either string (for map keys) or int (for slice indexes).
 // If a key type doesn't match the corresponding element type (string for map, int for slice), an error is returned.
-func GetFromValuesMap(values map[string]interface{}, keys ...interface{}) (interface{}, error) {
+func GetFromValuesMap(values map[string]any, keys ...any) (any, error) {
 	return getFromValues(fromMap(values), keys...)
 }
 
@@ -132,7 +132,7 @@ func GetFromValuesMap(values map[string]interface{}, keys ...interface{}) (inter
 // All keys must be of type either string (for map keys) or int (for slice indexes).
 // Slice indexes must refer to existing slice elements or the first element beyond the end of a slice.
 // If a key type doesn't match the corresponding element type (string for map, int for slice), an error is returned.
-func SetToValuesMap(values map[string]interface{}, v interface{}, keys ...interface{}) (map[string]interface{}, error) {
+func SetToValuesMap(values map[string]any, v any, keys ...any) (map[string]any, error) {
 	x, err := setToValues(fromMap(values), v, keys...)
 	return toMap(x), err
 }
@@ -142,14 +142,14 @@ func SetToValuesMap(values map[string]interface{}, v interface{}, keys ...interf
 // If such an element does not exist, it returns the given values map unmodified.
 // All keys must be of type either string (for map keys) or int (for slice indexes).
 // If a key type doesn't match the corresponding element type (string for map, int for slice), an error is returned.
-func DeleteFromValuesMap(values map[string]interface{}, keys ...interface{}) (map[string]interface{}, error) {
+func DeleteFromValuesMap(values map[string]any, keys ...any) (map[string]any, error) {
 	x, err := deleteFromValues(fromMap(values), keys...)
 	return toMap(x), err
 }
 
 // convert converts x to y by first marshalling x to JSON, and then unmarshalling the result from JSON into y.
 // If x cannot be marshalled to JSON, or if the result cannot be unmarshalled into y, an error is returned.
-func convert(x, y interface{}) error {
+func convert(x, y any) error {
 	jsonBytes, err := json.Marshal(x)
 	if err != nil {
 		return err
@@ -162,7 +162,7 @@ func convert(x, y interface{}) error {
 // If such an element does not exist, it returns nil.
 // All keys must be of type either string (for map keys) or int (for slice indexes).
 // If a key type doesn't match the corresponding element type (string for map, int for slice), an error is returned.
-func getFromValues(values interface{}, keys ...interface{}) (interface{}, error) {
+func getFromValues(values any, keys ...any) (any, error) {
 	if values == nil {
 		return nil, nil
 	}
@@ -175,9 +175,9 @@ func getFromValues(values interface{}, keys ...interface{}) (interface{}, error)
 	switch keys[0].(type) {
 	case string:
 		key := keys[0].(string)
-		var m map[string]interface{}
+		var m map[string]any
 
-		if m, ok = values.(map[string]interface{}); !ok {
+		if m, ok = values.(map[string]any); !ok {
 			return nil, fmt.Errorf("cannot use key '%s' with a non-map value", key)
 		}
 		if _, ok = m[key]; !ok {
@@ -187,10 +187,10 @@ func getFromValues(values interface{}, keys ...interface{}) (interface{}, error)
 	case int:
 		var (
 			index = keys[0].(int)
-			s     []interface{}
+			s     []any
 		)
 
-		if s, ok = values.([]interface{}); !ok {
+		if s, ok = values.([]any); !ok {
 			return nil, fmt.Errorf("cannot use index '%d' with a non-slice value", index)
 		}
 		if index < 0 || index >= len(s) {
@@ -208,7 +208,7 @@ func getFromValues(values interface{}, keys ...interface{}) (interface{}, error)
 // All keys must be of type either string (for map keys) or int (for slice indexes).
 // Slice indexes must refer to existing slice elements or the first element beyond the end of a slice.
 // If a key type doesn't match the corresponding element type (string for map, int for slice), an error is returned.
-func setToValues(values interface{}, v interface{}, keys ...interface{}) (interface{}, error) {
+func setToValues(values any, v any, keys ...any) (any, error) {
 	if len(keys) == 0 {
 		return values, nil
 	}
@@ -220,11 +220,11 @@ func setToValues(values interface{}, v interface{}, keys ...interface{}) (interf
 		key := keys[0].(string)
 
 		if values == nil {
-			values = map[string]interface{}{}
+			values = map[string]any{}
 		}
 
-		var m map[string]interface{}
-		if m, ok = values.(map[string]interface{}); !ok {
+		var m map[string]any
+		if m, ok = values.(map[string]any); !ok {
 			return values, fmt.Errorf("cannot use key '%s' with a non-map value", key)
 		}
 		if len(keys) == 1 {
@@ -241,12 +241,12 @@ func setToValues(values interface{}, v interface{}, keys ...interface{}) (interf
 		index := keys[0].(int)
 
 		if values == nil {
-			values = []interface{}{}
+			values = []any{}
 		}
 
-		var s []interface{}
+		var s []any
 
-		if s, ok = values.([]interface{}); !ok {
+		if s, ok = values.([]any); !ok {
 			return values, fmt.Errorf("cannot use index '%d' with a non-slice value", index)
 		}
 		if index >= 0 && index < len(s) {
@@ -284,7 +284,7 @@ func setToValues(values interface{}, v interface{}, keys ...interface{}) (interf
 // If such an element does not exist, it returns the given values unmodified.
 // All keys must be of type either string (for map keys) or int (for slice indexes).
 // If a key type doesn't match the corresponding element type (string for map, int for slice), an error is returned.
-func deleteFromValues(values interface{}, keys ...interface{}) (interface{}, error) {
+func deleteFromValues(values any, keys ...any) (any, error) {
 	if values == nil {
 		return nil, nil
 	}
@@ -297,9 +297,9 @@ func deleteFromValues(values interface{}, keys ...interface{}) (interface{}, err
 	switch keys[0].(type) {
 	case string:
 		key := keys[0].(string)
-		var m map[string]interface{}
+		var m map[string]any
 
-		if m, ok = values.(map[string]interface{}); !ok {
+		if m, ok = values.(map[string]any); !ok {
 			return values, fmt.Errorf("cannot use key '%s' with a non-map value", key)
 		}
 		if _, ok = m[key]; ok {
@@ -316,9 +316,9 @@ func deleteFromValues(values interface{}, keys ...interface{}) (interface{}, err
 		return m, nil
 	case int:
 		index := keys[0].(int)
-		var s []interface{}
+		var s []any
 
-		if s, ok = values.([]interface{}); !ok {
+		if s, ok = values.([]any); !ok {
 			return values, fmt.Errorf("cannot use index '%d' with a non-slice value", index)
 		}
 		if index >= 0 && index < len(s) {
@@ -338,16 +338,16 @@ func deleteFromValues(values interface{}, keys ...interface{}) (interface{}, err
 	}
 }
 
-func fromMap(values map[string]interface{}) interface{} {
+func fromMap(values map[string]any) any {
 	if values == nil {
 		return nil
 	}
 	return values
 }
 
-func toMap(x interface{}) map[string]interface{} {
+func toMap(x any) map[string]any {
 	if x == nil {
 		return nil
 	}
-	return x.(map[string]interface{})
+	return x.(map[string]any)
 }

--- a/pkg/utils/values_test.go
+++ b/pkg/utils/values_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Values", func() {
 	var (
 		obj      *object
 		objUpper *objectUpperCase
-		values   map[string]interface{}
+		values   map[string]any
 	)
 
 	BeforeEach(func() {
@@ -62,10 +62,10 @@ var _ = Describe("Values", func() {
 			Bool: ptr.To(true),
 		}
 
-		values = map[string]interface{}{
-			"objects": []interface{}{
-				map[string]interface{}{
-					"object": map[string]interface{}{
+		values = map[string]any{
+			"objects": []any{
+				map[string]any{
+					"object": map[string]any{
 						"string": "foo",
 					},
 					"int": float64(42),
@@ -85,7 +85,7 @@ var _ = Describe("Values", func() {
 		It("should convert an empty object to an empty values map", func() {
 			result, err := ToValuesMap(&object{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(map[string]interface{}{}))
+			Expect(result).To(Equal(map[string]any{}))
 		})
 
 		It("should convert nil to a nil values map", func() {
@@ -141,15 +141,15 @@ var _ = Describe("Values", func() {
 				Bool: ptr.To(true),
 			}
 
-			values = map[string]interface{}{
-				"objects": []interface{}{
-					map[string]interface{}{
-						"object": map[string]interface{}{
+			values = map[string]any{
+				"objects": []any{
+					map[string]any{
+						"object": map[string]any{
 							"string": "foo",
 						},
-						"objects": []interface{}{
-							map[string]interface{}{
-								"object": map[string]interface{}{
+						"objects": []any{
+							map[string]any{
+								"object": map[string]any{
 									"string": "bar",
 								},
 								"int": float64(50),
@@ -216,25 +216,25 @@ var _ = Describe("Values", func() {
 				Bool: ptr.To(true),
 			}
 
-			values = map[string]interface{}{
-				"objects": []interface{}{
-					map[string]interface{}{
-						"object": map[string]interface{}{
+			values = map[string]any{
+				"objects": []any{
+					map[string]any{
+						"object": map[string]any{
 							"string": "one",
-							"objects": []interface{}{
-								map[string]interface{}{
+							"objects": []any{
+								map[string]any{
 									"string": "two-l1",
-									"objects": []interface{}{
-										map[string]interface{}{
+									"objects": []any{
+										map[string]any{
 											// empty string removed
 											"int": float64(3),
 										},
 									},
 								},
-								map[string]interface{}{
+								map[string]any{
 									"string": "two-l2",
-									"objects": []interface{}{
-										map[string]interface{}{
+									"objects": []any{
+										map[string]any{
 											"int": float64(4),
 										},
 									},
@@ -267,7 +267,7 @@ var _ = Describe("Values", func() {
 		})
 
 		It("should convert an empty values map to an empty object", func() {
-			err := FromValuesMap(map[string]interface{}{}, &result)
+			err := FromValuesMap(map[string]any{}, &result)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(&object{}))
 		})
@@ -279,12 +279,12 @@ var _ = Describe("Values", func() {
 		})
 
 		It("should fail if the values map cannot be marshalled to JSON", func() {
-			err := FromValuesMap(map[string]interface{}{"foo": func() {}}, &result)
+			err := FromValuesMap(map[string]any{"foo": func() {}}, &result)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should fail if the values map cannot be unmarshalled back to an object", func() {
-			err := FromValuesMap(map[string]interface{}{"object": "foo"}, &result)
+			err := FromValuesMap(map[string]any{"object": "foo"}, &result)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -295,7 +295,7 @@ var _ = Describe("Values", func() {
 		})
 
 		It("should return a new values map if the given values map is nil", func() {
-			Expect(InitValuesMap(nil)).To(Equal(map[string]interface{}{}))
+			Expect(InitValuesMap(nil)).To(Equal(map[string]any{}))
 		})
 	})
 
@@ -303,7 +303,7 @@ var _ = Describe("Values", func() {
 		It("should return the element at the specified location in the given values map", func() {
 			result, err := GetFromValuesMap(values, "objects", 0, "object")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(map[string]interface{}{"string": "foo"}))
+			Expect(result).To(Equal(map[string]any{"string": "foo"}))
 		})
 
 		It("should return nil if a map key doesn't exist", func() {
@@ -351,12 +351,12 @@ var _ = Describe("Values", func() {
 
 	Describe("#SetToValuesMap", func() {
 		It("should set the element at the specified location in the given values map", func() {
-			result, err := SetToValuesMap(values, map[string]interface{}{"foo": "bar"}, "objects", 0, "object")
+			result, err := SetToValuesMap(values, map[string]any{"foo": "bar"}, "objects", 0, "object")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(map[string]interface{}{
-				"objects": []interface{}{
-					map[string]interface{}{
-						"object": map[string]interface{}{
+			Expect(result).To(Equal(map[string]any{
+				"objects": []any{
+					map[string]any{
+						"object": map[string]any{
 							"foo": "bar",
 						},
 						"int": float64(42),
@@ -367,20 +367,20 @@ var _ = Describe("Values", func() {
 		})
 
 		It("should create the element if a map key doesn't exist", func() {
-			result, err := SetToValuesMap(values, map[string]interface{}{"foo": "bar"}, "foo", "bar")
+			result, err := SetToValuesMap(values, map[string]any{"foo": "bar"}, "foo", "bar")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(map[string]interface{}{
-				"objects": []interface{}{
-					map[string]interface{}{
-						"object": map[string]interface{}{
+			Expect(result).To(Equal(map[string]any{
+				"objects": []any{
+					map[string]any{
+						"object": map[string]any{
 							"string": "foo",
 						},
 						"int": float64(42),
 					},
 				},
 				"bool": true,
-				"foo": map[string]interface{}{
-					"bar": map[string]interface{}{
+				"foo": map[string]any{
+					"bar": map[string]any{
 						"foo": "bar",
 					},
 				},
@@ -388,18 +388,18 @@ var _ = Describe("Values", func() {
 		})
 
 		It("should create the element if a slice index doesn't exist", func() {
-			result, err := SetToValuesMap(values, map[string]interface{}{"foo": "bar"}, "objects", 1, 0)
+			result, err := SetToValuesMap(values, map[string]any{"foo": "bar"}, "objects", 1, 0)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(map[string]interface{}{
-				"objects": []interface{}{
-					map[string]interface{}{
-						"object": map[string]interface{}{
+			Expect(result).To(Equal(map[string]any{
+				"objects": []any{
+					map[string]any{
+						"object": map[string]any{
 							"string": "foo",
 						},
 						"int": float64(42),
 					},
-					[]interface{}{
-						map[string]interface{}{
+					[]any{
+						map[string]any{
 							"foo": "bar",
 						},
 					},
@@ -409,23 +409,23 @@ var _ = Describe("Values", func() {
 		})
 
 		It("should create a new values map with a nil values map", func() {
-			result, err := SetToValuesMap(nil, map[string]interface{}{"foo": "bar"}, "foo")
+			result, err := SetToValuesMap(nil, map[string]any{"foo": "bar"}, "foo")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(map[string]interface{}{
-				"foo": map[string]interface{}{
+			Expect(result).To(Equal(map[string]any{
+				"foo": map[string]any{
 					"foo": "bar",
 				},
 			}))
 		})
 
 		It("should return the given values map with no keys", func() {
-			result, err := SetToValuesMap(values, map[string]interface{}{"foo": "bar"})
+			result, err := SetToValuesMap(values, map[string]any{"foo": "bar"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(values))
 		})
 
 		It("should return nil with a nil values map and no keys", func() {
-			result, err := SetToValuesMap(nil, map[string]interface{}{"foo": "bar"})
+			result, err := SetToValuesMap(nil, map[string]any{"foo": "bar"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -459,9 +459,9 @@ var _ = Describe("Values", func() {
 		It("should delete the element at the specified location in the given values map", func() {
 			result, err := DeleteFromValuesMap(values, "objects", 0, "object")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(map[string]interface{}{
-				"objects": []interface{}{
-					map[string]interface{}{
+			Expect(result).To(Equal(map[string]any{
+				"objects": []any{
+					map[string]any{
 						"int": float64(42),
 					},
 				},

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -132,27 +132,27 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	}
 
 	ginkgo.By("Apply redis chart")
-	masterValues := map[string]interface{}{
+	masterValues := map[string]any{
 		"command": "redis-server",
 	}
 	if shoot.Spec.Provider.Type == "alicloud" {
 		// AliCloud requires a minimum of 20 GB for its PVCs
-		masterValues["persistence"] = map[string]interface{}{
+		masterValues["persistence"] = map[string]any{
 			"size": "20Gi",
 		}
 	}
 
 	// redis-slaves are not required for test success
-	values := map[string]interface{}{
-		"image": map[string]interface{}{
+	values := map[string]any{
+		"image": map[string]any{
 			"registry":   "eu.gcr.io",
 			"repository": "gardener-project/3rd/redis",
 			"tag":        "5.0.8",
 		},
-		"cluster": map[string]interface{}{
+		"cluster": map[string]any{
 			"enabled": false,
 		},
-		"rbac": map[string]interface{}{
+		"rbac": map[string]any{
 			"create": true,
 		},
 		"master": masterValues,

--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -41,7 +41,7 @@ const (
 type SearchResponse struct {
 	Data struct {
 		Result []struct {
-			Value []interface{} `json:"value"`
+			Value []any `json:"value"`
 		} `json:"result"`
 	} `json:"data"`
 }

--- a/test/framework/gomega_utils.go
+++ b/test/framework/gomega_utils.go
@@ -9,6 +9,6 @@ import (
 )
 
 // ExpectNoError checks if an error has occurred
-func ExpectNoError(actual interface{}, extra ...interface{}) {
+func ExpectNoError(actual any, extra ...any) {
 	gomega.ExpectWithOffset(1, actual, extra...).ToNot(gomega.HaveOccurred())
 }

--- a/test/framework/template.go
+++ b/test/framework/template.go
@@ -18,7 +18,7 @@ import (
 )
 
 // RenderAndDeployTemplate renders a template from the resource template directory and deploys it to the cluster
-func (f *CommonFramework) RenderAndDeployTemplate(ctx context.Context, k8sClient kubernetes.Interface, templateName string, values interface{}) error {
+func (f *CommonFramework) RenderAndDeployTemplate(ctx context.Context, k8sClient kubernetes.Interface, templateName string, values any) error {
 	templateFilepath := filepath.Join(f.TemplatesDir, templateName)
 	if _, err := os.Stat(templateFilepath); err != nil {
 		return fmt.Errorf("could not find template in %q", templateFilepath)

--- a/test/framework/utils.go
+++ b/test/framework/utils.go
@@ -42,7 +42,7 @@ func checkAssignable(src, dst reflect.Value) error {
 	return nil
 }
 
-func dereference(v interface{}) interface{} {
+func dereference(v any) any {
 	dstValue := reflect.ValueOf(v)
 	Must(checkPtr(dstValue))
 
@@ -50,7 +50,7 @@ func dereference(v interface{}) interface{} {
 }
 
 // RevertableSet sets the element of dst to src and returns a function that can revert back to the original values.
-func RevertableSet(dst, src interface{}) (revert func()) {
+func RevertableSet(dst, src any) (revert func()) {
 	tmp := dereference(dst)
 	Set(dst, src)
 	return func() { Set(dst, tmp) }
@@ -59,7 +59,7 @@ func RevertableSet(dst, src interface{}) (revert func()) {
 // Set sets the pointer dst to the value of src.
 //
 // dst has to be a pointer, src has to be assignable to the element type of dst.
-func Set(dst, src interface{}) {
+func Set(dst, src any) {
 	dstValue := reflect.ValueOf(dst)
 	Must(checkPtr(dstValue))
 

--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
@@ -56,7 +56,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		port6TargetPort = intstr.FromInt32(1023)
 		port6Suffix     = fmt.Sprintf("-%s-%s", strings.ToLower(string(port6Protocol)), port6TargetPort.String())
 
-		ensureNetworkPolicies = func(asyncAssertion func(int, interface{}, ...interface{}) AsyncAssertion, should bool) func() {
+		ensureNetworkPolicies = func(asyncAssertion func(int, any, ...any) AsyncAssertion, should bool) func() {
 			return func() {
 				assertedFunc := func(g Gomega) []networkingv1.NetworkPolicy {
 					networkPolicyList := &networkingv1.NetworkPolicyList{}
@@ -82,7 +82,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		ensureNetworkPoliciesDoNotGetCreated = ensureNetworkPolicies(ConsistentlyWithOffset, false)
 		ensureNetworkPoliciesDoNotGetDeleted = ensureNetworkPolicies(ConsistentlyWithOffset, true)
 
-		ensureCrossNamespaceNetworkPolicies = func(asyncAssertion func(int, interface{}, ...interface{}) AsyncAssertion, should bool) func() {
+		ensureCrossNamespaceNetworkPolicies = func(asyncAssertion func(int, any, ...any) AsyncAssertion, should bool) func() {
 			return func() {
 				// ingress rules
 				assertedFunc := func(g Gomega) []networkingv1.NetworkPolicy {
@@ -123,7 +123,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		ensureCrossNamespaceNetworkPoliciesGetDeleted      = ensureCrossNamespaceNetworkPolicies(EventuallyWithOffset, false)
 		ensureCrossNamespaceNetworkPoliciesDoNotGetCreated = ensureCrossNamespaceNetworkPolicies(ConsistentlyWithOffset, false)
 
-		ensureNetworkPoliciesWithCustomPodLabelSelectors = func(asyncAssertion func(int, interface{}, ...interface{}) AsyncAssertion, should bool) func() {
+		ensureNetworkPoliciesWithCustomPodLabelSelectors = func(asyncAssertion func(int, any, ...any) AsyncAssertion, should bool) func() {
 			return func() {
 				assertedFunc := func(g Gomega) []networkingv1.NetworkPolicy {
 					networkPolicyList := &networkingv1.NetworkPolicyList{}
@@ -151,7 +151,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		ensureNetworkPoliciesWithCustomPodLabelSelectorsGetCreated = ensureNetworkPoliciesWithCustomPodLabelSelectors(EventuallyWithOffset, true)
 		ensureNetworkPoliciesWithCustomPodLabelSelectorsGetDeleted = ensureNetworkPoliciesWithCustomPodLabelSelectors(EventuallyWithOffset, false)
 
-		ensureIngressFromWorldNetworkPolicy = func(asyncAssertion func(int, interface{}, ...interface{}) AsyncAssertion, should bool) func() {
+		ensureIngressFromWorldNetworkPolicy = func(asyncAssertion func(int, any, ...any) AsyncAssertion, should bool) func() {
 			return func() {
 				assertedFunc := func(g Gomega) []networkingv1.NetworkPolicy {
 					networkPolicyList := &networkingv1.NetworkPolicyList{}
@@ -960,7 +960,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 
 	Context("service exposed via ingress", func() {
 		var (
-			ensureExposedViaIngressNetworkPolicies = func(asyncAssertion func(int, interface{}, ...interface{}) AsyncAssertion, should bool) func() {
+			ensureExposedViaIngressNetworkPolicies = func(asyncAssertion func(int, any, ...any) AsyncAssertion, should bool) func() {
 				return func() {
 					assertedFunc := func(g Gomega) []networkingv1.NetworkPolicy {
 						networkPolicyList := &networkingv1.NetworkPolicyList{}

--- a/test/testmachinery/extensions/generator/helper.go
+++ b/test/testmachinery/extensions/generator/helper.go
@@ -16,7 +16,7 @@ import (
 )
 
 // MarshalAndWriteConfig marshals the provided config and write is as a file to the provided path
-func MarshalAndWriteConfig(filepath string, config interface{}) error {
+func MarshalAndWriteConfig(filepath string, config any) error {
 	raw, err := yaml.Marshal(config)
 	if err != nil {
 		return fmt.Errorf("unable to parse config: %w", err)

--- a/test/testmachinery/shoots/logging/seed_logging_stack.go
+++ b/test/testmachinery/shoots/logging/seed_logging_stack.go
@@ -391,7 +391,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 			)
 
 			ginkgo.By(fmt.Sprintf("Deploy the logger application in shoot namespace %s", shootNamespace.Name))
-			loggerParams := map[string]interface{}{
+			loggerParams := map[string]any{
 				"LoggerName":          loggerName,
 				"HelmDeployNamespace": shootNamespace.Name,
 				"AppLabel":            loggerName,

--- a/test/testmachinery/shoots/logging/shoot_logging.go
+++ b/test/testmachinery/shoots/logging/shoot_logging.go
@@ -88,7 +88,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		framework.ExpectNoError(err)
 
 		// Deploy Vali ValidatingWebhookConfiguration
-		validatingWebhookParams := map[string]interface{}{
+		validatingWebhookParams := map[string]any{
 			"NamespaceLabelKey":   shootNamespaceLabelKey,
 			"NamespaceLabelValue": shootNamespaceLabelValue,
 			"CABundle": utils.EncodeBase64([]byte(`-----BEGIN CERTIFICATE-----
@@ -143,7 +143,7 @@ epFdd1fXLwuwn7fvPMmJqD3HtLalX1AZmPk+BI8ezfAiVcVqnTJQMXlYPpYe9A==
 		)
 
 		ginkgo.By("Deploy the logger application")
-		loggerParams := map[string]interface{}{
+		loggerParams := map[string]any{
 			"LoggerName":          fullLoggerName,
 			"HelmDeployNamespace": shootFramework.ShootSeedNamespace(),
 			"AppLabel":            loggerAppLabel,

--- a/test/testmachinery/shoots/vpntunnel/vpntunnel.go
+++ b/test/testmachinery/shoots/vpntunnel/vpntunnel.go
@@ -47,7 +47,7 @@ var _ = ginkgo.Describe("Shoot vpn tunnel testing", func() {
 
 	f.Beta().CIt("should get container logs from logging-pod", func(ctx context.Context) {
 		ginkgo.By("Deploy the logging-pod")
-		loggerParams := map[string]interface{}{
+		loggerParams := map[string]any{
 			"LoggerName":          deploymentName,
 			"HelmDeployNamespace": namespace,
 			"AppLabel":            loggerAppLabel,
@@ -145,7 +145,7 @@ var _ = ginkgo.Describe("Shoot vpn tunnel testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Deploy the source and target pod")
-		params := map[string]interface{}{
+		params := map[string]any{
 			"Name":        copyDeployment,
 			"Namespace":   namespace,
 			"AppLabel":    copyLabel,


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

With go-1.18 `interface{}` was replaced with a type-alias to `any` to enhance readability see https://pkg.go.dev/builtin#any

With this all occurrences in the codebase, except the generated and third-party code was modified to use `any` now.

This was done with:

```
gofmt -r 'interface{} -> any' -w *.go
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
