### PR TITLE
Check network range values before propagating them to kubernetes components

### DIFF
--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -174,6 +174,10 @@ func (k *kubeAPIServer) reconcileDeployment(
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameServiceAccountKey)
 	}
 
+	if err := netutils.CheckDualStackForKubeComponents(k.values.ServiceNetworkCIDRs, "service"); err != nil {
+		return err
+	}
+
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client.Client(), deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(GetLabels(), map[string]string{
 			resourcesv1alpha1.HighAvailabilityConfigType:                        resourcesv1alpha1.HighAvailabilityConfigTypeServer,

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -293,6 +293,13 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	if err := netutils.CheckDualStackForKubeComponents(k.values.PodNetworks, "pod"); err != nil {
+		return err
+	}
+	if err := netutils.CheckDualStackForKubeComponents(k.values.ServiceNetworks, "service"); err != nil {
+		return err
+	}
+
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.seedClient.Client(), deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
 			v1beta1constants.GardenRole:                                         v1beta1constants.GardenRoleControlPlane,

--- a/pkg/component/kubernetes/proxy/resources.go
+++ b/pkg/component/kubernetes/proxy/resources.go
@@ -459,6 +459,10 @@ func (k *kubeProxy) getRawComponentConfig() (string, error) {
 	}
 
 	if !k.values.IPVSEnabled && len(k.values.PodNetworkCIDRs) > 0 {
+		if err := netutils.CheckDualStackForKubeComponents(k.values.PodNetworkCIDRs, "pod"); err != nil {
+			return "", err
+		}
+
 		config.ClusterCIDR = netutils.JoinByComma(k.values.PodNetworkCIDRs)
 	}
 

--- a/pkg/utils/net/ipnet.go
+++ b/pkg/utils/net/ipnet.go
@@ -5,6 +5,7 @@
 package net
 
 import (
+	"fmt"
 	"net"
 	"strings"
 )
@@ -21,4 +22,37 @@ func Join(cidrs []net.IPNet, sep string) string {
 		result += cidr.String() + sep
 	}
 	return strings.TrimSuffix(result, sep)
+}
+
+// CheckDualStackForKubeComponents checks if the given list of CIDRs does not include more than one element of the same IP family.
+func CheckDualStackForKubeComponents(cidrs []net.IPNet, networkType string) error {
+	if len(cidrs) > 2 {
+		return fmt.Errorf("%s network CIDRs must not contain more than two elements: '%s'", networkType, cidrs)
+	}
+
+	if len(cidrs) == 2 {
+		if dualStack, err := dualStack(cidrs); err != nil {
+			return fmt.Errorf("invalid %s network CIDRs ('%s'): %w", networkType, cidrs, err)
+		} else if !dualStack {
+			return fmt.Errorf("%s network CIDRs must be of different IP family: '%s'", networkType, cidrs)
+		}
+	}
+
+	return nil
+}
+
+func dualStack(cidrs []net.IPNet) (bool, error) {
+	v4 := false
+	v6 := false
+	for _, cidr := range cidrs {
+		switch true {
+		case cidr.IP.To4() != nil:
+			v4 = true
+		case cidr.IP.To16() != nil:
+			v6 = true
+		default:
+			return false, fmt.Errorf("invalid CIDR: %v", cidr.String())
+		}
+	}
+	return v4 && v6, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Check network range values before propagating them to kubernetes components.

Kubernetes components like `kube-apiserver`, `kube-controller-manager` and `kube-proxy` allow specification off multiple IP ranges. However, they only allow up to two ranges. In case two ranges are specified they have to be from different IP families, i.e. one should be IPv4 and one should be IPv6. This very strict configuration is enforced by checks of the command line/configuration options.
To prevent components from crash-looping due to different kind of network ranges this change implements the changes as pre-checks in `gardenlet`. Therefore, error should be caught by `gardenlet` before deploying the components.
Please note that provider extensions may change the deployments of some control plane components via web hooks, e.g. disabling the IPAM controller in `kube-controller-manager` and replacing it with a different one. Unfortunately, this makes the overall setup less straight forward to comprehend.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
In case multiple network ranges are configured via infrastructure status propagation for pod, service or node network, `gardenlet` will check whether they comply to the requirements of Kubernetes components like `kube-apiserver`, `kube-controller-manager`, and `kube-proxy`.
```
