### PR TITLE
cloudprovider webhook: Enforce object selector unconditionally

### DIFF
--- a/extensions/pkg/webhook/controlplane/controlplane.go
+++ b/extensions/pkg/webhook/controlplane/controlplane.go
@@ -62,7 +62,7 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 	logger.Info("Creating webhook", "name", getName(args.Kind))
 
 	// Build namespace selector from the webhook kind and provider
-	namespaceSelector, err := buildSelector(args.Kind, args.Provider)
+	namespaceSelector, err := buildNamespaceSelector(args.Kind, args.Provider)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +90,8 @@ func getName(kind string) string {
 	}
 }
 
-// buildSelector creates and returns a LabelSelector for the given webhook kind and provider.
-func buildSelector(kind, provider string) (*metav1.LabelSelector, error) {
+// buildNamespaceSelector creates and returns a LabelSelector for the given webhook kind and provider.
+func buildNamespaceSelector(kind, provider string) (*metav1.LabelSelector, error) {
 	// Determine label selector key from the kind
 	var key string
 

--- a/extensions/pkg/webhook/network/network.go
+++ b/extensions/pkg/webhook/network/network.go
@@ -57,12 +57,12 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 		Target:            extensionswebhook.TargetSeed,
 		Path:              path,
 		Webhook:           &admission.Webhook{Handler: handler, RecoverPanic: true},
-		NamespaceSelector: buildSelector(args.NetworkProvider, args.CloudProvider),
+		NamespaceSelector: buildNamespaceSelector(args.NetworkProvider, args.CloudProvider),
 	}, nil
 }
 
-// buildSelector creates and returns a LabelSelector for the given webhook kind and provider.
-func buildSelector(networkProvider, cloudProvider string) *metav1.LabelSelector {
+// buildNamespaceSelector creates and returns a LabelSelector for the given webhook kind and provider.
+func buildNamespaceSelector(networkProvider, cloudProvider string) *metav1.LabelSelector {
 	// Create and return LabelSelector
 	return &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/extensions/pkg/webhook/shoot/shoot.go
+++ b/extensions/pkg/webhook/shoot/shoot.go
@@ -49,7 +49,7 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 		Types:             args.Types,
 		Path:              WebhookName,
 		Target:            extensionswebhook.TargetShoot,
-		NamespaceSelector: buildSelector(),
+		NamespaceSelector: buildNamespaceSelector(),
 		ObjectSelector:    args.ObjectSelector,
 		FailurePolicy:     args.FailurePolicy,
 	}
@@ -77,8 +77,8 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 	return nil, fmt.Errorf("neither mutator nor mutator with shoot client is set")
 }
 
-// buildSelector creates and returns a LabelSelector for the given webhook kind and provider.
-func buildSelector() *metav1.LabelSelector {
+// buildNamespaceSelector creates and returns a LabelSelector for the given webhook kind and provider.
+func buildNamespaceSelector() *metav1.LabelSelector {
 	// Create and return LabelSelector
 	return &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
+++ b/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
@@ -161,9 +161,8 @@ func addTestWebhookToManager(mgr manager.Manager) error {
 	switchOptions := extensionscmdwebhook.NewSwitchOptions(
 		extensionscmdwebhook.Switch("cloudprovider", func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			return cloudprovider.New(mgr, cloudprovider.Args{
-				Provider:             providerName,
-				Mutator:              cloudprovider.NewMutator(mgr, log, testcloudprovider.NewEnsurer(log)),
-				EnableObjectSelector: true,
+				Provider: providerName,
+				Mutator:  cloudprovider.NewMutator(mgr, log, testcloudprovider.NewEnsurer(log)),
 			})
 		}),
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/pull/9981#discussion_r1646167631 we were wondering why the object selector of this webhook is not enforced unconditionally. Then @kon-angelo explained that it was due to backwards compatibility reasons. See https://github.com/gardener/gardener/pull/5527#discussion_r820474834 and https://github.com/gardener/gardener-extension-provider-openstack/blob/20aaecdfc7738c681feb8aabd6e3334ae34c7441/pkg/webhook/cloudprovider/add.go#L33-L50>

It should be good now to enforce this object selector assuming that provider extensions now anyways require Gardener >= 1.42 due to other breaking changes.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9864

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The `github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider.Args#EnableObjectSelector` field is now removed. The corresponding webhook's object selector is now enforced unconditionally.
```
