### PR TITLE
Add the certificate controller manager metrics to the seed Prometheus

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/seed/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/scrapeconfigs.go
@@ -80,7 +80,7 @@ func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
 				HonorTimestamps: ptr.To(false),
 				MetricsPath:     ptr.To("/metrics"),
 				StaticConfigs: []monitoringv1alpha1.StaticConfig{{
-					Targets: []monitoringv1alpha1.Target{"cert-controller-manager.shoot--garden--aws-ap1.svc:10258"},
+					Targets: []monitoringv1alpha1.Target{"cert-controller-manager:10258"},
 				}},
 				RelabelConfigs: []monitoringv1.RelabelConfig{{
 					Action:      "replace",
@@ -91,7 +91,7 @@ func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
 					Action:      "replace",
 					TargetLabel: "__name__",
 					Regex:       "promhttp_metric_handler_requests_total",
-					Replacement: "cert_manager_promhttp_metric_handler_requests_total",
+					Replacement: ptr.To("cert_manager_promhttp_metric_handler_requests_total"),
 				}},
 			},
 		},

--- a/pkg/component/observability/monitoring/prometheus/seed/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/scrapeconfigs.go
@@ -71,5 +71,29 @@ func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
 				),
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cert-controller-manager",
+			},
+			Spec: monitoringv1alpha1.ScrapeConfigSpec{
+				HonorLabels:     ptr.To(true),
+				HonorTimestamps: ptr.To(false),
+				MetricsPath:     ptr.To("/metrics"),
+				StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+					Targets: []monitoringv1alpha1.Target{"cert-controller-manager.shoot--garden--aws-ap1.svc:10258"},
+				}},
+				RelabelConfigs: []monitoringv1.RelabelConfig{{
+					Action:      "replace",
+					Replacement: ptr.To("cert-controller-manager"),
+					TargetLabel: "job",
+				}},
+				MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
+					Action:      "replace",
+					TargetLabel: "__name__",
+					Regex:       "promhttp_metric_handler_requests_total",
+					Replacement: "cert_manager_promhttp_metric_handler_requests_total",
+				}},
+			},
+		},
 	}
 }

--- a/pkg/component/observability/monitoring/prometheus/seed/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/scrapeconfigs_test.go
@@ -65,6 +65,39 @@ var _ = Describe("ScrapeConfigs", func() {
 						}},
 					},
 				},
+
+				&monitoringv1alpha1.ScrapeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cadvisor",
+					},
+					Spec: monitoringv1alpha1.ScrapeConfigSpec{
+						HonorLabels:     ptr.To(true),
+						HonorTimestamps: ptr.To(false),
+						MetricsPath:     ptr.To("/metrics"),
+						Params: map[string][]string{
+							"match[]": {
+								`{job="cadvisor",namespace=~"extension-(.+)"}`,
+								`{job="cadvisor",namespace="garden"}`,
+								`{job="cadvisor",namespace=~"istio-(.+)"}`,
+								`{job="cadvisor",namespace="kube-system"}`,
+							},
+						},
+						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+							Targets: []monitoringv1alpha1.Target{"cert-controller-manager:10258"},
+						}},
+						RelabelConfigs: []monitoringv1.RelabelConfig{{
+							Action:      "replace",
+							Replacement: ptr.To("cadvisor"),
+							TargetLabel: "job",
+						}},
+						MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
+							SourceLabels: []monitoringv1.LabelName{"__name__"},
+							Action:       "keep",
+							Regex:        "promhttp_metric_handler_requests_total",
+							Replacement: ptr.To("cert_manager_promhttp_metric_handler_requests_total")
+						}},
+					},
+				},
 			))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring

**What this PR does / why we need it**:
I need this PR to capture the certificate controller manager metrics in each seed and later propagate those logs into the long-term Prometheus. This will allow the Argus team and me to create new monitoring dashboards.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I might be missing something here, let me know If I need to change more file
**Release note**:

```other operator
1. Add the certificate controller manager to the seed Prometheus scrape configuration
```
