### PR TITLE
Revert "Remove resource limits for the observability components (#9785)"

### DIFF
--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
@@ -251,6 +251,9 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 										corev1.ResourceCPU:    resource.MustParse("10m"),
 										corev1.ResourceMemory: resource.MustParse("25Mi"),
 									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
 								},
 								Ports: []corev1.ContainerPort{
 									{

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
@@ -199,6 +199,8 @@ spec:
           name: probe
           protocol: TCP
         resources:
+          limits:
+            memory: 128Mi
           requests:
             cpu: 10m
             memory: 25Mi

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -425,6 +425,9 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 										corev1.ResourceCPU:    resource.MustParse("50m"),
 										corev1.ResourceMemory: resource.MustParse("50Mi"),
 									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceMemory: resource.MustParse("250Mi"),
+									},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -362,6 +362,8 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
         resources:
+          limits:
+            memory: 250Mi
           requests:
             cpu: 50m
             memory: 50Mi

--- a/pkg/component/observability/monitoring/prometheusoperator/deployment.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/deployment.go
@@ -55,7 +55,7 @@ func (p *prometheusOperator) deployment() *appsv1.Deployment {
 								"--config-reloader-cpu-request=10m",
 								"--config-reloader-cpu-limit=0",
 								"--config-reloader-memory-request=25Mi",
-								"--config-reloader-memory-limit=0",
+								"--config-reloader-memory-limit=50Mi",
 								"--enable-config-reloader-probes=false",
 							},
 							Env: []corev1.EnvVar{{

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -157,7 +157,7 @@ var _ = Describe("PrometheusOperator", func() {
 									"--config-reloader-cpu-request=10m",
 									"--config-reloader-cpu-limit=0",
 									"--config-reloader-memory-request=25Mi",
-									"--config-reloader-memory-limit=0",
+									"--config-reloader-memory-limit=50Mi",
 									"--enable-config-reloader-probes=false",
 								},
 								Env: []corev1.EnvVar{{

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -618,6 +618,9 @@ func (p *plutono) getDeployment(providerConfigMap, dataSourceConfigMap *corev1.C
 									corev1.ResourceCPU:    resource.MustParse("5m"),
 									corev1.ResourceMemory: resource.MustParse("45Mi"),
 								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("400Mi"),
+								},
 							},
 						},
 						{

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -353,6 +353,9 @@ metadata:
 												corev1.ResourceCPU:    resource.MustParse("5m"),
 												corev1.ResourceMemory: resource.MustParse("45Mi"),
 											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceMemory: resource.MustParse("400Mi"),
+											},
 										},
 									},
 									{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This reverts commit 0be0fdc5db1370a3c9e67ac112dd03640c6d9678.

The issue described in https://github.com/gardener/gardener/pull/9785 is rather caused by the fact that in gardener/gardener@v1.94.0 the prometheus VPA didn't had a containerPolicy set for the blackbox-exporter sidecar: https://github.com/gardener/gardener/blob/b600fcdd1698c9b30d83259a9950cce7b60fc024/pkg/component/observability/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml#L17-L31. Hence, in gardener/gardener@v1.94.0 VPA was using `controlledValues: RequestsAndLimits` for scaling the blackbox-exporter sidecar. That's why VPA reduced the limits to 13.42MB which caused the OOM kill. 
However, in gardener/gardener@v1.95.0 the blackbox-exporeter is extracted to a Deployment and its VPA is configured with `controlledValues: RequestsOnly`. With `controlledValues: RequestsOnly` we should be on the safe side as VPA won't reduce the memory limits. node-exporter also runs with `controlledValues: RequestsOnly`. For plutono, there is no VPA. We haven't faced issues with its memory limit, so I would also keep it for now.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Memory limits for the blackbox-exporeter, node-exporter and plutono components are introduced again.
```
