### PR TITLE
extensions local setup: Update registry image to 3.0.0-beta.1

### DIFF
--- a/example/provider-extensions/registry-seed/deploy-registry.sh
+++ b/example/provider-extensions/registry-seed/deploy-registry.sh
@@ -45,7 +45,6 @@ kubectl --kubeconfig "$kubeconfig" --server-side=true apply -f "$SCRIPT_DIR"/loa
 kubectl create secret generic -n registry registry-htpasswd --from-file="$SCRIPT_DIR"/htpasswd/auth --dry-run=client -o yaml | \
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 kubectl rollout restart statefulsets -n registry -l app=registry --kubeconfig "$kubeconfig"
-# TODO(oliver-goetz): contribute basic authentication support for registry to https://github.com/distribution/distribution and switch back to the official image afterwards
 kubectl --kubeconfig "$kubeconfig" apply -f - << EOF
 apiVersion: v1
 kind: Secret
@@ -108,9 +107,9 @@ stringData:
       ctr snapshot rm seed-registry-cache
     fi
     echo "Pulling registry-cache image"
-    ctr image pull ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev
+    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-beta.1
     echo "Starting registry-cache"
-    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/docker/registry/config.yml,options=rbind:ro --net-host ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev seed-registry-cache
+    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-beta.1 seed-registry-cache
   stop-seed-registry-cache.sh: |
     #!/usr/bin/env bash
     echo "stopping seed-registry-cache"

--- a/example/provider-extensions/registry-seed/registry/registry.yaml
+++ b/example/provider-extensions/registry-seed/registry/registry.yaml
@@ -24,7 +24,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:2.8.3
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         env:
         - name: REGISTRY_HTTP_TLS_CERTIFICATE
@@ -37,6 +37,12 @@ spec:
           value: /htpasswd/auth
         - name: REGISTRY_AUTH_HTPASSWD_REALM
           value: Registry Realm
+        - name: REGISTRY_HTTP_DEBUG_ADDR
+          value: ""
+        - name: REGISTRY_LOG_LEVEL
+          value: info
+        - name: OTEL_TRACES_EXPORTER
+          value: none
         ports:
         - name: registry
           containerPort: 5000


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
The 1st commit updates the registry image used in the provider-extensions local setup from `ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev` to `europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-beta.1`.

~~The 2nd commit updates the registry image used in provider-local based local setups from `europe-docker.pkg.dev/gardener-project/releases/3rd/registry:2.8.3` to `europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-beta.1`.~~

<details>

I had to overwrite several settings because the dafault config.yml of the registry between 2.8.3 and 3.0.0-beta1. changes as follows:
```diff
 version: 0.1
 log:
+  level: debug
   fields:
     service: registry
+    environment: development
 storage:
+  delete:
+    enabled: true
   cache:
     blobdescriptor: inmemory
   filesystem:
     rootdirectory: /var/lib/registry
+  tag:
+    concurrencylimit: 5
 http:
   addr: :5000
-  headers:
-    X-Content-Type-Options: [nosniff]
+  debug:
+    addr: :5001
+    prometheus:
+      enabled: true
+      path: /metrics
 health:
   storagedriver:
     enabled: true
```

I had to:
- disable the debug endpoint (with `REGISTRY_HTTP_DEBUG_ADDR`) because in local setup all registries run in the host network and all of them try to bind to the default debug port (:5001) which fails. It is also not recommended to enable the debug endpoint for publicly exposed registries such as the one in the provider-extensions setup
- bring back log level to `info` (with `REGISTRY_LOG_LEVEL`)
- disable otel traces as a workaround of https://github.com/distribution/distribution/issues/4270

</details>

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener-extension-registry-cache/issues/202
Addresses TODO introduced with https://github.com/gardener/gardener/pull/9048.

**Special notes for your reviewer**:
See above

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The images of the registry caches used in the extensions local setup are now updated to [distribution/distribution@3.0.0 beta.1](https://github.com/distribution/distribution/releases/tag/v3.0.0-beta.1).
```
