### PR TITLE
Handle conflicting label & finalizer when deleting CredentialsBinding or SecretBinding

### DIFF
--- a/pkg/controllermanager/controller/credentialsbinding/reconciler_test.go
+++ b/pkg/controllermanager/controller/credentialsbinding/reconciler_test.go
@@ -124,6 +124,33 @@ var _ = Describe("CredentialsBindingControl", func() {
 				HaveKeyWithValue("provider.shoot.gardener.cloud/some-provider", "true"),
 			))
 		})
+
+		It("should only remove the credentialsbinding ref label from the secret when secret is labeled with secretbinding reference", func() {
+			Expect(fakeClient.Delete(ctx, secret)).To(Succeed())
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "namespace",
+					Labels:    map[string]string{"reference.gardener.cloud/secretbinding": "true"},
+				},
+			}
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Delete(ctx, credentialsBinding)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			Expect(secret.ObjectMeta.Labels).To(Equal(map[string]string{
+				"provider.shoot.gardener.cloud/some-provider": "true",
+				"reference.gardener.cloud/secretbinding":      "true",
+			}))
+			Expect(secret.ObjectMeta.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+		})
 	})
 
 	Describe("CredentialsBinding label for Quotas", func() {

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -78,13 +78,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 					if hasProviderLabel || metav1.HasLabel(secret.ObjectMeta, v1beta1constants.LabelSecretBindingReference) {
 						patch := client.MergeFrom(secret.DeepCopy())
 						delete(secret.ObjectMeta.Labels, v1beta1constants.LabelSecretBindingReference)
-						delete(secret.ObjectMeta.Labels, providerLabel)
+
+						// The secret can be still referenced by a credentialsbinding so
+						// only remove the provider label if there is no credentialsbinding reference label
+						if !metav1.HasLabel(secret.ObjectMeta, v1beta1constants.LabelCredentialsBindingReference) {
+							delete(secret.ObjectMeta.Labels, providerLabel)
+						}
+
 						if err := r.Client.Patch(ctx, secret, patch); err != nil {
 							return reconcile.Result{}, fmt.Errorf("failed to remove referred label from Secret: %w", err)
 						}
 					}
 					// Remove finalizer from referenced secret
-					if controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
+					// only if the secret does not have a credentialsbinding reference label
+					if controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) && !metav1.HasLabel(secret.ObjectMeta, v1beta1constants.LabelCredentialsBindingReference) {
 						log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secret))
 						if err := controllerutils.RemoveFinalizers(ctx, r.Client, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 							return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)

--- a/pkg/controllermanager/controller/secretbinding/reconciler_test.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler_test.go
@@ -190,6 +190,33 @@ var _ = Describe("SecretBindingControl", func() {
 				HaveKeyWithValue("provider.shoot.gardener.cloud/provider", "true"),
 			))
 		})
+
+		It("should only remove the secretbinding ref label from the secret when secret is labeled with credentialsbinding reference", func() {
+			Expect(fakeClient.Delete(ctx, secret)).To(Succeed())
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "namespace",
+					Labels:    map[string]string{"reference.gardener.cloud/credentialsbinding": "true"},
+				},
+			}
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Delete(ctx, secretBinding)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			Expect(secret.ObjectMeta.Labels).To(Equal(map[string]string{
+				"provider.shoot.gardener.cloud/provider":      "true",
+				"reference.gardener.cloud/credentialsbinding": "true",
+			}))
+			Expect(secret.ObjectMeta.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+		})
 	})
 
 	Describe("SecretBinding label for Quotas", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality ipcei
/kind bug
/label ipcei/workload-identity

**What this PR does / why we need it**:
Please see issue description.

cc @vpnachev 

**Which issue(s) this PR fixes**:
Fixes #10159

Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
