### PR TITLE
Split SeedConditionFailing alert to reduce alert noise

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -283,11 +283,33 @@ spec:
       expr: |
         max by (name, condition) (
           last_over_time((
-            garden_seed_condition <= 0
+            garden_seed_condition{condition = "GardenletReady"} <= 0
             or
-            garden_shoot_condition{is_seed   = "true",
+            garden_shoot_condition{condition = "APIServerUnavailable",
+                                   is_seed   = "true",
                                    operation = "Reconcile"} <= 0)[5m:]))
       for: 10m
+      labels:
+        severity: critical
+        topology: seed
+        mute_on_weekends: "true"
+      annotations:
+        summary: >-
+          Seed Condition Failing
+        description: >-
+          The seed cluster {{$labels.name}} in {{$externalLabels.landscape}}
+          has a failing condition: {{$labels.condition}}.
+
+    - alert: SeedConditionFailing
+      expr: |
+        max by (name, condition) (
+          last_over_time((
+            garden_seed_condition{condition != "GardenletReady"} <= 0
+            or
+            garden_shoot_condition{condition != "APIServerUnavailable",
+                                   is_seed    = "true",
+                                   operation  = "Reconcile"} <= 0)[5m:]))
+      for: 30m # avoid alert noise for flapping conditions except for GardenletReady and APIServerUnavailable
       labels:
         severity: critical
         topology: seed

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -16,15 +16,31 @@ tests:
     input_series:
       - series: garden_seed_condition{condition = "ExtensionsReady",
                                       name      = "seed-flapping"}
-        values: 0 0 2 -1 2 0
+        values: 0 0 2 -1 2 0x25
       - series: garden_seed_condition{condition = "ExtensionsReady",
                                       name      = "seed-progressing-for-long"}
-        values: 2 2 0 0 2 2 0 0 0 0 0
+        values: 2 2 0 0 2 2 0x24
+      - series: garden_seed_condition{condition = "GardenletReady",
+                                      name      = "seed-flapping"}
+        values: 0 0 2 -1 2 0 0 0 0 0
+      - series: garden_seed_condition{condition = "GardenletReady",
+                                      name      = "seed-progressing-for-long"}
+        values: 2 2 0 0 2 2 0 0 0 0
+      - series: garden_shoot_condition{condition = "APIServerUnavailable",
+                                       is_seed   = "true",
+                                       operation = "Reconcile",
+                                       name      = "seed-flapping"}
+        values: 0 0 2 -1 2 0 0 0 0 0
+      - series: garden_shoot_condition{condition = "APIServerUnavailable",
+                                       is_seed   = "true",
+                                       operation = "Reconcile",
+                                       name      = "seed-progressing-for-long"}
+        values: 2 2 0 0 2 2 0 0 0 0
     external_labels:
       landscape: landscape-unit-tests
     alert_rule_test:
       - alertname: SeedConditionFailing
-        eval_time: 10m
+        eval_time: 30m
         exp_alerts:
           - exp_labels:
               severity: critical
@@ -38,19 +54,54 @@ tests:
               description: >-
                 The seed cluster seed-flapping in landscape-unit-tests
                 has a failing condition: ExtensionsReady.
+      - alertname: SeedConditionFailing
+        eval_time: 10m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              topology: seed
+              condition: GardenletReady
+              name: seed-flapping
+              mute_on_weekends: "true"
+            exp_annotations:
+              summary: >-
+                Seed Condition Failing
+              description: >-
+                The seed cluster seed-flapping in landscape-unit-tests
+                has a failing condition: GardenletReady.
+          - exp_labels:
+              severity: critical
+              topology: seed
+              condition: APIServerUnavailable
+              name: seed-flapping
+              mute_on_weekends: "true"
+            exp_annotations:
+              summary: >-
+                Seed Condition Failing
+              description: >-
+                The seed cluster seed-flapping in landscape-unit-tests
+                has a failing condition: APIServerUnavailable.
 
   - name: SeedConditionFailing:MultipleSeeds
     interval: 1m
     input_series:
       - series: garden_shoot_condition{is_seed="true", operation="Reconcile", condition="SystemComponentsHealthy", name="seed-one"}
-        values: "0x10"
+        values: "0x30"
       - series: garden_seed_condition{condition="SeedSystemComponentsHealthy", name="seed-two"}
+        values: "0x30"
+      - series: garden_seed_condition{condition = "GardenletReady",
+                                      name      = "seed-three"}
+        values: "0x10"
+      - series: garden_shoot_condition{condition = "APIServerUnavailable",
+                                       is_seed   = "true",
+                                       operation = "Reconcile",
+                                       name      = "seed-four"}
         values: "0x10"
     external_labels:
       landscape: landscape-unit-tests
     alert_rule_test:
       - alertname: SeedConditionFailing
-        eval_time: 10m
+        eval_time: 30m
         exp_alerts:
           - exp_labels:
               severity: critical
@@ -76,3 +127,30 @@ tests:
               description: >-
                 The seed cluster seed-two in landscape-unit-tests
                 has a failing condition: SeedSystemComponentsHealthy.
+      - alertname: SeedConditionFailing
+        eval_time: 10m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              topology: seed
+              condition: GardenletReady
+              name: seed-three
+              mute_on_weekends: "true"
+            exp_annotations:
+              summary: >-
+                Seed Condition Failing
+              description: >-
+                The seed cluster seed-three in landscape-unit-tests
+                has a failing condition: GardenletReady.
+          - exp_labels:
+              severity: critical
+              topology: seed
+              condition: APIServerUnavailable
+              name: seed-four
+              mute_on_weekends: "true"
+            exp_annotations:
+              summary: >-
+                Seed Condition Failing
+              description: >-
+                The seed cluster seed-four in landscape-unit-tests
+                has a failing condition: APIServerUnavailable.


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The `SeedConditionFailing` alert can produce a lot of noise when it is flapping. This PR attempts to reduce the number of not really actionable notifications by splitting this alert into two alert definitions, each with different pending times. 

Alerts for the `GardenletReady` and `APIServerUnavailable` conditions will continue to fire after 10 minutes. They were configured to fire more often ([seed.yaml#L38-L65](https://github.com/gardener/gardener/blob/dfae57820e611d1a33f62c0c0f43e731a048163f/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml#L38-L65) and [seed.yaml#L67-L81](https://github.com/gardener/gardener/blob/dfae57820e611d1a33f62c0c0f43e731a048163f/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml#L67-L81)), even before we introduced the `SeedConditionFailing` alert ([b48c204](https://github.com/gardener/gardener/commit/b48c204dd19180ad3ce14d886f72764033c4db04)). They also appear to flap very little. 

If the other conditions are failing, the alert will fire only after 30 minutes now. We expect a condition that has been false for 30 minutes or more to not autoresolve without manual intervention, so it is worthwhile to trigger a notification.

**Special notes for your reviewer**:

/cc @istvanballok @rickardsjp @chrkl 

**Release note**:

```other operator
Extend pending time to 30 minutes for `SeedCondtionFailing` alerts to reduce alert noise.
```
