### PR TITLE
VPN sidecar containers: Disable autoscaling and reduce resource requests

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -465,25 +465,16 @@ var _ = Describe("KubeAPIServer", func() {
 							},
 						},
 						{
-							ContainerName:    "vpn-client-0",
-							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("20Mi"),
-							},
+							ContainerName: "vpn-client-0",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 						},
 						{
-							ContainerName:    "vpn-client-1",
-							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("20Mi"),
-							},
+							ContainerName: "vpn-client-1",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 						},
 						{
-							ContainerName:    "vpn-path-controller",
-							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("20Mi"),
-							},
+							ContainerName: "vpn-path-controller",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 						},
 					},
 				),

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -2507,8 +2507,8 @@ rules:
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("100Mi"),
+								corev1.ResourceCPU:    resource.MustParse("20m"),
+								corev1.ResourceMemory: resource.MustParse("10Mi"),
 							},
 							Limits: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -2607,7 +2607,7 @@ rules:
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),
-							corev1.ResourceMemory: resource.MustParse("20Mi"),
+							corev1.ResourceMemory: resource.MustParse("10Mi"),
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("50Mi"),

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -793,8 +793,8 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("100Mi"),
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -854,7 +854,7 @@ func (k *kubeAPIServer) vpnSeedPathControllerContainer() *corev1.Container {
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("20Mi"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("50Mi"),

--- a/pkg/component/kubernetes/apiserver/hvpa.go
+++ b/pkg/component/kubernetes/apiserver/hvpa.go
@@ -197,18 +197,12 @@ func (k *kubeAPIServer) computeVerticalPodAutoscalerContainerResourcePolicies(ku
 		for i := 0; i < k.values.VPN.HighAvailabilityNumberOfSeedServers; i++ {
 			vpaContainerResourcePolicies = append(vpaContainerResourcePolicies, vpaautoscalingv1.ContainerResourcePolicy{
 				ContainerName: fmt.Sprintf("%s-%d", containerNameVPNSeedClient, i),
-				MinAllowed: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("20Mi"),
-				},
-				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+				Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 			})
 		}
 		vpaContainerResourcePolicies = append(vpaContainerResourcePolicies, vpaautoscalingv1.ContainerResourcePolicy{
 			ContainerName: containerNameVPNPathController,
-			MinAllowed: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("20Mi"),
-			},
-			ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+			Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 		})
 	}
 

--- a/pkg/component/shared/kubeapiserver.go
+++ b/pkg/component/shared/kubeapiserver.go
@@ -230,6 +230,8 @@ func DeployKubeAPIServer(
 	//   resources in VPAAndHPA mode.
 	if deployment != nil {
 		for _, container := range deployment.Spec.Template.Spec.Containers {
+			// Autoscaling for the VPN sidecar containers is disabled,
+			// that's why it is enough to preserve the resource requests for the kube-apiserver container only.
 			if container.Name == kubeapiserver.ContainerNameKubeAPIServer {
 				// Only set requests to allow limits to be removed
 				kubeAPIServer.SetAutoscalingAPIServerResources(corev1.ResourceRequirements{Requests: container.Resources.Requests})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling networking
/kind bug

**What this PR does / why we need it**:
1. Disable autoscaling for the VPN sidecar containers: In the light of https://github.com/gardener/gardener/issues/9866, we decided to directly disable the autoscaling for the VPN sidecar containers instead of preserving the container resource requests.

The resource usage of the VPN sidecar containers is looks stable.

The below tables are from a landscape from the last 7days.

```
cpu
| component           | usage max | usage min | usage avg | requests | limits |
|---------------------|-----------|-----------|-----------|----------|--------|
| vpn-client-0        | 316m      | 0.4m      | 2.61m     | 100m     | -      |
| vpn-client-1        | 7.48m     | 0m        | 0m        | 100m     | -      |
| vpn-path-controller | 13.1m     | 2.91m     | 4.33m     | 10m      | -      |

memory
| component           | usage max | usage min | usage avg | requests | limits |
|---------------------|-----------|-----------|-----------|----------|--------|
| vpn-client-0        | 5.87MiB   | 1.94MiB   | 2.13MiB   | 100Mi    | 100Mi  |
| vpn-client-1        | 5.05MiB   | 1.91MiB   | 2.1MiB    | 100Mi    | 100Mi  |
| vpn-path-controller | 4.86MiB   | 1.29MiB   | 1.37MiB   | 20Mi     | 50Mi   |
```

@MartinWeindel also shared that the sidecar containers should not be autoscaled as `vpn-client-0` or `vpn-client-1` work in active-passive mode and for example `vpn-client-1` should not be down-scaled as this can potentially cause issues when `vpn-client-1` takes over the active role.

2. Reduce resource requests for the VPN sidecar containers: Based on the data from the above tables, I decided to reduce the resource requests for the VPN sidecar containers as follows:

vpn-client-0 and vpn-client-1:
```diff
  resources:
    requests:
-      cpu: 100m
-      memory: 100Mi
+      cpu: 20m
+      memory: 10Mi
    limits:
      memory: 100Mi
```

vpn-path-controller:
```diff
  resources:
    requests:
      cpu: 10m
-      memory: 20Mi
+      memory: 10Mi
    limits:
      memory: 50Mi
```


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/9866

**Special notes for your reviewer**:
N/A, thanks to @ScheererJ @MartinWeindel and @voelzmo for the internal discussion

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
gardenlet: An issue causing gardenlet to trigger unnecessary kube-apiserver rolling updates by reverting the VPN sidercar containers resource requests set by HVPA for HA Shoots is now fixed by disabling autoscaling for the VPN sidecar containers.
```

```other operator
The resource requests of the `vpn-client-{0,1}` sidecar container are reduced from 100m and 100Mi to 20m and 10Mi. The resource requests of the `vpn-controller-path` sidecar container are reduced from 20Mi to 10Mi.
```
