### PR TITLE
Register `Node` tains with Kubelet

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -541,6 +541,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		valitailEnabled:         o.values.ValitailEnabled,
 		nodeLocalDNSEnabled:     o.values.NodeLocalDNSEnabled,
 		primaryIPFamily:         o.values.PrimaryIPFamily,
+		taints:                  worker.Taints,
 	}, nil
 }
 
@@ -604,6 +605,7 @@ type deployer struct {
 	valitailEnabled         bool
 	nodeLocalDNSEnabled     bool
 	primaryIPFamily         gardencorev1beta1.IPFamily
+	taints                  []corev1.Taint
 }
 
 // exposed for testing
@@ -641,6 +643,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		APIServerURL:            d.apiServerURL,
 		Sysctls:                 d.worker.Sysctls,
 		PreferIPv6:              d.primaryIPFamily == gardencorev1beta1.IPFamilyIPv6,
+		Taints:                  d.taints,
 	}
 
 	switch d.purpose {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/components.go
@@ -6,6 +6,7 @@ package components
 
 import (
 	"github.com/Masterminds/semver/v3"
+	corev1 "k8s.io/api/core/v1"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -40,4 +41,5 @@ type Context struct {
 	APIServerURL            string
 	Sysctls                 map[string]string
 	PreferIPv6              bool
+	Taints                  []corev1.Taint
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/imagevector"
@@ -52,7 +53,7 @@ func (component) Name() string {
 }
 
 func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
-	fileContentKubeletConfig, err := getFileContentKubeletConfig(ctx.KubernetesVersion, ctx.ClusterDNSAddress, ctx.ClusterDomain, ctx.KubeletConfigParameters)
+	fileContentKubeletConfig, err := getFileContentKubeletConfig(ctx.KubernetesVersion, ctx.ClusterDNSAddress, ctx.ClusterDomain, ctx.Taints, ctx.KubeletConfigParameters)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,9 +113,9 @@ ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/kubelet
 	return []extensionsv1alpha1.Unit{kubeletUnit}, kubeletFiles, nil
 }
 
-func getFileContentKubeletConfig(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain string, params components.ConfigurableKubeletConfigParameters) (*extensionsv1alpha1.FileContentInline, error) {
+func getFileContentKubeletConfig(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain string, taints []corev1.Taint, params components.ConfigurableKubeletConfigParameters) (*extensionsv1alpha1.FileContentInline, error) {
 	var (
-		kubeletConfig = Config(kubernetesVersion, clusterDNSAddress, clusterDomain, params)
+		kubeletConfig = Config(kubernetesVersion, clusterDNSAddress, clusterDomain, taints, params)
 		configFCI     = &extensionsv1alpha1.FileContentInline{Encoding: "b64"}
 		kcCodec       = NewConfigCodec(oscutils.NewFileContentInlineCodec())
 	)

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -52,6 +52,12 @@ var _ = Describe("Config", func() {
 			StreamingConnectionIdleTimeout:   &metav1.Duration{Duration: time.Minute * 12},
 		}
 
+		taints = []corev1.Taint{{
+			Key:    "foo",
+			Value:  "bar",
+			Effect: corev1.TaintEffectNoSchedule,
+		}}
+
 		kubeletConfigWithDefaults = &kubeletconfigv1beta1.KubeletConfiguration{
 			Authentication: kubeletconfigv1beta1.KubeletAuthentication{
 				Anonymous: kubeletconfigv1beta1.KubeletAnonymousAuthentication{
@@ -135,10 +141,11 @@ var _ = Describe("Config", func() {
 			PodsPerCore:    0,
 			ReadOnlyPort:   0,
 			ResolverConfig: ptr.To("/etc/resolv.conf"),
-			RegisterWithTaints: []corev1.Taint{{
-				Key:    "node.gardener.cloud/critical-components-not-ready",
-				Effect: corev1.TaintEffectNoSchedule,
-			}},
+			RegisterWithTaints: append(taints,
+				corev1.Taint{
+					Key:    "node.gardener.cloud/critical-components-not-ready",
+					Effect: corev1.TaintEffectNoSchedule,
+				}),
 			RuntimeRequestTimeout:          metav1.Duration{Duration: 2 * time.Minute},
 			SerializeImagePulls:            ptr.To(true),
 			ServerTLSBootstrap:             true,
@@ -257,12 +264,6 @@ var _ = Describe("Config", func() {
 			if mutateExpectConfigFn != nil {
 				mutateExpectConfigFn(expectation)
 			}
-
-			taints := []corev1.Taint{{
-				Key:    "foo",
-				Value:  "bar",
-				Effect: corev1.TaintEffectNoSchedule,
-			}}
 
 			Expect(kubelet.Config(semver.MustParse(kubernetesVersion), clusterDNSAddress, clusterDomain, taints, params)).To(DeepEqual(expectation))
 		},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -226,10 +226,17 @@ var _ = Describe("Config", func() {
 			PodPidsLimit:                     params.PodPidsLimit,
 			ProtectKernelDefaults:            true,
 			ReadOnlyPort:                     0,
-			RegisterWithTaints: []corev1.Taint{{
-				Key:    "node.gardener.cloud/critical-components-not-ready",
-				Effect: corev1.TaintEffectNoSchedule,
-			}},
+			RegisterWithTaints: []corev1.Taint{
+				{
+					Key:    "foo",
+					Value:  "bar",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "node.gardener.cloud/critical-components-not-ready",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
 			RegistryBurst:                  20,
 			RegistryPullQPS:                ptr.To[int32](10),
 			ResolverConfig:                 ptr.To("/etc/resolv.conf"),
@@ -251,7 +258,13 @@ var _ = Describe("Config", func() {
 				mutateExpectConfigFn(expectation)
 			}
 
-			Expect(kubelet.Config(semver.MustParse(kubernetesVersion), clusterDNSAddress, clusterDomain, params)).To(DeepEqual(expectation))
+			taints := []corev1.Taint{{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: corev1.TaintEffectNoSchedule,
+			}}
+
+			Expect(kubelet.Config(semver.MustParse(kubernetesVersion), clusterDNSAddress, clusterDomain, taints, params)).To(DeepEqual(expectation))
 		},
 
 		Entry(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR makes Kubelet to register desired taints during node registration. Earlier, we needed to wait for MCM to configure the taints which can happen too late and leads to several issues, as reported in https://github.com/gardener/machine-controller-manager/issues/740.

A similar approach was already followed by https://github.com/gardener/gardener/pull/7202.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager/issues/740.

**Special notes for your reviewer**:
/cc @aaronfern @rishabh-11 @DockToFuture @dhague

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The Kubelet configuration was enhanced to add configured worker taints during node registration. Earlier, only the `machine-controller-manager` was responsible to add taints to the `Node`s which happened asynchronously, so that unwanted workload might have already scheduled to these workers.
```
