### PR TITLE
Fix the {virtual|runtime}-garden probes in the local gardener-operator setup

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -331,7 +331,6 @@ if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]] ; then
 fi
 
 garden_cluster_ip="$(docker inspect "$garden_cluster"-control-plane | yq ".[].NetworkSettings.Networks.kind.$ip_address_field")"
-docker_ip=$(ip addr show docker0 | awk '/inet .* docker0/{print substr($2, 0, index($2, "/") - 1)}')
 
 # Inject garden.local.gardener.cloud into all nodes
 kubectl get nodes -o name |\
@@ -344,8 +343,8 @@ kubectl -n kube-system get configmap coredns -ojson | \
   sed '0,/ready.*$/s//&'"\n\
     hosts {\n\
       $garden_cluster_ip garden.local.gardener.cloud\n\
-      $docker_ip gardener.virtual-garden.local.gardener.cloud\n\
-      $docker_ip dashboard.ingress.runtime-garden.local.gardener.cloud\n\
+      $garden_cluster_ip gardener.virtual-garden.local.gardener.cloud\n\
+      $garden_cluster_ip dashboard.ingress.runtime-garden.local.gardener.cloud\n\
       fallthrough\n\
     }\
 "'/' | \

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -331,6 +331,7 @@ if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]] ; then
 fi
 
 garden_cluster_ip="$(docker inspect "$garden_cluster"-control-plane | yq ".[].NetworkSettings.Networks.kind.$ip_address_field")"
+docker_ip=$(ip addr show docker0 | awk '/inet .* docker0/{print substr($2, 0, index($2, "/") - 1)}')
 
 # Inject garden.local.gardener.cloud into all nodes
 kubectl get nodes -o name |\
@@ -343,6 +344,8 @@ kubectl -n kube-system get configmap coredns -ojson | \
   sed '0,/ready.*$/s//&'"\n\
     hosts {\n\
       $garden_cluster_ip garden.local.gardener.cloud\n\
+      $docker_ip gardener.virtual-garden.local.gardener.cloud\n\
+      $docker_ip dashboard.ingress.runtime-garden.local.gardener.cloud\n\
       fallthrough\n\
     }\
 "'/' | \

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
@@ -22,7 +22,7 @@ const (
 )
 
 // Config returns the blackbox-exporter config for the garden use-case.
-func Config() blackboxexporterconfig.Config {
+func Config(isDashboardCertificateIssuedByGardener bool) blackboxexporterconfig.Config {
 	var (
 		defaultModuleConfig = func() blackboxexporterconfig.Module {
 			return blackboxexporterconfig.Module{
@@ -52,6 +52,10 @@ func Config() blackboxexporterconfig.Config {
 	httpKubeAPIServerModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathKubeAPIServerCABundle
 	httpKubeAPIServerModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
 	httpKubeAPIServerRootCAsModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
+
+	if isDashboardCertificateIssuedByGardener {
+		httpGardenerDashboardModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathGardenerAPIServerCABundle
+	}
 
 	return blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
 		httpGardenerAPIServerModuleName:    httpGardenerAPIServerModule,

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("Config", func() {
 	Describe("#Config", func() {
 		It("should return the expected config for the garden's blackbox-exporter", func() {
-			Expect(Config()).To(Equal(blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
+			Expect(Config(false)).To(Equal(blackboxexporterconfig.Config{Modules: map[string]blackboxexporterconfig.Module{
 				"http_gardener_apiserver": {
 					Prober:  "http",
 					Timeout: 10 * time.Second,
@@ -74,6 +74,15 @@ var _ = Describe("Config", func() {
 					},
 				},
 			}}))
+		})
+
+		When("isDashboardCertificateIssuedByGardener is true", func() {
+			It("should configure the Gardener CA for the http_gardener_dashboard module", func() {
+				Expect(Config(true).Modules["http_gardener_dashboard"].HTTP.HTTPClientConfig.TLSConfig).To(Equal(
+					prometheuscommonconfig.TLSConfig{
+						CAFile: "/var/run/secrets/blackbox_exporter/gardener-ca/bundle.crt"},
+				))
+			})
 		})
 	})
 })

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1287,7 +1287,7 @@ func (r *Reconciler) newPrometheusLongTerm(log logr.Logger, garden *operatorv1al
 func (r *Reconciler) newBlackboxExporter(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
 	var (
 		kubeAPIServerTargets    = []monitoringv1alpha1.Target{monitoringv1alpha1.Target("https://" + gardenerDNSNamePrefix + garden.Spec.VirtualCluster.DNS.Domains[0] + "/healthz")}
-		gardenerDashboardTarget = monitoringv1alpha1.Target("https://dashboard." + garden.Spec.VirtualCluster.DNS.Domains[0] + "/healthz")
+		gardenerDashboardTarget = monitoringv1alpha1.Target("https://dashboard." + garden.Spec.RuntimeCluster.Ingress.Domains[0] + "/healthz")
 	)
 
 	if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR ensures that the `{virtual|runtime}-garden.local.gardener.cloud` domains in the local setup are resolved to the istio ingress gateway service, such that the Garden Prometheus can successfully probe the `https://gardener.virtual-garden.local.gardener.cloud/healthz` and `https://dashboard.ingress.runtime-garden.local.gardener.cloud/healthz` endpoints via the blackbox exporter.

**Which issue(s) this PR fixes**:

<details>
<summary>In the local gardener operator setup, the <code>DashboardDown</code> and <code>ApiServerDown</code> alerts are firing. These are false positives.</summary>

In the local gardener-operator setup

```
make kind-operator-up operator-up
export KUBECONFIG=$PWD/example/gardener-local/kind/operator/kubeconfig
k apply -f example/operator/20-garden.yaml
```

port-forward to Prometheus:

```
k port-forward prometheus-garden-0 9090
```

to see that the virtual garden API server and Dashboard probes via the blackbox-exporter fail.

```
probe_success{purpose="availability"}

probe_success{instance="https://gardener.virtual-garden.local.gardener.cloud/healthz", job="blackbox-apiserver", purpose="availability"}  0
probe_success{instance="https://dashboard.virtual-garden.local.gardener.cloud/healthz", job="blackbox-dashboard", purpose="availability"} 0
probe_success{instance="https://gardener-apiserver.garden.svc/healthz", job="blackbox-gardener-apiserver", purpose="availability"}        1
```

Consequently, the `ALERTS`: `DashboardDown`, `ApiServerDown` are firing.

Port-forwarding to the blackbox-exporter reveals more details

```
k port-forward deployment/blackbox-exporter 9115
```

```
Error resolving address
  err="lookup gardener.virtual-garden.local.gardener.cloud on 10.2.0.10:53: no such host"
```

</details>

**Special notes for your reviewer**:

cc @ScheererJ @vicwicker @rickardsjp 

Related to
- #9543
- #9583

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The `{virtual|runtime}-garden` Prometheus / blackbox-exporter probes in the local `gardener-operator` setup are fixed.
```
