### PR TITLE
node-problem-detector: Do not consider VPAEnabled for setting memory limits

### DIFF
--- a/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
@@ -248,7 +248,9 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 										corev1.ResourceCPU:    resource.MustParse("20m"),
 										corev1.ResourceMemory: resource.MustParse("20Mi"),
 									},
-									Limits: c.getResourceLimits(),
+									Limits: corev1.ResourceList{
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
 								},
 							},
 						},
@@ -365,18 +367,6 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 		service,
 		vpa,
 	)
-}
-
-func (c *nodeProblemDetector) getResourceLimits() corev1.ResourceList {
-	if c.values.VPAEnabled {
-		return corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("120Mi"),
-		}
-	}
-
-	return corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("500Mi"),
-	}
 }
 
 func getLabels() map[string]string {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
In the last weeks we see many cases of node-problem-detector being OOMKilled:
```
% k -n kube-system get po node-problem-detector-hn7qs
NAME                          READY   STATUS             RESTARTS          AGE
node-problem-detector-hn7qs   0/1     CrashLoopBackOff   321 (2m35s ago)   13d

% k -n kube-system describe po node-problem-detector-hn7qs

    Command:
      /bin/sh
      -c
      exec /node-problem-detector --logtostderr --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json .. --config.custom-plugin-monitor=/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json .. --config.system-stats-monitor=/config/system-stats-monitor.json --prometheus-port=20257
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Mon, 20 May 2024 14:46:12 +0300
      Finished:     Mon, 20 May 2024 14:46:25 +0300
    Ready:          False
    Restart Count:  321
```

We see that the node-problem-detector has a limit of 120Mi:
```
% k -n kube-system get po node-problem-detector-hn7qs -o yaml

    name: node-problem-detector
    resources:
      limits:
        memory: 120Mi
      requests:
        cpu: 23m
        memory: 120Mi
```

This is caused by https://github.com/gardener/gardener/blob/efcf5bbe801dce529749a5ef8da5ba24536c4520/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go#L370-L380

I think this handling is leftover from the times we were using VPAs with `controllerValues: RequestsAndLimits`. 2 years ago https://github.com/gardener/gardener/pull/5638 adapted all Shoot system components' VPAs to use `controllerValues: RequestsOnly`. With this having different memory limits for VPA enabled/disabled (120Mi/500Mi) does no longer make sense as VPA cannot cross the limits of 120Mi.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing the `node-problem-detector` to be `OOMKilled` is now fixed. Previously, too low memory limit was set when VPA was enabled for the `Shoot`.
```
