### PR TITLE
[renovate] Ignore `local-skaffold` packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -185,6 +185,13 @@
       "enabled": false
     },
     {
+      // Ignore local-skaffold packages because they are virtual packages for local setup only.
+      "matchPackagePatterns": [
+        "local-skaffold\/.+"
+      ],
+      "enabled": false
+    },
+    {
       // Ignore dependency updates from k8s.io/kube-openapi because it depends on k8s.io/apiserver.
       "matchDatasources": ["go"],
       "matchPackagePatterns": ["k8s\\.io\/kube-openapi"],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR should remove the following warning:

> [!WARNING]
> Renovate failed to look up the following dependencies: `Failed to look up docker package local-skaffold/gardener-extension-provider-local-node`.
> 
> Files affected: `example/provider-local/garden/base/cloudprofile.yaml`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
