### PR TITLE
Fixed broken link - 2024.07

### DIFF
--- a/docs/concepts/node-agent.md
+++ b/docs/concepts/node-agent.md
@@ -23,7 +23,7 @@ Finally, the `gardener-node-agent` runs a systemd service watching on secret res
 
 This section describes how the `gardener-node-agent` is initially installed onto the worker node.
 
-In the beginning, there is a very small bash script called [`gardener-node-init.sh`](../../pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh) (deprecated), which will be copied to `/var/lib/gardener-node-agent/init.sh` on the node with cloud-init data.
+In the beginning, there is a very small bash script called [`gardener-node-init.sh`](../../pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh), which will be copied to `/var/lib/gardener-node-agent/init.sh` on the node with cloud-init data.
 This script's sole purpose is downloading and starting the `gardener-node-agent`.
 The binary artifact is extracted from an [OCI artifact](https://github.com/opencontainers/image-spec/blob/main/manifest.md) and lives at `/opt/bin/gardener-node-agent`.
 

--- a/docs/concepts/node-agent.md
+++ b/docs/concepts/node-agent.md
@@ -23,7 +23,7 @@ Finally, the `gardener-node-agent` runs a systemd service watching on secret res
 
 This section describes how the `gardener-node-agent` is initially installed onto the worker node.
 
-In the beginning, there is a very small bash script called [`gardener-node-init.sh`](../../pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh), which will be copied to `/var/lib/gardener-node-agent/init.sh` on the node with cloud-init data.
+In the beginning, there is a very small bash script called [`gardener-node-init.sh`](../../pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh) (deprecated), which will be copied to `/var/lib/gardener-node-agent/init.sh` on the node with cloud-init data.
 This script's sole purpose is downloading and starting the `gardener-node-agent`.
 The binary artifact is extracted from an [OCI artifact](https://github.com/opencontainers/image-spec/blob/main/manifest.md) and lives at `/opt/bin/gardener-node-agent`.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR fixes a broken link in the documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
~~As the script has been deprecated, the entire section needs to be analyzed for outdated information.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
