### PR TITLE
Cleanup provider-local CtrlDeploy

### DIFF
--- a/example/provider-local/garden/base/controllerdeployment.yaml
+++ b/example/provider-local/garden/base/controllerdeployment.yaml
@@ -3,14 +3,6 @@ kind: ControllerDeployment
 metadata:
   name: provider-local
 helm:
-  # During upgrade tests the old ControllerDeployment still specifies a `rawChart`, so we need
-  # to explicitly unset the field, otherwise the validation fails.
-  # TODO(maboehm): Remove empty field after next gardener release.
-  rawChart: ""
   ociRepository:
     ref: local-skaffold/gardener-extension-provider-local/charts/extension:v0.0.0
   values:
-    # we bake the exact image into the pushed helm chart in `push-helm.sh`, but during upgrade tests,
-    # the image value is still present, so we still override it, even if its no longer necessary.
-    # TODO(maboehm): # Remove field entirely after next gardener release.
-    image: local-skaffold/gardener-extension-provider-local:v0.0.0

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -831,7 +831,6 @@ resourceSelector:
     - groupKind: ControllerDeployment.core.gardener.cloud
       image:
         - ".helm.ociRepository.ref"
-        - ".*"
     - groupKind: CloudProfile.core.gardener.cloud
       image: [".*"]
 manifests:


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/kind cleanup

**What this PR does / why we need it**:
Removes values from the provider-local ControllerDeployment that were needed for the upgrade tests to work. Now that the "old" version also uses the new `ociRepository` fields, they can be removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
