### PR TITLE
Adapt TM tests to remove checks for `containerd-initializer`

### DIFF
--- a/test/testmachinery/shoots/operations/containerruntime.go
+++ b/test/testmachinery/shoots/operations/containerruntime.go
@@ -92,9 +92,6 @@ var _ = Describe("Shoot container runtime testing", func() {
 		rootPodExecutor := framework.NewRootPodExecutor(f.Logger, f.ShootClient, &nodeList.Items[0].Name, "kube-system")
 
 		// check the configuration on the host
-		initializerServiceCommand := fmt.Sprintf("systemctl is-active %s", "containerd-initializer")
-		executeCommand(ctx, rootPodExecutor, initializerServiceCommand, "active")
-
 		containerdServiceCommand := fmt.Sprintf("systemctl is-active %s", "containerd")
 		executeCommand(ctx, rootPodExecutor, containerdServiceCommand, "active")
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
`container-initializer` service was replaced in https://github.com/gardener/gardener/pull/10050. This PR adapts the TM test to not check for it.

**Which issue(s) this PR fixes**:
TM test fails with:
```
Shoot container runtime testing [It] [DEFAULT] [SERIAL] [SHOOT] should add worker pool with containerd
/Users/I545724/go/src/github.com/gardener/gardener/test/framework/gingko_utils.go:16

  [FAILED] Unexpected error:
      <exec.CodeExitError>:
      command terminated with exit code 4
      {
          Err: <*errors.errorString | 0x1400049b330>{
              s: "command terminated with exit code 4",
          },
          Code: 4,
      }
  occurred
  In [It] at: /Users/I545724/go/src/github.com/gardener/gardener/test/testmachinery/shoots/operations/containerruntime.go:114 @ 07/25/24 14:48:41.699
```
since this service is no longer present.
```
/ # chroot /hostroot systemctl list-units --type=service | grep containerd
  containerd-monitor.service                    loaded active     running      Containerd-monitor daemon
  containerd.service                            loaded active     running      containerd container runtime
```
**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
