### PR TITLE
Use original curl container image from quay.io to reduce HA test flakes due to docker rate limits.

### DIFF
--- a/test/utils/shoots/update/highavailability/upgrade.go
+++ b/test/utils/shoots/update/highavailability/upgrade.go
@@ -142,7 +142,7 @@ func DeployZeroDownTimeValidatorJob(ctx context.Context, c client.Client, testNa
 					Containers: []corev1.Container{
 						{
 							Name:  "validator",
-							Image: "alpine/curl",
+							Image: "quay.io/curl/curl",
 							Command: []string{"/bin/sh", "-ec",
 								// To avoid flakiness, consider downtime when curl fails consecutively back-to-back three times.
 								"failed=0; threshold=3; " +


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/area robustness
/kind flake

**What this PR does / why we need it**:

Use original curl container image from quay.io to reduce HA test flakes due to docker rate limits.

Previously, `alpine/curl` was used, which is not affiliated with `curl`. `curl/curl` comes from the original `curl` team and is available on quay.io in addition to docker.io. quay.io is preferred as it does not cause as much pain with regards to rate limits.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

An example of this failure is https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10158/pull-gardener-e2e-kind-ha-multi-zone/1815316767304585216. The corresponding event was

```
16s         Warning   Failed                         pod/zero-down-time-validator-update-mc9hz                  Failed to pull image "alpine/curl": failed to pull and unpack image "docker.io/alpine/curl:latest": failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/alpine/curl/manifests/sha256:64fae54aa0cb0b88a091beef102bc8036ffb9f4309d79ad13e47eec37434f4d5: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
