### PR TITLE
[release-v1.95] Automated cherry pick of #9870: The shoot control plane Prometheus forwards its alerts to the seed alertmanager

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -134,10 +134,19 @@ type CentralConfigs struct {
 
 // AlertingValues contains alerting configuration for this Prometheus instance.
 type AlertingValues struct {
-	// AlertmanagerName is the name of the alertmanager to which alerts should be sent.
-	AlertmanagerName string
+	// Alertmanagers is a slice containing the alertmanager names (and namespaces) to which alerts should be sent.
+	Alertmanagers []*Alertmanager
 	// AdditionalAlertmanager contains the data of the 'alerting' secret (url, credentials, etc.).
 	AdditionalAlertmanager map[string][]byte
+}
+
+// Alertmanager contains the name and namespace of an alertmanager to which alerts should be sent.
+type Alertmanager struct {
+	// Name is the name of the alertmanager to which alerts should be sent.
+	Name string
+	// Namespace is the namespace of the alertmanager to which alerts should be sent.
+	// If not set, the namespace of the Prometheus instance is used.
+	Namespace *string
 }
 
 // RemoteWriteValues contains remote write configuration for this Prometheus instance.

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -108,12 +108,11 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 			obj.Spec.Alerting = &monitoringv1.AlertingSpec{}
 		}
 		for _, alertManager := range p.values.Alerting.Alertmanagers {
-			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers,
-				monitoringv1.AlertmanagerEndpoints{
-					Namespace: ptr.Deref(alertManager.Namespace, p.namespace),
-					Name:      alertManager.Name,
-					Port:      intstr.FromString(alertmanager.PortNameMetrics),
-				})
+			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers, monitoringv1.AlertmanagerEndpoints{
+				Namespace: ptr.Deref(alertManager.Namespace, p.namespace),
+				Name:      alertManager.Name,
+				Port:      intstr.FromString(alertmanager.PortNameMetrics),
+			})
 		}
 		obj.Spec.AdditionalAlertRelabelConfigs = &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{Name: p.name() + secretNameSuffixAdditionalAlertRelabelConfigs},

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -107,15 +107,15 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 		if len(p.values.Alerting.Alertmanagers) > 0 {
 			obj.Spec.Alerting = &monitoringv1.AlertingSpec{}
 		}
-		for _, alertmanagerItem := range p.values.Alerting.Alertmanagers {
+		for _, alertManager := range p.values.Alerting.Alertmanagers {
 			namespace := p.namespace
-			if alertmanagerItem.Namespace != nil {
-				namespace = *alertmanagerItem.Namespace
+			if alertManager.Namespace != nil {
+				namespace = *alertManager.Namespace
 			}
 			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers,
 				monitoringv1.AlertmanagerEndpoints{
 					Namespace: namespace,
-					Name:      alertmanagerItem.Name,
+					Name:      alertManager.Name,
 					Port:      intstr.FromString(alertmanager.PortNameMetrics),
 				})
 		}

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -108,13 +108,9 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 			obj.Spec.Alerting = &monitoringv1.AlertingSpec{}
 		}
 		for _, alertManager := range p.values.Alerting.Alertmanagers {
-			namespace := p.namespace
-			if alertManager.Namespace != nil {
-				namespace = *alertManager.Namespace
-			}
 			obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers,
 				monitoringv1.AlertmanagerEndpoints{
-					Namespace: namespace,
+					Namespace: ptr.Deref(alertManager.Namespace, p.namespace),
 					Name:      alertManager.Name,
 					Port:      intstr.FromString(alertmanager.PortNameMetrics),
 				})

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -45,6 +45,11 @@ import (
 )
 
 var _ = Describe("Prometheus", func() {
+	type alertmanager struct {
+		name      string
+		namespace string
+	}
+
 	var (
 		ctx context.Context
 
@@ -62,6 +67,8 @@ var _ = Describe("Prometheus", func() {
 		externalLabels                        = map[string]string{"seed": "test"}
 		additionalLabels                      = map[string]string{"foo": "bar"}
 		alertmanagerName                      = "alertmgr-test"
+		alertmanagerName2                     = "alertmgr-test-2"
+		alertmanagerNamespace2                = "alertmanager-namespace-2"
 		serviceAccountNameTargetCluster       = "target-cluster-service-account"
 
 		additionalScrapeConfig1 = `job_name: foo
@@ -87,7 +94,7 @@ honor_labels: true`
 		serviceAccount                      *corev1.ServiceAccount
 		service                             *corev1.Service
 		clusterRoleBinding                  *rbacv1.ClusterRoleBinding
-		prometheusFor                       func(string, bool) *monitoringv1.Prometheus
+		prometheusFor                       func([]alertmanager, bool) *monitoringv1.Prometheus
 		vpa                                 *vpaautoscalingv1.VerticalPodAutoscaler
 		ingress                             *networkingv1.Ingress
 		prometheusRule                      *monitoringv1.PrometheusRule
@@ -203,7 +210,7 @@ honor_labels: true`
 				Namespace: namespace,
 			}},
 		}
-		prometheusFor = func(alertmanagerName string, restrictToNamespace bool) *monitoringv1.Prometheus {
+		prometheusFor = func(alertmanagers []alertmanager, restrictToNamespace bool) *monitoringv1.Prometheus {
 			obj := &monitoringv1.Prometheus{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -282,13 +289,16 @@ honor_labels: true`
 				obj.Spec.RuleNamespaceSelector = nil
 			}
 
-			if alertmanagerName != "" {
-				obj.Spec.Alerting = &monitoringv1.AlertingSpec{
-					Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
-						Namespace: namespace,
-						Name:      alertmanagerName,
-						Port:      intstr.FromString("metrics"),
-					}},
+			if len(alertmanagers) > 0 {
+				obj.Spec.Alerting = &monitoringv1.AlertingSpec{}
+
+				for _, alertmanager := range alertmanagers {
+					obj.Spec.Alerting.Alertmanagers = append(obj.Spec.Alerting.Alertmanagers,
+						monitoringv1.AlertmanagerEndpoints{
+							Namespace: alertmanager.namespace,
+							Name:      alertmanager.name,
+							Port:      intstr.FromString("metrics"),
+						})
 				}
 				obj.Spec.AdditionalAlertRelabelConfigs = &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "prometheus-" + name + "-additional-alert-relabel-configs"},
@@ -601,7 +611,7 @@ honor_labels: true`
 					serviceAccount,
 					service,
 					clusterRoleBinding,
-					prometheusFor("", false),
+					prometheusFor(nil, false),
 					vpa,
 					prometheusRule,
 					scrapeConfig,
@@ -638,7 +648,7 @@ honor_labels: true`
 						serviceAccount,
 						service,
 						clusterRoleBinding,
-						prometheusFor("", false),
+						prometheusFor(nil, false),
 						vpa,
 						prometheusRule,
 						scrapeConfig,
@@ -672,7 +682,7 @@ honor_labels: true`
 						serviceAccount,
 						service,
 						clusterRoleBinding,
-						prometheusFor("", true),
+						prometheusFor(nil, true),
 						vpa,
 						prometheusRule,
 						scrapeConfig,
@@ -687,7 +697,7 @@ honor_labels: true`
 			When("ingress is configured", func() {
 				test := func() {
 					It("should successfully deploy all resources", func() {
-						prometheusObj := prometheusFor("", false)
+						prometheusObj := prometheusFor(nil, false)
 						prometheusObj.Spec.ExternalURL = "https://" + ingressHost
 
 						prometheusRule.Namespace = namespace
@@ -731,7 +741,7 @@ honor_labels: true`
 						})
 
 						It("should successfully deploy all resources", func() {
-							prometheusObj := prometheusFor("", false)
+							prometheusObj := prometheusFor(nil, false)
 							prometheusObj.Spec.ExternalURL = "https://" + ingressHost
 							ingress.Annotations["nginx.ingress.kubernetes.io/server-snippet"] = `location /-/reload {
   return 403;
@@ -781,7 +791,7 @@ location /api/v1/targets {
 
 			When("alerting is configured", func() {
 				BeforeEach(func() {
-					values.Alerting = &AlertingValues{AlertmanagerName: alertmanagerName}
+					values.Alerting = &AlertingValues{Alertmanagers: []*Alertmanager{{Name: alertmanagerName}}}
 					deployer = New(logr.Discard(), fakeClient, namespace, values)
 				})
 
@@ -796,7 +806,7 @@ location /api/v1/targets {
 						serviceAccount,
 						service,
 						clusterRoleBinding,
-						prometheusFor(alertmanagerName, false),
+						prometheusFor([]alertmanager{{name: alertmanagerName, namespace: namespace}}, false),
 						vpa,
 						prometheusRule,
 						scrapeConfig,
@@ -808,7 +818,39 @@ location /api/v1/targets {
 					))
 				})
 
-				When("additional alertmanagers are configured", func() {
+				When("an additional alertmanager is configured via the Alertmananagers slice", func() {
+					BeforeEach(func() {
+						values.Alerting.Alertmanagers = append(values.Alerting.Alertmanagers, &Alertmanager{Name: alertmanagerName2, Namespace: ptr.To(alertmanagerNamespace2)})
+					})
+
+					It("should successfully deploy all resources", func() {
+						prometheusRule.Namespace = namespace
+						metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", name)
+						metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", name)
+						metav1.SetMetaDataLabel(&serviceMonitor.ObjectMeta, "prometheus", name)
+						metav1.SetMetaDataLabel(&podMonitor.ObjectMeta, "prometheus", name)
+
+						Expect(managedResource).To(contain(
+							serviceAccount,
+							service,
+							clusterRoleBinding,
+							prometheusFor(
+								[]alertmanager{
+									{name: alertmanagerName, namespace: namespace},
+									{name: alertmanagerName2, namespace: alertmanagerNamespace2}},
+								false),
+							vpa,
+							prometheusRule,
+							scrapeConfig,
+							serviceMonitor,
+							podMonitor,
+							secretAdditionalScrapeConfigs,
+							additionalConfigMap,
+						))
+					})
+				})
+
+				When("additional alertmanagers are configured via the AdditionalAlertmanager field", func() {
 					When("configured w/ basic auth", func() {
 						BeforeEach(func() {
 							values.Alerting.AdditionalAlertmanager = map[string][]byte{
@@ -820,7 +862,7 @@ location /api/v1/targets {
 						})
 
 						It("should successfully deploy all resources", func() {
-							prometheusObj := prometheusFor(alertmanagerName, false)
+							prometheusObj := prometheusFor([]alertmanager{{name: alertmanagerName, namespace: namespace}}, false)
 							prometheusObj.Spec.AdditionalAlertManagerConfigs = &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{Name: secretAdditionalAlertmanagerConfigs.Name},
 								Key:                  "configs.yaml",
@@ -871,7 +913,7 @@ basic_auth:
 						})
 
 						It("should successfully deploy all resources", func() {
-							prometheusObj := prometheusFor(alertmanagerName, false)
+							prometheusObj := prometheusFor([]alertmanager{{name: alertmanagerName, namespace: namespace}}, false)
 							prometheusObj.Spec.AdditionalAlertManagerConfigs = &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{Name: secretAdditionalAlertmanagerConfigs.Name},
 								Key:                  "configs.yaml",
@@ -920,7 +962,7 @@ tls_config:
 				})
 
 				It("should successfully deploy all resources", func() {
-					prometheusObj := prometheusFor("", false)
+					prometheusObj := prometheusFor(nil, false)
 					prometheusObj.Spec.Replicas = ptr.To(int32(2))
 
 					prometheusRule.Namespace = namespace
@@ -952,7 +994,7 @@ tls_config:
 				})
 
 				It("should successfully deploy all resources", func() {
-					prometheusObj := prometheusFor("", false)
+					prometheusObj := prometheusFor(nil, false)
 					prometheusObj.Spec.ScrapeTimeout = "10s"
 
 					prometheusRule.Namespace = namespace
@@ -1022,7 +1064,7 @@ query_range:
 					}
 					Expect(kubernetesutils.MakeUnique(cortexConfigMap)).To(Succeed())
 
-					prometheusObj := prometheusFor("", false)
+					prometheusObj := prometheusFor(nil, false)
 					prometheusObj.Spec.Containers = append(prometheusObj.Spec.Containers, corev1.Container{
 						Name:            "cortex",
 						Image:           cortexImage,
@@ -1093,7 +1135,7 @@ query_range:
 				})
 
 				It("should successfully deploy all resources", func() {
-					prometheusObj := prometheusFor("", false)
+					prometheusObj := prometheusFor(nil, false)
 					prometheusObj.Spec.RemoteWrite = []monitoringv1.RemoteWriteSpec{{
 						URL: "rw-url",
 						WriteRelabelConfigs: []monitoringv1.RelabelConfig{{
@@ -1133,7 +1175,7 @@ query_range:
 					})
 
 					It("should successfully deploy all resources", func() {
-						prometheusObj := prometheusFor("", false)
+						prometheusObj := prometheusFor(nil, false)
 						prometheusObj.Spec.RemoteWrite = []monitoringv1.RemoteWriteSpec{{
 							URL: "rw-url",
 							WriteRelabelConfigs: []monitoringv1.RelabelConfig{{
@@ -1256,7 +1298,7 @@ query_range:
 						serviceAccount,
 						service,
 						clusterRoleBinding,
-						prometheusFor("", false),
+						prometheusFor(nil, false),
 						vpa,
 						prometheusRule,
 						scrapeConfig,
@@ -1301,7 +1343,7 @@ query_range:
 							serviceAccount,
 							service,
 							clusterRoleBinding,
-							prometheusFor("", false),
+							prometheusFor(nil, false),
 							vpa,
 							prometheusRule,
 							scrapeConfig,

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -666,7 +666,7 @@ func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed,
 	}
 
 	if alertingSMTPSecret != nil {
-		values.Alerting = &prometheus.AlertingValues{AlertmanagerName: "alertmanager-seed"}
+		values.Alerting = &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-seed"}}}
 	}
 
 	return sharedcomponent.NewPrometheus(log, r.SeedClientSet.Client(), r.GardenNamespace, values)

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -130,8 +130,9 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		},
 	}
 
+	values.Alerting = &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-seed", Namespace: ptr.To(v1beta1constants.GardenNamespace)}}}
 	if b.Shoot.WantsAlertmanager {
-		values.Alerting = &prometheus.AlertingValues{AlertmanagerName: "alertmanager-shoot"}
+		values.Alerting.Alertmanagers = append(values.Alerting.Alertmanagers, &prometheus.Alertmanager{Name: "alertmanager-shoot"})
 
 		if secret := b.LoadSecret(v1beta1constants.GardenRoleAlerting); secret != nil &&
 			len(secret.Data["auth_type"]) > 0 &&

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -115,6 +115,10 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 			PrometheusRules: shootprometheus.CentralPrometheusRules(b.Shoot.IsWorkerless, b.Shoot.WantsAlertmanager),
 			ServiceMonitors: shootprometheus.CentralServiceMonitors(b.Shoot.WantsAlertmanager),
 		},
+		Alerting: &prometheus.AlertingValues{
+			Alertmanagers: []*prometheus.Alertmanager{{
+				Name:      "alertmanager-seed",
+				Namespace: ptr.To(v1beta1constants.GardenNamespace)}}},
 		Ingress: &prometheus.IngressValues{
 			Host:                              b.ComputePrometheusHost(),
 			SecretsManager:                    b.SecretsManager,
@@ -130,7 +134,6 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		},
 	}
 
-	values.Alerting = &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-seed", Namespace: ptr.To(v1beta1constants.GardenNamespace)}}}
 	if b.Shoot.WantsAlertmanager {
 		values.Alerting.Alertmanagers = append(values.Alerting.Alertmanagers, &prometheus.Alertmanager{Name: "alertmanager-shoot"})
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1201,7 +1201,7 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 			PrometheusRules:         gardenprometheus.CentralPrometheusRules(),
 			ServiceMonitors:         gardenprometheus.CentralServiceMonitors(),
 		},
-		Alerting: &prometheus.AlertingValues{AlertmanagerName: "alertmanager-garden"},
+		Alerting: &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-garden"}}},
 		Ingress: &prometheus.IngressValues{
 			Host:                   "prometheus-garden." + ingressDomain,
 			SecretsManager:         secretsManager,


### PR DESCRIPTION
/area monitoring
/kind regression

Cherry pick of #9870 on release-v1.95.

#9870: The shoot control plane Prometheus forwards its alerts to the seed alertmanager

**Notes from the cherry-pick process:**

Some conflicts had to be resolved while rebasing #9870 to `release-v1.95`.

/cc @rfranzke 

<details>
<summary>I used the following approach to verify the end to end scenario for this fix on the <code>release-v1.95</code> branch:</summary>

- [x] With the PR base commit of #9695

  - [x] Create a seed and a shoot in the local setup
  - [x] Configure the seed alertmanager (see comment in 9870)
  - [x] Configure the shoot alertmanager (see comment in 9870)
  - [x] Add a shoot alerting rule to the shoot control plane Prometheus that always fires (see comment in 9870)
  - [x] Verify that the shoot control plane Prometheus forwards the alerts to both alertmanagers

<details>

<summary>The alerting configuration of the shoot control plane Prometheus</summary>

```bash
k port-forward prometheus-0 9090
curl -s localhost:9090/api/v1/status/config | jq .data.yaml -r | yq .alerting
```

```yaml
alert_relabel_configs:
  - source_labels: [ignoreAlerts]
    separator: ;
    regex: "true"
    replacement: $1
    action: drop
alertmanagers:
  - follow_redirects: true
    enable_http2: true
    scheme: http
    timeout: 10s
    api_version: v2
    relabel_configs:
      - source_labels: [__meta_kubernetes_service_label_component]
        separator: ;
        regex: alertmanager
        replacement: $1
        action: keep
      - source_labels: [__meta_kubernetes_service_label_role]
        separator: ;
        regex: monitoring
        replacement: $1
        action: keep
      - source_labels: [__meta_kubernetes_endpoint_port_name]
        separator: ;
        regex: metrics
        replacement: $1
        action: keep
    kubernetes_sd_configs:
      - role: endpoints
        kubeconfig_file: ""
        follow_redirects: true
        enable_http2: true
        namespaces:
          own_namespace: false
          names:
            - garden
            - shoot--local--local
```

The alertmanagers are discovered in both namespaces:

```text
            - garden
            - shoot--local--local
```

</details>

- [x] With the `release-v1.95` branch

  - [x] Reconcile the shoot to deploy 9695
  - [x] Verify that the the shoot control plane Prometheus no longer forwards the alerts to the seed alertmanager (this is the **regression** introduced by 9695)

<details>

<summary>The alerting configuration of the shoot control plane Prometheus</summary>

```bash
k port-forward prometheus-shoot-0 9090
curl -s localhost:9090/api/v1/status/config | jq .data.yaml -r | yq .alerting
```

```yaml
alert_relabel_configs:
  - separator: ;
    regex: prometheus_replica
    replacement: $1
    action: labeldrop
  - source_labels: [ignoreAlerts]
    separator: ;
    regex: "true"
    replacement: $1
    action: drop
alertmanagers:
  - follow_redirects: true
    enable_http2: true
    scheme: http
    path_prefix: /
    timeout: 10s
    api_version: v2
    relabel_configs:
      - source_labels: [__meta_kubernetes_service_name]
        separator: ;
        regex: alertmanager-shoot
        replacement: $1
        action: keep
      - source_labels: [__meta_kubernetes_endpoint_port_name]
        separator: ;
        regex: metrics
        replacement: $1
        action: keep
    kubernetes_sd_configs:
      - role: endpoints
        kubeconfig_file: ""
        follow_redirects: true
        enable_http2: true
        namespaces:
          own_namespace: false
          names:
            - shoot--local--local
```

The alertmanager is only discovered in the shoot control plane namespace:

```text
            - shoot--local--local
```

</details>

- [x] With this PR

  - [x] Reconcile the shoot to deploy this fix
  - [x] Verify that the regression is fixed and the shoot control plane Prometheus forwards the alerts to both alertmanagers

<details>

<summary>The alerting configuration of the shoot control plane Prometheus</summary>

```bash
k port-forward prometheus-shoot-0 9090
curl -s localhost:9090/api/v1/status/config | jq .data.yaml -r | yq .alerting
```

```yaml
alert_relabel_configs:
  - separator: ;
    regex: prometheus_replica
    replacement: $1
    action: labeldrop
  - source_labels: [ignoreAlerts]
    separator: ;
    regex: "true"
    replacement: $1
    action: drop
alertmanagers:
  - follow_redirects: true
    enable_http2: true
    scheme: http
    path_prefix: /
    timeout: 10s
    api_version: v2
    relabel_configs:
      - source_labels: [__meta_kubernetes_service_name]
        separator: ;
        regex: alertmanager-seed
        replacement: $1
        action: keep
      - source_labels: [__meta_kubernetes_endpoint_port_name]
        separator: ;
        regex: metrics
        replacement: $1
        action: keep
    kubernetes_sd_configs:
      - role: endpoints
        kubeconfig_file: ""
        follow_redirects: true
        enable_http2: true
        namespaces:
          own_namespace: false
          names:
            - garden
  - follow_redirects: true
    enable_http2: true
    scheme: http
    path_prefix: /
    timeout: 10s
    api_version: v2
    relabel_configs:
      - source_labels: [__meta_kubernetes_service_name]
        separator: ;
        regex: alertmanager-shoot
        replacement: $1
        action: keep
      - source_labels: [__meta_kubernetes_endpoint_port_name]
        separator: ;
        regex: metrics
        replacement: $1
        action: keep
    kubernetes_sd_configs:
      - role: endpoints
        kubeconfig_file: ""
        follow_redirects: true
        enable_http2: true
        namespaces:
          own_namespace: false
          names:
            - shoot--local--local
```

Both alertmanagers are configured.

Verify that the temporarily added, always firing alert shows up in both alertmanager instances.

</details>

- [x] Turn off shoot alerting
  - [x] Verify that the shoot control plane Prometheus forwards the alerts only to the seed alertmanager

<details>

<summary>The alerting configuration of the shoot control plane Prometheus</summary>

```bash
k port-forward prometheus-shoot-0 9090
curl -s localhost:9090/api/v1/status/config | jq .data.yaml -r | yq .alerting
```

```yaml
alert_relabel_configs:
  - separator: ;
    regex: prometheus_replica
    replacement: $1
    action: labeldrop
  - source_labels: [ignoreAlerts]
    separator: ;
    regex: "true"
    replacement: $1
    action: drop
alertmanagers:
  - follow_redirects: true
    enable_http2: true
    scheme: http
    path_prefix: /
    timeout: 10s
    api_version: v2
    relabel_configs:
      - source_labels: [__meta_kubernetes_service_name]
        separator: ;
        regex: alertmanager-seed
        replacement: $1
        action: keep
      - source_labels: [__meta_kubernetes_endpoint_port_name]
        separator: ;
        regex: metrics
        replacement: $1
        action: keep
    kubernetes_sd_configs:
      - role: endpoints
        kubeconfig_file: ""
        follow_redirects: true
        enable_http2: true
        namespaces:
          own_namespace: false
          names:
            - garden
```

Only the seed alertmanager is configured.

</details>

</details>

**Release Notes:**
```bugfix operator
A regression is fixed and now the shoot control plane Prometheus forwards its alerts to the seed alertmanager.
```