### PR TITLE
Fix `fluent-bit` source repository

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -154,8 +154,7 @@
       ],
       "excludePackagePatterns": [
         "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/alpine",
-        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubernetesui\/.+",
-        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubesphere\/.+"
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubernetesui\/.+"
       ],
       "enabled": false
     },
@@ -166,7 +165,8 @@
       "excludePackagePatterns": [
         "gardener\/.+",
         "credativ\/.+",
-        "envoyproxy\/.+"
+        "envoyproxy\/.+",
+        "fluent\/.+"
       ],
       "enabled": false
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -93,17 +93,43 @@
       "matchPackagePatterns": ["quay\\.io\/prometheus-operator\/.+"],
     },
     {
+      // Ask for manual approval to create PRs for minor and major updates of dependencies which most likely
+      // require manual adaptations of the code.
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchPackagePatterns": [
+        "k8s\\.io\/.+",
+        "sigs\\.k8s\\.io\/controller-runtime",
+        "istio\\.io\/.+",
+        "github\\.com\/fluent\/.+"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      // Ask for manual approval to create PRs for minor and major updates of container images which most likely
+      // require manual adaptations of the code.
+      "matchDatasources": ["docker", "github-releases"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchFileNames": ["imagevector/**"],
+      "matchPackagePatterns": [
+        "fluent\/.+",
+        "gcr\\.io\/istio-release\/.+",
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      // Ask for manual approval to create PRs for kindest/node image. Minor and major versions are updated when new
+      // versions of Kubernetes are introduced only.
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchPackagePatterns": ["kindest\/node"],
+      "dependencyDashboardApproval": true
+    },
+    {
       // Only patch level updates for golang-test image. Minor and major versions are updated manually.
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["major", "minor"],
       "matchFileNames": ["hack\/tools\/image\/variants\\.yaml"],
-      "enabled": false
-    },
-    {
-      // Only patch level updates for kindest/node image. Minor and major versions are updated manually.
-      "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["major", "minor"],
-      "matchPackagePatterns": ["kindest\/node"],
       "enabled": false
     },
     {
@@ -122,26 +148,14 @@
       "enabled": false
     },
     {
-      // Update only patchlevels of major dependencies like kubernetes, controller-runtime and istio.
-      // Minor and major upgrades most likely require manual adaptations of the code.
-      "matchDatasources": ["go"],
-      "matchUpdateTypes": ["major", "minor"],
-      "matchPackagePatterns": [
-        "k8s\\.io\/.+",
-        "sigs\\.k8s\\.io\/controller-runtime",
-        "istio\\.io\/.+"
-      ],
-      "enabled": false
-    },
-    {
-      // Update only patch levels container images of istio and cluster-autoscaler.
-      // Minor and major upgrades most likely require manual adaptations of the code.
+      // Update only patch levels for cluster-autoscaler container images.
+      // There is a different minor version for each Kubernetes version active at the same time. In this scenario,
+      // renovate is able to handle patch updates properly only.
       "matchDatasources": ["docker", "github-releases"],
       "matchUpdateTypes": ["major", "minor"],
       "matchFileNames": ["imagevector/**"],
       "matchPackagePatterns": [
         "gardener\/autoscaler",
-        "gcr\\.io\/istio-release\/.+",
       ],
       "enabled": false
     },

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -476,7 +476,7 @@ images:
     - type: 'githubTeam'
       teamname: 'gardener/logging-maintainers'
 - name: fluent-bit
-  sourceRepository: github.com/fluent/fluent-operator
+  sourceRepository: github.com/fluent/fluent-bit
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-bit
   tag: "v2.2.2"
   labels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind bug

**What this PR does / why we need it**:
The source repository for `fluent-bit` is https://github.com/fluent/fluent-bit not https://github.com/fluent/fluent-operator.
When we change this, we can also switch to github-releases as source for `fluent` dependencies in `renovate`.
Fluent-operator go module ([ref](https://github.com/gardener/gardener/blob/01bf6d01f4ee7f47ec681c1252871d4bd4373a38/go.mod#L13)) and fluent-operator ([ref](https://github.com/gardener/gardener/blob/01bf6d01f4ee7f47ec681c1252871d4bd4373a38/imagevector/images.yaml#L464)) are currently out of sync, because we missed one update of the later.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We still have to copy the image though.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
