### PR TITLE
extensions lib: Add ObjectSelector arg to the shoot webhook

### DIFF
--- a/extensions/pkg/webhook/shoot/shoot.go
+++ b/extensions/pkg/webhook/shoot/shoot.go
@@ -34,6 +34,8 @@ type Args struct {
 	Mutator extensionswebhook.Mutator
 	// MutatorWithShootClient is a mutator to be used by the admission handler. It needs the shoot client.
 	MutatorWithShootClient extensionswebhook.MutatorWithShootClient
+	// ObjectSelector is the object selector of the underlying webhook.
+	ObjectSelector *metav1.LabelSelector
 	// FailurePolicy is the failure policy for the webhook (defaults to Ignore).
 	FailurePolicy *admissionregistrationv1.FailurePolicyType
 }
@@ -48,6 +50,7 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 		Path:              WebhookName,
 		Target:            extensionswebhook.TargetShoot,
 		NamespaceSelector: buildSelector(),
+		ObjectSelector:    args.ObjectSelector,
 		FailurePolicy:     args.FailurePolicy,
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Add ObjectSelector arg to the shoot webhook.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9864

**Special notes for your reviewer**:
See https://github.com/gardener/gardener-extension-provider-aws/pull/988 for example usage in the extension.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
extensions lib: The shoot webhook does now support specifying an object selector.
```
