### PR TITLE
[renovate] Add release notes for docker and github-releases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -187,13 +187,9 @@
       "enabled": false
     },
     {
-      // Add PR footer with release notes link for gardener/dashboard and gardener/terminal-controller-manager.
-      "matchDatasources": ["docker", "github-releases"],
+      // Add PR footer with release notes link for github-releases.
+      "matchDatasources": ["github-releases"],
       "matchFileNames": ["imagevector/**"],
-      "matchPackagePatterns": [
-        "gardener/dashboard",
-        "gardener/terminal-controller-manager"
-      ],
       "prFooter": "```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`. [Release Notes](https://github.com/{{depName}}/releases/tag/{{newVersion}})\n```"
     }
   ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -187,6 +187,12 @@
       "enabled": false
     },
     {
+      // Add PR footer with release notes for docker releases.
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["imagevector/**"],
+      "prFooter": "```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`.\n```"
+    },
+    {
       // Add PR footer with release notes link for github-releases.
       "matchDatasources": ["github-releases"],
       "matchFileNames": ["imagevector/**"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -185,6 +185,16 @@
           "third_party/**"
       ],
       "enabled": false
+    },
+    {
+      // Add PR footer with release notes link for gardener/dashboard and gardener/terminal-controller-manager.
+      "matchDatasources": ["docker", "github-releases"],
+      "matchFileNames": ["imagevector/**"],
+      "matchPackagePatterns": [
+        "gardener/dashboard",
+        "gardener/terminal-controller-manager"
+      ],
+      "prFooter": "```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`. [Release Notes](https://github.com/{{depName}}/releases/tag/{{newVersion}})\n```"
     }
   ]
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR updates the Renovate configuration to include a PR footer with release notes for `docker` datasource and release notes with links for `github-releases` datasource.

Thanks @timebertt for the [suggestion](https://github.com/gardener/ci-infra/issues/1734#issuecomment-2124429769)

Example PR:
![Screenshot 2024-05-23 at 14 34 42](https://github.com/gardener/gardener/assets/5526658/11311f69-9260-41c8-9ca9-3ec56854904b)

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/ci-infra/issues/1734

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```

