### PR TITLE
Increase VPA admission-controller QPS values

### DIFF
--- a/pkg/component/autoscaling/vpa/admissioncontroller.go
+++ b/pkg/component/autoscaling/vpa/admissioncontroller.go
@@ -181,6 +181,8 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 					Args: []string{
 						"--v=2",
 						"--stderrthreshold=info",
+						"--kube-api-qps=100",
+						"--kube-api-burst=120",
 						fmt.Sprintf("--client-ca-file=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyCertificateBundle),
 						fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyCertificate),
 						fmt.Sprintf("--tls-private-key=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyPrivateKey),

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -869,6 +869,8 @@ var _ = Describe("VPA", func() {
 								Args: []string{
 									"--v=2",
 									"--stderrthreshold=info",
+									"--kube-api-qps=100",
+									"--kube-api-burst=120",
 									"--client-ca-file=/etc/tls-certs/bundle.crt",
 									"--tls-cert-file=/etc/tls-certs/tls.crt",
 									"--tls-private-key=/etc/tls-certs/tls.key",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Increase the QPS and burst values for the vpa admission-controller to the same values that we already have set on the vpa-recommender and vpa-updater to avoid client-side throttling when lots of Pods are evicted at the same time.

**Which issue(s) this PR fixes**:
If client-side throttling happens on the admission-controller side and the webhook doesn't answer within its 10 second delay, Pods are created with default requests and will be evicted in the next vpa-updater cycle again. This can lead to endless eviction cycles, as the load on the admission-controller doesn't decrease.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Increase VPA admission-controller rate limits to avoid endless eviction loops in case when many Pods are evicted at the same time.
```
