### PR TITLE
Fix permissions for cert-management to handle DNSRecords 

### DIFF
--- a/pkg/component/certmanagement/certmanagement.go
+++ b/pkg/component/certmanagement/certmanagement.go
@@ -153,9 +153,9 @@ func (d *certmanagement) Deploy(ctx context.Context) error {
 					Verbs:         []string{"get", "watch", "update"},
 				},
 				{
-					APIGroups: []string{"dns.gardener.cloud"},
-					Resources: []string{"dnsentries"},
-					Verbs:     []string{"get", "list", "update", "watch", "create", "delete"},
+					APIGroups: []string{"extensions.gardener.cloud"},
+					Resources: []string{"dnsrecords"},
+					Verbs:     []string{"get", "list", "update", "watch", "create", "delete", "patch"},
 				},
 			},
 		}

--- a/pkg/component/certmanagement/certmanagement_test.go
+++ b/pkg/component/certmanagement/certmanagement_test.go
@@ -191,9 +191,9 @@ var _ = Describe("CertManagement", func() {
 					Verbs:         []string{"get", "watch", "update"},
 				},
 				{
-					APIGroups: []string{"dns.gardener.cloud"},
-					Resources: []string{"dnsentries"},
-					Verbs:     []string{"get", "list", "update", "watch", "create", "delete"},
+					APIGroups: []string{"extensions.gardener.cloud"},
+					Resources: []string{"dnsrecords"},
+					Verbs:     []string{"get", "list", "update", "watch", "create", "delete", "patch"},
 				},
 			},
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This is a bug fix for  PR "[OPERATOR] Optional deployment of cert-management component" #9957.
The deployed cert-controller-manager is missing permissions to manage `DNSRecords`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix permissions for `cert-management` to handle `DNSRecord`s when enabled in the `operator.gardener.cloud/v1alpha1.Garden` resource.
```
