### PR TITLE
Redirect non-vpn traffic on port 8132 of istio ingress gateway to https port

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -33,6 +33,23 @@ spec:
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+              # Redirect requests to the https port to make probing more painful/cost intensive
+              - match:
+                  prefix: "/"
+                  headers:
+                    - name: ":method"
+                      string_match:
+                        exact: CONNECT
+                      invert_match: true
+                redirect:
+                  https_redirect: true
+                  port_redirect: 443
+                typed_per_filter_config:
+                  # No need to bother the external authorization server with the request
+                  # as it will most likely reject it anyway.
+                  envoy.filters.http.ext_authz:
+                    '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                    disabled: true
             # Redirect all other requests to the https port to make probing more painful/cost intensive
             - domains:
               - "*"

--- a/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -32,6 +32,23 @@ spec:
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+              # Redirect requests to the https port to make probing more painful/cost intensive
+              - match:
+                  prefix: "/"
+                  headers:
+                    - name: ":method"
+                      string_match:
+                        exact: CONNECT
+                      invert_match: true
+                redirect:
+                  https_redirect: true
+                  port_redirect: 443
+                typed_per_filter_config:
+                  # No need to bother the external authorization server with the request
+                  # as it will most likely reject it anyway.
+                  envoy.filters.http.ext_authz:
+                    '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                    disabled: true
             # Redirect all other requests to the https port to make probing more painful/cost intensive
             - domains:
               - "*"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area security
/kind enhancement

**What this PR does / why we need it**:

Redirect non-vpn traffic on port 8132 of istio ingress gateway to https port.

With #9332, traffic with a host header not starting with 'api.\*' was redirected to the https port. However, ordinary GET/POST/PUT request with a host header of 'api.\*' were not. This is addressed in this pull request with a separate match clause.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Port 8132 of istio ingress gateway will respond to all ordinary http requests regardless of the target domain with a redirect (301) to the https port
```
