### PR TITLE
Use the operating system's default file permissions if no permissions are given in extensions/v1alpha.File

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3114,7 +3114,7 @@ int32
 <td>
 <em>(Optional)</em>
 <p>Permissions describes with which permissions the file should get written to the file system.
-Should be defaulted to octal 0644.</p>
+If no permissions are set, the operating system&rsquo;s defaults are used.</p>
 </td>
 </tr>
 <tr>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -215,7 +215,7 @@ spec:
                     permissions:
                       description: |-
                         Permissions describes with which permissions the file should get written to the file system.
-                        Should be defaulted to octal 0644.
+                        If no permissions are set, the operating system's defaults are used.
                       format: int32
                       type: integer
                   required:
@@ -429,7 +429,7 @@ spec:
                     permissions:
                       description: |-
                         Permissions describes with which permissions the file should get written to the file system.
-                        Should be defaulted to octal 0644.
+                        If no permissions are set, the operating system's defaults are used.
                       format: int32
                       type: integer
                   required:

--- a/extensions/pkg/controller/operatingsystemconfig/bash_test.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash_test.go
@@ -110,6 +110,7 @@ var _ = Describe("Bash", func() {
 						},
 						TransmitUnencoded: ptr.To(true),
 					},
+					Permissions: ptr.To(int32(0777)),
 				},
 			}
 
@@ -136,7 +137,8 @@ mkdir -p "` + folder4 + `"
 
 cat << EOF > "` + file4 + `"
 transmit-unencoded
-EOF`))
+EOF
+chmod "0777" "` + file4 + `"`))
 
 			By("Ensure that the bash script can be executed and performs the desired operations")
 			tempDir, err := os.MkdirTemp("", "tempdir")
@@ -154,6 +156,7 @@ EOF`))
 				tempDir+file3,
 				tempDir+file4,
 			)
+			checkFilePermissions(tempDir+file4, 0777)
 		})
 	})
 
@@ -228,6 +231,11 @@ func runScriptAndCheckFiles(script string, filePaths ...string) {
 		fileInfo, err := os.Stat(filePath)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "file at path "+filePath)
 		ExpectWithOffset(1, fileInfo.Mode().IsRegular()).To(BeTrue(), "file at path "+filePath)
-		ExpectWithOffset(1, fileInfo.Mode().Perm()).To(Equal(fs.FileMode(0644)), "file at path "+filePath)
 	}
+}
+
+func checkFilePermissions(path string, permissions int32) {
+	fileInfo, err := os.Stat(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "file at path "+path)
+	ExpectWithOffset(1, fileInfo.Mode().Perm()).To(Equal(fs.FileMode(permissions)), "file at path "+path)
 }

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -135,7 +135,7 @@ type File struct {
 	// Path is the path of the file system where the file should get written to.
 	Path string `json:"path"`
 	// Permissions describes with which permissions the file should get written to the file system.
-	// Should be defaulted to octal 0644.
+	// If no permissions are set, the operating system's defaults are used.
 	// +optional
 	Permissions *int32 `json:"permissions,omitempty"`
 	// Content describe the file's content.

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -217,7 +217,7 @@ spec:
                     permissions:
                       description: |-
                         Permissions describes with which permissions the file should get written to the file system.
-                        Should be defaulted to octal 0644.
+                        If no permissions are set, the operating system's defaults are used.
                       format: int32
                       type: integer
                   required:
@@ -431,7 +431,7 @@ spec:
                     permissions:
                       description: |-
                         Permissions describes with which permissions the file should get written to the file system.
-                        Should be defaulted to octal 0644.
+                        If no permissions are set, the operating system's defaults are used.
                       format: int32
                       type: integer
                   required:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes the difference between the actual behavior of `operatingsystemconfig.FilesToDiskScript` and the documentation of `v1alpha.File` and adapts the tests accordingly.

**Which issue(s) this PR fixes**:
Fixes #10151 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
The documentation of the handling of file permissions in OperatingSystemConfig is now reflecting the actual behavior: if no permissions are defined, the operating system's defaults are used.
```
