### PR TITLE
Fix termination of `sshd` processes when `SSHAccess` is disabled

### DIFF
--- a/docs/usage/shoot_workers_settings.md
+++ b/docs/usage/shoot_workers_settings.md
@@ -9,7 +9,7 @@ Users can configure settings affecting all worker nodes via `.spec.provider.work
 
 ## SSH Access
 
-`SSHAccess` indicates whether the `sshd.service` should be running on the worker nodes. This is ensured by a systemd service called `sshd-ensurer.service` which runs every 15 seconds on each worker node. When set to `true`, the systemd service ensures that the `sshd.service` is enabled and running. If it is set to `false`, the systemd service ensures that `sshd.service` is stopped and disabled. This also terminates all established SSH connections. In addition, when this value is set to `false`, existing `Bastion` resources are deleted during `Shoot` reconciliation and new ones are prevented from being created, SSH keypairs are not created/rotated, SSH keypair secrets are deleted from the Garden cluster, and the `gardener-user.service` is not deployed to the worker nodes.
+`SSHAccess` indicates whether the `sshd.service` should be running on the worker nodes. This is ensured by a systemd service called `sshd-ensurer.service` which runs every 15 seconds on each worker node. When set to `true`, the systemd service ensures that the `sshd.service` is unmasked, enabled and running. If it is set to `false`, the systemd service ensures that `sshd.service` is disabled, masked and stopped. This also terminates all established SSH connections on the host. In addition, when this value is set to `false`, existing `Bastion` resources are deleted during `Shoot` reconciliation and new ones are prevented from being created, SSH keypairs are not created/rotated, SSH keypair secrets are deleted from the Garden cluster, and the `gardener-user.service` is not deployed to the worker nodes.
 
 `sshAccess.enabled` is set to `true` by default.
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
@@ -134,8 +134,8 @@ if systemctl is-active --quiet sshd.service ; then
     systemctl stop sshd.service
 fi
 
-# Disabling the sshd service does not terminate already established connections
-# Kill all currently established ssh connections
-pkill -x sshd || true
+# Stopping the sshd service does not terminate already established connections
+# Kill all currently established orphaned ssh connections on the host
+pkill -P 1 -x sshd || true
 `
 )

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
@@ -128,12 +128,7 @@ set -e
 # Disable and mask sshd service if not masked
 if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
     systemctl disable sshd.service || true
-    systemctl mask sshd.service
-fi
-
-# Stop sshd service if active
-if systemctl is-active --quiet sshd.service ; then
-    systemctl stop sshd.service
+    systemctl mask --now sshd.service
 fi
 
 # Stopping the sshd service does not terminate already established connections

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
@@ -107,8 +107,9 @@ const (
 	enableScript = `#!/bin/bash -eu
 set -e
 
-# Enable sshd service if disabled
+# Unmask and enable sshd service if not enabled
 if ! systemctl is-enabled --quiet sshd.service ; then
+    systemctl unmask sshd.service
     # When sshd.service is disabled on gardenlinux the service is deleted
     # On gardenlinux sshd.service is enabled by enabling ssh.service
     if ! systemctl enable sshd.service ; then
@@ -124,9 +125,10 @@ fi
 	disableScript = `#!/bin/bash -eu
 set -e
 
-# Disable sshd service if enabled
-if systemctl is-enabled --quiet sshd.service ; then
-    systemctl disable sshd.service
+# Disable and mask sshd service if not masked
+if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
+    systemctl disable sshd.service || true
+    systemctl mask sshd.service
 fi
 
 # Stop sshd service if active

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
@@ -128,10 +128,12 @@ set -e
 # Disable and mask sshd service if not masked
 if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
     systemctl disable sshd.service || true
+    # Using the --now flag stops the selected service
     systemctl mask --now sshd.service
 fi
 
-# Stopping the sshd service does not terminate already established connections
+# Stopping the sshd service with the --now flag does
+# not terminate already established connections
 # Kill all currently established orphaned ssh connections on the host
 pkill -P 1 -x sshd || true
 `

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
@@ -11,6 +11,6 @@ if systemctl is-active --quiet sshd.service ; then
     systemctl stop sshd.service
 fi
 
-# Disabling the sshd service does not terminate already established connections
-# Kill all currently established ssh connections
-pkill -x sshd || true
+# Stopping the sshd service does not terminate already established connections
+# Kill all currently established orphaned ssh connections on the host
+pkill -P 1 -x sshd || true

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
@@ -1,9 +1,10 @@
 #!/bin/bash -eu
 set -e
 
-# Disable sshd service if enabled
-if systemctl is-enabled --quiet sshd.service ; then
-    systemctl disable sshd.service
+# Disable and mask sshd service if not masked
+if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
+    systemctl disable sshd.service || true
+    systemctl mask sshd.service
 fi
 
 # Stop sshd service if active

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
@@ -4,12 +4,7 @@ set -e
 # Disable and mask sshd service if not masked
 if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
     systemctl disable sshd.service || true
-    systemctl mask sshd.service
-fi
-
-# Stop sshd service if active
-if systemctl is-active --quiet sshd.service ; then
-    systemctl stop sshd.service
+    systemctl mask --now sshd.service
 fi
 
 # Stopping the sshd service does not terminate already established connections

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
@@ -4,9 +4,11 @@ set -e
 # Disable and mask sshd service if not masked
 if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
     systemctl disable sshd.service || true
+    # Using the --now flag stops the selected service
     systemctl mask --now sshd.service
 fi
 
-# Stopping the sshd service does not terminate already established connections
+# Stopping the sshd service with the --now flag does
+# not terminate already established connections
 # Kill all currently established orphaned ssh connections on the host
 pkill -P 1 -x sshd || true

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/enable-sshd.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/enable-sshd.tpl.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -eu
 set -e
 
-# Enable sshd service if disabled
+# Unmask and enable sshd service if not enabled
 if ! systemctl is-enabled --quiet sshd.service ; then
+    systemctl unmask sshd.service
     # When sshd.service is disabled on gardenlinux the service is deleted
     # On gardenlinux sshd.service is enabled by enabling ssh.service
     if ! systemctl enable sshd.service ; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug which was causing the termination of cluster pod `sshd` processes when `SSHAccess` is disabled. The command used to kill existing `sshd` connections `pkill -x sshd` kills `sshd` processes regardless of whether they are from the host or container.

To fix this issue we add the `-P 1` flag to `pkill` which causes the termination of only processes with parent `pid` = `1`. The container processes cannot have such `ppid` and the ones on the host would have inherited `ppid=1` when the `sshd` service was stopped https://github.com/gardener/gardener/blob/720e534ee0ece2bd5fc5aa16d38559887daf2946/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh#L9-L12
Selecting by `ppid` would also catch orphaned connections that have persisted through service restart. 

This PR also improves the disablement of the `sshd.service` by also masking it after disabling it. Masking the service disallows other processes of activating the service.

**Which issue(s) this PR fixes**:
Fixes #10108
/cc @dimityrmirchev 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing `sshd` running in cluster pods to receive a SIGTERM when `SSHAccess` for worker nodes is disabled is now fixed.
```
