### PR TITLE
Federate apiserver_total_request metric to the Prometheus longterm instance

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
@@ -61,6 +61,7 @@ func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
 						`{__name__="garden_seed_usage"}`,
 						`{__name__="garden_seed_capacity"}`,
 						`{__name__="etcdbr_snapshot_duration_seconds_count"}`,
+						`{__name__="apiserver_request_total", job=~="(virtual-garden-kube-apiserver)"}`,
 					},
 				},
 				StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: []monitoringv1alpha1.Target{"prometheus-" + garden.Label}}},


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR Federate apiserver_total_request metric to the Prometheus longterm instance

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
Federate apiserver_total_request metric to the Prometheus longterm instance
```
