### PR TITLE
🧹 Cleanup some `TODOs`

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -1429,23 +1429,6 @@ This field is immutable.</p>
 </tr>
 <tr>
 <td>
-<code>reloadConfigFilePath</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ReloadConfigFilePath is the path to the generated operating system configuration. If set, controllers
-are asked to use it when determining the .status.command of this resource. For example, if for CoreOS
-the reload-path might be &ldquo;/var/lib/config&rdquo;; then the controller shall set .status.command to
-&ldquo;/usr/bin/coreos-cloudinit &ndash;from-file=/var/lib/config&rdquo;.
-Deprecated: This field is deprecated and has no further usage.
-TODO(rfranzke): Remove this field after v1.95 got released.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>units</code></br>
 <em>
 <a href="#extensions.gardener.cloud/v1alpha1.Unit">
@@ -3747,23 +3730,6 @@ This field is immutable.</p>
 </tr>
 <tr>
 <td>
-<code>reloadConfigFilePath</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ReloadConfigFilePath is the path to the generated operating system configuration. If set, controllers
-are asked to use it when determining the .status.command of this resource. For example, if for CoreOS
-the reload-path might be &ldquo;/var/lib/config&rdquo;; then the controller shall set .status.command to
-&ldquo;/usr/bin/coreos-cloudinit &ndash;from-file=/var/lib/config&rdquo;.
-Deprecated: This field is deprecated and has no further usage.
-TODO(rfranzke): Remove this field after v1.95 got released.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>units</code></br>
 <em>
 <a href="#extensions.gardener.cloud/v1alpha1.Unit">
@@ -3866,52 +3832,6 @@ CloudConfig
 <em>(Optional)</em>
 <p>CloudConfig is a structure for containing the generated output for the given operating system
 config spec. It contains a reference to a secret as the result may contain confidential data.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Command is the command whose execution renews/reloads the cloud config on an existing VM, e.g.
-&ldquo;/usr/bin/reload-cloud-config -from-file=<path>&rdquo;. The <path> is optionally provided by Gardener
-in the .spec.reloadConfigFilePath field.
-Deprecated: This field is deprecated and has no further usage.
-TODO(rfranzke): Remove this field after v1.95 got released.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>units</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Units is a list of systemd unit names that are part of the generated Cloud Config and shall be
-restarted when a new version has been downloaded.
-Deprecated: This field is deprecated and has no further usage.
-TODO(rfranzke): Remove this field after v1.95 got released.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>files</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Files is a list of file paths that are part of the generated Cloud Config and shall be
-written to the host&rsquo;s file system.
-Deprecated: This field is deprecated and has no further usage.
-TODO(rfranzke): Remove this field after v1.95 got released.</p>
 </td>
 </tr>
 </tbody>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -160,15 +160,6 @@ spec:
                   gardener-node-agent already running on a bootstrapped VM.
                   This field is immutable.
                 type: string
-              reloadConfigFilePath:
-                description: |-
-                  ReloadConfigFilePath is the path to the generated operating system configuration. If set, controllers
-                  are asked to use it when determining the .status.command of this resource. For example, if for CoreOS
-                  the reload-path might be "/var/lib/config"; then the controller shall set .status.command to
-                  "/usr/bin/coreos-cloudinit --from-file=/var/lib/config".
-                  Deprecated: This field is deprecated and has no further usage.
-                  TODO(rfranzke): Remove this field after v1.95 got released.
-                type: string
               type:
                 description: Type contains the instance of the resource's kind.
                 type: string
@@ -250,14 +241,6 @@ spec:
                 required:
                 - secretRef
                 type: object
-              command:
-                description: |-
-                  Command is the command whose execution renews/reloads the cloud config on an existing VM, e.g.
-                  "/usr/bin/reload-cloud-config -from-file=<path>". The <path> is optionally provided by Gardener
-                  in the .spec.reloadConfigFilePath field.
-                  Deprecated: This field is deprecated and has no further usage.
-                  TODO(rfranzke): Remove this field after v1.95 got released.
-                type: string
               conditions:
                 description: Conditions represents the latest available observations
                   of a Seed's current state.
@@ -428,15 +411,6 @@ spec:
                   - name
                   type: object
                 type: array
-              files:
-                description: |-
-                  Files is a list of file paths that are part of the generated Cloud Config and shall be
-                  written to the host's file system.
-                  Deprecated: This field is deprecated and has no further usage.
-                  TODO(rfranzke): Remove this field after v1.95 got released.
-                items:
-                  type: string
-                type: array
               lastError:
                 description: LastError holds information about the last occurred error
                   during an operation.
@@ -540,15 +514,6 @@ spec:
                   what ever data it needs.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-              units:
-                description: |-
-                  Units is a list of systemd unit names that are part of the generated Cloud Config and shall be
-                  restarted when a new version has been downloaded.
-                  Deprecated: This field is deprecated and has no further usage.
-                  TODO(rfranzke): Remove this field after v1.95 got released.
-                items:
-                  type: string
-                type: array
             type: object
         required:
         - spec

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -74,14 +74,6 @@ type OperatingSystemConfigSpec struct {
 	// gardener-node-agent already running on a bootstrapped VM.
 	// This field is immutable.
 	Purpose OperatingSystemConfigPurpose `json:"purpose"`
-	// ReloadConfigFilePath is the path to the generated operating system configuration. If set, controllers
-	// are asked to use it when determining the .status.command of this resource. For example, if for CoreOS
-	// the reload-path might be "/var/lib/config"; then the controller shall set .status.command to
-	// "/usr/bin/coreos-cloudinit --from-file=/var/lib/config".
-	// Deprecated: This field is deprecated and has no further usage.
-	// TODO(rfranzke): Remove this field after v1.95 got released.
-	// +optional
-	ReloadConfigFilePath *string `json:"reloadConfigFilePath,omitempty"`
 	// Units is a list of unit for the operating system configuration (usually, a systemd unit).
 	// +patchMergeKey=name
 	// +patchStrategy=merge
@@ -209,25 +201,6 @@ type OperatingSystemConfigStatus struct {
 	// config spec. It contains a reference to a secret as the result may contain confidential data.
 	// +optional
 	CloudConfig *CloudConfig `json:"cloudConfig,omitempty"`
-	// Command is the command whose execution renews/reloads the cloud config on an existing VM, e.g.
-	// "/usr/bin/reload-cloud-config -from-file=<path>". The <path> is optionally provided by Gardener
-	// in the .spec.reloadConfigFilePath field.
-	// Deprecated: This field is deprecated and has no further usage.
-	// TODO(rfranzke): Remove this field after v1.95 got released.
-	// +optional
-	Command *string `json:"command,omitempty"`
-	// Units is a list of systemd unit names that are part of the generated Cloud Config and shall be
-	// restarted when a new version has been downloaded.
-	// Deprecated: This field is deprecated and has no further usage.
-	// TODO(rfranzke): Remove this field after v1.95 got released.
-	// +optional
-	Units []string `json:"units,omitempty"`
-	// Files is a list of file paths that are part of the generated Cloud Config and shall be
-	// written to the host's file system.
-	// Deprecated: This field is deprecated and has no further usage.
-	// TODO(rfranzke): Remove this field after v1.95 got released.
-	// +optional
-	Files []string `json:"files,omitempty"`
 }
 
 // CloudConfig contains the generated output for the given operating system

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1488,11 +1488,6 @@ func (in *OperatingSystemConfigSpec) DeepCopyInto(out *OperatingSystemConfigSpec
 		**out = **in
 	}
 	in.DefaultSpec.DeepCopyInto(&out.DefaultSpec)
-	if in.ReloadConfigFilePath != nil {
-		in, out := &in.ReloadConfigFilePath, &out.ReloadConfigFilePath
-		*out = new(string)
-		**out = **in
-	}
 	if in.Units != nil {
 		in, out := &in.Units, &out.Units
 		*out = make([]Unit, len(*in))
@@ -1542,21 +1537,6 @@ func (in *OperatingSystemConfigStatus) DeepCopyInto(out *OperatingSystemConfigSt
 		in, out := &in.CloudConfig, &out.CloudConfig
 		*out = new(CloudConfig)
 		**out = **in
-	}
-	if in.Command != nil {
-		in, out := &in.Command, &out.Command
-		*out = new(string)
-		**out = **in
-	}
-	if in.Units != nil {
-		in, out := &in.Units, &out.Units
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	if in.Files != nil {
-		in, out := &in.Files, &out.Files
-		*out = make([]string, len(*in))
-		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -20,8 +20,6 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 	var osc *extensionsv1alpha1.OperatingSystemConfig
 
 	BeforeEach(func() {
-		reloadConfigFilePath := "some-path"
-
 		osc = &extensionsv1alpha1.OperatingSystemConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-osc",
@@ -32,8 +30,7 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 					Type:           "provider",
 					ProviderConfig: &runtime.RawExtension{},
 				},
-				Purpose:              extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
-				ReloadConfigFilePath: &reloadConfigFilePath,
+				Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
 				Units: []extensionsv1alpha1.Unit{
 					{
 						Name: "foo",

--- a/pkg/apiserver/registry/core/shoot/storage/kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/kubeconfig.go
@@ -31,7 +31,7 @@ import (
 
 // KubeconfigREST implements a RESTStorage for a kubeconfig request.
 type KubeconfigREST struct {
-	// TODO(petersutter): Remove secretLister field from struct after v1.96 has been released, as the cluster CA should then only be read from the ConfigMap.
+	// TODO(petersutter): Remove secretLister field from struct after v1.110 has been released, as the cluster CA should then only be read from the ConfigMap.
 	secretLister         kubecorev1listers.SecretLister
 	internalSecretLister gardencorev1beta1listers.InternalSecretLister
 	configMapLister      kubecorev1listers.ConfigMapLister
@@ -123,7 +123,7 @@ func (r *KubeconfigREST) Create(ctx context.Context, name string, obj runtime.Ob
 
 	var clusterCABundle []byte
 	caClusterConfigMap, err := r.configMapLister.ConfigMaps(shoot.Namespace).Get(gardenerutils.ComputeShootProjectResourceName(shoot.Name, gardenerutils.ShootProjectConfigMapSuffixCACluster))
-	// TODO(petersutter): Remove this fallback of reading the <shoot-name>.ca-cluster Secret after v1.96 has been released
+	// TODO(petersutter): Remove this fallback of reading the <shoot-name>.ca-cluster Secret after v1.110 has been released
 	if apierrors.IsNotFound(err) {
 		caClusterSecret, err := r.secretLister.Secrets(shoot.Namespace).Get(gardenerutils.ComputeShootProjectResourceName(shoot.Name, gardenerutils.ShootProjectSecretSuffixCACluster))
 		if err != nil {

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -368,7 +368,6 @@ func (c *clusterAutoscaler) Destroy(ctx context.Context) error {
 		ctx,
 		c.client,
 		c.emptyManagedResource(),
-		c.emptyManagedResourceSecret(),
 		c.emptyVPA(),
 		c.emptyPodDisruptionBudget(),
 		c.emptyDeployment(),
@@ -426,11 +425,6 @@ func (c *clusterAutoscaler) emptyServiceMonitor() *monitoringv1.ServiceMonitor {
 
 func (c *clusterAutoscaler) emptyManagedResource() *resourcesv1alpha1.ManagedResource {
 	return &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceTargetName, Namespace: c.namespace}}
-}
-
-func (c *clusterAutoscaler) emptyManagedResourceSecret() *corev1.Secret {
-	// TODO(dimityrmirchev): Remove this once mr secrets are turned into garbage-collectable, immutable secrets, after Gardener v1.90
-	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "managedresource-" + managedResourceTargetName, Namespace: c.namespace}}
 }
 
 func (c *clusterAutoscaler) computeCommand() []string {

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -737,19 +737,9 @@ subjects:
 			Expect(clusterAutoscaler.Destroy(ctx)).To(MatchError(fakeErr))
 		})
 
-		It("should fail because the managed resource secret cannot be deleted", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}).Return(fakeErr),
-			)
-
-			Expect(clusterAutoscaler.Destroy(ctx)).To(MatchError(fakeErr))
-		})
-
 		It("should fail because the vpa cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}).Return(fakeErr),
 			)
 
@@ -759,7 +749,6 @@ subjects:
 		It("should fail because the pod disruption budget cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}).Return(fakeErr),
 			)
@@ -770,7 +759,6 @@ subjects:
 		It("should fail because the deployment cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}).Return(fakeErr),
@@ -782,7 +770,6 @@ subjects:
 		It("should fail because the cluster role binding cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
@@ -795,7 +782,6 @@ subjects:
 		It("should fail because the secret cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
@@ -809,7 +795,6 @@ subjects:
 		It("should fail because the service cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
@@ -824,7 +809,6 @@ subjects:
 		It("should fail because the service account cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
@@ -840,7 +824,6 @@ subjects:
 		It("should fail because the prometheus rule cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
@@ -857,7 +840,6 @@ subjects:
 		It("should fail because the service monitor cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
@@ -875,7 +857,6 @@ subjects:
 		It("should successfully delete all the resources", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceSecretName}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -162,15 +162,6 @@ spec:
                   gardener-node-agent already running on a bootstrapped VM.
                   This field is immutable.
                 type: string
-              reloadConfigFilePath:
-                description: |-
-                  ReloadConfigFilePath is the path to the generated operating system configuration. If set, controllers
-                  are asked to use it when determining the .status.command of this resource. For example, if for CoreOS
-                  the reload-path might be "/var/lib/config"; then the controller shall set .status.command to
-                  "/usr/bin/coreos-cloudinit --from-file=/var/lib/config".
-                  Deprecated: This field is deprecated and has no further usage.
-                  TODO(rfranzke): Remove this field after v1.95 got released.
-                type: string
               type:
                 description: Type contains the instance of the resource's kind.
                 type: string
@@ -252,14 +243,6 @@ spec:
                 required:
                 - secretRef
                 type: object
-              command:
-                description: |-
-                  Command is the command whose execution renews/reloads the cloud config on an existing VM, e.g.
-                  "/usr/bin/reload-cloud-config -from-file=<path>". The <path> is optionally provided by Gardener
-                  in the .spec.reloadConfigFilePath field.
-                  Deprecated: This field is deprecated and has no further usage.
-                  TODO(rfranzke): Remove this field after v1.95 got released.
-                type: string
               conditions:
                 description: Conditions represents the latest available observations
                   of a Seed's current state.
@@ -430,15 +413,6 @@ spec:
                   - name
                   type: object
                 type: array
-              files:
-                description: |-
-                  Files is a list of file paths that are part of the generated Cloud Config and shall be
-                  written to the host's file system.
-                  Deprecated: This field is deprecated and has no further usage.
-                  TODO(rfranzke): Remove this field after v1.95 got released.
-                items:
-                  type: string
-                type: array
               lastError:
                 description: LastError holds information about the last occurred error
                   during an operation.
@@ -542,15 +516,6 @@ spec:
                   what ever data it needs.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-              units:
-                description: |-
-                  Units is a list of systemd unit names that are part of the generated Cloud Config and shall be
-                  restarted when a new version has been downloaded.
-                  Deprecated: This field is deprecated and has no further usage.
-                  TODO(rfranzke): Remove this field after v1.95 got released.
-                items:
-                  type: string
-                type: array
             type: object
         required:
         - spec

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -187,12 +187,6 @@ type Data struct {
 	GardenerNodeAgentSecretName string
 	// SecretName is the name of a secret storing the actual cloud-config user data.
 	SecretName *string
-	// Command is the command for reloading the cloud-config (in case a new version was downloaded).
-	Command *string
-	// Units is the list of systemd unit names.
-	Units []string
-	// Files is the list of file paths.
-	Files []string
 }
 
 // Deploy uses the client to create or update the OperatingSystemConfig custom resources.
@@ -266,9 +260,6 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 					Content:                     string(secret.Data[extensionsv1alpha1.OperatingSystemConfigSecretDataKey]),
 					GardenerNodeAgentSecretName: oscKey,
 					SecretName:                  &secret.Name,
-					Command:                     osc.Status.Command,
-					Units:                       osc.Status.Units,
-					Files:                       osc.Status.Files,
 				}
 
 				o.lock.Lock()

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -603,9 +603,6 @@ var _ = Describe("OperatingSystemConfig", func() {
 							Namespace: expected[i].Name,
 						},
 					}
-					// set other status fields
-					expected[i].Status.Command = ptr.To("foo-" + expected[i].Name)
-					expected[i].Status.Units = []string{"bar-" + expected[i].Name, "baz-" + expected[i].Name}
 					Expect(c.Patch(ctx, expected[i], patch)).ToNot(HaveOccurred(), "patching operatingsystemconfig succeeds")
 
 					// create cloud-config secret
@@ -655,9 +652,6 @@ var _ = Describe("OperatingSystemConfig", func() {
 							Namespace: expected[i].Name,
 						},
 					}
-					// set other status fields
-					expected[i].Status.Command = ptr.To("foo-" + expected[i].Name)
-					expected[i].Status.Units = []string{"bar-" + expected[i].Name, "baz-" + expected[i].Name}
 					Expect(c.Patch(ctx, expected[i], patch)).ToNot(HaveOccurred(), "patching operatingsystemconfig succeeds")
 
 					// create cloud-config secret
@@ -694,9 +688,6 @@ var _ = Describe("OperatingSystemConfig", func() {
 							Namespace: expected[i].Name,
 						},
 					}
-					// set other status fields
-					expected[i].Status.Command = ptr.To("foo-" + expected[i].Name)
-					expected[i].Status.Units = []string{"bar-" + expected[i].Name, "baz-" + expected[i].Name}
 					Expect(c.Create(ctx, expected[i])).To(Succeed())
 
 					// create cloud-config secret
@@ -731,23 +722,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 							Content:                     "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker1Name + "-77ac3",
 							SecretName:                  ptr.To("cc-" + expected[0].Name),
-							Command:                     ptr.To("foo-gardener-node-agent-" + worker1Name + "-77ac3-type1-init"),
-							Units: []string{
-								"bar-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
-								"baz-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
-							},
-							Object: worker1OSCDownloader,
+							Object:                      worker1OSCDownloader,
 						},
 						Original: Data{
 							Content:                     "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker1Name + "-77ac3",
 							SecretName:                  ptr.To("cc-" + expected[1].Name),
-							Command:                     ptr.To("foo-gardener-node-agent-" + worker1Name + "-77ac3-type1-original"),
-							Units: []string{
-								"bar-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
-								"baz-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
-							},
-							Object: worker1OSCOriginal,
+							Object:                      worker1OSCOriginal,
 						},
 					},
 					worker2Name: {
@@ -755,23 +736,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 							Content:                     "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker2Name + "-d9e53",
 							SecretName:                  ptr.To("cc-" + expected[2].Name),
-							Command:                     ptr.To("foo-gardener-node-agent-" + worker2Name + "-d9e53-type2-init"),
-							Units: []string{
-								"bar-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
-								"baz-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
-							},
-							Object: worker2OSCDownloader,
+							Object:                      worker2OSCDownloader,
 						},
 						Original: Data{
 							Content:                     "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker2Name + "-d9e53",
 							SecretName:                  ptr.To("cc-" + expected[3].Name),
-							Command:                     ptr.To("foo-gardener-node-agent-" + worker2Name + "-d9e53-type2-original"),
-							Units: []string{
-								"bar-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",
-								"baz-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",
-							},
-							Object: worker2OSCOriginal,
+							Object:                      worker2OSCOriginal,
 						},
 					},
 				}))

--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -431,7 +431,6 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 func (k *kubeAPIServer) Destroy(ctx context.Context) error {
 	return kubernetesutils.DeleteObjects(ctx, k.client.Client(),
 		k.emptyManagedResource(),
-		k.emptyManagedResourceSecret(),
 		k.emptyHorizontalPodAutoscaler(),
 		k.emptyVerticalPodAutoscaler(),
 		k.emptyHVPA(),

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -3866,13 +3866,11 @@ rules:
 			Expect(c.Create(ctx, deployment)).To(Succeed())
 			Expect(c.Create(ctx, verticalPodAutoscaler)).To(Succeed())
 			Expect(c.Create(ctx, hvpa)).To(Succeed())
-			Expect(c.Create(ctx, managedResourceSecret)).To(Succeed())
 			Expect(c.Create(ctx, managedResource)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(verticalPodAutoscaler), verticalPodAutoscaler)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(hvpa), hvpa)).To(Succeed())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 		})
 
@@ -3880,7 +3878,6 @@ rules:
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(verticalPodAutoscaler), verticalPodAutoscaler)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(hvpa), hvpa)).To(BeNotFoundError())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
 		})
 

--- a/pkg/component/kubernetes/apiserver/shoot_resources.go
+++ b/pkg/component/kubernetes/apiserver/shoot_resources.go
@@ -5,7 +5,6 @@
 package apiserver
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,11 +18,6 @@ const ManagedResourceName = "shoot-core-kube-apiserver"
 
 func (k *kubeAPIServer) emptyManagedResource() *resourcesv1alpha1.ManagedResource {
 	return &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: ManagedResourceName, Namespace: k.namespace}}
-}
-
-func (k *kubeAPIServer) emptyManagedResourceSecret() *corev1.Secret {
-	// TODO(dimityrmirchev): Remove this once mr secrets are turned into garbage-collectable, immutable secrets, after Gardener v1.90
-	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "managedresource-" + ManagedResourceName, Namespace: k.namespace}}
 }
 
 func (k *kubeAPIServer) computeShootResourcesData() (map[string][]byte, error) {

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -550,7 +550,6 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 func (k *kubeControllerManager) Destroy(ctx context.Context) error {
 	return kubernetesutils.DeleteObjects(ctx, k.seedClient.Client(),
 		k.emptyManagedResource(),
-		k.emptyManagedResourceSecret(),
 		k.emptyVPA(),
 		k.emptyHVPA(),
 		k.emptyService(),
@@ -594,11 +593,6 @@ func (k *kubeControllerManager) newShootAccessSecret() *gardenerutils.AccessSecr
 
 func (k *kubeControllerManager) emptyManagedResource() *resourcesv1alpha1.ManagedResource {
 	return &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: ManagedResourceName, Namespace: k.namespace}}
-}
-
-func (k *kubeControllerManager) emptyManagedResourceSecret() *corev1.Secret {
-	// TODO(dimityrmirchev): Remove this once mr secrets are turned into garbage-collectable, immutable secrets, after Gardener v1.90
-	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "managedresource-" + ManagedResourceName, Namespace: k.namespace}}
 }
 
 func (k *kubeControllerManager) prometheusAccessSecretName() string {

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -875,7 +875,6 @@ namespace: kube-system
 	Describe("#Destroy", func() {
 		It("should successfully destroy all resources", func() {
 			mr := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}
-			mrSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: managedResourceSecretName, Namespace: namespace}}
 			vpa := &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: vpaName, Namespace: namespace}}
 			hvpa := &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: namespace}}
 			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace}}
@@ -884,8 +883,8 @@ namespace: kube-system
 			pdb := &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: pdbName, Namespace: namespace}}
 			deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-controller-manager", Namespace: namespace}}
 			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace}}
+
 			Expect(c.Create(ctx, mr)).To(Succeed())
-			Expect(c.Create(ctx, mrSecret)).To(Succeed())
 			Expect(c.Create(ctx, vpa)).To(Succeed())
 			Expect(c.Create(ctx, hvpa)).To(Succeed())
 			Expect(c.Create(ctx, service)).To(Succeed())
@@ -906,7 +905,6 @@ namespace: kube-system
 			Expect(kubeControllerManager.Destroy(ctx)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(mr), mr)).To(BeNotFoundError())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(mrSecret), mrSecret)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(vpa), vpa)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(hvpa), hvpa)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(service), service)).To(BeNotFoundError())

--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -1082,15 +1082,6 @@ status: {}
 	Describe("#Destroy", func() {
 		It("should successfully destroy all resources despite undesired managed resources", func() {
 			Expect(c.Create(ctx, managedResourceCentral)).To(Succeed())
-			// TODO(dimityrmirchev): Remove this once mr secrets are turned into garbage-collectable, immutable secrets, after Gardener v1.90
-			managedResourceSecretCentral = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "managedresource-" + managedResourceCentral.Name,
-					Namespace: namespace,
-					Labels:    map[string]string{"component": "kube-proxy"},
-				},
-			}
-			Expect(c.Create(ctx, managedResourceSecretCentral)).To(Succeed())
 
 			undesiredPool := WorkerPool{Name: "foo", KubernetesVersion: semver.MustParse("1.1.1")}
 			undesiredManagedResource := managedResourceForPool(undesiredPool)
@@ -1133,7 +1124,6 @@ status: {}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(undesiredManagedResourceSecret), undesiredManagedResourceSecret)).To(BeNotFoundError())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(BeNotFoundError())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(BeNotFoundError())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(BeNotFoundError())
@@ -1143,15 +1133,6 @@ status: {}
 	Describe("#DeleteStaleResources", func() {
 		It("should successfully delete all stale resources", func() {
 			Expect(c.Create(ctx, managedResourceCentral)).To(Succeed())
-			// TODO(dimityrmirchev): Remove this once mr secrets are turned into garbage-collectable, immutable secrets, after Gardener v1.90
-			managedResourceSecretCentral = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "managedresource-" + managedResourceCentral.Name,
-					Namespace: namespace,
-					Labels:    map[string]string{"component": "kube-proxy"},
-				},
-			}
-			Expect(c.Create(ctx, managedResourceSecretCentral)).To(Succeed())
 
 			undesiredPool := WorkerPool{Name: "foo", KubernetesVersion: semver.MustParse("1.1.1")}
 			undesiredManagedResource := managedResourceForPool(undesiredPool)
@@ -1200,7 +1181,6 @@ status: {}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(undesiredManagedResourceSecretForMajorMinorVersionOnly), undesiredManagedResourceSecretForMajorMinorVersionOnly)).To(BeNotFoundError())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(Succeed())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(Succeed())
 		})
 	})
 

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -409,7 +409,6 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 func (m *machineControllerManager) Destroy(ctx context.Context) error {
 	return kubernetesutils.DeleteObjects(ctx, m.client,
 		m.emptyManagedResource(),
-		m.emptyManagedResourceSecret(),
 		m.emptyServiceMonitor(),
 		m.emptyPrometheusRule(),
 		m.emptyVPA(),
@@ -595,11 +594,6 @@ func (m *machineControllerManager) emptyServiceMonitor() *monitoringv1.ServiceMo
 
 func (m *machineControllerManager) emptyManagedResource() *resourcesv1alpha1.ManagedResource {
 	return &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceTargetName, Namespace: m.namespace}}
-}
-
-func (m *machineControllerManager) emptyManagedResourceSecret() *corev1.Secret {
-	// TODO(dimityrmirchev): Remove this once mr secrets are turned into garbage-collectable, immutable secrets, after Gardener v1.90
-	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "managedresource-" + managedResourceTargetName, Namespace: m.namespace}}
 }
 
 func getLabels() map[string]string {

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -601,13 +601,11 @@ subjects:
 			Expect(fakeClient.Create(ctx, vpa)).To(Succeed())
 			Expect(fakeClient.Create(ctx, prometheusRule)).To(Succeed())
 			Expect(fakeClient.Create(ctx, serviceMonitor)).To(Succeed())
-			Expect(fakeClient.Create(ctx, managedResourceSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
 			Expect(mcm.Destroy(ctx)).To(Succeed())
 
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), &corev1.Secret{})).To(BeNotFoundError())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(serviceMonitor), &monitoringv1.ServiceMonitor{})).To(BeNotFoundError())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(prometheusRule), &monitoringv1.PrometheusRule{})).To(BeNotFoundError())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(vpa), &vpaautoscalingv1.VerticalPodAutoscaler{})).To(BeNotFoundError())

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -363,7 +363,7 @@ func (r *Reconciler) newIstio(ctx context.Context, seed *seedpkg.Seed, isGardenC
 		}
 	}
 
-	// TODO(scheererj): Remove this after v1.95 has been released.
+	// TODO(scheererj): Remove this after v1.102 has been released.
 	// Allow temporary creation of ingress gateway copy to easy migration
 
 	// Map all ingress gateway namespace names to the corresponding gateway values for easier access

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -7,7 +7,6 @@ package seed
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
 	proberapi "github.com/gardener/dependency-watchdog/api/prober"
@@ -358,66 +357,6 @@ func (r *Reconciler) newIstio(ctx context.Context, seed *seedpkg.Seed, isGardenC
 					seed.GetZonalLoadBalancerServiceProxyProtocolTermination(zone),
 				); err != nil {
 					return nil, nil, "", err
-				}
-			}
-		}
-	}
-
-	// TODO(scheererj): Remove this after v1.95 has been released.
-	// Allow temporary creation of ingress gateway copy to easy migration
-
-	// Map all ingress gateway namespace names to the corresponding gateway values for easier access
-	namespaceToGatewayValues := map[string]istio.IngressGatewayValues{}
-	for _, values := range istioDeployer.GetValues().IngressGateway {
-		namespaceToGatewayValues[values.Namespace] = values
-	}
-
-	// Search for istio namespaces with an annotation to copy them and add them to the list with a different namespace
-	for _, label := range []string{"istio", v1beta1constants.LabelExposureClassHandlerName} {
-		namespaceList := &metav1.PartialObjectMetadataList{}
-		namespaceList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NamespaceList"))
-		if err := r.SeedClientSet.Client().List(ctx, namespaceList, client.HasLabels{label}); err != nil {
-			return nil, nil, "", err
-		}
-		for _, ns := range namespaceList.Items {
-			if targetNamespace, ok := ns.Annotations["alpha.istio-ingress.gardener.cloud/migrate-to"]; ok && targetNamespace != "" {
-				if gatewayValues, ok := namespaceToGatewayValues[ns.Name]; ok {
-					// Labels need to be adjusted to contain the correct zone => copy the source labels
-					gatewayLabels := utils.MergeStringMaps(gatewayValues.Labels, map[string]string{})
-					var zone *string
-					if len(gatewayValues.Zones) == 1 {
-						zone = ptr.To(gatewayValues.Zones[0])
-						// The expected migration is from <region>-<zone> to <zone>
-						if lastSeparator := strings.LastIndex(*zone, "-"); lastSeparator >= 0 {
-							newZone := (*zone)[lastSeparator+1:]
-							// Unfortunately, ordinary istio ingress gateways (first case) use different labels than exposure classes (second case)
-							if value, ok := gatewayLabels[istio.DefaultZoneKey]; ok {
-								gatewayLabels[istio.DefaultZoneKey] = strings.ReplaceAll(value, "--zone--"+*zone, "--zone--"+newZone)
-							} else if value, ok := gatewayLabels[v1beta1constants.GardenRole]; ok {
-								gatewayLabels[v1beta1constants.GardenRole] = strings.ReplaceAll(value, "--zone--"+*zone, "--zone--"+newZone)
-							}
-							zone = &newZone
-						}
-					}
-					proxyProtocolTermination := seed.GetLoadBalancerServiceProxyProtocolTermination()
-					if zone != nil {
-						proxyProtocolTermination = seed.GetZonalLoadBalancerServiceProxyProtocolTermination(*zone)
-					}
-					if err := sharedcomponent.AddIstioIngressGateway(
-						ctx,
-						r.SeedClientSet.Client(),
-						istioDeployer,
-						targetNamespace,
-						gatewayValues.Annotations,
-						gatewayLabels,
-						gatewayValues.ExternalTrafficPolicy,
-						nil,
-						zone,
-						seed.IsDualStack(),
-						proxyProtocolTermination,
-					); err != nil {
-						return nil, nil, "", err
-					}
 				}
 			}
 		}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -529,7 +529,7 @@ func cleanupOrphanExposureClassHandlerResources(
 		}
 	}
 
-	// TODO(scheererj): Remove this after v1.95 has been released.
+	// TODO(scheererj): Remove this after v1.102 has been released.
 	// Allow temporary creation of ingress gateway copy to easy migration
 	migrationTargetToSource := map[string]string{}
 	for _, label := range []string{"istio", v1beta1constants.LabelExposureClassHandlerName} {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -529,22 +529,6 @@ func cleanupOrphanExposureClassHandlerResources(
 		}
 	}
 
-	// TODO(scheererj): Remove this after v1.95 has been released.
-	// Allow temporary creation of ingress gateway copy to easy migration
-	migrationTargetToSource := map[string]string{}
-	for _, label := range []string{"istio", v1beta1constants.LabelExposureClassHandlerName} {
-		namespaceList := &metav1.PartialObjectMetadataList{}
-		namespaceList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NamespaceList"))
-		if err := c.List(ctx, namespaceList, client.HasLabels{label}); err != nil {
-			return err
-		}
-		for _, ns := range namespaceList.Items {
-			if targetNamespace, ok := ns.Annotations["alpha.istio-ingress.gardener.cloud/migrate-to"]; ok && targetNamespace != "" {
-				migrationTargetToSource[targetNamespace] = ns.Name
-			}
-		}
-	}
-
 	// Remove zonal, orphaned istio exposure class namespaces
 	zonalExposureClassHandlerNamespaces := &corev1.NamespaceList{}
 	if err := c.List(ctx, zonalExposureClassHandlerNamespaces, client.MatchingLabelsSelector{
@@ -557,9 +541,6 @@ func cleanupOrphanExposureClassHandlerResources(
 	for _, namespace := range zonalExposureClassHandlerNamespaces.Items {
 		if ok, zone := sharedcomponent.IsZonalIstioExtension(namespace.Labels); ok {
 			if err := cleanupOrphanIstioNamespace(ctx, log, c, namespace, true, func() bool {
-				if migrationTargetToSource[namespace.Name] != "" {
-					return true
-				}
 				if !zoneSet.Has(zone) {
 					return false
 				}
@@ -586,7 +567,7 @@ func cleanupOrphanExposureClassHandlerResources(
 	for _, namespace := range zonalIstioNamespaces.Items {
 		if ok, zone := sharedcomponent.IsZonalIstioExtension(namespace.Labels); ok {
 			if err := cleanupOrphanIstioNamespace(ctx, log, c, namespace, false, func() bool {
-				return zoneSet.Has(zone) || migrationTargetToSource[namespace.Name] != ""
+				return zoneSet.Has(zone)
 			}); err != nil {
 				return err
 			}

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
@@ -79,7 +79,6 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			gateway         *istionetworkingv1beta1.Gateway
 			virtualService  *istionetworkingv1beta1.VirtualService
 			destinationRule *istionetworkingv1beta1.DestinationRule
-			ingress         *networkingv1.Ingress
 			secret          *corev1.Secret
 		)
 
@@ -128,13 +127,6 @@ var _ = Describe("KubeAPIServerExposure", func() {
 				},
 			}
 
-			ingress = &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kube-apiserver",
-					Namespace: namespace,
-				},
-			}
-
 			secret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "wildcard-secret",
@@ -153,7 +145,6 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(gateway), gateway)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(virtualService), virtualService)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(destinationRule), destinationRule)).To(Succeed())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(ingress), ingress)).To(BeNotFoundError())
 		})
 
 		It("should not create the ingress if there is no wildcard certificate", func() {
@@ -162,20 +153,6 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(gateway), gateway)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(virtualService), virtualService)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(destinationRule), destinationRule)).To(BeNotFoundError())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(ingress), ingress)).To(BeNotFoundError())
-		})
-
-		It("should delete an existing ingress if there is no wildcard certificate", func() {
-			Expect(c.Create(ctx, gateway)).To(Succeed())
-			Expect(c.Create(ctx, virtualService)).To(Succeed())
-			Expect(c.Create(ctx, destinationRule)).To(Succeed())
-			Expect(c.Create(ctx, ingress)).To(Succeed())
-			botanist.Shoot.Components.ControlPlane.KubeAPIServerIngress = botanist.DefaultKubeAPIServerIngress()
-			Expect(botanist.DeployKubeAPIServerIngress(ctx)).To(Succeed())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(gateway), gateway)).To(BeNotFoundError())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(virtualService), virtualService)).To(BeNotFoundError())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(destinationRule), destinationRule)).To(BeNotFoundError())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(ingress), ingress)).To(BeNotFoundError())
 		})
 	})
 })

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -192,16 +192,10 @@ var _ = Describe("operatingsystemconfig", func() {
 
 			worker1Name            = "worker1"
 			worker1OriginalContent = "w1content"
-			worker1OriginalCommand = "/foo"
-			worker1OriginalUnits   = []string{"w1u1", "w1u2"}
-			worker1OriginalFiles   = []string{"w1f1", "w1f2"}
 			worker1Key             = operatingsystemconfig.Key(worker1Name, semver.MustParse(kubernetesVersion), nil)
 
 			worker2Name                  = "worker2"
 			worker2OriginalContent       = "w2content"
-			worker2OriginalCommand       = "/bar"
-			worker2OriginalUnits         = []string{"w2u2", "w2u2", "w2u3"}
-			worker2OriginalFiles         = []string{"w2f2", "w2f2", "w2f3"}
 			worker2KubernetesVersion     = "4.5.6"
 			worker2Key                   = operatingsystemconfig.Key(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
 			worker2KubeletDataVolumeName = "vol"
@@ -211,9 +205,6 @@ var _ = Describe("operatingsystemconfig", func() {
 					Original: operatingsystemconfig.Data{
 						GardenerNodeAgentSecretName: worker1Key,
 						Content:                     worker1OriginalContent,
-						Command:                     &worker1OriginalCommand,
-						Units:                       worker1OriginalUnits,
-						Files:                       worker1OriginalFiles,
 						Object: &extensionsv1alpha1.OperatingSystemConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: worker1Name + "-original",
@@ -229,9 +220,6 @@ var _ = Describe("operatingsystemconfig", func() {
 					Original: operatingsystemconfig.Data{
 						GardenerNodeAgentSecretName: worker2Key,
 						Content:                     worker2OriginalContent,
-						Command:                     &worker2OriginalCommand,
-						Units:                       worker2OriginalUnits,
-						Files:                       worker2OriginalFiles,
 						Object: &extensionsv1alpha1.OperatingSystemConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: worker2Name + "-original",

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -224,7 +224,7 @@ func (b *Botanist) generateCertificateAuthorities(ctx context.Context) error {
 		return err
 	}
 
-	// TODO(petersutter): Remove this code and cleanup Secret after v1.96 has been released. The caBundle is now being stored in a <shootname>.ca-cluster ConfigMap.
+	// TODO(petersutter): Remove this code and cleanup Secret after v1.110 has been released. The caBundle is now being stored in a <shootname>.ca-cluster ConfigMap.
 	if err := b.syncShootCredentialToGarden(
 		ctx,
 		gardenerutils.ShootProjectSecretSuffixCACluster,

--- a/pkg/gardenlet/operation/botanist/worker_test.go
+++ b/pkg/gardenlet/operation/botanist/worker_test.go
@@ -390,7 +390,6 @@ var _ = Describe("Worker", func() {
 			shootClient    *mockclient.MockClient
 
 			namespace = "shoot--foo--bar"
-			name      = "shoot-cloud-config-execution"
 		)
 
 		BeforeEach(func() {
@@ -553,17 +552,6 @@ var _ = Describe("Worker", func() {
 					}}}
 					return nil
 				}).AnyTimes(),
-			)
-
-			gomock.InOrder(
-				seedInterface.EXPECT().Client().Return(seedClient),
-				seedClient.EXPECT().Delete(gomock.Any(), &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}),
-				seedInterface.EXPECT().Client().Return(seedClient),
-				seedClient.EXPECT().Delete(gomock.Any(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "shoot-access-cloud-config-downloader", Namespace: namespace}}),
-				seedInterface.EXPECT().Client().Return(seedClient),
-				seedClient.EXPECT().DeleteAllOf(gomock.Any(), &corev1.Secret{}, client.InNamespace(namespace), client.MatchingLabels{"managed-resource": name}),
-				shootInterface.EXPECT().Client().Return(shootClient),
-				shootClient.EXPECT().Delete(gomock.Any(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-config-downloader", Namespace: "kube-system"}}),
 			)
 
 			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx)).To(Succeed())

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1235,15 +1235,6 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 			WildcardCertSecretName: wildcardCertSecretName,
 		},
 		TargetCluster: &prometheus.TargetClusterValues{ServiceAccountName: gardenprometheus.ServiceAccountName},
-		// TODO(rfranzke): Remove this after v1.95 has been released.
-		DataMigration: monitoring.DataMigration{
-			StatefulSetName: "garden-prometheus",
-			OldSubPath:      ptr.To("/"),
-			PVCNames: []string{
-				"prometheus-db-garden-prometheus-0",
-				"prometheus-db-garden-prometheus-1",
-			},
-		},
 	})
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -63,7 +63,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/logging"
 	"github.com/gardener/gardener/pkg/component/observability/logging/fluentcustomresources"
 	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
-	"github.com/gardener/gardener/pkg/component/observability/monitoring"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/alertmanager"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter"
 	gardenblackboxexporter "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/garden"
@@ -1272,15 +1271,6 @@ func (r *Reconciler) newPrometheusLongTerm(log logr.Logger, garden *operatorv1al
 		Cortex: &prometheus.CortexValues{
 			Image:         imageCortex.String(),
 			CacheValidity: 7 * 24 * time.Hour, // 1 week
-		},
-		// TODO(rfranzke): Remove this after v1.96 has been released.
-		DataMigration: monitoring.DataMigration{
-			StatefulSetName: "availability-prometheus",
-			OldSubPath:      ptr.To("/"),
-			PVCNames: []string{
-				"prometheus-availability-db-availability-prometheus-0",
-				"prometheus-availability-db-availability-prometheus-1",
-			},
 		},
 	})
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -839,23 +839,7 @@ manifests:
       - example/provider-local/garden/skaffold
       - example/provider-local/seed-kind/skaffold
 deploy:
-  kubectl:
-    hooks:
-      before:
-        - host:
-            command:
-              # We need to wait for the new ControllerDeployment API to be available before we can deploy provider-local
-              # using the new ControllerDeployment in the v1 API version. Otherwise, the upgrade tests will fail when
-              # upgrading to the new version.
-              # TODO(timebertt): drop this after v1.96 has been released
-              - bash
-              - -ec
-              - |
-                until kubectl get controllerdeployments.v1.core.gardener.cloud >/dev/null; do 
-                  echo "Waiting for controllerdeployments.v1.core.gardener.cloud to be available..."
-                  sleep 5
-                done
-                echo "controllerdeployments.v1.core.gardener.cloud available"
+  kubectl: {}
 profiles:
   - name: ipv6
     activation:

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -8,10 +8,8 @@ import (
 	"context"
 	"net"
 	"os"
-	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -79,7 +77,8 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 			},
 			Networking: &gardencorev1beta1.Networking{
-				Type: ptr.To("calico"),
+				Type:  ptr.To("calico"),
+				Nodes: ptr.To("10.10.0.0/16"),
 			},
 			Provider: gardencorev1beta1.Provider{
 				Type: "local",
@@ -110,17 +109,6 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 				},
 			},
 		},
-	}
-
-	// We must not set the node CIDR in the pre-upgrade phase of the upgrade tests because it will not be handled
-	// by the Infrastructure and Worker controllers until https://github.com/gardener/gardener/pull/9752 is released
-	// (v1.96). Hence, we set it for upgrade tests from v1.95 in the post-upgrade phase.
-	// TODO(timebertt): drop this after v1.96 has been released
-	setNodeCIDR := !(ginkgo.Label("pre-upgrade").MatchesLabelFilter(ginkgo.GinkgoLabelFilter()) &&
-		strings.HasPrefix(os.Getenv("GARDENER_PREVIOUS_VERSION"), "v1.95."))
-
-	if setNodeCIDR {
-		shoot.Spec.Networking.Nodes = ptr.To("10.10.0.0/16")
 	}
 
 	if os.Getenv("IPFAMILY") == "ipv6" {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
- Remove deprecated fields from `OperatingSystemConfig` (from https://github.com/gardener/gardener/pull/9477, released with `v1.92.0`)
- Remove cleanup of old `kube-apiserver` `Ingress` resource (from https://github.com/gardener/gardener/pull/9300, released with `v1.91.0`), cc @ScheererJ
- ~~Remove Istio zone migration code (from https://github.com/gardener/gardener/pull/9304 and https://github.com/gardener/gardener/pull/9457, released with `v1.91.0` and `v1.92.0`)~~, cc @ScheererJ
- Remove PVC migration for `garden` Prometheus (from https://github.com/gardener/gardener/pull/9543, released with `v1.93.0`)
- Remove PVC migration for `longterm` Prometheus (from https://github.com/gardener/gardener/pull/9606, released with `v1.94.0`)
- Remove migration code in `skaffold.yaml` for `core.gardener.cloud/v1` API (from https://github.com/gardener/gardener/pull/9771, released with `v1.96.0`), cc @timebertt
- Remove migration code for e2e upgrade tests after `provider-local` VPN fix (from https://github.com/gardener/gardener/pull/9752, released with `v1.96.0`), cc @timebertt
- Remove cleanup of old `vali` `VerticalPodAutoscaler`s (from https://github.com/gardener/gardener/pull/9681, released with `v1.94.0`), cc @plkokanov
- Remove cleanuop code after making `Secret`s of `ManagedResource`s immutable (from https://github.com/gardener/gardener/pull/8116, released with `v1.77.0`), cc @dimityrmirchev
- Remove cleanup code of resources of legacy `cloud-config-downloader` (from https://github.com/gardener/gardener/pull/8847, released with `v1.85.0`)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The deprecated fields `.spec.{reloadConfigFilePath,command}` and `.status.{units,files}` have been removed from the `extensions.gardener.cloud/v1alpha1.OperatingSystemConfig` API.
```
