### PR TITLE
Fix and improve alert descriptions

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -63,7 +63,7 @@ func CentralPrometheusRules() []*monitoringv1.PrometheusRule {
 								"visibility": "operator",
 							},
 							Annotations: map[string]string{
-								"description": "Node {{$labels.node}} in landscape {{$externalLabels.landscape}} was not healthy for ten scrapes in the past 30 mins.",
+								"description": "Node {{$labels.node}} in seed {{$externalLabels.seed}} was not healthy for ten scrapes in the past 30 mins.",
 								"summary":     "A node is not healthy.",
 							},
 						},

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -55,7 +55,7 @@ var _ = Describe("PrometheusRules", func() {
 										"visibility": "operator",
 									},
 									Annotations: map[string]string{
-										"description": "Node {{$labels.node}} in landscape {{$externalLabels.landscape}} was not healthy for ten scrapes in the past 30 mins.",
+										"description": "Node {{$labels.node}} in seed {{$externalLabels.seed}} was not healthy for ten scrapes in the past 30 mins.",
 										"summary":     "A node is not healthy.",
 									},
 								},

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/auditlog.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/auditlog.yaml
@@ -28,6 +28,6 @@ spec:
         summary: >-
           The {{$labels.job}} server in landscape {{$externalLabels.landscape}}
           has too many failed attempts to log audit events.
-        description: >
+        description: >-
           The API server's cumulative failure rate in logging audit events is
           greater than 2%.

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
@@ -73,7 +73,7 @@ spec:
         summary: >-
           Virtual garden etcd main has no leader in landscape
           {{$externalLabels.landscape}}.
-        description: >
+        description: >-
           Virtual garden etcd main has no leader. Possible network partition in the etcd cluster.
 
     - alert: EtcdEventsNoLeader

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -275,10 +275,10 @@ spec:
         severity: warning
         topology: garden
       annotations:
-        summary:  A node was reported not healthy for 5 scrapes in the past 30 minutes.
+        summary:  A node was reported not healthy for several scrapes in the past 30 minutes.
         description: >-
           Node {{$labels.node}} in seed {{$labels.seed}} in landscape
-          {{$externalLabels.landscape}} was not healthy for five scrapes in the past 30 minutes.
+          {{$externalLabels.landscape}} was not healthy for several scrapes in the past 30 minutes.
 
     - alert: SeedConditionFailing
       expr: |

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -277,7 +277,7 @@ spec:
       annotations:
         summary:  A node was reported not healthy for 5 scrapes in the past 30 minutes.
         description: >-
-          Node {{$labels.node}} in landscape
+          Node {{$labels.node}} in seed {{$labels.seed}} in landscape
           {{$externalLabels.landscape}} was not healthy for five scrapes in the past 30 minutes.
 
     - alert: SeedConditionFailing

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -278,6 +278,7 @@ spec:
         summary:  A node was reported not healthy for 5 scrapes in the past 30 minutes.
         description: >-
           Node {{$labels.node}} in landscape
+          {{$externalLabels.landscape}} was not healthy for five scrapes in the past 30 minutes.
 
     - alert: SeedConditionFailing
       expr: |

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
@@ -31,7 +31,7 @@ spec:
         summary: >-
           Over 10% of productive shoots are unavailable on the 
           {{$externalLabels.landscape}} landscape.
-        description: >
+        description: >-
           Over 10% of the shoots have the condition APIServerAvailable false.
           (
           {{`count(
@@ -75,7 +75,7 @@ spec:
         summary: >-
           Over 10% of productive {{$labels.iaas}} shoots are unavailable on the 
           {{$externalLabels.landscape}} landscape.
-        description: >
+        description: >-
           Over 10% of {{$labels.iaas}} shoots have the condition
           APIServerAvailable == 0.
           (
@@ -108,6 +108,6 @@ spec:
         topology: seed
       annotations:
         summary: Node filesystem has less than 5% inodes left.
-        description: >
+        description: >-
           The seed cluster: {{$labels.project}}/{{$labels.name}} has a filesystem mounted at {{ $labels.mountpoint }}
           on node {{ $labels.node }} that has only {{ printf "%.2f" $value }}% available inodes left.


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This is a small PR to fix and improve some alert descriptions by addressing the following points:

1. Make sure the labels used in the alerts are available in the Prometheus where they are deployed.
2. No new empty blank line at the end of the alert description. Alert templates are responsible for creating the final alert message and their input should be stripped.
3. Fix missing and wrong alert descriptions.

**Special notes for your reviewer**:

/cc @rickardsjp @chrkl @istvanballok 

**Release note**:

```other operator
NONE
```
