### PR TITLE
Promote `MutableShootSpecNetworkingNodes` feature gate to GA

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8179,7 +8179,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Nodes is the CIDR of the entire node network.
-This field is immutable if the feature gate MutableShootSpecNetworkingNodes is disabled.</p>
+This field is mutable.</p>
 </td>
 </tr>
 <tr>

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,6 +28,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | IPv6SingleStack                    | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` | `1.95` |
 | MutableShootSpecNetworkingNodes    | `true`  | `Beta`  | `1.96` |        |
+| MutableShootSpecNetworkingNodes    | `true`  | `GA`    | `1.97` |        |
 | ShootForceDeletion                 | `false` | `Alpha` | `1.81` | `1.90` |
 | ShootForceDeletion                 | `true`  | `Beta`  | `1.91` |        |
 | UseNamespacedCloudProfile          | `false` | `Alpha` | `1.92` |        |

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -159,7 +159,6 @@ global:
         policy: ""
     featureGates:
       IPv6SingleStack: true
-      MutableShootSpecNetworkingNodes: true
       ShootForceDeletion: true
     resources: {}
     podLabels:

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -987,7 +987,7 @@ type Networking struct {
 	// Pods is the CIDR of the pod network. This field is immutable.
 	Pods *string
 	// Nodes is the CIDR of the entire node network.
-	// This field is immutable if the feature gate MutableShootSpecNetworkingNodes is disabled.
+	// This field is mutable.
 	Nodes *string
 	// Services is the CIDR of the service network. This field is immutable.
 	Services *string

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1872,7 +1872,7 @@ message Networking {
   optional string pods = 3;
 
   // Nodes is the CIDR of the entire node network.
-  // This field is immutable if the feature gate MutableShootSpecNetworkingNodes is disabled.
+  // This field is mutable.
   // +optional
   optional string nodes = 4;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1282,7 +1282,7 @@ type Networking struct {
 	// +optional
 	Pods *string `json:"pods,omitempty" protobuf:"bytes,3,opt,name=pods"`
 	// Nodes is the CIDR of the entire node network.
-	// This field is immutable if the feature gate MutableShootSpecNetworkingNodes is disabled.
+	// This field is mutable.
 	// +optional
 	Nodes *string `json:"nodes,omitempty" protobuf:"bytes,4,opt,name=nodes"`
 	// Services is the CIDR of the service network. This field is immutable.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -671,9 +671,6 @@ func validateNetworkingUpdate(newNetworking, oldNetworking *core.Networking, fld
 	if oldNetworking.Services != nil {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Services, oldNetworking.Services, fldPath.Child("services"))...)
 	}
-	if !features.DefaultFeatureGate.Enabled(features.MutableShootSpecNetworkingNodes) && oldNetworking.Nodes != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Nodes, oldNetworking.Nodes, fldPath.Child("nodes"))...)
-	}
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3253,22 +3253,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
-			It("should forbid changing the networking nodes range if feature gate is disabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.MutableShootSpecNetworkingNodes, false))
-				shoot.Spec.Networking.Nodes = ptr.To("10.181.0.0/18")
-				newShoot := prepareShootForUpdate(shoot)
-				newShoot.Spec.Networking.Nodes = ptr.To("10.181.0.0/16")
-
-				errorList := ValidateShootUpdate(newShoot, shoot)
-
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.networking.nodes"),
-				}))))
-			})
-
-			It("should allow increasing the networking nodes range if feature gate is enabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.MutableShootSpecNetworkingNodes, true))
+			It("should allow increasing the networking nodes range", func() {
 				shoot.Spec.Networking.Nodes = ptr.To("10.181.0.0/18")
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.Networking.Nodes = ptr.To("10.181.0.0/16")

--- a/pkg/apis/seedmanagement/validation/managedseedset_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset_test.go
@@ -12,15 +12,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
-	"github.com/gardener/gardener/pkg/features"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("ManagedSeedSet Validation Tests", func() {
@@ -388,7 +385,6 @@ var _ = Describe("ManagedSeedSet Validation Tests", func() {
 		})
 
 		It("should forbid changes to immutable fields in shootTemplate", func() {
-			DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.MutableShootSpecNetworkingNodes, true))
 			shootCopy := shoot.DeepCopy()
 			shootCopy.Spec.Region = "other-region"
 			shootCopy.Spec.Networking.Nodes = ptr.To("10.181.0.0/16")

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -5730,7 +5730,7 @@ func schema_pkg_apis_core_v1beta1_Networking(ref common.ReferenceCallback) commo
 					},
 					"nodes": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Nodes is the CIDR of the entire node network. This field is immutable if the feature gate MutableShootSpecNetworkingNodes is disabled.",
+							Description: "Nodes is the CIDR of the entire node network. This field is mutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -53,6 +53,7 @@ const (
 	// owner: @axel7born @ScheererJ @DockToFuture @kon-angelo
 	// alpha: v1.64.0
 	// beta: v1.96.0
+	// GA: v1.97.0
 	MutableShootSpecNetworkingNodes featuregate.Feature = "MutableShootSpecNetworkingNodes"
 
 	// ShootForceDeletion allows force deletion of Shoots.
@@ -116,7 +117,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:           {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting:           {Default: true, PreRelease: featuregate.Beta},
 	IPv6SingleStack:                 {Default: false, PreRelease: featuregate.Alpha},
-	MutableShootSpecNetworkingNodes: {Default: true, PreRelease: featuregate.Beta},
+	MutableShootSpecNetworkingNodes: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ShootManagedIssuer:              {Default: false, PreRelease: featuregate.Alpha},
 	ShootForceDeletion:              {Default: true, PreRelease: featuregate.Beta},
 	UseNamespacedCloudProfile:       {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Promote `MutableShootSpecNetworkingNodes` feature gate to GA and locks it to its default value (`true`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `MutableShootSpecNetworkingNodes` feature gate has been promoted to GA. It was already enabled by default and can now no longer be turned off. The feature gate will be removed in a future release.
```

/cc @axel7born @DockToFuture 