### PR TITLE
Promote feature gate `VPAForETCD` to beta status

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,7 +34,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootForceDeletion                 | `true`  | `Beta`  | `1.91` |        |
 | UseNamespacedCloudProfile          | `false` | `Alpha` | `1.92` |        |
 | ShootManagedIssuer                 | `false` | `Alpha` | `1.93` |        |
-| VPAForETCD                         | `false` | `Alpha` | `1.94` |        |
+| VPAForETCD                         | `false` | `Alpha` | `1.94` | `1.95` |
+| VPAForETCD                         | `true`  | `Beta`  | `1.96` |        |
 | VPAAndHPAForAPIServer              | `false` | `Alpha` | `1.95` |        |
 
 ## Feature Gates for Graduated or Deprecated Features

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,8 +34,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootForceDeletion                 | `true`  | `Beta`  | `1.91` |        |
 | UseNamespacedCloudProfile          | `false` | `Alpha` | `1.92` |        |
 | ShootManagedIssuer                 | `false` | `Alpha` | `1.93` |        |
-| VPAForETCD                         | `false` | `Alpha` | `1.94` | `1.95` |
-| VPAForETCD                         | `true`  | `Beta`  | `1.96` |        |
+| VPAForETCD                         | `false` | `Alpha` | `1.94` | `1.96` |
+| VPAForETCD                         | `true`  | `Beta`  | `1.97` |        |
 | VPAAndHPAForAPIServer              | `false` | `Alpha` | `1.95` |        |
 
 ## Feature Gates for Graduated or Deprecated Features

--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -17,13 +17,15 @@ However, there are two supported autoscaling modes for the Garden or Shoot clust
    In `HVPA` mode, the etcd is scaled by the [hvpa-controller](https://github.com/gardener/hvpa-controller). The gardenlet/gardener-operator is creating an `HVPA` resource for the etcd (`main` or `events`).
    The `HVPA` enables a vertical scaling for etcd.
 
-   The `HVPA` mode is the used autoscaling mode when the `HVPA` feature gate is enabled (and the `VPAForETCD` feature gate is disabled).
+   The `HVPA` mode is the used autoscaling mode when the `HVPA` feature gate is enabled and the `VPAForETCD` feature gate is disabled.
 
 - `VPA`
 
    In `VPA` mode, the etcd is scaled by a native `VPA` resource.
 
-   The `VPA` mode is the used autoscaling mode when the `VPAForETCD` feature gate is enabled (takes precedence over the `HVPA` feature gate).
+   The `VPA` mode is the used autoscaling mode when the `VPAForETCD` feature gate is enabled (takes precedence over the `HVPA` feature gate). 
+
+Note: starting with release 1.96, the `VPAForETCD` feature gate is enabled by default.
 
 For both of the autoscaling modes downscaling is handled more pessimistically to prevent many subsequent etcd restarts. Thus, for `production` and `infrastructure` Shoot clusters (or all Garden clusters), downscaling is deactivated for the main etcd. For all other Shoot clusters, lower advertised requests/limits are only applied during the Shoot's maintenance time window.
 

--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -25,7 +25,8 @@ However, there are two supported autoscaling modes for the Garden or Shoot clust
 
    The `VPA` mode is the used autoscaling mode when the `VPAForETCD` feature gate is enabled (takes precedence over the `HVPA` feature gate). 
 
-Note: starting with release 1.96, the `VPAForETCD` feature gate is enabled by default.
+> [!NOTE]
+> Starting with release `v1.97`, the `VPAForETCD` feature gate is enabled by default.
 
 For both of the autoscaling modes downscaling is handled more pessimistically to prevent many subsequent etcd restarts. Thus, for `production` and `infrastructure` Shoot clusters (or all Garden clusters), downscaling is deactivated for the main etcd. For all other Shoot clusters, lower advertised requests/limits are only applied during the Shoot's maintenance time window.
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -30,7 +30,7 @@ const (
 	// VPAForETCD enables using plain VPA for etcd-main and etcd-events, even if HVPA is enabled for the other components.
 	// owner @voelzmo
 	// alpha: v1.94.0
-	// beta: v1.96.0
+	// beta: v1.97.0
 	VPAForETCD featuregate.Feature = "VPAForETCD"
 
 	// DefaultSeccompProfile defaults the seccomp profile for Gardener managed workload in the seed to RuntimeDefault.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -30,6 +30,7 @@ const (
 	// VPAForETCD enables using plain VPA for etcd-main and etcd-events, even if HVPA is enabled for the other components.
 	// owner @voelzmo
 	// alpha: v1.94.0
+	// beta: v1.96.0
 	VPAForETCD featuregate.Feature = "VPAForETCD"
 
 	// DefaultSeccompProfile defaults the seccomp profile for Gardener managed workload in the seed to RuntimeDefault.
@@ -114,7 +115,7 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPA:                            {Default: false, PreRelease: featuregate.Alpha},
 	HVPAForShootedSeed:              {Default: false, PreRelease: featuregate.Alpha},
-	VPAForETCD:                      {Default: false, PreRelease: featuregate.Alpha},
+	VPAForETCD:                      {Default: true, PreRelease: featuregate.Beta},
 	DefaultSeccompProfile:           {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	IPv6SingleStack:                 {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
We have been running our internal landscapes with this feature gate enabled and didn't encounter any issues so far. Hence, we now promote this feature gate to beta.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `VPAForETCD` feature gate is promoted to beta and now enabled by default.
```
