### PR TITLE
Fix the `normalizeAlertingRules` func

### DIFF
--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -7,6 +7,7 @@ package botanist
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -290,11 +291,13 @@ spec:
 	return
 }
 
+var alertingRuleHeaderLineRegexp = regexp.MustCompile(`^\S+: \|`)
+
 // TODO(rfranzke): Remove this function after v1.100 has been released.
 func normalizeAlertingRules(input string) []string {
 	var cleanedLines []string
 	for _, line := range strings.Split(input, "\n") {
-		if strings.Contains(line, ": |") {
+		if alertingRuleHeaderLineRegexp.MatchString(line) {
 			continue
 		}
 		if len(line) >= 2 && line[:2] == "  " {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
Fix the `normalizeAlertingRules` func by skipping only lines that have no whitespace characters and ends with `: |`

**Which issue(s) this PR fixes**:
Part of #9065 

**Special notes for your reviewer**:
/cc @rfranzke @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
gardenlet: An issue causing alerts contributed by extensions containing a multi-line `expr` not to be properly translated in a PrometheusRule is now fixed.
```
