### PR TITLE
[renovate] Add `**Release note:**` heading and a `NONE` default release note

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,8 @@
   ],
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],
+  // Add PR footer with empty release note by default.
+  "prFooter": "**Release note**:\n```other dependency\nNONE\n```",
   "customManagers": [
     {
       // Update `_VERSION` and `_version` variables in Makefiles and scripts.
@@ -190,13 +192,13 @@
       // Add PR footer with release notes for docker releases.
       "matchDatasources": ["docker"],
       "matchFileNames": ["imagevector/**"],
-      "prFooter": "```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`.\n```"
+      "prFooter": "**Release note**:\n```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`.\n```"
     },
     {
       // Add PR footer with release notes link for github-releases.
       "matchDatasources": ["github-releases"],
       "matchFileNames": ["imagevector/**"],
-      "prFooter": "```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`. [Release Notes](https://github.com/{{depName}}/releases/tag/{{newVersion}})\n```"
+      "prFooter": "**Release note**:\n```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`. [Release Notes](https://github.com/{{depName}}/releases/tag/{{newVersion}})\n```"
     }
   ]
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Renovate release notes introduced in PR #9828 are working (see https://github.com/gardener/gardener/pull/9837#issue-2313912308).
This PR tune the result a bit. It adds a `**Release note:**` heading like in our PR template before the release note. Additionally, it adds `NONE` release note for every other case that renovate PRs look always similar. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Renovate applies all package rules sequentially, so the last match for the footer wins.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
