### PR TITLE
Include `provider-local`s image vector for Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,14 +44,14 @@
     {
       // Generic detection of container images in images.yaml via container registry.
       "customType": "regex",
-      "fileMatch": ["^imagevector\/images.yaml$"],
+      "fileMatch": ["^imagevector\/images.yaml$", "^pkg\/provider-local\/imagevector/images.yaml$"],
       "matchStrings": ["\\s+repository:\\s+(?<depName>.*?)\\n\\s+tag:\\s+[\"]?(?<currentValue>.*?)[\"]?\\n"],
       "datasourceTemplate": "docker"
     },
     {
       // Generic detection of container images in images.yaml via github releases.
       "customType": "regex",
-      "fileMatch": ["^imagevector\/images.yaml$"],
+      "fileMatch": ["^imagevector\/images.yaml$", "^pkg\/provider-local\/imagevector/images.yaml$"],
       "matchStrings": ["\\s+sourceRepository:\\s+github.com\/(?<depName>.*?)\\n\\s+repository:\\s+.*\\n\\s+tag:\\s+[\"]?(?<currentValue>.*?)[\"]?\\n"],
       "datasourceTemplate": "github-releases"
     }
@@ -191,7 +191,7 @@
     {
       // Add PR footer with release notes for docker releases.
       "matchDatasources": ["docker"],
-      "matchFileNames": ["imagevector/**"],
+      "matchFileNames": ["^imagevector/**"],
       "prFooter": "**Release note**:\n```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`.\n```"
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,16 +44,23 @@
     {
       // Generic detection of container images in images.yaml via container registry.
       "customType": "regex",
-      "fileMatch": ["^imagevector\/images.yaml$", "^pkg\/provider-local\/imagevector/images.yaml$"],
+      "fileMatch": ["^imagevector\/images.yaml$"],
       "matchStrings": ["\\s+repository:\\s+(?<depName>.*?)\\n\\s+tag:\\s+[\"]?(?<currentValue>.*?)[\"]?\\n"],
       "datasourceTemplate": "docker"
     },
     {
       // Generic detection of container images in images.yaml via github releases.
       "customType": "regex",
-      "fileMatch": ["^imagevector\/images.yaml$", "^pkg\/provider-local\/imagevector/images.yaml$"],
+      "fileMatch": ["^imagevector\/images.yaml$"],
       "matchStrings": ["\\s+sourceRepository:\\s+github.com\/(?<depName>.*?)\\n\\s+repository:\\s+.*\\n\\s+tag:\\s+[\"]?(?<currentValue>.*?)[\"]?\\n"],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      // Detection for images with prow like tags (e.g. v20240213-749005b2).
+      "customType": "regex",
+      "fileMatch": ["^pkg\/provider-local\/imagevector/images.yaml$"],
+      "matchStrings": ["(?<depName>gcr\\.io\/k8s-staging-kind\/.*?):(?<currentValue>.*?)\\s"],
+      "datasourceTemplate": "docker"
     }
   ],
   "separateMinorPatch": true,
@@ -191,7 +198,7 @@
     {
       // Add PR footer with release notes for docker releases.
       "matchDatasources": ["docker"],
-      "matchFileNames": ["^imagevector/**"],
+      "matchFileNames": ["imagevector/**"],
       "prFooter": "**Release note**:\n```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`.\n```"
     },
     {

--- a/pkg/provider-local/imagevector/images.yaml
+++ b/pkg/provider-local/imagevector/images.yaml
@@ -1,6 +1,6 @@
 images:
 - name: machine-controller-manager-provider-local
-  sourceRepository: github.com/gardener/machine-controller-manager-provider-local
+  sourceRepository: github.com/gardener/gardener
   repository: machine-controller-manager-provider-local
   tag: v0.0.0
 - name: local-path-provisioner

--- a/pkg/provider-local/imagevector/images.yaml
+++ b/pkg/provider-local/imagevector/images.yaml
@@ -5,9 +5,9 @@ images:
   tag: v0.0.0
 - name: local-path-provisioner
   sourceRepository: github.com/kubernetes-sigs/kind/tree/main/images/local-path-provisioner
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kindest/local-path-provisioner
-  tag: v0.0.22-kind.0
+  repository: gcr.io/k8s-staging-kind/local-path-provisioner
+  tag: v20240513-b9bba138
 - name: local-path-helper
   sourceRepository: github.com/kubernetes-sigs/kind/tree/main/images/local-path-helper
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kindest/local-path-helper
-  tag: v20220512-507ff70b
+  repository: gcr.io/k8s-staging-kind/local-path-helper
+  tag: v20240213-749005b2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Include `provider-local`s image vector for Renovate updates

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
