### PR TITLE
Fix cluster overview dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/cluster-overview-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/cluster-overview-dashboard.json
@@ -1249,7 +1249,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "absent(up{job=\"prometheus\"} == 1)",
+          "expr": "absent(up{job=\"prometheus-shoot\"} == 1)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 10,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/workerless/cluster-overview-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/workerless/cluster-overview-dashboard.json
@@ -851,7 +851,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "absent(up{job=\"prometheus\"} == 1)",
+          "expr": "absent(up{job=\"prometheus-shoot\"} == 1)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 10,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
With GEP-19, the name of the prometheus job changed. The expression used in the dashboard panel meant that because there didn't exist a time series named `up` with the label value pair `job="prometheus"`, the panel showed Prometheus as down. Thanks @ScheererJ for noticing this! 🙇 

**Special notes for your reviewer**:
/cc @istvanballok @vicwicker 
FYI @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
