### PR TITLE
conntrack-fix container: Disable autoscaling

### DIFF
--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -762,11 +762,13 @@ metadata:
 spec:
   resourcePolicy:
     containerPolicies:
-    - containerName: '*'
+    - containerName: kube-proxy
       controlledValues: RequestsOnly
       maxAllowed:
         cpu: "4"
         memory: 10G
+    - containerName: conntrack-fix
+      mode: "Off"
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Currently, the `conntrack-fix` sidecar container of kube-proxy is also scaled by VPA. This is a sidecar container that sleeps, executes a single conntrack comamand and then sleeps forever - ref https://github.com/gardener/gardener/blob/ed35517d533b2ee9e283168c699a23ef90a67f14/pkg/component/kubernetes/proxy/resources/conntrack-fix.sh. Hence, we don't need autoscaling enabled for this sidecar container. It results only in Pod evictions when VPA wants to apply the recommendations for this container.
Initially, I wanted to set some resource requests, however the actual usage is so low that it does not make sense, IMO.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The auto-scaling by VPA is now disabled for the `conntrack-fix` sidecar container of kube-proxy. The corresponding container does not need vertical auto-scaling.
```
