### PR TITLE
Links for additional primary DNS provider extensions

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -36,6 +36,8 @@ The primary DNS provider manages `DNSRecord` resources (mandatory for Gardener r
 - [CloudFlare](https://github.com/schrodit/gardener-extension-provider-dns-cloudflare)
 - [GCP](https://github.com/gardener/gardener-extension-provider-gcp)
 - [OpenStack](https://github.com/gardener/gardener-extension-provider-openstack)
+- [PowerDNS](https://github.com/metal-stack/gardener-extension-dns-powerdns)
+- [RFC2136](https://github.com/Avarei/gardener-extension-dns-rfc2136)
 
 ### Operating System
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**What this PR does / why we need it**:
Add links for additional primary DNS provider extensions RFC2136 and PowerDNS.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
NONE
```
