### PR TITLE
Work around for local gardener-operator kind setup on MacBooks: Use alternative IP address

### DIFF
--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -33,9 +33,9 @@ controllers:
   service:
     concurrentSyncs: 5
     hostIP: "127.0.0.1"
-    zone0IP: "127.0.0.10"
-    zone1IP: "127.0.0.11"
-    zone2IP: "127.0.0.12"
+    zone0IP: "172.18.255.10"
+    zone1IP: "172.18.255.11"
+    zone2IP: "172.18.255.12"
   backupbucket:
     localDir: "/dev/local-backupbuckets"
     containerMountPath: "/etc/gardener/local-backupbuckets"

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -32,7 +32,7 @@ controllers:
     concurrentSyncs: 5
   service:
     concurrentSyncs: 5
-    hostIP: "127.0.0.1"
+    hostIP: "172.18.255.1"
     zone0IP: "172.18.255.10"
     zone1IP: "172.18.255.11"
     zone2IP: "172.18.255.12"

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -835,7 +835,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 
 # Manually created to access local Gardener virtual garden cluster.
 # TODO: Remove this again when the virtual garden cluster access is no longer required.
-127.0.0.3 api.virtual-garden.local.gardener.cloud
+172.18.255.3 api.virtual-garden.local.gardener.cloud
 EOF
 ```
 

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -51,7 +51,7 @@ spec:
           echo node-shell      && krew install node-shell
           bash -c "echo {{p,g}-seed,{gu,p,v}-local--local}.ingress.local.seed.local.gardener.cloud api.{e2e-managedseed.garden,{local,e2e-{hib,hib-wl,unpriv,wake-up,wake-up-wl,migrate,migrate-wl,mgr-hib,rotate,rotate-wl,default,default-wl,force-delete,fd-hib,upd-node,upd-node-wl,upgrade,upgrade-wl,upg-hib,upg-hib-wl}}.local}.{internal,external}.local.gardener.cloud" \
             | sed 's/ /\n/g' | sed 's/^/127.0.0.1 /' | sort >> /etc/hosts
-          echo "127.0.0.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
+          echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
 
           # Resolve e.g. gu-local--e2e-rotate{-wl}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:
           echo '

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -279,7 +279,7 @@ There are cases where you would want to create a second seed cluster in your loc
 If you are on macOS, add a new IP address on your loopback device which will be necessary for the new KinD cluster that you will create. On macOS, the default loopback device is `lo0`.
 
 ```bash
-sudo ip addr add 127.0.0.2 dev lo0                                     # adding 127.0.0.2 ip to the loopback interface
+sudo ip addr add 172.18.255.2 dev lo0                                  # adding 172.18.255.2 ip to the loopback interface
 ```
 
 Next, setup the second KinD cluster:
@@ -341,7 +341,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 
 # Manually created to access local Gardener virtual garden cluster.
 # TODO: Remove this again when the virtual garden cluster access is no longer required.
-127.0.0.3 api.virtual-garden.local.gardener.cloud
+172.18.255.3 api.virtual-garden.local.gardener.cloud
 EOF
 ```
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -210,48 +210,50 @@ cat <<EOF | sudo tee -a /etc/hosts
 127.0.0.1 v-local--local.ingress.local.seed.local.gardener.cloud
 
 # E2e tests
-127.0.0.1 api.e2e-managedseed.garden.external.local.gardener.cloud
-127.0.0.1 api.e2e-managedseed.garden.internal.local.gardener.cloud
-127.0.0.1 api.e2e-hib.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-hib.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-hib-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-hib-wl.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-unpriv.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-unpriv.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-wake-up.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-wake-up.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-wake-up-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-wake-up-wl.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-migrate.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-migrate.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-migrate-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-migrate-wl.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-mgr-hib.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-mgr-hib.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-rotate.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-rotate.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-rotate-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-rotate-wl.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-default.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-default.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-default-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-default-wl.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-force-delete.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-force-delete.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-fd-hib.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-fd-hib.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-upd-node.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-upd-node.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-upd-node-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-upd-node-wl.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-upgrade.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-upgrade.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-upgrade-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-upgrade-wl.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-upg-hib.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-upg-hib.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-upg-hib-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-upg-hib-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-managedseed.garden.external.local.gardener.cloud
+172.18.255.1 api.e2e-managedseed.garden.internal.local.gardener.cloud
+172.18.255.1 api.e2e-hib.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-hib.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-hib-wl.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-hib-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-unpriv.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-unpriv.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-wake-up.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-wake-up.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-wake-up-wl.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-wake-up-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-migrate.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-migrate.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-migrate-wl.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-migrate-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-mgr-hib.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-mgr-hib.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-rotate.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-rotate.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-rotate-wl.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-rotate-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-default.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-default.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-default-wl.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-default-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-force-delete.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-force-delete.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-fd-hib.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-fd-hib.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-upd-node.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-upd-node.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-upd-node-wl.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-upd-node-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-upgrade.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-upgrade.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-upgrade-wl.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-upgrade-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-upg-hib.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-upg-hib.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-upg-hib-wl.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-upg-hib-wl.local.internal.local.gardener.cloud
+172.18.255.1 gu-local--e2e-rotate.ingress.local.seed.local.gardener.cloud
+172.18.255.1 gu-local--e2e-rotate-wl.ingress.local.seed.local.gardener.cloud
 # End of Gardener local setup section
 EOF
 ```
@@ -361,13 +363,13 @@ You find the kubeconfig for the KinD cluster at `./example/gardener-local/kind/o
 The one for the virtual garden is accessible at `./example/operator/virtual-garden/kubeconfig`.
 
 > [!IMPORTANT]
-> When you create non-HA shoot clusters (i.e., `Shoot`s with `.spec.controlPlane.highAvailability.failureTolerance != zone`), then they are not exposed via `127.0.0.1` ([ref](#accessing-the-shoot-cluster)).
+> When you create non-HA shoot clusters (i.e., `Shoot`s with `.spec.controlPlane.highAvailability.failureTolerance != zone`), then they are not exposed via `172.18.255.1` ([ref](#accessing-the-shoot-cluster)).
 > Instead, you need to find out under which Istio instance they got exposed, and put the corresponding IP address into your `/etc/hosts` file:
 > ```shell
 > # replace <shoot-namespace> with your shoot namespace (e.g., `shoot--foo--bar`):
 > kubectl -n "$(kubectl -n <shoot-namespace> get gateway kube-apiserver -o jsonpath={.spec.selector.istio} | sed 's/.*--/istio-ingress--/')" get svc istio-ingressgateway -o jsonpath={.status.loadBalancer.ingress..ip}
 > ```
-> When the shoot cluster is HA (i.e., `.spec.controlPlane.highAvailability.failureTolerance == zone`), then you can access it via `127.0.0.1`.
+> When the shoot cluster is HA (i.e., `.spec.controlPlane.highAvailability.failureTolerance == zone`), then you can access it via `172.18.255.1`.
 
 Please use this command to tear down your environment:
 

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -121,7 +121,7 @@ It makes important LoadBalancer Services (e.g. `istio-ingress/istio-ingressgatew
 
 `istio-ingress/istio-ingressgateway` is set to be exposed on `nodePort` `30433` by this controller.
 
-In case the seed has multiple availability zones (`.spec.provider.zones`) and it uses SNI, the different zone-specific `istio-ingressgateway` loadbalancers are exposed via different IP addresses. Per default, IP addresses `127.0.0.10`, `127.0.0.11`, and `127.0.0.12` are used for the zones `0`, `1`, and `2` respectively.
+In case the seed has multiple availability zones (`.spec.provider.zones`) and it uses SNI, the different zone-specific `istio-ingressgateway` loadbalancers are exposed via different IP addresses. Per default, IP addresses `172.18.255.10`, `172.18.255.11`, and `172.18.255.12` are used for the zones `0`, `1`, and `2` respectively.
 
 #### ETCD Backups
 This controller reconciles the `BackupBucket` and `BackupEntry` of the shoot allowing the `etcd-backup-restore` to create and copy backups using the `local` provider functionality. The backups are stored on the host file system. This is achieved by mounting that directory to the `etcd-backup-restore` container.

--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -12,7 +12,7 @@
 {{- if $.Values.gardener.controlPlane.deployed }}
   hostPort: 443
 {{- else }}
-  # TODO (plkokanov): when using skaffold to deploy, 127.0.0.2 is not used as listenAddress (unlike the local
+  # TODO (plkokanov): when using skaffold to deploy, 172.18.255.2 is not used as listenAddress (unlike the local
   #  deployment) because secondary IPs cannot be easily added to inside the `prow` containers. Additionally, there is no
   #  way currently to swap the dns record of the shoot's `kube-apiserver` once it is migrated to this seed.
   hostPort: 9443
@@ -26,7 +26,7 @@
 {{- if .Values.gardener.garden.deployed -}}
 - containerPort: 31443
   hostPort: 443
-  listenAddress: 127.0.0.3
+  listenAddress: 172.18.255.3
 {{- end -}}
 {{- end -}}
 

--- a/example/gardener-local/kind/cluster/values-dual.yaml
+++ b/example/gardener-local/kind/cluster/values-dual.yaml
@@ -3,7 +3,7 @@ gardener:
     istio:
       listenAddresses:
       - "::1"
-      - "127.0.0.1"
+      - "172.18.255.1"
 
 networking:
   ipFamily: dual

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -13,7 +13,7 @@ gardener:
     deployed: true
     istio:
       listenAddresses:
-      - 127.0.0.1
+      - 172.18.255.1
   repositoryRoot: "."
   garden:
     deployed: false

--- a/example/gardener-local/kind/ha-multi-zone/values.yaml
+++ b/example/gardener-local/kind/ha-multi-zone/values.yaml
@@ -3,7 +3,7 @@ gardener:
     istio:
       # Add one 'global' address and one per zone, see https://github.com/gardener/gardener/pull/6997
       listenAddresses:
-      - 127.0.0.1
+      - 172.18.255.1
       - 172.18.255.10
       - 172.18.255.11
       - 172.18.255.12

--- a/example/gardener-local/kind/ha-multi-zone/values.yaml
+++ b/example/gardener-local/kind/ha-multi-zone/values.yaml
@@ -4,9 +4,9 @@ gardener:
       # Add one 'global' address and one per zone, see https://github.com/gardener/gardener/pull/6997
       listenAddresses:
       - 127.0.0.1
-      - 127.0.0.10
-      - 127.0.0.11
-      - 127.0.0.12
+      - 172.18.255.10
+      - 172.18.255.11
+      - 172.18.255.12
 
 workers:
 - zone: "1"

--- a/example/gardener-local/kind/ha-single-zone2/values.yaml
+++ b/example/gardener-local/kind/ha-single-zone2/values.yaml
@@ -4,7 +4,7 @@ gardener:
   seed:
     istio:
       listenAddresses:
-      - 127.0.0.2
+      - 172.18.255.2
 
 registry:
   deployed: false

--- a/example/gardener-local/kind/local2/values.yaml
+++ b/example/gardener-local/kind/local2/values.yaml
@@ -4,7 +4,7 @@ gardener:
   seed:
     istio:
       listenAddresses:
-      - 127.0.0.2
+      - 172.18.255.2
 
 registry:
   deployed: false

--- a/example/gardener-local/kind/operator/values.yaml
+++ b/example/gardener-local/kind/operator/values.yaml
@@ -7,7 +7,7 @@ gardener:
     istio:
       # Add one 'global' address and one per zone, see https://github.com/gardener/gardener/pull/6997
       listenAddresses:
-      - 127.0.0.1
+      - 172.18.255.1
       - 172.18.255.10
       - 172.18.255.11
       - 172.18.255.12

--- a/example/gardener-local/kind/operator/values.yaml
+++ b/example/gardener-local/kind/operator/values.yaml
@@ -8,9 +8,9 @@ gardener:
       # Add one 'global' address and one per zone, see https://github.com/gardener/gardener/pull/6997
       listenAddresses:
       - 127.0.0.1
-      - 127.0.0.10
-      - 127.0.0.11
-      - 127.0.0.12
+      - 172.18.255.10
+      - 172.18.255.11
+      - 172.18.255.12
   nginxIngress:
     deployed: true
   garden:

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -205,12 +205,11 @@ $(dirname "${0}")/download_gardener_source_code.sh --gardener-version $GARDENER_
 export GARDENER_PREVIOUS_VERSION="$(cat $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/VERSION)"
 
 # temporary fix of addresses in previous release (can be removed > v1.102)
+sed -i -e 's/hostIP: "127.0.0.1"/hostIP: "172.18.255.1"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
 sed -i -e 's/zone0IP: "127.0.0.10"/zone0IP: "172.18.255.10"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
 sed -i -e 's/zone1IP: "127.0.0.11"/zone1IP: "172.18.255.11"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
 sed -i -e 's/zone2IP: "127.0.0.12"/zone2IP: "172.18.255.12"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
-sed -i -e 's/- 127.0.0.10/- 172.18.255.10/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/example/gardener-local/kind/ha-multi-zone/values.yaml
-sed -i -e 's/- 127.0.0.11/- 172.18.255.11/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/example/gardener-local/kind/ha-multi-zone/values.yaml
-sed -i -e 's/- 127.0.0.12/- 172.18.255.12/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/example/gardener-local/kind/ha-multi-zone/values.yaml
+sed -i -e 's/- 127.0.0./- 172.18.255./' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/example/gardener-local/kind/ha-multi-zone/values.yaml
 
 # test setup
 kind_up

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -204,6 +204,14 @@ set_seed_name
 $(dirname "${0}")/download_gardener_source_code.sh --gardener-version $GARDENER_PREVIOUS_RELEASE --download-path $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases
 export GARDENER_PREVIOUS_VERSION="$(cat $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/VERSION)"
 
+# temporary fix of addresses in previous release (can be removed > v1.102)
+sed -i -e 's/zone0IP: "127.0.0.10"/zone0IP: "172.18.255.10"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
+sed -i -e 's/zone1IP: "127.0.0.11"/zone1IP: "172.18.255.11"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
+sed -i -e 's/zone2IP: "127.0.0.12"/zone2IP: "172.18.255.12"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
+sed -i -e 's/- 127.0.0.10/- 172.18.255.10/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/example/gardener-local/kind/ha-multi-zone/values.yaml
+sed -i -e 's/- 127.0.0.11/- 172.18.255.11/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/example/gardener-local/kind/ha-multi-zone/values.yaml
+sed -i -e 's/- 127.0.0.12/- 172.18.255.12/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/example/gardener-local/kind/ha-multi-zone/values.yaml
+
 # test setup
 kind_up
 

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -204,7 +204,7 @@ set_seed_name
 $(dirname "${0}")/download_gardener_source_code.sh --gardener-version $GARDENER_PREVIOUS_RELEASE --download-path $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases
 export GARDENER_PREVIOUS_VERSION="$(cat $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/VERSION)"
 
-# temporary fix of addresses in previous release (can be removed > v1.102)
+# TODO(MartinWeindel): Temporary fix of addresses in previous release for e2e upgrade tests (remove this after v1.102 has been released).
 sed -i -e 's/hostIP: "127.0.0.1"/hostIP: "172.18.255.1"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
 sed -i -e 's/zone0IP: "127.0.0.10"/zone0IP: "172.18.255.10"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
 sed -i -e 's/zone1IP: "127.0.0.11"/zone1IP: "172.18.255.11"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -97,7 +97,7 @@ setup_loopback_device() {
   LOOPBACK_DEVICE=$(ip address | grep LOOPBACK | sed "s/^[0-9]\+: //g" | awk '{print $1}' | sed "s/:$//g")
   echo "Checking loopback device ${LOOPBACK_DEVICE}..."
   for address in "${LOOPBACK_IP_ADDRESSES[@]}"; do
-    if ip address show dev ${LOOPBACK_DEVICE} | grep -q $address; then
+    if ip address show dev ${LOOPBACK_DEVICE} | grep -q $address/; then
       echo "IP address $address already assigned to ${LOOPBACK_DEVICE}."
     else
       echo "Adding IP address $address to ${LOOPBACK_DEVICE}..."
@@ -259,26 +259,29 @@ mkdir -m 0755 -p \
   "$(dirname "$0")/../dev/local-backupbuckets" \
   "$(dirname "$0")/../dev/local-registry"
 
+LOOPBACK_IP_ADDRESSES=(172.18.255.1)
+if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+  LOOPBACK_IP_ADDRESSES+=(::1)
+fi
+
 if [[ "$MULTI_ZONAL" == "true" ]]; then
-  LOOPBACK_IP_ADDRESSES=(172.18.255.10 172.18.255.11 172.18.255.12)
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.10 172.18.255.11 172.18.255.12)
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::10 ::11 ::12)
   fi
-  setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
 fi
 if [[ "$CLUSTER_NAME" == "gardener-operator-local" ]]; then
-  LOOPBACK_IP_ADDRESSES=(172.18.255.3)
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.3)
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::3)
   fi
-  setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
 elif [[ "$CLUSTER_NAME" == "gardener-local2" || "$CLUSTER_NAME" == "gardener-local2-ha-single-zone" ]]; then
-  LOOPBACK_IP_ADDRESSES=(172.18.255.2)
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.2)
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::2)
   fi
-  setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
 fi
+setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
 
 setup_kind_network
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -260,16 +260,22 @@ mkdir -m 0755 -p \
   "$(dirname "$0")/../dev/local-registry"
 
 if [[ "$MULTI_ZONAL" == "true" ]]; then
-  LOOPBACK_IP_ADDRESSES=(127.0.0.10 127.0.0.11 127.0.0.12)
+  LOOPBACK_IP_ADDRESSES=(172.18.255.10 172.18.255.11 172.18.255.12)
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::10 ::11 ::12)
   fi
   setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
 fi
 if [[ "$CLUSTER_NAME" == "gardener-operator-local" ]]; then
-  LOOPBACK_IP_ADDRESSES=(127.0.0.3)
+  LOOPBACK_IP_ADDRESSES=(172.18.255.3)
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::3)
+  fi
+  setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
+elif [[ "$CLUSTER_NAME" == "gardener-local2" || "$CLUSTER_NAME" == "gardener-local2-ha-single-zone" ]]; then
+  LOOPBACK_IP_ADDRESSES=(172.18.255.2)
+  if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(::2)
   fi
   setup_loopback_device "${LOOPBACK_IP_ADDRESSES[@]}"
 fi

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -35,7 +35,7 @@ local_address="127.0.0.1"
 if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
   local_address="::1"
 fi
-local_address_operator="127.0.0.3"
+local_address_operator="172.18.255.3"
 if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
   local_address_operator="::3"
 fi

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -31,7 +31,7 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   fi
 fi
 
-local_address="127.0.0.1"
+local_address="172.18.255.1"
 if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
   local_address="::1"
 fi
@@ -97,6 +97,11 @@ else
     e2e-upg-hib-wl.local
   )
 
+  ingress_names=(
+    gu-local--e2e-rotate
+    gu-local--e2e-rotate-wl
+  )
+
   if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     for shoot in "${shoot_names[@]}" ; do
       if [[ "${SHOOT_FAILURE_TOLERANCE_TYPE:-}" == "zone" && ("$shoot" == "e2e-upg-ha.local" || "$shoot" == "e2e-upg-ha-wl.local") ]]; then
@@ -109,8 +114,9 @@ else
       fi
       printf "\n$local_address api.%s.external.local.gardener.cloud\n$local_address api.%s.internal.local.gardener.cloud\n" $shoot $shoot >>/etc/hosts
     done
-    printf "\n$local_address gu-local--e2e-rotate.ingress.$seed_name.seed.local.gardener.cloud\n" >>/etc/hosts
-    printf "\n$local_address gu-local--e2e-rotate-wl.ingress.$seed_name.seed.local.gardener.cloud\n" >>/etc/hosts
+    for ingress in "${ingress_names[@]}" ; do
+      printf "\n$local_address %s.ingress.$seed_name.seed.local.gardener.cloud\n" $ingress >>/etc/hosts
+    done
   else
     missing_entries=()
 
@@ -124,6 +130,11 @@ else
           missing_entries+=("$local_address api.$shoot.$ip.local.gardener.cloud")
         fi
       done
+    done
+    for ingress in "${ingress_names[@]}" ; do
+        if ! grep -q -x "$local_address $ingress.ingress.$seed_name.seed.local.gardener.cloud" /etc/hosts; then
+          missing_entries+=("$local_address $ingress.ingress.$seed_name.seed.local.gardener.cloud")
+        fi
     done
 
     if [ ${#missing_entries[@]} -gt 0 ]; then

--- a/pkg/controller/service/add.go
+++ b/pkg/controller/service/add.go
@@ -21,7 +21,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, predicates ...predicate.P
 		r.Client = mgr.GetClient()
 	}
 	if r.HostIP == "" {
-		r.HostIP = "127.0.0.1"
+		r.HostIP = "172.18.255.1"
 	}
 
 	return builder.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind discussion

**What this PR does / why we need it**:
On some corporate MacBooks the [Alternative way to set up Garden and Seed leveraging gardener-operator](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator) is not working with the local IP `127.0.0.3`. 

The Skaffold command `skaffold run ... -f=skaffold-operator-garden.yaml ...` fails with 
```
Deploy Failed. Could not connect to cluster due to "https://api.virtual-garden.local.gardener.cloud/version": EOF. Check your connection for the cluster.
```

It turned out that it works when using an IP address from the docker network kind `172.18.0.0/16`.
So this PR suggests to use the IP address `172.18.255.x` instead of `127.0.0.x` if x > 1 as a work around. 
Using an IP address from the upper end of the IP range of the docker network should be save for typical usage.
There is still no resolution in sight with the interference between Docker Desktop and corporate network extension patches even after involving IT support.

/hold First want to check if all tests are working with the alternative IP address as expected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Replaces #9987 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The IPv4 addresses for the local Gardener setup was changed from `127.0.0.x` to `172.18.255.x` (default kind subnet) to resolve an issue on developer machines which can't use additional IP addressed from the `127.0.0.0/8` space. Please consider updating your `/etc/hosts` file to adjust to the the newly added addresses. Please see [Deploying Gardener Locally#Accessing the Shoot Cluster](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster) for more details.
```