### PR TITLE
[Secretsmanager] Drop old CA from bundle if not valid anymore

### DIFF
--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -248,9 +248,13 @@ func (m *manager) generateBundleSecret(ctx context.Context, config secretsutils.
 }
 
 func (m *manager) isStillValid(secret *corev1.Secret) (bool, error) {
-	validUntilUnix, err := strconv.ParseInt(secret.Labels[LabelKeyValidUntilTime], 10, 64)
+	value := secret.Labels[LabelKeyValidUntilTime]
+	if value == "" {
+		return true, nil
+	}
+	validUntilUnix, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("parsing secret label %q failed: %w", LabelKeyValidUntilTime, err)
 	}
 	return m.clock.Now().UTC().Unix() < validUntilUnix, nil
 }

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -254,7 +254,7 @@ func (m *manager) isStillValid(secret *corev1.Secret) (bool, error) {
 	}
 	validUntilUnix, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		return false, fmt.Errorf("parsing label %q of secret %s/%s failed: %w", LabelKeyValidUntilTime, secret.Namespace, secret.Name, err)
+		return false, fmt.Errorf("parsing label %q of secret %s failed: %w", LabelKeyValidUntilTime, client.ObjectKeyFromObject(secret), err)
 	}
 	return m.clock.Now().UTC().Unix() < validUntilUnix, nil
 }

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -254,7 +254,7 @@ func (m *manager) isStillValid(secret *corev1.Secret) (bool, error) {
 	}
 	validUntilUnix, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		return false, fmt.Errorf("parsing secret label %q failed: %w", LabelKeyValidUntilTime, err)
+		return false, fmt.Errorf("parsing label %q of secret %s/%s failed: %w", LabelKeyValidUntilTime, secret.Namespace, secret.Name, err)
 	}
 	return m.clock.Now().UTC().Unix() < validUntilUnix, nil
 }

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -543,7 +543,7 @@ var _ = Describe("Certificates tests", func() {
 				}).Should(And(
 					Not(BeEmpty()),
 					Not(BeEquivalentTo(caBundle1)),
-					ContainSubstring(string(caBundle1)),
+					Not(ContainSubstring(string(caBundle1))),
 				))
 
 				Eventually(func(g Gomega) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind robustness

**What this PR does / why we need it**:
There are edge cases where the old CA can be added to a CA bundle, even if it already had run out of its validity period.
Examples are e.g. generation has not been run for an unexpected long time, misconfiguration, or configuration changes with unhandled side-effects during migration period.
As the old CA may still be used for signing server certificates, this can result in certificates signed with an invalid CA.  
The outdated CA should not be added to the CA bundle to avoid that.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[Secretsmanager] Drop old CA from bundle if not valid anymore.
```
