### PR TITLE
Specify args instead of command for etcd-druid

### DIFF
--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -290,8 +290,7 @@ var _ = Describe("Etcd", func() {
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{
-										Command: []string{
-											"/etcd-druid",
+										Args: []string{
 											"--enable-leader-election=true",
 											"--ignore-operation-annotation=false",
 											"--disable-etcd-serviceaccount-automount=true",
@@ -331,8 +330,8 @@ var _ = Describe("Etcd", func() {
 
 				// Add feature gate command if useEtcdWrapper is true
 				if useEtcdWrapper {
-					deployment.Spec.Template.Spec.Containers[0].Command = append(
-						deployment.Spec.Template.Spec.Containers[0].Command,
+					deployment.Spec.Template.Spec.Containers[0].Args = append(
+						deployment.Spec.Template.Spec.Containers[0].Args,
 						"--feature-gates=UseEtcdWrapper=true",
 					)
 				}
@@ -374,8 +373,7 @@ var _ = Describe("Etcd", func() {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Command: []string{
-										"/etcd-druid",
+									Args: []string{
 										"--enable-leader-election=true",
 										"--ignore-operation-annotation=false",
 										"--disable-etcd-serviceaccount-automount=true",


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Use `args` instead of `command` in the etcd-druid Deployment. This is only a minor improvement, but would allow someone to provide their own image, where the binary is not at `/etcd-druid` (e.g. when building with ko)

etcd-druid already specifies an entrypoint: https://github.com/gardener/etcd-druid/blob/v0.22.0/Dockerfile#L19
```sh
$ docker run europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid:v0.22.0
{"level":"info","ts":"2024-06-12T11:16:36.751Z","logger":"druid","msg":"Etcd-druid build information","Etcd-druid Version":"v0.22.0","Git SHA":"932162f8"}
```
and an upcoming large change in etcd-druid also changes their Helm chart: https://github.com/gardener/etcd-druid/pull/777/files#diff-55614d2196fe90a91849e301a38aca7c9497529c2b9d79906ec69ff74eecf2d4R25

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Not sure if this requires a release note in case someone uses their own etcd-druid image without an entrypoint.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
