### PR TITLE
Shoot deletion: Prevent false negative validation when maintenance operation annotation is still present

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2303,7 +2303,13 @@ func validateShootOperation(operation, maintenanceOperation string, shoot *core.
 	}
 
 	allErrs = append(allErrs, validateShootOperationContext(operation, shoot, fldPathOp)...)
-	allErrs = append(allErrs, validateShootOperationContext(maintenanceOperation, shoot, fldPathMaintOp)...)
+	if shoot.DeletionTimestamp == nil {
+		// Only validate maintenance operation context when shoot has no deletion timestamp. If it has such a timestamp,
+		// any validation is pointless since there are no maintenance operations for shoots in deletion, so we basically
+		// don't care. Without this, we could wrongly prevent metadata changes in case the annotation is still present
+		// but the shoot is in deletion.
+		allErrs = append(allErrs, validateShootOperationContext(maintenanceOperation, shoot, fldPathMaintOp)...)
+	}
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -4688,6 +4688,23 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Entry("rotate-serviceaccount-key-complete", "rotate-serviceaccount-key-complete"),
 			)
 
+			DescribeTable("not forbid certain rotation maintenance operations when shoot is in deletion",
+				func(operation string) {
+					shoot.DeletionTimestamp = &metav1.Time{}
+
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", operation)
+					Expect(ValidateShoot(shoot)).To(BeEmpty())
+					delete(shoot.Annotations, "maintenance.gardener.cloud/operation")
+				},
+
+				Entry("rotate-credentials-start", "rotate-credentials-start"),
+				Entry("rotate-credentials-complete", "rotate-credentials-complete"),
+				Entry("rotate-etcd-encryption-key-start", "rotate-etcd-encryption-key-start"),
+				Entry("rotate-etcd-encryption-key-complete", "rotate-etcd-encryption-key-complete"),
+				Entry("rotate-serviceaccount-key-start", "rotate-serviceaccount-key-start"),
+				Entry("rotate-serviceaccount-key-complete", "rotate-serviceaccount-key-complete"),
+			)
+
 			DescribeTable("forbid hibernating the shoot when certain rotation maintenance operations are set",
 				func(operation string) {
 					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", operation)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Currently, `Shoot`s cannot fully deleted in case they were annotated with `maintenance.gardener.cloud/operation`: Eventually, `gardenlet` successfully deletes the cluster (i.e., `lastOperation` shows `Delete Succeeded`), however, it fails to remove its finalizer from the resource:

```
{"level":"error","ts":"2024-05-24T11:14:47.734Z","msg":"Reconciler error","controller":"shoot","object":{"name":"local","namespace":"garden-local"},"namespace":"garden-local","name":"local","reconcileID":"6086b9d5-2d00-4224-a4e2-40be425353b2","error":"failed to remove finalizer: Shoot.core.gardener.cloud \"local\" is invalid: metadata.annotations[maintenance.gardener.cloud/operation]: Forbidden: cannot start rotation of all credentials if shoot was not yet created successfully or is not ready for reconciliation","stacktrace":"..."}
```

This can be reproduced locally as follows:

```
$ kubectl create -f example/provider-local/shoot.yaml
shoot.core.gardener.cloud/local created

$ kubectl -n garden-local patch shoot local --type=merge --patch='{"metadata":{"finalizers":["foo.com/bar"]}}'
shoot.core.gardener.cloud/local patched

$ kubectl -n garden-local patch shoot local --subresource=status --type=merge --patch='{"status":{"lastOperation":{"type":"Create","state":"Succeeded"}}}'
shoot.core.gardener.cloud/local patched

$ kubectl -n garden-local annotate shoot local maintenance.gardener.cloud/operation=rotate-credentials-start
shoot.core.gardener.cloud/local annotated

$ ./hack/usage/delete shoot local garden-local
shoot.core.gardener.cloud/local annotated
shoot.core.gardener.cloud "local" deleted

$ kubectl -n garden-local patch shoot local --subresource=status --type=merge --patch='{"status":{"lastOperation":{"type":"Delete","state":"Succeeded"}}}'
shoot.core.gardener.cloud/local patched

$ kubectl -n garden-local patch shoot local --type=merge --patch='{"metadata":{"finalizers":null}}'
The Shoot "local" is invalid: metadata.annotations[maintenance.gardener.cloud/operation]: Forbidden: cannot start rotation of all credentials if shoot was not yet created successfully or is not ready for reconciliation
```

This PR relaxes the corresponding validation to only perform the related annotation operation checks when the `Shoot` has no deletion timestamp (if it has, we don't care anymore since there are no maintenance operations for "shoots in deletion" anyways).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which prevented `Shoot` deletion in case it was still annotated with `maintenance.gardener.cloud/operation`.
```
