### PR TITLE
Refine documentation for ManagedIssuer feature

### DIFF
--- a/docs/usage/shoot_serviceaccounts.md
+++ b/docs/usage/shoot_serviceaccounts.md
@@ -67,7 +67,7 @@ If uncertain that these prerequisites are met, please contact your Gardener Admi
 
 ### Enablement
 
-If the prerequisites are met then the feature can be enabled for a shoot cluster by annotating it with `authentication.gardener.cloud/issuer: managed`. Mind that once enabled, this feature cannot be disabled. After the shoot is reconciled, you can retrieve the new shoot service account issuer value from the shoot's status. A sample query that will retrieve the managed issuer looks like this:
+If the prerequisites are met then the feature can be enabled for a shoot cluster by annotating it with `authentication.gardener.cloud/issuer=managed`. Mind that once enabled, this feature cannot be disabled. After the shoot is reconciled, you can retrieve the new shoot service account issuer value from the shoot's status. A sample query that will retrieve the managed issuer looks like this:
 
 ```bash
 kubectl -n my-project get shoot my-shoot -o jsonpath='{.status.advertisedAddresses[?(@.name=="service-account-issuer")].url}'

--- a/docs/usage/shoot_serviceaccounts.md
+++ b/docs/usage/shoot_serviceaccounts.md
@@ -67,7 +67,7 @@ If uncertain that these prerequisites are met, please contact your Gardener Admi
 
 ### Enablement
 
-If the prerequisites are met then the feature can be enabled for a shoot cluster by annotating it with `authentication.gardener.cloud/issuer=managed`. Mind that once enabled, this feature cannot be disabled. After the shoot is reconciled, you can retrieve the new shoot service account issuer value from the shoot's status. A sample query that will retrieve the managed issuer looks like this:
+If the prerequisites are met then the feature can be enabled for a shoot cluster by annotating it with `authentication.gardener.cloud/issuer: managed`. Mind that once enabled, this feature cannot be disabled. After the shoot is reconciled, you can retrieve the new shoot service account issuer value from the shoot's status. A sample query that will retrieve the managed issuer looks like this:
 
 ```bash
 kubectl -n my-project get shoot my-shoot -o jsonpath='{.status.advertisedAddresses[?(@.name=="service-account-issuer")].url}'
@@ -79,7 +79,7 @@ Mind that this annotation is incompatible with the `.spec.kubernetes.kubeAPIServ
 
 > [!CAUTION]
 > If you change from the default issuer to a managed issuer, all previously issued tokens will still be valid/accepted.
-> However, if you change from a custom `issuer` `A` to a managed issuer, then you have to add `A` to the `acceptedIssuers` so that previously issued tokens are not invalidated.
+> However, if you change from a custom `issuer` `A` to a managed issuer, then you have to add `A` to the `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.acceptedIssuers` so that previously issued tokens are not invalidated.
 > Otherwise, the control plane components as well as system components and your workload pods might fail.
 > You can remove `A` from the `acceptedIssuers` when all currently active tokens have been issued solely by the managed issuer.
 > This can be ensured by using [projected token volumes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) with a short validity, or by rolling out all pods.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR improves one small things I stumbled upon when trying the `ManagedIssuer`:
- While I was able to guess the right place for the `acceptedIssuers` when migrating from my self-exposed issuer highlighting the full path directly with `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.acceptedIssuers` would have saved me a few brain cycles and double checking.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
NONE
```
