### PR TITLE
gardenlet: Do not deploy blackbox-exporter for Shoots with .spec.purpose=testing

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -828,7 +828,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying control plane blackbox-exporter",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.Monitoring.BlackboxExporter.Deploy).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(botanist.ReconcileBlackboxExporterControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady, migratePrometheus).InsertIf(!staticNodesCIDR, waitUntilInfrastructureReady),
 		})
 		_ = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/9695, Shoots with spec.purpose=testing are unhealthy with:
```
Deployment "shoot--foo--bar/blackbox-exporter" is unhealthy: condition "Available" has invalid status False (expected True) due to MinimumReplicasUnavailable: Deployment does not have minimum availability.
```

```
% k -n shoot--foo--bar get po -l app=blackbox-exporter
NAME                                 READY   STATUS              RESTARTS   AGE
blackbox-exporter-6dd585c5cf-j8z2w   0/1     ContainerCreating   0          21m
blackbox-exporter-6dd585c5cf-k89n8   0/1     ContainerCreating   0          46m
```

```
% k -n shoot--foo--bar describe po blackbox-exporter-6dd585c5cf-j8z2w

  Warning  FailedMount       19s (x18 over 20m)  kubelet                MountVolume.SetUp failed for volume "cluster-access" : secret "shoot-access-prometheus-shoot" not found
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardenlet: An issue causing the blackbox-exporter Deployment to be created and to be unhealthy in the Shoot control plane for Shoots with `.spec.purpose=testing` is now fixed.
```
