### PR TITLE
Fix plutono dashboard `ConfigMap` update

### DIFF
--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -164,8 +164,19 @@ func (p *plutono) Deploy(ctx context.Context) error {
 
 	// dashboards configmap is not deployed as part of MR because it can breach the secret size limit.
 	if dashboardConfigMap != nil {
-		if _, err = controllerutils.GetAndCreateOrMergePatch(ctx, p.client, dashboardConfigMap, func() error {
-			metav1.SetMetaDataLabel(&dashboardConfigMap.ObjectMeta, "component", name)
+		configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: dashboardConfigMap.Name, Namespace: dashboardConfigMap.Namespace}}
+		if _, err = controllerutils.GetAndCreateOrMergePatch(ctx, p.client, configMap, func() error {
+			for k, v := range dashboardConfigMap.Annotations {
+				metav1.SetMetaDataAnnotation(&configMap.ObjectMeta, k, v)
+			}
+
+			for k, v := range dashboardConfigMap.Labels {
+				metav1.SetMetaDataLabel(&configMap.ObjectMeta, k, v)
+			}
+
+			configMap.Immutable = dashboardConfigMap.Immutable
+			configMap.Data = dashboardConfigMap.Data
+			configMap.BinaryData = dashboardConfigMap.BinaryData
 			return nil
 		}); err != nil {
 			return err

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -174,7 +174,6 @@ func (p *plutono) Deploy(ctx context.Context) error {
 				metav1.SetMetaDataLabel(&configMap.ObjectMeta, k, v)
 			}
 
-			configMap.Immutable = dashboardConfigMap.Immutable
 			configMap.Data = dashboardConfigMap.Data
 			configMap.BinaryData = dashboardConfigMap.BinaryData
 			return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
The plutono dashboard `ConfigMap` was not updated properly after https://github.com/gardener/gardener/pull/9624. This resulted in some dashboards provided from extensions to not appear in the UI.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9624

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented Plutono dashboards contributed from extensions to appear in the UI.
```
