### PR TITLE
Use hooks instead of build command for mcm-provider-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,18 +343,18 @@ gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_CACHE_ARTIFACTS =
 gardener-ha-single-zone%: export SKAFFOLD_PROFILE=ha-single-zone
 gardener-ha-multi-zone%: export SKAFFOLD_PROFILE=ha-multi-zone
 
-gardener-up gardener-ha-single-zone-up gardener-ha-multi-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ) $(KO)
+gardener-up gardener-ha-single-zone-up gardener-ha-multi-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
 	$(SKAFFOLD) run
-gardener-dev gardener-ha-single-zone-dev gardener-ha-multi-zone-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ) $(KO)
+gardener-dev gardener-ha-single-zone-dev gardener-ha-multi-zone-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
 	$(SKAFFOLD) dev
-gardener-debug gardener-ha-single-zone-debug gardener-ha-multi-zone-debug: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ) $(KO)
+gardener-debug gardener-ha-single-zone-debug gardener-ha-multi-zone-debug: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
 	$(SKAFFOLD) debug
 gardener-down gardener-ha-single-zone-down gardener-ha-multi-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh
 
 gardener-extensions-%: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-extensions
 
-gardener-extensions-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ) $(KO)
+gardener-extensions-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
 	./hack/gardener-extensions-up.sh --path-garden-kubeconfig $(REPO_ROOT)/example/provider-extensions/garden/kubeconfig --path-seed-kubeconfig $(SEED_KUBECONFIG) --seed-name $(SEED_NAME)
 gardener-extensions-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-extensions-down.sh --path-garden-kubeconfig $(REPO_ROOT)/example/provider-extensions/garden/kubeconfig --path-seed-kubeconfig $(SEED_KUBECONFIG) --seed-name $(SEED_NAME)
@@ -364,31 +364,31 @@ gardenlet-kind2-ha-single-zone-up gardenlet-kind2-ha-single-zone-dev gardenlet-k
 gardenlet-kind2-up gardenlet-kind2-dev gardenlet-kind2-debug gardenlet-kind2-down: export SKAFFOLD_COMMAND_KUBECONFIG := $(GARDENER_LOCAL_KUBECONFIG)
 gardenlet-kind2-ha-single-zone-up gardenlet-kind2-ha-single-zone-dev gardenlet-kind2-ha-single-zone-debug gardenlet-kind2-ha-single-zone-down: export SKAFFOLD_COMMAND_KUBECONFIG := $(GARDENER_LOCAL_HA_SINGLE_ZONE_KUBECONFIG)
 
-gardenlet-kind2-up gardenlet-kind2-ha-single-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KO)
+gardenlet-kind2-up gardenlet-kind2-ha-single-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) deploy -m $(SKAFFOLD_PREFIX_NAME)-env -p $(SKAFFOLD_PREFIX_NAME) --kubeconfig=$(SKAFFOLD_COMMAND_KUBECONFIG)
 	@# define GARDENER_LOCAL_KUBECONFIG so that it can be used by skaffold when checking whether the seed managed by this gardenlet is ready
 	GARDENER_LOCAL_KUBECONFIG=$(SKAFFOLD_COMMAND_KUBECONFIG) $(SKAFFOLD) run -m gardenlet -p $(SKAFFOLD_PREFIX_NAME)
-gardenlet-kind2-dev gardenlet-kind2-ha-single-zone-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KO)
+gardenlet-kind2-dev gardenlet-kind2-ha-single-zone-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) deploy -m $(SKAFFOLD_PREFIX_NAME)-env -p $(SKAFFOLD_PREFIX_NAME) --kubeconfig=$(SKAFFOLD_COMMAND_KUBECONFIG)
 	@# define GARDENER_LOCAL_KUBECONFIG so that it can be used by skaffold when checking whether the seed managed by this gardenlet is ready
 	GARDENER_LOCAL_KUBECONFIG=$(SKAFFOLD_COMMAND_KUBECONFIG) $(SKAFFOLD) dev -m gardenlet -p $(SKAFFOLD_PREFIX_NAME)
-gardenlet-kind2-debug gardenlet-kind2-ha-single-zone-debug: $(SKAFFOLD) $(HELM) $(KO)
+gardenlet-kind2-debug gardenlet-kind2-ha-single-zone-debug: $(SKAFFOLD) $(HELM)
 	$(SKAFFOLD) deploy -m $(SKAFFOLD_PREFIX_NAME)-env -p $(SKAFFOLD_PREFIX_NAME) --kubeconfig=$(SKAFFOLD_COMMAND_KUBECONFIG)
 	@# define GARDENER_LOCAL_KUBECONFIG so that it can be used by skaffold when checking whether the seed managed by this gardenlet is ready
 	GARDENER_LOCAL_KUBECONFIG=$(SKAFFOLD_COMMAND_KUBECONFIG) $(SKAFFOLD) debug -m gardenlet -p $(SKAFFOLD_PREFIX_NAME)
-gardenlet-kind2-down gardenlet-kind2-ha-single-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KO)
+gardenlet-kind2-down gardenlet-kind2-ha-single-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) delete -m $(SKAFFOLD_PREFIX_NAME)-env -p $(SKAFFOLD_PREFIX_NAME) --kubeconfig=$(SKAFFOLD_COMMAND_KUBECONFIG)
 	$(SKAFFOLD) delete -m gardenlet,$(SKAFFOLD_PREFIX_NAME)-env -p $(SKAFFOLD_PREFIX_NAME)
 
 operator-%: export SKAFFOLD_FILENAME = skaffold-operator.yaml
 
-operator-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KO)
+operator-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) run
-operator-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KO)
+operator-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) dev
-operator-debug: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KO)
+operator-debug: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) debug
-operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KO)
+operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) annotate garden --all confirmation.gardener.cloud/deletion=true
 	$(KUBECTL) delete garden --all --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete

--- a/hack/mcm-provider-local-overwrite.sh
+++ b/hack/mcm-provider-local-overwrite.sh
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+repository=$(echo $SKAFFOLD_IMAGE | cut -d':' -f 1,2)
+# Make sure to extract everything after the last ':'.
+# E.g. 
+# registry.io/repo:tag -> tag
+# registry.io:5001/repo:tag -> tag
+tag=$(echo $SKAFFOLD_IMAGE | rev | cut -d':' -f 1 | rev)
+
+cat <<EOF > example/provider-local/garden/base/patch-imagevector-overwrite.yaml
+apiVersion: core.gardener.cloud/v1
+kind: ControllerDeployment
+metadata:
+  name: provider-local
+helm:
+  values:
+    imageVectorOverwrite: |
+      images:
+      - name: machine-controller-manager-provider-local
+        repository: ${repository}
+        tag: ${tag}
+EOF
+

--- a/hack/mcm-provider-local-overwrite.sh
+++ b/hack/mcm-provider-local-overwrite.sh
@@ -4,11 +4,7 @@
 
 set -e
 
-repository=$(echo $SKAFFOLD_IMAGE | cut -d':' -f 1,2)
-# Make sure to extract everything after the last ':'.
-# E.g. 
-# registry.io/repo:tag -> tag
-# registry.io:5001/repo:tag -> tag
+repository=$(echo $SKAFFOLD_IMAGE | rev | cut -d':' -f 2- | rev)
 tag=$(echo $SKAFFOLD_IMAGE | rev | cut -d':' -f 1 | rev)
 
 cat <<EOF > example/provider-local/garden/base/patch-imagevector-overwrite.yaml

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -35,7 +35,6 @@ GO_TO_PROTOBUF             := $(TOOLS_BIN_DIR)/go-to-protobuf
 HELM                       := $(TOOLS_BIN_DIR)/helm
 IMPORT_BOSS                := $(TOOLS_BIN_DIR)/import-boss
 KIND                       := $(TOOLS_BIN_DIR)/kind
-KO                         := $(TOOLS_BIN_DIR)/ko
 KUBECTL                    := $(TOOLS_BIN_DIR)/kubectl
 KUSTOMIZE                  := $(TOOLS_BIN_DIR)/kustomize
 LOGCHECK                   := $(TOOLS_BIN_DIR)/logcheck.so # plugin binary
@@ -66,8 +65,6 @@ GO_VULN_CHECK_VERSION ?= latest
 HELM_VERSION ?= v3.15.2
 # renovate: datasource=github-releases depName=kubernetes-sigs/kind
 KIND_VERSION ?= v0.23.0
-# renovate: datasource=github-releases depName=ko-build/ko
-KO_VERSION ?= v0.15.4
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.30.2
 # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
@@ -185,9 +182,6 @@ $(IMPORT_BOSS): $(call tool_version_file,$(IMPORT_BOSS),$(CODE_GENERATOR_VERSION
 $(KIND): $(call tool_version_file,$(KIND),$(KIND_VERSION))
 	curl -L -o $(KIND) https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(SYSTEM_NAME)-$(SYSTEM_ARCH)
 	chmod +x $(KIND)
-
-$(KO): $(call tool_version_file,$(KO),$(KO_VERSION))
-	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/ko@$(KO_VERSION)
 
 $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(SYSTEM_NAME)/$(SYSTEM_ARCH)/kubectl

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -593,8 +593,7 @@ build:
           envTemplate:
             template: "{{.GARDENER_VERSION}}"
         - name: sha
-          gitCommit:
-            variant: AbbrevCommitSha
+          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-provider-local
       ko:
@@ -773,16 +772,12 @@ build:
       context: pkg/provider-local/node
       docker: {}
     - image: local-skaffold/machine-controller-manager-provider-local
-      # Use a custom builder that executes ko instead of using skaffold's native ko integration.
-      # This allows us to get a hold of the built image ref so that we can inject it into the imageVectorOverwrite.
-      # Alternatives:
-      # - contribute to skaffold that hooks are templated (https://skaffold.dev/docs/environment/templating/) so
-      #   that we can write the patch after building the image with the native ko builder
-      # - use a wrapper chart for provider-local's ControllerDeployment (dropped in https://github.com/gardener/gardener/pull/7757)
-      # - allow setting ref in image vector instead of repository+tag and replace current imageVectorOverwrite string
-      #   chart value with a structure so that it can be patched by skaffold using resourceSelector
-      #   (skaffold cannot split the image ref into separate fields like repository and tag)
-      custom:
+      hooks:
+        after:
+          - command: 
+              - bash 
+              - hack/mcm-provider-local-overwrite.sh
+      ko:
         dependencies:
           paths:
             - cmd/machine-controller-manager-provider-local
@@ -790,32 +785,9 @@ build:
             - pkg/provider-local/machine-provider/api/validation
             - pkg/provider-local/machine-provider/local
             - VERSION
-        buildCommand: |
-          set -e
-
-          # parse image tag that skaffold expects us to build
-          repository=${IMAGE%:*}
-          tag=${IMAGE##*:}
-
-          image="$(KO_DOCKER_REPO=$repository ko build --push=$PUSH_IMAGE --sbom=none --bare --platform=$PLATFORMS -t $tag ./cmd/machine-controller-manager-provider-local)"
-
-          # parse image ref that we just built
-          repository=${image%:*:*}
-          digest=${image##*@}
-
-          cat <<EOF > example/provider-local/garden/base/patch-imagevector-overwrite.yaml
-          apiVersion: core.gardener.cloud/v1
-          kind: ControllerDeployment
-          metadata:
-            name: provider-local
-          helm:
-            values:
-              imageVectorOverwrite: |
-                images:
-                - name: machine-controller-manager-provider-local
-                  repository: ${repository}
-                  tag: ${digest}
-          EOF
+        ldflags:
+          - '{{.LD_FLAGS}}'
+        main: ./cmd/machine-controller-manager-provider-local
     - image: local-skaffold/gardener-extension-provider-local/charts/extension
       custom:
         dependencies:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Hooks can now be used to generate the needed patch file for imageVectorOverwrite.
This removes the need to call ko outside of skaffold.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
