### PR TITLE
Make yaml serialization in `controllerinstallation.mutateObjects` deterministic

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -51,7 +51,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/oci"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
-
 	forkedyaml "github.com/gardener/gardener/third_party/gopkg.in/yaml.v2"
 )
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -496,7 +496,7 @@ func injectGardenAccessSecrets(secretData map[string][]byte, namespace, genericG
 }
 
 // mutateObject iterates over the given rendered secret data and calls the given mutator for each of them. It marshals
-// the objects back in a deterministic way after mutation and updates the secret data.
+// the objects back (with stable key ordering) after mutation and updates the secret data.
 func mutateObjects(secretData map[string][]byte, mutate func(obj *unstructured.Unstructured) error) error {
 	for key, data := range secretData {
 		buffer := &bytes.Buffer{}
@@ -519,7 +519,7 @@ func mutateObjects(secretData map[string][]byte, mutate func(obj *unstructured.U
 				return err
 			}
 
-			// serialize unstructured back to secret data in a deterministic way
+			// serialize unstructured back to secret data (with stable key ordering)
 			// Note: we have to do this for all objects, not only for mutated ones, as there could be multiple objects in one file
 			objBytes, err := forkedyaml.Marshal(obj.Object)
 			if err != nil {

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/yaml"
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -52,6 +51,8 @@ import (
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/oci"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+
+	forkedyaml "github.com/gardener/gardener/third_party/gopkg.in/yaml.v2"
 )
 
 const finalizerName = "core.gardener.cloud/controllerinstallation"
@@ -496,7 +497,7 @@ func injectGardenAccessSecrets(secretData map[string][]byte, namespace, genericG
 }
 
 // mutateObject iterates over the given rendered secret data and calls the given mutator for each of them. It marshals
-// the objects back after mutation and updates the secret data.
+// the objects back in a deterministic way after mutation and updates the secret data.
 func mutateObjects(secretData map[string][]byte, mutate func(obj *unstructured.Unstructured) error) error {
 	for key, data := range secretData {
 		buffer := &bytes.Buffer{}
@@ -519,9 +520,9 @@ func mutateObjects(secretData map[string][]byte, mutate func(obj *unstructured.U
 				return err
 			}
 
-			// serialize unstructured back to secret data
+			// serialize unstructured back to secret data in a deterministic way
 			// Note: we have to do this for all objects, not only for mutated ones, as there could be multiple objects in one file
-			objBytes, err := yaml.Marshal(obj)
+			objBytes, err := forkedyaml.Marshal(obj.Object)
 			if err != nil {
 				return err
 			}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_export_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_export_test.go
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerinstallation
+
+var MutateObjects = mutateObjects

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("Reconciler", func() {
 	Describe("#mutateObjects", func() {
-		It("serializes yaml with stable key ordering, func() {
+		It("serializes yaml with stable key ordering", func() {
 		content := `
 ---
 apiVersion: v1

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Reconciler", func() {
 	Describe("#mutateObjects", func() {
 		It("serializes yaml with stable key ordering", func() {
-		content := `
+			content := `
 ---
 apiVersion: v1
 kind: Secret
@@ -31,7 +31,7 @@ metadata:
 
 ---
 `
-		stableContent := `
+			stableContent := `
 ---
 apiVersion: v1
 kind: Secret
@@ -47,14 +47,14 @@ metadata:
 
 ---
 `
-		secret := map[string][]byte{
-			"keyA": []byte(content),
-		}
-		err := controllerinstallation.MutateObjects(secret, func(_ *unstructured.Unstructured) error {
-			return nil
+			secret := map[string][]byte{
+				"keyA": []byte(content),
+			}
+			err := controllerinstallation.MutateObjects(secret, func(_ *unstructured.Unstructured) error {
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(secret["keyA"])).To(Equal(stableContent))
 		})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(secret["keyA"])).To(Equal(stableContent))
 	})
-
 })

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/yaml_consistency_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/yaml_consistency_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
 )
 
-var _ = Describe("Ensuring MutateObjects makes deterministic yaml serialization ", func() {
-	It("serializes yaml in a deterministic way", func() {
+var _ = Describe("Reconciler", func() {
+	Describe("#mutateObjects", func() {
+		It("serializes yaml with stable key ordering, func() {
 		content := `
 ---
 apiVersion: v1

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/yaml_consistency_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/yaml_consistency_test.go
@@ -49,7 +49,7 @@ metadata:
 		secret := map[string][]byte{
 			"keyA": []byte(content),
 		}
-		err := controllerinstallation.MutateObjects(secret, func(obj *unstructured.Unstructured) error {
+		err := controllerinstallation.MutateObjects(secret, func(_ *unstructured.Unstructured) error {
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/yaml_consistency_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/yaml_consistency_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerinstallation_test
+
+import (
+	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Ensuring MutateObjects makes deterministic yaml serialization ", func() {
+	It("serializes yaml in a deterministic way", func() {
+		content := `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    reference.resources.gardener.cloud/configmap-32c4dfab: oidc-apps-controller-imagevector-overwrite
+    reference.resources.gardener.cloud/secret-795f7ca6: garden-access-extension
+    reference.resources.gardener.cloud/secret-83438e60: generic-garden-kubeconfig-a1b02908
+    reference.resources.gardener.cloud/secret-8d3ae69b: oidc-apps-controller
+  creationTimestamp: null
+  name: foo
+  namespace: bar
+
+---
+`
+		stableContent := `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    reference.resources.gardener.cloud/configmap-32c4dfab: oidc-apps-controller-imagevector-overwrite
+    reference.resources.gardener.cloud/secret-8d3ae69b: oidc-apps-controller
+    reference.resources.gardener.cloud/secret-795f7ca6: garden-access-extension
+    reference.resources.gardener.cloud/secret-83438e60: generic-garden-kubeconfig-a1b02908
+  creationTimestamp: null
+  name: foo
+  namespace: bar
+
+---
+`
+		secret := map[string][]byte{
+			"keyA": []byte(content),
+		}
+		err := controllerinstallation.MutateObjects(secret, func(obj *unstructured.Unstructured) error {
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(secret["keyA"])).To(Equal(stableContent))
+	})
+
+})

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/yaml_consistency_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/yaml_consistency_test.go
@@ -5,10 +5,11 @@
 package controllerinstallation_test
 
 import (
-	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
 )
 
 var _ = Describe("Ensuring MutateObjects makes deterministic yaml serialization ", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR utilises `forkedyaml` for deterministic yaml parsing in `controllerinstallation.mutateObjects`

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/10092

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`controllerinstallation` controller should not recreate MR secrets that differ just in the order of annotations.
```
