### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ hack/tools/logcheck/pkg/logcheck/testdata/src/sigs.k8s.io/controller-runtime/pkg
 
 # GitGuardian
 .cache_ggshield
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,14 @@ format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@./hack/format.sh ./charts ./cmd ./extensions ./pkg ./plugin ./test ./hack
 	@cd $(LOGCHECK_DIR); $(abspath $(GOIMPORTS)) -l -w .
 
+.PHONY: sast
+sast: $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@./hack/sast.sh --gosec-report true
+
 .PHONY: test
 test: $(REPORT_COLLECTOR) $(PROMTOOL) $(HELM) logcheck-symlinks
 	@./hack/test.sh ./charts/... ./cmd/... ./extensions/pkg/... ./pkg/... ./plugin/...
@@ -230,10 +238,10 @@ check-vulnerabilities: $(GO_VULN_CHECK)
 	$(GO_VULN_CHECK) ./...
 
 .PHONY: verify
-verify: check format test test-integration
+verify: check format test test-integration sast
 
 .PHONY: verify-extended
-verify-extended: check-generate check format test-cov test-cov-clean test-integration
+verify-extended: check-generate check format test-cov test-cov-clean test-integration sast-report
 
 #####################################################################
 # Rules for local environment                                       #

--- a/extensions/pkg/webhook/certificates/certificates.go
+++ b/extensions/pkg/webhook/certificates/certificates.go
@@ -97,11 +97,11 @@ func writeCertificatesToDisk(certDir string, serverCert, serverKey []byte) error
 		serverCertPath = filepath.Join(certDir, secretsutils.DataKeyCertificate)
 	)
 
-	if err := os.MkdirAll(certDir, 0755); err != nil {
+	if err := os.MkdirAll(certDir, 0750); err != nil {
 		return err
 	}
-	if err := os.WriteFile(serverKeyPath, serverKey, 0666); err != nil {
+	if err := os.WriteFile(serverKeyPath, serverKey, 0600); err != nil {
 		return err
 	}
-	return os.WriteFile(serverCertPath, serverCert, 0666)
+	return os.WriteFile(serverCertPath, serverCert, 0600)
 }

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -27,6 +27,7 @@ GINKGO                     := $(TOOLS_BIN_DIR)/ginkgo
 GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
 GOIMPORTSREVISER           := $(TOOLS_BIN_DIR)/goimports-reviser
 GOLANGCI_LINT              := $(TOOLS_BIN_DIR)/golangci-lint
+GOSEC                      := $(TOOLS_BIN_DIR)/gosec
 GO_ADD_LICENSE             := $(TOOLS_BIN_DIR)/addlicense
 GO_APIDIFF                 := $(TOOLS_BIN_DIR)/go-apidiff
 GO_VULN_CHECK              := $(TOOLS_BIN_DIR)/govulncheck
@@ -52,6 +53,8 @@ VGOPATH                    := $(TOOLS_BIN_DIR)/vgopath
 # default tool versions
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.59.1
+# renovate: datasource=github-releases depName=securego/gosec
+GOSEC_VERSION ?= v2.20.0
 # renovate: datasource=github-releases depName=joelanford/go-apidiff
 GO_APIDIFF_VERSION ?= v0.8.2
 # renovate: datasource=github-releases depName=google/addlicense
@@ -132,7 +135,7 @@ ifeq ($(shell if [ -d $(TOOLS_BIN_SOURCE_DIR) ]; then echo "found"; fi),found)
 endif
 
 .PHONY: create-tools-bin
-create-tools-bin: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GINKGO) $(GOIMPORTS) $(GOIMPORTSREVISER) $(GO_ADD_LICENSE) $(GO_APIDIFF) $(GO_VULN_CHECK) $(GO_TO_PROTOBUF) $(HELM) $(IMPORT_BOSS) $(KIND) $(KUBECTL) $(MOCKGEN) $(OPENAPI_GEN) $(PROMTOOL) $(PROTOC) $(PROTOC_GEN_GOGO) $(SETUP_ENVTEST) $(SKAFFOLD) $(YQ) $(VGOPATH) $(KUSTOMIZE)
+create-tools-bin: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GINKGO) $(GOIMPORTS) $(GOIMPORTSREVISER) $(GOSEC) $(GO_ADD_LICENSE) $(GO_APIDIFF) $(GO_VULN_CHECK) $(GO_TO_PROTOBUF) $(HELM) $(IMPORT_BOSS) $(KIND) $(KUBECTL) $(MOCKGEN) $(OPENAPI_GEN) $(PROMTOOL) $(PROTOC) $(PROTOC_GEN_GOGO) $(SETUP_ENVTEST) $(SKAFFOLD) $(YQ) $(VGOPATH) $(KUSTOMIZE)
 
 #########################################
 # Tools                                 #
@@ -157,6 +160,9 @@ $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERS
 	@# CGO_ENABLED has to be set to 1 in order for golangci-lint to be able to load plugins
 	@# see https://github.com/golangci/golangci-lint/issues/1276
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) CGO_ENABLED=1 go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+$(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
+	@GOSEC_VERSION=$(GOSEC_VERSION) $(TOOLS_PKG_PATH)/install-gosec.sh
 
 $(GO_ADD_LICENSE):  $(call tool_version_file,$(GO_ADD_LICENSE),$(GO_ADD_LICENSE_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/addlicense@$(GO_ADD_LICENSE_VERSION)

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Installing gosec"
+
+TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version=$GOSEC_VERSION
+case $(uname -m) in
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit -1
+    ;;
+esac
+
+archive_name="gosec_${version#v}_${platform}_${arch}"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+
+curl -L -o ${temp_dir}/${file_name} "https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/gosec" $TOOLS_BIN_DIR
+chmod +x $TOOLS_BIN_DIR/gosec

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -25,7 +25,7 @@ const (
 	SecretNameCAETCD = "ca-etcd"
 	// SecretNameCAETCDPeer is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of the etcd peer network of a shoot cluster.
-	SecretNameCAETCDPeer = "ca-etcd-peer"
+	SecretNameCAETCDPeer = "ca-etcd-peer" // #nosec G101 -- No credential.
 	// SecretNameCAFrontProxy is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of the kube-aggregator a shoot cluster.
 	SecretNameCAFrontProxy = "ca-front-proxy"
@@ -34,7 +34,7 @@ const (
 	SecretNameCAKubelet = "ca-kubelet"
 	// SecretNameCAMetricsServer is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of the metrics-server of a shoot cluster.
-	SecretNameCAMetricsServer = "ca-metrics-server"
+	SecretNameCAMetricsServer = "ca-metrics-server" // #nosec G101 -- No credential.
 	// SecretNameCAVPN is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of the VPN components of a shoot cluster.
 	SecretNameCAVPN = "ca-vpn"
@@ -47,22 +47,22 @@ const (
 	SecretNameCloudProvider = "cloudprovider"
 	// SecretNameSSHKeyPair is a constant for the name of a Kubernetes secret object that contains the SSH key pair
 	// (public and private key) that can be used to SSH into the shoot nodes.
-	SecretNameSSHKeyPair = "ssh-keypair"
+	SecretNameSSHKeyPair = "ssh-keypair" // #nosec G101 -- No credential.
 	// SecretNameServiceAccountKey is a constant for the name of a Kubernetes secret object that contains a
 	// PEM-encoded private RSA or ECDSA key used by the Kube Controller Manager to sign service account tokens.
 	SecretNameServiceAccountKey = "service-account-key"
 	// SecretNameObservabilityIngress is a constant for the name of a Kubernetes secret object that contains the ingress
 	// credentials for observability components.
-	SecretNameObservabilityIngress = "observability-ingress"
+	SecretNameObservabilityIngress = "observability-ingress" // #nosec G101 -- No credential.
 	// SecretNameObservabilityIngressUsers is a constant for the name of a Kubernetes secret object that contains the
 	// user's ingress credentials for observability components.
-	SecretNameObservabilityIngressUsers = "observability-ingress-users"
+	SecretNameObservabilityIngressUsers = "observability-ingress-users" // #nosec G101 -- No credential.
 	// SecretNameETCDEncryptionKey is a constant for the name of a Kubernetes secret object that contains the key
 	// for encryption data in ETCD.
-	SecretNameETCDEncryptionKey = "kube-apiserver-etcd-encryption-key"
+	SecretNameETCDEncryptionKey = "kube-apiserver-etcd-encryption-key" // #nosec G101 -- No credential.
 	// SecretNamePrefixETCDEncryptionConfiguration is a constant for the name prefix of a Kubernetes secret object that
 	// contains the configuration for encryption data in ETCD.
-	SecretNamePrefixETCDEncryptionConfiguration = "kube-apiserver-etcd-encryption-configuration"
+	SecretNamePrefixETCDEncryptionConfiguration = "kube-apiserver-etcd-encryption-configuration" // #nosec G101 -- No credential.
 	// SecretNameGardenerETCDEncryptionKey is a constant for the name of a Kubernetes secret object that contains the
 	// key for encryption data in ETCD for gardener-apiserver.
 	SecretNameGardenerETCDEncryptionKey = "gardener-apiserver-etcd-encryption-key"
@@ -351,13 +351,13 @@ const (
 	// OperationRotateCredentialsStart is a constant for an annotation indicating that the rotation of all credentials
 	// shall be started. This includes CAs, certificates, kubeconfigs, SSH keypairs, observability credentials, and
 	// ServiceAccount signing key.
-	OperationRotateCredentialsStart = "rotate-credentials-start"
+	OperationRotateCredentialsStart = "rotate-credentials-start" // #nosec G101 -- No credential.
 	// OperationRotateCredentialsComplete is a constant for an annotation indicating that the rotation of the
 	// credentials shall be completed.
-	OperationRotateCredentialsComplete = "rotate-credentials-complete"
+	OperationRotateCredentialsComplete = "rotate-credentials-complete" // #nosec G101 -- No credential.
 	// ShootOperationRotateKubeconfigCredentials is a constant for an annotation on a Shoot indicating that the
 	// credentialscontained in the kubeconfig that is handed out to the user shall be rotated.
-	ShootOperationRotateKubeconfigCredentials = "rotate-kubeconfig-credentials"
+	ShootOperationRotateKubeconfigCredentials = "rotate-kubeconfig-credentials" // #nosec G101 -- No credential.
 	// ShootOperationRotateSSHKeypair is a constant for an annotation on a Shoot indicating that the SSH keypair for the
 	// shoot nodes shall be rotated.
 	ShootOperationRotateSSHKeypair = "rotate-ssh-keypair"
@@ -370,7 +370,7 @@ const (
 	// OperationRotateObservabilityCredentials is a constant for an annotation indicating that the
 	// credentials for the observability stack secret shall be rotated. Note that this only affects the user credentials
 	// since the operator credentials are rotated automatically each `30d`.
-	OperationRotateObservabilityCredentials = "rotate-observability-credentials"
+	OperationRotateObservabilityCredentials = "rotate-observability-credentials" // #nosec G101 -- No credential.
 	// OperationRotateServiceAccountKeyStart is a constant for an annotation on a Shoot indicating that the
 	// rotation of the service account signing key shall be started.
 	OperationRotateServiceAccountKeyStart = "rotate-serviceaccount-key-start"
@@ -385,7 +385,7 @@ const (
 	OperationRotateETCDEncryptionKeyComplete = "rotate-etcd-encryption-key-complete"
 	// SeedOperationRenewGardenAccessSecrets is a constant for an annotation on a Seed indicating that the
 	// all garden access secrets on the seed shall be renewed.
-	SeedOperationRenewGardenAccessSecrets = "renew-garden-access-secrets"
+	SeedOperationRenewGardenAccessSecrets = "renew-garden-access-secrets" // #nosec G101 -- No credential.
 	// KubeconfigSecretOperationRenew is a constant for an annotation on the secret in a Seed containing the garden
 	// cluster kubeconfig of a gardenlet indicating that it should be renewed.
 	KubeconfigSecretOperationRenew = "renew"

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -225,7 +225,7 @@ const (
 	OperatingSystemConfigDefaultFilePermission int32 = 0644
 	// OperatingSystemConfigSecretDataKey is a constant for the key in a secret's `.data` field containing the
 	// results of a computed cloud config.
-	OperatingSystemConfigSecretDataKey = "cloud_config"
+	OperatingSystemConfigSecretDataKey = "cloud_config" // #nosec G101 -- No credential.
 )
 
 // CRIConfig contains configurations of the CRI library.

--- a/pkg/component/apiserver/admission.go
+++ b/pkg/component/apiserver/admission.go
@@ -55,7 +55,7 @@ const (
 	volumeNameAdmissionConfiguration          = "admission-config"
 	volumeNameAdmissionKubeconfigSecrets      = "admission-kubeconfigs"
 	volumeMountPathAdmissionConfiguration     = "/etc/kubernetes/admission"
-	volumeMountPathAdmissionKubeconfigSecrets = "/etc/kubernetes/admission-kubeconfigs"
+	volumeMountPathAdmissionKubeconfigSecrets = "/etc/kubernetes/admission-kubeconfigs" // #nosec G101 -- No credential.
 )
 
 // ReconcileSecretAdmissionKubeconfigs reconciles the secret containing the kubeconfig for admission plugins.

--- a/pkg/component/apiserver/audit.go
+++ b/pkg/component/apiserver/audit.go
@@ -43,7 +43,7 @@ func init() {
 
 const (
 	// SecretWebhookKubeconfigDataKey is a constant for a key in the data of the secret containing a kubeconfig.
-	SecretWebhookKubeconfigDataKey = "kubeconfig.yaml"
+	SecretWebhookKubeconfigDataKey = "kubeconfig.yaml" // #nosec G101 -- No credential.
 
 	configMapAuditPolicyDataKey = "audit-policy.yaml"
 

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -66,10 +66,10 @@ const (
 
 	// SecretNameClient is the name of the secret containing the client certificate and key for the etcd.
 	SecretNameClient       = "etcd-client"
-	secretNamePrefixServer = "etcd-server-"
+	secretNamePrefixServer = "etcd-server-" // #nosec G101 -- No credential.
 
 	// secretNamePrefixPeerServer is the prefix for the secret containing the server certificate and key for the etcd peer network.
-	secretNamePrefixPeerServer = "etcd-peer-server-"
+	secretNamePrefixPeerServer = "etcd-peer-server-" // #nosec G101 -- No credential.
 
 	// LabelAppValue is the value of a label whose key is 'app'.
 	LabelAppValue = "etcd-statefulset"

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -54,7 +54,7 @@ const (
 	// of an OperatingSystemConfig resource.
 	DefaultTimeout = 3 * time.Minute
 	// WorkerPoolHashesSecretName is the name of the secret that tracks the OSC key calculation version used for each worker pool.
-	WorkerPoolHashesSecretName = "worker-pools-operatingsystemconfig-hashes"
+	WorkerPoolHashesSecretName = "worker-pools-operatingsystemconfig-hashes" // #nosec G101 -- No credential.
 	// poolHashesDataKey is the key in the data of the WorkerPoolHashesSecretName used to store the calculated hashes.
 	poolHashesDataKey = "pools"
 )

--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// SecretNameUserKubeconfig is the name for the user kubeconfig.
-	SecretNameUserKubeconfig = "user-kubeconfig"
+	SecretNameUserKubeconfig = "user-kubeconfig" // #nosec G101 -- No credential.
 	// ServicePortName is the name of the port in the service.
 	ServicePortName = "kube-apiserver"
 	// UserNameVPNSeedClient is the user name for the HA vpn-seed-client components (used as common name in its client certificate)

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -37,10 +37,10 @@ import (
 
 const (
 	secretNameServerCert             = "kube-apiserver"
-	secretNameKubeAPIServerToKubelet = "kube-apiserver-kubelet"
-	secretNameKubeAggregator         = "kube-aggregator"
-	secretNameHTTPProxy              = "kube-apiserver-http-proxy"
-	secretNameHAVPNSeedClient        = "vpn-seed-client"
+	secretNameKubeAPIServerToKubelet = "kube-apiserver-kubelet"    // #nosec G101 -- No credential.
+	secretNameKubeAggregator         = "kube-aggregator"           // #nosec G101 -- No credential.
+	secretNameHTTPProxy              = "kube-apiserver-http-proxy" // #nosec G101 -- No credential.
+	secretNameHAVPNSeedClient        = "vpn-seed-client"           // #nosec G101 -- No credential.
 
 	// ContainerNameKubeAPIServer is the name of the kube-apiserver container.
 	ContainerNameKubeAPIServer     = "kube-apiserver"
@@ -84,8 +84,8 @@ const (
 	volumeMountPathOIDCCABundle                    = "/srv/kubernetes/oidc"
 	volumeMountPathServiceAccountKey               = "/srv/kubernetes/service-account-key"
 	volumeMountPathServiceAccountKeyBundle         = "/srv/kubernetes/service-account-key-bundle"
-	volumeMountPathStaticToken                     = "/srv/kubernetes/token"
-	volumeMountPathPrefixTLSSNISecret              = "/srv/kubernetes/tls-sni/"
+	volumeMountPathStaticToken                     = "/srv/kubernetes/token"    // #nosec G101 -- No credential.
+	volumeMountPathPrefixTLSSNISecret              = "/srv/kubernetes/tls-sni/" // #nosec G101 -- No credential.
 	volumeMountPathVPNSeedClient                   = "/srv/secrets/vpn-client"
 	volumeMountPathAPIServerAccess                 = "/var/run/secrets/kubernetes.io/serviceaccount"
 	volumeMountPathVPNSeedTLSAuth                  = "/srv/secrets/tlsauth"

--- a/pkg/component/kubernetes/apiserver/secrets.go
+++ b/pkg/component/kubernetes/apiserver/secrets.go
@@ -28,17 +28,17 @@ import (
 
 const (
 	// SecretStaticTokenName is a constant for the name of the static-token secret.
-	SecretStaticTokenName = "kube-apiserver-static-token"
+	SecretStaticTokenName = "kube-apiserver-static-token" // #nosec G101 -- No credential.
 
-	secretOIDCCABundleNamePrefix   = "kube-apiserver-oidc-cabundle"
+	secretOIDCCABundleNamePrefix   = "kube-apiserver-oidc-cabundle" // #nosec G101 -- No credential.
 	secretOIDCCABundleDataKeyCaCrt = "ca.crt"
 
-	secretAuditWebhookKubeconfigNamePrefix          = "kube-apiserver-audit-webhook-kubeconfig"
-	secretAuthenticationWebhookKubeconfigNamePrefix = "kube-apiserver-authentication-webhook-kubeconfig"
-	secretAuthorizationWebhookKubeconfigNamePrefix  = "kube-apiserver-authorization-webhook-kubeconfig"
+	secretAuditWebhookKubeconfigNamePrefix          = "kube-apiserver-audit-webhook-kubeconfig"          // #nosec G101 -- No credential.
+	secretAuthenticationWebhookKubeconfigNamePrefix = "kube-apiserver-authentication-webhook-kubeconfig" // #nosec G101 -- No credential.
+	secretAuthorizationWebhookKubeconfigNamePrefix  = "kube-apiserver-authorization-webhook-kubeconfig"  // #nosec G101 -- No credential.
 
 	secretETCDEncryptionConfigurationDataKey = "encryption-configuration.yaml"
-	secretAdmissionKubeconfigsNamePrefix     = "kube-apiserver-admission-kubeconfigs"
+	secretAdmissionKubeconfigsNamePrefix     = "kube-apiserver-admission-kubeconfigs" // #nosec G101 -- No credential.
 
 	userNameClusterAdmin = "system:cluster-admin"
 	userNameHealthCheck  = "health-check"

--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -50,7 +50,7 @@ const (
 	BinPackingSchedulerName = "bin-packing-scheduler"
 
 	serviceName         = "kube-scheduler"
-	secretNameServer    = "kube-scheduler-server"
+	secretNameServer    = "kube-scheduler-server" // #nosec G101 -- No credential.
 	managedResourceName = "shoot-core-kube-scheduler"
 
 	containerName   = v1beta1constants.DeploymentNameKubeScheduler

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -53,7 +53,7 @@ const (
 	// GatewayPort is the port exposed by the istio ingress gateway
 	GatewayPort = 8132
 	// SecretNameTLSAuth is the name of seed server tlsauth Secret.
-	SecretNameTLSAuth = "vpn-seed-server-tlsauth"
+	SecretNameTLSAuth = "vpn-seed-server-tlsauth" // #nosec G101 -- No credential.
 	deploymentName    = v1beta1constants.DeploymentNameVPNSeedServer
 	// ServiceName is the name of the vpn seed server service running internally on the control plane in seed.
 	ServiceName = deploymentName

--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -59,8 +59,8 @@ const (
 	volumeNameTLSAuth   = "vpn-shoot-tlsauth"
 	volumeNameDevNetTun = "dev-net-tun"
 
-	volumeMountPathSecret    = "/srv/secrets/vpn-client"
-	volumeMountPathSecretTLS = "/srv/secrets/tlsauth"
+	volumeMountPathSecret    = "/srv/secrets/vpn-client" // #nosec G101 -- No credential.
+	volumeMountPathSecretTLS = "/srv/secrets/tlsauth"    // #nosec G101 -- No credential.
 	volumeMountPathDevNetTun = "/dev/net/tun"
 )
 

--- a/pkg/component/shared/etcd.go
+++ b/pkg/component/shared/etcd.go
@@ -30,7 +30,8 @@ func SnapshotEtcd(ctx context.Context, secretsManager secretsmanager.Interface, 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs: caCerts,
+				RootCAs:    caCerts,
+				MinVersion: tls.VersionTLS12,
 			},
 		},
 	}

--- a/pkg/component/test/prometheusrule.go
+++ b/pkg/component/test/prometheusrule.go
@@ -24,7 +24,7 @@ func PrometheusRule(rule *monitoringv1.PrometheusRule, filenameRulesTest string)
 `), data...)
 
 	filepath := filepath.Join("testdata", rule.Name+".prometheusrule.yaml")
-	ExpectWithOffset(1, os.WriteFile(filepath, data, 0644)).To(Succeed())
+	ExpectWithOffset(1, os.WriteFile(filepath, data, 0600)).To(Succeed())
 	defer func() {
 		ExpectWithOffset(1, os.Remove(filepath)).To(Succeed())
 	}()

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -181,7 +181,7 @@ func (r *Reconciler) remediateAllocatedNodePorts(ctx context.Context, log logr.L
 				port.NodePort == nodePortIstioIngressGatewayZone2 {
 				var (
 					min, max    = 30000, 32767
-					newNodePort = int32(rand.N(max-min) + min)
+					newNodePort = int32(rand.N(max-min) + min) // #nosec: G404 -- No cryptographic context.
 				)
 
 				log.Info("Assigning new nodePort to service which already allocates the nodePort",

--- a/pkg/gardenlet/controller/managedseed/add.go
+++ b/pkg/gardenlet/controller/managedseed/add.go
@@ -37,10 +37,10 @@ const (
 
 	// GardenletDefaultKubeconfigSecretName is the default name for the field in the Gardenlet component configuration
 	// .gardenClientConnection.KubeconfigSecret.Name
-	GardenletDefaultKubeconfigSecretName = "gardenlet-kubeconfig"
+	GardenletDefaultKubeconfigSecretName = "gardenlet-kubeconfig" // #nosec G101 -- No credential.
 	// GardenletDefaultKubeconfigBootstrapSecretName is the default name for the field in the Gardenlet component configuration
 	// .gardenClientConnection.BootstrapKubeconfig.Name
-	GardenletDefaultKubeconfigBootstrapSecretName = "gardenlet-kubeconfig-bootstrap"
+	GardenletDefaultKubeconfigBootstrapSecretName = "gardenlet-kubeconfig-bootstrap" // #nosec G101 -- No credential.
 )
 
 // AddToManager adds Reconciler to the given manager.

--- a/pkg/gardenlet/controller/managedseed/valueshelper.go
+++ b/pkg/gardenlet/controller/managedseed/valueshelper.go
@@ -293,7 +293,7 @@ func getParentGardenletDeployment() (*seedmanagementv1alpha1.GardenletDeployment
 func getParentImageVectorOverwrite() (*string, error) {
 	var imageVectorOverwrite *string
 	if overWritePath := os.Getenv(imagevectorutils.OverrideEnv); len(overWritePath) > 0 {
-		data, err := os.ReadFile(overWritePath)
+		data, err := os.ReadFile(overWritePath) // #nosec: G304 -- ImageVectorOverwrite is a feature. In reality files can be read from the Pod's file system only.
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func getParentImageVectorOverwrite() (*string, error) {
 func getParentComponentImageVectorOverwrites() (*string, error) {
 	var componentImageVectorOverwrites *string
 	if overWritePath := os.Getenv(imagevectorutils.ComponentOverrideEnv); len(overWritePath) > 0 {
-		data, err := os.ReadFile(overWritePath)
+		data, err := os.ReadFile(overWritePath) // #nosec: G304 -- ImageVectorOverwrite is a feature. In reality files can be read from the Pod's file system only.
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -337,7 +337,7 @@ func getReplicaCount(obj client.Object, currentOrMinReplicas *int32, failureTole
 		if err != nil {
 			return nil, err
 		}
-		replicas = ptr.To(int32(v))
+		replicas = ptr.To(int32(v)) // #nosec: G109 - There is a validation for `replicas` in `Deployments` and `StatefulSets`.
 	}
 	return replicas, nil
 }

--- a/pkg/utils/encoding_test.go
+++ b/pkg/utils/encoding_test.go
@@ -7,18 +7,23 @@ package utils_test
 import (
 	"crypto/x509"
 	"errors"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	"golang.org/x/crypto/bcrypt"
 
 	. "github.com/gardener/gardener/pkg/utils"
 )
 
 var _ = Describe("Encoding", func() {
-	Describe("#CreateSHA1Secret", func() {
-		It("should create the expected secret", func() {
-			Expect(CreateSHA1Secret([]byte("username"), []byte("password"))).To(Equal([]byte("username:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=")))
+	Describe("#CreateBcryptCredentials", func() {
+		It("should create the expected credentials", func() {
+			credentials, err := CreateBcryptCredentials([]byte("username"), []byte("password"))
+			Expect(err).ToNot(HaveOccurred())
+			hashedPassword := strings.TrimPrefix(string(credentials), "username:")
+			Expect(bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte("password"))).To(Succeed())
 		})
 	})
 

--- a/pkg/utils/gardener/secrets.go
+++ b/pkg/utils/gardener/secrets.go
@@ -59,8 +59,12 @@ func ReplicateGlobalMonitoringSecret(ctx context.Context, c client.Client, prefi
 		globalMonitoringSecretReplica.Data = globalMonitoringSecret.Data
 		globalMonitoringSecretReplica.Immutable = globalMonitoringSecret.Immutable
 
-		if _, ok := globalMonitoringSecretReplica.Data[secretsutils.DataKeySHA1Auth]; !ok {
-			globalMonitoringSecretReplica.Data[secretsutils.DataKeySHA1Auth] = utils.CreateSHA1Secret(globalMonitoringSecret.Data[secretsutils.DataKeyUserName], globalMonitoringSecret.Data[secretsutils.DataKeyPassword])
+		if _, ok := globalMonitoringSecretReplica.Data[secretsutils.DataKeyAuth]; !ok {
+			credentials, err := utils.CreateBcryptCredentials(globalMonitoringSecret.Data[secretsutils.DataKeyUserName], globalMonitoringSecret.Data[secretsutils.DataKeyPassword])
+			if err != nil {
+				return err
+			}
+			globalMonitoringSecretReplica.Data[secretsutils.DataKeyAuth] = credentials
 		}
 
 		return nil

--- a/pkg/utils/gardener/secrets_test.go
+++ b/pkg/utils/gardener/secrets_test.go
@@ -6,9 +6,11 @@ package gardener_test
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -51,7 +53,8 @@ var _ = Describe("Secrets", func() {
 				for k, v := range globalMonitoringSecret.Data {
 					Expect(secret.Data).To(HaveKeyWithValue(k, v), "have key "+k+" with value "+string(v))
 				}
-				Expect(secret.Data).To(HaveKeyWithValue("auth", []byte("bar:{SHA}u+lgol6jEdIdQGaek98gA7qbkKI=")))
+				hashedPassword := strings.TrimPrefix(string(secret.Data["auth"]), string(secret.Data["username"])+":")
+				Expect(bcrypt.CompareHashAndPassword([]byte(hashedPassword), secret.Data["password"])).To(Succeed())
 			}
 
 			secret, err := ReplicateGlobalMonitoringSecret(ctx, fakeClient, prefix, namespace, globalMonitoringSecret)

--- a/pkg/utils/imagevector/imagevector.go
+++ b/pkg/utils/imagevector/imagevector.go
@@ -45,7 +45,7 @@ func Read(buf []byte) (ImageVector, error) {
 
 // ReadFile reads an ImageVector from the file with the given name.
 func ReadFile(name string) (ImageVector, error) {
-	buf, err := os.ReadFile(name)
+	buf, err := os.ReadFile(name) // #nosec: G304 -- ImageVectorOverwrite is a feature. In reality files can be read from the Pod's file system only.
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/imagevector/imagevector_components.go
+++ b/pkg/utils/imagevector/imagevector_components.go
@@ -41,7 +41,7 @@ func ReadComponentOverwrite(buf []byte) (ComponentImageVectors, error) {
 
 // ReadComponentOverwriteFile reads an ComponentImageVector from the file with the given name.
 func ReadComponentOverwriteFile(name string) (ComponentImageVectors, error) {
-	buf, err := os.ReadFile(name)
+	buf, err := os.ReadFile(name) // #nosec: G304 -- ImageVectorOverwrite is a feature. In reality files can be read from the Pod's file system only.
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -43,7 +43,7 @@ func RandomDuration(max time.Duration) time.Duration {
 	if max.Nanoseconds() <= 0 {
 		return time.Duration(0)
 	}
-	return time.Duration(mathrand.N(max.Nanoseconds()))
+	return time.Duration(mathrand.N(max.Nanoseconds())) // #nosec: G404 -- No cryptographic context.
 }
 
 // RandomDurationWithMetaDuration takes a *metav1.Duration and computes a non-negative pseudo-random duration in [0,max).

--- a/pkg/utils/secrets/basic_auth.go
+++ b/pkg/utils/secrets/basic_auth.go
@@ -19,7 +19,7 @@ const (
 	DataKeyUserName = "username"
 	// DataKeyPassword is the key in a secret data holding the password.
 	DataKeyPassword = "password"
-	// DataKeyAuth is the key in a secret data holding the sha1-schemed credentials pair as string.
+	// DataKeyAuth is the key in a secret data holding the basic authentication schemed credentials pair as string.
 	DataKeyAuth = "auth"
 )
 

--- a/pkg/utils/secrets/basic_auth.go
+++ b/pkg/utils/secrets/basic_auth.go
@@ -19,8 +19,8 @@ const (
 	DataKeyUserName = "username"
 	// DataKeyPassword is the key in a secret data holding the password.
 	DataKeyPassword = "password"
-	// DataKeySHA1Auth is the key in a secret data holding the sha1-schemed credentials pair as string.
-	DataKeySHA1Auth = "auth"
+	// DataKeyAuth is the key in a secret data holding the sha1-schemed credentials pair as string.
+	DataKeyAuth = "auth"
 )
 
 // BasicAuthSecretConfig contains the specification for a to-be-generated basic authentication secret.
@@ -44,6 +44,7 @@ type BasicAuth struct {
 
 	Username string
 	Password string
+	Auth     []byte
 }
 
 // GetName returns the name of the secret.
@@ -58,11 +59,17 @@ func (s *BasicAuthSecretConfig) Generate() (DataInterface, error) {
 		return nil, err
 	}
 
+	auth, err := utils.CreateBcryptCredentials([]byte(s.Username), []byte(password))
+	if err != nil {
+		return nil, err
+	}
+
 	basicAuth := &BasicAuth{
 		Name: s.Name,
 
 		Username: s.Username,
 		Password: password,
+		Auth:     auth,
 	}
 
 	return basicAuth, nil
@@ -74,7 +81,7 @@ func (b *BasicAuth) SecretData() map[string][]byte {
 
 	data[DataKeyUserName] = []byte(b.Username)
 	data[DataKeyPassword] = []byte(b.Password)
-	data[DataKeySHA1Auth] = utils.CreateSHA1Secret(data[DataKeyUserName], data[DataKeyPassword])
+	data[DataKeyAuth] = b.Auth
 
 	return data
 }

--- a/pkg/utils/secrets/basic_auth.go
+++ b/pkg/utils/secrets/basic_auth.go
@@ -44,7 +44,7 @@ type BasicAuth struct {
 
 	Username string
 	Password string
-	Auth     []byte
+	auth     []byte
 }
 
 // GetName returns the name of the secret.
@@ -69,7 +69,7 @@ func (s *BasicAuthSecretConfig) Generate() (DataInterface, error) {
 
 		Username: s.Username,
 		Password: password,
-		Auth:     auth,
+		auth:     auth,
 	}
 
 	return basicAuth, nil
@@ -81,7 +81,7 @@ func (b *BasicAuth) SecretData() map[string][]byte {
 
 	data[DataKeyUserName] = []byte(b.Username)
 	data[DataKeyPassword] = []byte(b.Password)
-	data[DataKeyAuth] = b.Auth
+	data[DataKeyAuth] = b.auth
 
 	return data
 }

--- a/pkg/utils/secrets/basic_auth_test.go
+++ b/pkg/utils/secrets/basic_auth_test.go
@@ -5,32 +5,18 @@
 package secrets_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/bcrypt"
 
 	. "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
 var _ = Describe("Basic Auth Secrets", func() {
-	Describe("Basic Auth Configuration", func() {
-		compareCurrentAndExpectedBasicAuth := func(current DataInterface, expected *BasicAuth, comparePasswords bool) {
-			basicAuth, ok := current.(*BasicAuth)
-			Expect(ok).To(BeTrue())
-
-			Expect(basicAuth.Name).To(Equal(expected.Name))
-			Expect(basicAuth.Username).To(Equal(expected.Username))
-
-			if comparePasswords {
-				Expect(basicAuth.Password).To(Equal(expected.Password))
-			} else {
-				Expect(basicAuth.Password).NotTo(Equal(""))
-			}
-		}
-
-		var (
-			expectedBasicAuthObject *BasicAuth
-			basicAuthConfiguration  *BasicAuthSecretConfig
-		)
+	Describe("Configuration", func() {
+		var basicAuthConfiguration *BasicAuthSecretConfig
 
 		BeforeEach(func() {
 			basicAuthConfiguration = &BasicAuthSecretConfig{
@@ -39,46 +25,29 @@ var _ = Describe("Basic Auth Secrets", func() {
 				Username:       "admin",
 				PasswordLength: 32,
 			}
-
-			expectedBasicAuthObject = &BasicAuth{
-				Name:     "basic-auth",
-				Username: "admin",
-				Password: "foo",
-			}
 		})
 
 		Describe("#Generate", func() {
 			It("should properly generate Basic Auth Object", func() {
 				obj, err := basicAuthConfiguration.Generate()
 				Expect(err).NotTo(HaveOccurred())
-				compareCurrentAndExpectedBasicAuth(obj, expectedBasicAuthObject, false)
+
+				basicAuth, ok := obj.(*BasicAuth)
+				Expect(ok).To(BeTrue())
+
+				password := strings.TrimPrefix(string(basicAuth.Auth), basicAuthConfiguration.Username+":")
+				Expect(bcrypt.CompareHashAndPassword([]byte(password), []byte(basicAuth.Password))).To(Succeed())
 			})
-		})
-	})
-
-	Describe("Basic Auth Object", func() {
-		var (
-			basicAuth                *BasicAuth
-			expectedNormalFormatData map[string][]byte
-		)
-		BeforeEach(func() {
-			basicAuth = &BasicAuth{
-				Name:     "basicauth",
-				Username: "admin",
-				Password: "foo",
-			}
-
-			expectedNormalFormatData = map[string][]byte{
-				DataKeyUserName: []byte("admin"),
-				DataKeyPassword: []byte("foo"),
-				DataKeySHA1Auth: []byte("admin:{SHA}C+7Hteo/D9vJXQ3UfzxbwnXaijM="),
-			}
 		})
 
 		Describe("#SecretData", func() {
 			It("should properly return secret data if format is BasicAuthFormatNormal", func() {
-				data := basicAuth.SecretData()
-				Expect(data).To(Equal(expectedNormalFormatData))
+				obj, err := basicAuthConfiguration.Generate()
+				Expect(err).NotTo(HaveOccurred())
+
+				data := obj.SecretData()
+				password := strings.TrimPrefix(string(data[DataKeyAuth]), string(data[DataKeyUserName])+":")
+				Expect(bcrypt.CompareHashAndPassword([]byte(password), data[DataKeyPassword])).To(Succeed())
 			})
 		})
 	})

--- a/pkg/utils/secrets/basic_auth_test.go
+++ b/pkg/utils/secrets/basic_auth_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Basic Auth Secrets", func() {
 				basicAuth, ok := obj.(*BasicAuth)
 				Expect(ok).To(BeTrue())
 
-				password := strings.TrimPrefix(string(basicAuth.Auth), basicAuthConfiguration.Username+":")
+				password := strings.TrimPrefix(string(basicAuth.SecretData()[DataKeyAuth]), basicAuthConfiguration.Username+":")
 				Expect(bcrypt.CompareHashAndPassword([]byte(password), []byte(basicAuth.Password))).To(Succeed())
 			})
 		})

--- a/pkg/utils/secrets/certificate.go
+++ b/pkg/utils/secrets/certificate.go
@@ -280,10 +280,10 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.
 	}
 	caCertificateData := caCertificate.SecretData()
 
-	if err := os.WriteFile(filepath.Join(tempDir, DataKeyCertificateCA), caCertificateData[DataKeyCertificateCA], 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyCertificateCA), caCertificateData[DataKeyCertificateCA], 0600); err != nil {
 		return nil, nil, "", err
 	}
-	if err := os.WriteFile(filepath.Join(tempDir, DataKeyPrivateKeyCA), caCertificateData[DataKeyPrivateKeyCA], 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyPrivateKeyCA), caCertificateData[DataKeyPrivateKeyCA], 0600); err != nil {
 		return nil, nil, "", err
 	}
 
@@ -300,10 +300,10 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.
 	}
 	certificateData := certificate.SecretData()
 
-	if err := os.WriteFile(filepath.Join(tempDir, DataKeyCertificate), certificateData[DataKeyCertificate], 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyCertificate), certificateData[DataKeyCertificate], 0600); err != nil {
 		return nil, nil, "", err
 	}
-	if err := os.WriteFile(filepath.Join(tempDir, DataKeyPrivateKey), certificateData[DataKeyPrivateKey], 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyPrivateKey), certificateData[DataKeyPrivateKey], 0600); err != nil {
 		return nil, nil, "", err
 	}
 

--- a/pkg/utils/secrets/static_token.go
+++ b/pkg/utils/secrets/static_token.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// DataKeyStaticTokenCSV is the key in a secret data holding the CSV format of a secret.
-	DataKeyStaticTokenCSV = "static_tokens.csv"
+	DataKeyStaticTokenCSV = "static_tokens.csv" // #nosec G101 -- No credential.
 	// DataKeyToken is the key in a secret data holding the token.
 	DataKeyToken = "token"
 )

--- a/pkg/utils/test/test_resources.go
+++ b/pkg/utils/test/test_resources.go
@@ -101,7 +101,7 @@ func ReadTestResources(scheme *runtime.Scheme, namespaceName, path string) ([]cl
 
 // readDocuments reads documents from file
 func readDocuments(fp string) ([][]byte, error) {
-	b, err := os.ReadFile(fp)
+	b, err := os.ReadFile(fp) // #nosec: G304 -- Test only.
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -243,7 +243,7 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 })
 
 const (
-	gardenletKubeconfigSecretName      = "gardenlet-kubeconfig"
+	gardenletKubeconfigSecretName      = "gardenlet-kubeconfig" // #nosec G101 -- No credential.
 	gardenletKubeconfigSecretNamespace = "garden"
 )
 

--- a/test/envtest/aggregator.go
+++ b/test/envtest/aggregator.go
@@ -63,7 +63,7 @@ func (a AggregatorConfig) generateCerts() error {
 	}
 	caData := ca.SecretData()
 
-	if err := os.WriteFile(a.caCrtPath(), caData[secrets.DataKeyCertificateCA], 0640); err != nil {
+	if err := os.WriteFile(a.caCrtPath(), caData[secrets.DataKeyCertificateCA], 0600); err != nil {
 		return fmt.Errorf("unable to save the proxy client CA certificate to %s: %w", a.caCrtPath(), err)
 	}
 
@@ -78,10 +78,10 @@ func (a AggregatorConfig) generateCerts() error {
 	}
 	clientCertData := clientCert.SecretData()
 
-	if err := os.WriteFile(a.clientCrtPath(), clientCertData[secrets.DataKeyCertificate], 0640); err != nil {
+	if err := os.WriteFile(a.clientCrtPath(), clientCertData[secrets.DataKeyCertificate], 0600); err != nil {
 		return fmt.Errorf("unable to save the proxy client certificate to %s: %w", a.clientCrtPath(), err)
 	}
-	if err := os.WriteFile(a.clientKeyPath(), clientCertData[secrets.DataKeyPrivateKey], 0640); err != nil {
+	if err := os.WriteFile(a.clientKeyPath(), clientCertData[secrets.DataKeyPrivateKey], 0600); err != nil {
 		return fmt.Errorf("unable to save the proxy client key to %s: %w", a.clientKeyPath(), err)
 	}
 

--- a/test/envtest/apiserver.go
+++ b/test/envtest/apiserver.go
@@ -134,7 +134,7 @@ func (g *GardenerAPIServer) Start() error {
 
 func (g *GardenerAPIServer) runAPIServerBinary() error {
 	log.V(1).Info("Starting gardener-apiserver", "path", g.Path, "args", g.Args)
-	command := exec.Command(g.Path, g.Args...)
+	command := exec.Command(g.Path, g.Args...) // #nosec: G204 -- Test only.
 	session, err := gexec.Start(command, g.Out, g.Err)
 	if err != nil {
 		return err

--- a/test/envtest/apiserver.go
+++ b/test/envtest/apiserver.go
@@ -281,7 +281,7 @@ func (g *GardenerAPIServer) waitUntilHealthy(ctx context.Context) error {
 	// setup secure http client
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(g.caCert.CertificatePEM)
-	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: certPool}}}
+	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: certPool, MinVersion: tls.VersionTLS12}}}
 
 	healthCheckURL := g.listenURL
 	healthCheckURL.Path = g.HealthCheckEndpoint

--- a/test/framework/http_utils.go
+++ b/test/framework/http_utils.go
@@ -46,7 +46,7 @@ func TestHTTPEndpointWithToken(ctx context.Context, url, token string) error {
 
 func testHTTPEndpointWith(ctx context.Context, url string, mutator func(*http.Request)) error {
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec: G402 -- Test only.
 		Proxy:           http.ProxyFromEnvironment,
 	}
 

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -377,7 +377,7 @@ func DownloadKubeconfig(ctx context.Context, client kubernetes.Interface, namesp
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(downloadPath, []byte(kubeconfig), 0755)
+	err = os.WriteFile(downloadPath, []byte(kubeconfig), 0600)
 	if err != nil {
 		return err
 	}
@@ -394,7 +394,7 @@ func DownloadAdminKubeconfigForShoot(ctx context.Context, client kubernetes.Inte
 		return err
 	}
 
-	err = os.WriteFile(downloadPath, kubeconfig, 0755)
+	err = os.WriteFile(downloadPath, kubeconfig, 0600)
 	if err != nil {
 		return err
 	}

--- a/test/framework/reporter/esreporter.go
+++ b/test/framework/reporter/esreporter.go
@@ -156,7 +156,7 @@ func (reporter *GardenerESReporter) storeResults() {
 			return
 		}
 
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(dir, 0750); err != nil {
 			fmt.Printf("Failed to create report directory %s: %s\n", dir, err.Error())
 			return
 		}

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -110,6 +110,7 @@ func (f *ShootCreationFramework) AfterEach(ctx context.Context) {
 func validateShootCreationConfig(cfg *ShootCreationConfig) {
 	if cfg == nil {
 		ginkgo.Fail("no shoot creation framework configuration provided")
+		return
 	}
 
 	if StringSet(cfg.shootAnnotations) {

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -198,6 +198,7 @@ func (f *ShootFramework) AddShoot(ctx context.Context, shootName, shootNamespace
 func validateShootConfig(cfg *ShootConfig) {
 	if cfg == nil {
 		ginkgo.Fail("no shoot framework configuration provided")
+		return
 	}
 	if !StringSet(cfg.ShootName) {
 		ginkgo.Fail("You should specify a shootName to test against")

--- a/test/framework/utils.go
+++ b/test/framework/utils.go
@@ -109,7 +109,7 @@ func FileExists(kc string) bool {
 
 // ReadObject loads the contents of file and decodes it as an object.
 func ReadObject(file string, into apimachineryRuntime.Object) error {
-	data, err := os.ReadFile(file)
+	data, err := os.ReadFile(file) // #nosec: G304 -- Test only.
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func ReadObject(file string, into apimachineryRuntime.Object) error {
 
 // ParseFileAsProviderConfig parses a file as a ProviderConfig
 func ParseFileAsProviderConfig(filepath string) (*apimachineryRuntime.RawExtension, error) {
-	data, err := os.ReadFile(filepath)
+	data, err := os.ReadFile(filepath) // #nosec: G304 -- Test only.
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func ParseFileAsProviderConfig(filepath string) (*apimachineryRuntime.RawExtensi
 
 // ParseFileAsWorkers parses a file as a Worker configuration
 func ParseFileAsWorkers(filepath string) ([]gardencorev1beta1.Worker, error) {
-	data, err := os.ReadFile(filepath)
+	data, err := os.ReadFile(filepath) // #nosec: G304 -- Test only.
 	if err != nil {
 		return nil, err
 	}

--- a/test/testmachinery/extensions/generator/helper.go
+++ b/test/testmachinery/extensions/generator/helper.go
@@ -22,10 +22,10 @@ func MarshalAndWriteConfig(filepath string, config any) error {
 		return fmt.Errorf("unable to parse config: %w", err)
 	}
 
-	if err := os.MkdirAll(path.Dir(filepath), os.ModePerm); err != nil {
+	if err := os.MkdirAll(path.Dir(filepath), 0750); err != nil {
 		return fmt.Errorf("unable to create path %s: %w", path.Dir(filepath), err)
 	}
-	if err := os.WriteFile(filepath, raw, os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath, raw, 0600); err != nil {
 		return fmt.Errorf("unable to write config to %s: %w", filepath, err)
 	}
 

--- a/test/testmachinery/shoots/operations/operations.go
+++ b/test/testmachinery/shoots/operations/operations.go
@@ -148,7 +148,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 				return
 			}
 			shootKubeconfigPath := filepath.Join(kubeconfigsPath, "shoot.config")
-			framework.ExpectNoError(os.WriteFile(shootKubeconfigPath, []byte(newKubeconfig), os.ModePerm))
+			framework.ExpectNoError(os.WriteFile(shootKubeconfigPath, []byte(newKubeconfig), 0600))
 		}()
 
 		newClient, err := kubernetes.NewClientFromBytes([]byte(newKubeconfig))

--- a/test/utils/rotation/observability.go
+++ b/test/utils/rotation/observability.go
@@ -104,7 +104,7 @@ func (v *ObservabilityVerifier) AfterCompleted(_ context.Context) {}
 func accessEndpoint(ctx context.Context, url string, username, password []byte) (*http.Response, error) {
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec: G402 -- Test only.
 		},
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance security
/kind enhancement

**What this PR does / why we need it**:
This PR introduces `gosec` for Static Application Security Testing at Gardener and should replace other code scanners.

It uses the default ruleset of `gosec` with two exceptions.
1. Scanning generated code is disabled. The Kubernetes code-gen creates hundreds of low priority findings for unsafe pointers (G103). The generated code has proven that it is working and it is not possible to address those findings.
2. The `./hack` folder is excluded, because `gosec` does not support nested go modules (like logcheck) and there is no productive code in this folder anyway. 

All findings based on these settings have been mitigated in this PR.

There are two new `make` targets.
- `make sast` is supposed to be called in unit tests. It logs all finding to console and fails in case of errors.
- `make sast-report` can be used in build pipelines. It fails on errors too. Additionally, it creates a report in sarif format to `./gosec-report.sarif` file. This report also tracks suppressed findings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @ccwienk @ThormaehlenFred @dkistner 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
`gosec` was introduced for Static Application Security Testing (SAST).
```
