### PR TITLE
`gardenlet`'s pod garbage collector considers pods with reason `NodeAffinity`

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -469,7 +469,7 @@ Please see [Shoot Status](../usage/shoot_status.md#constraints) for more details
 Stale pods in the shoot namespace in the seed cluster and in the `kube-system` namespace in the shoot cluster are deleted.
 A pod is considered stale when:
 
-- it was terminated with reason `Evicted`.
+- it was terminated with reason `Evicted`, `NodeAffinity`, or because node has insufficient ressources, i.e., reason starts with `OutOf*`, e.g., `OutOfCpu`, `OutOfMemory`, `OutOfDisk`.
 - it was terminated with reason starting with `OutOf` (e.g., `OutOfCpu`).
 - it is stuck in termination (i.e., if its `deletionTimestamp` is more than `5m` ago).
 

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -469,8 +469,9 @@ Please see [Shoot Status](../usage/shoot_status.md#constraints) for more details
 Stale pods in the shoot namespace in the seed cluster and in the `kube-system` namespace in the shoot cluster are deleted.
 A pod is considered stale when:
 
-- it was terminated with reason `Evicted`, `NodeAffinity`, or because node has insufficient ressources, i.e., reason starts with `OutOf*`, e.g., `OutOfCpu`, `OutOfMemory`, `OutOfDisk`.
+- it was terminated with reason `Evicted`.
 - it was terminated with reason starting with `OutOf` (e.g., `OutOfCpu`).
+- it was terminated with reason `NodeAffinity`.
 - it is stuck in termination (i.e., if its `deletionTimestamp` is more than `5m` ago).
 
 #### ["State" Reconciler](../../pkg/gardenlet/controller/shoot/state)

--- a/pkg/gardenlet/controller/shoot/care/garbage_collection.go
+++ b/pkg/gardenlet/controller/shoot/care/garbage_collection.go
@@ -147,7 +147,9 @@ func (g *GarbageCollection) deleteStalePods(ctx context.Context, c client.Client
 	for _, pod := range podList.Items {
 		log := g.log.WithValues("pod", client.ObjectKeyFromObject(&pod))
 
-		if strings.Contains(pod.Status.Reason, "Evicted") || strings.HasPrefix(pod.Status.Reason, "OutOf") {
+		if strings.Contains(pod.Status.Reason, "Evicted") ||
+			strings.HasPrefix(pod.Status.Reason, "OutOf") ||
+			strings.Contains(pod.Status.Reason, "NodeAffinity") {
 			log.V(1).Info("Deleting pod", "reason", pod.Status.Reason)
 			if err := c.Delete(ctx, &pod, kubernetes.DefaultDeleteOptions...); client.IgnoreNotFound(err) != nil {
 				result = multierror.Append(result, err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
`gardenlet`'s pod garbage collector considers pods with reason `NodeAffinity` which can occur after `kubelet` restarts.

**Which issue(s) this PR fixes**:
Related: https://github.com/kubernetes/kubernetes/issues/100467

**Special notes for your reviewer**:
/cc @ashwani2k 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardenlet`'s `Pod` garbage collector (part of its `shoot-care` controller) now considers `Pod`s with reason `NodeAffinity`, i.e., it auto-deletes such `Pod`s.
```
