### PR TITLE
Cleanup `kubernetes.{Parse}ObjectName` functions

### DIFF
--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils"
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Ensurer ensures that various standard Kubernetes control plane objects conform to the provider requirements.
@@ -298,7 +297,7 @@ func (m *mutator) mutateOperatingSystemConfigReconcile(ctx context.Context, gctx
 
 	// Mutate 99 kubernetes general configuration file, if present
 	if content := getKubernetesGeneralConfiguration(osc); content != nil {
-		if err := m.ensureKubernetesGeneralConfiguration(ctx, gctx, content, getKubernetesGeneralConfiguration(oldOSC), kubernetesutils.ObjectName(osc)); err != nil {
+		if err := m.ensureKubernetesGeneralConfiguration(ctx, gctx, content, getKubernetesGeneralConfiguration(oldOSC), client.ObjectKeyFromObject(osc)); err != nil {
 			return err
 		}
 	}
@@ -395,7 +394,7 @@ func (m *mutator) ensureKubeletConfigFileContent(ctx context.Context, gctx exten
 	return nil
 }
 
-func (m *mutator) ensureKubernetesGeneralConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, fci, oldFCI *extensionsv1alpha1.FileContentInline, objectName string) error {
+func (m *mutator) ensureKubernetesGeneralConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, fci, oldFCI *extensionsv1alpha1.FileContentInline, key client.ObjectKey) error {
 	var (
 		data, oldData []byte
 		err           error
@@ -421,7 +420,7 @@ func (m *mutator) ensureKubernetesGeneralConfiguration(ctx context.Context, gctx
 
 	if len(s) == 0 {
 		// File entries with empty content are not valid, so we do not add them to the OperatingSystemConfig resource.
-		m.logger.Info("Skipping modification of kubernetes general configuration file entry because the new content is empty", "operatingsystemconfig", objectName)
+		m.logger.Info("Skipping modification of kubernetes general configuration file entry because the new content is empty", "operatingsystemconfig", key)
 		return nil
 	}
 
@@ -449,7 +448,7 @@ func (m *mutator) ensureKubeletCloudProviderConfig(ctx context.Context, gctx ext
 
 	if len(s) == 0 {
 		// File entries with empty content are not valid, so we do not add them to the OperatingSystemConfig resource.
-		m.logger.Info("Skipping addition of kubelet cloud provider config file entry because its content is empty", "operatingsystemconfig", kubernetesutils.ObjectName(osc))
+		m.logger.Info("Skipping addition of kubelet cloud provider config file entry because its content is empty", "operatingsystemconfig", client.ObjectKeyFromObject(osc))
 		return nil
 	}
 

--- a/pkg/component/etcd/copybackupstask/copybackupstask.go
+++ b/pkg/component/etcd/copybackupstask/copybackupstask.go
@@ -148,7 +148,7 @@ func waitForConditions(obj client.Object) error {
 		return fmt.Errorf("expected *druidv1alpha1.EtcdCopyBackupsTask but got %T", obj)
 	}
 	if task.DeletionTimestamp != nil {
-		return fmt.Errorf("task %s has a deletion timestamp", kubernetesutils.ObjectName(task))
+		return fmt.Errorf("task %s has a deletion timestamp", client.ObjectKeyFromObject(task))
 	}
 
 	generation := task.Generation

--- a/pkg/controllermanager/controller/managedseedset/reconciler.go
+++ b/pkg/controllermanager/controller/managedseedset/reconciler.go
@@ -19,7 +19,6 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles the ManagedSeedSet.
@@ -71,7 +70,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, managedSeed
 	// Reconcile creation or update
 	log.V(1).Info("Reconciling creation or update")
 	if status, _, err = r.Actuator.Reconcile(ctx, log, managedSeedSet); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeedSet %s creation or update: %w", kubernetesutils.ObjectName(managedSeedSet), err)
+		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeedSet %s creation or update: %w", client.ObjectKeyFromObject(managedSeedSet), err)
 	}
 	log.V(1).Info("Creation or update reconciled")
 
@@ -104,7 +103,7 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, managedSeedSet
 	// Reconcile deletion
 	log.V(1).Info("Reconciling deletion")
 	if status, removeFinalizer, err = r.Actuator.Reconcile(ctx, log, managedSeedSet); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeedSet %s deletion: %w", kubernetesutils.ObjectName(managedSeedSet), err)
+		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeedSet %s deletion: %w", client.ObjectKeyFromObject(managedSeedSet), err)
 	}
 	log.V(1).Info("Deletion reconciled")
 

--- a/pkg/controllermanager/controller/managedseedset/replica.go
+++ b/pkg/controllermanager/controller/managedseedset/replica.go
@@ -166,7 +166,7 @@ func (r *replica) GetFullName() string {
 	if r.shoot == nil {
 		return ""
 	}
-	return kubernetesutils.ObjectName(r.shoot)
+	return client.ObjectKeyFromObject(r.shoot).String()
 }
 
 // GetObjectKey returns this replica's ObjectKey. This is the namespace/name of the shoot and managed seed of this replica.

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles the ManagedSeed.
@@ -85,7 +84,7 @@ func (r *Reconciler) reconcile(
 	log.V(1).Info("Reconciling")
 	var wait bool
 	if status, wait, err = r.Actuator.Reconcile(ctx, log, ms); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeed %s creation or update: %w", kubernetesutils.ObjectName(ms), err)
+		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeed %s creation or update: %w", client.ObjectKeyFromObject(ms), err)
 	}
 	log.V(1).Info("Reconciliation finished")
 
@@ -127,7 +126,7 @@ func (r *Reconciler) delete(
 	// Reconcile deletion
 	log.V(1).Info("Deletion")
 	if status, wait, removeFinalizer, err = r.Actuator.Delete(ctx, log, ms); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeed %s deletion: %w", kubernetesutils.ObjectName(ms), err)
+		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeed %s deletion: %w", client.ObjectKeyFromObject(ms), err)
 	}
 	log.V(1).Info("Deletion finished")
 

--- a/pkg/provider-local/apis/local/helper/scheme.go
+++ b/pkg/provider-local/apis/local/helper/scheme.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	api "github.com/gardener/gardener/pkg/provider-local/apis/local"
@@ -37,7 +36,7 @@ func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfi
 	if cluster != nil && cluster.CloudProfile != nil && cluster.CloudProfile.Spec.ProviderConfig != nil && cluster.CloudProfile.Spec.ProviderConfig.Raw != nil {
 		cloudProfileConfig = &api.CloudProfileConfig{}
 		if _, _, err := decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
-			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", client.ObjectKeyFromObject(cluster.CloudProfile), err)
+			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", cluster.CloudProfile.Name, err)
 		}
 	}
 	return cloudProfileConfig, nil

--- a/pkg/provider-local/apis/local/helper/scheme.go
+++ b/pkg/provider-local/apis/local/helper/scheme.go
@@ -10,11 +10,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	api "github.com/gardener/gardener/pkg/provider-local/apis/local"
 	"github.com/gardener/gardener/pkg/provider-local/apis/local/install"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var (
@@ -37,7 +37,7 @@ func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfi
 	if cluster != nil && cluster.CloudProfile != nil && cluster.CloudProfile.Spec.ProviderConfig != nil && cluster.CloudProfile.Spec.ProviderConfig.Raw != nil {
 		cloudProfileConfig = &api.CloudProfileConfig{}
 		if _, _, err := decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
-			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", kubernetesutils.ObjectName(cluster.CloudProfile), err)
+			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", client.ObjectKeyFromObject(cluster.CloudProfile), err)
 		}
 	}
 	return cloudProfileConfig, nil

--- a/pkg/provider-local/controller/worker/helper.go
+++ b/pkg/provider-local/controller/worker/helper.go
@@ -14,7 +14,6 @@ import (
 
 	api "github.com/gardener/gardener/pkg/provider-local/apis/local"
 	"github.com/gardener/gardener/pkg/provider-local/apis/local/v1alpha1"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error) {
@@ -25,7 +24,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error)
 	}
 
 	if _, _, err := w.decoder.Decode(w.worker.Status.ProviderStatus.Raw, nil, workerStatus); err != nil {
-		return nil, fmt.Errorf("could not decode WorkerStatus '%s': %w", kubernetesutils.ObjectName(w.worker), err)
+		return nil, fmt.Errorf("could not decode WorkerStatus '%s': %w", client.ObjectKeyFromObject(w.worker), err)
 	}
 
 	return workerStatus, nil

--- a/pkg/provider-local/controller/worker/machine_images.go
+++ b/pkg/provider-local/controller/worker/machine_images.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"fmt"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	api "github.com/gardener/gardener/pkg/provider-local/apis/local"
 	"github.com/gardener/gardener/pkg/provider-local/apis/local/helper"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // UpdateMachineImagesStatus implements genericactuator.WorkerDelegate.
@@ -46,7 +47,7 @@ func (w *workerDelegate) findMachineImage(name, version string) (string, error) 
 	if providerStatus := w.worker.Status.ProviderStatus; providerStatus != nil {
 		workerStatus := &api.WorkerStatus{}
 		if _, _, err := w.decoder.Decode(providerStatus.Raw, nil, workerStatus); err != nil {
-			return "", fmt.Errorf("could not decode worker status of worker '%s': %w", kubernetesutils.ObjectName(w.worker), err)
+			return "", fmt.Errorf("could not decode worker status of worker '%s': %w", client.ObjectKeyFromObject(w.worker), err)
 		}
 
 		machineImage, err := helper.FindMachineImage(workerStatus.MachineImages, name, version)

--- a/pkg/utils/kubernetes/object.go
+++ b/pkg/utils/kubernetes/object.go
@@ -23,14 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
-// ObjectName returns the name of the given object in the format <namespace>/<name>
-func ObjectName(obj client.Object) string {
-	if obj.GetNamespace() == "" {
-		return obj.GetName()
-	}
-	return client.ObjectKeyFromObject(obj).String()
-}
-
 // DeleteObjects deletes a list of Kubernetes objects.
 func DeleteObjects(ctx context.Context, c client.Writer, objects ...client.Object) error {
 	for _, obj := range objects {

--- a/pkg/utils/kubernetes/object.go
+++ b/pkg/utils/kubernetes/object.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,15 +29,6 @@ func ObjectName(obj client.Object) string {
 		return obj.GetName()
 	}
 	return client.ObjectKeyFromObject(obj).String()
-}
-
-// ParseObjectName parses the given object name (in the format <namespace>/<name>) to its constituent namespace and name.
-// If the given object name is not namespaced, an empty namespace is returned.
-func ParseObjectName(objectName string) (string, string) {
-	if parts := strings.Split(objectName, string(types.Separator)); len(parts) == 2 {
-		return parts[0], parts[1]
-	}
-	return "", objectName
 }
 
 // DeleteObjects deletes a list of Kubernetes objects.

--- a/pkg/utils/kubernetes/object_test.go
+++ b/pkg/utils/kubernetes/object_test.go
@@ -49,18 +49,6 @@ var _ = Describe("Object", func() {
 		ctrl.Finish()
 	})
 
-	DescribeTable("#ParseObjectName",
-		func(objectName, expectedNamespace, expectedName string) {
-			namespace, name := ParseObjectName(objectName)
-			Expect(namespace).To(Equal(expectedNamespace))
-			Expect(name).To(Equal(expectedName))
-		},
-		Entry("namespaced name", "foo/bar", "foo", "bar"),
-		Entry("non-namespaced name", "foo", "", "foo"),
-		Entry("non-namespaced name with a separator", "/foo", "", "foo"),
-		Entry("empty name", "", "", ""),
-	)
-
 	Describe("#DeleteObjects", func() {
 		It("should fail because an object fails to delete", func() {
 			gomock.InOrder(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
The function was either unused or can be replaced with `client.ObjectKeyFromObject` (which is already used widely in the code base).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The `pkg/utils/kubernetes.{Parse}ObjectName` functions have been dropped. Use `client.ObjectKeyFromObject` instead.
```
