### PR TITLE
Add warning to kind-up if non-gnu tools were detected

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -221,22 +221,30 @@ setup_kind_with_lpp_resize_support() {
 }
 
 check_shell_dependencies() {
-  if ! sed --version  >/dev/null 2>&1; then
-    echo "WARNING: Your sed version does not support the --version flag. Please ensure you have a compatible version of GNU sed installed."
+  errors=()
+
+  if ! sed --version >/dev/null 2>&1; then
+    errors+=("Current sed version does not support the --version flag. Please ensure GNU sed is installed.")
   fi
 
   if tar --version 2>&1 | grep -q "bsdtar"; then
-    echo "WARNING: You are using BSD tar, which may not be fully compatible with this script. Please ensure you have a compatible version of GNU tar installed."
+    errors+=("BSD tar detected. Please ensure GNU tar is installed.")
   fi
 
   if grep --version 2>&1 | grep -q "BSD grep"; then
-    echo "WARNING: You are using BSD grep, which may not be fully compatible with this script. Please ensure you have a compatible version of GNU grep installed."
+    errors+=("BSD grep detected. Please ensure GNU grep is installed.")
   fi
 
-  if [ "$(uname -s)" = "Darwin" ]; then
+  if [[ "$OSTYPE" == "darwin"* ]]; then
     if gzip --version 2>&1 | grep -q "Apple"; then
-      echo "WARNING: You are using the built-in Apple gzip utility, which may not be fully compatible with this script. Please ensure you have a compatible version of GNU gzip installed."
+      errors+=("Apple built-in gzip utility detected. Please ensure GNU gzip is installed.")
     fi
+  fi
+
+  if [ "${#errors[@]}" -gt 0 ]; then
+    printf 'Error: Required shell dependencies not met. Please refer to https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#macos-only-install-gnu-core-utilities:\n'
+    printf '    - %s\n' "${errors[@]}"
+    exit 1
   fi
 }
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -236,6 +236,10 @@ check_shell_dependencies() {
   fi
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
+    if ! date --version >/dev/null 2>&1; then
+      errors+=("Coreutils not found. Please ensure coreutils are installed.")
+    fi
+
     if gzip --version 2>&1 | grep -q "Apple"; then
       errors+=("Apple built-in gzip utility detected. Please ensure GNU gzip is installed.")
     fi

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -220,6 +220,28 @@ setup_kind_with_lpp_resize_support() {
   kubectl delete --ignore-not-found=true storageclass local-path
 }
 
+check_shell_dependencies() {
+  if ! sed --version  >/dev/null 2>&1; then
+    echo "WARNING: Your sed version does not support the --version flag. Please ensure you have a compatible version of GNU sed installed."
+  fi
+
+  if tar --version 2>&1 | grep -q "bsdtar"; then
+    echo "WARNING: You are using BSD tar, which may not be fully compatible with this script. Please ensure you have a compatible version of GNU tar installed."
+  fi
+
+  if grep --version 2>&1 | grep -q "BSD grep"; then
+    echo "WARNING: You are using BSD grep, which may not be fully compatible with this script. Please ensure you have a compatible version of GNU grep installed."
+  fi
+
+  if [ "$(uname -s)" = "Darwin" ]; then
+    if gzip --version 2>&1 | grep -q "Apple"; then
+      echo "WARNING: You are using the built-in Apple gzip utility, which may not be fully compatible with this script. Please ensure you have a compatible version of GNU gzip installed."
+    fi
+  fi
+}
+
+check_shell_dependencies
+
 parse_flags "$@"
 
 mkdir -m 0755 -p \

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -224,7 +224,7 @@ check_shell_dependencies() {
   errors=()
 
   if ! sed --version >/dev/null 2>&1; then
-    errors+=("Current sed version does not support the --version flag. Please ensure GNU sed is installed.")
+    errors+=("Current sed version does not support --version flag. Please ensure GNU sed is installed.")
   fi
 
   if tar --version 2>&1 | grep -q "bsdtar"; then
@@ -237,7 +237,7 @@ check_shell_dependencies() {
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     if ! date --version >/dev/null 2>&1; then
-      errors+=("Coreutils not found. Please ensure coreutils are installed.")
+      errors+=("Current date version does not support --version flag. Please ensure coreutils are installed.")
     fi
 
     if gzip --version 2>&1 | grep -q "Apple"; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Add checks to verify that the required Gnu tools are being used, and print a warning otherwise.

**Which issue(s) this PR fixes:**

`make kind-up` will succeed without errors, even if e.g. `BSD sed` is used. However, the results of the commands while using `BSD sed` are different and may cause some "hidden" issues. In my particular case, the required patches for the CorerDNS condfigMap were missing, which caused the gardenlet to fail to start during the `make gardener-up`. 

Thanks @timebertt for the troubleshooting.