### PR TITLE
add dashboard url in external labels

### DIFF
--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1186,7 +1186,10 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 		RetentionSize:     "190GB",
 		ScrapeTimeout:     "50s", // This is intentionally smaller than the scrape interval of 1m.
 		RuntimeVersion:    r.RuntimeVersion,
-		ExternalLabels:    map[string]string{"landscape": garden.Spec.VirtualCluster.Gardener.ClusterIdentity},
+		ExternalLabels: map[string]string{
+			"landscape":    garden.Spec.VirtualCluster.Gardener.ClusterIdentity,
+			"dashboardUrl": "dashboard." + ingressDomain,
+		},
 		VPAMaxAllowed: &corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("4"),
 			corev1.ResourceMemory: resource.MustParse("50G"),


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring

**What this PR does / why we need it**:
based on some discussion with @vicwicker i'm adding dashboard url into external labels field, `might also be valuable for the open source users so that they can easily add links to the dashboard in their alert descriptions if they want to`
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
add dashboard url in external labels
```
