### PR TITLE
Reduce `apiserver-proxy` `sidecar` and `proxy` container resources

### DIFF
--- a/pkg/component/networking/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy.go
@@ -342,8 +342,8 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("20m"),
-										corev1.ResourceMemory: resource.MustParse("20Mi"),
+										corev1.ResourceCPU:    resource.MustParse("5m"),
+										corev1.ResourceMemory: resource.MustParse("15Mi"),
 									},
 									Limits: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("90Mi"),
@@ -372,8 +372,8 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("20m"),
-										corev1.ResourceMemory: resource.MustParse("20Mi"),
+										corev1.ResourceCPU:    resource.MustParse("5m"),
+										corev1.ResourceMemory: resource.MustParse("30Mi"),
 									},
 									Limits: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("1Gi"),

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -621,8 +621,8 @@ func getDaemonSet(hash string, advertiseIPAddress string) *appsv1.DaemonSet {
 									corev1.ResourceMemory: resource.MustParse("90Mi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("20m"),
-									corev1.ResourceMemory: resource.MustParse("20Mi"),
+									corev1.ResourceCPU:    resource.MustParse("5m"),
+									corev1.ResourceMemory: resource.MustParse("15Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
@@ -673,8 +673,8 @@ func getDaemonSet(hash string, advertiseIPAddress string) *appsv1.DaemonSet {
 									corev1.ResourceMemory: resource.MustParse("1Gi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("20m"),
-									corev1.ResourceMemory: resource.MustParse("20Mi"),
+									corev1.ResourceCPU:    resource.MustParse("5m"),
+									corev1.ResourceMemory: resource.MustParse("30Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR optimises the requests for the static (not under VPA) containers of the `apiserver-proxy` DaemonSet based on usage metrics from our landscapes. Namely, the `resources.requests.cpu` and `resources.requests.memory` of the `sidecar` container are reduced to `5m` and `15Mi`, respectively. The `resources.requests.cpu` and `resources.requests.memory` of the `proxy` container are modified to `5m` and `30Mi`, respectively. This optimisation is based on the 95th percentile across all containers of that component found in our landscapes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
**Note** that I did not touch the limits, however, the memory limits of the `proxy` container seem very large - `1Gi`. whereas the max usage on our landscapes is around `70Mi`. Potentially we could reduce the limit or remove it (considering the huge difference)?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The resource requests of the `sidecar` and `proxy` containers of the `apiserver-proxy` DaemonSet have been reduced as follows:
- `sidecar` container `resources.requests.cpu` and `resources.requests.memory` were reduced to  `5m` and `15Mi`, respectively
- `proxy` container `resources.requests.cpu` and `resources.requests.memory` were modified to `5m` and `30Mi`, respectively
```
