### PR TITLE
Simplify local gardener-operator kind setup

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -721,7 +721,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 
 # Manually created to access local Gardener virtual garden cluster.
 # TODO: Remove this again when the virtual garden cluster access is no longer required.
-127.0.0.3 api.virtual-garden.local.gardener.cloud
+127.0.0.1 api.virtual-garden.local.gardener.cloud
 EOF
 ```
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -341,7 +341,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 
 # Manually created to access local Gardener virtual garden cluster.
 # TODO: Remove this again when the virtual garden cluster access is no longer required.
-127.0.0.3 api.virtual-garden.local.gardener.cloud
+127.0.0.1 api.virtual-garden.local.gardener.cloud
 EOF
 ```
 

--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -26,10 +26,8 @@
 {{- if .Values.gardener.garden.deployed -}}
 - containerPort: 30443
   hostPort: 443
-  listenAddress: 127.0.0.1
 - containerPort: 31443
-  hostPort: 443
-  listenAddress: 127.0.0.3
+  hostPort: 31443
 {{- end -}}
 {{- end -}}
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -266,12 +266,6 @@ if [[ "$MULTI_ZONAL" == "true" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::10 ::11 ::12)
   fi
   setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
-elif [[ "$CLUSTER_NAME" == "gardener-operator-local" ]]; then
-  LOOPBACK_IP_ADDRESSES=(127.0.0.3)
-  if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
-    LOOPBACK_IP_ADDRESSES+=(::3)
-  fi
-  setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
 fi
 
 setup_kind_network

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -35,9 +35,9 @@ local_address="127.0.0.1"
 if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
   local_address="::1"
 fi
-local_address_operator="127.0.0.3"
+local_address_operator="127.0.0.1"
 if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
-  local_address_operator="::3"
+  local_address_operator="::1"
 fi
 
 # If we are running the gardener-operator tests then we have to make the virtual garden domains accessible.

--- a/skaffold-operator-garden.yaml
+++ b/skaffold-operator-garden.yaml
@@ -19,7 +19,7 @@ deploy:
             command:
               - bash
               - -ec
-              - kubectl -n garden get secret gardener -o jsonpath={.data.kubeconfig} | base64 -d > $VIRTUAL_GARDEN_KUBECONFIG
+              - kubectl -n garden get secret gardener -o jsonpath={.data.kubeconfig} | base64 -d | sed -e 's/api.virtual-garden.local.gardener.cloud.*/api.virtual-garden.local.gardener.cloud:31443/' > $VIRTUAL_GARDEN_KUBECONFIG
 ---
 apiVersion: skaffold/v4beta7
 kind: Config


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
There is a new issue with Docker Desktop on Mac with accessing the virtual garden kube-apiserver from the MacBook.
Skaffold command `skaffold run ... -f=skaffold-operator-garden.yaml ...` fails with 
```
Deploy Failed. Could not connect to cluster due to "https://api.virtual-garden.local.gardener.cloud/version": EOF. Check your connection for the cluster.
```
To resolve the issue, the network setup was simplified. The virtual-garden api-server now uses the local endpoint `127.0.0.1:31443` instead of  `127.0.0.3:443`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
As a side benefit, the `make kind-operator-up operator-up operator-seed-up` now also runs with `podman` on Mac.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The local gardener-operator kind setup was simplified. The virtual-garden api-server now uses the local endpoint `127.0.0.1:31443` instead of `127.0.0.3:443`.
```
