### PR TITLE
Drop `pkg/utils/kubernetes.{Key,ObjectMeta{FromKey}}` functions

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -61,7 +61,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Name is a const for the name of this component.
@@ -431,7 +430,7 @@ func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) e
 	defer cancel()
 
 	return wait.PollUntilContextCancel(timeoutCtx, 500*time.Millisecond, false, func(context.Context) (done bool, err error) {
-		if err := gardenClient.Get(ctx, kubernetesutils.Key(gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.Name)), &corev1.Namespace{}); err != nil {
+		if err := gardenClient.Get(ctx, client.ObjectKey{Name: gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.Name)}, &corev1.Namespace{}); err != nil {
 			if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 				return false, nil
 			}

--- a/cmd/gardenlet/app/bootstrappers/seed_config.go
+++ b/cmd/gardenlet/app/bootstrappers/seed_config.go
@@ -14,9 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // SeedConfigChecker checks whether the seed networks in the specification of the provided SeedConfig are correctly
@@ -34,7 +33,7 @@ func (s *SeedConfigChecker) Start(ctx context.Context) error {
 	}
 
 	shootInfo := &corev1.ConfigMap{}
-	if err := s.SeedClient.Get(ctx, kubernetes.Key(metav1.NamespaceSystem, constants.ConfigMapNameShootInfo), shootInfo); client.IgnoreNotFound(err) != nil {
+	if err := s.SeedClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: v1beta1constants.ConfigMapNameShootInfo}, shootInfo); client.IgnoreNotFound(err) != nil {
 		return err
 	} else if errors.IsNotFound(err) {
 		// Seed cluster does not seem to be managed by Gardener

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -49,7 +49,7 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, log logr.Logger, 
 	shootTechnicalID, _ := backupentry.ExtractShootDetailsFromBackupEntryName(be.Name)
 
 	namespace := &corev1.Namespace{}
-	if err := a.client.Get(ctx, kubernetesutils.Key(shootTechnicalID), namespace); err != nil {
+	if err := a.client.Get(ctx, client.ObjectKey{Name: shootTechnicalID}, namespace); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("SeedNamespace for shoot not found. Avoiding etcd backup secret deployment")
 			return nil

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -434,7 +434,7 @@ webhooks:
 			vp.EXPECT().GetStorageClassesChartValues(ctx, cp, cluster).Return(storageClassesChartValues, nil)
 
 			// Handle shoot access secrets and legacy secret cleanup
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootAccessSecretsFunc(namespace)[0].Secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: shootAccessSecretsFunc(namespace)[0].Secret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 				Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) {
 					obj.SetResourceVersion("0")
 				})
@@ -615,7 +615,7 @@ webhooks:
 			vp.EXPECT().GetControlPlaneExposureChartValues(ctx, cpExposure, cluster, gomock.Any(), exposureChecksums).Return(controlPlaneExposureChartValues, nil)
 
 			// Handle shoot access secrets and legacy secret cleanup
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, exposureShootAccessSecretsFunc(namespace)[0].Secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: exposureShootAccessSecretsFunc(namespace)[0].Secret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 				Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) {
 					obj.SetResourceVersion("0")
 				})

--- a/extensions/pkg/controller/operatingsystemconfig/bash.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash.go
@@ -16,7 +16,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // FilesToDiskScript is a utility function which generates a bash script for writing the provided files to the disk.
@@ -76,7 +75,7 @@ func dataForFileContent(ctx context.Context, c client.Reader, namespace string, 
 	}
 
 	secret := &corev1.Secret{}
-	if err := c.Get(ctx, kubernetesutils.Key(namespace, content.SecretRef.Name), secret); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: content.SecretRef.Name}, secret); err != nil {
 		return nil, err
 	}
 

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -13,10 +13,9 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 func scaleMachineControllerManager(ctx context.Context, logger logr.Logger, cl client.Client, worker *extensionsv1alpha1.Worker, replicas int32) error {
 	logger.Info("Scaling machine-controller-manager", "replicas", replicas)
-	return client.IgnoreNotFound(kubernetes.ScaleDeployment(ctx, cl, kubernetesutils.Key(worker.Namespace, v1beta1constants.DeploymentNameMachineControllerManager), replicas))
+	return client.IgnoreNotFound(kubernetes.ScaleDeployment(ctx, cl, client.ObjectKey{Namespace: worker.Namespace, Name: v1beta1constants.DeploymentNameMachineControllerManager}, replicas))
 }

--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -216,19 +216,19 @@ func DefaultInitializer(c client.Client, main, variables string, tfvars []byte, 
 func (t *terraformer) NumberOfResources(ctx context.Context) (int, error) {
 	numberOfExistingResources := 0
 
-	if err := t.client.Get(ctx, kubernetesutils.Key(t.namespace, t.stateName), &corev1.ConfigMap{}); err == nil {
+	if err := t.client.Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: t.stateName}, &corev1.ConfigMap{}); err == nil {
 		numberOfExistingResources++
 	} else if !apierrors.IsNotFound(err) {
 		return -1, err
 	}
 
-	if err := t.client.Get(ctx, kubernetesutils.Key(t.namespace, t.variablesName), &corev1.Secret{}); err == nil {
+	if err := t.client.Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: t.variablesName}, &corev1.Secret{}); err == nil {
 		numberOfExistingResources++
 	} else if !apierrors.IsNotFound(err) {
 		return -1, err
 	}
 
-	if err := t.client.Get(ctx, kubernetesutils.Key(t.namespace, t.configName), &corev1.ConfigMap{}); err == nil {
+	if err := t.client.Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: t.configName}, &corev1.ConfigMap{}); err == nil {
 		numberOfExistingResources++
 	} else if !apierrors.IsNotFound(err) {
 		return -1, err
@@ -273,7 +273,7 @@ func (t *terraformer) RemoveTerraformerFinalizerFromConfig(ctx context.Context) 
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: t.stateName}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: t.configName}},
 	} {
-		if err := t.client.Get(ctx, kubernetesutils.Key(t.namespace, obj.GetName()), obj); client.IgnoreNotFound(err) != nil {
+		if err := t.client.Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: obj.GetName()}, obj); client.IgnoreNotFound(err) != nil {
 			return err
 		}
 

--- a/extensions/pkg/terraformer/raw_state.go
+++ b/extensions/pkg/terraformer/raw_state.go
@@ -12,8 +12,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Marshal transform RawState to []byte representation. It encodes the raw state data
@@ -24,7 +23,7 @@ func (trs *RawState) Marshal() ([]byte, error) {
 // GetRawState returns the content of terraform state config map
 func (t *terraformer) GetRawState(ctx context.Context) (*RawState, error) {
 	configMap := &corev1.ConfigMap{}
-	if err := t.client.Get(ctx, kubernetesutils.Key(t.namespace, t.stateName), configMap); err != nil {
+	if err := t.client.Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: t.stateName}, configMap); err != nil {
 		return nil, err
 	}
 	return &RawState{
@@ -98,7 +97,7 @@ func (trs *RawState) decode() (*RawState, error) {
 		trs.Data = string(trsDec)
 		trs.Encoding = NoneEncoding
 	case NoneEncoding:
-		//do nothing
+		// do nothing
 	default:
 		return nil, fmt.Errorf("unrecognised encoding %q for RawState.Data", trs.Encoding)
 	}

--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -43,7 +43,7 @@ type terraformStateV4 struct {
 // GetState returns the Terraform state as byte slice.
 func (t *terraformer) GetState(ctx context.Context) ([]byte, error) {
 	configMap := &corev1.ConfigMap{}
-	if err := t.client.Get(ctx, kubernetesutils.Key(t.namespace, t.stateName), configMap); err != nil {
+	if err := t.client.Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: t.stateName}, configMap); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +97,7 @@ func (t *terraformer) IsStateEmpty(ctx context.Context) bool {
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: t.variablesName}},
 	} {
 		resourceName := obj.GetName()
-		if err := t.client.Get(ctx, kubernetesutils.Key(t.namespace, resourceName), obj); client.IgnoreNotFound(err) != nil {
+		if err := t.client.Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: resourceName}, obj); client.IgnoreNotFound(err) != nil {
 			t.logger.Error(err, "Failed to get resource", "name", resourceName)
 			return false
 		}

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -90,7 +90,7 @@ var _ = Describe("terraformer", func() {
 
 			gomock.InOrder(
 				c.EXPECT().
-					Get(gomock.Any(), kubernetesutils.Key(namespace, name), &corev1.ConfigMap{ObjectMeta: objectMeta}).
+					Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: name}, &corev1.ConfigMap{ObjectMeta: objectMeta}).
 					Return(apierrors.NewNotFound(configMapGroupResource, name)),
 				c.EXPECT().
 					Create(gomock.Any(), expected.DeepCopy()),
@@ -125,7 +125,7 @@ var _ = Describe("terraformer", func() {
 
 			gomock.InOrder(
 				c.EXPECT().
-					Get(gomock.Any(), kubernetesutils.Key(namespace, name), &corev1.ConfigMap{ObjectMeta: objectMeta}).
+					Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: name}, &corev1.ConfigMap{ObjectMeta: objectMeta}).
 					Return(apierrors.NewNotFound(configMapGroupResource, name)),
 				c.EXPECT().
 					Create(gomock.Any(), expected.DeepCopy()),
@@ -194,7 +194,7 @@ var _ = Describe("terraformer", func() {
 			It("Should create the ConfigMap", func() {
 				var (
 					state      = "state"
-					stateKey   = kubernetesutils.Key(namespace, name)
+					stateKey   = client.ObjectKey{Namespace: namespace, Name: name}
 					objectMeta = metav1.ObjectMeta{
 						Namespace: namespace,
 						Name:      name,
@@ -246,7 +246,7 @@ var _ = Describe("terraformer", func() {
 
 			gomock.InOrder(
 				c.EXPECT().
-					Get(gomock.Any(), kubernetesutils.Key(namespace, name), &corev1.Secret{ObjectMeta: objectMeta}).
+					Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: name}, &corev1.Secret{ObjectMeta: objectMeta}).
 					Return(apierrors.NewNotFound(secretGroupResource, name)),
 				c.EXPECT().
 					Create(gomock.Any(), expected.DeepCopy()),
@@ -281,7 +281,7 @@ var _ = Describe("terraformer", func() {
 
 			gomock.InOrder(
 				c.EXPECT().
-					Get(gomock.Any(), kubernetesutils.Key(namespace, name), &corev1.Secret{ObjectMeta: objectMeta}).
+					Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: name}, &corev1.Secret{ObjectMeta: objectMeta}).
 					Return(apierrors.NewNotFound(secretGroupResource, name)),
 				c.EXPECT().
 					Create(gomock.Any(), expected.DeepCopy()),
@@ -316,9 +316,9 @@ var _ = Describe("terraformer", func() {
 		BeforeEach(func() {
 			tfVars = []byte("tfvars")
 
-			configurationKey = kubernetesutils.Key(namespace, configurationName)
-			variablesKey = kubernetesutils.Key(namespace, variablesName)
-			stateKey = kubernetesutils.Key(namespace, stateName)
+			configurationKey = client.ObjectKey{Namespace: namespace, Name: configurationName}
+			variablesKey = client.ObjectKey{Namespace: namespace, Name: variablesName}
+			stateKey = client.ObjectKey{Namespace: namespace, Name: stateName}
 
 			configurationObjectMeta = kubernetesutils.ObjectMeta(namespace, configurationName)
 			variablesObjectMeta = kubernetesutils.ObjectMeta(namespace, variablesName)
@@ -482,7 +482,7 @@ var _ = Describe("terraformer", func() {
 	Describe("#GetStateOutputVariables", func() {
 		var (
 			stateName = fmt.Sprintf("%s.%s.tf-state", name, purpose)
-			stateKey  = kubernetesutils.Key(namespace, stateName)
+			stateKey  = client.ObjectKey{Namespace: namespace, Name: stateName}
 		)
 
 		It("should return err when state version is not supported", func() {
@@ -614,7 +614,7 @@ var _ = Describe("terraformer", func() {
 
 			gomock.InOrder(
 				c.EXPECT().
-					Get(gomock.Any(), kubernetesutils.Key(namespace, variablesName), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: variablesName}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 					DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
 						s.SetFinalizers([]string{TerraformerFinalizer})
 						return nil
@@ -623,7 +623,7 @@ var _ = Describe("terraformer", func() {
 					Patch(gomock.Any(), gomock.AssignableToTypeOf(secret.DeepCopy()), gomock.AssignableToTypeOf(client.MergeFromWithOptions(secret.DeepCopy(), client.MergeFromWithOptimisticLock{}))),
 
 				c.EXPECT().
-					Get(gomock.Any(), kubernetesutils.Key(namespace, stateName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
+					Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: stateName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
 					DoAndReturn(func(_ context.Context, _ client.ObjectKey, configMap *corev1.ConfigMap, _ ...client.GetOption) error {
 						configMap.SetFinalizers([]string{TerraformerFinalizer})
 						return nil
@@ -632,7 +632,7 @@ var _ = Describe("terraformer", func() {
 					Patch(gomock.Any(), gomock.AssignableToTypeOf(config.DeepCopy()), gomock.AssignableToTypeOf(client.MergeFromWithOptions(config.DeepCopy(), client.MergeFromWithOptimisticLock{}))),
 
 				c.EXPECT().
-					Get(gomock.Any(), kubernetesutils.Key(namespace, configName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
+					Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: configName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
 					DoAndReturn(func(_ context.Context, _ client.ObjectKey, configMap *corev1.ConfigMap, _ ...client.GetOption) error {
 						configMap.SetFinalizers([]string{TerraformerFinalizer})
 						return nil

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -320,9 +319,9 @@ var _ = Describe("terraformer", func() {
 			variablesKey = client.ObjectKey{Namespace: namespace, Name: variablesName}
 			stateKey = client.ObjectKey{Namespace: namespace, Name: stateName}
 
-			configurationObjectMeta = kubernetesutils.ObjectMeta(namespace, configurationName)
-			variablesObjectMeta = kubernetesutils.ObjectMeta(namespace, variablesName)
-			stateObjectMeta = kubernetesutils.ObjectMeta(namespace, stateName)
+			configurationObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: configurationName}
+			variablesObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: variablesName}
+			stateObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: stateName}
 
 			getConfiguration = &corev1.ConfigMap{ObjectMeta: configurationObjectMeta}
 			getVariables = &corev1.Secret{ObjectMeta: variablesObjectMeta}

--- a/extensions/pkg/util/shoot_clients.go
+++ b/extensions/pkg/util/shoot_clients.go
@@ -22,7 +22,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	kubernetesclient "github.com/gardener/gardener/pkg/client/kubernetes"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 )
 
@@ -81,11 +80,11 @@ func NewClientForShoot(ctx context.Context, c client.Client, namespace string, o
 	)
 
 	if os.Getenv("GARDENER_SHOOT_CLIENT") != "external" {
-		if err = c.Get(ctx, kubernetesutils.Key(namespace, v1beta1constants.SecretNameGardenerInternal), gardenerSecret); err != nil && apierrors.IsNotFound(err) {
-			err = c.Get(ctx, kubernetesutils.Key(namespace, v1beta1constants.SecretNameGardener), gardenerSecret)
+		if err = c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameGardenerInternal}, gardenerSecret); err != nil && apierrors.IsNotFound(err) {
+			err = c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameGardener}, gardenerSecret)
 		}
 	} else {
-		err = c.Get(ctx, kubernetesutils.Key(namespace, v1beta1constants.SecretNameGardener), gardenerSecret)
+		err = c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameGardener}, gardenerSecret)
 	}
 	if err != nil {
 		return nil, nil, err

--- a/extensions/pkg/webhook/shoot/webhook_test.go
+++ b/extensions/pkg/webhook/shoot/webhook_test.go
@@ -27,7 +27,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -230,6 +229,6 @@ func expectWebhookConfigReconciliation(ctx context.Context, fakeClient client.Cl
 }
 
 func expectNoWebhookConfigReconciliation(ctx context.Context, fakeClient client.Client, namespace, managedResourceName string) {
-	ExpectWithOffset(1, fakeClient.Get(ctx, kubernetesutils.Key(namespace, managedResourceName), &corev1.Secret{})).To(BeNotFoundError())
-	ExpectWithOffset(1, fakeClient.Get(ctx, kubernetesutils.Key(namespace, managedResourceName), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: managedResourceName}, &corev1.Secret{})).To(BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: managedResourceName}, &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
 }

--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/handler.go
@@ -32,7 +32,6 @@ import (
 	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 const auditPolicyConfigMapDataKey = "policy"
@@ -127,7 +126,7 @@ func (h *Handler) admitShoot(ctx context.Context, request admission.Request) adm
 	}
 
 	auditPolicyCm := &corev1.ConfigMap{}
-	if err := h.APIReader.Get(ctx, kubernetesutils.Key(shoot.Namespace, newAuditPolicyConfigMapName), auditPolicyCm); err != nil {
+	if err := h.APIReader.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: newAuditPolicyConfigMapName}, auditPolicyCm); err != nil {
 		if apierrors.IsNotFound(err) {
 			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("referenced audit policy does not exist: namespace: %s, name: %s", shoot.Namespace, newAuditPolicyConfigMapName))
 		}

--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
@@ -29,7 +29,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -229,7 +228,7 @@ rules:
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
 					Data:       map[string]string{"policy": validAuditPolicy},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -250,7 +249,7 @@ rules:
 				shootv1beta1.Spec.Kubernetes.KubeAPIServer = nil
 				newShoot := shootv1beta1.DeepCopy()
 				newShoot.Spec.Kubernetes.KubeAPIServer = apiServerConfig
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -263,7 +262,7 @@ rules:
 				}
 				newShoot := shootv1beta1.DeepCopy()
 				newShoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name = cmNameOther
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmNameOther), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmNameOther}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -297,21 +296,21 @@ rules:
 
 		Context("Deny", func() {
 			It("references a configmap that does not exist", func() {
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmName), &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ *corev1.ConfigMap, _ ...client.GetOption) error {
 					return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cmName)
 				})
 				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "referenced audit policy does not exist", "")
 			})
 
 			It("fails getting cm", func() {
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmName), &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ *corev1.ConfigMap, _ ...client.GetOption) error {
 					return errors.New("fake")
 				})
 				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInternalError, "could not retrieve config map: fake", "")
 			})
 
 			It("references configmap without a policy key", func() {
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmName), &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = corev1.ConfigMap{
 						Data: nil,
 					}
@@ -326,7 +325,7 @@ rules:
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": invalidAuditPolicy},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -339,7 +338,7 @@ rules:
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": missingKeyAuditPolicy},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -352,7 +351,7 @@ rules:
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": validAuditPolicyV1alpha1},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kubernetesutils.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})

--- a/pkg/admissioncontroller/webhook/admission/namespacedeletion/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/namespacedeletion/handler_test.go
@@ -26,7 +26,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -79,17 +78,17 @@ var _ = Describe("handler", func() {
 	}
 
 	It("should pass because no projects available", func() {
-		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+		mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 			namespace.DeepCopyInto(obj)
 			return nil
 		})
-		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
 		test(Succeed())
 	})
 
 	It("should pass because namespace is not project related", func() {
-		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+		mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 			(&corev1.Namespace{}).DeepCopyInto(obj)
 			return nil
 		})
@@ -98,23 +97,23 @@ var _ = Describe("handler", func() {
 	})
 
 	It("should fail because get namespace fails", func() {
-		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(errors.New("fake"))
+		mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(errors.New("fake"))
 
 		test(MatchError(ContainSubstring("fake")))
 	})
 
 	It("should fail because getting the projects fails", func() {
-		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+		mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 			namespace.DeepCopyInto(obj)
 			return nil
 		})
-		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(errors.New("fake"))
+		mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(errors.New("fake"))
 
 		test(MatchError(ContainSubstring("fake")))
 	})
 
 	It("should pass because namespace is already gone", func() {
-		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
 		test(Succeed())
 	})
@@ -123,23 +122,23 @@ var _ = Describe("handler", func() {
 		var relatedProject gardencorev1beta1.Project
 
 		It("should pass because namespace is already marked for deletion", func() {
-			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 				now := metav1.Now()
 				namespace.SetDeletionTimestamp(&now)
 				namespace.DeepCopyInto(obj)
 				return nil
 			})
-			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}))
+			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}))
 
 			test(Succeed())
 		})
 
 		It("should forbid namespace deletion because project is not marked for deletion", func() {
-			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 				namespace.DeepCopyInto(obj)
 				return nil
 			})
-			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}))
+			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}))
 
 			test(MatchError(ContainSubstring("direct deletion of namespace")))
 		})
@@ -149,11 +148,11 @@ var _ = Describe("handler", func() {
 				now := metav1.Now()
 				relatedProject.SetDeletionTimestamp(&now)
 
-				mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+				mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 					namespace.DeepCopyInto(obj)
 					return nil
 				})
-				mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
+				mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
 					relatedProject.DeepCopyInto(obj)
 					return nil
 				})

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
@@ -36,7 +36,6 @@ import (
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var (
@@ -116,7 +115,7 @@ func (h *Handler) admitBackupBucket(ctx context.Context, seedName string, reques
 		// If a gardenlet tries to delete a BackupBucket then it may only be allowed if the name is equal to the UID of
 		// the gardenlet's seed.
 		seed := &gardencorev1beta1.Seed{}
-		if err := h.Client.Get(ctx, kubernetesutils.Key(seedName), seed); err != nil {
+		if err := h.Client.Get(ctx, client.ObjectKey{Name: seedName}, seed); err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 		if string(seed.UID) != request.Name {
@@ -147,7 +146,7 @@ func (h *Handler) admitBackupEntry(ctx context.Context, seedName string, request
 	}
 
 	backupBucket := &gardencorev1beta1.BackupBucket{}
-	if err := h.Client.Get(ctx, kubernetesutils.Key(backupEntry.Spec.BucketName), backupBucket); err != nil {
+	if err := h.Client.Get(ctx, client.ObjectKey{Name: backupEntry.Spec.BucketName}, backupBucket); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
@@ -159,7 +158,7 @@ func (h *Handler) admitSourceBackupEntry(ctx context.Context, backupEntry *garde
 	// so allow creations only if the shoot that owns the BackupEntry is currently being restored.
 	shootName := gardenerutils.GetShootNameFromOwnerReferences(backupEntry)
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := h.Client.Get(ctx, kubernetesutils.Key(backupEntry.Namespace, shootName), shoot); err != nil {
+	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: backupEntry.Namespace, Name: shootName}, shoot); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
@@ -172,7 +171,7 @@ func (h *Handler) admitSourceBackupEntry(ctx context.Context, backupEntry *garde
 	// The original BackupEntry is modified after the source BackupEntry has been deployed and successfully reconciled.
 	shootBackupEntryName := strings.TrimPrefix(backupEntry.Name, fmt.Sprintf("%s-", v1beta1constants.BackupSourcePrefix))
 	shootBackupEntry := &gardencorev1beta1.BackupEntry{}
-	if err := h.Client.Get(ctx, kubernetesutils.Key(backupEntry.Namespace, shootBackupEntryName), shootBackupEntry); err != nil {
+	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: backupEntry.Namespace, Name: shootBackupEntryName}, shootBackupEntry); err != nil {
 		if apierrors.IsNotFound(err) {
 			return admission.Errored(http.StatusForbidden, fmt.Errorf("could not find original BackupEntry %s: %w", shootBackupEntryName, err))
 		}
@@ -264,7 +263,7 @@ func (h *Handler) admitInternalSecret(ctx context.Context, seedName string, requ
 	// Check if the internal secret is related to a Shoot assigned to the seed the gardenlet is responsible for.
 	if shootName, ok := gardenerutils.IsShootProjectInternalSecret(request.Name); ok {
 		shoot := &gardencorev1beta1.Shoot{}
-		if err := h.Client.Get(ctx, kubernetesutils.Key(request.Namespace, shootName), shoot); err != nil {
+		if err := h.Client.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: shootName}, shoot); err != nil {
 			if apierrors.IsNotFound(err) {
 				return admission.Errored(http.StatusForbidden, err)
 			}
@@ -311,7 +310,7 @@ func (h *Handler) admitSecret(ctx context.Context, seedName string, request admi
 	// Check if the secret is related to a BackupBucket assigned to the seed the gardenlet is responsible for.
 	if strings.HasPrefix(request.Name, v1beta1constants.SecretPrefixGeneratedBackupBucket) {
 		backupBucket := &gardencorev1beta1.BackupBucket{}
-		if err := h.Client.Get(ctx, kubernetesutils.Key(strings.TrimPrefix(request.Name, v1beta1constants.SecretPrefixGeneratedBackupBucket)), backupBucket); err != nil {
+		if err := h.Client.Get(ctx, client.ObjectKey{Name: strings.TrimPrefix(request.Name, v1beta1constants.SecretPrefixGeneratedBackupBucket)}, backupBucket); err != nil {
 			if apierrors.IsNotFound(err) {
 				return admission.Errored(http.StatusForbidden, err)
 			}
@@ -324,7 +323,7 @@ func (h *Handler) admitSecret(ctx context.Context, seedName string, request admi
 	// Check if the secret is related to a Shoot assigned to the seed the gardenlet is responsible for.
 	if shootName, ok := gardenerutils.IsShootProjectSecret(request.Name); ok {
 		shoot := &gardencorev1beta1.Shoot{}
-		if err := h.Client.Get(ctx, kubernetesutils.Key(request.Namespace, shootName), shoot); err != nil {
+		if err := h.Client.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: shootName}, shoot); err != nil {
 			if apierrors.IsNotFound(err) {
 				return admission.Errored(http.StatusForbidden, err)
 			}
@@ -406,7 +405,7 @@ func (h *Handler) admitSecret(ctx context.Context, seedName string, request admi
 
 	for _, managedSeed := range managedSeedList.Items {
 		shoot := &gardencorev1beta1.Shoot{}
-		if err := h.Client.Get(ctx, kubernetesutils.Key(managedSeed.Namespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
+		if err := h.Client.Get(ctx, client.ObjectKey{Namespace: managedSeed.Namespace, Name: managedSeed.Spec.Shoot.Name}, shoot); err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
@@ -437,7 +436,7 @@ func (h *Handler) admitConfigMap(ctx context.Context, seedName string, request a
 	// Check if the config map is related to a Shoot assigned to the seed the gardenlet is responsible for.
 	if shootName, ok := gardenerutils.IsShootProjectConfigMap(request.Name); ok {
 		shoot := &gardencorev1beta1.Shoot{}
-		if err := h.Client.Get(ctx, kubernetesutils.Key(request.Namespace, shootName), shoot); err != nil {
+		if err := h.Client.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: shootName}, shoot); err != nil {
 			if apierrors.IsNotFound(err) {
 				return admission.Errored(http.StatusForbidden, err)
 			}
@@ -456,7 +455,7 @@ func (h *Handler) admitSeed(ctx context.Context, seedName string, request admiss
 		// If the deletion request is not allowed, then it might be submitted by the "parent gardenlet".
 		// This is the gardenlet/seed which is responsible for the `managedseed` in question.
 		managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-		if err := h.Client.Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, request.Name), managedSeed); err != nil {
+		if err := h.Client.Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: request.Name}, managedSeed); err != nil {
 			if apierrors.IsNotFound(err) {
 				return response
 			}
@@ -478,7 +477,7 @@ func (h *Handler) admitSeed(ctx context.Context, seedName string, request admiss
 		// Check if the `.spec.seedName` of the Shoot referenced in the `.spec.shoot.name` field of the ManagedSeed matches
 		// the seed name of the requesting gardenlet.
 		shoot := &gardencorev1beta1.Shoot{}
-		if err := h.Client.Get(ctx, kubernetesutils.Key(managedSeed.Namespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
+		if err := h.Client.Get(ctx, client.ObjectKey{Namespace: managedSeed.Namespace, Name: managedSeed.Spec.Shoot.Name}, shoot); err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
@@ -517,7 +516,7 @@ func (h *Handler) admitShootState(ctx context.Context, seedName string, request 
 	}
 
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := h.Client.Get(ctx, kubernetesutils.Key(request.Namespace, request.Name), shoot); err != nil {
+	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: request.Name}, shoot); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
@@ -537,7 +536,7 @@ func (h *Handler) admit(seedName string, seedNamesForObject ...*string) admissio
 
 func (h *Handler) allowIfManagedSeedIsNotYetBootstrapped(ctx context.Context, seedName, managedSeedNamespace, managedSeedName string) admission.Response {
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := h.Client.Get(ctx, kubernetesutils.Key(managedSeedNamespace, managedSeedName), managedSeed); err != nil {
+	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: managedSeedNamespace, Name: managedSeedName}, managedSeed); err != nil {
 		if apierrors.IsNotFound(err) {
 			return admission.Errored(http.StatusForbidden, err)
 		}
@@ -545,7 +544,7 @@ func (h *Handler) allowIfManagedSeedIsNotYetBootstrapped(ctx context.Context, se
 	}
 
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := h.Client.Get(ctx, kubernetesutils.Key(managedSeed.Namespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
+	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: managedSeed.Namespace, Name: managedSeed.Spec.Shoot.Name}, shoot); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
@@ -554,7 +553,7 @@ func (h *Handler) allowIfManagedSeedIsNotYetBootstrapped(ctx context.Context, se
 	}
 
 	seed := &gardencorev1beta1.Seed{}
-	if err := h.Client.Get(ctx, kubernetesutils.Key(managedSeedName), seed); err != nil {
+	if err := h.Client.Get(ctx, client.ObjectKey{Name: managedSeedName}, seed); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
@@ -13,13 +13,13 @@ import (
 	toolscache "k8s.io/client-go/tools/cache"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	seedmanagementv1alpha1helper "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 func (g *graph) setupManagedSeedWatch(ctx context.Context, informer cache.Informer) error {
@@ -93,7 +93,7 @@ func (g *graph) handleManagedSeedCreateOrUpdate(ctx context.Context, managedSeed
 	allowBootstrap := false
 
 	seed := &gardencorev1beta1.Seed{}
-	if err := g.client.Get(ctx, kubernetesutils.Key(managedSeed.Name), seed); err != nil {
+	if err := g.client.Get(ctx, client.ObjectKey{Name: managedSeed.Name}, seed); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return
 		}

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -38,7 +38,6 @@ import (
 	. "github.com/gardener/gardener/pkg/component/autoscaling/vpa"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -1485,7 +1484,7 @@ var _ = Describe("VPA", func() {
 					Expect(secret).To(Equal(shootAccessSecretUpdater))
 
 					deployment := &appsv1.Deployment{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, "vpa-updater"), deployment)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpa-updater"}, deployment)).To(Succeed())
 					deploymentUpdater := deploymentUpdaterFor(false, nil, nil, nil, nil, nil)
 					deploymentUpdater.ResourceVersion = "1"
 					Expect(deployment).To(Equal(deploymentUpdater))
@@ -1513,13 +1512,13 @@ var _ = Describe("VPA", func() {
 					Expect(secret).To(Equal(shootAccessSecretRecommender))
 
 					deployment = &appsv1.Deployment{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, "vpa-recommender"), deployment)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpa-recommender"}, deployment)).To(Succeed())
 					deploymentRecommender := deploymentRecommenderFor(false, nil, nil, component.ClusterTypeShoot, nil)
 					deploymentRecommender.ResourceVersion = "1"
 					Expect(deployment).To(Equal(deploymentRecommender))
 
 					service := &corev1.Service{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, "vpa-recommender"), service)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpa-recommender"}, service)).To(Succeed())
 					serviceRecommender := serviceRecommenderFor(component.ClusterTypeShoot)
 					serviceRecommender.ResourceVersion = "1"
 					Expect(service).To(Equal(serviceRecommender))
@@ -1541,13 +1540,13 @@ var _ = Describe("VPA", func() {
 					Expect(secret).To(Equal(shootAccessSecretAdmissionController))
 
 					service = &corev1.Service{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, "vpa-webhook"), service)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpa-webhook"}, service)).To(Succeed())
 					serviceAdmissionController := serviceAdmissionControllerFor(component.ClusterTypeShoot, false)
 					serviceAdmissionController.ResourceVersion = "1"
 					Expect(service).To(Equal(serviceAdmissionController))
 
 					deployment = &appsv1.Deployment{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, "vpa-admission-controller"), deployment)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpa-admission-controller"}, deployment)).To(Succeed())
 					deploymentAdmissionController := deploymentAdmissionControllerFor(false)
 					deploymentAdmissionController.ResourceVersion = "1"
 					Expect(deployment).To(Equal(deploymentAdmissionController))
@@ -1624,7 +1623,7 @@ var _ = Describe("VPA", func() {
 					Expect(vpa.Deploy(ctx)).To(Succeed())
 
 					service := &corev1.Service{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, "vpa-webhook"), service)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpa-webhook"}, service)).To(Succeed())
 					serviceAdmissionController := serviceAdmissionControllerFor(component.ClusterTypeShoot, true)
 					serviceAdmissionController.ResourceVersion = "1"
 					Expect(service).To(Equal(serviceAdmissionController))

--- a/pkg/component/clusteridentity/clusteridentity.go
+++ b/pkg/component/clusteridentity/clusteridentity.go
@@ -18,7 +18,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
@@ -151,7 +150,7 @@ func (c *clusterIdentity) WaitCleanup(ctx context.Context) error {
 // IsClusterIdentityEmptyOrFromOrigin checks if the cluster-identity config map does not exist or is from the same origin
 func IsClusterIdentityEmptyOrFromOrigin(ctx context.Context, c client.Client, origin string) (bool, error) {
 	clusterIdentity := &corev1.ConfigMap{}
-	if err := c.Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, v1beta1constants.ClusterIdentity), clusterIdentity); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: v1beta1constants.ClusterIdentity}, clusterIdentity); err != nil {
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/etcd/etcd/constants"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
@@ -655,14 +654,14 @@ var _ = Describe("Etcd", func() {
 
 	Describe("#Deploy", func() {
 		It("should fail because the etcd object retrieval fails", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(fakeErr)
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(fakeErr)
 
 			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
 		})
 
 		It("should fail because the statefulset object retrieval fails (using the default sts name)", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-			c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
 
 			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
 		})
@@ -670,7 +669,7 @@ var _ = Describe("Etcd", func() {
 		It("should fail because the statefulset object retrieval fails (using the sts name from etcd object)", func() {
 			statefulSetName := "sts-name"
 
-			c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					(&druidv1alpha1.Etcd{
 						Status: druidv1alpha1.EtcdStatus{
@@ -682,16 +681,16 @@ var _ = Describe("Etcd", func() {
 					return nil
 				},
 			)
-			c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, statefulSetName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: statefulSetName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
 
 			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
 		})
 
 		It("should fail because the etcd cannot be created", func() {
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Return(fakeErr),
 			)
 
@@ -700,12 +699,12 @@ var _ = Describe("Etcd", func() {
 
 		It("should fail because the hvpa cannot be created", func() {
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Return(fakeErr),
 			)
 
@@ -729,9 +728,9 @@ var _ = Describe("Etcd", func() {
 			})
 
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
 				c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Return(fakeErr),
 			)
@@ -745,9 +744,9 @@ var _ = Describe("Etcd", func() {
 			TimeNow = func() time.Time { return now }
 
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(etcdObjFor(
 						class,
@@ -765,7 +764,7 @@ var _ = Describe("Etcd", func() {
 						false)))
 				}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
 				}),
@@ -797,7 +796,7 @@ var _ = Describe("Etcd", func() {
 			})
 
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					(&druidv1alpha1.Etcd{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      etcdName,
@@ -809,8 +808,8 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
 					// ignore status when comparing
 					obj.Status = druidv1alpha1.EtcdStatus{}
@@ -831,7 +830,7 @@ var _ = Describe("Etcd", func() {
 						false)))
 				}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, updateModeMaintenanceWindow)))
 				}),
@@ -863,7 +862,7 @@ var _ = Describe("Etcd", func() {
 			})
 
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					(&druidv1alpha1.Etcd{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      etcdName,
@@ -880,8 +879,8 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
 					// ignore status when comparing
 					obj.Status = druidv1alpha1.EtcdStatus{}
@@ -902,7 +901,7 @@ var _ = Describe("Etcd", func() {
 						false)))
 				}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, updateModeMaintenanceWindow)))
 				}),
@@ -917,7 +916,7 @@ var _ = Describe("Etcd", func() {
 			TimeNow = func() time.Time { return now }
 
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					(&druidv1alpha1.Etcd{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
@@ -934,8 +933,8 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
 					// ignore status when comparing
 					obj.Status = druidv1alpha1.EtcdStatus{}
@@ -961,7 +960,7 @@ var _ = Describe("Etcd", func() {
 					Expect(obj).To(DeepEqual(expectedObj))
 				}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
 				}),
@@ -978,7 +977,7 @@ var _ = Describe("Etcd", func() {
 			existingDefragmentationSchedule := "foobardefragexisting"
 
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					(&druidv1alpha1.Etcd{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      etcdName,
@@ -997,8 +996,8 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
 					// ignore status when comparing
 					obj.Status = druidv1alpha1.EtcdStatus{}
@@ -1019,7 +1018,7 @@ var _ = Describe("Etcd", func() {
 						false)))
 				}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
 				}),
@@ -1064,8 +1063,8 @@ var _ = Describe("Etcd", func() {
 			)
 
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					(&appsv1.StatefulSet{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      etcdName,
@@ -1090,7 +1089,7 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*appsv1.StatefulSet))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(etcdObjFor(
 						class,
@@ -1108,7 +1107,7 @@ var _ = Describe("Etcd", func() {
 						false)))
 				}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
 				}),
@@ -1150,8 +1149,8 @@ var _ = Describe("Etcd", func() {
 				)
 
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 						(&appsv1.StatefulSet{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      etcdName,
@@ -1176,7 +1175,7 @@ var _ = Describe("Etcd", func() {
 						}).DeepCopyInto(obj.(*appsv1.StatefulSet))
 						return nil
 					}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
@@ -1194,7 +1193,7 @@ var _ = Describe("Etcd", func() {
 							false)))
 					}),
 					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, vpaName), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 						Expect(obj).To(DeepEqual(expectedVPA))
 					}),
@@ -1233,9 +1232,9 @@ var _ = Describe("Etcd", func() {
 				})
 
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
@@ -1253,7 +1252,7 @@ var _ = Describe("Etcd", func() {
 							false)))
 					}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateMode)))
 					}),
@@ -1283,9 +1282,9 @@ var _ = Describe("Etcd", func() {
 				TimeNow = func() time.Time { return now }
 
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
@@ -1303,7 +1302,7 @@ var _ = Describe("Etcd", func() {
 							false)))
 					}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
 					}),
@@ -1320,7 +1319,7 @@ var _ = Describe("Etcd", func() {
 				existingBackupSchedule := "foobarbackupexisting"
 
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 						(&druidv1alpha1.Etcd{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      etcdName,
@@ -1339,8 +1338,8 @@ var _ = Describe("Etcd", func() {
 						}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 						return nil
 					}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						expobj := etcdObjFor(
 							class,
@@ -1361,7 +1360,7 @@ var _ = Describe("Etcd", func() {
 						Expect(obj).To(DeepEqual(expobj))
 					}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
 					}),
@@ -1382,9 +1381,9 @@ var _ = Describe("Etcd", func() {
 
 			createExpectations := func(caSecretName, clientSecretName, serverSecretName, peerCASecretName, peerServerSecretName string) {
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 						func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 							if peerServerSecretName != "" {
 								etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
@@ -1414,7 +1413,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, vpaName), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 						Expect(obj).To(DeepEqual(expectedVPA))
 					}),
@@ -1570,7 +1569,7 @@ var _ = Describe("Etcd", func() {
 			Context("when peer url secrets are present in etcd CR", func() {
 				It("should not remove peer URL secrets", func() {
 					gomock.InOrder(
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 							(&druidv1alpha1.Etcd{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      etcdName,
@@ -1590,8 +1589,8 @@ var _ = Describe("Etcd", func() {
 							}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 							return nil
 						}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 							func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 								etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
 									ServerTLSSecretRef: corev1.SecretReference{
@@ -1606,7 +1605,7 @@ var _ = Describe("Etcd", func() {
 							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).NotTo(BeNil())
 						}),
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, vpaName), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(expectedVPA))
 						}),
@@ -1619,7 +1618,7 @@ var _ = Describe("Etcd", func() {
 			Context("when peer url secrets are not present in etcd CR", func() {
 				It("should add peer url secrets", func() {
 					gomock.InOrder(
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 							(&druidv1alpha1.Etcd{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      etcdName,
@@ -1634,8 +1633,8 @@ var _ = Describe("Etcd", func() {
 							}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 							return nil
 						}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 							func(_ context.Context, _ client.ObjectKey, _ *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 								return nil
 							}),
@@ -1644,7 +1643,7 @@ var _ = Describe("Etcd", func() {
 							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).NotTo(BeNil())
 						}),
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, vpaName), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(expectedVPA))
 						}),
@@ -1682,9 +1681,9 @@ var _ = Describe("Etcd", func() {
 				})
 
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
@@ -1702,7 +1701,7 @@ var _ = Describe("Etcd", func() {
 							true)))
 					}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateMode)))
 					}),
@@ -1767,15 +1766,15 @@ var _ = Describe("Etcd", func() {
 				hvpaObj.Name = hvpaName
 
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObj))
 					}),
 					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: testNamespace}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: vpaName, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, "garden-virtual-garden-etcd-main"), gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "garden-virtual-garden-etcd-main"}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor))
 					}),
@@ -2147,7 +2146,7 @@ var _ = Describe("Etcd", func() {
 			It("should patch the etcd resource with the new peer CA secret name", func() {
 				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd-peer", Namespace: testNamespace}})).To(Succeed())
 
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					createEtcdObj("old-ca").DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				})
@@ -2160,7 +2159,7 @@ var _ = Describe("Etcd", func() {
 						return nil
 					})
 
-				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					createEtcdObj("old-ca").DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					obj.(*druidv1alpha1.Etcd).ObjectMeta.Annotations = map[string]string{"gardener.cloud/timestamp": "0001-01-01T00:00:00Z"}
 					return nil
@@ -2174,7 +2173,7 @@ var _ = Describe("Etcd", func() {
 
 				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: peerCAName, Namespace: testNamespace}})).To(Succeed())
 
-				c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					createEtcdObj(peerCAName).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				})
@@ -2187,7 +2186,7 @@ var _ = Describe("Etcd", func() {
 						return nil
 					})
 
-				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					createEtcdObj(peerCAName).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					obj.(*druidv1alpha1.Etcd).ObjectMeta.Annotations = map[string]string{"gardener.cloud/timestamp": "0001-01-01T00:00:00Z"}
 					return nil

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
@@ -250,7 +249,7 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 				}
 
 				secret := &corev1.Secret{}
-				if err := o.client.Get(ctx, kubernetesutils.Key(osc.Status.CloudConfig.SecretRef.Namespace, osc.Status.CloudConfig.SecretRef.Name), secret); err != nil {
+				if err := o.client.Get(ctx, client.ObjectKey{Namespace: osc.Status.CloudConfig.SecretRef.Namespace, Name: osc.Status.CloudConfig.SecretRef.Name}, secret); err != nil {
 					return err
 				}
 

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -39,7 +39,6 @@ import (
 	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -483,7 +482,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				mc.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
 
-				mc.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "shoot-access-gardener-node-agent"), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				mc.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-access-gardener-node-agent"}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 				mc.EXPECT().Create(ctx, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "shoot-access-gardener-node-agent",

--- a/pkg/component/garden/backupentry/backupentry_test.go
+++ b/pkg/component/garden/backupentry/backupentry_test.go
@@ -21,7 +21,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/component/garden/backupentry"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	mocktime "github.com/gardener/gardener/third_party/mock/go/time"
@@ -234,7 +233,7 @@ var _ = Describe("BackupEntry", func() {
 
 			Expect(c.Create(ctx, expected)).To(Succeed(), "migrating BackupEntry succeeds")
 			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(HaveOccurred())
-			Expect(c.Get(ctx, kubernetesutils.Key(expected.Namespace, expected.Name), migrated)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expected.Namespace, Name: expected.Name}, migrated)).To(Succeed())
 			Expect(migrated.Status.LastOperation).To(Equal(expected.Status.LastOperation))
 		})
 
@@ -297,7 +296,7 @@ var _ = Describe("BackupEntry", func() {
 
 			Expect(c.Create(ctx, expected)).To(Succeed())
 			Expect(defaultDepWaiter.SetForceDeletionAnnotation(ctx)).To(Succeed())
-			Expect(c.Get(ctx, kubernetesutils.Key(modified.Namespace, modified.Name), modified)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: modified.Namespace, Name: modified.Name}, modified)).To(Succeed())
 			Expect(modified.Annotations["backupentry.core.gardener.cloud/force-deletion"]).To(Equal("true"))
 		})
 	})

--- a/pkg/component/garden/projectrbac/projectrbac_test.go
+++ b/pkg/component/garden/projectrbac/projectrbac_test.go
@@ -19,7 +19,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/component/garden/projectrbac"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -419,41 +418,41 @@ var _ = Describe("ProjectRBAC", func() {
 			roleBindingProjectExtensionRole1.Subjects = []rbacv1.Subject{member1}
 
 			// project admin
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleProjectAdmin.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleProjectAdmin.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
 			c.EXPECT().Patch(ctx, clusterRoleProjectAdmin, gomock.Any())
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleBindingProjectAdmin.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleBindingProjectAdmin.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
 			c.EXPECT().Patch(ctx, clusterRoleBindingProjectAdmin, gomock.Any())
 
 			// project uam
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleProjectUAM.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleProjectUAM.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
 			c.EXPECT().Patch(ctx, clusterRoleProjectUAM, gomock.Any())
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleBindingProjectUAM.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleBindingProjectUAM.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
 			c.EXPECT().Patch(ctx, clusterRoleBindingProjectUAM, gomock.Any())
 
 			// project serviceaccountmanager
-			c.EXPECT().Get(ctx, kubernetesutils.Key(roleBindingProjectServiceAccountManager.Namespace, roleBindingProjectServiceAccountManager.Name), gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: roleBindingProjectServiceAccountManager.Namespace, Name: roleBindingProjectServiceAccountManager.Name}, gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}))
 			c.EXPECT().Patch(ctx, roleBindingProjectServiceAccountManager, gomock.Any())
 
 			// project member
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleProjectMember.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleProjectMember.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
 			c.EXPECT().Patch(ctx, clusterRoleProjectMember, gomock.Any())
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleBindingProjectMember.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleBindingProjectMember.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
 			c.EXPECT().Patch(ctx, clusterRoleBindingProjectMember, gomock.Any())
-			c.EXPECT().Get(ctx, kubernetesutils.Key(roleBindingProjectMember.Namespace, roleBindingProjectMember.Name), gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: roleBindingProjectMember.Namespace, Name: roleBindingProjectMember.Name}, gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}))
 			c.EXPECT().Patch(ctx, roleBindingProjectMember, gomock.Any())
 
 			// project viewer
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleProjectViewer.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleProjectViewer.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
 			c.EXPECT().Patch(ctx, clusterRoleProjectViewer, gomock.Any())
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleBindingProjectViewer.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleBindingProjectViewer.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
 			c.EXPECT().Patch(ctx, clusterRoleBindingProjectViewer, gomock.Any())
-			c.EXPECT().Get(ctx, kubernetesutils.Key(roleBindingProjectViewer.Namespace, roleBindingProjectViewer.Name), gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: roleBindingProjectViewer.Namespace, Name: roleBindingProjectViewer.Name}, gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}))
 			c.EXPECT().Patch(ctx, roleBindingProjectViewer, gomock.Any())
 
 			// project extension roles
-			c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleProjectExtensionRole1.Name), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleProjectExtensionRole1.Name}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}))
 			c.EXPECT().Patch(ctx, clusterRoleProjectExtensionRole1, gomock.Any())
-			c.EXPECT().Get(ctx, kubernetesutils.Key(roleBindingProjectExtensionRole1.Namespace, roleBindingProjectExtensionRole1.Name), gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: roleBindingProjectExtensionRole1.Namespace, Name: roleBindingProjectExtensionRole1.Name}, gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}))
 			c.EXPECT().Patch(ctx, roleBindingProjectExtensionRole1, gomock.Any())
 
 			Expect(projectRBAC.Deploy(ctx)).To(Succeed())

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -1910,7 +1910,7 @@ subjects:
 			Context("should successfully deploy all resources (w/ shoot access secret)", func() {
 				JustBeforeEach(func() {
 					gomock.InOrder(
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: secret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 							Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) {
 								obj.SetResourceVersion("0")
 							}),
@@ -1918,7 +1918,7 @@ subjects:
 							Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(secret))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(serviceAccount))
@@ -1927,36 +1927,36 @@ subjects:
 							Do(func(_ context.Context, obj *corev1.ConfigMap, _ ...client.CreateOption) {
 								Expect(obj).To(DeepEqual(configMap))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(watchedNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&rbacv1.Role{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: watchedNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&rbacv1.Role{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.Role{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(role))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&rbacv1.RoleBinding{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&rbacv1.RoleBinding{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(roleBinding))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.Service{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.Service{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(service))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(deployment))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager-vpa"), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(vpa))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})),
 						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(managedResourceSecret))
 						}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "shoot-core-gardener-resource-manager"), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(managedResource))
 						}),
@@ -1965,7 +1965,7 @@ subjects:
 
 				Context("Kubernetes version < 1.26", func() {
 					It("should successfully deploy all resources (w/ shoot access secret)", func() {
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, pdb.Name), gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}))
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: pdb.Name}, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}))
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(pdb))
@@ -1984,7 +1984,7 @@ subjects:
 						unhealthyPodEvictionPolicyAlwatysAllow := policyv1.AlwaysAllow
 						pdb.Spec.UnhealthyPodEvictionPolicy = &unhealthyPodEvictionPolicyAlwatysAllow
 
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, pdb.Name), gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}))
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: pdb.Name}, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}))
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(pdb))
@@ -2008,7 +2008,7 @@ subjects:
 					deployment = deploymentFor(configMap.Name, true, &secretNameBootstrapKubeconfig)
 
 					gomock.InOrder(
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: secret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 							Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) {
 								obj.SetResourceVersion("0")
 							}),
@@ -2016,7 +2016,7 @@ subjects:
 							Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(secret))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(serviceAccount))
@@ -2025,36 +2025,36 @@ subjects:
 							Do(func(_ context.Context, obj *corev1.ConfigMap, _ ...client.CreateOption) {
 								Expect(obj).To(DeepEqual(configMap))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(watchedNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&rbacv1.Role{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: watchedNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&rbacv1.Role{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.Role{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(role))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&rbacv1.RoleBinding{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&rbacv1.RoleBinding{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.RoleBinding{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(roleBinding))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.Service{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.Service{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(service))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(deployment))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager-vpa"), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).
 							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(vpa))
 							}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})),
 						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(managedResourceSecret))
 						}),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "shoot-core-gardener-resource-manager"), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(managedResource))
 						}),
@@ -2062,7 +2062,7 @@ subjects:
 				})
 
 				It("should successfully deploy all resources (w/ bootstrap kubeconfig)", func() {
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, pdb.Name), gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}))
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: pdb.Name}, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}))
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(pdb))
@@ -2088,7 +2088,7 @@ subjects:
 
 			It("should deploy a ClusterRole allowing access to mr related resources", func() {
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: secret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 						Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) {
 							obj.SetResourceVersion("0")
 						}),
@@ -2096,7 +2096,7 @@ subjects:
 						Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(secret))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(serviceAccount))
@@ -2105,41 +2105,41 @@ subjects:
 						Do(func(_ context.Context, obj *corev1.ConfigMap, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(configMap))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(clusterRole))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(clusterRoleBinding))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.Service{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.Service{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(service))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(deployment))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, pdb.Name), gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: pdb.Name}, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(pdb))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager-vpa"), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(vpa))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})),
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "shoot-core-gardener-resource-manager"), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
@@ -2149,15 +2149,15 @@ subjects:
 
 			It("should fail because the ClusterRole can not be created", func() {
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: secret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 						Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) {
 							obj.SetResourceVersion("0")
 						}),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.ConfigMap{})),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}), gomock.Any()).Return(fakeErr),
 				)
 
@@ -2166,17 +2166,17 @@ subjects:
 
 			It("should fail because the ClusterRoleBinding can not be created", func() {
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: secret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 						Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) {
 							obj.SetResourceVersion("0")
 						}),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.ConfigMap{})),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}), gomock.Any()).Return(fakeErr),
 				)
 
@@ -2200,7 +2200,7 @@ subjects:
 
 			It("should disable controllers and webhooks properly in resource manager configuration", func() {
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: secret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 						Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) {
 							obj.SetResourceVersion("0")
 						}),
@@ -2208,7 +2208,7 @@ subjects:
 						Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(secret))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(serviceAccount))
@@ -2217,41 +2217,41 @@ subjects:
 						Do(func(_ context.Context, obj *corev1.ConfigMap, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(configMap))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(clusterRole))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(clusterRoleBinding))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.Service{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.Service{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(service))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(deployment))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, pdb.Name), gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: pdb.Name}, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(pdb))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager-vpa"), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(vpa))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})),
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "shoot-core-gardener-resource-manager"), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
 						Expect(obj).To(Equal(managedResource))
 					}),
@@ -2302,9 +2302,9 @@ subjects:
 
 			It("should deploy a cluster role allowing all access", func() {
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key("managedresources.resources.gardener.cloud"), gomock.AssignableToTypeOf(&apiextensionsv1.CustomResourceDefinition{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: "managedresources.resources.gardener.cloud"}, gomock.AssignableToTypeOf(&apiextensionsv1.CustomResourceDefinition{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&apiextensionsv1.CustomResourceDefinition{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(serviceAccount))
@@ -2313,47 +2313,47 @@ subjects:
 						Do(func(_ context.Context, obj *corev1.ConfigMap, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(configMap))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(clusterRole))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(clusterRoleName), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(clusterRoleBinding))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&corev1.Service{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.Service{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(service))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(deployment))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, pdb.Name), gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: pdb.Name}, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(pdb))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager-vpa"), gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(vpa))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(mutatingWebhookConfiguration))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(validatingWebhookConfiguration))
 						}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "seed-gardener-resource-manager"), gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "seed-gardener-resource-manager"}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(serviceMonitor))

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -2726,7 +2726,7 @@ rules:
 					))
 
 					secret := &corev1.Secret{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, secretNameStaticToken), secret)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretNameStaticToken}, secret)).To(Succeed())
 					Expect(secret.Data).To(HaveKey("static_tokens.csv"))
 				})
 
@@ -2866,7 +2866,7 @@ rules:
 					deployAndRead()
 
 					secret := &corev1.Secret{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, secretNameStaticToken), secret)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretNameStaticToken}, secret)).To(Succeed())
 					Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElements(
 						corev1.Volume{
 							Name: "static-token",
@@ -2913,7 +2913,7 @@ rules:
 					))
 
 					secret = &corev1.Secret{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, newSecretNameStaticToken), secret)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: newSecretNameStaticToken}, secret)).To(Succeed())
 					Expect(secret.Data).To(HaveKey("static_tokens.csv"))
 				})
 

--- a/pkg/component/kubernetes/apiserverexposure/service_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/service_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -131,7 +130,7 @@ var _ = Describe("#Service", func() {
 			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 			actual := &corev1.Service{}
-			Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), actual)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, actual)).To(Succeed())
 
 			Expect(actual).To(DeepEqual(expected))
 			Expect(clusterIP).To(Equal("1.1.1.1"))
@@ -147,14 +146,14 @@ var _ = Describe("#Service", func() {
 		It("deletes service", func() {
 			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), &corev1.Service{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, &corev1.Service{})).To(BeNotFoundError())
 		})
 
 		It("waits for deletion service", func() {
 			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), &corev1.Service{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, &corev1.Service{})).To(BeNotFoundError())
 		})
 	}
 
@@ -206,7 +205,7 @@ var _ = Describe("#Service", func() {
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				actual := &corev1.Service{}
-				Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), actual)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, actual)).To(Succeed())
 
 				expected.Annotations = map[string]string{
 					"foo":                          "bar",
@@ -250,7 +249,7 @@ var _ = Describe("#Service", func() {
 					Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 					actual := &corev1.Service{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), actual)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, actual)).To(Succeed())
 
 					Expect(actual.Spec.ClusterIP).To(Equal(expected.Spec.ClusterIP))
 				})
@@ -265,7 +264,7 @@ var _ = Describe("#Service", func() {
 					Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 					actual := &corev1.Service{}
-					Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), actual)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, actual)).To(Succeed())
 
 					Expect(actual.Spec.ClusterIP).To(Equal(clusterIP))
 				})

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -30,7 +30,6 @@ import (
 	. "github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure"
 	comptest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -206,26 +205,26 @@ var _ = Describe("#SNI", func() {
 			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 			actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), actualDestinationRule)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDestinationRule.Namespace, Name: expectedDestinationRule.Name}, actualDestinationRule)).To(Succeed())
 			Expect(actualDestinationRule).To(BeComparableTo(expectedDestinationRule, comptest.CmpOptsForDestinationRule()))
 
 			actualGateway := &istionetworkingv1beta1.Gateway{}
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedGateway.Namespace, expectedGateway.Name), actualGateway)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedGateway.Namespace, Name: expectedGateway.Name}, actualGateway)).To(Succeed())
 			Expect(actualGateway).To(BeComparableTo(expectedGateway, comptest.CmpOptsForGateway()))
 
 			actualVirtualService := &istionetworkingv1beta1.VirtualService{}
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), actualVirtualService)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVirtualService.Namespace, Name: expectedVirtualService.Name}, actualVirtualService)).To(Succeed())
 			Expect(actualVirtualService).To(BeComparableTo(expectedVirtualService, comptest.CmpOptsForVirtualService()))
 
 			if apiServerProxyValues != nil {
 				managedResource := &resourcesv1alpha1.ManagedResource{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, expectedManagedResource.Name), managedResource)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedManagedResource.Namespace, Name: expectedManagedResource.Name}, managedResource)).To(Succeed())
 				expectedManagedResource.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResource.Spec.SecretRefs[0].Name}}
 				utilruntime.Must(references.InjectAnnotations(expectedManagedResource))
 				Expect(managedResource).To(DeepEqual(expectedManagedResource))
 
 				managedResourceSecret := &corev1.Secret{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, expectedManagedResource.Spec.SecretRefs[0].Name), managedResourceSecret)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedManagedResource.Namespace, Name: expectedManagedResource.Spec.SecretRefs[0].Name}, managedResourceSecret)).To(Succeed())
 				Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecret.Data).To(HaveLen(1))
 				Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
@@ -260,21 +259,21 @@ var _ = Describe("#SNI", func() {
 	It("should succeed destroying", func() {
 		Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedGateway.Namespace, expectedGateway.Name), &istionetworkingv1beta1.Gateway{})).To(Succeed())
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(Succeed())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDestinationRule.Namespace, Name: expectedDestinationRule.Name}, &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedGateway.Namespace, Name: expectedGateway.Name}, &istionetworkingv1beta1.Gateway{})).To(Succeed())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVirtualService.Namespace, Name: expectedVirtualService.Name}, &istionetworkingv1beta1.VirtualService{})).To(Succeed())
 		managedResource := &resourcesv1alpha1.ManagedResource{}
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, expectedManagedResource.Name), managedResource)).To(Succeed())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedManagedResource.Namespace, Name: expectedManagedResource.Name}, managedResource)).To(Succeed())
 		managedResourceSecretName := managedResource.Spec.SecretRefs[0].Name
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, managedResourceSecretName), &corev1.Secret{})).To(Succeed())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedManagedResource.Namespace, Name: managedResourceSecretName}, &corev1.Secret{})).To(Succeed())
 
 		Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedGateway.Namespace, expectedGateway.Name), &istionetworkingv1beta1.Gateway{})).To(BeNotFoundError())
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, expectedManagedResource.Name), managedResource)).To(BeNotFoundError())
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, managedResourceSecretName), &corev1.Secret{})).To(BeNotFoundError())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDestinationRule.Namespace, Name: expectedDestinationRule.Name}, &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedGateway.Namespace, Name: expectedGateway.Name}, &istionetworkingv1beta1.Gateway{})).To(BeNotFoundError())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVirtualService.Namespace, Name: expectedVirtualService.Name}, &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedManagedResource.Namespace, Name: expectedManagedResource.Name}, managedResource)).To(BeNotFoundError())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedManagedResource.Namespace, Name: managedResourceSecretName}, &corev1.Secret{})).To(BeNotFoundError())
 	})
 
 	Describe("#Wait", func() {

--- a/pkg/component/kubernetes/controllermanager/waiter.go
+++ b/pkg/component/kubernetes/controllermanager/waiter.go
@@ -53,7 +53,7 @@ func (k *kubeControllerManager) WaitForControllerToBeActive(ctx context.Context)
 	)
 
 	// Check whether the kube-controller-manager deployment exists
-	if err := k.seedClient.Client().Get(ctx, kubernetesutils.Key(k.namespace, v1beta1constants.DeploymentNameKubeControllerManager), &appsv1.Deployment{}); err != nil {
+	if err := k.seedClient.Client().Get(ctx, client.ObjectKey{Namespace: k.namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager}, &appsv1.Deployment{}); err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("kube controller manager deployment not found: %w", err)
 		}

--- a/pkg/component/kubernetes/controllermanager/waiter_test.go
+++ b/pkg/component/kubernetes/controllermanager/waiter_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/component/kubernetes/controllermanager"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -92,7 +91,7 @@ var _ = Describe("WaiterTest", func() {
 
 		It("should fail if the seed client cannot talk to the Seed API Server", func() {
 			gomock.InOrder(
-				seedClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(fakeErr),
+				seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(fakeErr),
 			)
 
 			Expect(kubeControllerManager.WaitForControllerToBeActive(ctx)).To(MatchError(fakeErr))
@@ -101,7 +100,7 @@ var _ = Describe("WaiterTest", func() {
 		It("should fail if the kube controller manager deployment does not exist", func() {
 			notFoundError := apierrors.NewNotFound(schema.GroupResource{}, "kube-controller-manager")
 			gomock.InOrder(
-				seedClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(notFoundError),
+				seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(notFoundError),
 			)
 
 			Expect(kubeControllerManager.WaitForControllerToBeActive(ctx)).To(MatchError("kube controller manager deployment not found:  \"kube-controller-manager\" not found"))
@@ -109,7 +108,7 @@ var _ = Describe("WaiterTest", func() {
 
 		It("should fail if it fails to list pods in the shoot namespace in the Seed", func() {
 			gomock.InOrder(
-				seedClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+				seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 				seedClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PodList{}), listOptions).Return(fakeErr),
 			)
 
@@ -118,7 +117,7 @@ var _ = Describe("WaiterTest", func() {
 
 		It("should fail if no kube controller manager pod can be found", func() {
 			gomock.InOrder(
-				seedClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+				seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 				seedClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PodList{}), listOptions).DoAndReturn(func(_ context.Context, list *corev1.PodList, _ ...client.ListOption) error {
 					*list = corev1.PodList{Items: []corev1.Pod{}}
 					return nil
@@ -130,7 +129,7 @@ var _ = Describe("WaiterTest", func() {
 
 		It("should fail if one of the existing kube controller manager pods has a deletion timestamp", func() {
 			gomock.InOrder(
-				seedClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+				seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 				seedClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PodList{}), listOptions).DoAndReturn(func(_ context.Context, list *corev1.PodList, _ ...client.ListOption) error {
 					now := metav1.Now()
 					*list = corev1.PodList{Items: []corev1.Pod{
@@ -146,14 +145,14 @@ var _ = Describe("WaiterTest", func() {
 
 		It("should fail if the existing kube controller manager fails to acquire leader election", func() {
 			gomock.InOrder(
-				seedClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+				seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 				seedClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PodList{}), listOptions).DoAndReturn(func(_ context.Context, list *corev1.PodList, _ ...client.ListOption) error {
 					*list = corev1.PodList{Items: []corev1.Pod{
 						{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}},
 					}}
 					return nil
 				}),
-				shootClient.EXPECT().Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, "kube-controller-manager"), gomock.AssignableToTypeOf(&coordinationv1.Lease{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *coordinationv1.Lease, _ ...client.GetOption) error {
+				shootClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&coordinationv1.Lease{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *coordinationv1.Lease, _ ...client.GetOption) error {
 					*actual = coordinationv1.Lease{
 						Spec: coordinationv1.LeaseSpec{
 							RenewTime: &metav1.MicroTime{Time: time.Now().UTC().Add(-10 * time.Second)},
@@ -168,14 +167,14 @@ var _ = Describe("WaiterTest", func() {
 
 		It("should succeed", func() {
 			gomock.InOrder(
-				seedClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+				seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 				seedClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PodList{}), listOptions).DoAndReturn(func(_ context.Context, list *corev1.PodList, _ ...client.ListOption) error {
 					*list = corev1.PodList{Items: []corev1.Pod{
 						{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}},
 					}}
 					return nil
 				}),
-				shootClient.EXPECT().Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, "kube-controller-manager"), gomock.AssignableToTypeOf(&coordinationv1.Lease{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *coordinationv1.Lease, _ ...client.GetOption) error {
+				shootClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&coordinationv1.Lease{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *coordinationv1.Lease, _ ...client.GetOption) error {
 					*actual = coordinationv1.Lease{
 						Spec: coordinationv1.LeaseSpec{
 							RenewTime: &metav1.MicroTime{Time: time.Now().UTC()},

--- a/pkg/component/networking/vpn/authzserver/authzserver_test.go
+++ b/pkg/component/networking/vpn/authzserver/authzserver_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	vpnauthzserver "github.com/gardener/gardener/pkg/component/networking/vpn/authzserver"
 	"github.com/gardener/gardener/pkg/component/test"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -278,23 +277,23 @@ var _ = Describe("ExtAuthzServer", func() {
 			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 			actualDeployment := &appsv1.Deployment{}
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedDeployment.Namespace, expectedDeployment.Name), actualDeployment)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDeployment.Namespace, Name: expectedDeployment.Name}, actualDeployment)).To(Succeed())
 			Expect(actualDeployment).To(DeepEqual(expectedDeployment))
 
 			actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), actualDestinationRule)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDestinationRule.Namespace, Name: expectedDestinationRule.Name}, actualDestinationRule)).To(Succeed())
 			Expect(actualDestinationRule).To(BeComparableTo(expectedDestinationRule, test.CmpOptsForDestinationRule()))
 
 			actualService := &corev1.Service{}
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedService.Namespace, expectedService.Name), actualService)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedService.Namespace, Name: expectedService.Name}, actualService)).To(Succeed())
 			Expect(actualService).To(DeepEqual(expectedService))
 
 			actualVirtualService := &istionetworkingv1beta1.VirtualService{}
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), actualVirtualService)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVirtualService.Namespace, Name: expectedVirtualService.Name}, actualVirtualService)).To(Succeed())
 			Expect(actualVirtualService).To(BeComparableTo(expectedVirtualService, test.CmpOptsForVirtualService()))
 
 			actualVpa := &vpaautoscalingv1.VerticalPodAutoscaler{}
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedVpa.Namespace, expectedVpa.Name), actualVpa)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVpa.Namespace, Name: expectedVpa.Name}, actualVpa)).To(Succeed())
 			Expect(actualVpa).To(DeepEqual(expectedVpa))
 		})
 
@@ -305,7 +304,7 @@ var _ = Describe("ExtAuthzServer", func() {
 
 			It("should successfully deploy all the components", func() {
 				actualPodDisruptionBudget := &policyv1.PodDisruptionBudget{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedPodDisruptionBudget.Namespace, expectedPodDisruptionBudget.Name), actualPodDisruptionBudget)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedPodDisruptionBudget.Namespace, Name: expectedPodDisruptionBudget.Name}, actualPodDisruptionBudget)).To(Succeed())
 				Expect(actualPodDisruptionBudget).To(DeepEqual(expectedPodDisruptionBudget))
 			})
 		})
@@ -316,7 +315,7 @@ var _ = Describe("ExtAuthzServer", func() {
 				expectedPodDisruptionBudget.Spec.UnhealthyPodEvictionPolicy = &unhealthyPodEvictionPolicyAlwatysAllow
 
 				actualPodDisruptionBudget := &policyv1.PodDisruptionBudget{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedPodDisruptionBudget.Namespace, expectedPodDisruptionBudget.Name), actualPodDisruptionBudget)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedPodDisruptionBudget.Namespace, Name: expectedPodDisruptionBudget.Name}, actualPodDisruptionBudget)).To(Succeed())
 				Expect(actualPodDisruptionBudget).To(DeepEqual(expectedPodDisruptionBudget))
 			})
 		})
@@ -326,24 +325,24 @@ var _ = Describe("ExtAuthzServer", func() {
 		JustBeforeEach(func() {
 			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedDeployment.Namespace, expectedDeployment.Name), &appsv1.Deployment{})).To(Succeed())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedService.Namespace, expectedService.Name), &corev1.Service{})).To(Succeed())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(Succeed())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedVpa.Namespace, expectedVpa.Name), &vpaautoscalingv1.VerticalPodAutoscaler{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDeployment.Namespace, Name: expectedDeployment.Name}, &appsv1.Deployment{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDestinationRule.Namespace, Name: expectedDestinationRule.Name}, &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedService.Namespace, Name: expectedService.Name}, &corev1.Service{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVirtualService.Namespace, Name: expectedVirtualService.Name}, &istionetworkingv1beta1.VirtualService{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVpa.Namespace, Name: expectedVpa.Name}, &vpaautoscalingv1.VerticalPodAutoscaler{})).To(Succeed())
 		})
 		AfterEach(func() {
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedDeployment.Namespace, expectedDeployment.Name), &appsv1.Deployment{})).To(BeNotFoundError())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedService.Namespace, expectedService.Name), &corev1.Service{})).To(BeNotFoundError())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedVpa.Namespace, expectedVpa.Name), &vpaautoscalingv1.VerticalPodAutoscaler{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDeployment.Namespace, Name: expectedDeployment.Name}, &appsv1.Deployment{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDestinationRule.Namespace, Name: expectedDestinationRule.Name}, &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedService.Namespace, Name: expectedService.Name}, &corev1.Service{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVirtualService.Namespace, Name: expectedVirtualService.Name}, &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVpa.Namespace, Name: expectedVpa.Name}, &vpaautoscalingv1.VerticalPodAutoscaler{})).To(BeNotFoundError())
 		})
 
 		It("should successfully delete all the components", func() {
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedPodDisruptionBudget.Namespace, expectedPodDisruptionBudget.Name), &policyv1.PodDisruptionBudget{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedPodDisruptionBudget.Namespace, Name: expectedPodDisruptionBudget.Name}, &policyv1.PodDisruptionBudget{})).To(Succeed())
 			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
-			Expect(c.Get(ctx, kubernetesutils.Key(expectedPodDisruptionBudget.Namespace, expectedPodDisruptionBudget.Name), &policyv1.PodDisruptionBudget{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedPodDisruptionBudget.Namespace, Name: expectedPodDisruptionBudget.Name}, &policyv1.PodDisruptionBudget{})).To(BeNotFoundError())
 		})
 	})
 

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -652,37 +652,37 @@ var _ = Describe("VpnSeedServer", func() {
 				Expect(vpnSeedServer.Deploy(ctx)).To(Succeed())
 
 				actualSecretServer := &corev1.Secret{}
-				Expect(c.Get(ctx, kubernetesutils.Key(namespace, "vpn-seed-server"), actualSecretServer)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpn-seed-server"}, actualSecretServer)).To(Succeed())
 				Expect(actualSecretServer.Immutable).To(PointTo(BeTrue()))
 				Expect(actualSecretServer.Data).NotTo(BeEmpty())
 
 				actualSecretTLSAuth := &corev1.Secret{}
-				Expect(c.Get(ctx, kubernetesutils.Key(namespace, secretNameTLSAuth), actualSecretTLSAuth)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretNameTLSAuth}, actualSecretTLSAuth)).To(Succeed())
 				Expect(actualSecretTLSAuth.Immutable).To(PointTo(BeTrue()))
 				Expect(actualSecretTLSAuth.Data).NotTo(BeEmpty())
 
 				actualService := &corev1.Service{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedService.Namespace, expectedService.Name), actualService)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedService.Namespace, Name: expectedService.Name}, actualService)).To(Succeed())
 				Expect(actualService).To(DeepEqual(expectedService))
 
 				actualConfigMap := &corev1.ConfigMap{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedConfigMap.Namespace, expectedConfigMap.Name), actualConfigMap)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedConfigMap.Namespace, Name: expectedConfigMap.Name}, actualConfigMap)).To(Succeed())
 				Expect(actualConfigMap).To(DeepEqual(expectedConfigMap))
 
 				actualVpa := &vpaautoscalingv1.VerticalPodAutoscaler{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedVpa.Namespace, expectedVpa.Name), actualVpa)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVpa.Namespace, Name: expectedVpa.Name}, actualVpa)).To(Succeed())
 				Expect(actualVpa).To(DeepEqual(expectedVpa))
 
 				actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
 				expectedDestinationRule := destinationRule()
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), actualDestinationRule)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDestinationRule.Namespace, Name: expectedDestinationRule.Name}, actualDestinationRule)).To(Succeed())
 				Expect(actualDestinationRule).To(BeComparableTo(expectedDestinationRule, comptest.CmpOptsForDestinationRule()))
 
 				actualPodDisruptionBudget := &policyv1.PodDisruptionBudget{}
 				expectedPDB := expectedPodDisruptionBudgetFor(false)
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedPDB.Namespace, expectedPDB.Name), actualPodDisruptionBudget)).To(BeNotFoundError())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedPDB.Namespace, Name: expectedPDB.Name}, actualPodDisruptionBudget)).To(BeNotFoundError())
 
-				Expect(c.Get(ctx, kubernetesutils.Key(namespace, DeploymentName), &appsv1.StatefulSet{})).To(BeNotFoundError())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: DeploymentName}, &appsv1.StatefulSet{})).To(BeNotFoundError())
 				for i := 0; i < 2; i++ {
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(indexedDestinationRule(i)), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(indexedService(i)), &corev1.Service{})).To(BeNotFoundError())
@@ -697,7 +697,7 @@ var _ = Describe("VpnSeedServer", func() {
 				It("should successfully deploy all resources", func() {
 					actualDeployment := &appsv1.Deployment{}
 					expectedDeployment := deployment("")
-					Expect(c.Get(ctx, kubernetesutils.Key(expectedDeployment.Namespace, expectedDeployment.Name), actualDeployment)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDeployment.Namespace, Name: expectedDeployment.Name}, actualDeployment)).To(Succeed())
 					Expect(actualDeployment).To(DeepEqual(expectedDeployment))
 				})
 			})
@@ -706,7 +706,7 @@ var _ = Describe("VpnSeedServer", func() {
 				It("should successfully deploy all resources", func() {
 					actualDeployment := &appsv1.Deployment{}
 					expectedDeployment := deployment(values.Network.NodeCIDR)
-					Expect(c.Get(ctx, kubernetesutils.Key(expectedDeployment.Namespace, expectedDeployment.Name), actualDeployment)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDeployment.Namespace, Name: expectedDeployment.Name}, actualDeployment)).To(Succeed())
 					Expect(actualDeployment).To(DeepEqual(expectedDeployment))
 				})
 
@@ -726,7 +726,7 @@ var _ = Describe("VpnSeedServer", func() {
 					It("should successfully deploy all resources", func() {
 						actualDeployment := &appsv1.Deployment{}
 						expectedDeployment := deployment(values.Network.NodeCIDR)
-						Expect(c.Get(ctx, kubernetesutils.Key(expectedDeployment.Namespace, expectedDeployment.Name), actualDeployment)).To(Succeed())
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDeployment.Namespace, Name: expectedDeployment.Name}, actualDeployment)).To(Succeed())
 						Expect(actualDeployment).To(DeepEqual(expectedDeployment))
 					})
 				})
@@ -758,41 +758,41 @@ var _ = Describe("VpnSeedServer", func() {
 				Expect(vpnSeedServer.Deploy(ctx)).To(Succeed())
 
 				actualSecretServer := &corev1.Secret{}
-				Expect(c.Get(ctx, kubernetesutils.Key(namespace, "vpn-seed-server"), actualSecretServer)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpn-seed-server"}, actualSecretServer)).To(Succeed())
 				Expect(actualSecretServer.Immutable).To(PointTo(BeTrue()))
 				Expect(actualSecretServer.Data).NotTo(BeEmpty())
 
 				actualSecretTLSAuth := &corev1.Secret{}
-				Expect(c.Get(ctx, kubernetesutils.Key(namespace, secretNameTLSAuth), actualSecretTLSAuth)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretNameTLSAuth}, actualSecretTLSAuth)).To(Succeed())
 				Expect(actualSecretTLSAuth.Immutable).To(PointTo(BeTrue()))
 				Expect(actualSecretTLSAuth.Data).NotTo(BeEmpty())
 
 				for i := 0; i < 2; i++ {
 					actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
 					expectedDestinationRule := indexedDestinationRule(i)
-					Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), actualDestinationRule)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedDestinationRule.Namespace, Name: expectedDestinationRule.Name}, actualDestinationRule)).To(Succeed())
 					Expect(actualDestinationRule).To(BeComparableTo(expectedDestinationRule, comptest.CmpOptsForDestinationRule()))
 
 					actualService := &corev1.Service{}
 					expectedService := indexedService(i)
-					Expect(c.Get(ctx, kubernetesutils.Key(expectedService.Namespace, expectedService.Name), actualService)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedService.Namespace, Name: expectedService.Name}, actualService)).To(Succeed())
 					Expect(actualService).To(DeepEqual(expectedService))
 				}
 
 				actualConfigMap := &corev1.ConfigMap{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedConfigMap.Namespace, expectedConfigMap.Name), actualConfigMap)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedConfigMap.Namespace, Name: expectedConfigMap.Name}, actualConfigMap)).To(Succeed())
 				Expect(actualConfigMap).To(DeepEqual(expectedConfigMap))
 
 				actualVpa := &vpaautoscalingv1.VerticalPodAutoscaler{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedVpa.Namespace, expectedVpa.Name), actualVpa)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVpa.Namespace, Name: expectedVpa.Name}, actualVpa)).To(Succeed())
 				Expect(actualVpa).To(DeepEqual(expectedVpa))
 
 				actualStatefulSet := &appsv1.StatefulSet{}
 				expectedStatefulSet := statefulSet(values.Network.NodeCIDR)
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedStatefulSet.Namespace, expectedStatefulSet.Name), actualStatefulSet)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedStatefulSet.Namespace, Name: expectedStatefulSet.Name}, actualStatefulSet)).To(Succeed())
 				Expect(actualStatefulSet).To(DeepEqual(expectedStatefulSet))
 
-				Expect(c.Get(ctx, kubernetesutils.Key(namespace, DeploymentName), &appsv1.Deployment{})).To(BeNotFoundError())
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: DeploymentName}, &appsv1.Deployment{})).To(BeNotFoundError())
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(destinationRule()), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(expectedService), &corev1.Service{})).To(BeNotFoundError())
 			})
@@ -801,7 +801,7 @@ var _ = Describe("VpnSeedServer", func() {
 				It("should successfully deploy all resources", func() {
 					actualPodDisruptionBudget := &policyv1.PodDisruptionBudget{}
 					expectedPDB := expectedPodDisruptionBudgetFor(false)
-					Expect(c.Get(ctx, kubernetesutils.Key(expectedPDB.Namespace, expectedPDB.Name), actualPodDisruptionBudget)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedPDB.Namespace, Name: expectedPDB.Name}, actualPodDisruptionBudget)).To(Succeed())
 					Expect(actualPodDisruptionBudget).To(DeepEqual(expectedPDB))
 				})
 			})
@@ -814,7 +814,7 @@ var _ = Describe("VpnSeedServer", func() {
 				It("should successfully deploy all resources", func() {
 					actualPodDisruptionBudget := &policyv1.PodDisruptionBudget{}
 					expectedPDB := expectedPodDisruptionBudgetFor(true)
-					Expect(c.Get(ctx, kubernetesutils.Key(expectedPDB.Namespace, expectedPDB.Name), actualPodDisruptionBudget)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedPDB.Namespace, Name: expectedPDB.Name}, actualPodDisruptionBudget)).To(Succeed())
 					Expect(actualPodDisruptionBudget).To(DeepEqual(expectedPDB))
 				})
 			})
@@ -863,16 +863,16 @@ var _ = Describe("VpnSeedServer", func() {
 		})
 
 		JustAfterEach(func() {
-			Expect(c.Get(ctx, kubernetesutils.Key(namespace, DeploymentName), &appsv1.StatefulSet{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: DeploymentName}, &appsv1.StatefulSet{})).To(BeNotFoundError())
 			for i := 0; i < 2; i++ {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(indexedDestinationRule(i)), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(indexedService(i)), &corev1.Service{})).To(BeNotFoundError())
 			}
-			Expect(c.Get(ctx, kubernetesutils.Key(namespace, DeploymentName), &appsv1.Deployment{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: DeploymentName}, &appsv1.Deployment{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(destinationRule()), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(expectedService), &corev1.Service{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(expectedVpa), &vpaautoscalingv1.VerticalPodAutoscaler{})).To(BeNotFoundError())
-			Expect(c.Get(ctx, kubernetesutils.Key(istioNamespace, namespace+"-vpn"), &networkingv1alpha3.EnvoyFilter{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: istioNamespace, Name: namespace + "-vpn"}, &networkingv1alpha3.EnvoyFilter{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(expectedPodDisruptionBudgetFor(false)), &policyv1.PodDisruptionBudget{})).To(BeNotFoundError())
 		})
 

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -952,7 +952,7 @@ func (v *vali) resizeOrDeleteValiDataVolumeIfStorageNotTheSame(ctx context.Conte
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{}
-	if err := v.client.Get(ctx, kubernetesutils.Key(v.namespace, "vali-vali-0"), pvc); err != nil {
+	if err := v.client.Get(ctx, client.ObjectKey{Namespace: v.namespace, Name: "vali-vali-0"}, pvc); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -336,8 +336,8 @@ var _ = Describe("Vali", func() {
 			new200GiStorageQuantity = resource.MustParse("200Gi")
 			new100GiStorageQuantity = resource.MustParse("100Gi")
 			new80GiStorageQuantity  = resource.MustParse("80Gi")
-			valiPVCKey              = kubernetesutils.Key("garden", "vali-vali-0")
-			valiStatefulSetKey      = kubernetesutils.Key("garden", "vali")
+			valiPVCKey              = client.ObjectKey{Namespace: "garden", Name: "vali-vali-0"}
+			valiStatefulSetKey      = client.ObjectKey{Namespace: "garden", Name: "vali"}
 			//nolint:unparam
 			funcGetValiPVC = func(_ context.Context, _ types.NamespacedName, pvc *corev1.PersistentVolumeClaim, _ ...client.GetOption) error {
 				*pvc = *valiPVC
@@ -391,7 +391,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -402,13 +402,13 @@ var _ = Describe("Vali", func() {
 				// Path Vali PVC
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypePVC, gomock.AssignableToTypeOf(patch)).DoAndReturn(funcPatchTo200GiStorage),
 				// Remove Ignore annotation form the managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				// Delete target managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceNameTarget), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceNameTarget}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 				runtimeClient.EXPECT().Delete(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameTarget, Namespace: gardenNamespace}}),
 				// Delete shoot access secrets
@@ -417,7 +417,7 @@ var _ = Describe("Vali", func() {
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -428,7 +428,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -439,13 +439,13 @@ var _ = Describe("Vali", func() {
 				// Delete the Vali PVC
 				runtimeClient.EXPECT().Delete(ctx, valiPVC),
 				// Remove Ignore annotation form the managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				// Delete target managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceNameTarget), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceNameTarget}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 				runtimeClient.EXPECT().Delete(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameTarget, Namespace: gardenNamespace}}),
 				// Delete shoot access secrets
@@ -454,7 +454,7 @@ var _ = Describe("Vali", func() {
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -465,13 +465,13 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC).Return(errNotFound),
 				// Remove Ignore annotation form the managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				// Delete target managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceNameTarget), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceNameTarget}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 				runtimeClient.EXPECT().Delete(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameTarget, Namespace: gardenNamespace}}),
 				// Delete shoot access secrets
@@ -480,7 +480,7 @@ var _ = Describe("Vali", func() {
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -491,13 +491,13 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Remove Ignore annotation form the managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				// Delete target managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceNameTarget), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceNameTarget}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 				runtimeClient.EXPECT().Delete(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameTarget, Namespace: gardenNamespace}}),
 				// Delete shoot access secrets
@@ -506,7 +506,7 @@ var _ = Describe("Vali", func() {
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -517,7 +517,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -527,13 +527,13 @@ var _ = Describe("Vali", func() {
 				// Path Vali PVC
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypePVC, gomock.AssignableToTypeOf(patch)).DoAndReturn(funcPatchTo200GiStorage),
 				// Remove Ignore annotation form the managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				// Delete target managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceNameTarget), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceNameTarget}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 				runtimeClient.EXPECT().Delete(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameTarget, Namespace: gardenNamespace}}),
 				// Delete shoot access secrets
@@ -542,7 +542,7 @@ var _ = Describe("Vali", func() {
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -553,7 +553,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -564,13 +564,13 @@ var _ = Describe("Vali", func() {
 				// Path Vali PVC
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypePVC, gomock.AssignableToTypeOf(patch)).DoAndReturn(funcPatchTo200GiStorage).Return(errNotFound),
 				// Remove Ignore annotation form the managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				// Delete target managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceNameTarget), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceNameTarget}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 				runtimeClient.EXPECT().Delete(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameTarget, Namespace: gardenNamespace}}),
 				// Delete shoot access secrets
@@ -579,7 +579,7 @@ var _ = Describe("Vali", func() {
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -590,7 +590,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -601,13 +601,13 @@ var _ = Describe("Vali", func() {
 				// Delete the Vali PVC
 				runtimeClient.EXPECT().Delete(ctx, valiPVC).Return(errNotFound),
 				// Remove Ignore annotation form the managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				// Delete target managed resource
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceNameTarget), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceNameTarget}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 				runtimeClient.EXPECT().Delete(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameTarget, Namespace: gardenNamespace}}),
 				// Delete shoot access secrets
@@ -616,7 +616,7 @@ var _ = Describe("Vali", func() {
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -635,7 +635,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -651,7 +651,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -668,7 +668,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -687,7 +687,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).
 					Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(skipedManagedResource))
@@ -706,7 +706,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR).Return(errForbidden),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR).Return(errForbidden),
 			)
 			Expect(valiDeployer.Deploy(ctx)).ToNot(Succeed())
 		})
@@ -716,7 +716,7 @@ var _ = Describe("Vali", func() {
 			gomock.InOrder(
 				runtimeClient.EXPECT().Get(ctx, valiPVCKey, objectOfTypePVC).DoAndReturn(funcGetValiPVC),
 				// Annotate the Vali MamangedResource with Ignore annotation
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
+				runtimeClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: managedResourceName}, objectOfTypeMR),
 				runtimeClient.EXPECT().Patch(ctx, objectOfTypeMR, gomock.Any()).Return(errForbidden),
 			)
 			Expect(valiDeployer.Deploy(ctx)).ToNot(Succeed())

--- a/pkg/component/shared/apiserver.go
+++ b/pkg/component/shared/apiserver.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/apiserver"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 func computeAPIServerAuditConfig(
@@ -42,7 +41,7 @@ func computeAPIServerAuditConfig(
 		out = &apiserver.AuditConfig{
 			Webhook: webhookConfig,
 		}
-		key = kubernetesutils.Key(objectMeta.Namespace, config.AuditPolicy.ConfigMapRef.Name)
+		key = client.ObjectKey{Namespace: objectMeta.Namespace, Name: config.AuditPolicy.ConfigMapRef.Name}
 	)
 
 	configMap := &corev1.ConfigMap{}
@@ -145,7 +144,7 @@ func computeAPIServerETCDEncryptionConfig(
 	if etcdEncryptionKeyRotationPhase == gardencorev1beta1.RotationPreparing {
 		deployment := &metav1.PartialObjectMetadata{}
 		deployment.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
-		if err := runtimeClient.Get(ctx, kubernetesutils.Key(runtimeNamespace, deploymentName), deployment); err != nil {
+		if err := runtimeClient.Get(ctx, client.ObjectKey{Namespace: runtimeNamespace, Name: deploymentName}, deployment); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return apiserver.ETCDEncryptionConfig{}, err
 			}

--- a/pkg/component/shared/kubeapiserver.go
+++ b/pkg/component/shared/kubeapiserver.go
@@ -211,7 +211,7 @@ func DeployKubeAPIServer(
 	)
 
 	deployment := &appsv1.Deployment{}
-	if err := runtimeClient.Get(ctx, kubernetesutils.Key(runtimeNamespace, deploymentName), deployment); err != nil {
+	if err := runtimeClient.Get(ctx, client.ObjectKey{Namespace: runtimeNamespace, Name: deploymentName}, deployment); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
 	mockresourcemanager "github.com/gardener/gardener/pkg/component/gardener/resourcemanager/mock"
 	. "github.com/gardener/gardener/pkg/component/shared"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -81,7 +80,7 @@ var _ = Describe("ResourceManager", func() {
 			getAPIServerAddress = func() string { return "kube-apiserver" }
 
 			By("Ensure secrets managed outside of this function for which secretsmanager.Get() will be called")
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, "ca"), gomock.AssignableToTypeOf(&corev1.Secret{})).AnyTimes()
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "ca"}, gomock.AssignableToTypeOf(&corev1.Secret{})).AnyTimes()
 
 			secrets = resourcemanager.Secrets{}
 

--- a/pkg/controllermanager/controller/bastion/reconciler.go
+++ b/pkg/controllermanager/controller/bastion/reconciler.go
@@ -19,7 +19,6 @@ import (
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles Bastions.
@@ -50,7 +49,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	shootKey := kubernetesutils.Key(bastion.Namespace, bastion.Spec.ShootRef.Name)
+	shootKey := client.ObjectKey{Namespace: bastion.Namespace, Name: bastion.Spec.ShootRef.Name}
 	log = log.WithValues("shoot", shootKey)
 
 	// fetch associated Shoot

--- a/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
@@ -22,7 +22,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/cloudprofile"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -60,7 +59,7 @@ var _ = Describe("Reconciler", func() {
 	})
 
 	It("should return nil because object not found", func() {
-		c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 		Expect(result).To(Equal(reconcile.Result{}))
@@ -68,7 +67,7 @@ var _ = Describe("Reconciler", func() {
 	})
 
 	It("should return err because object reading failed", func() {
-		c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(fakeErr)
+		c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(fakeErr)
 
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 		Expect(result).To(Equal(reconcile.Result{}))
@@ -77,7 +76,7 @@ var _ = Describe("Reconciler", func() {
 
 	Context("when deletion timestamp not set", func() {
 		BeforeEach(func() {
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
 				*obj = *cloudProfile
 				return nil
 			})
@@ -114,7 +113,7 @@ var _ = Describe("Reconciler", func() {
 			cloudProfile.DeletionTimestamp = &now
 			cloudProfile.Finalizers = []string{finalizerName}
 
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
 				*obj = *cloudProfile
 				return nil
 			})

--- a/pkg/controllermanager/controller/controllerdeployment/reconciler.go
+++ b/pkg/controllermanager/controller/controllerdeployment/reconciler.go
@@ -19,7 +19,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles ControllerDeployment.
@@ -39,7 +38,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	defer cancel()
 
 	controllerDeployment := &gardencorev1beta1.ControllerDeployment{}
-	if err := r.Client.Get(ctx, kubernetesutils.Key(req.Name), controllerDeployment); err != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: req.Name}, controllerDeployment); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(1).Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 const (
@@ -407,7 +406,7 @@ func deployNeededInstallations(
 			// Today, only one DeploymentRef element is allowed, which is why can simply pick the first one from the slice.
 			controllerDeployment = &gardencorev1beta1.ControllerDeployment{}
 
-			if err := c.Get(ctx, kubernetesutils.Key(controllerRegistration.Spec.Deployment.DeploymentRefs[0].Name), controllerDeployment); err != nil {
+			if err := c.Get(ctx, client.ObjectKey{Name: controllerRegistration.Spec.Deployment.DeploymentRefs[0].Name}, controllerDeployment); err != nil {
 				return fmt.Errorf("cannot deploy ControllerInstallation because the referenced ControllerDeployment cannot be retrieved: %w", err)
 			}
 		}

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler_test.go
@@ -24,7 +24,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -717,7 +716,7 @@ var _ = Describe("Reconciler", func() {
 			ctrl = gomock.NewController(GinkgoT())
 			k8sClient = mockclient.NewMockClient(ctrl)
 
-			k8sClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(controllerDeployment.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerDeployment{})).DoAndReturn(
+			k8sClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: controllerDeployment.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerDeployment{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.ControllerDeployment, _ ...client.GetOption) error {
 					*obj = *controllerDeployment
 					return nil
@@ -742,7 +741,7 @@ var _ = Describe("Reconciler", func() {
 					fakeErr = errors.New("err")
 				)
 
-				k8sClient.EXPECT().Get(ctx, kubernetesutils.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{})).Return(fakeErr)
+				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{})).Return(fakeErr)
 
 				err := deployNeededInstallations(ctx, nopLogger, k8sClient, seed, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
 
@@ -789,10 +788,10 @@ var _ = Describe("Reconciler", func() {
 					SeedSpecHash:         "8e09957b7d0d3c19",
 				}
 
-				k8sClient.EXPECT().Get(ctx, kubernetesutils.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
-				k8sClient.EXPECT().Get(ctx, kubernetesutils.Key(controllerInstallation3.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation3.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation3, gomock.Any())
 
 				k8sClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
@@ -824,7 +823,7 @@ var _ = Describe("Reconciler", func() {
 					SeedSpecHash:             "8e09957b7d0d3c19",
 				}
 
-				k8sClient.EXPECT().Get(ctx, kubernetesutils.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
 				err := deployNeededInstallations(ctx, nopLogger, k8sClient, seed, wantedControllerRegistrations, registrations, registrationNameToInstallation)
@@ -881,7 +880,7 @@ var _ = Describe("Reconciler", func() {
 					v1beta1constants.AnnotationPodSecurityEnforce: "baseline",
 				}
 
-				k8sClient.EXPECT().Get(ctx, kubernetesutils.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
 				err := deployNeededInstallations(ctx, nopLogger, k8sClient, seed, wantedControllerRegistrations, registrations, registrationNameToInstallation)
@@ -916,7 +915,7 @@ var _ = Describe("Reconciler", func() {
 					v1beta1constants.AnnotationPodSecurityEnforce: "baseline",
 				}
 
-				k8sClient.EXPECT().Get(ctx, kubernetesutils.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
 				err := deployNeededInstallations(ctx, nopLogger, k8sClient, seed, wantedControllerRegistrations, registrations, registrationNameToInstallation)
@@ -932,7 +931,7 @@ var _ = Describe("Reconciler", func() {
 					SeedSpecHash:             "8e09957b7d0d3c19",
 				}
 
-				k8sClient.EXPECT().Get(ctx, kubernetesutils.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
 				err = deployNeededInstallations(ctx, nopLogger, k8sClient, seed, wantedControllerRegistrations, registrations, registrationNameToInstallation)

--- a/pkg/controllermanager/controller/managedseedset/add.go
+++ b/pkg/controllermanager/controller/managedseedset/add.go
@@ -28,7 +28,6 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ControllerName is the name of this controller.
@@ -174,7 +173,7 @@ func (p *shootPredicate) getManagedSeedSetPendingReplicaReason(shoot *gardencore
 	}
 
 	managedSeedSet := &seedmanagementv1alpha1.ManagedSeedSet{}
-	if err := p.reader.Get(p.ctx, kubernetesutils.Key(shoot.Namespace, controllerRef.Name), managedSeedSet); err != nil {
+	if err := p.reader.Get(p.ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: controllerRef.Name}, managedSeedSet); err != nil {
 		return "", false
 	}
 
@@ -268,7 +267,7 @@ func (p *managedSeedPredicate) getManagedSeedSetPendingReplicaReason(managedSeed
 	}
 
 	managedSeedSet := &seedmanagementv1alpha1.ManagedSeedSet{}
-	if err := p.reader.Get(p.ctx, kubernetesutils.Key(managedSeed.Namespace, controllerRef.Name), managedSeedSet); err != nil {
+	if err := p.reader.Get(p.ctx, client.ObjectKey{Namespace: managedSeed.Namespace, Name: controllerRef.Name}, managedSeedSet); err != nil {
 		return "", false
 	}
 
@@ -325,7 +324,7 @@ func (p *seedPredicate) filterSeed(obj client.Object) bool {
 	}
 
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := p.reader.Get(p.ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
+	if err := p.reader.Get(p.ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: seed.Name}, managedSeed); err != nil {
 		return false
 	}
 
@@ -335,7 +334,7 @@ func (p *seedPredicate) filterSeed(obj client.Object) bool {
 	}
 
 	managedSeedSet := &seedmanagementv1alpha1.ManagedSeedSet{}
-	if err := p.reader.Get(p.ctx, kubernetesutils.Key(seed.Namespace, controllerRef.Name), managedSeedSet); err != nil {
+	if err := p.reader.Get(p.ctx, client.ObjectKey{Namespace: seed.Namespace, Name: controllerRef.Name}, managedSeedSet); err != nil {
 		return false
 	}
 
@@ -359,7 +358,7 @@ func (r *Reconciler) MapSeedToManagedSeedSet(ctx context.Context, log logr.Logge
 	}
 
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := reader.Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: seed.Name}, managedSeed); err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Failed to get ManagedSeed for Seed", "seed", client.ObjectKeyFromObject(seed))
 		}
@@ -372,7 +371,7 @@ func (r *Reconciler) MapSeedToManagedSeedSet(ctx context.Context, log logr.Logge
 	}
 
 	managedSeedSet := &seedmanagementv1alpha1.ManagedSeedSet{}
-	if err := reader.Get(ctx, kubernetesutils.Key(managedSeed.Namespace, controllerRef.Name), managedSeedSet); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Namespace: managedSeed.Namespace, Name: controllerRef.Name}, managedSeedSet); err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Failed to get ManagedSeedSet for ManagedSeed", "managedseed", client.ObjectKeyFromObject(managedSeed))
 		}

--- a/pkg/controllermanager/controller/managedseedset/reconciler_test.go
+++ b/pkg/controllermanager/controller/managedseedset/reconciler_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
 	mockmanagedseedset "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset/mock"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -63,7 +62,7 @@ var _ = Describe("reconciler", func() {
 		reconciler = &Reconciler{Client: c, Actuator: actuator, Config: cfg}
 
 		ctx = context.TODO()
-		request = reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, name)}
+		request = reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: name}}
 
 		managedSeedSet = &seedmanagementv1alpha1.ManagedSeedSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -83,7 +82,7 @@ var _ = Describe("reconciler", func() {
 
 	var (
 		expectGetManagedSeedSet = func() {
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{})).DoAndReturn(
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, mss *seedmanagementv1alpha1.ManagedSeedSet, _ ...client.GetOption) error {
 					*mss = *managedSeedSet
 					return nil

--- a/pkg/controllermanager/controller/project/project/reconciler.go
+++ b/pkg/controllermanager/controller/project/project/reconciler.go
@@ -359,7 +359,7 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, project *garde
 
 func (r *Reconciler) releaseNamespace(ctx context.Context, log logr.Logger, project *gardencorev1beta1.Project, namespaceName string) (bool, error) {
 	namespace := &corev1.Namespace{}
-	if err := r.Client.Get(ctx, kubernetesutils.Key(namespaceName), namespace); err != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: namespaceName}, namespace); err != nil {
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}

--- a/pkg/controllermanager/controller/project/project/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/project/reconciler_test.go
@@ -18,7 +18,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -199,7 +198,7 @@ var _ = Describe("Default Resource Quota", func() {
 				Config: resourceQuota,
 			}
 
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, ResourceQuotaName), gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: ResourceQuotaName}, gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
 				Return(apierrors.NewNotFound(corev1.Resource("resourcequota"), "resourcequota"))
 
 			expectedResourceQuota := resourceQuota.DeepCopy()
@@ -233,7 +232,7 @@ var _ = Describe("Default Resource Quota", func() {
 				},
 			}
 
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, ResourceQuotaName), gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: ResourceQuotaName}, gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
 				DoAndReturn(func(_ context.Context, _ client.ObjectKey, resourceQuota *corev1.ResourceQuota, _ ...client.GetOption) error {
 					*resourceQuota = *existingResourceQuota
 					return nil

--- a/pkg/controllermanager/controller/project/stale/reconciler.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler.go
@@ -66,7 +66,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, project *ga
 
 	// Skip projects whose namespace is annotated with the skip-stale-check annotation.
 	namespace := &corev1.Namespace{}
-	if err := r.Client.Get(ctx, kubernetesutils.Key(*project.Spec.Namespace), namespace); err != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: *project.Spec.Namespace}, namespace); err != nil {
 		return err
 	}
 

--- a/pkg/controllermanager/controller/project/stale/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/project/stale"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
@@ -112,7 +111,7 @@ var _ = Describe("Reconciler", func() {
 			Clock:  fakeClock,
 		}
 
-		k8sGardenRuntimeClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(project.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
+		k8sGardenRuntimeClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: project.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
 			*obj = *project
 			return nil
 		})
@@ -130,7 +129,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		BeforeEach(func() {
-			k8sGardenRuntimeClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+			k8sGardenRuntimeClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 				*obj = *namespace
 				return nil
 			}).AnyTimes()

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -24,7 +24,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles SecretBindings.
@@ -73,7 +72,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 			if mayReleaseSecret {
 				secret := &corev1.Secret{}
-				if err := r.Client.Get(ctx, kubernetesutils.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name), secret); err == nil {
+				if err := r.Client.Get(ctx, client.ObjectKey{Namespace: secretBinding.SecretRef.Namespace, Name: secretBinding.SecretRef.Name}, secret); err == nil {
 					// Remove shoot provider label and 'referred by a secret binding' label
 					hasProviderLabel, providerLabel := getProviderLabel(secret.Labels)
 					if hasProviderLabel || metav1.HasLabel(secret.ObjectMeta, v1beta1constants.LabelSecretBindingReference) {
@@ -126,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add the Gardener finalizer to the referenced Secret to protect it from deletion as long as the
 	// SecretBinding resource exists.
 	secret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, kubernetesutils.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name), secret); err != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: secretBinding.SecretRef.Namespace, Name: secretBinding.SecretRef.Name}, secret); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -155,7 +154,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if len(secretBinding.Quotas) != 0 {
 		for _, objRef := range secretBinding.Quotas {
 			quota := &gardencorev1beta1.Quota{}
-			if err := r.Client.Get(ctx, kubernetesutils.Key(objRef.Namespace, objRef.Name), quota); err != nil {
+			if err := r.Client.Get(ctx, client.ObjectKey{Namespace: objRef.Namespace, Name: objRef.Name}, quota); err != nil {
 				return reconcile.Result{}, err
 			}
 
@@ -214,7 +213,7 @@ func (r *Reconciler) removeLabelFromQuotas(ctx context.Context, quotas []corev1.
 		}
 
 		quota := &gardencorev1beta1.Quota{}
-		if err := r.Client.Get(ctx, kubernetesutils.Key(q.Namespace, q.Name), quota); err != nil {
+		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: q.Namespace, Name: q.Name}, quota); err != nil {
 			return err
 		}
 

--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -61,7 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	lease := &coordinationv1.Lease{}
-	if err := r.Client.Get(ctx, kubernetesutils.Key(r.LeaseNamespace, seed.Name), lease); client.IgnoreNotFound(err) != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: r.LeaseNamespace, Name: seed.Name}, lease); client.IgnoreNotFound(err) != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controllermanager/controller/shoot/conditions/add.go
+++ b/pkg/controllermanager/controller/shoot/conditions/add.go
@@ -26,7 +26,6 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ControllerName is the name of this controller.
@@ -89,7 +88,7 @@ func (r *Reconciler) MapSeedToShoot(ctx context.Context, log logr.Logger, reader
 	}
 
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := reader.Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: seed.Name}, managedSeed); err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Failed to get ManagedSeed for Seed", "seed", client.ObjectKeyFromObject(seed))
 		}
@@ -101,7 +100,7 @@ func (r *Reconciler) MapSeedToShoot(ctx context.Context, log logr.Logger, reader
 	}
 
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := reader.Get(ctx, kubernetesutils.Key(managedSeed.Namespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Namespace: managedSeed.Namespace, Name: managedSeed.Spec.Shoot.Name}, shoot); err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Failed to get Shoot for ManagedSeed", "managedSeed", client.ObjectKeyFromObject(managedSeed))
 		}

--- a/pkg/controllermanager/controller/shoot/conditions/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/conditions/reconciler.go
@@ -83,7 +83,7 @@ func (r *Reconciler) getShootSeed(ctx context.Context, shoot *gardencorev1beta1.
 
 	// Get the seed registered by the managed seed
 	seed := &gardencorev1beta1.Seed{}
-	if err := r.Client.Get(ctx, kubernetesutils.Key(ms.Name), seed); err != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: ms.Name}, seed); err != nil {
 		return nil, client.IgnoreNotFound(err)
 	}
 	return seed, nil

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	admissionpluginsvalidation "github.com/gardener/gardener/pkg/utils/validation/admissionplugins"
 	featuresvalidation "github.com/gardener/gardener/pkg/utils/validation/features"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -115,7 +114,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 	workerToMachineImageUpdate := make(map[string]updateResult)
 
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
-	if err = r.Client.Get(ctx, kubernetesutils.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
+	if err = r.Client.Get(ctx, client.ObjectKey{Name: shoot.Spec.CloudProfileName}, cloudProfile); err != nil {
 		return err
 	}
 

--- a/pkg/controllermanager/controller/shoot/quota/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/quota/reconciler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles Shoots and auto-deletes them if they are bound to a Quota with a configured cluster lifetime.
@@ -53,14 +52,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	)
 
 	if shoot.Spec.SecretBindingName != nil {
-		if err := r.Client.Get(ctx, kubernetesutils.Key(shoot.Namespace, *shoot.Spec.SecretBindingName), secretBinding); err != nil {
+		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.SecretBindingName}, secretBinding); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 
 	for _, quotaRef := range secretBinding.Quotas {
 		quota := &gardencorev1beta1.Quota{}
-		if err := r.Client.Get(ctx, kubernetesutils.Key(quotaRef.Namespace, quotaRef.Name), quota); err != nil {
+		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: quotaRef.Namespace, Name: quotaRef.Name}, quota); err != nil {
 			return reconcile.Result{}, err
 		}
 

--- a/pkg/extensions/cluster.go
+++ b/pkg/extensions/cluster.go
@@ -17,7 +17,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // SyncClusterResourceToSeed creates or updates the `extensions.gardener.cloud/v1alpha1.Cluster` resource in the seed
@@ -99,7 +98,7 @@ type Cluster struct {
 // GetCluster tries to read Gardener's Cluster extension resource in the given namespace.
 func GetCluster(ctx context.Context, c client.Reader, namespace string) (*Cluster, error) {
 	cluster := &extensionsv1alpha1.Cluster{}
-	if err := c.Get(ctx, kubernetesutils.Key(namespace), cluster); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Name: namespace}, cluster); err != nil {
 		return nil, err
 	}
 
@@ -194,7 +193,7 @@ func GetShootStateForCluster(
 	error,
 ) {
 	cluster := &extensionsv1alpha1.Cluster{}
-	if err := seedClient.Get(ctx, kubernetesutils.Key(clusterName), cluster); err != nil {
+	if err := seedClient.Get(ctx, client.ObjectKey{Name: clusterName}, cluster); err != nil {
 		return nil, nil, err
 	}
 
@@ -208,7 +207,7 @@ func GetShootStateForCluster(
 	}
 
 	shootState := &gardencorev1beta1.ShootState{}
-	if err := gardenClient.Get(ctx, kubernetesutils.Key(shoot.Namespace, shoot.Name), shootState); err != nil {
+	if err := gardenClient.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, shootState); err != nil {
 		return nil, nil, err
 	}
 
@@ -218,7 +217,7 @@ func GetShootStateForCluster(
 // GetShoot tries to read Gardener's Cluster extension resource in the given namespace and return the embedded Shoot resource.
 func GetShoot(ctx context.Context, c client.Reader, namespace string) (*gardencorev1beta1.Shoot, error) {
 	cluster := &extensionsv1alpha1.Cluster{}
-	if err := c.Get(ctx, kubernetesutils.Key(namespace), cluster); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Name: namespace}, cluster); err != nil {
 		return nil, err
 	}
 

--- a/pkg/gardenlet/bootstrap/bootstrap.go
+++ b/pkg/gardenlet/bootstrap/bootstrap.go
@@ -76,7 +76,7 @@ func RequestKubeconfigWithBootstrapClient(
 // also deletes the corresponding ClusterRoleBinding.
 func DeleteBootstrapAuth(ctx context.Context, reader client.Reader, writer client.Writer, csrName string) error {
 	csr := &certificatesv1.CertificateSigningRequest{}
-	if err := reader.Get(ctx, kubernetesutils.Key(csrName), csr); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Name: csrName}, csr); err != nil {
 		return err
 	}
 

--- a/pkg/gardenlet/bootstrap/bootstrap_test.go
+++ b/pkg/gardenlet/bootstrap/bootstrap_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Bootstrap", func() {
 				WithKubernetes(kubeClient).
 				Build()
 
-			seedClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
+			seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{}))
 
 			seedClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 				DoAndReturn(func(_ context.Context, secret *corev1.Secret, _ client.Patch, _ ...client.PatchOption) error {
@@ -237,7 +237,7 @@ var _ = Describe("Bootstrap", func() {
 	Describe("#DeleteBootstrapAuth", func() {
 		var (
 			csrName = "csr-name"
-			csrKey  = kubernetesutils.Key(csrName)
+			csrKey  = client.ObjectKey{Name: csrName}
 		)
 
 		It("should return an error because the CSR was not found", func() {

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -188,7 +188,7 @@ func waitForCertificateRotation(
 
 func readCertificateFromKubeconfigSecret(ctx context.Context, log logr.Logger, seedClient client.Client, gardenClientConnection *config.GardenClientConnection) (*corev1.Secret, *tls.Certificate, error) {
 	kubeconfigSecret := &corev1.Secret{}
-	if err := seedClient.Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), kubeconfigSecret); client.IgnoreNotFound(err) != nil {
+	if err := seedClient.Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, kubeconfigSecret); client.IgnoreNotFound(err) != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
@@ -155,7 +154,7 @@ var _ = Describe("Certificates", func() {
 			mockGardenInterface.EXPECT().RESTConfig().Return(certClientConfig)
 
 			// mock update of secret in seed with the rotated kubeconfig
-			mockSeedClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
+			mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{}))
 			mockSeedClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 				DoAndReturn(func(_ context.Context, secret *corev1.Secret, _ client.Patch, _ ...client.PatchOption) error {
 					Expect(secret.Name).To(Equal(gardenClientConnection.KubeconfigSecret.Name))
@@ -265,7 +264,7 @@ users:
 			It("should return an error - kubeconfig secret does not exist", func() {
 				secretGroupResource := schema.GroupResource{Resource: "Secrets"}
 				secretNotFoundErr := apierrors.NewNotFound(secretGroupResource, gardenClientConnection.KubeconfigSecret.Name)
-				mockSeedClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(secretNotFoundErr)
+				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(secretNotFoundErr)
 
 				_, _, err := readCertificateFromKubeconfigSecret(ctx, log, mockSeedClient, gardenClientConnection)
 				Expect(err).To(MatchError(ContainSubstring("does not contain a kubeconfig and there is no fallback kubeconfig")))
@@ -273,7 +272,7 @@ users:
 
 			It("should return an error - secret does not contain a kubeconfig", func() {
 				// mock existing secret with missing garden kubeconfig
-				mockSeedClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
+				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
 					secret.ObjectMeta = metav1.ObjectMeta{
 						Name:      gardenClientConnection.KubeconfigSecret.Name,
 						Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
@@ -300,7 +299,7 @@ users:
 					testKubeconfig = fmt.Sprintf(baseKubeconfig, utils.EncodeBase64(cert.CertificatePEM), utils.EncodeBase64(cert.PrivateKeyPEM))
 
 					// mock first secret retrieval
-					mockSeedClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
+					mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
 						secret.ObjectMeta = metav1.ObjectMeta{
 							Name:      gardenClientConnection.KubeconfigSecret.Name,
 							Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
@@ -313,7 +312,7 @@ users:
 				It("should not return an error", func() {
 					// mock second secret retrieval - check the validity of the certificate again
 					// in this case the secret has not changed
-					mockSeedClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
+					mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
 						secret.ObjectMeta = metav1.ObjectMeta{
 							Name:      gardenClientConnection.KubeconfigSecret.Name,
 							Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
@@ -339,7 +338,7 @@ users:
 
 					// mock second secret retrieval - check the validity of the certificate again
 					// the secret has been updated!
-					mockSeedClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
+					mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
 						secret.ObjectMeta = metav1.ObjectMeta{
 							Name:      gardenClientConnection.KubeconfigSecret.Name,
 							Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
@@ -361,7 +360,7 @@ users:
 
 				// mock first secret retrieval - it is annotated with the renew operation - hence, no need to mock
 				// second secret retrieval
-				mockSeedClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
+				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: gardenClientConnection.KubeconfigSecret.Namespace, Name: gardenClientConnection.KubeconfigSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
 					secret.ObjectMeta = metav1.ObjectMeta{
 						Name:        gardenClientConnection.KubeconfigSecret.Name,
 						Namespace:   gardenClientConnection.KubeconfigSecret.Namespace,

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -219,7 +219,7 @@ func ComputeGardenletKubeconfigWithBootstrapToken(ctx context.Context, gardenCli
 	)
 
 	secret := &corev1.Secret{}
-	if err := gardenClient.Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, bootstraptokenutil.BootstrapTokenSecretName(tokenID)), secret); client.IgnoreNotFound(err) != nil {
+	if err := gardenClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: bootstraptokenutil.BootstrapTokenSecretName(tokenID)}, secret); client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
 

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	. "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
@@ -348,13 +347,13 @@ var _ = Describe("Util", func() {
 			It("should successfully refresh the bootstrap token", func() {
 				// There are 3 calls requesting the same secret in the code. This can be improved.
 				// However it is not critical as bootstrap token generation does not happen too frequently
-				c.EXPECT().Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, bootstrapTokenSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: bootstrapTokenSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
 					s.Data = map[string][]byte{
 						bootstraptokenapi.BootstrapTokenExpirationKey: []byte(timestampInThePast),
 					}
 					return nil
 				})
-				c.EXPECT().Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, bootstrapTokenSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(nil).Times(2)
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: bootstrapTokenSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(nil).Times(2)
 
 				c.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, s *corev1.Secret, _ client.Patch, _ ...client.PatchOption) error {
@@ -381,7 +380,7 @@ var _ = Describe("Util", func() {
 			})
 
 			It("should reuse existing bootstrap token", func() {
-				c.EXPECT().Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, bootstrapTokenSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: bootstrapTokenSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
 					s.Data = map[string][]byte{
 						bootstraptokenapi.BootstrapTokenExpirationKey: []byte(timestampInTheFuture),
 						bootstraptokenapi.BootstrapTokenIDKey:         []byte("dummy"),

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -33,7 +34,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/controller/vpaevictionrequirements"
 	"github.com/gardener/gardener/pkg/healthz"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // AddToManager adds all gardenlet controllers to the given manager.
@@ -53,7 +53,7 @@ func AddToManager(
 	}
 
 	configMap := &corev1.ConfigMap{}
-	if err := gardenCluster.GetClient().Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, v1beta1constants.ClusterIdentity), configMap); err != nil {
+	if err := gardenCluster.GetClient().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: v1beta1constants.ClusterIdentity}, configMap); err != nil {
 		return fmt.Errorf("failed getting cluster-identity ConfigMap in garden cluster: %w", err)
 	}
 	gardenClusterIdentity, ok := configMap.Data[v1beta1constants.ClusterIdentity]

--- a/pkg/gardenlet/controller/backupentry/add.go
+++ b/pkg/gardenlet/controller/backupentry/add.go
@@ -29,7 +29,6 @@ import (
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	"github.com/gardener/gardener/pkg/extensions"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ControllerName is the name of this controller.
@@ -123,7 +122,7 @@ func (r *Reconciler) MapExtensionBackupEntryToCoreBackupEntry(ctx context.Contex
 		return nil
 	}
 	if shoot == nil {
-		log.Info("Shoot is missing in cluster resource", "cluster", kubernetesutils.Key(shootTechnicalID))
+		log.Info("Shoot is missing in cluster resource", "cluster", client.ObjectKey{Name: shootTechnicalID})
 		return nil
 	}
 

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -684,7 +684,7 @@ func (r *Reconciler) reconcileBackupEntryExtension(gardenCtx context.Context, se
 
 	shootName := gardenerutils.GetShootNameFromOwnerReferences(backupEntry)
 	shootState := &gardencorev1beta1.ShootState{}
-	if err := r.GardenClient.Get(gardenCtx, kubernetesutils.Key(backupEntry.Namespace, shootName), shootState); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Namespace: backupEntry.Namespace, Name: shootName}, shootState); err != nil {
 		return err
 	}
 	return component.Restore(seedCtx, shootState)

--- a/pkg/gardenlet/controller/bastion/add.go
+++ b/pkg/gardenlet/controller/bastion/add.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	"github.com/gardener/gardener/pkg/extensions"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ControllerName is the name of this controller.
@@ -77,7 +76,7 @@ func (r *Reconciler) MapExtensionsBastionToOperationsBastion(ctx context.Context
 	}
 
 	if shoot == nil {
-		log.Info("Shoot is missing in cluster resource", "cluster", kubernetesutils.Key(obj.GetNamespace()))
+		log.Info("Shoot is missing in cluster resource", "clusterName", obj.GetNamespace())
 		return nil
 	}
 

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -68,7 +68,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// get Shoot for the bastion
 	shoot := gardencorev1beta1.Shoot{}
-	shootKey := kubernetesutils.Key(bastion.Namespace, bastion.Spec.ShootRef.Name)
+	shootKey := client.ObjectKey{Namespace: bastion.Namespace, Name: bastion.Spec.ShootRef.Name}
 	if err := r.GardenClient.Get(gardenCtx, shootKey, &shoot); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not get shoot %v: %w", shootKey, err)
 	}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
@@ -21,7 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ControllerName is the name of this controller.
@@ -111,7 +110,7 @@ func (p *helmTypePredicate) isResponsible(obj client.Object) bool {
 
 	if deploymentName := controllerInstallation.Spec.DeploymentRef; deploymentName != nil {
 		controllerDeployment := &gardencorev1beta1.ControllerDeployment{}
-		if err := p.reader.Get(p.ctx, kubernetesutils.Key(deploymentName.Name), controllerDeployment); err != nil {
+		if err := p.reader.Get(p.ctx, client.ObjectKey{Name: deploymentName.Name}, controllerDeployment); err != nil {
 			return false
 		}
 		return controllerDeployment.Type == "helm"

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -144,7 +144,7 @@ func (r *Reconciler) reconcile(
 	var providerConfig *runtime.RawExtension
 	if deploymentRef := controllerInstallation.Spec.DeploymentRef; deploymentRef != nil {
 		controllerDeployment := &gardencorev1beta1.ControllerDeployment{}
-		if err := r.GardenClient.Get(gardenCtx, kubernetesutils.Key(deploymentRef.Name), controllerDeployment); err != nil {
+		if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: deploymentRef.Name}, controllerDeployment); err != nil {
 			return reconcile.Result{}, err
 		}
 		providerConfig = &controllerDeployment.ProviderConfig

--- a/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
@@ -21,7 +21,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles ControllerInstallations. It checks whether they are still required by using the
@@ -54,7 +53,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	controllerRegistration := &gardencorev1beta1.ControllerRegistration{}
-	if err := r.GardenClient.Get(ctx, kubernetesutils.Key(controllerInstallation.Spec.RegistrationRef.Name), controllerRegistration); err != nil {
+	if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: controllerInstallation.Spec.RegistrationRef.Name}, controllerRegistration); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/gardenlet/controller/managedseed/actuator.go
+++ b/pkg/gardenlet/controller/managedseed/actuator.go
@@ -490,7 +490,7 @@ func (a *actuator) reconcileSeedSecrets(ctx context.Context, spec *gardencorev1b
 		// Create or update backup secret if it doesn't exist or is owned by the managed seed
 		if apierrors.IsNotFound(err) || metav1.IsControlledBy(backupSecret, managedSeed) {
 			secret := &corev1.Secret{
-				ObjectMeta: kubernetesutils.ObjectMeta(spec.Backup.SecretRef.Namespace, spec.Backup.SecretRef.Name),
+				ObjectMeta: metav1.ObjectMeta{Namespace: spec.Backup.SecretRef.Namespace, Name: spec.Backup.SecretRef.Name},
 			}
 			if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, a.gardenClient, secret, func() error {
 				secret.OwnerReferences = []metav1.OwnerReference{

--- a/pkg/gardenlet/controller/managedseed/actuator.go
+++ b/pkg/gardenlet/controller/managedseed/actuator.go
@@ -108,7 +108,7 @@ func (a *actuator) Reconcile(
 
 	// Get shoot
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := a.gardenAPIReader.Get(ctx, kubernetesutils.Key(ms.Namespace, ms.Spec.Shoot.Name), shoot); err != nil {
+	if err := a.gardenAPIReader.Get(ctx, client.ObjectKey{Namespace: ms.Namespace, Name: ms.Spec.Shoot.Name}, shoot); err != nil {
 		return status, false, fmt.Errorf("could not get shoot %s/%s: %w", ms.Namespace, ms.Spec.Shoot.Name, err)
 	}
 
@@ -205,7 +205,7 @@ func (a *actuator) Delete(
 
 	// Get shoot
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := a.gardenAPIReader.Get(ctx, kubernetesutils.Key(ms.Namespace, ms.Spec.Shoot.Name), shoot); err != nil {
+	if err := a.gardenAPIReader.Get(ctx, client.ObjectKey{Namespace: ms.Namespace, Name: ms.Spec.Shoot.Name}, shoot); err != nil {
 		return status, false, false, fmt.Errorf("could not get shoot %s/%s: %w", ms.Namespace, ms.Spec.Shoot.Name, err)
 	}
 
@@ -342,7 +342,7 @@ func (a *actuator) deleteGardenNamespace(ctx context.Context, shootClient kubern
 
 func (a *actuator) getGardenNamespace(ctx context.Context, shootClient kubernetes.Interface) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{}
-	if err := shootClient.Client().Get(ctx, kubernetesutils.Key(a.gardenNamespaceShoot), ns); err != nil {
+	if err := shootClient.Client().Get(ctx, client.ObjectKey{Name: a.gardenNamespaceShoot}, ns); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -362,7 +362,7 @@ func (a *actuator) deleteSeed(ctx context.Context, managedSeed *seedmanagementv1
 
 func (a *actuator) getSeed(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed) (*gardencorev1beta1.Seed, error) {
 	seed := &gardencorev1beta1.Seed{}
-	if err := a.gardenClient.Get(ctx, kubernetesutils.Key(managedSeed.Name), seed); err != nil {
+	if err := a.gardenClient.Get(ctx, client.ObjectKey{Name: managedSeed.Name}, seed); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -444,7 +444,7 @@ func (a *actuator) deleteGardenlet(
 
 func (a *actuator) getGardenletDeployment(ctx context.Context, shootClient kubernetes.Interface) (*appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
-	if err := shootClient.Client().Get(ctx, kubernetesutils.Key(a.gardenNamespaceShoot, v1beta1constants.DeploymentNameGardenlet), deployment); err != nil {
+	if err := shootClient.Client().Get(ctx, client.ObjectKey{Namespace: a.gardenNamespaceShoot, Name: v1beta1constants.DeploymentNameGardenlet}, deployment); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -557,14 +557,14 @@ func (a *actuator) getShootSecret(ctx context.Context, shoot *gardencorev1beta1.
 	if shoot.Spec.SecretBindingName == nil {
 		return nil, fmt.Errorf("secretbinding name is nil for the Shoot: %s/%s", shoot.Namespace, shoot.Name)
 	}
-	if err := a.gardenClient.Get(ctx, kubernetesutils.Key(shoot.Namespace, *shoot.Spec.SecretBindingName), shootSecretBinding); err != nil {
+	if err := a.gardenClient.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.SecretBindingName}, shootSecretBinding); err != nil {
 		return nil, err
 	}
 	return kubernetesutils.GetSecretByReference(ctx, a.gardenClient, &shootSecretBinding.SecretRef)
 }
 
 func (a *actuator) seedVPADeploymentExists(ctx context.Context, seedClient client.Client, shoot *gardencorev1beta1.Shoot) (bool, error) {
-	if err := seedClient.Get(ctx, kubernetesutils.Key(shoot.Status.TechnicalID, "vpa-admission-controller"), &appsv1.Deployment{}); err != nil {
+	if err := seedClient.Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: "vpa-admission-controller"}, &appsv1.Deployment{}); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/pkg/gardenlet/controller/managedseed/actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/actuator_test.go
@@ -35,7 +35,6 @@ import (
 	mockmanagedseed "github.com/gardener/gardener/pkg/gardenlet/controller/managedseed/mock"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	mockrecord "github.com/gardener/gardener/third_party/mock/client-go/tools/record"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
@@ -250,7 +249,7 @@ var _ = Describe("Actuator", func() {
 
 	var (
 		expectGetShoot = func() {
-			gardenAPIReader.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(
+			gardenAPIReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, s *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 					*s = *shoot
 					return nil
@@ -259,7 +258,7 @@ var _ = Describe("Actuator", func() {
 		}
 
 		expectCreateGardenNamespace = func() {
-			shootClient.EXPECT().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(
+			shootClient.EXPECT().Get(ctx, client.ObjectKey{Name: v1beta1constants.GardenNamespace}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, _ *corev1.Namespace, _ ...client.GetOption) error {
 					return apierrors.NewNotFound(corev1.Resource("namespace"), v1beta1constants.GardenNamespace)
 				},
@@ -282,7 +281,7 @@ var _ = Describe("Actuator", func() {
 		}
 
 		expectGetGardenNamespace = func(exists bool) {
-			shootClient.EXPECT().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(
+			shootClient.EXPECT().Get(ctx, client.ObjectKey{Name: v1beta1constants.GardenNamespace}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, ns *corev1.Namespace, _ ...client.GetOption) error {
 					if exists {
 						*ns = *gardenNamespace
@@ -295,7 +294,7 @@ var _ = Describe("Actuator", func() {
 
 		expectCheckSeedSpec = func() {
 			// Check if the shoot namespace in the seed contains a vpa-admission-controller deployment
-			seedClient.EXPECT().Get(ctx, kubernetesutils.Key(shoot.Status.TechnicalID, "vpa-admission-controller"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(
+			seedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: "vpa-admission-controller"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, _ *appsv1.Deployment, _ ...client.GetOption) error {
 					return apierrors.NewNotFound(appsv1.Resource("deployment"), "vpa-admission-controller")
 				},
@@ -304,13 +303,13 @@ var _ = Describe("Actuator", func() {
 
 		expectCreateSeedSecrets = func() {
 			// Get shoot secret
-			gardenClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, secretBindingName), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretBindingName}, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, sb *gardencorev1beta1.SecretBinding, _ ...client.GetOption) error {
 					*sb = *secretBinding
 					return nil
 				},
 			)
-			gardenClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
 					*s = *secret
 					return nil
@@ -318,7 +317,7 @@ var _ = Describe("Actuator", func() {
 			)
 
 			// Create backup secret
-			gardenClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, backupSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, _ *corev1.Secret, _ ...client.GetOption) error {
 					return apierrors.NewNotFound(corev1.Resource("secret"), backupSecretName)
 				},
@@ -333,7 +332,7 @@ var _ = Describe("Actuator", func() {
 
 		expectDeleteSeedSecrets = func() {
 			// Delete backup secret
-			gardenClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, backupSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
 					*s = *backupSecret
 					return nil
@@ -350,7 +349,7 @@ var _ = Describe("Actuator", func() {
 
 		expectGetSeedSecrets = func(exist bool) {
 			// Get backup secret
-			gardenClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, backupSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
 					if exist {
 						*s = *backupSecret
@@ -371,7 +370,7 @@ var _ = Describe("Actuator", func() {
 		}
 
 		expectGetSeed = func(exists bool) {
-			gardenClient.EXPECT().Get(ctx, kubernetesutils.Key(name), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, s *gardencorev1beta1.Seed, _ ...client.GetOption) error {
 					if exists {
 						*s = *seed
@@ -408,7 +407,7 @@ var _ = Describe("Actuator", func() {
 		expectPrepareGardenClientConnection = func(withAlreadyBootstrappedCheck bool) {
 			if withAlreadyBootstrappedCheck {
 				// Check if kubeconfig secret exists
-				shootClient.EXPECT().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, "gardenlet-kubeconfig"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+				shootClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: "gardenlet-kubeconfig"}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, _ *corev1.Secret, _ ...client.GetOption) error {
 						return apierrors.NewNotFound(corev1.Resource("secret"), "gardenlet-kubeconfig")
 					},
@@ -416,7 +415,7 @@ var _ = Describe("Actuator", func() {
 			}
 
 			// Create bootstrap token secret
-			gardenClient.EXPECT().Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, "bootstrap-token-a82f8a"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "bootstrap-token-a82f8a"}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, _ *corev1.Secret, _ ...client.GetOption) error {
 					return apierrors.NewNotFound(corev1.Resource("secret"), "bootstrap-token-a82f8a")
 				},
@@ -478,7 +477,7 @@ var _ = Describe("Actuator", func() {
 		}
 
 		expectGetGardenletDeployment = func(exists bool) {
-			shootClient.EXPECT().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, v1beta1constants.DeploymentNameGardenlet), gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(
+			shootClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: v1beta1constants.DeploymentNameGardenlet}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, d *appsv1.Deployment, _ ...client.GetOption) error {
 					if exists {
 						*d = *gardenletDeployment

--- a/pkg/gardenlet/controller/managedseed/add.go
+++ b/pkg/gardenlet/controller/managedseed/add.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 const (
@@ -184,7 +183,7 @@ func (p *seedOfManagedSeedPredicate) filterSeedOfManagedSeed(obj client.Object) 
 	}
 
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := p.reader.Get(p.ctx, kubernetesutils.Key(p.gardenNamespace, seed.Name), managedSeed); err != nil {
+	if err := p.reader.Get(p.ctx, client.ObjectKey{Namespace: p.gardenNamespace, Name: seed.Name}, managedSeed); err != nil {
 		return false
 	}
 
@@ -197,7 +196,7 @@ func filterManagedSeed(ctx context.Context, reader client.Reader, managedSeed *s
 	}
 
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := reader.Get(ctx, kubernetesutils.Key(managedSeed.Namespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Namespace: managedSeed.Namespace, Name: managedSeed.Spec.Shoot.Name}, shoot); err != nil {
 		return false
 	}
 

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -51,7 +51,7 @@ func ValidateGardenletChartVPA(ctx context.Context, c client.Client) {
 
 	Expect(c.Get(
 		ctx,
-		kubernetesutils.Key(vpa.Namespace, vpa.Name),
+		client.ObjectKey{Namespace: vpa.Namespace, Name: vpa.Name},
 		vpa,
 	)).ToNot(HaveOccurred())
 
@@ -82,7 +82,7 @@ func ValidateGardenletChartPriorityClass(ctx context.Context, c client.Client) {
 
 	Expect(c.Get(
 		ctx,
-		kubernetesutils.Key(priorityClass.Name),
+		client.ObjectKey{Name: priorityClass.Name},
 		priorityClass,
 	)).ToNot(HaveOccurred())
 	Expect(priorityClass.GlobalDefault).To(BeFalse())
@@ -575,7 +575,7 @@ func ValidateGardenletChartServiceAccount(ctx context.Context, c client.Client, 
 	if hasSeedClientConnectionKubeconfig {
 		err := c.Get(
 			ctx,
-			kubernetesutils.Key(serviceAccount.Namespace, serviceAccount.Name),
+			client.ObjectKey{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name},
 			serviceAccount,
 		)
 		Expect(err).To(HaveOccurred())
@@ -588,7 +588,7 @@ func ValidateGardenletChartServiceAccount(ctx context.Context, c client.Client, 
 
 	Expect(c.Get(
 		ctx,
-		kubernetesutils.Key(serviceAccount.Namespace, serviceAccount.Name),
+		client.ObjectKey{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name},
 		serviceAccount,
 	)).ToNot(HaveOccurred())
 	Expect(serviceAccount.Labels).To(DeepEqual(expectedServiceAccount.Labels))
@@ -904,7 +904,7 @@ func VerifyGardenletComponentConfigConfigMap(
 	expectedComponentConfigCm := getEmptyGardenletConfigMap()
 	expectedComponentConfigCm.Labels = expectedLabels
 
-	if err := c.Get(ctx, kubernetesutils.Key(componentConfigCm.Namespace, uniqueName), componentConfigCm); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: componentConfigCm.Namespace, Name: uniqueName}, componentConfigCm); err != nil {
 		if !apierrors.IsNotFound(err) {
 			ginkgo.Fail(err.Error())
 		}
@@ -1259,7 +1259,7 @@ func VerifyGardenletDeployment(ctx context.Context,
 
 	Expect(c.Get(
 		ctx,
-		kubernetesutils.Key(deployment.Namespace, deployment.Name),
+		client.ObjectKey{Namespace: deployment.Namespace, Name: deployment.Name},
 		deployment,
 	)).ToNot(HaveOccurred())
 

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -40,7 +40,6 @@ import (
 	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/managedseed/charttest"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var (
@@ -505,7 +504,7 @@ func validateKubeconfigSecret(ctx context.Context, c client.Client, secret *core
 
 	Expect(c.Get(
 		ctx,
-		kubernetesutils.Key(secret.Namespace, name),
+		client.ObjectKey{Namespace: secret.Namespace, Name: name},
 		secret,
 	)).ToNot(HaveOccurred())
 	Expect(secret.Labels).To(Equal(expectedSecret.Labels))
@@ -522,7 +521,7 @@ func validateImageVectorOverwriteConfigMap(ctx context.Context, c client.Client,
 
 	Expect(c.Get(
 		ctx,
-		kubernetesutils.Key(cm.Namespace, uniqueName),
+		client.ObjectKey{Namespace: cm.Namespace, Name: uniqueName},
 		cm,
 	)).ToNot(HaveOccurred())
 

--- a/pkg/gardenlet/controller/managedseed/reconciler_test.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler_test.go
@@ -20,7 +20,6 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	mockmanagedseed "github.com/gardener/gardener/pkg/gardenlet/controller/managedseed/mock"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -72,7 +71,7 @@ var _ = Describe("Reconciler", func() {
 		reconciler = &Reconciler{GardenClient: gardenClient, Actuator: actuator, Config: cfg}
 
 		ctx = context.TODO()
-		request = reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, name)}
+		request = reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: name}}
 
 		managedSeed = &seedmanagementv1alpha1.ManagedSeed{
 			ObjectMeta: metav1.ObjectMeta{
@@ -97,7 +96,7 @@ var _ = Describe("Reconciler", func() {
 
 	var (
 		expectGetManagedSeed = func() {
-			gardenClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
+			gardenClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.GetOption) error {
 					*ms = *managedSeed
 					return nil

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/seed/care"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
@@ -63,7 +62,7 @@ var _ = Describe("Seed Care Control", func() {
 		var req reconcile.Request
 
 		BeforeEach(func() {
-			req = reconcile.Request{NamespacedName: kubernetesutils.Key(seedName)}
+			req = reconcile.Request{NamespacedName: client.ObjectKey{Name: seedName}}
 
 			controllerConfig = config.SeedCareControllerConfiguration{
 				SyncPeriod: &metav1.Duration{Duration: careSyncPeriod},
@@ -78,7 +77,7 @@ var _ = Describe("Seed Care Control", func() {
 			It("should stop reconciling and not requeue", func() {
 				reconciler = &Reconciler{GardenClient: gardenClient, SeedClient: seedClient, Config: controllerConfig, Clock: fakeClock}
 
-				req = reconcile.Request{NamespacedName: kubernetesutils.Key("some-other-seed")}
+				req = reconcile.Request{NamespacedName: client.ObjectKey{Name: "some-other-seed"}}
 				Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{}))
 			})
 		})

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -31,7 +31,6 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles Seed resources and provisions or de-provisions the seed system components.
@@ -254,13 +253,13 @@ func (r *Reconciler) updateStatusOperationError(ctx context.Context, seed *garde
 // an identity, it should not be changed.
 func determineClusterIdentity(ctx context.Context, c client.Client) (string, error) {
 	clusterIdentity := &corev1.ConfigMap{}
-	if err := c.Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, v1beta1constants.ClusterIdentity), clusterIdentity); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: v1beta1constants.ClusterIdentity}, clusterIdentity); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return "", err
 		}
 
 		gardenNamespace := &corev1.Namespace{}
-		if err := c.Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem), gardenNamespace); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, gardenNamespace); err != nil {
 			return "", err
 		}
 		return string(gardenNamespace.UID), nil

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -44,7 +44,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	healthchecker "github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
 )
@@ -321,7 +320,7 @@ func (h *Health) retrieveExtensions(ctx context.Context) ([]runtime.Object, erro
 	// Get BackupEntries separately as they are not namespaced i.e., they cannot be narrowed down
 	// to a shoot namespace like other extension resources above.
 	be := &extensionsv1alpha1.BackupEntry{}
-	if err := h.seedClient.Client().Get(ctx, kubernetesutils.Key(h.shoot.BackupEntryName), be); err == nil {
+	if err := h.seedClient.Client().Get(ctx, client.ObjectKey{Name: h.shoot.BackupEntryName}, be); err == nil {
 		allExtensions = append(allExtensions, be)
 	} else if !apierrors.IsNotFound(err) {
 		return nil, err

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -36,7 +36,6 @@ import (
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -105,7 +104,7 @@ var _ = Describe("Shoot Care Control", func() {
 				},
 			}}
 
-			req = reconcile.Request{NamespacedName: kubernetesutils.Key(shootNamespace, shootName)}
+			req = reconcile.Request{NamespacedName: client.ObjectKey{Namespace: shootNamespace, Name: shootName}}
 
 			gardenletConf = gardenletconfig.GardenletConfiguration{
 				Controllers: &gardenletconfig.GardenletControllerConfiguration{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -257,7 +257,7 @@ func (r *Reconciler) prepareOperation(ctx context.Context, log logr.Logger, shoo
 	}
 
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
-	if err := r.GardenClient.Get(ctx, kubernetesutils.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
+	if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: shoot.Spec.CloudProfileName}, cloudProfile); err != nil {
 		return nil, reconcile.Result{}, err
 	}
 
@@ -927,7 +927,7 @@ func (r *Reconciler) patchBastions(ctx context.Context, shoot *gardencorev1beta1
 }
 
 func extensionResourceStillExists(ctx context.Context, reader client.Reader, obj client.Object, namespace, name string) (bool, bool, error) {
-	if err := reader.Get(ctx, kubernetesutils.Key(namespace, name), obj); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, false, nil
 		}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -14,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -24,7 +25,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -79,7 +79,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		// to delete anymore.
 		errors.ToExecute("Retrieve kube-apiserver deployment in the shoot namespace in the seed cluster", func() error {
 			deploymentKubeAPIServer := &appsv1.Deployment{}
-			if err := botanist.SeedClientSet.APIReader().Get(ctx, kubernetesutils.Key(o.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deploymentKubeAPIServer); err != nil {
+			if err := botanist.SeedClientSet.APIReader().Get(ctx, client.ObjectKey{Namespace: o.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, deploymentKubeAPIServer); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return err
 				}
@@ -97,7 +97,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		// cleaned up.
 		errors.ToExecute("Retrieve the kube-controller-manager deployment in the shoot namespace in the seed cluster", func() error {
 			deploymentKubeControllerManager := &appsv1.Deployment{}
-			if err := botanist.SeedClientSet.APIReader().Get(ctx, kubernetesutils.Key(o.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeControllerManager), deploymentKubeControllerManager); err != nil {
+			if err := botanist.SeedClientSet.APIReader().Get(ctx, client.ObjectKey{Namespace: o.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeControllerManager}, deploymentKubeControllerManager); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return err
 				}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -60,7 +59,7 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 		}),
 		errorsutils.ToExecute("Retrieve kube-apiserver deployment in the shoot namespace in the seed cluster", func() error {
 			deploymentKubeAPIServer := &appsv1.Deployment{}
-			if err := botanist.SeedClientSet.APIReader().Get(ctx, kubernetesutils.Key(o.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deploymentKubeAPIServer); err != nil {
+			if err := botanist.SeedClientSet.APIReader().Get(ctx, client.ObjectKey{Namespace: o.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, deploymentKubeAPIServer); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return err
 				}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -988,7 +987,7 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 	// Check if shoot generation was changed mid-air, i.e., whether we need to wait for the next reconciliation until we
 	// can safely remove the task annotations to ensure all required tasks are executed.
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := o.GardenClient.Get(ctx, kubernetesutils.Key(o.Shoot.GetInfo().Namespace, o.Shoot.GetInfo().Name), shoot); err != nil {
+	if err := o.GardenClient.Get(ctx, client.ObjectKeyFromObject(o.Shoot.GetInfo()), shoot); err != nil {
 		return err
 	}
 

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/autoscaling/clusterautoscaler"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // DefaultClusterAutoscaler returns a deployer for the cluster-autoscaler.
@@ -60,7 +59,7 @@ func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 
 // ScaleClusterAutoscalerToZero scales cluster-autoscaler replicas to zero.
 func (b *Botanist) ScaleClusterAutoscalerToZero(ctx context.Context) error {
-	return client.IgnoreNotFound(kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameClusterAutoscaler), 0))
+	return client.IgnoreNotFound(kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameClusterAutoscaler}, 0))
 }
 
 // CalculateMaxNodesForShoot returns the maximum number of nodes the shoot supports. Function returns nil if there is no limitation.

--- a/pkg/gardenlet/operation/botanist/clusteridentity_test.go
+++ b/pkg/gardenlet/operation/botanist/clusteridentity_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var _ = Describe("ClusterIdentity", func() {
@@ -117,7 +116,7 @@ var _ = Describe("ClusterIdentity", func() {
 		test := func() {
 			Expect(botanist.EnsureShootClusterIdentity(ctx)).NotTo(HaveOccurred())
 
-			Expect(gardenClient.Get(ctx, kubernetesutils.Key(shootNamespace, shootName), shoot)).To(Succeed())
+			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: shootNamespace, Name: shootName}, shoot)).To(Succeed())
 			Expect(shoot.Status.ClusterIdentity).NotTo(BeNil())
 			Expect(*shoot.Status.ClusterIdentity).To(Equal(expectedShootClusterIdentity))
 		}

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -115,7 +115,7 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 		v1beta1constants.DeploymentNameKubeAPIServer,
 	}
 	for _, deployment := range deployments {
-		if err := kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), kubernetesutils.Key(b.Shoot.SeedNamespace, deployment), 0); client.IgnoreNotFound(err) != nil {
+		if err := kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: deployment}, 0); client.IgnoreNotFound(err) != nil {
 			return err
 		}
 	}

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -23,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
 )
 
@@ -87,7 +87,7 @@ func getScaleDownUpdateMode(c etcd.Class, s *shoot.Shoot) *string {
 func (b *Botanist) DeployEtcd(ctx context.Context) error {
 	if b.Seed.GetInfo().Spec.Backup != nil {
 		secret := &corev1.Secret{}
-		if err := b.SeedClientSet.Client().Get(ctx, kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.BackupSecretName), secret); err != nil {
+		if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.BackupSecretName}, secret); err != nil {
 			return err
 		}
 

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -42,7 +42,6 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -327,7 +326,7 @@ var _ = Describe("Etcd", func() {
 				}
 
 				expectGetBackupSecret = func() {
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "etcd-backup"}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 						func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 							backupSecret.DeepCopyInto(obj.(*corev1.Secret))
 							return nil
@@ -375,7 +374,7 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should fail when reading the backup secret fails", func() {
-				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "etcd-backup"}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
 
 				Expect(botanist.DeployEtcd(ctx)).To(MatchError(fakeErr))
 			})

--- a/pkg/gardenlet/operation/botanist/etcdcopybackupstask.go
+++ b/pkg/gardenlet/operation/botanist/etcdcopybackupstask.go
@@ -11,11 +11,11 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	etcdcopybackupstask "github.com/gardener/gardener/pkg/component/etcd/copybackupstask"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // NewEtcdCopyBackupsTask is a function exposed for testing.
@@ -51,16 +51,16 @@ func (b *Botanist) DeployEtcdCopyBackupsTask(ctx context.Context) error {
 
 	sourceBackupEntryName := fmt.Sprintf("%s-%s", v1beta1constants.BackupSourcePrefix, b.Shoot.BackupEntryName)
 	sourceBackupEntry := &extensionsv1alpha1.BackupEntry{}
-	if err := b.SeedClientSet.Client().Get(ctx, kubernetesutils.Key(sourceBackupEntryName), sourceBackupEntry); err != nil {
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Name: sourceBackupEntryName}, sourceBackupEntry); err != nil {
 		return err
 	}
 	sourceSecretName := fmt.Sprintf("%s-%s", v1beta1constants.BackupSourcePrefix, v1beta1constants.BackupSecretName)
 	sourceSecret := &corev1.Secret{}
-	if err := b.SeedClientSet.Client().Get(ctx, kubernetesutils.Key(b.Shoot.SeedNamespace, sourceSecretName), sourceSecret); err != nil {
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: sourceSecretName}, sourceSecret); err != nil {
 		return err
 	}
 	secret := &corev1.Secret{}
-	if err := b.SeedClientSet.Client().Get(ctx, kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.BackupSecretName), secret); err != nil {
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.BackupSecretName}, secret); err != nil {
 		return err
 	}
 

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -362,7 +363,7 @@ func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context) error {
 	if err := b.DeployKubeAPIServer(ctx); err != nil {
 		return err
 	}
-	if err := kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), 1); err != nil {
+	if err := kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, 1); err != nil {
 		return err
 	}
 	return b.Shoot.Components.ControlPlane.KubeAPIServer.Wait(ctx)
@@ -370,5 +371,5 @@ func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context) error {
 
 // ScaleKubeAPIServerToOne scales kube-apiserver replicas to one.
 func (b *Botanist) ScaleKubeAPIServerToOne(ctx context.Context) error {
-	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), 1)
+	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, 1)
 }

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -39,7 +39,6 @@ import (
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -630,12 +629,12 @@ var _ = Describe("KubeAPIServer", func() {
 			kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 			kubeAPIServer.EXPECT().Deploy(ctx)
 
-			Expect(gardenClient.Get(ctx, kubernetesutils.Key(projectNamespace, shootName+".kubeconfig"), &corev1.Secret{})).To(BeNotFoundError())
+			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
 
 			Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
 
 			kubeconfigSecret := &corev1.Secret{}
-			Expect(gardenClient.Get(ctx, kubernetesutils.Key(projectNamespace, shootName+".kubeconfig"), kubeconfigSecret)).To(Succeed())
+			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, kubeconfigSecret)).To(Succeed())
 			Expect(kubeconfigSecret.Annotations).To(HaveKeyWithValue("url", "https://api."+externalClusterDomain))
 			Expect(kubeconfigSecret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "kubeconfig"))
 			Expect(kubeconfigSecret.Data).To(And(
@@ -653,7 +652,7 @@ var _ = Describe("KubeAPIServer", func() {
 			}
 			Expect(gardenClient.Create(ctx, secret)).To(Succeed())
 
-			Expect(gardenClient.Get(ctx, kubernetesutils.Key(projectNamespace, shootName+".kubeconfig"), &corev1.Secret{})).To(Succeed())
+			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(Succeed())
 
 			kubeAPIServer.EXPECT().GetValues()
 			kubeAPIServer.EXPECT().SetAutoscalingReplicas(gomock.Any())
@@ -680,7 +679,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 			Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
 
-			Expect(gardenClient.Get(ctx, kubernetesutils.Key(projectNamespace, shootName+".kubeconfig"), &corev1.Secret{})).To(BeNotFoundError())
+			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
 		})
 	})
 

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
@@ -9,12 +9,12 @@ import (
 	"net"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubecontrollermanager "github.com/gardener/gardener/pkg/component/kubernetes/controllermanager"
 	"github.com/gardener/gardener/pkg/component/shared"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // DefaultKubeControllerManager returns a deployer for the kube-controller-manager.
@@ -67,5 +67,5 @@ func (b *Botanist) WaitForKubeControllerManagerToBeActive(ctx context.Context) e
 
 // ScaleKubeControllerManagerToOne scales kube-controller-manager replicas to one.
 func (b *Botanist) ScaleKubeControllerManagerToOne(ctx context.Context) error {
-	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeControllerManager), 1)
+	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeControllerManager}, 1)
 }

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -152,7 +151,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 					var replicas int32 = 4
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
 						obj.Spec.Replicas = ptr.To(replicas)
 						return nil
 					})
@@ -167,7 +166,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 					var replicas int32 = 4
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
 						obj.Spec.Replicas = ptr.To(replicas)
 						return nil
 					})
@@ -185,7 +184,7 @@ var _ = Describe("KubeControllerManager", func() {
 				It("hibernation enabled", func() {
 					botanist.Shoot.HibernationEnabled = true
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
 						obj.Spec.Replicas = ptr.To[int32](0)
 						return nil
 					})
@@ -197,7 +196,7 @@ var _ = Describe("KubeControllerManager", func() {
 				It("hibernation enabled and kube-controller-manager deployment does not exist", func() {
 					botanist.Shoot.HibernationEnabled = true
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(apierrors.NewNotFound(appsv1.Resource("Deployment"), "kube-controller-manager"))
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(apierrors.NewNotFound(appsv1.Resource("Deployment"), "kube-controller-manager"))
 					kubeControllerManager.EXPECT().SetReplicaCount(int32(0))
 
 					Expect(botanist.DeployKubeControllerManager(ctx)).To(Succeed())
@@ -206,7 +205,7 @@ var _ = Describe("KubeControllerManager", func() {
 				It("hibernation enabled and kube-controller-manager is already scaled up", func() {
 					botanist.Shoot.HibernationEnabled = true
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
 						obj.Spec.Replicas = ptr.To[int32](1)
 						return nil
 					})
@@ -233,7 +232,7 @@ var _ = Describe("KubeControllerManager", func() {
 				It("hibernation enabled", func() {
 					botanist.Shoot.HibernationEnabled = true
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
 						obj.Spec.Replicas = ptr.To[int32](0)
 						return nil
 					})
@@ -245,7 +244,7 @@ var _ = Describe("KubeControllerManager", func() {
 				It("hibernation enabled and kube-controller-manager deployment does not exist", func() {
 					botanist.Shoot.HibernationEnabled = true
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(apierrors.NewNotFound(appsv1.Resource("Deployment"), "kube-controller-manager"))
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(apierrors.NewNotFound(appsv1.Resource("Deployment"), "kube-controller-manager"))
 					kubeControllerManager.EXPECT().SetReplicaCount(int32(0))
 
 					Expect(botanist.DeployKubeControllerManager(ctx)).To(Succeed())
@@ -254,7 +253,7 @@ var _ = Describe("KubeControllerManager", func() {
 				It("hibernation enabled and kube-controller-manager is already scaled up", func() {
 					botanist.Shoot.HibernationEnabled = true
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
 						obj.Spec.Replicas = ptr.To[int32](1)
 						return nil
 					})
@@ -276,7 +275,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 		It("should fail when the replicas cannot be determined", func() {
 			kubernetesClient.EXPECT().Client().Return(c)
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(fakeErr)
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(fakeErr)
 
 			Expect(botanist.DeployKubeControllerManager(ctx)).To(Equal(fakeErr))
 		})
@@ -284,7 +283,7 @@ var _ = Describe("KubeControllerManager", func() {
 		It("should fail when the deploy function fails", func() {
 			kubernetesClient.EXPECT().Client().Return(c)
 			kubeAPIServer.EXPECT().GetValues().Return(kubeapiserver.Values{RuntimeConfig: map[string]bool{"foo": true}})
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, "kube-controller-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{}))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
 			kubeControllerManager.EXPECT().SetReplicaCount(int32(0))
 			kubeControllerManager.EXPECT().SetRuntimeConfig(map[string]bool{"foo": true})
 			kubeControllerManager.EXPECT().Deploy(ctx).Return(fakeErr)

--- a/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // DefaultMachineControllerManager returns a deployer for the machine-controller-manager.
@@ -77,7 +76,7 @@ func (b *Botanist) DeployMachineControllerManager(ctx context.Context) error {
 
 // ScaleMachineControllerManagerToZero scales machine-controller-manager replicas to zero.
 func (b *Botanist) ScaleMachineControllerManagerToZero(ctx context.Context) error {
-	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameMachineControllerManager), 0)
+	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameMachineControllerManager}, 0)
 }
 
 func machineDeploymentWithPositiveReplicaCountExist(existingMachineDeployments *machinev1alpha1.MachineDeploymentList) bool {

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -19,7 +20,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/logger"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // DefaultResourceManager returns an instance of Gardener Resource Manager with defaults configured for being deployed in a Shoot namespace
@@ -75,5 +75,5 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 
 // ScaleGardenerResourceManagerToOne scales the gardener-resource-manager deployment
 func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error {
-	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager), 1)
+	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, 1)
 }

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -34,7 +34,6 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -124,7 +123,7 @@ var _ = Describe("ResourceManager", func() {
 			sm = fakesecretsmanager.New(c, seedNamespace)
 
 			By("Ensure secrets managed outside of this function for which secretsmanager.Get() will be called")
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(seedNamespace, "ca"), gomock.AssignableToTypeOf(&corev1.Secret{})).AnyTimes()
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: seedNamespace, Name: "ca"}, gomock.AssignableToTypeOf(&corev1.Secret{})).AnyTimes()
 
 			botanist.SeedClientSet = k8sSeedClient
 			botanist.SecretsManager = sm
@@ -203,7 +202,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(seedNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})
@@ -242,7 +241,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(seedNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})
@@ -265,7 +264,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(seedNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})

--- a/pkg/gardenlet/operation/botanist/resources_test.go
+++ b/pkg/gardenlet/operation/botanist/resources_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -92,7 +91,7 @@ var _ = Describe("Resources", func() {
 	Describe("#DeployReferencedResources", func() {
 		expectReferencedResourcesInSeed := func(expectedObjects ...client.Object) {
 			managedResource := &resourcesv1alpha1.ManagedResource{}
-			Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, "referenced-resources"), managedResource)).To(Succeed())
+			Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: "referenced-resources"}, managedResource)).To(Succeed())
 			Expect(managedResource.Spec.Class).To(PointTo(Equal("seed")))
 			Expect(managedResource.Spec.ForceOverwriteAnnotations).To(PointTo(BeFalse()))
 			Expect(managedResource.Spec.KeepObjects).To(PointTo(BeFalse()))

--- a/pkg/gardenlet/operation/botanist/secrets_test.go
+++ b/pkg/gardenlet/operation/botanist/secrets_test.go
@@ -27,7 +27,6 @@ import (
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -117,20 +116,20 @@ var _ = Describe("Secrets", func() {
 
 				for _, name := range caSecretNames {
 					secret := &corev1.Secret{}
-					Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, name), secret)).To(Succeed())
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: name}, secret)).To(Succeed())
 					verifyCASecret(name, secret, And(HaveKey("ca.crt"), HaveKey("ca.key")))
 				}
 
 				gardenConfigMap := &corev1.ConfigMap{}
-				Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".ca-cluster"), gardenConfigMap)).To(Succeed())
+				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ca-cluster"}, gardenConfigMap)).To(Succeed())
 				Expect(gardenConfigMap.Labels).To(HaveKeyWithValue("gardener.cloud/role", "ca-cluster"))
 
 				gardenSecret := &corev1.Secret{}
-				Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".ca-cluster"), gardenSecret)).To(Succeed())
+				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ca-cluster"}, gardenSecret)).To(Succeed())
 				Expect(gardenSecret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "ca-cluster"))
 
 				internalSecret := &gardencorev1beta1.InternalSecret{}
-				Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".ca-client"), internalSecret)).To(Succeed())
+				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ca-client"}, internalSecret)).To(Succeed())
 				Expect(internalSecret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "ca-client"))
 				Expect(internalSecret.Data).To(And(HaveKey("ca.crt"), HaveKey("ca.key")))
 			})
@@ -139,11 +138,11 @@ var _ = Describe("Secrets", func() {
 				Expect(botanist.InitializeSecretsManagement(ctx)).To(Succeed())
 
 				cluster := &extensionsv1alpha1.Cluster{}
-				Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace), cluster)).To(Succeed())
+				Expect(seedClient.Get(ctx, client.ObjectKey{Name: seedNamespace}, cluster)).To(Succeed())
 				Expect(cluster.Annotations).To(HaveKey("generic-token-kubeconfig.secret.gardener.cloud/name"))
 
 				secret := &corev1.Secret{}
-				Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, cluster.Annotations["generic-token-kubeconfig.secret.gardener.cloud/name"]), secret)).To(Succeed())
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: cluster.Annotations["generic-token-kubeconfig.secret.gardener.cloud/name"]}, secret)).To(Succeed())
 			})
 
 			It("should generate the ssh keypair and sync it to the garden", func() {
@@ -166,7 +165,7 @@ var _ = Describe("Secrets", func() {
 				))
 
 				gardenSecret := &corev1.Secret{}
-				Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".ssh-keypair"), gardenSecret)).To(Succeed())
+				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ssh-keypair"}, gardenSecret)).To(Succeed())
 				Expect(gardenSecret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "ssh-keypair"))
 			})
 
@@ -191,7 +190,7 @@ var _ = Describe("Secrets", func() {
 				Expect(botanist.InitializeSecretsManagement(ctx)).To(Succeed())
 
 				gardenSecret := &corev1.Secret{}
-				Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".ssh-keypair.old"), gardenSecret)).To(Succeed())
+				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ssh-keypair.old"}, gardenSecret)).To(Succeed())
 				Expect(gardenSecret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "ssh-keypair"))
 			})
 
@@ -214,8 +213,8 @@ var _ = Describe("Secrets", func() {
 				Expect(botanist.InitializeSecretsManagement(ctx)).To(Succeed())
 
 				gardenSecret := &corev1.Secret{}
-				Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".ssh-keypair"), gardenSecret)).To(BeNotFoundError())
-				Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".ssh-keypair.old"), gardenSecret)).To(BeNotFoundError())
+				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ssh-keypair"}, gardenSecret)).To(BeNotFoundError())
+				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ssh-keypair.old"}, gardenSecret)).To(BeNotFoundError())
 			})
 
 			Context("observability credentials", func() {
@@ -239,7 +238,7 @@ var _ = Describe("Secrets", func() {
 					))
 
 					gardenSecret := &corev1.Secret{}
-					Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".monitoring"), gardenSecret)).To(Succeed())
+					Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".monitoring"}, gardenSecret)).To(Succeed())
 					Expect(gardenSecret.Annotations).To(HaveKeyWithValue("url", "https://gu-foo--bar.example.com"))
 					Expect(gardenSecret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "monitoring"))
 					Expect(gardenSecret.Data).To(And(HaveKey("username"), HaveKey("password"), HaveKey("auth")))
@@ -258,7 +257,7 @@ var _ = Describe("Secrets", func() {
 					Expect(secretList.Items).To(BeEmpty())
 
 					gardenSecret := &corev1.Secret{}
-					Expect(gardenClient.Get(ctx, kubernetesutils.Key(gardenNamespace, shootName+".monitoring"), gardenSecret)).To(BeNotFoundError())
+					Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".monitoring"}, gardenSecret)).To(BeNotFoundError())
 				})
 			})
 		})
@@ -325,31 +324,31 @@ var _ = Describe("Secrets", func() {
 				By("Verify existing CA secrets got restored")
 				for _, name := range caSecretNames[:2] {
 					secret := &corev1.Secret{}
-					Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, name), secret)).To(Succeed())
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: name}, secret)).To(Succeed())
 					verifyCASecret(name, secret, Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 				}
 
 				By("Verify missing CA secrets got generated")
 				for _, name := range caSecretNames[3:] {
 					secret := &corev1.Secret{}
-					Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, name), secret)).To(Succeed())
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: name}, secret)).To(Succeed())
 					verifyCASecret(name, secret, And(HaveKey("ca.crt"), HaveKey("ca.key")))
 				}
 
 				By("Verify non-CA secrets got restored")
 				secret := &corev1.Secret{}
-				Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, "non-ca-secret"), secret)).To(Succeed())
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: "non-ca-secret"}, secret)).To(Succeed())
 				Expect(secret.Labels).To(Equal(map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity}))
 				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 
 				By("Verify external secrets got restored")
-				Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, "extension-foo-secret"), secret)).To(Succeed())
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: "extension-foo-secret"}, secret)).To(Succeed())
 				Expect(secret.Labels).To(Equal(map[string]string{"managed-by": "secrets-manager", "manager-identity": "extension-foo"}))
 				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 
 				By("Verify unrelated data not to be restored")
-				Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, "secret-without-labels"), &corev1.Secret{})).To(BeNotFoundError())
-				Expect(seedClient.Get(ctx, kubernetesutils.Key(seedNamespace, "some-other-data"), &corev1.Secret{})).To(BeNotFoundError())
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: "secret-without-labels"}, &corev1.Secret{})).To(BeNotFoundError())
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: "some-other-data"}, &corev1.Secret{})).To(BeNotFoundError())
 			})
 		})
 	})

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -321,7 +321,7 @@ func (o *Operation) initShootClients(ctx context.Context, versionMatchRequired b
 func (o *Operation) IsAPIServerRunning(ctx context.Context) (bool, error) {
 	deployment := &appsv1.Deployment{}
 	// use API reader here to make sure, we're not reading from a stale cache, when checking if we should initialize a shoot client (e.g. from within the care controller)
-	if err := o.SeedClientSet.APIReader().Get(ctx, kubernetesutils.Key(o.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deployment); err != nil {
+	if err := o.SeedClientSet.APIReader().Get(ctx, client.ObjectKey{Namespace: o.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, deployment); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -30,7 +30,6 @@ import (
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // NewBuilder returns a new Builder.
@@ -80,7 +79,7 @@ func (b *Builder) WithCloudProfileObject(cloudProfileObject *gardencorev1beta1.C
 func (b *Builder) WithCloudProfileObjectFrom(reader client.Reader) *Builder {
 	b.cloudProfileFunc = func(ctx context.Context, name string) (*gardencorev1beta1.CloudProfile, error) {
 		obj := &gardencorev1beta1.CloudProfile{}
-		return obj, reader.Get(ctx, kubernetesutils.Key(name), obj)
+		return obj, reader.Get(ctx, client.ObjectKey{Name: name}, obj)
 	}
 	return b
 }
@@ -119,12 +118,12 @@ func (b *Builder) WithShootSecret(secret *corev1.Secret) *Builder {
 func (b *Builder) WithShootSecretFrom(c client.Reader) *Builder {
 	b.shootSecretFunc = func(ctx context.Context, namespace, secretBindingName string) (*corev1.Secret, error) {
 		binding := &gardencorev1beta1.SecretBinding{}
-		if err := c.Get(ctx, kubernetesutils.Key(namespace, secretBindingName), binding); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretBindingName}, binding); err != nil {
 			return nil, err
 		}
 
 		secret := &corev1.Secret{}
-		if err := c.Get(ctx, kubernetesutils.Key(binding.SecretRef.Namespace, binding.SecretRef.Name), secret); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Namespace: binding.SecretRef.Namespace, Name: binding.SecretRef.Name}, secret); err != nil {
 			return nil, err
 		}
 

--- a/pkg/operator/controller/garden/care/reconciler_test.go
+++ b/pkg/operator/controller/garden/care/reconciler_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/operator/apis/config"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	. "github.com/gardener/gardener/pkg/operator/controller/garden/care"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
@@ -75,7 +74,7 @@ var _ = Describe("Garden Care Control", func() {
 		var req reconcile.Request
 
 		BeforeEach(func() {
-			req = reconcile.Request{NamespacedName: kubernetesutils.Key(gardenName)}
+			req = reconcile.Request{NamespacedName: client.ObjectKey{Name: gardenName}}
 		})
 
 		JustBeforeEach(func() {
@@ -90,7 +89,7 @@ var _ = Describe("Garden Care Control", func() {
 
 		Context("when garden no longer exists", func() {
 			It("should stop reconciling and not requeue", func() {
-				req = reconcile.Request{NamespacedName: kubernetesutils.Key("some-other-garden")}
+				req = reconcile.Request{NamespacedName: client.ObjectKey{Name: "some-other-garden"}}
 				Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{}))
 			})
 		})

--- a/pkg/resourcemanager/webhook/projectedtokenmount/handler.go
+++ b/pkg/resourcemanager/webhook/projectedtokenmount/handler.go
@@ -50,7 +50,7 @@ func (h *Handler) Default(ctx context.Context, obj runtime.Object) error {
 
 	serviceAccount := &corev1.ServiceAccount{}
 	// We use `req.Namespace` instead of `pod.Namespace` due to https://github.com/kubernetes/kubernetes/issues/88282.
-	if err := h.TargetReader.Get(ctx, kubernetesutils.Key(req.Namespace, pod.Spec.ServiceAccountName), serviceAccount); err != nil {
+	if err := h.TargetReader.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: pod.Spec.ServiceAccountName}, serviceAccount); err != nil {
 		log.Error(err, "Error getting service account", "serviceAccountName", pod.Spec.ServiceAccountName)
 		return err
 	}

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -28,7 +28,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 )
 
@@ -133,7 +132,7 @@ func (r *Reconciler) determineSeed(
 	shootList := v1beta1helper.ConvertShootList(sl.Items)
 
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
-	if err := r.Client.Get(ctx, kubernetesutils.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: shoot.Spec.CloudProfileName}, cloudProfile); err != nil {
 		return nil, err
 	}
 	regionConfig, err := r.getRegionConfigMap(ctx, log, cloudProfile)

--- a/pkg/utils/gardener/project.go
+++ b/pkg/utils/gardener/project.go
@@ -14,7 +14,6 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ProjectNamespacePrefix is the prefix of namespaces representing projects.
@@ -39,7 +38,7 @@ func ProjectForNamespaceFromReader(ctx context.Context, reader client.Reader, na
 // fetches the project name label. Then it will read the project with the respective name.
 func ProjectAndNamespaceFromReader(ctx context.Context, reader client.Reader, namespaceName string) (*gardencorev1beta1.Project, *corev1.Namespace, error) {
 	namespace := &corev1.Namespace{}
-	if err := reader.Get(ctx, kubernetesutils.Key(namespaceName), namespace); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Name: namespaceName}, namespace); err != nil {
 		return nil, nil, err
 	}
 
@@ -49,7 +48,7 @@ func ProjectAndNamespaceFromReader(ctx context.Context, reader client.Reader, na
 	}
 
 	project := &gardencorev1beta1.Project{}
-	if err := reader.Get(ctx, kubernetesutils.Key(projectName), project); err != nil {
+	if err := reader.Get(ctx, client.ObjectKey{Name: projectName}, project); err != nil {
 		return nil, namespace, err
 	}
 

--- a/pkg/utils/gardener/project_test.go
+++ b/pkg/utils/gardener/project_test.go
@@ -18,7 +18,6 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
@@ -89,7 +88,7 @@ var _ = Describe("Project", func() {
 
 	Describe("#ProjectAndNamespaceFromReader", func() {
 		It("should return an error because getting the namespace failed", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(fakeErr)
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(fakeErr)
 
 			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
 			Expect(err).To(MatchError(fakeErr))
@@ -98,7 +97,7 @@ var _ = Describe("Project", func() {
 		})
 
 		It("should return the namespace but no project because labels missing", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 				namespace.DeepCopyInto(obj)
 				return nil
 			})
@@ -112,11 +111,11 @@ var _ = Describe("Project", func() {
 		It("should return an error because getting the project failed", func() {
 			namespace.Labels = map[string]string{"project.gardener.cloud/name": projectName}
 
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 				namespace.DeepCopyInto(obj)
 				return nil
 			})
-			c.EXPECT().Get(ctx, kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(fakeErr)
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(fakeErr)
 
 			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
 			Expect(err).To(MatchError(fakeErr))
@@ -127,11 +126,11 @@ var _ = Describe("Project", func() {
 		It("should return both namespace and project", func() {
 			namespace.Labels = map[string]string{"project.gardener.cloud/name": projectName}
 
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 				namespace.DeepCopyInto(obj)
 				return nil
 			})
-			c.EXPECT().Get(ctx, kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
 				project.DeepCopyInto(obj)
 				return nil
 			})

--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
@@ -51,7 +50,7 @@ func RewriteEncryptedDataAddLabel(
 	// Check if we have to label the resources to rewrite the data.
 	meta := &metav1.PartialObjectMetadata{}
 	meta.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
-	if err := runtimeClient.Get(ctx, kubernetesutils.Key(namespace, name), meta); err != nil {
+	if err := runtimeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, meta); err != nil {
 		return err
 	}
 
@@ -197,7 +196,7 @@ func SnapshotETCDAfterRewritingEncryptedData(
 	// Check if we have to snapshot ETCD now that we have rewritten all encrypted data.
 	meta := &metav1.PartialObjectMetadata{}
 	meta.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
-	if err := runtimeClient.Get(ctx, kubernetesutils.Key(namespace, name), meta); err != nil {
+	if err := runtimeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, meta); err != nil {
 		return err
 	}
 
@@ -221,7 +220,7 @@ func SnapshotETCDAfterRewritingEncryptedData(
 func PatchAPIServerDeploymentMeta(ctx context.Context, c client.Client, namespace, name string, mutate func(deployment *metav1.PartialObjectMetadata)) error {
 	meta := &metav1.PartialObjectMetadata{}
 	meta.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
-	if err := c.Get(ctx, kubernetesutils.Key(namespace, name), meta); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, meta); err != nil {
 		return err
 	}
 

--- a/pkg/utils/gardener/secretsrotation/serviceaccounts_test.go
+++ b/pkg/utils/gardener/secretsrotation/serviceaccounts_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -94,7 +93,7 @@ var _ = Describe("Service accounts", func() {
 				Expect(sa3.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "sa3secret1"}))
 
 				sa1Secret := &corev1.Secret{}
-				Expect(targetClient.Get(ctx, kubernetesutils.Key(sa1.Namespace, "sa1-token"+suffix), sa1Secret)).To(Succeed())
+				Expect(targetClient.Get(ctx, client.ObjectKey{Namespace: sa1.Namespace, Name: "sa1-token" + suffix}, sa1Secret)).To(Succeed())
 				verifyCreatedSATokenSecret(sa1Secret, sa1.Name)
 			})
 		})

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -604,7 +604,7 @@ func ConstructExternalDomain(ctx context.Context, c client.Reader, shoot *garden
 	case primaryProvider != nil:
 		if primaryProvider.SecretName != nil {
 			secret := &corev1.Secret{}
-			if err := c.Get(ctx, kubernetesutils.Key(shoot.Namespace, *primaryProvider.SecretName), secret); err != nil {
+			if err := c.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *primaryProvider.SecretName}, secret); err != nil {
 				return nil, fmt.Errorf("could not get dns provider secret %q: %+v", *shoot.Spec.DNS.Providers[0].SecretName, err)
 			}
 			externalDomain.SecretData = secret.Data

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -31,7 +31,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
 )
@@ -52,7 +51,7 @@ var _ = Describe("Shoot", func() {
 			BeFalse()),
 		Entry("don't respect overwrite but garden namespace",
 			false,
-			&gardencorev1beta1.Shoot{ObjectMeta: kubernetesutils.ObjectMeta(v1beta1constants.GardenNamespace, "foo")},
+			&gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "foo"}},
 			BeTrue()),
 	)
 

--- a/pkg/utils/kubernetes/bootstraptoken/bootstraptoken.go
+++ b/pkg/utils/kubernetes/bootstraptoken/bootstraptoken.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // validBootstrapTokenRegex is used to check if an existing token can be interpreted as a bootstrap token.
@@ -36,7 +35,7 @@ func ComputeBootstrapToken(ctx context.Context, c client.Client, tokenID, descri
 		},
 	}
 
-	if err = c.Get(ctx, kubernetes.Key(secret.Namespace, secret.Name), secret); client.IgnoreNotFound(err) != nil {
+	if err = c.Get(ctx, client.ObjectKeyFromObject(secret), secret); client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
 

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/kubernetes/client"
 	mockutilclient "github.com/gardener/gardener/pkg/utils/kubernetes/client/mock"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -66,9 +65,9 @@ var _ = Describe("Cleaner", func() {
 		c = mockclient.NewMockClient(ctrl)
 		ctx = context.Background()
 
-		cm1Key = kubernetesutils.Key("n", "foo")
-		cm2Key = kubernetesutils.Key("n", "bar")
-		nsKey = kubernetesutils.Key("baz")
+		cm1Key = client.ObjectKey{Namespace: "n", Name: "foo"}
+		cm2Key = client.ObjectKey{Namespace: "n", Name: "bar"}
+		nsKey = client.ObjectKey{Name: "baz"}
 
 		cm1 = corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
 		cm2 = corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar"}}

--- a/pkg/utils/kubernetes/deployment.go
+++ b/pkg/utils/kubernetes/deployment.go
@@ -48,9 +48,9 @@ func ValidDeploymentContainerImageVersion(deploymentToCheck *appsv1.Deployment, 
 }
 
 // CurrentReplicaCountForDeployment returns the current replicaCount for the given deployment.
-func CurrentReplicaCountForDeployment(ctx context.Context, client client.Client, namespace, deploymentName string) (int32, error) {
+func CurrentReplicaCountForDeployment(ctx context.Context, c client.Client, namespace, deploymentName string) (int32, error) {
 	deployment := &appsv1.Deployment{}
-	if err := client.Get(ctx, Key(namespace, deploymentName), deployment); err != nil && !apierrors.IsNotFound(err) {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: deploymentName}, deployment); err != nil && !apierrors.IsNotFound(err) {
 		return 0, err
 	}
 	if deployment.Spec.Replicas == nil {

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -96,18 +96,6 @@ func nameAndNamespace(namespaceOrName string, nameOpt ...string) (namespace, nam
 	return
 }
 
-// Key creates a new client.ObjectKey from the given parameters.
-// There are only two ways to call this function:
-//   - If only namespaceOrName is set, then a client.ObjectKey with name set to namespaceOrName is returned.
-//   - If namespaceOrName and one nameOpt is given, then a client.ObjectKey with namespace set to namespaceOrName
-//     and name set to nameOpt[0] is returned.
-//
-// For all other cases, this method panics.
-func Key(namespaceOrName string, nameOpt ...string) client.ObjectKey {
-	namespace, name := nameAndNamespace(namespaceOrName, nameOpt...)
-	return client.ObjectKey{Namespace: namespace, Name: name}
-}
-
 // ObjectMeta creates a new metav1.ObjectMeta from the given parameters.
 // There are only two ways to call this function:
 //   - If only namespaceOrName is set, then a metav1.ObjectMeta with name set to namespaceOrName is returned.

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -83,36 +83,6 @@ func SetAnnotationAndUpdate(ctx context.Context, c client.Client, obj client.Obj
 	return nil
 }
 
-func nameAndNamespace(namespaceOrName string, nameOpt ...string) (namespace, name string) {
-	if len(nameOpt) > 1 {
-		panic(fmt.Sprintf("more than name/namespace for key specified: %s/%v", namespaceOrName, nameOpt))
-	}
-	if len(nameOpt) == 0 {
-		name = namespaceOrName
-		return
-	}
-	namespace = namespaceOrName
-	name = nameOpt[0]
-	return
-}
-
-// ObjectMeta creates a new metav1.ObjectMeta from the given parameters.
-// There are only two ways to call this function:
-//   - If only namespaceOrName is set, then a metav1.ObjectMeta with name set to namespaceOrName is returned.
-//   - If namespaceOrName and one nameOpt is given, then a metav1.ObjectMeta with namespace set to namespaceOrName
-//     and name set to nameOpt[0] is returned.
-//
-// For all other cases, this method panics.
-func ObjectMeta(namespaceOrName string, nameOpt ...string) metav1.ObjectMeta {
-	namespace, name := nameAndNamespace(namespaceOrName, nameOpt...)
-	return metav1.ObjectMeta{Namespace: namespace, Name: name}
-}
-
-// ObjectMetaFromKey returns an ObjectMeta with the namespace and name set to the values from the key.
-func ObjectMetaFromKey(key client.ObjectKey) metav1.ObjectMeta {
-	return ObjectMeta(key.Namespace, key.Name)
-}
-
 // ObjectKeyFromSecretRef returns an ObjectKey for the given SecretReference.
 func ObjectKeyFromSecretRef(ref corev1.SecretReference) client.ObjectKey {
 	return client.ObjectKey{

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -67,20 +67,6 @@ var _ = Describe("kubernetes", func() {
 		ctrl.Finish()
 	})
 
-	Describe("#ObjectMeta", func() {
-		It("should return an ObjectKey with namespace and name set", func() {
-			Expect(ObjectMeta(namespace, name)).To(Equal(metav1.ObjectMeta{Namespace: namespace, Name: name}))
-		})
-
-		It("should return an ObjectKey with only name set", func() {
-			Expect(ObjectMeta(name)).To(Equal(metav1.ObjectMeta{Name: name}))
-		})
-
-		It("should panic if nameOpt is longer than 1", func() {
-			Expect(func() { ObjectMeta("foo", "bar", "baz") }).To(Panic())
-		})
-	})
-
 	Describe("#ObjectKeyFromSecretRef", func() {
 		It("should return an ObjectKey with namespace and name set", func() {
 			Expect(ObjectKeyFromSecretRef(corev1.SecretReference{Namespace: namespace, Name: name})).To(Equal(client.ObjectKey{Namespace: namespace, Name: name}))

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -67,20 +67,6 @@ var _ = Describe("kubernetes", func() {
 		ctrl.Finish()
 	})
 
-	Describe("#Key", func() {
-		It("should return an ObjectKey with namespace and name set", func() {
-			Expect(Key(namespace, name)).To(Equal(client.ObjectKey{Namespace: namespace, Name: name}))
-		})
-
-		It("should return an ObjectKey with only name set", func() {
-			Expect(Key(name)).To(Equal(client.ObjectKey{Name: name}))
-		})
-
-		It("should panic if nameOpt is longer than 1", func() {
-			Expect(func() { Key("foo", "bar", "baz") }).To(Panic())
-		})
-	})
-
 	Describe("#ObjectMeta", func() {
 		It("should return an ObjectKey with namespace and name set", func() {
 			Expect(ObjectMeta(namespace, name)).To(Equal(metav1.ObjectMeta{Namespace: namespace, Name: name}))
@@ -174,7 +160,7 @@ var _ = Describe("kubernetes", func() {
 		var (
 			namespace = "bar"
 			name      = "foo"
-			key       = Key(namespace, name)
+			key       = client.ObjectKey{Namespace: namespace, Name: name}
 			configMap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
@@ -270,7 +256,7 @@ var _ = Describe("kubernetes", func() {
 
 	Describe("#GetLoadBalancerIngress", func() {
 		var (
-			key     = Key(namespace, name)
+			key     = client.ObjectKey{Namespace: namespace, Name: name}
 			service = &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -346,7 +332,7 @@ var _ = Describe("kubernetes", func() {
 
 	Describe("#LookupObject", func() {
 		var (
-			key       = Key(namespace, name)
+			key       = client.ObjectKey{Namespace: namespace, Name: name}
 			configMap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,

--- a/pkg/utils/kubernetes/leaderelection.go
+++ b/pkg/utils/kubernetes/leaderelection.go
@@ -16,25 +16,25 @@ import (
 )
 
 // ReadLeaderElectionRecord returns the leader election record for a given lock type and a namespace/name combination.
-func ReadLeaderElectionRecord(ctx context.Context, client client.Client, lock, namespace, name string) (*resourcelock.LeaderElectionRecord, error) {
+func ReadLeaderElectionRecord(ctx context.Context, c client.Client, lock, namespace, name string) (*resourcelock.LeaderElectionRecord, error) {
 	switch lock {
 	case "endpoints":
 		endpoint := &corev1.Endpoints{}
-		if err := client.Get(ctx, Key(namespace, name), endpoint); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, endpoint); err != nil {
 			return nil, err
 		}
 		return leaderElectionRecordFromAnnotations(endpoint.Annotations)
 
 	case "configmaps":
 		configmap := &corev1.ConfigMap{}
-		if err := client.Get(ctx, Key(namespace, name), configmap); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, configmap); err != nil {
 			return nil, err
 		}
 		return leaderElectionRecordFromAnnotations(configmap.Annotations)
 
 	case resourcelock.LeasesResourceLock:
 		lease := &coordinationv1.Lease{}
-		if err := client.Get(ctx, Key(namespace, name), lease); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, lease); err != nil {
 			return nil, err
 		}
 		return resourcelock.LeaseSpecToLeaderElectionRecord(&lease.Spec), nil

--- a/pkg/utils/kubernetes/leaderelection_test.go
+++ b/pkg/utils/kubernetes/leaderelection_test.go
@@ -81,7 +81,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the object cannot be retrieved", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Endpoints{})).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Endpoints{})).Return(fakeErr)
 
 				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
 				Expect(lock).To(BeNil())
@@ -89,7 +89,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the object has no leader election annotation", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Endpoints{}))
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Endpoints{}))
 
 				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
 				Expect(lock).To(BeNil())
@@ -97,7 +97,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the leader election annotation cannot be unmarshalled", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Endpoints{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Endpoints, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Endpoints{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Endpoints, _ ...client.GetOption) error {
 					(&corev1.Endpoints{ObjectMeta: objectMetaInvalid}).DeepCopyInto(obj)
 					return nil
 				})
@@ -108,7 +108,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should successfully return the leader election record", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Endpoints{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Endpoints, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Endpoints{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Endpoints, _ ...client.GetOption) error {
 					(&corev1.Endpoints{ObjectMeta: objectMetaValid}).DeepCopyInto(obj)
 					return nil
 				})
@@ -131,7 +131,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the object cannot be retrieved", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).Return(fakeErr)
 
 				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
 				Expect(lock).To(BeNil())
@@ -139,7 +139,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the object has no leader election annotation", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&corev1.ConfigMap{}))
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.ConfigMap{}))
 
 				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
 				Expect(lock).To(BeNil())
@@ -147,7 +147,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the leader election annotation cannot be unmarshalled", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.ConfigMap, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.ConfigMap, _ ...client.GetOption) error {
 					(&corev1.ConfigMap{ObjectMeta: objectMetaInvalid}).DeepCopyInto(obj)
 					return nil
 				})
@@ -158,7 +158,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should successfully return the leader election record", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.ConfigMap, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.ConfigMap, _ ...client.GetOption) error {
 					(&corev1.ConfigMap{ObjectMeta: objectMetaValid}).DeepCopyInto(obj)
 					return nil
 				})
@@ -181,7 +181,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the object cannot be retrieved", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&coordinationv1.Lease{})).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&coordinationv1.Lease{})).Return(fakeErr)
 
 				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
 				Expect(lock).To(BeNil())
@@ -189,7 +189,7 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should successfully return the leader election record", func() {
-				c.EXPECT().Get(ctx, Key(namespace, name), gomock.AssignableToTypeOf(&coordinationv1.Lease{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *coordinationv1.Lease, _ ...client.GetOption) error {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&coordinationv1.Lease{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *coordinationv1.Lease, _ ...client.GetOption) error {
 					(&coordinationv1.Lease{Spec: leaseSpecValid}).DeepCopyInto(obj)
 					return nil
 				})

--- a/pkg/utils/kubernetes/managedseed.go
+++ b/pkg/utils/kubernetes/managedseed.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 )
@@ -34,9 +34,9 @@ func GetManagedSeedWithReader(ctx context.Context, r client.Reader, shootNamespa
 }
 
 // GetManagedSeedByName tries to read a ManagedSeed in the garden namespace. If it's not found then `nil` is returned.
-func GetManagedSeedByName(ctx context.Context, client client.Client, name string) (*seedmanagementv1alpha1.ManagedSeed, error) {
+func GetManagedSeedByName(ctx context.Context, c client.Client, name string) (*seedmanagementv1alpha1.ManagedSeed, error) {
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := client.Get(ctx, Key(constants.GardenNamespace, name), managedSeed); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: name}, managedSeed); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/utils/kubernetes/managedseed_test.go
+++ b/pkg/utils/kubernetes/managedseed_test.go
@@ -113,7 +113,7 @@ var _ = Describe("managedseed", func() {
 		})
 
 		It("should return nil since the ManagedSeed is not found", func() {
-			c.EXPECT().Get(ctx, Key("garden", seedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: "garden", Name: seedName}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
 			managedSeed, err := GetManagedSeedByName(ctx, c, seedName)
 			Expect(err).NotTo(HaveOccurred())
@@ -123,7 +123,7 @@ var _ = Describe("managedseed", func() {
 		It("should return an error since reading the ManagedSeed failed", func() {
 			fakeErr := errors.New("fake")
 
-			c.EXPECT().Get(ctx, Key("garden", seedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).Return(fakeErr)
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: "garden", Name: seedName}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).Return(fakeErr)
 
 			managedSeed, err := GetManagedSeedByName(ctx, c, seedName)
 			Expect(err).To(MatchError(fakeErr))
@@ -133,7 +133,7 @@ var _ = Describe("managedseed", func() {
 		It("should return the ManagedSeed since reading it succeeded", func() {
 			expected := &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: seedName}}
 
-			c.EXPECT().Get(ctx, Key("garden", seedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed, _ ...client.GetOption) error {
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: "garden", Name: seedName}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed, _ ...client.GetOption) error {
 				expected.DeepCopyInto(obj)
 				return nil
 			})

--- a/pkg/utils/kubernetes/secretref.go
+++ b/pkg/utils/kubernetes/secretref.go
@@ -15,7 +15,7 @@ import (
 // GetSecretByReference returns the secret referenced by the given secret reference.
 func GetSecretByReference(ctx context.Context, c client.Reader, ref *corev1.SecretReference) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
-	if err := c.Get(ctx, Key(ref.Namespace, ref.Name), secret); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}, secret); err != nil {
 		return nil, err
 	}
 	return secret, nil
@@ -28,7 +28,7 @@ func GetSecretMetadataByReference(ctx context.Context, c client.Reader, ref *cor
 			Kind:       "Secret",
 			APIVersion: "v1",
 		}}
-	if err := c.Get(ctx, Key(ref.Namespace, ref.Name), metadata); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}, metadata); err != nil {
 		return nil, err
 	}
 	return metadata, nil

--- a/pkg/utils/kubernetes/secretref_test.go
+++ b/pkg/utils/kubernetes/secretref_test.go
@@ -70,7 +70,7 @@ var _ = Describe("secretref", func() {
 
 	Describe("#GetSecretByReference", func() {
 		It("should get the secret", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
 				*s = *secret
 				return nil
 			})
@@ -81,7 +81,7 @@ var _ = Describe("secretref", func() {
 		})
 
 		It("should fail if getting the secret failed", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
 
 			result, err := kubernetesutils.GetSecretByReference(ctx, c, secretRef)
 			Expect(err).To(HaveOccurred())

--- a/pkg/utils/kubernetes/statefulset_test.go
+++ b/pkg/utils/kubernetes/statefulset_test.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
@@ -77,9 +78,9 @@ var _ = Describe("Statefulset.", func() {
 				},
 			}
 
-			c.EXPECT().Get(ctx, Key(testNamespace, testStatefulset), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).SetArg(2, *statefulSet).Return(nil)
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).SetArg(2, *statefulSet).Return(nil)
 
-			rr, err := GetContainerResourcesInStatefulSet(ctx, c, Key(testNamespace, testStatefulset))
+			rr, err := GetContainerResourcesInStatefulSet(ctx, c, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rr).To(HaveLen(len(statefulSet.Spec.Template.Spec.Containers)))
 			Expect(rr["container-1"]).To(Equal(expectedResources))
@@ -101,9 +102,9 @@ var _ = Describe("Statefulset.", func() {
 				},
 			}
 
-			c.EXPECT().Get(ctx, Key(testNamespace, testStatefulset), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).SetArg(2, *statefulSet).Return(nil)
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).SetArg(2, *statefulSet).Return(nil)
 
-			rr, err := GetContainerResourcesInStatefulSet(ctx, c, Key(testNamespace, testStatefulset))
+			rr, err := GetContainerResourcesInStatefulSet(ctx, c, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rr).To(HaveLen(len(statefulSet.Spec.Template.Spec.Containers)))
 			Expect(rr["container-1"]).To(Equal(expectedResources))
@@ -115,9 +116,9 @@ var _ = Describe("Statefulset.", func() {
 				ctx = context.TODO()
 			)
 
-			c.EXPECT().Get(ctx, Key(testNamespace, testStatefulset), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(errors.New("error"))
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(errors.New("error"))
 
-			_, err := GetContainerResourcesInStatefulSet(ctx, c, Key(testNamespace, testStatefulset))
+			_, err := GetContainerResourcesInStatefulSet(ctx, c, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset})
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/utils/managedresources/builder/resourcemanager_test.go
+++ b/pkg/utils/managedresources/builder/resourcemanager_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/managedresources/builder"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -56,7 +55,7 @@ var _ = Describe("Resource Manager", func() {
 			).To(Succeed())
 
 			secret := &corev1.Secret{}
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), secret)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret)).To(Succeed())
 
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -138,7 +137,7 @@ var _ = Describe("Resource Manager", func() {
 					Reconcile(ctx),
 			).To(Succeed())
 
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), secret)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret)).To(Succeed())
 
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -200,7 +199,7 @@ var _ = Describe("Resource Manager", func() {
 					Reconcile(ctx),
 			).To(Succeed())
 
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), secret)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret)).To(Succeed())
 
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -223,7 +222,7 @@ var _ = Describe("Resource Manager", func() {
 
 			Expect(secret.Reconcile(ctx)).To(BeNotFoundError())
 
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), &corev1.Secret{})).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &corev1.Secret{})).To(BeNotFoundError())
 		})
 	})
 
@@ -302,7 +301,7 @@ var _ = Describe("Resource Manager", func() {
 			).To(Succeed())
 
 			mr := &resourcesv1alpha1.ManagedResource{}
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), mr)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, mr)).To(Succeed())
 
 			expectedMr := &resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
@@ -395,7 +394,7 @@ var _ = Describe("Resource Manager", func() {
 					Reconcile(ctx),
 			).To(Succeed())
 
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), mr)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, mr)).To(Succeed())
 
 			Expect(mr).To(Equal(&resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
@@ -433,7 +432,7 @@ var _ = Describe("Resource Manager", func() {
 					Reconcile(ctx),
 			).To(Succeed())
 
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), mr)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, mr)).To(Succeed())
 
 			Expect(mr).To(Equal(&resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
@@ -463,7 +462,7 @@ var _ = Describe("Resource Manager", func() {
 					Reconcile(ctx),
 			).To(BeNotFoundError())
 
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), mr)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, mr)).To(BeNotFoundError())
 		})
 	})
 })

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -299,7 +299,7 @@ func WaitUntilHealthyAndNotProgressing(ctx context.Context, client client.Client
 	return waitUntilHealthy(ctx, client, namespace, name, true)
 }
 
-func waitUntilHealthy(ctx context.Context, client client.Client, namespace, name string, andNotProgressing bool) error {
+func waitUntilHealthy(ctx context.Context, c client.Client, namespace, name string, andNotProgressing bool) error {
 	obj := &resourcesv1alpha1.ManagedResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -308,7 +308,7 @@ func waitUntilHealthy(ctx context.Context, client client.Client, namespace, name
 	}
 
 	return retry.Until(ctx, IntervalWait, func(ctx context.Context) (done bool, err error) {
-		if err := client.Get(ctx, kubernetesutils.Key(namespace, name), obj); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
 			return retry.SevereError(err)
 		}
 

--- a/pkg/utils/managedresources/managedresources_test.go
+++ b/pkg/utils/managedresources/managedresources_test.go
@@ -125,7 +125,7 @@ var _ = Describe("managedresources", func() {
 			Expect(managedResource.Reconcile(ctx)).To(Succeed())
 
 			actual := &resourcesv1alpha1.ManagedResource{}
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), actual)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, actual)).To(Succeed())
 			Expect(actual).To(Equal(&resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            name,
@@ -151,7 +151,7 @@ var _ = Describe("managedresources", func() {
 			Expect(fakeClient.List(ctx, secretList, client.Limit(1))).To(Succeed())
 			Expect(secretList.Items[0].Name).To(HavePrefix(name))
 
-			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
 		})
 	})
 

--- a/pkg/utils/secrets/manager/fake/fake_manager.go
+++ b/pkg/utils/secrets/manager/fake/fake_manager.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
@@ -89,7 +88,7 @@ func (m *fakeManager) Generate(ctx context.Context, config secretsutils.ConfigIn
 		}
 
 		secret = &corev1.Secret{}
-		if err := m.client.Get(ctx, kubernetesutils.Key(objectMeta.Namespace, objectMeta.Name), secret); err != nil {
+		if err := m.client.Get(ctx, client.ObjectKey{Namespace: objectMeta.Namespace, Name: objectMeta.Name}, secret); err != nil {
 			return nil, err
 		}
 

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -46,7 +46,7 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 	}
 
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := f.GardenClient.Client().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
+	if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: seed.Name}, managedSeed); err != nil {
 		if apierrors.IsNotFound(err) {
 			f.Logger.Info("Seed is not a ManagedSeed, checking seed secret")
 
@@ -81,7 +81,7 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 	}
 
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := f.GardenClient.Client().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
+	if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: managedSeed.Spec.Shoot.Name}, shoot); err != nil {
 		return seed, nil, fmt.Errorf("failed to get Shoot %s for ManagedSeed, %s: %w", managedSeed.Spec.Shoot.Name, client.ObjectKeyFromObject(managedSeed), err)
 	}
 
@@ -103,7 +103,7 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 
 // GetShoot gets the test shoot
 func (f *GardenerFramework) GetShoot(ctx context.Context, shoot *gardencorev1beta1.Shoot) error {
-	return f.GardenClient.Client().Get(ctx, kubernetesutils.Key(shoot.Namespace, shoot.Name), shoot)
+	return f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, shoot)
 }
 
 // GetShootProject returns the project of a shoot

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -23,7 +23,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/test/utils/access"
 )
@@ -300,7 +299,7 @@ func (f *ShootFramework) WaitForShootCondition(ctx context.Context, interval, ti
 // available replica.
 func (f *ShootFramework) IsAPIServerRunning(ctx context.Context) (bool, error) {
 	deployment := &appsv1.Deployment{}
-	if err := f.SeedClient.Client().Get(ctx, kubernetesutils.Key(f.ShootSeedNamespace(), v1beta1constants.DeploymentNameKubeAPIServer), deployment); err != nil {
+	if err := f.SeedClient.Client().Get(ctx, client.ObjectKey{Namespace: f.ShootSeedNamespace(), Name: v1beta1constants.DeploymentNameKubeAPIServer}, deployment); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/test/integration/controllermanager/bastion/bastion_test.go
+++ b/test/integration/controllermanager/bastion/bastion_test.go
@@ -23,7 +23,6 @@ import (
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	bastionregistry "github.com/gardener/gardener/pkg/apiserver/registry/operations/bastion"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -46,7 +45,7 @@ var _ = Describe("Bastion controller tests", func() {
 		seedName := "foo"
 
 		shoot = &gardencorev1beta1.Shoot{
-			ObjectMeta: kubernetesutils.ObjectMetaFromKey(objectKey),
+			ObjectMeta: metav1.ObjectMeta{Namespace: objectKey.Namespace, Name: objectKey.Name},
 			Spec: gardencorev1beta1.ShootSpec{
 				SecretBindingName: ptr.To("my-provider-account"),
 				CloudProfileName:  "test-cloudprofile",
@@ -74,7 +73,7 @@ var _ = Describe("Bastion controller tests", func() {
 			},
 		}
 		bastion = &operationsv1alpha1.Bastion{
-			ObjectMeta: kubernetesutils.ObjectMetaFromKey(objectKey),
+			ObjectMeta: metav1.ObjectMeta{Namespace: objectKey.Namespace, Name: objectKey.Name},
 			Spec: operationsv1alpha1.BastionSpec{
 				ShootRef: corev1.LocalObjectReference{
 					Name: shoot.Name,

--- a/test/integration/controllermanager/quota/quota_test.go
+++ b/test/integration/controllermanager/quota/quota_test.go
@@ -8,12 +8,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -34,11 +34,11 @@ var _ = Describe("Quota controller tests", func() {
 		objectKey = client.ObjectKey{Namespace: testNamespace.Name, Name: resourceName}
 
 		secret = &corev1.Secret{
-			ObjectMeta: kubernetesutils.ObjectMetaFromKey(objectKey),
+			ObjectMeta: metav1.ObjectMeta{Namespace: objectKey.Namespace, Name: objectKey.Name},
 		}
 
 		quota = &gardencorev1beta1.Quota{
-			ObjectMeta: kubernetesutils.ObjectMetaFromKey(objectKey),
+			ObjectMeta: metav1.ObjectMeta{Namespace: objectKey.Namespace, Name: objectKey.Name},
 			Spec: gardencorev1beta1.QuotaSpec{
 				Scope: corev1.ObjectReference{
 					APIVersion: "v1",
@@ -48,7 +48,7 @@ var _ = Describe("Quota controller tests", func() {
 		}
 
 		secretBinding = &gardencorev1beta1.SecretBinding{
-			ObjectMeta: kubernetesutils.ObjectMetaFromKey(objectKey),
+			ObjectMeta: metav1.ObjectMeta{Namespace: objectKey.Namespace, Name: objectKey.Name},
 			Provider: &gardencorev1beta1.SecretBindingProvider{
 				Type: providerType,
 			},

--- a/test/integration/extensions/controller/backupbucket/actuator.go
+++ b/test/integration/extensions/controller/backupbucket/actuator.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller/backupbucket"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	extensionsintegrationtest "github.com/gardener/gardener/test/integration/extensions/controller"
 )
 
@@ -65,7 +64,7 @@ func (a *actuator) Delete(ctx context.Context, _ logr.Logger, bb *extensionsv1al
 	}
 
 	namespace := &corev1.Namespace{}
-	if err := a.client.Get(ctx, kubernetesutils.Key(bb.Spec.SecretRef.Namespace), namespace); err != nil {
+	if err := a.client.Get(ctx, client.ObjectKey{Name: bb.Spec.SecretRef.Namespace}, namespace); err != nil {
 		return err
 	}
 

--- a/test/integration/resourcemanager/crddeletionprotection/crddeletionprotection_test.go
+++ b/test/integration/resourcemanager/crddeletionprotection/crddeletionprotection_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	"github.com/gardener/gardener/pkg/component/extensions/crds"
 	"github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
@@ -173,7 +172,7 @@ var _ = Describe("Extension CRDs Webhook Handler", func() {
 				})
 				Expect(err).NotTo(HaveOccurred(), objectID(obj))
 				crd := &apiextensionsv1.CustomResourceDefinition{}
-				Expect(testClient.Get(context.TODO(), kubernetesutils.Key(obj.GetName()), crd)).To(Succeed())
+				Expect(testClient.Get(context.TODO(), client.ObjectKey{Name: obj.GetName()}, crd)).To(Succeed())
 			}
 
 			testDeleteCollectionConfirmed(ctx, crdObjects[0])

--- a/test/testmachinery/extensions/healthcheck/healthcheck_operation.go
+++ b/test/testmachinery/extensions/healthcheck/healthcheck_operation.go
@@ -23,7 +23,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/testmachinery/extensions/operation"
 )
@@ -122,7 +121,7 @@ func TestHealthCheckWithManagedResource(ctx context.Context, timeout time.Durati
 		framework.ExpectNoError(err)
 	}()
 	managedResource := &resourcesv1alpha1.ManagedResource{}
-	if err = f.SeedClient.Client().Get(ctx, kubernetesutils.Key(f.ShootSeedNamespace(), managedResourceName), managedResource); err != nil {
+	if err = f.SeedClient.Client().Get(ctx, client.ObjectKey{Namespace: f.ShootSeedNamespace(), Name: managedResourceName}, managedResource); err != nil {
 		return err
 	}
 	// overwrite Condition with type ResourcesHealthy on the managed resource to make the health check in the provider fail

--- a/test/testmachinery/shoots/applications/metrics.go
+++ b/test/testmachinery/shoots/applications/metrics.go
@@ -31,7 +31,6 @@ import (
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/resources/templates"
@@ -75,7 +74,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 		framework.ExpectNoError(
 			retry.Until(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
 				podMetrics := &metricsv1beta1.PodMetrics{}
-				if err := f.ShootClient.Client().Get(ctx, kubernetesutils.Key(f.Namespace, podName), podMetrics); err != nil {
+				if err := f.ShootClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Namespace, Name: podName}, podMetrics); err != nil {
 					if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) || apierrors.IsServiceUnavailable(err) {
 						f.Logger.Error(err, "No metrics for pod available yet", "pod", client.ObjectKeyFromObject(podMetrics))
 						return retry.MinorError(err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR drops the `pkg/utils/kubernetes.{Key,ObjectMeta{FromKey}}` functions since their usage is error-prone (it is not obvious in which order the arguments name/namespace need to be provided). Using `client.ObjectKey` or `metav1.ObjectMeta` structs is straight-forward and clear.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The `pkg/utils/kubernetes.{Key,ObjectMeta{FromKey}}` functions have been dropped. Use `client.ObjectKey` or `metav1.ObjectMeta` instead.
```
