### PR TITLE
The shoot control plane Prometheus forwards its alerts to the seed alertmanager

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -134,10 +134,19 @@ type CentralConfigs struct {
 
 // AlertingValues contains alerting configuration for this Prometheus instance.
 type AlertingValues struct {
-	// AlertmanagerName is the name of the alertmanager to which alerts should be sent.
-	AlertmanagerName string
+	// Alertmanagers is a slice containing the alertmanager names (and namespaces) to which alerts should be sent.
+	Alertmanagers []*Alertmanager
 	// AdditionalAlertmanager contains the data of the 'alerting' secret (url, credentials, etc.).
 	AdditionalAlertmanager map[string][]byte
+}
+
+// Alertmanager contains the name and namespace of an alertmanager to which alerts should be sent.
+type Alertmanager struct {
+	// Name is the name of the alertmanager to which alerts should be sent.
+	Name string
+	// Namespace is the namespace of the alertmanager to which alerts should be sent.
+	// If not set, the namespace of the Prometheus instance is used.
+	Namespace *string
 }
 
 // RemoteWriteValues contains remote write configuration for this Prometheus instance.

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -107,15 +107,15 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 		if len(p.values.Alerting.Alertmanagers) > 0 {
 			obj.Spec.Alerting = &monitoringv1.AlertingSpec{}
 		}
-		for _, alertmanagerItem := range p.values.Alerting.Alertmanagers {
+		for _, alertManager := range p.values.Alerting.Alertmanagers {
 			namespace := p.namespace
-			if alertmanagerItem.Namespace != nil {
-				namespace = *alertmanagerItem.Namespace
+			if alertManager.Namespace != nil {
+				namespace = *alertManager.Namespace
 			}
 			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers,
 				monitoringv1.AlertmanagerEndpoints{
 					Namespace: namespace,
-					Name:      alertmanagerItem.Name,
+					Name:      alertManager.Name,
 					Port:      intstr.FromString(alertmanager.PortNameMetrics),
 					AlertRelabelConfigs: append(
 						[]monitoringv1.RelabelConfig{{

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -108,20 +108,19 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 			obj.Spec.Alerting = &monitoringv1.AlertingSpec{}
 		}
 		for _, alertManager := range p.values.Alerting.Alertmanagers {
-			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers,
-				monitoringv1.AlertmanagerEndpoints{
-					Namespace: ptr.Deref(alertManager.Namespace, p.namespace),
-					Name:      alertManager.Name,
-					Port:      intstr.FromString(alertmanager.PortNameMetrics),
-					AlertRelabelConfigs: append(
-						[]monitoringv1.RelabelConfig{{
-							SourceLabels: []monitoringv1.LabelName{"ignoreAlerts"},
-							Regex:        `true`,
-							Action:       "drop",
-						}},
-						p.values.AdditionalAlertRelabelConfigs...,
-					),
-				})
+			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers, monitoringv1.AlertmanagerEndpoints{
+				Namespace: ptr.Deref(alertManager.Namespace, p.namespace),
+				Name:      alertManager.Name,
+				Port:      intstr.FromString(alertmanager.PortNameMetrics),
+				AlertRelabelConfigs: append(
+					[]monitoringv1.RelabelConfig{{
+						SourceLabels: []monitoringv1.LabelName{"ignoreAlerts"},
+						Regex:        `true`,
+						Action:       "drop",
+					}},
+					p.values.AdditionalAlertRelabelConfigs...,
+				),
+			})
 		}
 
 		if p.values.Alerting.AdditionalAlertmanager != nil {

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -104,20 +104,28 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 	}
 
 	if p.values.Alerting != nil {
-		obj.Spec.Alerting = &monitoringv1.AlertingSpec{
-			Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
-				Namespace: p.namespace,
-				Name:      p.values.Alerting.AlertmanagerName,
-				Port:      intstr.FromString(alertmanager.PortNameMetrics),
-				AlertRelabelConfigs: append(
-					[]monitoringv1.RelabelConfig{{
-						SourceLabels: []monitoringv1.LabelName{"ignoreAlerts"},
-						Regex:        `true`,
-						Action:       "drop",
-					}},
-					p.values.AdditionalAlertRelabelConfigs...,
-				),
-			}},
+		if len(p.values.Alerting.Alertmanagers) > 0 {
+			obj.Spec.Alerting = &monitoringv1.AlertingSpec{}
+		}
+		for _, alertmanagerItem := range p.values.Alerting.Alertmanagers {
+			namespace := p.namespace
+			if alertmanagerItem.Namespace != nil {
+				namespace = *alertmanagerItem.Namespace
+			}
+			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers,
+				monitoringv1.AlertmanagerEndpoints{
+					Namespace: namespace,
+					Name:      alertmanagerItem.Name,
+					Port:      intstr.FromString(alertmanager.PortNameMetrics),
+					AlertRelabelConfigs: append(
+						[]monitoringv1.RelabelConfig{{
+							SourceLabels: []monitoringv1.LabelName{"ignoreAlerts"},
+							Regex:        `true`,
+							Action:       "drop",
+						}},
+						p.values.AdditionalAlertRelabelConfigs...,
+					),
+				})
 		}
 
 		if p.values.Alerting.AdditionalAlertmanager != nil {

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -108,13 +108,9 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 			obj.Spec.Alerting = &monitoringv1.AlertingSpec{}
 		}
 		for _, alertManager := range p.values.Alerting.Alertmanagers {
-			namespace := p.namespace
-			if alertManager.Namespace != nil {
-				namespace = *alertManager.Namespace
-			}
 			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers,
 				monitoringv1.AlertmanagerEndpoints{
-					Namespace: namespace,
+					Namespace: ptr.Deref(alertManager.Namespace, p.namespace),
 					Name:      alertManager.Name,
 					Port:      intstr.FromString(alertmanager.PortNameMetrics),
 					AlertRelabelConfigs: append(

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -685,7 +685,7 @@ func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed,
 	}
 
 	if alertingSMTPSecret != nil {
-		values.Alerting = &prometheus.AlertingValues{AlertmanagerName: "alertmanager-seed"}
+		values.Alerting = &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-seed"}}}
 	}
 
 	return sharedcomponent.NewPrometheus(log, r.SeedClientSet.Client(), r.GardenNamespace, values)

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -114,6 +114,10 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 			PrometheusRules: shootprometheus.CentralPrometheusRules(b.Shoot.IsWorkerless, b.Shoot.WantsAlertmanager),
 			ServiceMonitors: shootprometheus.CentralServiceMonitors(b.Shoot.WantsAlertmanager),
 		},
+		Alerting: &prometheus.AlertingValues{
+			Alertmanagers: []*prometheus.Alertmanager{{
+				Name:      "alertmanager-seed",
+				Namespace: ptr.To(v1beta1constants.GardenNamespace)}}},
 		Ingress: &prometheus.IngressValues{
 			Host:                              b.ComputePrometheusHost(),
 			SecretsManager:                    b.SecretsManager,
@@ -129,7 +133,6 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		},
 	}
 
-	values.Alerting = &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-seed", Namespace: ptr.To(v1beta1constants.GardenNamespace)}}}
 	if b.Shoot.WantsAlertmanager {
 		values.Alerting.Alertmanagers = append(values.Alerting.Alertmanagers, &prometheus.Alertmanager{Name: "alertmanager-shoot"})
 

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -129,8 +129,9 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		},
 	}
 
+	values.Alerting = &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-seed", Namespace: ptr.To(v1beta1constants.GardenNamespace)}}}
 	if b.Shoot.WantsAlertmanager {
-		values.Alerting = &prometheus.AlertingValues{AlertmanagerName: "alertmanager-shoot"}
+		values.Alerting.Alertmanagers = append(values.Alerting.Alertmanagers, &prometheus.Alertmanager{Name: "alertmanager-shoot"})
 
 		if secret := b.LoadSecret(v1beta1constants.GardenRoleAlerting); secret != nil &&
 			len(secret.Data["auth_type"]) > 0 &&

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1211,7 +1211,7 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 			PrometheusRules:         gardenprometheus.CentralPrometheusRules(),
 			ServiceMonitors:         gardenprometheus.CentralServiceMonitors(),
 		},
-		Alerting: &prometheus.AlertingValues{AlertmanagerName: "alertmanager-garden"},
+		Alerting: &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-garden"}}},
 		AdditionalAlertRelabelConfigs: []monitoringv1.RelabelConfig{
 			{
 				SourceLabels: []monitoringv1.LabelName{"project", "name"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:

The shoot control plane Prometheus should forward its alerts to the alertmanager in the garden namespace of the seed, to the `alertmanager-seed`.

**Which issue(s) this PR fixes**:

Before #9695 (that was released with [v1.95.0](https://github.com/gardener/gardener/releases/tag/v1.95.0)), the shoot Prometheus always forwarded its alerts to the `alertmanager-seed`. The `alertmanager-seed` can be configured in real landscapes e.g. to send email notifications to Gardener operators. This can be useful if some shoot control plane alerts need to be acted upon e.g. for auditing purposes.

With #9695, the shoot control plane Prometheus only forwards the alerts to the shoot alertmanager. Note that the `alertmanager-shoot` is deployed only if the alerting feature is turned on (see [doc](https://gardener.cloud/docs/gardener/monitoring/alerting/#alerting-for-users)).

**Special notes for your reviewer**:

/cc @vicwicker @rfranzke @ScheererJ 

<details>
<summary>Additional hints when testing in the local setup...</summary>

In the local setup, to deploy the seed alertmanager, we can apply the following secret based on `example/10-secret-alerting.yaml`:

```bash
kubectl apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: alerting
  namespace: garden
  labels:
    gardener.cloud/role: alerting
type: Opaque
stringData:
  auth_type: smtp
  auth_identity: identity
  auth_password: password
  auth_username: username
  from: from@localhost
  smarthost: localhost:25
  to: to@localhost
EOF
```

and then restart the gardenlet(s) e.g. with `kubectl delete pods -l role=gardenlet`

Furthermore, in the shoot control plane namespace, we can add some alerts that are always firing:

```bash
k apply -f - <<EOF
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  labels:
    prometheus: shoot
  name: test
spec:
  groups:
  - name: test
    rules:
    - alert: TestOperator
      expr: vector(1)
      for: 1m
      labels:
        type: seed
        severity: critical
        visibility: operator
      annotations:
        summary: Shoot test summary (operator)
        description: |-
          Shoot test description (operator)
    - alert: TestAll
      expr: vector(1)
      for: 1m
      labels:
        type: seed
        severity: critical
        visibility: all
      annotations:
        summary: Shoot test summary (all)
        description: |-
          Shoot test description (all)
EOF
```

Then we can port-forward to the shoot and seed alertmanagers and verify that the alerts were sent there.

</details>

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A regression is fixed and now the shoot control plane Prometheus forwards its alerts to the seed alertmanager.
```
