### PR TITLE
gardener-apiserver: Improve the HPA -> VPAAndHPA transition

### DIFF
--- a/pkg/component/gardener/apiserver/deployment.go
+++ b/pkg/component/gardener/apiserver/deployment.go
@@ -151,7 +151,7 @@ func (g *gardenerAPIServer) deployment(
 	// Preserve the Deployment resources during the HPA -> VPAAndHPA transition.
 	//
 	// The gardener-apiserver is deployed via ManagedResource. In the general case, GRM preserves the Deployment resources when the resource is being scaled by HVPA.
-	// However, druing the HPA -> VPAAndHPA transition the flow is as follows:
+	// However, during the HPA -> VPAAndHPA transition the flow is as follows:
 	// 1. The HVPA resource is deleted.
 	// 2. The Deployment is updated.
 	// 3. The new HPA and VPA resources are created.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/blob/d744f46804ebe36ef944b5de2ece32950260d007/pkg/component/gardener/apiserver/deployment.go#L151-L161

**Which issue(s) this PR fixes**:
Follow-up after #9735 

**Special notes for your reviewer**:
The HPA -> VPAAndHPA transition for gardener-apiserver transition is not perfect as step 2. can also decrease the gardener-apiserver Deployment replicas to 2, set by the GRM's HA webhook because at that time there is no HPA object yet.  Then the new HPA gets created and for HA Garden cluster, it is created with minReplicas=3. There can be also a change in the Pod template in the Deployment - in the minDomains of the TSC which is computed as `min(maxReplicas, numberOfZones)`.

At least, this PR improves from Deployment resources aspect and makes sure that the new gardener-apiserver Pods won't be created with the initial/default Deployment resource requests.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-operator: The HVPA -> VPAAndHHPA autoscaling mode transition is now improved for the gardener-apiserver to preserve the Deployment resources.
```
