### PR TITLE
Fix cluster name in `Getting Started Locally With Extensions`

### DIFF
--- a/docs/deployment/getting_started_locally_with_extensions.md
+++ b/docs/deployment/getting_started_locally_with_extensions.md
@@ -76,7 +76,7 @@ There are no demo `CloudProfiles` yet. Thus, please copy `CloudProfiles` from an
 make kind-extensions-up
 ```
 
-This command sets up a new KinD cluster named `gardener-local` and stores the kubeconfig in the `./example/gardener-local/kind/extensions/kubeconfig` file.
+This command sets up a new KinD cluster named `gardener-extensions` and stores the kubeconfig in the `./example/gardener-local/kind/extensions/kubeconfig` file.
 
 > It might be helpful to copy this file to `$HOME/.kube/config`, since you will need to target this KinD cluster multiple times.
 Alternatively, make sure to set your `KUBECONFIG` environment variable to `./example/gardener-local/kind/extensions/kubeconfig` for all future steps via `export KUBECONFIG=$PWD/example/gardener-local/kind/extensions/kubeconfig`.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
After following https://gardener.cloud/docs/gardener/deployment/getting_started_locally_with_extensions/#setting-up-the-kind-cluster and running `make kind-extensions-up` I noticed:
```
$ kind get clusters
gardener-extensions
```
Also
https://github.com/gardener/gardener/blob/e89c6d3b0bc51db61dde19696420b1ed4c684227/hack/kind-extensions-up.sh#L14

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
