### PR TITLE
Ignore `status` subresources and `metadata.managedFields` for resource size limit admission

### DIFF
--- a/docs/concepts/admission-controller.md
+++ b/docs/concepts/admission-controller.md
@@ -35,7 +35,9 @@ One example is the creation of shoot resources with large annotation values (up 
 [Vertical autoscaling](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) can help to mitigate such situations, but we cannot expect to scale infinitely, and thus need means to block the attack itself.
 
 The Resource Size Validator checks arbitrary incoming admission requests against a configured maximum size for the resource's group-version-kind combination. It denies the request if the object exceeds the quota.
-The values of the following keys are not taken into account for the resource size calculation: `status`, `metadata.managedFields`
+
+> [!NOTE]
+> The contents of `status` subresources and `metadata.managedFields` are not taken into account for the resource size calculation.
 
 Example for Gardener Admission Controller configuration:
 ```yaml

--- a/docs/concepts/admission-controller.md
+++ b/docs/concepts/admission-controller.md
@@ -35,6 +35,7 @@ One example is the creation of shoot resources with large annotation values (up 
 [Vertical autoscaling](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) can help to mitigate such situations, but we cannot expect to scale infinitely, and thus need means to block the attack itself.
 
 The Resource Size Validator checks arbitrary incoming admission requests against a configured maximum size for the resource's group-version-kind combination. It denies the request if the object exceeds the quota.
+The values of the following keys are not taken into account for the resource size calculation: `status`, `metadata.managedFields`
 
 Example for Gardener Admission Controller configuration:
 ```yaml

--- a/pkg/admissioncontroller/webhook/admission/resourcesize/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/resourcesize/handler.go
@@ -112,6 +112,9 @@ func relevantObjectSize(rawObject []byte) (int64, error) {
 		return 0, err
 	}
 	delete(obj, "status")
+	if obj["metadata"] != nil {
+		delete(obj["metadata"].(map[string]any), "managedFields")
+	}
 	marshalled, err := json.Marshal(obj)
 	return int64(len(marshalled)), err
 }

--- a/pkg/admissioncontroller/webhook/admission/resourcesize/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/resourcesize/handler_test.go
@@ -264,7 +264,7 @@ var _ = Describe("handler", func() {
 			}
 			objData, err := runtime.Encode(testEncoder, shootWithLargeStatus)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(shootsv1beta1SizeLimit.CmpInt64(int64(len(objData)))).Should(BeNumerically("==", -1))
+			Expect(shootsv1beta1SizeLimit.CmpInt64(int64(len(objData)))).Should(Equal(-1))
 			return shootWithLargeStatus
 		}
 		test(largeShoot, restrictedUser, true)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Ignore `status` subresources fields and `metadata.managedFields` on update in admission controller size limit comparison to not block updates e.g. because of large status description contents.

**Which issue(s) this PR fixes**:
Fixes #9039

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The [Resource Size Validator](https://github.com/gardener/gardener/blob/master/docs/concepts/admission-controller.md) of the `gardener-admission-controller` ignores `status` subresource and `metadata.managedFields` for resource size limits. Please consider adjusting your configuration if you already increased the limits because of these now ignored sections.
```
