### PR TITLE
Add garden_seed_info to longterm prometheus

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
@@ -53,6 +53,7 @@ func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
 				Params: map[string][]string{
 					"match[]": {
 						`{__name__="garden_shoot_info"}`,
+						`{__name__="garden_seed_info"}`,
 						`{__name__=~"garden_shoot_info:timestamp:this_month"}`,
 						`{__name__=~"metering:(cpu_requests|memory_requests|network|persistent_volume_claims|disk_usage_seconds|memory_usage_seconds).*:this_month"}`,
 						`{__name__="garden_shoot_node_info"}`,

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
@@ -54,6 +54,7 @@ var _ = Describe("PrometheusRules", func() {
 						Params: map[string][]string{
 							"match[]": {
 								`{__name__="garden_shoot_info"}`,
+								`{__name__="garden_seed_info"}`,
 								`{__name__=~"garden_shoot_info:timestamp:this_month"}`,
 								`{__name__=~"metering:(cpu_requests|memory_requests|network|persistent_volume_claims|disk_usage_seconds|memory_usage_seconds).*:this_month"}`,
 								`{__name__="garden_shoot_node_info"}`,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
One of our internal dashboards requires the `garden_seed_info` metric to be included in the longterm prometheus.
This PR adds it to the scrape config.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adds the garden_seed_info metric to the longterm prometheus scrape config
```
