### PR TITLE
Since go-1.22 math/rand/v2 should be used

### DIFF
--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -7,7 +7,7 @@ package service
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -142,7 +142,7 @@ func (r *Reconciler) remediateAllocatedNodePorts(ctx context.Context, log logr.L
 				port.NodePort == nodePortIstioIngressGatewayZone2 {
 				var (
 					min, max    = 30000, 32767
-					newNodePort = int32(rand.Intn(max-min) + min)
+					newNodePort = int32(rand.N(max-min) + min)
 				)
 
 				log.Info("Assigning new nodePort to service which already allocates the nodePort",

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -7,7 +7,7 @@ package utils
 import (
 	cryptorand "crypto/rand"
 	"math/big"
-	mathrand "math/rand"
+	mathrand "math/rand/v2"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,7 +43,7 @@ func RandomDuration(max time.Duration) time.Duration {
 	if max.Nanoseconds() <= 0 {
 		return time.Duration(0)
 	}
-	return time.Duration(mathrand.Int63n(max.Nanoseconds()))
+	return time.Duration(mathrand.N(max.Nanoseconds()))
 }
 
 // RandomDurationWithMetaDuration takes a *metav1.Duration and computes a non-negative pseudo-random duration in [0,max).


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind technical-dept

**What this PR does / why we need it**:

Since go-1.22 the `math/rand/v2` package replaces `math/rand` with a more accurate and generic implementation and a polished API. Read the [Go Blog](https://go.dev/blog/randv2) for a detailed explanation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
