### PR TITLE
Scrape vpa-admission-controller metrics with prometheus

### DIFF
--- a/pkg/component/autoscaling/vpa/general.go
+++ b/pkg/component/autoscaling/vpa/general.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	metricsPortName = "metrics"
+	serverPortName  = "server"
 )
 
 func newDefaultLivenessProbe() *corev1.Probe {

--- a/pkg/component/autoscaling/vpa/recommender.go
+++ b/pkg/component/autoscaling/vpa/recommender.go
@@ -214,7 +214,7 @@ func (v *vpa) reconcileRecommenderDeployment(deployment *appsv1.Deployment, serv
 					LivenessProbe: newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{
 						{
-							Name:          "server",
+							Name:          serverPortName,
 							ContainerPort: recommenderPortServer,
 						},
 						{

--- a/pkg/component/autoscaling/vpa/updater.go
+++ b/pkg/component/autoscaling/vpa/updater.go
@@ -155,7 +155,7 @@ func (v *vpa) reconcileUpdaterDeployment(deployment *appsv1.Deployment, serviceA
 					LivenessProbe: newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{
 						{
-							Name:          "server",
+							Name:          serverPortName,
 							ContainerPort: updaterPortServer,
 						},
 						{

--- a/pkg/component/autoscaling/vpa/vpa.go
+++ b/pkg/component/autoscaling/vpa/vpa.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	vpaconstants "github.com/gardener/gardener/pkg/component/autoscaling/vpa/constants"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/seed"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -231,6 +232,10 @@ func (v *vpa) emptyPodMonitor(name string) *monitoringv1.PodMonitor {
 	return &monitoringv1.PodMonitor{ObjectMeta: monitoringutils.ConfigObjectMeta(name, v.namespace, seed.Label)}
 }
 
+func (v *vpa) emptyServiceMonitor(name string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{ObjectMeta: monitoringutils.ConfigObjectMeta(name, v.namespace, v.getPrometheusLabel())}
+}
+
 func (v *vpa) emptyVerticalPodAutoscaler(name string) *vpaautoscalingv1.VerticalPodAutoscaler {
 	return &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: v.namespace}}
 }
@@ -306,4 +311,11 @@ func (v *vpa) injectAPIServerConnectionSpec(deployment *appsv1.Deployment, name 
 
 		utilruntime.Must(gardenerutils.InjectGenericKubeconfig(deployment, *v.genericTokenKubeconfigSecretName, gardenerutils.SecretNamePrefixShootAccess+deployment.Name))
 	}
+}
+
+func (v *vpa) getPrometheusLabel() string {
+	if v.values.ClusterType == component.ClusterTypeSeed {
+		return seed.Label
+	}
+	return shoot.Label
 }

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -853,7 +853,6 @@ var _ = Describe("VPA", func() {
 			if clusterType == "shoot" {
 				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports", `[{"protocol":"TCP","port":10250}]`)
 				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports", `[{"protocol":"TCP","port":8944}]`)
-				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/pod-label-selector-namespace-alias", "all-shoots")
 			}
 
 			if topologyAwareRoutingEnabled {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Enable scraping for vpa-admission-controller, such that we can create some dashboards for the admission-controller metics, such as`vpa_admission_controller_execution_latency_seconds`.

The admission-controller in the Shoot namespaces are scraped by the Shoot's prometheus and the admission-controllers for our Seeds are scraped by the runtime cluster's seed-prometheus.

**Which issue(s) this PR fixes**:
part of #9954

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Scrape vpa-admission-controller metrics with prometheus
```
