### PR TITLE
Revert "chore(deps): update dependency gardener/logging to v0.55.7 (#9993)"

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -497,7 +497,7 @@ images:
     name: fluent-bit-to-vali
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-  tag: "v0.55.7"
+  tag: "v0.55.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -532,7 +532,7 @@ images:
 - name: vali-curator
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-  tag: "v0.55.7"
+  tag: "v0.55.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -587,7 +587,7 @@ images:
     name: telegraf-iptables
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-  tag: "v0.55.7"
+  tag: "v0.55.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -607,7 +607,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-  tag: "v0.55.7"
+  tag: "v0.55.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -624,7 +624,7 @@ images:
 - name: tune2fs
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-  tag: "v0.55.7"
+  tag: "v0.55.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind regression

**What this PR does / why we need it**:

Revert "chore(deps): update dependency gardener/logging to v0.55.7 (#9993)"

This reverts commit 0921e6e06bbe41ab401eac63223dd78faaa4e5e6.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

After #9993, `fluent-bit` pods failed with the following error message and ended in `CrashLoopBackOff`:

```
level=info time=2024-06-28T11:09:51Z msg="fluent-bit started"
[2024/06/28 11:09:51] [error] [proxy] error opening plugin /fluent-bit/plugins/out_vali.so: '/lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /fluent-bit/plugins/out_vali.so)'
[2024/06/28 11:09:51] [error] [plugin] error loading proxy plugin: /fluent-bit/plugins/out_vali.so
level=error time=2024-06-28T11:09:51Z msg="Failure during the run time of fluent-bit" error="failed to run fluent-bit: exit status 1"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
```
