### PR TITLE
Fix network access to virtual garden `kube-apiserver` for extensions when seed is garden at the same time

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         networking.gardener.cloud/to-kind-network: allowed
         networking.resources.gardener.cloud/to-all-istio-ingresses-istio-ingressgateway-tcp-9443: allowed
         networking.resources.gardener.cloud/to-all-shoots-kube-apiserver-tcp-443: allowed
+        networking.resources.gardener.cloud/to-garden-virtual-garden-kube-apiserver-tcp-443: allowed
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -87,7 +87,10 @@ var _ = BeforeSuite(func() {
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		Environment: &envtest.Environment{
 			CRDInstallOptions: envtest.CRDInstallOptions{
-				Paths: []string{filepath.Join("..", "..", "..", "..", "..", "example", "resource-manager", "10-crd-resources.gardener.cloud_managedresources.yaml")},
+				Paths: []string{
+					filepath.Join("..", "..", "..", "..", "..", "example", "resource-manager", "10-crd-resources.gardener.cloud_managedresources.yaml"),
+					filepath.Join("..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
+				},
 			},
 			ErrorIfCRDPathMissing: true,
 		},
@@ -108,6 +111,7 @@ var _ = BeforeSuite(func() {
 
 	testSchemeBuilder := runtime.NewSchemeBuilder(
 		kubernetes.AddGardenSchemeToScheme,
+		kubernetes.AddSeedSchemeToScheme,
 		resourcesv1alpha1.AddToScheme,
 	)
 	testScheme := runtime.NewScheme()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
When the seed is the garden cluster at the same time (like in https://testgrid.k8s.io/gardener-gardener#ci-gardener-e2e-kind-operator-seed), extensions might need to talk to the garden cluster ([ref](https://github.com/gardener/gardener/blob/master/docs/extensions/garden-api-access.md)). This might be exposed via the virtual garden `kube-apiserver` running in the same cluster like the extensions.

Following https://github.com/gardener/gardener/blob/master/docs/operations/network_policies.md#communication-with-kube-apiserver-for-components-in-custom-namespaces: In order to make the `NetworkPolicy` controller create the needed resources:

- extension namespaces would be needed to be labeled with `networking.gardener.cloud/access-target-apiserver=allowed`
- extension pods would be needed to be labeled with `networking.resources.gardener.cloud/to-garden-virtual-garden-kube-apiserver-tcp-443=allowed`

This is missing today, leading to the fact that the extension indeed starts (and maybe succeeds to reconcile some extension resources), but eventually fails and goes into a crash loop. See https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10161/pull-gardener-e2e-kind-operator-seed/1815351892650233856:

```
{"level":"info","ts":"2024-07-22T12:11:01.549Z","logger":"shoot-test.test","msg":"Last Operation","shoot":{"name":"e2e-managedseed","namespace":"garden"},"lastOperation":"&LastOperation{Description:Shoot cannot be synced with Seed: seed is not yet ready: condition \"SeedSystemComponentsHealthy\" has invalid status False (expected True) due to DeploymentUnhealthy: Deployment \"extension-provider-local-pfkfk/gardener-extension-provider-local\" is unhealthy: condition \"Available\" has invalid status False (expected True) due to MinimumReplicasUnavailable: Deployment does not have minimum availability.,LastUpdateTime:2024-07-22 12:10:52 +0000 UTC,Progress:0,State:Processing,Type:Reconcile,}"}
```

From https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/10161/pull-gardener-e2e-kind-operator-seed/1815351892650233856/artifacts/gardener-operator-local/gardener-operator-local-worker/pods/extension-provider-local-pfkfk_gardener-extension-provider-local-7884b88dbc-xtp4q_8024afa7-248b-4dd9-b271-8458dc1be696/gardener-extension-provider-local/6.log:

```
[...]
2024-07-22T12:09:15.873045164Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.872Z","msg":"Starting workers","controller":"dnsrecord","worker count":5}
2024-07-22T12:09:15.877119134Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Starting workers","controller":"controlplane","worker count":5}
2024-07-22T12:09:15.877155244Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Starting workers","controller":"local-ext-seed","worker count":5}
2024-07-22T12:09:15.877311714Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Starting workers","controller":"operatingsystemconfig","worker count":5}
2024-07-22T12:09:15.877340714Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Starting workers","controller":"ingress","worker count":5}
2024-07-22T12:09:15.877358944Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Starting workers","controller":"local-ext-shoot-after-worker","worker count":5}
2024-07-22T12:09:15.877427714Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"alertmanager-garden","namespace":"garden"},"namespace":"garden","name":"alertmanager-garden","reconcileID":"5d48d4f0-4267-4996-aa70-09260f4ab556"}
2024-07-22T12:09:15.877509894Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"alertmanager-garden","namespace":"garden"},"namespace":"garden","name":"alertmanager-garden","reconcileID":"5d48d4f0-4267-4996-aa70-09260f4ab556","dnsRecord":{"name":"alertmanager-garden-8ea59d6c","namespace":"garden"},"host":"alertmanager-garden.ingress.runtime-garden.local.gardener.cloud"}
2024-07-22T12:09:15.877524184Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Starting workers","controller":"backupbucket","worker count":1}
2024-07-22T12:09:15.877553444Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Starting workers","controller":"local-ext-shoot","worker count":5}
2024-07-22T12:09:15.877718634Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"prometheus-aggregate","namespace":"garden"},"namespace":"garden","name":"prometheus-aggregate","reconcileID":"1aa67b88-c728-4a4a-8373-eadb9bba8aea"}
2024-07-22T12:09:15.877731024Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"prometheus-aggregate","namespace":"garden"},"namespace":"garden","name":"prometheus-aggregate","reconcileID":"1aa67b88-c728-4a4a-8373-eadb9bba8aea","dnsRecord":{"name":"prometheus-aggregate-12dcc185","namespace":"garden"},"host":"p-seed.ingress.local.seed.local.gardener.cloud"}
2024-07-22T12:09:15.877741194Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"prometheus-garden","namespace":"garden"},"namespace":"garden","name":"prometheus-garden","reconcileID":"4e29614a-efc0-41bb-a0fe-7f6277014123"}
2024-07-22T12:09:15.877745204Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"prometheus-garden","namespace":"garden"},"namespace":"garden","name":"prometheus-garden","reconcileID":"4e29614a-efc0-41bb-a0fe-7f6277014123","dnsRecord":{"name":"prometheus-garden-4067ea0d","namespace":"garden"},"host":"prometheus-garden.ingress.runtime-garden.local.gardener.cloud"}
2024-07-22T12:09:15.877748574Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"gardener-dashboard","namespace":"garden"},"namespace":"garden","name":"gardener-dashboard","reconcileID":"db79c1a3-514e-4ead-9e11-41d44dc76ec2"}
2024-07-22T12:09:15.877752284Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"prometheus-longterm","namespace":"garden"},"namespace":"garden","name":"prometheus-longterm","reconcileID":"11228e66-2801-44db-838b-42fc5ef1ffee"}
2024-07-22T12:09:15.877759204Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"prometheus-longterm","namespace":"garden"},"namespace":"garden","name":"prometheus-longterm","reconcileID":"11228e66-2801-44db-838b-42fc5ef1ffee","dnsRecord":{"name":"prometheus-longterm-ec8d6089","namespace":"garden"},"host":"prometheus-longterm.ingress.runtime-garden.local.gardener.cloud"}
2024-07-22T12:09:15.877762834Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"gardener-dashboard","namespace":"garden"},"namespace":"garden","name":"gardener-dashboard","reconcileID":"db79c1a3-514e-4ead-9e11-41d44dc76ec2","dnsRecord":{"name":"gardener-dashboard-fc4a13d1","namespace":"garden"},"host":"dashboard.ingress.runtime-garden.local.gardener.cloud"}
2024-07-22T12:09:15.879275044Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.877Z","msg":"Starting workers","controller":"service","controllerGroup":"","controllerKind":"Service","worker count":5}
2024-07-22T12:09:15.879309454Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.878Z","msg":"Reconciling service","controller":"service","controllerGroup":"","controllerKind":"Service","Service":{"name":"istio-ingressgateway","namespace":"istio-ingress--1"},"namespace":"istio-ingress--1","name":"istio-ingressgateway","reconcileID":"f3e93d32-253a-4452-b85e-d37c4b634633"}
2024-07-22T12:09:15.879314184Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.878Z","msg":"Reconciling service","controller":"service","controllerGroup":"","controllerKind":"Service","Service":{"name":"istio-ingressgateway","namespace":"istio-ingress--0"},"namespace":"istio-ingress--0","name":"istio-ingressgateway","reconcileID":"cd78e714-1257-42cf-bb39-59f20dc3631c"}
2024-07-22T12:09:15.879317834Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.878Z","msg":"Reconciling service","controller":"service","controllerGroup":"","controllerKind":"Service","Service":{"name":"istio-ingressgateway","namespace":"istio-ingress--2"},"namespace":"istio-ingress--2","name":"istio-ingressgateway","reconcileID":"e0f9bdf7-0b27-4aa5-ad83-85e870c819ee"}
2024-07-22T12:09:15.879321544Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.878Z","msg":"Reconciling service","controller":"service","controllerGroup":"","controllerKind":"Service","Service":{"name":"istio-ingressgateway","namespace":"istio-ingress"},"namespace":"istio-ingress","name":"istio-ingressgateway","reconcileID":"5d328f6f-20fa-4ffe-acc3-50cdb7fb8237"}
2024-07-22T12:09:15.879325844Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.878Z","msg":"Reconciling service","controller":"service","controllerGroup":"","controllerKind":"Service","Service":{"name":"istio-ingressgateway","namespace":"virtual-garden-istio-ingress"},"namespace":"virtual-garden-istio-ingress","name":"istio-ingressgateway","reconcileID":"3e3c7601-25fe-4a50-8d32-82b5713d8dc6"}
2024-07-22T12:09:15.897027134Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.896Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"gardener-discovery-server","namespace":"garden"},"namespace":"garden","name":"gardener-discovery-server","reconcileID":"e94d5e2d-2b4c-450a-8d83-58f15218c188"}
2024-07-22T12:09:15.897061963Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.896Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"gardener-discovery-server","namespace":"garden"},"namespace":"garden","name":"gardener-discovery-server","reconcileID":"e94d5e2d-2b4c-450a-8d83-58f15218c188","dnsRecord":{"name":"gardener-discovery-server-1e52a925","namespace":"garden"},"host":"discovery.ingress.runtime-garden.local.gardener.cloud"}
2024-07-22T12:09:15.900340843Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.900Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"plutono","namespace":"garden"},"namespace":"garden","name":"plutono","reconcileID":"516bf59a-6ca3-4322-bd31-6a78a3f54a36"}
2024-07-22T12:09:15.900374613Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.900Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"plutono","namespace":"garden"},"namespace":"garden","name":"plutono","reconcileID":"516bf59a-6ca3-4322-bd31-6a78a3f54a36","dnsRecord":{"name":"plutono-c282472b","namespace":"garden"},"host":"plutono-garden.ingress.runtime-garden.local.gardener.cloud"}
2024-07-22T12:09:15.901076413Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.900Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"plutono","namespace":"shoot--garden--e2e-managedseed"},"namespace":"shoot--garden--e2e-managedseed","name":"plutono","reconcileID":"1f1f9fad-cde0-4536-9c33-543975e25bc0"}
2024-07-22T12:09:15.901107983Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.900Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"plutono","namespace":"shoot--garden--e2e-managedseed"},"namespace":"shoot--garden--e2e-managedseed","name":"plutono","reconcileID":"1f1f9fad-cde0-4536-9c33-543975e25bc0","dnsRecord":{"name":"plutono-f5511ee7","namespace":"shoot--garden--e2e-managedseed"},"host":"gu-garden--e2e-managedseed.ingress.local.seed.local.gardener.cloud"}
2024-07-22T12:09:15.901121503Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.901Z","msg":"Reconciling ingress","controller":"ingress","object":{"name":"prometheus-shoot","namespace":"shoot--garden--e2e-managedseed"},"namespace":"shoot--garden--e2e-managedseed","name":"prometheus-shoot","reconcileID":"f346ee2e-ee1c-45ea-b922-21171f3f95ef"}
2024-07-22T12:09:15.901133853Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.901Z","msg":"Applying DNSRecord","controller":"ingress","object":{"name":"prometheus-shoot","namespace":"shoot--garden--e2e-managedseed"},"namespace":"shoot--garden--e2e-managedseed","name":"prometheus-shoot","reconcileID":"f346ee2e-ee1c-45ea-b922-21171f3f95ef","dnsRecord":{"name":"prometheus-shoot-264c23d6","namespace":"shoot--garden--e2e-managedseed"},"host":"p-garden--e2e-managedseed.ingress.local.seed.local.gardener.cloud"}
2024-07-22T12:09:15.97333812Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.973Z","msg":"Starting workers","controller":"networkpolicy","controllerGroup":"","controllerKind":"Namespace","worker count":5}
2024-07-22T12:09:15.97337524Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.973Z","msg":"Starting workers","controller":"worker","worker count":5}
2024-07-22T12:09:15.97445889Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.974Z","msg":"Starting workers","controller":"infrastructure","worker count":5}
2024-07-22T12:09:15.97575516Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.975Z","msg":"Starting workers","controller":"healthcheck-Worker-extensions.gardener.cloud-v1alpha1-SRgxR5puX1","worker count":5}
2024-07-22T12:09:15.97580226Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.975Z","msg":"Starting workers","controller":"backupentry","worker count":1}
2024-07-22T12:09:15.991611299Z stderr F {"level":"info","ts":"2024-07-22T12:09:15.991Z","msg":"Updated all shoot mutating webhook configs with new CA bundle","controller":"webhook-certificate","object":{"name":""},"namespace":"","name":"","reconcileID":"b896f5cf-e207-40d3-ad84-3708e5090a01","secretNamespace":"extension-provider-local-pfkfk","identity":"gardener-extension-provider-local-webhook","caSecretName":"ca-provider-local-webhook-f0e82f96","caBundleSecretName":"ca-provider-local-webhook-bundle-d2128837","webhookConfig":{"name":"gardener-extension-provider-local-shoot"}}
2024-07-22T12:09:45.771263939Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Stopping and waiting for non leader election runnables"}
2024-07-22T12:09:45.771309359Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"webhook-certificate-reloader"}
2024-07-22T12:09:45.771318019Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"webhook-certificate-reloader"}
2024-07-22T12:09:45.771323569Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Stopping and waiting for leader election runnables"}
2024-07-22T12:09:45.771329359Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"healthcheck-Worker-extensions.gardener.cloud-v1alpha1-SRgxR5puX1"}
2024-07-22T12:09:45.771334789Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"worker"}
2024-07-22T12:09:45.771339519Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"infrastructure"}
2024-07-22T12:09:45.771361079Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"backupentry"}
2024-07-22T12:09:45.771364869Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"networkpolicy","controllerGroup":"","controllerKind":"Namespace"}
2024-07-22T12:09:45.771368099Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"heartbeat"}
2024-07-22T12:09:45.771737249Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"dnsrecord"}
2024-07-22T12:09:45.771748249Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"worker"}
2024-07-22T12:09:45.771752559Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"heartbeat"}
2024-07-22T12:09:45.771756299Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"ingress"}
2024-07-22T12:09:45.771760169Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"webhook-certificate"}
2024-07-22T12:09:45.771765859Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"local-ext-shoot-after-worker"}
2024-07-22T12:09:45.771769659Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"healthcheck-Worker-extensions.gardener.cloud-v1alpha1-SRgxR5puX1"}
2024-07-22T12:09:45.771773529Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"local-ext-seed"}
2024-07-22T12:09:45.771777069Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"infrastructure"}
2024-07-22T12:09:45.771780679Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"service","controllerGroup":"","controllerKind":"Service"}
2024-07-22T12:09:45.771784189Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"controlplane"}
2024-07-22T12:09:45.771787439Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"operatingsystemconfig"}
2024-07-22T12:09:45.771790899Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"networkpolicy","controllerGroup":"","controllerKind":"Namespace"}
2024-07-22T12:09:45.771795039Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"local-ext-shoot-after-worker"}
2024-07-22T12:09:45.771798379Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"local-ext-seed"}
2024-07-22T12:09:45.771801619Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"local-ext-shoot"}
2024-07-22T12:09:45.771805369Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"local-ext-shoot"}
2024-07-22T12:09:45.771809179Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"backupentry"}
2024-07-22T12:09:45.771812389Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"dnsrecord"}
2024-07-22T12:09:45.771815469Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Shutdown signal received, waiting for all workers to finish","controller":"backupbucket"}
2024-07-22T12:09:45.771830919Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"webhook-certificate"}
2024-07-22T12:09:45.771834649Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"service","controllerGroup":"","controllerKind":"Service"}
2024-07-22T12:09:45.771837949Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"operatingsystemconfig"}
2024-07-22T12:09:45.771841259Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"backupbucket"}
2024-07-22T12:09:45.771844629Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"ingress"}
2024-07-22T12:09:45.771848209Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"All workers finished","controller":"controlplane"}
2024-07-22T12:09:45.771851979Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Stopping and waiting for caches"}
2024-07-22T12:09:45.771862519Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","msg":"Stopping and waiting for webhooks"}
2024-07-22T12:09:45.773733299Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.771Z","logger":"controller-runtime.webhook","msg":"Shutting down webhook server with timeout of 1 minute"}
2024-07-22T12:09:45.773754109Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.772Z","msg":"Stopping and waiting for HTTP servers"}
2024-07-22T12:09:45.773759199Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.772Z","msg":"shutting down server","kind":"health probe","addr":"[::]:8081"}
2024-07-22T12:09:45.773763009Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.772Z","logger":"controller-runtime.metrics","msg":"Shutting down metrics server with timeout of 1 minute"}
2024-07-22T12:09:45.773768729Z stderr F {"level":"info","ts":"2024-07-22T12:09:45.772Z","msg":"Wait completed, proceeding to shutdown the manager"}
2024-07-22T12:09:45.773869099Z stderr F Error: error running manager: failed reading seed local: failed to get API group resources: unable to retrieve the complete list of server APIs: core.gardener.cloud/v1beta1: Get "https://virtual-garden-kube-apiserver.garden.svc.cluster.local/apis/core.gardener.cloud/v1beta1": dial tcp 10.2.130.200:443: i/o timeout
[...]
```

This PR fixes this by 

- making `gardenlet` adding the label to extension namespaces when the seed is the garden at the same time
- adding the label to the `provider-local` pods unconditionally via its Helm chart

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
