### PR TITLE
Remove obsolet and exported OSC Default Permissions const

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -221,8 +221,6 @@ const (
 	// provisioned VM by the gardener-node-agent.
 	OperatingSystemConfigPurposeReconcile OperatingSystemConfigPurpose = "reconcile"
 
-	// OperatingSystemConfigDefaultFilePermission is the default value for a permission of a file.
-	OperatingSystemConfigDefaultFilePermission int32 = 0644
 	// OperatingSystemConfigSecretDataKey is a constant for the key in a secret's `.data` field containing the
 	// results of a computed cloud config.
 	OperatingSystemConfigSecretDataKey = "cloud_config" // #nosec G101 -- No credential.


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

I cannot find any usage of the `OperatingSystemConfigDefaultFilePermission`, neither in gardener/gardener, nor in any of repo in the whole gardener org.

It might mislead some users/developers that these filepermissions are still in use and applied.
