### PR TITLE
Configure `0640` permissions to `vpn` container volumes in `kube-apiserver`

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -2658,7 +2658,10 @@ rules:
 					corev1.Volume{
 						Name: "vpn-seed-tlsauth",
 						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: secretNameVPNSeedServerTLSAuth},
+							Secret: &corev1.SecretVolumeSource{
+								SecretName:  secretNameVPNSeedServerTLSAuth,
+								DefaultMode: ptr.To[int32](0640),
+							},
 						},
 					},
 					corev1.Volume{

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -2621,7 +2621,7 @@ rules:
 						Name: "vpn-seed-client",
 						VolumeSource: corev1.VolumeSource{
 							Projected: &corev1.ProjectedVolumeSource{
-								DefaultMode: ptr.To[int32](400),
+								DefaultMode: ptr.To[int32](0640),
 								Sources: []corev1.VolumeProjection{
 									{
 										Secret: &corev1.SecretProjection{

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -697,7 +697,7 @@ func (k *kubeAPIServer) handleVPNSettingsHA(
 			Name: volumeNameVPNSeedClient,
 			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
-					DefaultMode: ptr.To[int32](400),
+					DefaultMode: ptr.To[int32](0640),
 					Sources: []corev1.VolumeProjection{
 						{
 							Secret: &corev1.SecretProjection{

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -659,7 +659,7 @@ func (k *kubeAPIServer) handleVPNSettingsHA(
 			Name: volumeNameAPIServerAccess,
 			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
-					DefaultMode: ptr.To[int32](420),
+					DefaultMode: ptr.To[int32](0640),
 					Sources: []corev1.VolumeProjection{
 						{
 							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
@@ -734,7 +734,10 @@ func (k *kubeAPIServer) handleVPNSettingsHA(
 		{
 			Name: volumeNameVPNSeedTLSAuth,
 			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: secretHAVPNSeedClientSeedTLSAuth.Name},
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  secretHAVPNSeedClientSeedTLSAuth.Name,
+					DefaultMode: ptr.To[int32](0640),
+				},
 			},
 		},
 		{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR enhances security by removing `group` write access of mounted files from the `vpn` container volumes. These files are `key` files which we want permissions `0640` or more restrictive.

This PR completes leftover from https://github.com/gardener/gardener/pull/8790

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
