### PR TITLE
Check if seed kubeconfig using client-certificate has expired in `gardener-extensions-up.sh` and `gardener-extensions-down.sh`

### DIFF
--- a/example/provider-extensions/seed/configure-seed.sh
+++ b/example/provider-extensions/seed/configure-seed.sh
@@ -132,6 +132,21 @@ relay_domain=
 internal_dns_secret=$(yq -e 'select(document_index == 1) | .metadata.name' "$REPO_ROOT_DIR"/example/provider-extensions/garden/controlplane/domain-secrets.yaml)
 dns_provider_type=$(yq -e 'select(document_index == 1) | .metadata.annotations.["dns.gardener.cloud/provider"]' "$REPO_ROOT_DIR"/example/provider-extensions/garden/controlplane/domain-secrets.yaml)
 
+CERT_DATA=$(kubectl config view --kubeconfig "$seed_kubeconfig" --raw -o jsonpath='{.users[0].user.client-certificate-data}')
+if [[ -n "$CERT_DATA" ]]; then 
+  echo "Verifying that seed kubeconfig has not expired"
+  EXPIRY_DATE=$(echo "$CERT_DATA" | base64 --decode | openssl x509 -noout -enddate 2>/dev/null | sed -E 's/notAfter=(.+)/\1/')
+  EXPIRY_DATE_TIMESTAMP=$(date -d "$EXPIRY_DATE" +%s)
+  CURRENT_DATE_TIMESTAMP=$(date -u +%s)
+  if [ "$CURRENT_DATE_TIMESTAMP" -ge "$EXPIRY_DATE_TIMESTAMP" ]; then
+    echo "Seed kubeconfig has expired. Please provide a unexpired kubeconfig"
+    exit
+  fi
+else 
+  echo "Could not extract user's client-certificate-data from seed kubeconfig. Skipping check if seed kubeconfig has not expired"
+fi
+
+
 if kubectl get configmaps -n kube-system shoot-info --kubeconfig "$seed_kubeconfig" -o yaml > "$temp_shoot_info"; then
   use_shoot_info="true"
   echo "Getting config from shoot"

--- a/hack/gardener-extensions-down.sh
+++ b/hack/gardener-extensions-down.sh
@@ -34,6 +34,11 @@ parse_flags() {
 
 parse_flags "$@"
 
+if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 10 2>/dev/null ;then 
+  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired. Please provide a non-exipired kubeconfig and try again"
+  exit
+fi
+
 # Delete stuff gradually in the right order, otherwise several dependencies will prevent the cleanup from succeeding.
 # Deleting seed will fail as long as there are shoots scheduled on it. This is desired to ensure that there are no orphan infrastructure elements left.
 echo "Deleting $SEED_NAME seed"

--- a/hack/gardener-extensions-down.sh
+++ b/hack/gardener-extensions-down.sh
@@ -35,7 +35,7 @@ parse_flags() {
 parse_flags "$@"
 
 if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ;then 
-  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired. Please provide a non-exipired kubeconfig and try again"
+  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired or will expire soon. Please provide a valid kubeconfig and try again"
   exit
 fi
 

--- a/hack/gardener-extensions-down.sh
+++ b/hack/gardener-extensions-down.sh
@@ -34,7 +34,7 @@ parse_flags() {
 
 parse_flags "$@"
 
-if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 10 2>/dev/null ;then 
+if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ;then 
   echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired. Please provide a non-exipired kubeconfig and try again"
   exit
 fi

--- a/hack/gardener-extensions-down.sh
+++ b/hack/gardener-extensions-down.sh
@@ -35,9 +35,9 @@ parse_flags() {
 parse_flags "$@"
 
 client_certificate_data=$(kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}')
-if [[ -n "$client_certificate_data" ]] && ! echo "$client_certificate_data"| base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ; then
-  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired or will expire soon. Please provide a valid kubeconfig and try again"
-  exit
+if [[ -n "$client_certificate_data" ]] && ! echo "$client_certificate_data" | base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ; then
+  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired or will expire in 5min. Please provide a valid kubeconfig and try again!"
+  exit 1
 fi
 
 # Delete stuff gradually in the right order, otherwise several dependencies will prevent the cleanup from succeeding.

--- a/hack/gardener-extensions-down.sh
+++ b/hack/gardener-extensions-down.sh
@@ -34,7 +34,8 @@ parse_flags() {
 
 parse_flags "$@"
 
-if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ;then 
+client_certificate_data=$(kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}')
+if [[ -n "$client_certificate_data" ]] && ! echo "$client_certificate_data"| base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ; then
   echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired or will expire soon. Please provide a valid kubeconfig and try again"
   exit
 fi

--- a/hack/gardener-extensions-up.sh
+++ b/hack/gardener-extensions-up.sh
@@ -34,6 +34,11 @@ parse_flags() {
 
 parse_flags "$@"
 
+if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 10 2>/dev/null ;then 
+  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired. Please provide a non-exipired kubeconfig and try again"
+  exit
+fi
+
 echo "Configure seed cluster"
 "$SCRIPT_DIR"/../example/provider-extensions/seed/configure-seed.sh "$PATH_GARDEN_KUBECONFIG" "$PATH_SEED_KUBECONFIG" "$SEED_NAME"
 echo "Start bootstrapping Gardener"

--- a/hack/gardener-extensions-up.sh
+++ b/hack/gardener-extensions-up.sh
@@ -35,7 +35,7 @@ parse_flags() {
 parse_flags "$@"
 
 if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ;then 
-  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired. Please provide a non-exipired kubeconfig and try again"
+  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired or will expire soon. Please provide a valid kubeconfig and try again"
   exit
 fi
 

--- a/hack/gardener-extensions-up.sh
+++ b/hack/gardener-extensions-up.sh
@@ -34,7 +34,7 @@ parse_flags() {
 
 parse_flags "$@"
 
-if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 10 2>/dev/null ;then 
+if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ;then 
   echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired. Please provide a non-exipired kubeconfig and try again"
   exit
 fi

--- a/hack/gardener-extensions-up.sh
+++ b/hack/gardener-extensions-up.sh
@@ -35,9 +35,9 @@ parse_flags() {
 parse_flags "$@"
 
 client_certificate_data=$(kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}')
-if [[ -n "$client_certificate_data" ]] && ! echo "$client_certificate_data"| base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ; then
-  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired or will expire soon. Please provide a valid kubeconfig and try again"
-  exit
+if [[ -n "$client_certificate_data" ]] && ! echo "$client_certificate_data" | base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ; then
+  echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired or will expire in 5min. Please provide a valid kubeconfig and try again!"
+  exit 1
 fi
 
 echo "Configure seed cluster"

--- a/hack/gardener-extensions-up.sh
+++ b/hack/gardener-extensions-up.sh
@@ -34,7 +34,8 @@ parse_flags() {
 
 parse_flags "$@"
 
-if ! kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ;then 
+client_certificate_data=$(kubectl config view --kubeconfig "$PATH_SEED_KUBECONFIG" --raw -o jsonpath='{.users[0].user.client-certificate-data}')
+if [[ -n "$client_certificate_data" ]] && ! echo "$client_certificate_data"| base64 --decode | openssl x509 -noout -checkend 300 2>/dev/null ; then
   echo "Seed kubeconfig ${PATH_SEED_KUBECONFIG} has expired or will expire soon. Please provide a valid kubeconfig and try again"
   exit
 fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR ensures that the seed kubeconfig has not expired before executing `gardener-extensions-up.sh` and `gardener-extensions-down.sh`

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/10024

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Seed kubeconfig is checked for expiration before running `gardener-extensions-up.sh` and `gardener-extensions-down.sh`
```
