### PR TITLE
Promote `VPAAndHPAForAPIServer` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -18,27 +18,28 @@ The following tables are a summary of the feature gates that you can set on diff
 
 ## Feature Gates for Alpha or Beta Features
 
-| Feature                            | Default | Stage   | Since  | Until  |
-|------------------------------------|---------|---------|--------|--------|
-| HVPA                               | `false` | `Alpha` | `0.31` |        |
-| HVPAForShootedSeed                 | `false` | `Alpha` | `0.32` |        |
-| DefaultSeccompProfile              | `false` | `Alpha` | `1.54` |        |
-| CoreDNSQueryRewriting              | `false` | `Alpha` | `1.55` | `1.95` |
-| CoreDNSQueryRewriting              | `true`  | `Beta`  | `1.96` |        |
-| CoreDNSQueryRewriting              | `true`  | `GA`    | `1.97` |        |
-| IPv6SingleStack                    | `false` | `Alpha` | `1.63` |        |
-| MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` | `1.95` |
-| MutableShootSpecNetworkingNodes    | `true`  | `Beta`  | `1.96` |        |
-| MutableShootSpecNetworkingNodes    | `true`  | `GA`    | `1.97` |        |
-| ShootForceDeletion                 | `false` | `Alpha` | `1.81` | `1.90` |
-| ShootForceDeletion                 | `true`  | `Beta`  | `1.91` |        |
-| UseNamespacedCloudProfile          | `false` | `Alpha` | `1.92` |        |
-| ShootManagedIssuer                 | `false` | `Alpha` | `1.93` |        |
-| VPAForETCD                         | `false` | `Alpha` | `1.94` | `1.96` |
-| VPAForETCD                         | `true`  | `Beta`  | `1.97` |        |
-| VPAAndHPAForAPIServer              | `false` | `Alpha` | `1.95` |        |
-| ShootCredentialsBinding            | `false` | `Alpha` | `1.98` |        |
-| NewWorkerPoolHash                  | `false` | `Alpha` | `1.98` |        |
+| Feature                         | Default | Stage   | Since   | Until   |
+|---------------------------------|---------|---------|---------|---------|
+| HVPA                            | `false` | `Alpha` | `0.31`  |         |
+| HVPAForShootedSeed              | `false` | `Alpha` | `0.32`  |         |
+| DefaultSeccompProfile           | `false` | `Alpha` | `1.54`  |         |
+| CoreDNSQueryRewriting           | `false` | `Alpha` | `1.55`  | `1.95`  |
+| CoreDNSQueryRewriting           | `true`  | `Beta`  | `1.96`  |         |
+| CoreDNSQueryRewriting           | `true`  | `GA`    | `1.97`  |         |
+| IPv6SingleStack                 | `false` | `Alpha` | `1.63`  |         |
+| MutableShootSpecNetworkingNodes | `false` | `Alpha` | `1.64`  | `1.95`  |
+| MutableShootSpecNetworkingNodes | `true`  | `Beta`  | `1.96`  |         |
+| MutableShootSpecNetworkingNodes | `true`  | `GA`    | `1.97`  |         |
+| ShootForceDeletion              | `false` | `Alpha` | `1.81`  | `1.90`  |
+| ShootForceDeletion              | `true`  | `Beta`  | `1.91`  |         |
+| UseNamespacedCloudProfile       | `false` | `Alpha` | `1.92`  |         |
+| ShootManagedIssuer              | `false` | `Alpha` | `1.93`  |         |
+| VPAForETCD                      | `false` | `Alpha` | `1.94`  | `1.96`  |
+| VPAForETCD                      | `true`  | `Beta`  | `1.97`  |         |
+| VPAAndHPAForAPIServer           | `false` | `Alpha` | `1.95`  | `1.100` |
+| VPAAndHPAForAPIServer           | `true`  | `Beta`  | `1.101` |         |
+| ShootCredentialsBinding         | `false` | `Alpha` | `1.98`  |         |
+| NewWorkerPoolHash               | `false` | `Alpha` | `1.98`  |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -75,6 +75,9 @@ There are three supported autoscaling modes for the Shoot Kubernetes API server.
 
    The `VPAAndHPA` mode is the used autoscaling mode when the `VPAAndHPAForAPIServer` feature gate is enabled (takes precedence over the `HVPA` feature gate).
 
+> [!NOTE]
+> Starting with release `v1.101`, the `VPAAndHPAForAPIServer` feature gate is enabled by default.
+
 In all scaling modes the min replicas count of 2 is imposed by the [High Availability of Shoot Control Plane Components](../development/high-availability.md#control-plane-components).
 
 The gardenlet sets the initial API server resource requests only when the Deployment is not found. When the Deployment exists, it is not overwriting the kube-apiserver container resources.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -85,6 +85,7 @@ const (
 	// The feature gate takes precedence over the `HVPA` feature gate when they are both enabled.
 	// owner: @ialidzhikov
 	// alpha: v1.95.0
+	// beta: v1.101.0
 	VPAAndHPAForAPIServer featuregate.Feature = "VPAAndHPAForAPIServer"
 
 	// ShootCredentialsBinding enables the usage of the CredentialsBindingName API in shoot spec.
@@ -137,7 +138,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ShootManagedIssuer:              {Default: false, PreRelease: featuregate.Alpha},
 	ShootForceDeletion:              {Default: true, PreRelease: featuregate.Beta},
 	UseNamespacedCloudProfile:       {Default: false, PreRelease: featuregate.Alpha},
-	VPAAndHPAForAPIServer:           {Default: false, PreRelease: featuregate.Alpha},
+	VPAAndHPAForAPIServer:           {Default: true, PreRelease: featuregate.Beta},
 	ShootCredentialsBinding:         {Default: false, PreRelease: featuregate.Alpha},
 	NewWorkerPoolHash:               {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
N/A

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9562

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `VPAAndHPAForAPIServer` feature gate has been promoted to beta and is now turned on by default.
```
