### PR TITLE
Use machine class namespace as fallback if machine namespace is not set

### DIFF
--- a/pkg/provider-local/machine-provider/local/create_machine.go
+++ b/pkg/provider-local/machine-provider/local/create_machine.go
@@ -37,7 +37,7 @@ func (d *localDriver) CreateMachine(ctx context.Context, req *driver.CreateMachi
 		return nil, err
 	}
 
-	userDataSecret := userDataSecretForMachine(req.Machine)
+	userDataSecret := userDataSecretForMachine(req.Machine, req.MachineClass)
 	userDataSecret.Data = map[string][]byte{"userdata": req.Secret.Data["userData"]}
 
 	if err := controllerutil.SetControllerReference(req.Machine, userDataSecret, d.client.Scheme()); err != nil {

--- a/pkg/provider-local/machine-provider/local/delete_machine.go
+++ b/pkg/provider-local/machine-provider/local/delete_machine.go
@@ -28,7 +28,7 @@ func (d *localDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachi
 	klog.V(3).Infof("Machine deletion request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
 
-	userDataSecret := userDataSecretForMachine(req.Machine)
+	userDataSecret := userDataSecretForMachine(req.Machine, req.MachineClass)
 	if err := d.client.Delete(ctx, userDataSecret); client.IgnoreNotFound(err) != nil {
 		// Unknown leads to short retry in machine controller
 		return nil, status.Error(codes.Unknown, fmt.Sprintf("error deleting user data secret: %s", err.Error()))

--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -55,7 +55,12 @@ func podForMachine(machine *machinev1alpha1.Machine) *corev1.Pod {
 	}
 }
 
-func userDataSecretForMachine(machine *machinev1alpha1.Machine) *corev1.Secret {
+func userDataSecretForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) *corev1.Secret {
+	namespace := machine.Namespace
+	// machine.Namespace may be empty due to machine controller manager omitting namespace
+	if namespace == "" {
+		namespace = machineClass.Namespace
+	}
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -63,7 +68,7 @@ func userDataSecretForMachine(machine *machinev1alpha1.Machine) *corev1.Secret {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName(machine.Name) + "-userdata",
-			Namespace: machine.Namespace,
+			Namespace: namespace,
 		},
 	}
 }

--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -56,6 +56,7 @@ func podForMachine(machine *machinev1alpha1.Machine) *corev1.Pod {
 }
 
 func userDataSecretForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) *corev1.Secret {
+	// TODO(scheererj): Remove the empty namespace mitigation after https://github.com/gardener/machine-controller-manager/pull/932 has been adopted
 	namespace := machine.Namespace
 	// machine.Namespace may be empty due to machine controller manager omitting namespace
 	if namespace == "" {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

Use machine class namespace as fallback if machine namespace is not set.

Previously, the provider-local driver for machine controller manager produced log output indicating that something was not correctly configured:

```
2024-07-22T12:15:15.442238153Z stderr F E0722 12:15:15.441534       1 machine_safety.go:288] SafetyController: Error while trying to DELETE VM on CP - machine codes error: code = [Unknown] message = [error deleting user data secret: an empty namespace may not be set when a resource name is provided]. Shall retry in next safety controller sync.
```

This was due to the fact that machine controller manager did not set the namespace of some dummy machine resources (see https://github.com/gardener/machine-controller-manager/blob/58eddb261756ade5fba5318205d7d13b1eb845cb/pkg/util/provider/machinecontroller/machine_safety.go#L273). To mitigate this issue the provider-local driver for machine controller manager now takes the namespace of the machine class into account as a fallback option.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

See https://github.com/gardener/machine-controller-manager/pull/932 for the corresponding fix in machine controller manager.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
