### PR TITLE
Revert "chore(deps): update quay.io/kiwigrid/k8s-sidecar docker tag to v1.27.4 (#9943)"

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -322,7 +322,7 @@ images:
 - name: plutono-dashboard-refresher
   sourceRepository: github.com/kiwigrid/k8s-sidecar
   repository: quay.io/kiwigrid/k8s-sidecar
-  tag: "1.27.4"
+  tag: "1.27.2"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind regression
/cherry-pick release-v1.97

**What this PR does / why we need it**:
The latest version of https://github.com/kiwigrid/k8s-sidecar is `v1.27.4`, which was updated by renovate in #9943.

The `quay.io/kiwigrid/k8s-sidecar:1.27.4` image is based on `python:3.12-alpine`, (https://github.com/kiwigrid/k8s-sidecar/blob/1.27.4/Dockerfile) which indeed contains `usr/lib/liblzma.so.5.6.1`: a binary that is reported to be affected by the CVE-2024-3094.

```text
docker pull quay.io/kiwigrid/k8s-sidecar:1.27.4
docker create --name my_container quay.io/kiwigrid/k8s-sidecar:1.27.4
docker export my_container > my_container.tar
tar -xvf my_container.tar
file ./usr/lib/liblzma.so.5.6.1
./usr/lib/liblzma.so.5.6.1:
  ELF 64-bit LSB shared object, x86-64, version 1 (SYSV),
  dynamically linked,
  BuildID[sha1]=aff9093d7ea50d9edc4aeca78d785bd94eb30148, stripped
```

Although the `plutono-dashboard-refresher` is not exposed to the Internet, and hence this vulnerability can not be exploited easily, we decided to revert #9943 until a newer version without `usr/lib/liblzma.so.5.6.1` is released.

Note that although the index digest matches, the dockerhub UI is not showing this vulnerability.

<img width="300" alt="image" src="https://github.com/gardener/gardener/assets/23032437/15c2d42c-10ee-4edc-ab9e-6d103aaa7af4">

https://hub.docker.com/layers/library/python/3.12-alpine/images/sha256-7a502d6c806079d7c4e49d8541fb0393c47e03a189363858929897e16a0e126b?context=explore

```text
# docker pull python:3.12-alpine
3.12-alpine: Pulling from library/python
Digest: sha256:dc095966439c68283a01dde5e5bc9819ba24b28037dddd64ea224bf7aafc0c82
Status: Image is up to date for python:3.12-alpine
docker.io/library/python:3.12-alpine

docker create --name my_container2 python:3.12-alpine
docker export my_container2 > my_container.tar
tar -xvf my_container.tar
file ./usr/lib/liblzma.so.5.6.1
./usr/lib/liblzma.so.5.6.1:
  ELF 64-bit LSB shared object, x86-64, version 1 (SYSV),
  dynamically linked,
  BuildID[sha1]=aff9093d7ea50d9edc4aeca78d785bd94eb30148, stripped
```

**Which issue(s) this PR fixes**:

`quay.io/kiwigrid/k8s-sidecar:1.27.4` is affected by `CVE-2024-3094`.

**Special notes for your reviewer**:

/cc @vicwicker
FYI @oliver-goetz 

```text
docker pull quay.io/kiwigrid/k8s-sidecar:1.27.2
docker create --name my_container quay.io/kiwigrid/k8s-sidecar:1.27.2
docker export my_container > my_container.tar
tar -xvf my_container.tar

find . | grep ./usr/lib/liblzma
./usr/lib/liblzma.so.5
./usr/lib/liblzma.so.5.4.5
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
