### PR TITLE
Improve the cache Prometheus for seeds with many shoots

### DIFF
--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -626,19 +626,6 @@ var _ = Describe("Etcd", func() {
 				},
 			}
 		}
-		scrapeConfig = &monitoringv1alpha1.ScrapeConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "shoot-etcd-druid",
-				Namespace: testNamespace,
-				Labels:    map[string]string{"prometheus": "shoot"},
-			},
-			Spec: monitoringv1alpha1.ScrapeConfigSpec{
-				HonorTimestamps: ptr.To(false),
-				MetricsPath:     ptr.To("/federate"),
-				Params:          map[string][]string{"match[]": {`{job="etcd-druid",etcd_namespace="` + testNamespace + `"}`}},
-				StaticConfigs:   []monitoringv1alpha1.StaticConfig{{Targets: []monitoringv1alpha1.Target{"prometheus-cache.garden.svc"}}},
-			},
-		}
 		prometheusRule = func(prometheusName string, class Class, replicas int32, backupEnabled bool) *monitoringv1.PrometheusRule {
 			jobNameEtcd, jobNameBackupRestore := serviceMonitorJobNames(prometheusName)
 
@@ -982,10 +969,7 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(scrapeConfig))
-				}),
+				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1060,10 +1044,7 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(scrapeConfig))
-				}),
+				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, existingReplicas, false)))
@@ -1143,10 +1124,7 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(scrapeConfig))
-				}),
+				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, existingReplicas, false)))
@@ -1214,10 +1192,7 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(scrapeConfig))
-				}),
+				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1284,10 +1259,7 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(scrapeConfig))
-				}),
+				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1385,10 +1357,7 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(scrapeConfig))
-				}),
+				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1483,10 +1452,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(scrapeConfig))
-					}),
+					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1554,10 +1520,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(scrapeConfig))
-					}),
+					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1616,10 +1579,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(scrapeConfig))
-					}),
+					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, *replicas, true)))
@@ -1686,10 +1646,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(scrapeConfig))
-					}),
+					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, *replicas, true)))
@@ -1751,10 +1708,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", clientSecretName)))
 					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(scrapeConfig))
-					}),
+					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, *replicas, false)))
@@ -1956,10 +1910,7 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(serviceMonitor("shoot", clientSecretName)))
 						}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(scrapeConfig))
-						}),
+						c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -2009,10 +1960,7 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(serviceMonitor("shoot", clientSecretName)))
 						}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(scrapeConfig))
-						}),
+						c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -2079,10 +2027,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-druid"}, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1alpha1.ScrapeConfig{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(scrapeConfig))
-					}),
+					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -81,6 +81,9 @@ func (p *prometheus) prometheus(takeOverOldPV bool, cortexConfigMap *corev1.Conf
 				PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
 				ProbeNamespaceSelector:          &metav1.LabelSelector{},
 				ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+				Web: &monitoringv1.PrometheusWebSpec{
+					MaxConnections: ptr.To[int32](1024),
+				},
 			},
 			RuleSelector:          &metav1.LabelSelector{MatchLabels: monitoringutils.Labels(p.values.Name)},
 			RuleNamespaceSelector: &metav1.LabelSelector{},

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -274,6 +274,9 @@ honor_labels: true`
 						PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
 						ProbeNamespaceSelector:          &metav1.LabelSelector{},
 						ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+						Web: &monitoringv1.PrometheusWebSpec{
+							MaxConnections: ptr.To[int32](1024),
+						},
 					},
 					RuleSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"prometheus": name}},
 					RuleNamespaceSelector: &metav1.LabelSelector{},

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -40,6 +40,7 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 						`{job="cadvisor",namespace="` + namespace + `"}`,
 						`{job="kube-state-metrics",namespace="` + namespace + `"}`,
 						`{__name__=~"metering:.+",namespace="` + namespace + `"}`,
+						`{job="etcd-druid",etcd_namespace="` + namespace + `"}`,
 					},
 				},
 				RelabelConfigs: []monitoringv1.RelabelConfig{{

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -42,6 +42,7 @@ var _ = Describe("ScrapeConfigs", func() {
 								`{job="cadvisor",namespace="` + namespace + `"}`,
 								`{job="kube-state-metrics",namespace="` + namespace + `"}`,
 								`{__name__=~"metering:.+",namespace="` + namespace + `"}`,
+								`{job="etcd-druid",etcd_namespace="` + namespace + `"}`,
 							},
 						},
 						RelabelConfigs: []monitoringv1.RelabelConfig{{


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
In seeds with many shoots, we observed that the cache Prometheus in the garden namespace of the seed was restarted by the kubelet again and again because of failing readiness and liveness probes. This PR improves the cache Prometheus configuration and the related scrape configuration in the shoot control plane Prometheus to prevent this issue, such that the cache Prometheus should stay healthy even in seeds with 250+ running shoots.

**Which issue(s) this PR fixes**:
Fixes an issue that the cache Prometheus was constantly restarted in seeds with 250+ shoots.

**Special notes for your reviewer**:
Tested in remote local setup with a modified etcd druid image reporting all compaction jobs as failing (see #9739). Federation works, as does the etcd compaction dashboard.

/cc @istvanballok @chrkl @vicwicker 
FYI: @oliver-goetz, @hendrikKahl, @lsroe 

**Release note**:
```other operator
Improve the cache Prometheus configuration for seeds with many shoots
```
