### PR TITLE
Introduce secret to track hash version used by OperatingSystemConfig

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -130,7 +130,7 @@ func createOSCHashMigrationSecret(ctx context.Context, seedClient client.Client)
 		tasks = append(tasks, func(ctx context.Context) error {
 			if err := seedClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: operatingsystemconfig.PoolHashesSecretName}, &corev1.Secret{}); err == nil {
 				// nothing to do if secret already exists
-				return err
+				return nil
 			} else if client.IgnoreNotFound(err) != nil {
 				return fmt.Errorf("could not query pool-hashes secret in namespace %v: %w", ns.Name, err)
 			}

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -128,20 +128,20 @@ func createOSCHashMigrationSecret(ctx context.Context, seedClient client.Client)
 			continue
 		}
 		tasks = append(tasks, func(ctx context.Context) error {
-			if err := seedClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: operatingsystemconfig.PoolHashesSecretName}, &corev1.Secret{}); err == nil {
+			if err := seedClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: operatingsystemconfig.WorkerPoolHashesSecretName}, &corev1.Secret{}); err == nil {
 				// nothing to do if secret already exists
 				return nil
 			} else if client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("could not query pool-hashes secret in namespace %v: %w", ns.Name, err)
+				return fmt.Errorf("could not query worker-pools-operatingsystemconfig-hashes secret in namespace %v: %w", ns.Name, err)
 			}
 
 			secret, err := operatingsystemconfig.CreateMigrationSecret(ns.Name)
 			if err != nil {
-				return fmt.Errorf("failed to serialize pool-hashes secret for namespace %v: %w", ns.Name, err)
+				return fmt.Errorf("failed to serialize worker-pools-operatingsystemconfig-hashes secret for namespace %v: %w", ns.Name, err)
 			}
 
 			if err := seedClient.Create(ctx, secret); client.IgnoreAlreadyExists(err) != nil {
-				return fmt.Errorf("could not create pool-hashes secret in namespace %v: %w", ns.Name, err)
+				return fmt.Errorf("could not create worker-pools-operatingsystemconfig-hashes secret in namespace %v: %w", ns.Name, err)
 			}
 
 			return nil

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -135,7 +135,10 @@ func createOSCHashMigrationSecret(ctx context.Context, seedClient client.Client)
 				return fmt.Errorf("could not query pool-hashes secret in namespace %v: %w", ns.Name, err)
 			}
 
-			secret := operatingsystemconfig.CreateMigrationSecret(ns.Name)
+			secret, err := operatingsystemconfig.CreateMigrationSecret(ns.Name)
+			if err != nil {
+				return fmt.Errorf("failed to serialize pool-hashes secret for namespace %v: %w", ns.Name, err)
+			}
 
 			if err := seedClient.Create(ctx, secret); client.IgnoreAlreadyExists(err) != nil {
 				return fmt.Errorf("could not create pool-hashes secret in namespace %v: %w", ns.Name, err)

--- a/pkg/component/extensions/operatingsystemconfig/mock/mocks.go
+++ b/pkg/component/extensions/operatingsystemconfig/mock/mocks.go
@@ -203,16 +203,16 @@ func (mr *MockInterfaceMockRecorder) WaitMigrate(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitMigrate", reflect.TypeOf((*MockInterface)(nil).WaitMigrate), arg0)
 }
 
-// WorkerNameToOperatingSystemConfigsMap mocks base method.
-func (m *MockInterface) WorkerNameToOperatingSystemConfigsMap() map[string]*operatingsystemconfig.OperatingSystemConfigs {
+// WorkerPoolNameToOperatingSystemConfigsMap mocks base method.
+func (m *MockInterface) WorkerPoolNameToOperatingSystemConfigsMap() map[string]*operatingsystemconfig.OperatingSystemConfigs {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkerNameToOperatingSystemConfigsMap")
+	ret := m.ctrl.Call(m, "WorkerPoolNameToOperatingSystemConfigsMap")
 	ret0, _ := ret[0].(map[string]*operatingsystemconfig.OperatingSystemConfigs)
 	return ret0
 }
 
-// WorkerNameToOperatingSystemConfigsMap indicates an expected call of WorkerNameToOperatingSystemConfigsMap.
-func (mr *MockInterfaceMockRecorder) WorkerNameToOperatingSystemConfigsMap() *gomock.Call {
+// WorkerPoolNameToOperatingSystemConfigsMap indicates an expected call of WorkerPoolNameToOperatingSystemConfigsMap.
+func (mr *MockInterfaceMockRecorder) WorkerPoolNameToOperatingSystemConfigsMap() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkerNameToOperatingSystemConfigsMap", reflect.TypeOf((*MockInterface)(nil).WorkerNameToOperatingSystemConfigsMap))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkerPoolNameToOperatingSystemConfigsMap", reflect.TypeOf((*MockInterface)(nil).WorkerPoolNameToOperatingSystemConfigsMap))
 }

--- a/pkg/component/extensions/operatingsystemconfig/mock/mocks.go
+++ b/pkg/component/extensions/operatingsystemconfig/mock/mocks.go
@@ -97,6 +97,20 @@ func (mr *MockInterfaceMockRecorder) Migrate(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Migrate", reflect.TypeOf((*MockInterface)(nil).Migrate), arg0)
 }
 
+// MigrateWorkerPoolHashes mocks base method.
+func (m *MockInterface) MigrateWorkerPoolHashes(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MigrateWorkerPoolHashes", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MigrateWorkerPoolHashes indicates an expected call of MigrateWorkerPoolHashes.
+func (mr *MockInterfaceMockRecorder) MigrateWorkerPoolHashes(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateWorkerPoolHashes", reflect.TypeOf((*MockInterface)(nil).MigrateWorkerPoolHashes), arg0)
+}
+
 // Restore mocks base method.
 func (m *MockInterface) Restore(arg0 context.Context, arg1 *v1beta1.ShootState) error {
 	m.ctrl.T.Helper()

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -250,9 +250,9 @@ type poolHash struct {
 }
 
 type poolHashEntry struct {
-	Name                  string
-	CurrentVersion        int
-	HashVersionToPoolName map[int]string
+	Name                string         `yaml:"name"`
+	CurrentVersion      int            `yaml:"currentVersion"`
+	HashVersionToOSCKey map[int]string `yaml:"hashVersionToOSCKey"`
 }
 
 func decodePoolHashes(secret *corev1.Secret) (map[string]poolHashEntry, bool, error) {
@@ -315,7 +315,7 @@ func (o *operatingSystemConfig) updateHashVersioningSecret(ctx context.Context) 
 
 			// check if hashes still match
 			hashHasChanged := false
-			for version, hash := range workerHash.HashVersionToPoolName {
+			for version, hash := range workerHash.HashVersionToOSCKey {
 				expectedHash, err := o.calculateKeyForVersion(version, &worker)
 				if err != nil {
 					return err
@@ -341,12 +341,12 @@ func (o *operatingSystemConfig) updateHashVersioningSecret(ctx context.Context) 
 			}
 
 			// rebuild hashes
-			clear(workerHash.HashVersionToPoolName)
-			if workerHash.HashVersionToPoolName == nil {
-				workerHash.HashVersionToPoolName = map[int]string{}
+			clear(workerHash.HashVersionToOSCKey)
+			if workerHash.HashVersionToOSCKey == nil {
+				workerHash.HashVersionToOSCKey = map[int]string{}
 			}
-			workerHash.HashVersionToPoolName[workerHash.CurrentVersion] = currentHash
-			workerHash.HashVersionToPoolName[LatestHashVersion] = latestHash
+			workerHash.HashVersionToOSCKey[workerHash.CurrentVersion] = currentHash
+			workerHash.HashVersionToOSCKey[LatestHashVersion] = latestHash
 
 			// update secret
 			hashesByName[worker.Name] = workerHash

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -393,15 +393,14 @@ func (o *operatingSystemConfig) hashVersion(workerName string) (int, error) {
 
 // CreateMigrationSecret creates a pool-hash secret for initially deploying the
 // pool hash secret into a shoot (namespace).
-func CreateMigrationSecret(namespace string) *corev1.Secret {
+func CreateMigrationSecret(namespace string) (*corev1.Secret, error) {
 	pools := poolHash{
 		Migrated: ptr.To(true),
 	}
 
 	var buf bytes.Buffer
 	if err := yaml.NewEncoder(&buf).Encode(&pools); err != nil {
-		// this really should be impossible
-		panic(err)
+		return nil, err
 	}
 
 	return &corev1.Secret{
@@ -410,7 +409,7 @@ func CreateMigrationSecret(namespace string) *corev1.Secret {
 		Data: map[string][]byte{
 			poolHashesDataKey: buf.Bytes(),
 		},
-	}
+	}, nil
 }
 
 // Wait waits until the OperatingSystemConfig CRD is ready (deployed or restored). It also reads the produced secret

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -333,12 +333,12 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Data: map[string][]byte{
 					"pools": []byte(`pools:
     - name: worker1
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: gardener-node-agent-worker1-77ac3
     - name: worker2
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: gardener-node-agent-worker2-d9e53
 `)},
 			}
@@ -388,12 +388,12 @@ var _ = Describe("OperatingSystemConfig", func() {
 				pools := secret.Data["pools"]
 				Expect(string(pools)).To(Equal(`pools:
     - name: worker1
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: gardener-node-agent-worker1-77ac3
     - name: worker2
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: gardener-node-agent-worker2-d9e53
 `))
 			})
@@ -418,7 +418,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				poolHashesSecret.Data["pools"] = []byte(`pools:
     - name: worker1
-      currentversion: 1
+      currentVersion: 1
 `)
 				Expect(c.Create(ctx, poolHashesSecret)).To(Succeed())
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
@@ -431,13 +431,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 				pools := secret.Data["pools"]
 				Expect(string(pools)).To(Equal(`pools:
     - name: worker1
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: worker1-version1
         2: worker1-version2
     - name: worker2
-      currentversion: 2
-      hashes:
+      currentVersion: 2
+      hashVersionToOSCKey:
         2: worker2-version2
 `))
 
@@ -461,12 +461,12 @@ var _ = Describe("OperatingSystemConfig", func() {
 				pools := secret.Data["pools"]
 				Expect(string(pools)).To(Equal(`pools:
     - name: worker1
-      currentversion: 2
-      hashes:
+      currentVersion: 2
+      hashVersionToOSCKey:
         2: worker1-version2
     - name: worker2
-      currentversion: 2
-      hashes:
+      currentVersion: 2
+      hashVersionToOSCKey:
         2: worker2-version2
 `))
 			})
@@ -500,13 +500,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 				pools := secret.Data["pools"]
 				Expect(string(pools)).To(Equal(`pools:
     - name: worker1
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: gardener-node-agent-worker1-77ac3
         2: worker1-version2
     - name: worker2
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: gardener-node-agent-worker2-d9e53
         2: worker2-version2
 `))
@@ -530,13 +530,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 				pools := secret.Data["pools"]
 				Expect(string(pools)).To(Equal(`pools:
     - name: worker1
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: gardener-node-agent-worker1-77ac3
         2: worker1-version2
     - name: worker2
-      currentversion: 1
-      hashes:
+      currentVersion: 1
+      hashVersionToOSCKey:
         1: gardener-node-agent-worker2-d9e53
         2: worker2-version2
 `))

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -323,7 +323,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 			poolHashesSecret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pool-hashes",
+					Name:      "worker-pools-operatingsystemconfig-hashes",
 					Namespace: namespace,
 					Labels: map[string]string{
 						"persist": "true",
@@ -374,14 +374,14 @@ var _ = Describe("OperatingSystemConfig", func() {
 				}))
 			})
 
-			It("should successfully create the pool-hashes secret", func() {
+			It("should successfully create the worker-pools-operatingsystemconfig-hashes secret", func() {
 				DeferCleanup(test.WithVars(
 					&OriginalConfigFn, originalConfigFn,
 				))
 
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 				secret := &corev1.Secret{}
-				Expect(c.Get(ctx, client.ObjectKey{Name: "pool-hashes", Namespace: namespace}, secret)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Name: "worker-pools-operatingsystemconfig-hashes", Namespace: namespace}, secret)).To(Succeed())
 				Expect(secret.Labels).To(Equal(map[string]string{
 					"persist": "true",
 				}))
@@ -409,7 +409,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				}
 			}
 
-			It("should successfully fill missing hashes and workers in the pool-hashes secret", func() {
+			It("should successfully fill missing hashes and workers in the worker-pools-operatingsystemconfig-hashes secret", func() {
 				DeferCleanup(test.WithVars(
 					&OriginalConfigFn, originalConfigFn,
 					&LatestHashVersion, 2,
@@ -424,7 +424,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				secret := &corev1.Secret{}
-				Expect(c.Get(ctx, client.ObjectKey{Name: "pool-hashes", Namespace: namespace}, secret)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Name: "worker-pools-operatingsystemconfig-hashes", Namespace: namespace}, secret)).To(Succeed())
 				Expect(secret.Labels).To(Equal(map[string]string{
 					"persist": "true",
 				}))
@@ -443,7 +443,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 			})
 
-			It("should successfully upgrade the hash versions in the pool-hashes secret", func() {
+			It("should successfully upgrade the hash versions in the worker-pools-operatingsystemconfig-hashes secret", func() {
 				DeferCleanup(test.WithVars(
 					&OriginalConfigFn, originalConfigFn,
 					&LatestHashVersion, 2,
@@ -454,7 +454,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				secret := &corev1.Secret{}
-				Expect(c.Get(ctx, client.ObjectKey{Name: "pool-hashes", Namespace: namespace}, secret)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Name: "worker-pools-operatingsystemconfig-hashes", Namespace: namespace}, secret)).To(Succeed())
 				Expect(secret.Labels).To(Equal(map[string]string{
 					"persist": "true",
 				}))
@@ -482,7 +482,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				}
 			}
 
-			It("should successfully keep the current hash versions if nothing changes in the pool-hashes secret", func() {
+			It("should successfully keep the current hash versions if nothing changes in the worker-pools-operatingsystemconfig-hashes secret", func() {
 				DeferCleanup(test.WithVars(
 					&OriginalConfigFn, originalConfigFn,
 					&LatestHashVersion, 2,
@@ -493,7 +493,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				secret := &corev1.Secret{}
-				Expect(c.Get(ctx, client.ObjectKey{Name: "pool-hashes", Namespace: namespace}, secret)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Name: "worker-pools-operatingsystemconfig-hashes", Namespace: namespace}, secret)).To(Succeed())
 				Expect(secret.Labels).To(Equal(map[string]string{
 					"persist": "true",
 				}))
@@ -525,7 +525,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				secret := &corev1.Secret{}
-				Expect(c.Get(ctx, client.ObjectKey{Name: "pool-hashes", Namespace: namespace}, secret)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Name: "worker-pools-operatingsystemconfig-hashes", Namespace: namespace}, secret)).To(Succeed())
 				Expect(secret.Labels).To(Equal(map[string]string{
 					"persist": "true",
 				}))
@@ -958,7 +958,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				Expect(defaultDepWaiter.Wait(ctx)).To(Succeed())
 
-				wn := defaultDepWaiter.WorkerNameToOperatingSystemConfigsMap()
+				wn := defaultDepWaiter.WorkerPoolNameToOperatingSystemConfigsMap()
 				exp := map[string]*OperatingSystemConfigs{
 					worker1Name: {
 						Init: Data{

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -922,9 +922,12 @@ var _ = Describe("OperatingSystemConfig", func() {
 						"gardener.cloud/timestamp": now.UTC().Format(time.RFC3339Nano),
 					}
 					// set last operation
+					lastUpdateTime := metav1.Time{Time: now}.Rfc3339Copy()
+					// fix timezone
+					lastUpdateTime.Time = lastUpdateTime.Local()
 					expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
 						State:          gardencorev1beta1.LastOperationStateSucceeded,
-						LastUpdateTime: metav1.Time{Time: now}.Rfc3339Copy(),
+						LastUpdateTime: lastUpdateTime,
 					}
 					// set cloud-config secret information
 					expected[i].Status.CloudConfig = &extensionsv1alpha1.CloudConfig{

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -519,7 +519,9 @@ var _ = Describe("OperatingSystemConfig", func() {
 					&CalculateKeyForVersion, calculateStableKeyForVersionFn,
 				))
 
-				Expect(c.Create(ctx, CreateMigrationSecret(namespace))).To(Succeed())
+				migrationSecret, err := CreateMigrationSecret(namespace)
+				Expect(err).To(Succeed())
+				Expect(c.Create(ctx, migrationSecret)).To(Succeed())
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				secret := &corev1.Secret{}

--- a/pkg/component/extensions/worker/mock/mocks.go
+++ b/pkg/component/extensions/worker/mock/mocks.go
@@ -137,16 +137,16 @@ func (mr *MockInterfaceMockRecorder) SetSSHPublicKey(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSSHPublicKey", reflect.TypeOf((*MockInterface)(nil).SetSSHPublicKey), arg0)
 }
 
-// SetWorkerNameToOperatingSystemConfigsMap mocks base method.
-func (m *MockInterface) SetWorkerNameToOperatingSystemConfigsMap(arg0 map[string]*operatingsystemconfig.OperatingSystemConfigs) {
+// SetWorkerPoolNameToOperatingSystemConfigsMap mocks base method.
+func (m *MockInterface) SetWorkerPoolNameToOperatingSystemConfigsMap(arg0 map[string]*operatingsystemconfig.OperatingSystemConfigs) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetWorkerNameToOperatingSystemConfigsMap", arg0)
+	m.ctrl.Call(m, "SetWorkerPoolNameToOperatingSystemConfigsMap", arg0)
 }
 
-// SetWorkerNameToOperatingSystemConfigsMap indicates an expected call of SetWorkerNameToOperatingSystemConfigsMap.
-func (mr *MockInterfaceMockRecorder) SetWorkerNameToOperatingSystemConfigsMap(arg0 any) *gomock.Call {
+// SetWorkerPoolNameToOperatingSystemConfigsMap indicates an expected call of SetWorkerPoolNameToOperatingSystemConfigsMap.
+func (mr *MockInterfaceMockRecorder) SetWorkerPoolNameToOperatingSystemConfigsMap(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkerNameToOperatingSystemConfigsMap", reflect.TypeOf((*MockInterface)(nil).SetWorkerNameToOperatingSystemConfigsMap), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkerPoolNameToOperatingSystemConfigsMap", reflect.TypeOf((*MockInterface)(nil).SetWorkerPoolNameToOperatingSystemConfigsMap), arg0)
 }
 
 // Wait mocks base method.

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -49,7 +49,7 @@ type Interface interface {
 	component.DeployMigrateWaiter
 	SetSSHPublicKey([]byte)
 	SetInfrastructureProviderStatus(*runtime.RawExtension)
-	SetWorkerNameToOperatingSystemConfigsMap(map[string]*operatingsystemconfig.OperatingSystemConfigs)
+	SetWorkerPoolNameToOperatingSystemConfigsMap(map[string]*operatingsystemconfig.OperatingSystemConfigs)
 	MachineDeployments() []extensionsv1alpha1.MachineDeployment
 	WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx context.Context) error
 }
@@ -75,8 +75,8 @@ type Values struct {
 	// InfrastructureProviderStatus is the provider status of the Infrastructure resource which might be relevant for
 	// the Worker reconciliation.
 	InfrastructureProviderStatus *runtime.RawExtension
-	// WorkerNameToOperatingSystemConfigsMap contains the operating system configurations for the worker pools.
-	WorkerNameToOperatingSystemConfigsMap map[string]*operatingsystemconfig.OperatingSystemConfigs
+	// WorkerPoolNameToOperatingSystemConfigsMap contains the operating system configurations for the worker pools.
+	WorkerPoolNameToOperatingSystemConfigsMap map[string]*operatingsystemconfig.OperatingSystemConfigs
 	// NodeLocalDNSEnabled indicates whether node local dns is enabled or not.
 	NodeLocalDNSEnabled bool
 }
@@ -166,7 +166,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			}
 		}
 
-		oscConfig, ok := w.values.WorkerNameToOperatingSystemConfigsMap[workerPool.Name]
+		oscConfig, ok := w.values.WorkerPoolNameToOperatingSystemConfigsMap[workerPool.Name]
 		if !ok {
 			return nil, fmt.Errorf("missing operating system config for worker pool %v", workerPool.Name)
 		}
@@ -385,9 +385,9 @@ func (w *worker) SetInfrastructureProviderStatus(status *runtime.RawExtension) {
 	w.values.InfrastructureProviderStatus = status
 }
 
-// SetWorkerNameToOperatingSystemConfigsMap sets the operating system config maps in the values.
-func (w *worker) SetWorkerNameToOperatingSystemConfigsMap(maps map[string]*operatingsystemconfig.OperatingSystemConfigs) {
-	w.values.WorkerNameToOperatingSystemConfigsMap = maps
+// SetWorkerPoolNameToOperatingSystemConfigsMap sets the operating system config maps in the values.
+func (w *worker) SetWorkerPoolNameToOperatingSystemConfigsMap(maps map[string]*operatingsystemconfig.OperatingSystemConfigs) {
+	w.values.WorkerPoolNameToOperatingSystemConfigsMap = maps
 }
 
 // MachineDeployments returns the generated machine deployments of the Worker.

--- a/pkg/component/extensions/worker/worker_test.go
+++ b/pkg/component/extensions/worker/worker_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Worker", func() {
 			MachineTypes:                 machineTypes,
 			SSHPublicKey:                 sshPublicKey,
 			InfrastructureProviderStatus: infrastructureProviderStatus,
-			WorkerNameToOperatingSystemConfigsMap: map[string]*operatingsystemconfig.OperatingSystemConfigs{
+			WorkerPoolNameToOperatingSystemConfigsMap: map[string]*operatingsystemconfig.OperatingSystemConfigs{
 				worker1Name: {
 					Init: operatingsystemconfig.Data{
 						Content:                     string(worker1UserData),

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -244,7 +244,7 @@ var _ = Describe("health check", func() {
 			nodeName                   = "node1"
 			oscSecretMeta              = map[string]metav1.ObjectMeta{
 				workerPoolName1: {
-					Name:        operatingsystemconfig.Key(workerPoolName1, kubernetesVersion, nil),
+					Name:        operatingsystemconfig.KeyV1(workerPoolName1, kubernetesVersion, nil),
 					Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
 					Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
 				},
@@ -393,7 +393,7 @@ var _ = Describe("health check", func() {
 				},
 				map[string]metav1.ObjectMeta{
 					workerPoolName1: {
-						Name:        operatingsystemconfig.Key(workerPoolName1, kubernetesVersion, nil),
+						Name:        operatingsystemconfig.KeyV1(workerPoolName1, kubernetesVersion, nil),
 						Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
 						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
 					},
@@ -413,7 +413,7 @@ var _ = Describe("health check", func() {
 				},
 				map[string]metav1.ObjectMeta{
 					workerPoolName1: {
-						Name:        operatingsystemconfig.Key(workerPoolName1, kubernetesVersion, nil),
+						Name:        operatingsystemconfig.KeyV1(workerPoolName1, kubernetesVersion, nil),
 						Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
 						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
 					},

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -92,6 +92,13 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 	), nil
 }
 
+// MigrateOperatingSystemConfigWorkerPoolHashes performs migration steps for the initial rollout of the
+// operating system config hash calculation.
+// TODO(MichaelEischer) Remove after Gardener 1.99 is released.
+func (b *Botanist) MigrateOperatingSystemConfigWorkerPoolHashes(ctx context.Context) error {
+	return b.Shoot.Components.Extensions.OperatingSystemConfig.MigrateWorkerPoolHashes(ctx)
+}
+
 // DeployOperatingSystemConfig deploys the OperatingSystemConfig custom resource and triggers the restore operation in
 // case the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -167,7 +167,7 @@ func (b *Botanist) DeployManagedResourceForGardenerNodeAgent(ctx context.Context
 		managedResourceSecretNameToData  = make(map[string]map[string][]byte, managedResourceSecretsCount)
 
 		secretNames                           []string
-		workerNameToOperatingSystemConfigMaps = b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerNameToOperatingSystemConfigsMap()
+		workerNameToOperatingSystemConfigMaps = b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerPoolNameToOperatingSystemConfigsMap()
 
 		fns = make([]flow.TaskFn, 0, managedResourceSecretsCount)
 	)

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -269,14 +269,14 @@ var _ = Describe("operatingsystemconfig", func() {
 			})
 
 			It("should fail because the operating system config maps for a worker pool are not available", func() {
-				operatingSystemConfig.EXPECT().WorkerNameToOperatingSystemConfigsMap().Return(nil)
+				operatingSystemConfig.EXPECT().WorkerPoolNameToOperatingSystemConfigsMap().Return(nil)
 
 				Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx)).To(MatchError(ContainSubstring("did not find osc data for worker pool")))
 			})
 
 			When("operating system config maps are available", func() {
 				BeforeEach(func() {
-					operatingSystemConfig.EXPECT().WorkerNameToOperatingSystemConfigsMap().Return(workerNameToOperatingSystemConfigMaps)
+					operatingSystemConfig.EXPECT().WorkerPoolNameToOperatingSystemConfigsMap().Return(workerNameToOperatingSystemConfigMaps)
 				})
 
 				It("should fail because the secret data generation function fails", func() {

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -192,12 +192,12 @@ var _ = Describe("operatingsystemconfig", func() {
 
 			worker1Name            = "worker1"
 			worker1OriginalContent = "w1content"
-			worker1Key             = operatingsystemconfig.Key(worker1Name, semver.MustParse(kubernetesVersion), nil)
+			worker1Key             = operatingsystemconfig.KeyV1(worker1Name, semver.MustParse(kubernetesVersion), nil)
 
 			worker2Name                  = "worker2"
 			worker2OriginalContent       = "w2content"
 			worker2KubernetesVersion     = "4.5.6"
-			worker2Key                   = operatingsystemconfig.Key(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
+			worker2Key                   = operatingsystemconfig.KeyV1(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
 			worker2KubeletDataVolumeName = "vol"
 
 			workerNameToOperatingSystemConfigMaps = map[string]*operatingsystemconfig.OperatingSystemConfigs{

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -62,7 +62,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 	}
 
 	b.Shoot.Components.Extensions.Worker.SetInfrastructureProviderStatus(b.Shoot.Components.Extensions.Infrastructure.ProviderStatus())
-	b.Shoot.Components.Extensions.Worker.SetWorkerNameToOperatingSystemConfigsMap(b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerNameToOperatingSystemConfigsMap())
+	b.Shoot.Components.Extensions.Worker.SetWorkerPoolNameToOperatingSystemConfigsMap(b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerPoolNameToOperatingSystemConfigsMap())
 
 	if b.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Worker.Restore(ctx, b.Shoot.GetShootState())

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -191,7 +191,7 @@ func nodeUsesOutdatedGardenerNodeAgentSecret(node corev1.Node, gardenerNodeAgent
 		criConfig = &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRIName(v)}
 	}
 
-	return operatingsystemconfig.Key(node.Labels[v1beta1constants.LabelWorkerPool], kubernetesVersion, criConfig) != gardenerNodeAgentSecretName, nil
+	return operatingsystemconfig.KeyV1(node.Labels[v1beta1constants.LabelWorkerPool], kubernetesVersion, criConfig) != gardenerNodeAgentSecretName, nil
 }
 
 // exposed for testing

--- a/pkg/gardenlet/operation/botanist/worker_test.go
+++ b/pkg/gardenlet/operation/botanist/worker_test.go
@@ -104,11 +104,11 @@ var _ = Describe("Worker", func() {
 	Describe("#DeployWorker", func() {
 		BeforeEach(func() {
 			infrastructure.EXPECT().ProviderStatus().Return(infrastructureProviderStatus)
-			operatingSystemConfig.EXPECT().WorkerNameToOperatingSystemConfigsMap().Return(workerNameToOperatingSystemConfigMaps)
+			operatingSystemConfig.EXPECT().WorkerPoolNameToOperatingSystemConfigsMap().Return(workerNameToOperatingSystemConfigMaps)
 
 			worker.EXPECT().SetSSHPublicKey(gomock.Any())
 			worker.EXPECT().SetInfrastructureProviderStatus(infrastructureProviderStatus)
-			worker.EXPECT().SetWorkerNameToOperatingSystemConfigsMap(workerNameToOperatingSystemConfigMaps)
+			worker.EXPECT().SetWorkerPoolNameToOperatingSystemConfigsMap(workerNameToOperatingSystemConfigMaps)
 		})
 
 		Context("deploy", func() {

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -158,8 +158,7 @@ func computeSecretsToPersist(
 ) {
 	secretList := &corev1.SecretList{}
 	if err := seedClient.List(ctx, secretList, client.InNamespace(seedNamespace), client.MatchingLabels{
-		secretsmanager.LabelKeyManagedBy: secretsmanager.LabelValueSecretsManager,
-		secretsmanager.LabelKeyPersist:   secretsmanager.LabelValueTrue,
+		secretsmanager.LabelKeyPersist: secretsmanager.LabelValueTrue,
 	}); err != nil {
 		return nil, fmt.Errorf("failed listing all secrets that must be persisted: %w", err)
 	}

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -434,7 +434,7 @@ func (t *ShootMigrationTest) checkForOrphanedNonNamespacedResources(ctx context.
 // MarkOSCSecret marks the operating system config pool hashes secret to verify that it is correctly migrated
 func (t ShootMigrationTest) MarkOSCSecret(ctx context.Context) error {
 	secret := &corev1.Secret{}
-	if err := t.SourceSeedClient.Client().Get(ctx, types.NamespacedName{Namespace: t.SeedShootNamespace, Name: operatingsystemconfig.PoolHashesSecret}, secret); err != nil {
+	if err := t.SourceSeedClient.Client().Get(ctx, types.NamespacedName{Namespace: t.SeedShootNamespace, Name: operatingsystemconfig.PoolHashesSecretName}, secret); err != nil {
 		return err
 	}
 	metav1.SetMetaDataLabel(&secret.ObjectMeta, "gardener.cloud/custom-test-annotation", "test")

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -434,7 +434,7 @@ func (t *ShootMigrationTest) checkForOrphanedNonNamespacedResources(ctx context.
 // MarkOSCSecret marks the operating system config pool hashes secret to verify that it is correctly migrated
 func (t ShootMigrationTest) MarkOSCSecret(ctx context.Context) error {
 	secret := &corev1.Secret{}
-	if err := t.SourceSeedClient.Client().Get(ctx, types.NamespacedName{Namespace: t.SeedShootNamespace, Name: operatingsystemconfig.PoolHashesSecretName}, secret); err != nil {
+	if err := t.SourceSeedClient.Client().Get(ctx, types.NamespacedName{Namespace: t.SeedShootNamespace, Name: operatingsystemconfig.WorkerPoolHashesSecretName}, secret); err != nil {
 		return err
 	}
 	metav1.SetMetaDataLabel(&secret.ObjectMeta, "gardener.cloud/custom-test-annotation", "test")

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -29,6 +30,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/test/utils/access"
 )
@@ -427,6 +429,16 @@ func (t *ShootMigrationTest) checkForOrphanedNonNamespacedResources(ctx context.
 		return fmt.Errorf("the following object(s) still exists in the source seed %v", leakedObjects)
 	}
 	return nil
+}
+
+// MarkOSCSecret marks the operating system config pool hashes secret to verify that it is correctly migrated
+func (t ShootMigrationTest) MarkOSCSecret(ctx context.Context) error {
+	secret := &corev1.Secret{}
+	if err := t.SourceSeedClient.Client().Get(ctx, types.NamespacedName{Namespace: t.SeedShootNamespace, Name: operatingsystemconfig.PoolHashesSecret}, secret); err != nil {
+		return err
+	}
+	metav1.SetMetaDataLabel(&secret.ObjectMeta, "gardener.cloud/custom-test-annotation", "test")
+	return t.SourceSeedClient.Client().Update(ctx, secret)
 }
 
 // CreateSecretAndServiceAccount creates test secret and service account

--- a/test/integration/gardenlet/shoot/state/state_test.go
+++ b/test/integration/gardenlet/shoot/state/state_test.go
@@ -63,9 +63,8 @@ var _ = Describe("Shoot State controller tests", func() {
 				Name:      "some-secret",
 				Namespace: seedNamespace.Name,
 				Labels: map[string]string{
-					testID:       testRunID,
-					"managed-by": "secrets-manager",
-					"persist":    "true",
+					testID:    testRunID,
+					"persist": "true",
 				},
 			},
 		}

--- a/test/testmachinery/system/shoot_cp_migration/migrate_test.go
+++ b/test/testmachinery/system/shoot_cp_migration/migrate_test.go
@@ -108,6 +108,11 @@ func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *a
 		return errors.New("the shoot must have the nginx-ingress addon enabled")
 	}
 
+	ginkgo.By("Mark osc hash secret")
+	if err := t.MarkOSCSecret(ctx); err != nil {
+		return err
+	}
+
 	ginkgo.By("Create test Secret and Service Account")
 	if err := t.CreateSecretAndServiceAccount(ctx); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

This PR implements the `pool-hashes` secret, proposed in https://github.com/gardener/gardener/issues/9699, that is stored in the shoot namespaces on each seed cluster. The secret contains information on which hash version is used for the OperatingSystemConfig as well as the calculated hash values. If the calculated and stored hash values differ, then the hash is upgraded to the latest version.

Currently, only hash version 1 exists. Version 2 will be introduced in a follow-up PR.

The PR includes migration code, that creates a placeholder secret in each shoot namespace. As a small difference to the proposal in https://github.com/gardener/gardener/issues/9699, that secret only contains a "migrated" field. This field causes the normal reconcile for the secret to bootstrap the secret with version 1 instead of the latest version (which currently is still 1, but version 2 will be added in a follow-up PR). This minimizes the complexity of the migration code, but might require keeping a part of it around for some time.


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9699

**Special notes for your reviewer**:

I'm somewhat unsure what the best approach is to check that the `pool-hashes` secret properly survives a control plane migration. I've extended the corresponding e2e test to add a special label to the secret, which will be checked by the existing test code.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
gardenlet now creates a secret called `worker-pools-operatingsystemconfig-hashes` in the shoot namespace on seed clusters. This secret will be used to upgrade the operating system config key calculation in the future.
```
