### PR TITLE
Promote feature gate `CoreDNSQueryRewriting` to beta and enable by default

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -23,7 +23,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | HVPA                               | `false` | `Alpha` | `0.31` |        |
 | HVPAForShootedSeed                 | `false` | `Alpha` | `0.32` |        |
 | DefaultSeccompProfile              | `false` | `Alpha` | `1.54` |        |
-| CoreDNSQueryRewriting              | `false` | `Alpha` | `1.55` |        |
+| CoreDNSQueryRewriting              | `false` | `Alpha` | `1.55` | `1.95` |
+| CoreDNSQueryRewriting              | `true`  | `Beta`  | `1.96` |        |
 | IPv6SingleStack                    | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` |        |
 | ShootForceDeletion                 | `false` | `Alpha` | `1.81` | `1.90` |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -39,8 +39,9 @@ const (
 
 	// CoreDNSQueryRewriting enables automatic DNS query rewriting in shoot cluster's CoreDNS to shortcut name resolution of
 	// fully qualified in-cluster and out-of-cluster names, which follow a user-defined pattern.
-	// owner: @ScheererJ @DockToFuture
+	// owner: @ScheererJ @DockToFuture @axel7born
 	// alpha: v1.55.0
+	// beta: v1.96.0
 	CoreDNSQueryRewriting featuregate.Feature = "CoreDNSQueryRewriting"
 
 	// IPv6SingleStack allows creating shoot clusters with IPv6 single-stack networking (GEP-21).
@@ -111,7 +112,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPAForShootedSeed:              {Default: false, PreRelease: featuregate.Alpha},
 	VPAForETCD:                      {Default: false, PreRelease: featuregate.Alpha},
 	DefaultSeccompProfile:           {Default: false, PreRelease: featuregate.Alpha},
-	CoreDNSQueryRewriting:           {Default: false, PreRelease: featuregate.Alpha},
+	CoreDNSQueryRewriting:           {Default: true, PreRelease: featuregate.Beta},
 	IPv6SingleStack:                 {Default: false, PreRelease: featuregate.Alpha},
 	MutableShootSpecNetworkingNodes: {Default: false, PreRelease: featuregate.Alpha},
 	ShootManagedIssuer:              {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Promote feature gate `CoreDNSQueryRewriting` to beta and enable by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `CoreDNSQueryRewriting` feature gate has been promoted to beta and is turned on by default. 
```
