### PR TITLE
Force containerd to use HTTP for garden.local.gardener.cloud

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -198,6 +198,9 @@ Hence, if you want to access the shoot cluster, you have to run the following co
 cat <<EOF | sudo tee -a /etc/hosts
 
 # Begin of Gardener local setup section
+# Garden Cluster domain
+127.0.0.1 garden.local.gardener.cloud
+
 # Shoot API server domains
 127.0.0.1 api.local.local.external.local.gardener.cloud
 127.0.0.1 api.local.local.internal.local.gardener.cloud

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -198,9 +198,6 @@ Hence, if you want to access the shoot cluster, you have to run the following co
 cat <<EOF | sudo tee -a /etc/hosts
 
 # Begin of Gardener local setup section
-# Garden Cluster domain
-127.0.0.1 garden.local.gardener.cloud
-
 # Shoot API server domains
 127.0.0.1 api.local.local.external.local.gardener.cloud
 127.0.0.1 api.local.local.internal.local.gardener.cloud

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -122,6 +122,7 @@ setup_containerd_registry_mirrors() {
     setup_containerd_registry_mirror $NODE "registry.k8s.io" "https://registry.k8s.io" "http://${REGISTRY_HOSTNAME}:5006"
     setup_containerd_registry_mirror $NODE "quay.io" "https://quay.io" "http://${REGISTRY_HOSTNAME}:5007"
     setup_containerd_registry_mirror $NODE "europe-docker.pkg.dev" "https://europe-docker.pkg.dev" "http://${REGISTRY_HOSTNAME}:5008"
+    setup_containerd_registry_mirror $NODE "garden.local.gardener.cloud:5001" "http://garden.local.gardener.cloud:5001" "http://${REGISTRY_HOSTNAME}:5001"
   done
 }
 

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -337,6 +337,47 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 			}))))
 		})
 
+		It("should forbid containerd config with an upstream that contains a scheme", func() {
+			oscCopy := osc.DeepCopy()
+			oscCopy.Spec.CRIConfig.Containerd.Registries = []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "http://foo.bar",
+				},
+			}
+
+			Expect(ValidateOperatingSystemConfig(oscCopy)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("spec.criConfig.containerd.registries[0].upstream"),
+				"BadValue": Equal("http://foo.bar"),
+			}))))
+		})
+
+		It("should forbid containerd config with an upstream that contains a path", func() {
+			oscCopy := osc.DeepCopy()
+			oscCopy.Spec.CRIConfig.Containerd.Registries = []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "foo.bar/baz",
+				},
+			}
+
+			Expect(ValidateOperatingSystemConfig(oscCopy)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("spec.criConfig.containerd.registries[0].upstream"),
+				"BadValue": Equal("foo.bar/baz"),
+			}))))
+		})
+
+		It("should allow containerd config with an upstream that contains a port", func() {
+			oscCopy := osc.DeepCopy()
+			oscCopy.Spec.CRIConfig.Containerd.Registries = []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "foo.bar:5001",
+				},
+			}
+
+			Expect(ValidateOperatingSystemConfig(oscCopy)).To(BeEmpty())
+		})
+
 		It("should allow containerd config with _default upstream name", func() {
 			oscCopy := osc.DeepCopy()
 			oscCopy.Spec.CRIConfig.Containerd.Registries = []extensionsv1alpha1.RegistryConfig{

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -92,11 +92,6 @@ func (e *ensurer) EnsureAdditionalProvisionFiles(_ context.Context, _ extensions
 			UpstreamHost: "europe-docker.pkg.dev",
 			MirrorHost:   "http://garden.local.gardener.cloud:5008",
 		},
-		// Enable containerd to reach registry at garden.local.gardener.cloud:5001 via HTTP.
-		{
-			UpstreamHost: "garden.local.gardener.cloud:5001",
-			MirrorHost:   "http://garden.local.gardener.cloud:5001",
-		},
 	} {
 		*new = webhook.EnsureFileWithPath(*new, extensionsv1alpha1.File{
 			Path:        filepath.Join("/etc/containerd/certs.d", mirror.UpstreamHost, "hosts.toml"),
@@ -142,6 +137,12 @@ func (e *ensurer) EnsureCRIConfig(_ context.Context, _ extensionscontextwebhook.
 			Upstream: "quay.io",
 			Server:   ptr.To("https://quay.io"),
 			Hosts:    []extensionsv1alpha1.RegistryHost{{URL: "http://garden.local.gardener.cloud:5007"}},
+		},
+		// Enable containerd to reach registry at garden.local.gardener.cloud:5001 via HTTP.
+		{
+			Upstream: "garden.local.gardener.cloud:5001",
+			Server:   ptr.To("http://garden.local.gardener.cloud:5001"),
+			Hosts:    []extensionsv1alpha1.RegistryHost{{URL: "http://garden.local.gardener.cloud:5001"}},
 		},
 	} {
 		// Only add registry when it is not already set in the OSC.

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -92,6 +92,11 @@ func (e *ensurer) EnsureAdditionalProvisionFiles(_ context.Context, _ extensions
 			UpstreamHost: "europe-docker.pkg.dev",
 			MirrorHost:   "http://garden.local.gardener.cloud:5008",
 		},
+		// Enable containerd to reach registry at garden.local.gardener.cloud:5001 via HTTP.
+		{
+			UpstreamHost: "garden.local.gardener.cloud:5001",
+			MirrorHost:   "http://garden.local.gardener.cloud:5001",
+		},
 	} {
 		*new = webhook.EnsureFileWithPath(*new, extensionsv1alpha1.File{
 			Path:        filepath.Join("/etc/containerd/certs.d", mirror.UpstreamHost, "hosts.toml"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Every image in Gardener gets tagged as `localhost:5001/repository:tag`. So when containerd tries to pull an image, it does so by reaching localhost:5001 via HTTP. Due to the setup of the local registry, localhost:5001 successfully targets the deployed local registry.

An issue arises when a pod in the cluster also wants to reach this local registry, as in the case of Lakom [1].
Since localhost:5001 is the loopback of the pod container, it can't find the registry. This can be worked around by tagging images using `garden.local.gardener.cloud:5001` instead of `localhost`.
Due to some configuration that is done in the hack/kind-up.sh script[2], this domain always resolves to the IP of the KinD node where the local registry resides and has its port exposed.

This, however, creates a problem for containerd in the node. When it tries to pull an image from `garden.local.gardener.cloud` it always expects that the communication will be via HTTPS which results in an error.
This change instructs containerd to use HTTP when the domain of the registry is `garden.local.gardener.cloud`.

[1] https://github.com/gardener/gardener-extension-shoot-lakom-service
[2] https://github.com/gardener/gardener/blob/720e534ee0ece2bd5fc5aa16d38559887daf2946/hack/kind-up.sh#L376-L396
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
NONE
```
