### PR TITLE
Fix shoot:apiserver_latency_seconds:quantile federation configuration

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
@@ -33,7 +33,7 @@ func CentralServiceMonitors() []*monitoringv1.ServiceMonitor {
 					Params: map[string][]string{
 						"match[]": {
 							`{__name__="shoot:availability"}`,
-							`{__name__=~"shoot:(.+):(.+)"}`,
+							`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_latency_seconds:quantile"}`,
 							`{__name__="ALERTS"}`,
 							`{__name__="prometheus_tsdb_lowest_timestamp"}`,
 							`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,

--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors_test.go
@@ -32,7 +32,7 @@ var _ = Describe("ServiceMonitors", func() {
 						Params: map[string][]string{
 							"match[]": {
 								`{__name__="shoot:availability"}`,
-								`{__name__=~"shoot:(.+):(.+)"}`,
+								`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_latency_seconds:quantile"}`,
 								`{__name__="ALERTS"}`,
 								`{__name__="prometheus_tsdb_lowest_timestamp"}`,
 								`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,

--- a/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
+++ b/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
@@ -1055,7 +1055,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "max by(verb, quantile) (apiserver_latency_seconds:quantile{job=~\"$job\",pod=~\"$pod\", verb=~\"$verb\",quantile=~\"$quantile\",subresource!~\"log|portforward|exec|proxy|attach\"})",
+          "expr": "max by(verb, quantile) (shoot:apiserver_latency_seconds:quantile{job=~\"$job\",pod=~\"$pod\", verb=~\"$verb\",quantile=~\"$quantile\",subresource!~\"log|portforward|exec|proxy|attach\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3530,7 +3530,7 @@
           "value": "0.99"
         },
         "datasource": null,
-        "definition": "label_values(apiserver_latency_seconds:quantile, quantile)",
+        "definition": "label_values(shoot:apiserver_latency_seconds:quantile, quantile)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3540,7 +3540,7 @@
         "name": "quantile",
         "options": [],
         "query": {
-          "query": "label_values(apiserver_latency_seconds:quantile, quantile)",
+          "query": "label_values(shoot:apiserver_latency_seconds:quantile, quantile)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/kubernetes-api-server-details.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/kubernetes-api-server-details.json
@@ -179,7 +179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(verb) (rate(apiserver_latency_seconds:quantile{verb=~\"$verbs\"}[$rate]) >= 0)",
+          "expr": "sum by(verb) (rate(shoot:apiserver_latency_seconds:quantile{verb=~\"$verbs\"}[$rate]) >= 0)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{verb}}",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/kubernetes-control-plane-status-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/kubernetes-control-plane-status-dashboard.json
@@ -1004,7 +1004,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by(verb) (apiserver_latency_seconds:quantile{quantile=\"0.99\"})",
+          "expr": "max by(verb) (shoot:apiserver_latency_seconds:quantile{quantile=\"0.99\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{verb}}",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/workerless/kubernetes-control-plane-status-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/workerless/kubernetes-control-plane-status-dashboard.json
@@ -831,7 +831,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by(verb) (apiserver_latency_seconds:quantile{quantile=\"0.99\"})",
+          "expr": "max by(verb) (shoot:apiserver_latency_seconds:quantile{quantile=\"0.99\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{verb}}",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
In 9f3b25415, the recording rule previously named `apiserver_latency_seconds:quantile` was renamed to `shoot:apiserver_latency_seconds:quantile`. This had two consequences. 
The less significant one is that it broke some dashboards. This commit fixes those dashboards. 
The more significant one is that the aggregate prometheus then started federating this recording rule due to the `{__name__=~"shoot:(.+):(.+)"}` line in its federation parameters. This expression is intended to federate shoot metrics. Metrics matching that expression are federated twice in gardener. Once, as just explained, from the shoot control plane Prometheus to the aggregate Prometheus, and a second time from the aggregate Prometheus to the garden Prometheus. By the time this recording rule made it to the garden prometheus, it caused the number of samples scraped to increase massively. This in turn was significant enough for the garden Prometheus to consume more than twice as much memory as before. Therefore, this commit also excludes this recording rule from federation at the aggregate Prometheus level.

**Which issue(s) this PR fixes**:
Fixes an issue with the garden Prometheus consuming excessive amounts of memory.

**Special notes for your reviewer**:
/cc @istvanballok @vicwicker @chrkl  

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix an issue with federation that causes garden-prometheus to consume excessive amounts of memory.
```
