### PR TITLE
adapt provider-local chart for operator-extensions support

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- end }}
 {{ include "labels" . | indent 8 }}
     spec:
-      priorityClassName: gardener-system-900
+      priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: {{ include "name" . }}
       containers:
       - name: {{ include "name" . }}

--- a/charts/gardener/provider-local/templates/rbac.yaml
+++ b/charts/gardener/provider-local/templates/rbac.yaml
@@ -129,7 +129,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Namespace }}
+  name: {{ include "name" . }}-{{ .Release.Namespace }}
   labels:
 {{ include "labels" . | indent 4 }}
 roleRef:

--- a/charts/gardener/provider-local/templates/rbac.yaml
+++ b/charts/gardener/provider-local/templates/rbac.yaml
@@ -129,7 +129,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "name" . }}
+  name: {{ .Release.Namespace }}
   labels:
 {{ include "labels" . | indent 4 }}
 roleRef:

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -2,6 +2,7 @@ image: local-skaffold/gardener-extension-provider-local:latest
 imagePullPolicy: IfNotPresent
 
 replicaCount: 1
+priorityClassName: gardener-system-900
 
 #podLabels: {}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
- makes priorityClass configurable
- makes cluster-level resources (the clusterrolebinding in particular) named after the deployment namespace to avoid collisions with other replicas.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt provider-local charts to allow usage by the gardener-operator when deploying extension resources.
```
