### PR TITLE
Skip shoots with `status.technicalID` not set while deleting DWD secrets

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -173,7 +173,7 @@ func cleanupDWDAccess(ctx context.Context, gardenClient client.Client, seedClien
 	var taskFns []flow.TaskFn
 
 	for _, shoot := range shootList.Items {
-		if !v1beta1helper.IsWorkerless(&shoot) || shoot.DeletionTimestamp != nil {
+		if !v1beta1helper.IsWorkerless(&shoot) || shoot.DeletionTimestamp != nil || shoot.Status.TechnicalID == "" {
 			continue
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cleanup
/kind bug

**What this PR does / why we need it**:
Skip shoots with `status.technicalID` not set while deleting DWD secrets to prevent gardenlet panic, if it restarts during while some workerless shoots are getting created and the field is not set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing gardenlet to panic while deleting `dependency-watchdog-access` secrets for workerless Shoots if the `status.technicalID` is not set for the Shoot is now fixed.
```
