### PR TITLE
[release-v1.95] Automated cherry pick of #9903: Fix the `normalizeAlertingRules` func

### DIFF
--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -7,6 +7,7 @@ package botanist
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -350,11 +351,13 @@ func (b *Botanist) getMonitoringComponents() []component.MonitoringComponent {
 	return monitoringComponents
 }
 
+var alertingRuleHeaderLineRegexp = regexp.MustCompile(`^\S+: \|`)
+
 // TODO(rfranzke): Remove this function after v1.100 has been released.
 func normalizeAlertingRules(input string) []string {
 	var cleanedLines []string
 	for _, line := range strings.Split(input, "\n") {
-		if strings.Contains(line, ": |") {
+		if alertingRuleHeaderLineRegexp.MatchString(line) {
 			continue
 		}
 		if len(line) >= 2 && line[:2] == "  " {


### PR DESCRIPTION
/area monitoring
/kind regression

Cherry pick of #9903 on release-v1.95.

#9903: Fix the `normalizeAlertingRules` func

**Release Notes:**
```bugfix operator
gardenlet: An issue causing alerts contributed by extensions containing a multi-line `expr` not to be properly translated in a PrometheusRule is now fixed.
```