### PR TITLE
node-agent: Drop `fileExists` func in favor of `r.FS.Exists`

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -337,7 +337,7 @@ func (r *Reconciler) removeDeletedUnits(ctx context.Context, log logr.Logger, no
 	for _, unit := range units {
 		unitFilePath := path.Join(etcSystemdSystem, unit.Name)
 
-		unitFileExists, err := r.fileExists(unitFilePath)
+		unitFileExists, err := r.FS.Exists(unitFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to check whether unit file %q exists: %w", unitFilePath, err)
 		}
@@ -398,14 +398,4 @@ func (r *Reconciler) executeUnitCommands(ctx context.Context, log logr.Logger, n
 	}
 
 	return mustRestartGardenerNodeAgent, flow.Parallel(fns...)(ctx)
-}
-
-func (r *Reconciler) fileExists(path string) (bool, error) {
-	if _, err := r.FS.Stat(path); err != nil {
-		if errors.Is(err, afero.ErrFileNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
A side finding when looking into https://github.com/gardener/gardener/pull/10050.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
