### PR TITLE
Introduce `shoot_dashboard_url` label

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -107,7 +107,7 @@ type Values struct {
 	// TargetCluster contains configuration in case Prometheus scrapes metrics from another kube-apiserver (e.g.,
 	// virtual garden, or shoot cluster) or other components running in this cluster.
 	TargetCluster *TargetClusterValues
-	// AdditionalAlertLabelReconfigs contains additional alert relabel configurations
+	// AdditionalAlertLabelReconfigs contains additional alert relabel configurations.
 	AdditionalAlertLabelReconfigs []monitoringv1.RelabelConfig
 	// DataMigration is a struct for migrating data from existing disks.
 	// TODO(rfranzke): Remove this after v1.97 has been released.

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -107,7 +107,8 @@ type Values struct {
 	// TargetCluster contains configuration in case Prometheus scrapes metrics from another kube-apiserver (e.g.,
 	// virtual garden, or shoot cluster) or other components running in this cluster.
 	TargetCluster *TargetClusterValues
-
+	// AdditionalAlertLabelReconfigs contains additional alert relabel configurations
+	AdditionalAlertLabelReconfigs []monitoringv1.RelabelConfig
 	// DataMigration is a struct for migrating data from existing disks.
 	// TODO(rfranzke): Remove this after v1.97 has been released.
 	DataMigration monitoring.DataMigration

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -107,8 +107,8 @@ type Values struct {
 	// TargetCluster contains configuration in case Prometheus scrapes metrics from another kube-apiserver (e.g.,
 	// virtual garden, or shoot cluster) or other components running in this cluster.
 	TargetCluster *TargetClusterValues
-	// AdditionalAlertLabelReconfigs contains additional alert relabel configurations.
-	AdditionalAlertLabelReconfigs []monitoringv1.RelabelConfig
+	// AdditionalAlertRelabelConfigs contains additional alert relabel configurations.
+	AdditionalAlertRelabelConfigs []monitoringv1.RelabelConfig
 	// DataMigration is a struct for migrating data from existing disks.
 	// TODO(rfranzke): Remove this after v1.97 has been released.
 	DataMigration monitoring.DataMigration

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -115,8 +115,7 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 						Regex:        `true`,
 						Action:       "drop",
 					}},
-					p.values.AdditionalAlertLabelReconfigs...,
-				),
+					p.values.AdditionalAlertRelabelConfigs...),
 			}},
 		}
 

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -115,7 +115,8 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 						Regex:        `true`,
 						Action:       "drop",
 					}},
-					p.values.AdditionalAlertRelabelConfigs...),
+					p.values.AdditionalAlertRelabelConfigs...,
+				),
 			}},
 		}
 

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -109,11 +109,13 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 				Namespace: p.namespace,
 				Name:      p.values.Alerting.AlertmanagerName,
 				Port:      intstr.FromString(alertmanager.PortNameMetrics),
-				AlertRelabelConfigs: []monitoringv1.RelabelConfig{{
-					SourceLabels: []monitoringv1.LabelName{"ignoreAlerts"},
-					Regex:        `true`,
-					Action:       "drop",
-				}},
+				AlertRelabelConfigs: append(
+					[]monitoringv1.RelabelConfig{{
+						SourceLabels: []monitoringv1.LabelName{"ignoreAlerts"},
+						Regex:        `true`,
+						Action:       "drop",
+					}},
+					p.values.AdditionalAlertLabelReconfigs...),
 			}},
 		}
 

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -115,7 +115,8 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 						Regex:        `true`,
 						Action:       "drop",
 					}},
-					p.values.AdditionalAlertLabelReconfigs...),
+					p.values.AdditionalAlertLabelReconfigs...,
+				),
 			}},
 		}
 

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -891,6 +891,52 @@ tls_config:
 						})
 					})
 				})
+
+				When("additional alert relabel configs is provided", func() {
+					BeforeEach(func() {
+						values.AdditionalAlertLabelReconfigs = []monitoringv1.RelabelConfig{{
+							SourceLabels: []monitoringv1.LabelName{"project", "name"},
+							Regex:        "(.+);(.+)",
+							Action:       "replace",
+							Replacement:  ptr.To("https://dashboard.ingress.gardener.cloud/namespace/garden-$1/shoots/$2"),
+							TargetLabel:  "shoot_dashboard_url",
+						}}
+					})
+
+					It("should succeesfully append the additional alert relabel config", func() {
+						prometheusRule.Namespace = namespace
+						metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", name)
+						metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", name)
+						metav1.SetMetaDataLabel(&serviceMonitor.ObjectMeta, "prometheus", name)
+						metav1.SetMetaDataLabel(&podMonitor.ObjectMeta, "prometheus", name)
+
+						prometheus := prometheusFor(alertmanagerName, false)
+						prometheus.Spec.Alerting.Alertmanagers[0].AlertRelabelConfigs = append(
+							prometheus.Spec.Alerting.Alertmanagers[0].AlertRelabelConfigs,
+							monitoringv1.RelabelConfig{
+								SourceLabels: []monitoringv1.LabelName{"project", "name"},
+								Regex:        "(.+);(.+)",
+								Action:       "replace",
+								Replacement:  ptr.To("https://dashboard.ingress.gardener.cloud/namespace/garden-$1/shoots/$2"),
+								TargetLabel:  "shoot_dashboard_url",
+							},
+						)
+
+						Expect(managedResource).To(contain(
+							serviceAccount,
+							service,
+							clusterRoleBinding,
+							prometheus,
+							vpa,
+							prometheusRule,
+							scrapeConfig,
+							serviceMonitor,
+							podMonitor,
+							secretAdditionalScrapeConfigs,
+							additionalConfigMap,
+						))
+					})
+				})
 			})
 
 			When("there is more than 1 replica", func() {

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -894,7 +894,7 @@ tls_config:
 
 				When("additional alert relabel configs are provided", func() {
 					BeforeEach(func() {
-						values.AdditionalAlertLabelReconfigs = []monitoringv1.RelabelConfig{{
+						values.AdditionalAlertRelabelConfigs = []monitoringv1.RelabelConfig{{
 							SourceLabels: []monitoringv1.LabelName{"project", "name"},
 							Regex:        "(.+);(.+)",
 							Action:       "replace",

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -892,7 +892,7 @@ tls_config:
 					})
 				})
 
-				When("additional alert relabel configs is provided", func() {
+				When("additional alert relabel configs are provided", func() {
 					BeforeEach(func() {
 						values.AdditionalAlertLabelReconfigs = []monitoringv1.RelabelConfig{{
 							SourceLabels: []monitoringv1.LabelName{"project", "name"},

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -903,7 +903,7 @@ tls_config:
 						}}
 					})
 
-					It("should succeesfully append the additional alert relabel config", func() {
+					It("should successfully append the additional alert relabel config", func() {
 						prometheusRule.Namespace = namespace
 						metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", name)
 						metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", name)

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1202,6 +1202,15 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 			ServiceMonitors:         gardenprometheus.CentralServiceMonitors(),
 		},
 		Alerting: &prometheus.AlertingValues{AlertmanagerName: "alertmanager-garden"},
+		AdditionalAlertLabelReconfigs: []monitoringv1.RelabelConfig{
+			{
+				SourceLabels: []monitoringv1.LabelName{"project", "name", "topology"},
+				Regex:        "(.+);(.+);shoot",
+				Action:       "replace",
+				Replacement:  ptr.To("https://dashboard." + ingressDomain + "/namespace/garden-$1/shoots/$2"),
+				TargetLabel:  "shoot_dashboard_url",
+			},
+		},
 		Ingress: &prometheus.IngressValues{
 			Host:                   "prometheus-garden." + ingressDomain,
 			SecretsManager:         secretsManager,

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1202,7 +1202,7 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 			ServiceMonitors:         gardenprometheus.CentralServiceMonitors(),
 		},
 		Alerting: &prometheus.AlertingValues{AlertmanagerName: "alertmanager-garden"},
-		AdditionalAlertLabelReconfigs: []monitoringv1.RelabelConfig{
+		AdditionalAlertRelabelConfigs: []monitoringv1.RelabelConfig{
 			{
 				SourceLabels: []monitoringv1.LabelName{"project", "name"},
 				Regex:        "(.+);(.+)",

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1204,10 +1204,17 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 		Alerting: &prometheus.AlertingValues{AlertmanagerName: "alertmanager-garden"},
 		AdditionalAlertLabelReconfigs: []monitoringv1.RelabelConfig{
 			{
-				SourceLabels: []monitoringv1.LabelName{"project", "name", "topology"},
-				Regex:        "(.+);(.+);shoot",
+				SourceLabels: []monitoringv1.LabelName{"project", "name"},
+				Regex:        "(.+);(.+)",
 				Action:       "replace",
 				Replacement:  ptr.To("https://dashboard." + ingressDomain + "/namespace/garden-$1/shoots/$2"),
+				TargetLabel:  "shoot_dashboard_url",
+			},
+			{
+				SourceLabels: []monitoringv1.LabelName{"project", "name"},
+				Regex:        "garden;(.+)",
+				Action:       "replace",
+				Replacement:  ptr.To("https://dashboard." + ingressDomain + "/namespace/garden/shoots/$1"),
 				TargetLabel:  "shoot_dashboard_url",
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR introduces a new alert label `shoot_dashboard_url` that can be used in alerts to quickly access the shoot dashboard URL for more information. We use the configuration property `alert_relabel_configs` so that this new label is only added for alerts. In the past, there was a similar feature using external labels to calculate the dashboard URL but this changed after GEP-19. For this improvement, we decided against external labels because they are always added (i.e., not only on alerts) and a constant dashboard URL in the external labels would probably add some additional payload in the HTTP requests and that is not necessary nor desired.

This change also covers seeds that are shoots and are consequently accessible via the dashboard. The slight difference is that the `garden` project does not become `/namespace/garden-garden/` in the URL but simply `/namespace/garden`. To circumvent this, a second alert relabel config captures when the project is `garden` and builds the URL correctly. 

As for the code change, the new alert relabel config only applies to the garden Prometheus for now. Therefore, a new configuration property `AdditionalAlertRelabelConfigs` is introduced and only the garden Prometheus configuration populates it. Note it is called "additional" because there is always a default relabel config to drop alerts with label `ignoreAlerts = true`.

**Special notes for your reviewer**:

/cc @istvanballok @rickardsjp 
/fyi @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Introduce new label `shoot_dashboard_url` in the alerts from the garden Prometheus
```
