### PR TITLE
feat(logging): gardener/logging plugin now supports fluent-bit v3 hot reload

### DIFF
--- a/example/seed-crds/10-crd-fluentbit.fluent.io_clusteroutputs.yaml
+++ b/example/seed-crds/10-crd-fluentbit.fluent.io_clusteroutputs.yaml
@@ -355,7 +355,33 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: |-
                       Compress  the payload in GZIP format.
@@ -661,6 +687,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                   traceError:
                     description: When enabled print the elasticsearch API calls to
                       stdout when elasticsearch returns an error
@@ -831,6 +861,11 @@ spec:
                   sharedKey:
                     description: A key string known by the remote Fluentd used for
                       authorization.
+                    type: string
+                  tag:
+                    description: |-
+                      Overwrite the tag as we transmit. This allows the receiving pipeline start
+                      fresh, or to attribute source.
                     type: string
                   timeAsInteger:
                     description: Set timestamps in integer format, it enable compatibility

--- a/example/seed-crds/10-crd-fluentbit.fluent.io_outputs.yaml
+++ b/example/seed-crds/10-crd-fluentbit.fluent.io_outputs.yaml
@@ -355,7 +355,33 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: |-
                       Compress  the payload in GZIP format.
@@ -661,6 +687,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                   traceError:
                     description: When enabled print the elasticsearch API calls to
                       stdout when elasticsearch returns an error
@@ -831,6 +861,11 @@ spec:
                   sharedKey:
                     description: A key string known by the remote Fluentd used for
                       authorization.
+                    type: string
+                  tag:
+                    description: |-
+                      Overwrite the tag as we transmit. This allows the receiving pipeline start
+                      fresh, or to attribute source.
                     type: string
                   timeAsInteger:
                     description: Set timestamps in integer format, it enable compatibility

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/containerd v1.7.18
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/distribution/v3 v3.0.0-alpha.1
-	github.com/fluent/fluent-operator/v2 v2.8.0
+	github.com/fluent/fluent-operator/v2 v2.9.0
 	github.com/gardener/cert-management v0.15.0
 	github.com/gardener/dependency-watchdog v1.2.3
 	github.com/gardener/etcd-druid v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4Nij
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fluent/fluent-operator/v2 v2.8.0 h1:G6TB1Fq6wx+HflXmv2mc7bhj2MiDoT9OfAeq/XkPCgI=
-github.com/fluent/fluent-operator/v2 v2.8.0/go.mod h1:nGKS5Iryq98Jqt+Ixc8YSMmOzM/yNxD8Xwtt76DhmTg=
+github.com/fluent/fluent-operator/v2 v2.9.0 h1:VFGgRPOI+yxnOrTIAL6sgFCtc+quDda12iyVL1lRQag=
+github.com/fluent/fluent-operator/v2 v2.9.0/go.mod h1:Hthhi/3oO26udvro6t5foUx20PZAMn7WGUhSnEWUV9U=
 github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6FI=
 github.com/foxcpp/go-mockdns v1.0.0/go.mod h1:lgRN6+KxQBawyIghpnl5CezHFGS9VLzvtVlwxvzXTQ4=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -41,7 +41,7 @@ images:
 - name: gardener-discovery-server
   sourceRepository: github.com/gardener/gardener-discovery-server
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/gardener-discovery-server
-  tag: "v0.1.0" 
+  tag: "v0.1.0"
 
 # Gardener Dashboard components
 - name: gardener-dashboard
@@ -460,8 +460,8 @@ images:
 # Logging
 - name: fluent-operator
   sourceRepository: github.com/fluent/fluent-operator
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator
-  tag: "v2.7.0"
+  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-operator
+  tag: "v2.9.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -476,9 +476,9 @@ images:
     - type: 'githubTeam'
       teamname: 'gardener/logging-maintainers'
 - name: fluent-bit
-  sourceRepository: github.com/fluent/fluent-bit
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-bit
-  tag: "v2.2.2"
+  sourceRepository: github.com/fluent/fluent-operator
+  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
+  tag: "v3.0.7"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -497,7 +497,7 @@ images:
     name: fluent-bit-to-vali
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-  tag: "v0.55.6"
+  tag: "v0.60.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -532,7 +532,7 @@ images:
 - name: vali-curator
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-  tag: "v0.55.6"
+  tag: "v0.60.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -587,7 +587,7 @@ images:
     name: telegraf-iptables
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-  tag: "v0.55.6"
+  tag: "v0.60.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -607,7 +607,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-  tag: "v0.55.6"
+  tag: "v0.60.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -624,7 +624,7 @@ images:
 - name: tune2fs
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-  tag: "v0.55.6"
+  tag: "v0.60.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -778,7 +778,7 @@ images:
       version: '9.1.0'
     - name: 'boringssl'
       version: '45cf810'
-    # lua version is unclear. lua runtime is luajit. 
+    # lua version is unclear. lua runtime is luajit.
     # luajit is compatible with lua 5.1 but contains feature of lua 5.2 and 5.3
     # https://luajit.org/extensions.html
     - name: 'lua'

--- a/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_clusteroutputs.yaml
+++ b/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_clusteroutputs.yaml
@@ -355,7 +355,33 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: |-
                       Compress  the payload in GZIP format.
@@ -661,6 +687,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                   traceError:
                     description: When enabled print the elasticsearch API calls to
                       stdout when elasticsearch returns an error
@@ -831,6 +861,11 @@ spec:
                   sharedKey:
                     description: A key string known by the remote Fluentd used for
                       authorization.
+                    type: string
+                  tag:
+                    description: |-
+                      Overwrite the tag as we transmit. This allows the receiving pipeline start
+                      fresh, or to attribute source.
                     type: string
                   timeAsInteger:
                     description: Set timestamps in integer format, it enable compatibility

--- a/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_outputs.yaml
+++ b/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_outputs.yaml
@@ -355,7 +355,33 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: |-
                       Compress  the payload in GZIP format.
@@ -661,6 +687,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                   traceError:
                     description: When enabled print the elasticsearch API calls to
                       stdout when elasticsearch returns an error
@@ -831,6 +861,11 @@ spec:
                   sharedKey:
                     description: A key string known by the remote Fluentd used for
                       authorization.
+                    type: string
+                  tag:
+                    description: |-
+                      Overwrite the tag as we transmit. This allows the receiving pipeline start
+                      fresh, or to attribute source.
                     type: string
                   timeAsInteger:
                     description: Set timestamps in integer format, it enable compatibility


### PR DESCRIPTION
This PR upgrades the complete logging stack featuring latest fluent-bit v3.

/area logging
/kind enhancement

- bumps up fluent operator to v2.0.9
- upgrades fluent-bit to v3.0.7
- upgrades gardener/logging to v0.60.0


```other operator
Gardener logging stack now features fluent-bit v3.
```
