### PR TITLE
kube-apiserver: Increase HPA's max replicas count from 3 to 6 in `VPAAndHPA` autoscaling mode

### DIFF
--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -47,6 +47,8 @@ There are three supported autoscaling modes for the Shoot Kubernetes API server.
    | (50, 100]   | `2500m`, `5200Mi` |
    | (100, inf.) | `3000m`, `5200Mi` |
 
+   The API server's min replicas count is 2, the max replicas count - 3.
+
    The `Baseline` mode is the used autoscaling mode when the `HVPA` and `VPAAndHPAForAPIServer` feature gates are not enabled.
 
 - `HVPA`
@@ -55,6 +57,8 @@ There are three supported autoscaling modes for the Shoot Kubernetes API server.
 
    The initial API server resource requests are `500m` and `1Gi`.
    HVPA's HPA is scaling only on CPU (average utilization 80%). HVPA's VPA max allowed values are `8` CPU and `25G`.
+
+   The API server's min replicas count is 2, the max replicas count - 3.
 
    The `HVPA` mode is the used autoscaling mode when the `HVPA` feature gate is enabled (and the `VPAAndHPAForAPIServer` feature gate is disabled).
 
@@ -67,9 +71,11 @@ There are three supported autoscaling modes for the Shoot Kubernetes API server.
    The initial API server resource requests are `250m` and `500Mi`.
    VPA's max allowed values are `7` CPU and `28G`. HPA's average target usage values are `6` CPU and `24G`.
 
+   The API server's min replicas count is 2, the max replicas count - 6.
+
    The `VPAAndHPA` mode is the used autoscaling mode when the `VPAAndHPAForAPIServer` feature gate is enabled (takes precedence over the `HVPA` feature gate).
 
-The API server's replica count in all scaling modes varies between 2 and 3. The min replicas count of 2 is imposed by the [High Availability of Shoot Control Plane Components](../development/high-availability.md#control-plane-components).
+In all scaling modes the min replicas count of 2 is imposed by the [High Availability of Shoot Control Plane Components](../development/high-availability.md#control-plane-components).
 
 The gardenlet sets the initial API server resource requests only when the Deployment is not found. When the Deployment exists, it is not overwriting the kube-apiserver container resources.
 
@@ -81,7 +87,7 @@ To prevent such disruptive scale-down actions it is possible to disable scale do
 
 There are the following specifics for when disabling scale-down for the Kubernetes API server component:
 - In `Baseline` and `HVPA` modes the HPA's min and max replicas count are set to 4.
-- In `VPAAndHPA` mode if the HPA resource exists and HPA's `spec.minReplicas` is not nil then the min replicas count is `max(spec.minReplicas, status.desiredReplicas)`. When scale-down is disabled, this allows operators to specify a custom value for HPA `spec.minReplicas` and this value not to be reverted by gardenlet. I.e, HPA _does_ scale down to min replicas but not below min replicas. HPA's max replicas count is 4.
+- In `VPAAndHPA` mode if the HPA resource exists and HPA's `spec.minReplicas` is not nil then the min replicas count is `max(spec.minReplicas, status.desiredReplicas)`. When scale-down is disabled, this allows operators to specify a custom value for HPA `spec.minReplicas` and this value not to be reverted by gardenlet. I.e, HPA _does_ scale down to min replicas but not below min replicas. HPA's max replicas count is 6.
 
 > Note: The `alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled` annotation is alpha and can be removed anytime without further notice. Only use it if you know what you do.
 
@@ -94,6 +100,6 @@ The virtual Kubernetes API server's autoscaling is same as the Shoot Kubernetes 
 
 The Gardener API server's autoscaling is the same as the Shoot Kubernetes API server's with the following differences:
 - The initial API server resource requests are `600m` and `512Mi` in all autoscaling modes.
-- The min replicas count is 2. The max replicas count is 4.
+- The min replicas count is 2 for a non-HA virtual cluster and 3 for an HA virtual cluster. The max replicas count is 6.
 - In `HVPA` mode, HVPA's HPA is scaling on both CPU and memory (average utilization 80% for both).
 - In `HVPA` mode, HVPA's VPA max allowed values are `4` CPU and `25G`.

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -83,6 +83,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 
 func (b *Botanist) computeKubeAPIServerAutoscalingConfig() apiserver.AutoscalingConfig {
 	var (
+		autoscalingMode           = b.autoscalingMode()
 		useMemoryMetricForHvpaHPA = false
 		scaleDownDisabled         = false
 		defaultReplicas           *int32
@@ -98,14 +99,15 @@ func (b *Botanist) computeKubeAPIServerAutoscalingConfig() apiserver.Autoscaling
 	if v1beta1helper.IsHAControlPlaneConfigured(b.Shoot.GetInfo()) {
 		minReplicas = 3
 	}
-
 	if metav1.HasAnnotation(b.Shoot.GetInfo().ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
 		minReplicas = 4
 		maxReplicas = 4
 		scaleDownDisabled = true
 	}
+	if autoscalingMode == apiserver.AutoscalingModeVPAAndHPA {
+		maxReplicas = 6
+	}
 
-	autoscalingMode := b.autoscalingMode()
 	nodeCount := b.Shoot.GetMinNodeCount()
 
 	switch autoscalingMode {

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -231,7 +231,7 @@ var _ = Describe("KubeAPIServer", func() {
 							},
 						},
 						MinReplicas:               2,
-						MaxReplicas:               3,
+						MaxReplicas:               6,
 						UseMemoryMetricForHvpaHPA: false,
 						ScaleDownDisabled:         false,
 					},
@@ -260,6 +260,27 @@ var _ = Describe("KubeAPIServer", func() {
 						APIServerResources:        resourcesRequirementsForKubeAPIServerInBaselineMode(4),
 						MinReplicas:               4,
 						MaxReplicas:               4,
+						UseMemoryMetricForHvpaHPA: false,
+						ScaleDownDisabled:         true,
+					},
+				),
+				Entry("shoot disables scale down, VPAAndHPAForAPIServer is enabled",
+					func() {
+						botanist.Shoot.GetInfo().Annotations = map[string]string{"alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled": "true"}
+					},
+					map[featuregate.Feature]bool{
+						features.VPAAndHPAForAPIServer: true,
+					},
+					apiserver.AutoscalingConfig{
+						Mode: apiserver.AutoscalingModeVPAAndHPA,
+						APIServerResources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("250m"),
+								corev1.ResourceMemory: resource.MustParse("500Mi"),
+							},
+						},
+						MinReplicas:               4,
+						MaxReplicas:               6,
 						UseMemoryMetricForHvpaHPA: false,
 						ScaleDownDisabled:         true,
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/9956

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/9956

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
kube-apiserver HPA's max replicas count from 3 to 6 in `VPAAndHPA` autoscaling mode to support very large control planes.
```
