### PR TITLE
Secrets manager: Custom early renewal of certificates.

### DIFF
--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -22,6 +22,7 @@ It is built on top of the `ConfigInterface` and `DataInterface` interfaces part 
   - `IgnoreOldSecrets()`: This specifies that old secrets should not be considered and loaded (contrary to the default behavior). It should be used when old secrets are no longer important and can be "forgotten" (e.g. in ["phase 2" (`t2`) of the CA certificate rotation](../proposals/18-shoot-CA-rotation.md#rotation-sequence-for-cluster-and-client-ca)). Such old secrets will be deleted on `Cleanup()`.
   - `IgnoreOldSecretsAfter(time.Duration)`: This specifies that old secrets should not be considered and loaded once a given duration after rotation has passed. It can be used to clean up old secrets after automatic rotation (e.g. the Seed cluster CA is automatically rotated when its validity will soon end and the old CA will be cleaned up 24 hours after triggering the rotation).
   - `Validity(time.Duration)`: This specifies how long the secret should be valid. For certificate secret configurations, the manager will automatically deduce this information from the generated certificate.
+  - `RenewAfterValidityPercentage(int)`: This specifies the percentage of validity for renewal. The secret will be renewed based on whichever comes first: The specified percentage of validity or 10 days before end of validity. If not specified, the default percentage is `80`.
 
 - `Get(string, ...GetOption) (*corev1.Secret, bool)`
 

--- a/pkg/utils/secrets/certificate.go
+++ b/pkg/utils/secrets/certificate.go
@@ -62,8 +62,11 @@ type CertificateSecretConfig struct {
 	SigningCA *Certificate
 	PKCS      int
 
-	Validity                          *time.Duration
-	RenewAt                           *time.Duration
+	Validity *time.Duration
+	// RenewAfterValidityPercentage sets the percentage of the validity when the certificate should be renewed.
+	// The effective check for renewal is after the given percentage of validity or 10d before the end of validity.
+	// If not specified the default percentage is 80.
+	RenewAfterValidityPercentage      *int
 	SkipPublishingCACertificate       bool
 	IncludeCACertificateInServerChain bool
 }

--- a/pkg/utils/secrets/certificate.go
+++ b/pkg/utils/secrets/certificate.go
@@ -62,11 +62,7 @@ type CertificateSecretConfig struct {
 	SigningCA *Certificate
 	PKCS      int
 
-	Validity *time.Duration
-	// RenewAfterValidityPercentage sets the percentage of the validity when the certificate should be renewed.
-	// The effective check for renewal is after the given percentage of validity or 10d before the end of validity.
-	// If not specified the default percentage is 80.
-	RenewAfterValidityPercentage      *int
+	Validity                          *time.Duration
 	SkipPublishingCACertificate       bool
 	IncludeCACertificateInServerChain bool
 }

--- a/pkg/utils/secrets/certificate.go
+++ b/pkg/utils/secrets/certificate.go
@@ -63,6 +63,7 @@ type CertificateSecretConfig struct {
 	PKCS      int
 
 	Validity                          *time.Duration
+	RenewAt                           *time.Duration
 	SkipPublishingCACertificate       bool
 	IncludeCACertificateInServerChain bool
 }

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -278,15 +278,15 @@ func (m *manager) maintainLifetimeLabels(
 	}
 
 	var dataKeyCertificate string
-	var earlyRenewal time.Duration
+	var renewAfterValidityPercentage int
 	switch cfg := config.(type) {
 	case *secretsutils.CertificateSecretConfig:
 		dataKeyCertificate = secretsutils.DataKeyCertificate
 		if cfg.CertType == secretsutils.CACert {
 			dataKeyCertificate = secretsutils.DataKeyCertificateCA
 		}
-		if cfg.RenewAt != nil {
-			earlyRenewal = *cfg.RenewAt
+		if cfg.RenewAfterValidityPercentage != nil {
+			renewAfterValidityPercentage = *cfg.RenewAfterValidityPercentage
 		}
 	case *secretsutils.ControlPlaneSecretConfig:
 		if cfg.CertificateSecretConfig == nil {
@@ -304,8 +304,8 @@ func (m *manager) maintainLifetimeLabels(
 
 	desiredLabels[LabelKeyIssuedAtTime] = unixTime(certificate.NotBefore)
 	desiredLabels[LabelKeyValidUntilTime] = unixTime(certificate.NotAfter)
-	if earlyRenewal > 0 {
-		desiredLabels[LabelKeyRenewAtTime] = unixTime(certificate.NotBefore.Add(earlyRenewal))
+	if renewAfterValidityPercentage > 0 {
+		desiredLabels[LabelKeyRenewAfterValidityPercentage] = fmt.Sprintf("%d", renewAfterValidityPercentage)
 	}
 	return nil
 }

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -60,7 +60,7 @@ func (m *manager) Generate(ctx context.Context, config secretsutils.ConfigInterf
 		}
 	}
 
-	if err := m.maintainLifetimeLabels(config, secret, desiredLabels, options.Validity); err != nil {
+	if err := m.maintainLifetimeLabels(config, secret, desiredLabels, options.Validity, options.RenewAfterValidityPercentage); err != nil {
 		return nil, fmt.Errorf("failed maintaining lifetime labels on secret %s for config %s: %w", client.ObjectKeyFromObject(secret), config.GetName(), err)
 	}
 
@@ -246,12 +246,16 @@ func (m *manager) maintainLifetimeLabels(
 	secret *corev1.Secret,
 	desiredLabels map[string]string,
 	validity time.Duration,
+	renewAfterValidityPercentage int,
 ) error {
 	issuedAt := secret.Labels[LabelKeyIssuedAtTime]
 	if issuedAt == "" {
 		issuedAt = unixTime(m.clock.Now())
 	}
 	desiredLabels[LabelKeyIssuedAtTime] = issuedAt
+	if renewAfterValidityPercentage > 0 {
+		desiredLabels[LabelKeyRenewAfterValidityPercentage] = fmt.Sprintf("%d", renewAfterValidityPercentage)
+	}
 
 	if validity > 0 {
 		desiredLabels[LabelKeyValidUntilTime] = unixTime(m.clock.Now().Add(validity))
@@ -278,15 +282,11 @@ func (m *manager) maintainLifetimeLabels(
 	}
 
 	var dataKeyCertificate string
-	var renewAfterValidityPercentage int
 	switch cfg := config.(type) {
 	case *secretsutils.CertificateSecretConfig:
 		dataKeyCertificate = secretsutils.DataKeyCertificate
 		if cfg.CertType == secretsutils.CACert {
 			dataKeyCertificate = secretsutils.DataKeyCertificateCA
-		}
-		if cfg.RenewAfterValidityPercentage != nil {
-			renewAfterValidityPercentage = *cfg.RenewAfterValidityPercentage
 		}
 	case *secretsutils.ControlPlaneSecretConfig:
 		if cfg.CertificateSecretConfig == nil {
@@ -304,9 +304,6 @@ func (m *manager) maintainLifetimeLabels(
 
 	desiredLabels[LabelKeyIssuedAtTime] = unixTime(certificate.NotBefore)
 	desiredLabels[LabelKeyValidUntilTime] = unixTime(certificate.NotAfter)
-	if renewAfterValidityPercentage > 0 {
-		desiredLabels[LabelKeyRenewAfterValidityPercentage] = fmt.Sprintf("%d", renewAfterValidityPercentage)
-	}
 	return nil
 }
 
@@ -358,6 +355,10 @@ type GenerateOptions struct {
 	IgnoreOldSecretsAfter *time.Duration
 	// Validity specifies for how long the secret should be valid.
 	Validity time.Duration
+	// RenewAfterValidityPercentage sets the percentage of the validity when the certificate should be renewed.
+	// The effective check for renewal is after the given percentage of validity or 10d before the end of validity.
+	// Zero value means the default percentage is used (80%).
+	RenewAfterValidityPercentage int
 	// IgnoreConfigChecksumForCASecretName specifies whether the secret config checksum should be ignored when
 	// computing the secret name for CA secrets.
 	IgnoreConfigChecksumForCASecretName bool
@@ -509,6 +510,15 @@ func IgnoreOldSecretsAfter(d time.Duration) GenerateOption {
 func Validity(v time.Duration) GenerateOption {
 	return func(_ Interface, _ secretsutils.ConfigInterface, options *GenerateOptions) error {
 		options.Validity = v
+		return nil
+	}
+}
+
+// RenewAfterValidityPercentage returns a function which sets the 'RenewAfterValidityPercentage' field to the provided
+// value.
+func RenewAfterValidityPercentage(v int) GenerateOption {
+	return func(_ Interface, _ secretsutils.ConfigInterface, options *GenerateOptions) error {
+		options.RenewAfterValidityPercentage = v
 		return nil
 	}
 }

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -442,6 +442,59 @@ var _ = Describe("Generate", func() {
 				Expect(secretInfos.old.obj).To(Equal(secret))
 				Expect(secretInfos.bundle.obj).NotTo(PointTo(Equal(oldBundleSecret)))
 			})
+
+			DescribeTable("should rotate CA as configured",
+				func(validity, renewAt *time.Duration, unchanged, renewed time.Duration) {
+					lastCommonName := config.CommonName
+					config.Validity = validity
+					config.RenewAt = renewAt
+					fakeClock.SetTime(time.Now())
+
+					By("Generate new secret")
+					firstSecret, err := m.Generate(ctx, config)
+					Expect(err).NotTo(HaveOccurred())
+					expectSecretWasCreated(ctx, fakeClient, firstSecret)
+
+					By("storing old bundle secret")
+					_, found := m.getFromStore(name)
+					Expect(found).To(BeTrue())
+
+					By("some time later: no new CA should be generated")
+					fakeClock.Step(unchanged)
+					mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{CASecretAutoRotation: true})
+					Expect(err).NotTo(HaveOccurred())
+					m = mgr.(*manager)
+					config.CommonName = lastCommonName
+					newSecret, err := m.Generate(ctx, config, Rotate(KeepOld))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(newSecret.Name).To(Equal(firstSecret.Name))
+
+					By("after expected renewal time: new CA should be generated")
+					fakeClock.Step(renewed - unchanged)
+					mgr, err = New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{CASecretAutoRotation: true})
+					Expect(err).NotTo(HaveOccurred())
+					m = mgr.(*manager)
+					config.CommonName = lastCommonName
+					newSecret, err = m.Generate(ctx, config, Rotate(KeepOld))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(newSecret.Name).NotTo(Equal(firstSecret.Name))
+					expectSecretWasCreated(ctx, fakeClient, newSecret)
+
+					By("Find created bundle secret")
+					secretList := &corev1.SecretList{}
+					Expect(fakeClient.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabels{
+						"managed-by":       "secrets-manager",
+						"manager-identity": "test",
+						"bundle-for":       name,
+					})).To(Succeed())
+					Expect(secretList.Items).To(HaveLen(2))
+				},
+
+				Entry("default 80% of 100d (=80d)", ptr.To(100*24*time.Hour), nil, 79*24*time.Hour, 81*24*time.Hour),
+				Entry("default 30d-10d (=20d)", ptr.To(30*24*time.Hour), nil, 19*24*time.Hour, 21*24*time.Hour),
+				Entry("renewAt 10d", ptr.To(30*24*time.Hour), ptr.To(10*24*time.Hour), 9*24*time.Hour, 11*24*time.Hour),
+				Entry("non-effective renewAt 25d (> default 30d-10d=20d)", ptr.To(30*24*time.Hour), ptr.To(25*24*time.Hour), 19*24*time.Hour, 21*24*time.Hour),
+			)
 		})
 
 		Context("for certificate secrets", func() {

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -311,6 +311,46 @@ var _ = Describe("Generate", func() {
 				))
 				Expect(foundSecret.Immutable).To(PointTo(BeTrue()))
 			})
+
+			DescribeTable("should rotate secrets as configured",
+				func(validity time.Duration, renewAfterValidityPercentage int, unchanged, renewed time.Duration) {
+					fakeClock.SetTime(time.Now())
+					options := []GenerateOption{Validity(validity), RenewAfterValidityPercentage(renewAfterValidityPercentage)}
+
+					By("Generate new secret")
+					firstSecret, err := m.Generate(ctx, config, options...)
+					Expect(err).NotTo(HaveOccurred())
+					expectSecretWasCreated(ctx, fakeClient, firstSecret)
+
+					By("storing old bundle secret")
+					_, found := m.getFromStore(name)
+					Expect(found).To(BeTrue())
+
+					By("some time later: no new CA should be generated")
+					fakeClock.Step(unchanged)
+					mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
+					Expect(err).NotTo(HaveOccurred())
+					m = mgr.(*manager)
+					newSecret, err := m.Generate(ctx, config, options...)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(newSecret.Name).To(Equal(firstSecret.Name))
+
+					By("after expected renewal time: new secret should be generated")
+					fakeClock.Step(renewed - unchanged)
+					mgr, err = New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
+					Expect(err).NotTo(HaveOccurred())
+					m = mgr.(*manager)
+					newSecret, err = m.Generate(ctx, config, options...)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(newSecret.Name).NotTo(Equal(firstSecret.Name))
+					expectSecretWasCreated(ctx, fakeClient, newSecret)
+				},
+
+				Entry("default 80% of 100d (=80d)", 100*24*time.Hour, 0, 79*24*time.Hour, 81*24*time.Hour),
+				Entry("default 30d-10d (=20d)", 30*24*time.Hour, 0, 19*24*time.Hour, 21*24*time.Hour),
+				Entry("renewAfterValidityPercentage 33% (=10d)", 30*24*time.Hour, 33, 9*24*time.Hour, 11*24*time.Hour),
+				Entry("non-effective renewAfterValidityPercentage 70% (14d> default 20d-10d=10d)", 20*24*time.Hour, 70, 9*24*time.Hour, 11*24*time.Hour),
+			)
 		})
 
 		Context("for CA certificate secrets", func() {
@@ -444,14 +484,14 @@ var _ = Describe("Generate", func() {
 			})
 
 			DescribeTable("should rotate CA as configured",
-				func(validity *time.Duration, renewAfterValidityPercentage *int, unchanged, renewed time.Duration) {
+				func(validity *time.Duration, renewAfterValidityPercentage int, unchanged, renewed time.Duration) {
 					lastCommonName := config.CommonName
 					config.Validity = validity
-					config.RenewAfterValidityPercentage = renewAfterValidityPercentage
+					options := []GenerateOption{Rotate(KeepOld), RenewAfterValidityPercentage(renewAfterValidityPercentage)}
 					fakeClock.SetTime(time.Now())
 
 					By("Generate new secret")
-					firstSecret, err := m.Generate(ctx, config)
+					firstSecret, err := m.Generate(ctx, config, options...)
 					Expect(err).NotTo(HaveOccurred())
 					expectSecretWasCreated(ctx, fakeClient, firstSecret)
 
@@ -465,7 +505,7 @@ var _ = Describe("Generate", func() {
 					Expect(err).NotTo(HaveOccurred())
 					m = mgr.(*manager)
 					config.CommonName = lastCommonName
-					newSecret, err := m.Generate(ctx, config, Rotate(KeepOld))
+					newSecret, err := m.Generate(ctx, config, options...)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(newSecret.Name).To(Equal(firstSecret.Name))
 
@@ -475,7 +515,7 @@ var _ = Describe("Generate", func() {
 					Expect(err).NotTo(HaveOccurred())
 					m = mgr.(*manager)
 					config.CommonName = lastCommonName
-					newSecret, err = m.Generate(ctx, config, Rotate(KeepOld))
+					newSecret, err = m.Generate(ctx, config, options...)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(newSecret.Name).NotTo(Equal(firstSecret.Name))
 					expectSecretWasCreated(ctx, fakeClient, newSecret)
@@ -490,10 +530,10 @@ var _ = Describe("Generate", func() {
 					Expect(secretList.Items).To(HaveLen(2))
 				},
 
-				Entry("default 80% of 100d (=80d)", ptr.To(100*24*time.Hour), nil, 79*24*time.Hour, 81*24*time.Hour),
-				Entry("default 30d-10d (=20d)", ptr.To(30*24*time.Hour), nil, 19*24*time.Hour, 21*24*time.Hour),
-				Entry("renewAfterValidityPercentage 33% (=10d)", ptr.To(30*24*time.Hour), ptr.To(33), 9*24*time.Hour, 11*24*time.Hour),
-				Entry("non-effective renewAfterValidityPercentage 70% (14d> default 20d-10d=10d)", ptr.To(20*24*time.Hour), ptr.To(70), 9*24*time.Hour, 11*24*time.Hour),
+				Entry("default 80% of 100d (=80d)", ptr.To(100*24*time.Hour), 0, 79*24*time.Hour, 81*24*time.Hour),
+				Entry("default 30d-10d (=20d)", ptr.To(30*24*time.Hour), 0, 19*24*time.Hour, 21*24*time.Hour),
+				Entry("renewAfterValidityPercentage 33% (=10d)", ptr.To(30*24*time.Hour), 33, 9*24*time.Hour, 11*24*time.Hour),
+				Entry("non-effective renewAfterValidityPercentage 70% (14d> default 20d-10d=10d)", ptr.To(20*24*time.Hour), 70, 9*24*time.Hour, 11*24*time.Hour),
 			)
 		})
 

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -444,10 +444,10 @@ var _ = Describe("Generate", func() {
 			})
 
 			DescribeTable("should rotate CA as configured",
-				func(validity, renewAt *time.Duration, unchanged, renewed time.Duration) {
+				func(validity *time.Duration, renewAfterValidityPercentage *int, unchanged, renewed time.Duration) {
 					lastCommonName := config.CommonName
 					config.Validity = validity
-					config.RenewAt = renewAt
+					config.RenewAfterValidityPercentage = renewAfterValidityPercentage
 					fakeClock.SetTime(time.Now())
 
 					By("Generate new secret")
@@ -492,8 +492,8 @@ var _ = Describe("Generate", func() {
 
 				Entry("default 80% of 100d (=80d)", ptr.To(100*24*time.Hour), nil, 79*24*time.Hour, 81*24*time.Hour),
 				Entry("default 30d-10d (=20d)", ptr.To(30*24*time.Hour), nil, 19*24*time.Hour, 21*24*time.Hour),
-				Entry("renewAt 10d", ptr.To(30*24*time.Hour), ptr.To(10*24*time.Hour), 9*24*time.Hour, 11*24*time.Hour),
-				Entry("non-effective renewAt 25d (> default 30d-10d=20d)", ptr.To(30*24*time.Hour), ptr.To(25*24*time.Hour), 19*24*time.Hour, 21*24*time.Hour),
+				Entry("renewAfterValidityPercentage 33% (=10d)", ptr.To(30*24*time.Hour), ptr.To(33), 9*24*time.Hour, 11*24*time.Hour),
+				Entry("non-effective renewAfterValidityPercentage 70% (14d> default 20d-10d=10d)", ptr.To(20*24*time.Hour), ptr.To(70), 9*24*time.Hour, 11*24*time.Hour),
 			)
 		})
 

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -211,9 +211,11 @@ func (m *manager) mustAutoRenewSecret(secret corev1.Secret) (bool, error) {
 
 	renewAfterValidityPercentage := 80
 	if secret.Labels[LabelKeyRenewAfterValidityPercentage] != "" {
-		if value, err := strconv.Atoi(secret.Labels[LabelKeyRenewAfterValidityPercentage]); err == nil && value > 0 && value < 100 {
-			renewAfterValidityPercentage = value
+		value, err := strconv.Atoi(secret.Labels[LabelKeyRenewAfterValidityPercentage])
+		if err != nil {
+			return false, err
 		}
+		renewAfterValidityPercentage = value
 	}
 
 	var (

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -224,7 +224,7 @@ func (m *manager) mustAutoRenewSecret(secret corev1.Secret) (bool, error) {
 		now         = m.clock.Now().UTC()
 	)
 
-	// Renew if 80% of the validity or if the secret expires in less than 10d.
+	// Renew if 80% of the validity has been reached or if the secret expires in less than 10d.
 	return now.After(renewAt) || now.After(validUntil.Add(-10*24*time.Hour)), nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
The secrets manager can autorotate secrets at 80% of validity or 10 days before end of validity.
The renewal policy can now be adjusted with the generate option `RenewAfterValidityPercentage`.
It allows to override the default 80 % with an own value.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The secrets manager has new option for controlling the secret rotation. If the new generate option `RenewAfterValidityPercentage(v)` is set, a secret will be renewed based on whichever comes first: The percentage of validity you specify in `RenewAfterValidityPercentage` or 10 days before the secret's end of validity. If not specified, the default 80% is used as before. 
```
