### PR TITLE
Destroy shoot access for DWD if Shoot is workerless

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -359,7 +359,7 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := g.runMigrations(ctx, log, gardenCluster); err != nil {
+	if err := g.runMigrations(ctx, log, gardenCluster, g.config.SeedConfig.Name); err != nil {
 		return err
 	}
 

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -172,7 +172,7 @@ func cleanupDWDAccess(ctx context.Context, gardenClient client.Client, seedClien
 
 	workerlessShootNamespaces := sets.New[string]()
 	for _, shoot := range shootList.Items {
-		if v1beta1helper.IsWorkerless(&shoot) {
+		if v1beta1helper.IsWorkerless(&shoot) && shoot.DeletionTimestamp == nil {
 			workerlessShootNamespaces.Insert(shoot.Status.TechnicalID)
 		}
 	}

--- a/pkg/component/nodemanagement/dependencywatchdog/access.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/access.go
@@ -33,8 +33,8 @@ const (
 	DefaultWatchDuration = 5 * time.Minute
 	// KubeConfigSecretName is the name of the kubecfg secret with internal DNS for external access.
 	KubeConfigSecretName = gardenerutils.SecretNamePrefixShootAccess + "dependency-watchdog-probe"
-	// managedResourceName is the name of the managed resource created for DWD.
-	managedResourceName = "shoot-core-dependency-watchdog"
+	// ManagedResourceName is the name of the managed resource created for DWD.
+	ManagedResourceName = "shoot-core-dependency-watchdog"
 )
 
 // NewAccess creates a new instance of the deployer for shoot cluster access for the dependency-watchdog.
@@ -163,11 +163,11 @@ func (d *dependencyWatchdogAccess) createManagedResource(ctx context.Context) er
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, d.client, d.namespace, managedResourceName, managedresources.LabelValueGardener, false, resources)
+	return managedresources.CreateForShoot(ctx, d.client, d.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, resources)
 }
 
 func (d *dependencyWatchdogAccess) Destroy(ctx context.Context) error {
-	if err := managedresources.DeleteForShoot(ctx, d.client, d.namespace, managedResourceName); err != nil {
+	if err := managedresources.DeleteForShoot(ctx, d.client, d.namespace, ManagedResourceName); err != nil {
 		return err
 	}
 	return kubernetesutils.DeleteObjects(ctx, d.client,

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -464,8 +464,10 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Dependencies: flow.NewTaskIDs(syncPointCleanedKubernetesResources, waitUntilWorkerDeleted),
 		})
 		deleteDWDResources = g.Add(flow.Task{
-			Name:         "Deleting DWD managed resource and secrets",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.DependencyWatchdogAccess.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Name: "Deleting DWD managed resource and secrets",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.Shoot.Components.DependencyWatchdogAccess.Destroy(ctx)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       botanist.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deleteManagedResources),
 		})

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -498,6 +498,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Deploying dependency-watchdog shoot access resources",
 			Fn:           flow.TaskFn(botanist.DeployDependencyWatchdogAccess).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		deployKubeControllerManager = g.Add(flow.Task{

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -217,8 +217,10 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	// other components
 	o.Shoot.Components.SourceBackupEntry = b.SourceBackupEntry()
 	o.Shoot.Components.BackupEntry = b.DefaultCoreBackupEntry()
-	o.Shoot.Components.DependencyWatchdogAccess = b.DefaultDependencyWatchdogAccess()
 	o.Shoot.Components.GardenerAccess = b.DefaultGardenerAccess()
+	if !o.Shoot.IsWorkerless {
+		o.Shoot.Components.DependencyWatchdogAccess = b.DefaultDependencyWatchdogAccess()
+	}
 
 	// Addons
 	if !o.Shoot.IsWorkerless {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
The DWD probe is not created for workerless shoots, hence it doesn't need the shoot access secret and the `shoot-core-dependency-watchdog` MR. This PR adds cleanup code for this at gardenlet startup and also prevents deploying this component for workerless shoots in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @unmarshall @aaronfern 
FYI @ary1992 @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
