### PR TITLE
[provider-local] Increase workers for `Extension` controllers

### DIFF
--- a/pkg/provider-local/controller/extension/seed/add.go
+++ b/pkg/provider-local/controller/extension/seed/add.go
@@ -23,7 +23,7 @@ const (
 
 var (
 	// DefaultAddOptions are the default AddOptions for AddToManager.
-	DefaultAddOptions = AddOptions{}
+	DefaultAddOptions = AddOptions{Controller: controller.Options{MaxConcurrentReconciles: 5}}
 )
 
 // AddOptions are options to apply when adding the extension controller to the manager.

--- a/pkg/provider-local/controller/extension/shoot/add.go
+++ b/pkg/provider-local/controller/extension/shoot/add.go
@@ -23,7 +23,7 @@ const (
 
 var (
 	// DefaultAddOptions are the default AddOptions for AddToManager.
-	DefaultAddOptions = AddOptions{}
+	DefaultAddOptions = AddOptions{Controller: controller.Options{MaxConcurrentReconciles: 5}}
 )
 
 // AddOptions are options to apply when adding the extension controller to the manager.

--- a/pkg/provider-local/controller/extension/shootafterworker/add.go
+++ b/pkg/provider-local/controller/extension/shootafterworker/add.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package shoot
+package shootafterworker
 
 import (
 	"context"
@@ -23,7 +23,7 @@ const (
 
 var (
 	// DefaultAddOptions are the default AddOptions for AddToManager.
-	DefaultAddOptions = AddOptions{}
+	DefaultAddOptions = AddOptions{Controller: controller.Options{MaxConcurrentReconciles: 5}}
 )
 
 // AddOptions are options to apply when adding the extension controller to the manager.
@@ -40,7 +40,7 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 	return extension.Add(ctx, mgr, extension.AddArgs{
 		Actuator:          NewActuator(mgr),
 		ControllerOptions: opts.Controller,
-		Name:              ApplicationName,
+		Name:              applicationName,
 		FinalizerSuffix:   Type,
 		Resync:            60 * time.Minute,
 		Predicates:        extension.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind test

**What this PR does / why we need it**:
This PR increases the worker count for the local `Extension` controllers to prevent flakes like this: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/9752/pull-gardener-e2e-kind-ha-multi-zone/1793613395388272640

Currently, they are only started with one worker:

```
2024-05-23T12:13:05.015431029Z stderr F {"level":"info","ts":"2024-05-23T12:13:05.015Z","msg":"Starting workers","controller":"local-ext-shoot-after-worker","worker count":1}
2024-05-23T12:13:05.015446376Z stderr F {"level":"info","ts":"2024-05-23T12:13:05.015Z","msg":"Starting workers","controller":"local-ext-shoot","worker count":1}
2024-05-23T12:13:05.015463872Z stderr F {"level":"info","ts":"2024-05-23T12:13:05.015Z","msg":"Starting workers","controller":"local-ext-seed","worker count":1}
```

This is especially worse in combination with https://github.com/gardener/gardener/blob/6a16ed4f6bcd884913c9b82a06191c41e4bcfaae/pkg/provider-local/controller/extension/shootafterworker/actuator.go#L85

When a `Shoot` takes too long for a reconciliation, the entire test might abort/fail, negatively affecting other test cases and blurring the final test results.

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
