### PR TITLE
Promote feature gate `MutableShootSpecNetworkingNodes` to beta and enable it by default

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,7 +26,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | CoreDNSQueryRewriting              | `false` | `Alpha` | `1.55` | `1.95` |
 | CoreDNSQueryRewriting              | `true`  | `Beta`  | `1.96` |        |
 | IPv6SingleStack                    | `false` | `Alpha` | `1.63` |        |
-| MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` |        |
+| MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` | `1.95` |
+| MutableShootSpecNetworkingNodes    | `true`  | `Beta`  | `1.96` |        |
 | ShootForceDeletion                 | `false` | `Alpha` | `1.81` | `1.90` |
 | ShootForceDeletion                 | `true`  | `Beta`  | `1.91` |        |
 | UseNamespacedCloudProfile          | `false` | `Alpha` | `1.92` |        |

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3253,7 +3253,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
-			It("should forbid changing the networking nodes range", func() {
+			It("should forbid changing the networking nodes range if feature gate is disabled", func() {
+				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.MutableShootSpecNetworkingNodes, false))
 				shoot.Spec.Networking.Nodes = ptr.To("10.181.0.0/18")
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.Networking.Nodes = ptr.To("10.181.0.0/16")

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -52,6 +52,7 @@ const (
 	// MutableShootSpecNetworkingNodes allows updating the field `spec.networking.nodes`.
 	// owner: @axel7born @ScheererJ @DockToFuture @kon-angelo
 	// alpha: v1.64.0
+	// beta: v1.96.0
 	MutableShootSpecNetworkingNodes featuregate.Feature = "MutableShootSpecNetworkingNodes"
 
 	// ShootForceDeletion allows force deletion of Shoots.
@@ -114,7 +115,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:           {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting:           {Default: true, PreRelease: featuregate.Beta},
 	IPv6SingleStack:                 {Default: false, PreRelease: featuregate.Alpha},
-	MutableShootSpecNetworkingNodes: {Default: false, PreRelease: featuregate.Alpha},
+	MutableShootSpecNetworkingNodes: {Default: true, PreRelease: featuregate.Beta},
 	ShootManagedIssuer:              {Default: false, PreRelease: featuregate.Alpha},
 	ShootForceDeletion:              {Default: true, PreRelease: featuregate.Beta},
 	UseNamespacedCloudProfile:       {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Promote feature gate `MutableShootSpecNetworkingNodes` to beta and enable it by default

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `MutableShootSpecNetworkingNodes` feature gate has been promoted to beta and is turned on by default. 
```
