### PR TITLE
Promote `CoreDNSQueryRewriting` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -25,6 +25,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | DefaultSeccompProfile              | `false` | `Alpha` | `1.54` |        |
 | CoreDNSQueryRewriting              | `false` | `Alpha` | `1.55` | `1.95` |
 | CoreDNSQueryRewriting              | `true`  | `Beta`  | `1.96` |        |
+| CoreDNSQueryRewriting              | `true`  | `GA`    | `1.97` |        |
 | IPv6SingleStack                    | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` | `1.95` |
 | MutableShootSpecNetworkingNodes    | `true`  | `Beta`  | `1.96` |        |

--- a/docs/usage/dns-search-path-optimization.md
+++ b/docs/usage/dns-search-path-optimization.md
@@ -76,17 +76,7 @@ creation of DNS requests. Especially with the default setting of `ndots=5`, seem
 services in the cluster may trigger the DNS search path application.
 
 Gardener allows to automatically rewrite some obviously incorrect DNS names, which stem from an application of the DNS search
-path to the most likely desired name. The feature can be enabled by setting the Gardenlet feature gate `CoreDNSQueryRewriting` to `true`:
-
-```yaml
-featureGates:
-  CoreDNSQueryRewriting: true
-``` 
-
-In case the feature is enabled in the gardenlet, it can be disabled per shoot cluster by setting the annotation
-`alpha.featuregates.shoot.gardener.cloud/core-dns-rewriting-disabled` to any value.
-
-This will automatically rewrite requests like `service.namespace.svc.cluster.local.svc.cluster.local` to
+path to the most likely desired name. This will automatically rewrite requests like `service.namespace.svc.cluster.local.svc.cluster.local` to
 `service.namespace.svc.cluster.local`.
 
 In case the applications also target services for name resolution, which are outside of the cluster and have less than `ndots` dots,

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -114,7 +114,6 @@ featureGates:
   HVPA: true
   HVPAForShootedSeed: true
   DefaultSeccompProfile: true
-  CoreDNSQueryRewriting: true
   # Enable IPv6SingleStack to allow creating IPv6 seed clusters without changing the config.
   # This feature gate doesn't change gardenlet's default behavior, it only allows setting `ipFamilies=[IPv6]` in the
   # Seed config. Only when this is set, gardenlet's behavior changes.

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -39,7 +39,6 @@ config:
     HVPA: true
     HVPAForShootedSeed: true
     DefaultSeccompProfile: true
-    CoreDNSQueryRewriting: true
     # Enable IPv6SingleStack to allow creating IPv6 seed clusters without changing the config.
     # This feature gate doesn't change gardenlet's default behavior, it only allows setting `ipFamilies=[IPv6]` in the
     # Seed config. Only when this is set, gardenlet's behavior changes.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -657,8 +657,6 @@ const (
 	// Note that changing this value only applies to new nodes. Existing nodes which already computed their individual
 	// delays will not recompute it.
 	AnnotationShootCloudConfigExecutionMaxDelaySeconds = "shoot.gardener.cloud/cloud-config-execution-max-delay-seconds"
-	// AnnotationCoreDNSRewritingDisabled disables core dns query rewriting even if the corresponding feature gate is enabled.
-	AnnotationCoreDNSRewritingDisabled = "alpha.featuregates.shoot.gardener.cloud/core-dns-rewriting-disabled"
 
 	// AnnotationAuthenticationIssuer is the key for an annotation applied to a Shoot which specifies
 	// if the shoot's issuer is managed by Gardener.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1215,12 +1215,6 @@ func IsCoreDNSAutoscalingModeUsed(systemComponents *gardencorev1beta1.SystemComp
 	return systemComponents.CoreDNS.Autoscaling.Mode == autoscalingMode
 }
 
-// IsCoreDNSRewritingEnabled indicates whether automatic query rewriting in CoreDNS is enabled or not.
-func IsCoreDNSRewritingEnabled(featureGate bool, annotations map[string]string) bool {
-	_, disabled := annotations[v1beta1constants.AnnotationCoreDNSRewritingDisabled]
-	return featureGate && !disabled
-}
-
 // IsNodeLocalDNSEnabled indicates whether the node local DNS cache is enabled or not.
 func IsNodeLocalDNSEnabled(systemComponents *gardencorev1beta1.SystemComponents) bool {
 	return systemComponents != nil && systemComponents.NodeLocalDNS != nil && systemComponents.NodeLocalDNS.Enabled

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -22,7 +22,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 var _ = Describe("Helper", func() {
@@ -2665,25 +2664,6 @@ var _ = Describe("Helper", func() {
 		Entry("with cluster-proportional autoscaling mode (cluster-proportional)", &gardencorev1beta1.SystemComponents{CoreDNS: &gardencorev1beta1.CoreDNS{Autoscaling: &gardencorev1beta1.CoreDNSAutoscaling{Mode: "cluster-proportional"}}}, gardencorev1beta1.CoreDNSAutoscalingModeClusterProportional, true),
 		Entry("with cluster-proportional autoscaling mode (horizontal)", &gardencorev1beta1.SystemComponents{CoreDNS: &gardencorev1beta1.CoreDNS{Autoscaling: &gardencorev1beta1.CoreDNSAutoscaling{Mode: "cluster-proportional"}}}, gardencorev1beta1.CoreDNSAutoscalingModeHorizontal, false),
 	)
-
-	Context("#IsCoreDNSRewritingEnabled feature gate context", func() {
-		BeforeEach(func() {
-			gardenletfeatures.RegisterFeatureGates()
-		})
-
-		DescribeTable("#IsCoreDNSRewritingEnabled",
-			func(featureGate bool, annotations map[string]string, expected bool) {
-				Expect(IsCoreDNSRewritingEnabled(featureGate, annotations)).To(Equal(expected))
-			},
-
-			Entry("with feature gate enabled and no annotation", true, map[string]string{}, true),
-			Entry("with feature gate disabled and no annotation", false, map[string]string{}, false),
-			Entry("with feature gate enabled and incorrect annotations", true, map[string]string{"some annotation": "some value", "foo": "bar"}, true),
-			Entry("with feature gate disabled and incorrect annotation", false, map[string]string{"some annotation": "some value", "foo": "bar"}, false),
-			Entry("with feature gate enabled and correct annotations", true, map[string]string{v1beta1constants.AnnotationCoreDNSRewritingDisabled: "some value"}, false),
-			Entry("with feature gate disabled and correct annotation", false, map[string]string{v1beta1constants.AnnotationCoreDNSRewritingDisabled: "some value"}, false),
-		)
-	})
 
 	DescribeTable("#IsNodeLocalDNSEnabled",
 		func(systemComponents *gardencorev1beta1.SystemComponents, expected bool) {

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -94,8 +94,6 @@ type Values struct {
 	ClusterProportionalAutoscalerImage string
 	// WantsVerticalPodAutoscaler indicates whether vertical autoscaler should be used.
 	WantsVerticalPodAutoscaler bool
-	// SearchPathRewritesEnabled indicates whether obviously invalid requests due to search path should be rewritten.
-	SearchPathRewritesEnabled bool
 	// SearchPathRewriteCommonSuffixes contains common suffixes to be rewritten when SearchPathRewritesEnabled is set.
 	SearchPathRewriteCommonSuffixes []string
 }
@@ -296,7 +294,7 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
   health {
       lameduck 15s
   }
-  ready` + getSearchPathRewrites(c.values.SearchPathRewritesEnabled, c.values.ClusterDomain, c.values.SearchPathRewriteCommonSuffixes) + `
+  ready` + getSearchPathRewrites(c.values.ClusterDomain, c.values.SearchPathRewriteCommonSuffixes) + `
   kubernetes ` + c.values.ClusterDomain + ` in-addr.arpa ip6.arpa {
       pods insecure
       fallthrough in-addr.arpa ip6.arpa
@@ -817,10 +815,7 @@ func getClusterProportionalDNSAutoscalerLabels() map[string]string {
 	}
 }
 
-func getSearchPathRewrites(enabled bool, clusterDomain string, commonSuffixes []string) string {
-	if !enabled {
-		return ``
-	}
+func getSearchPathRewrites(clusterDomain string, commonSuffixes []string) string {
 	quotedClusterDomain := regexp.QuoteMeta(clusterDomain)
 	suffixRewrites := ""
 	for _, suffix := range commonSuffixes {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -42,6 +42,7 @@ const (
 	// owner: @ScheererJ @DockToFuture @axel7born
 	// alpha: v1.55.0
 	// beta: v1.96.0
+	// GA: v1.97.0
 	CoreDNSQueryRewriting featuregate.Feature = "CoreDNSQueryRewriting"
 
 	// IPv6SingleStack allows creating shoot clusters with IPv6 single-stack networking (GEP-21).
@@ -114,7 +115,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPAForShootedSeed:              {Default: false, PreRelease: featuregate.Alpha},
 	VPAForETCD:                      {Default: false, PreRelease: featuregate.Alpha},
 	DefaultSeccompProfile:           {Default: false, PreRelease: featuregate.Alpha},
-	CoreDNSQueryRewriting:           {Default: true, PreRelease: featuregate.Beta},
+	CoreDNSQueryRewriting:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	IPv6SingleStack:                 {Default: false, PreRelease: featuregate.Alpha},
 	MutableShootSpecNetworkingNodes: {Default: true, PreRelease: featuregate.Beta},
 	ShootManagedIssuer:              {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/gardenlet/operation/botanist/coredns.go
+++ b/pkg/gardenlet/operation/botanist/coredns.go
@@ -19,7 +19,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 )
 
@@ -39,7 +38,6 @@ func (b *Botanist) DefaultCoreDNS() (coredns.Interface, error) {
 		PodNetworkCIDR: b.Shoot.Networks.Pods.String(),
 		// NodeNetworkCIDR is set on deployment to handle dynamice node network CIDRs
 		AutoscalingMode:                 gardencorev1beta1.CoreDNSAutoscalingModeHorizontal,
-		SearchPathRewritesEnabled:       v1beta1helper.IsCoreDNSRewritingEnabled(features.DefaultFeatureGate.Enabled(features.CoreDNSQueryRewriting), b.Shoot.GetInfo().GetAnnotations()),
 		SearchPathRewriteCommonSuffixes: getCommonSuffixesForRewriting(b.Shoot.GetInfo().Spec.SystemComponents),
 		KubernetesVersion:               b.Shoot.KubernetesVersion,
 	}
@@ -97,7 +95,7 @@ func (b *Botanist) getCoreDNSRestartedAtAnnotations(ctx context.Context) (map[st
 }
 
 func getCommonSuffixesForRewriting(systemComponents *gardencorev1beta1.SystemComponents) []string {
-	if features.DefaultFeatureGate.Enabled(features.CoreDNSQueryRewriting) && systemComponents != nil && systemComponents.CoreDNS != nil && systemComponents.CoreDNS.Rewriting != nil {
+	if systemComponents != nil && systemComponents.CoreDNS != nil && systemComponents.CoreDNS.Rewriting != nil {
 		return systemComponents.CoreDNS.Rewriting.CommonSuffixes
 	}
 	return []string{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Promote `CoreDNSQueryRewriting` feature gate to GA and locks it to its default value (`true`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `CoreDNSQueryRewriting` feature gate has been promoted to GA. It was already enabled by default and can now no longer be turned off. The feature gate will be removed in a future release.
```

/cc @DockToFuture @axel7born 