### PR TITLE
Fix etcd-druid alert

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
@@ -8,7 +8,7 @@ spec:
     rules:
     - alert: PrometheusCantScrape
       # Alert only if there are jobs but no samples scraped.
-      expr: scrape_samples_scraped == 0 and on(job) up{job!="etcd-druid"} == 1
+      expr: scrape_samples_scraped == 0 and on(job) up{job!~".*shoot-etcd-druid"} == 1
       for: 1h
       labels:
         service: prometheus


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
In v1.96.0, with #9848, the name of the etcd-druid scrape job changed due to the switch to the prometheus operator. This led to the `PrometheusCantScrape` alert firing for the `etcd-druid` job. This change excludes the `etc-druid` job from the alert again, as initially intended.

To reiterate the motivation for excluding etcd-druid metrics: If there are no compaction failures, no relevant metrics are exposed by the druid.

**Which issue(s) this PR fixes**:
Fixes false-positive PrometheusCantScrape etcd-druid alert. 

**Special notes for your reviewer**:
/cc @adenitiu @istvanballok @chrkl

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix false-positive PrometheusCantScrape etcd-druid alert. 
```
