### PR TITLE
Drop VPA MaxAllowed: KAPI,Etcd,Prometheus

### DIFF
--- a/docs/operations/seed_settings.md
+++ b/docs/operations/seed_settings.md
@@ -122,6 +122,20 @@ By setting the `.spec.settings.verticalPodAutoscaler.enabled=false`, you can dis
 
 ⚠️ In any case, there must be a VPA available for your seed cluster. Using a seed without VPA is not supported.
 
+### VPA Pitfall: Excessive Resource Requests Making Pod Unschedulable
+VPA is unaware of node capacity, and can increase the resource requests of a pod beyond the capacity of any single node.
+Such pod is likely to become permanently unschedulable. That problem can be partly mitigated by using the
+`VerticalPodAutoscaler.Spec.ResourcePolicy.ContainerPolicies[].MaxAllowed` field to constrain pod resource requests to
+the level of nodes' allocatable resources. The downside is that a pod constrained in such fashion would be using more
+resources than it has requested, and can starve for resources and/or negatively impact neighbour pods with which it is
+sharing a node.
+
+As an alternative, in scenarios where MaxAllowed is not set, it is important to maintain a worker pool which can
+accommodate the highest level of resources that VPA would actually request for the pods it controls.
+
+Finally, the optimal strategy typically is to both ensure large enough worker pools, and, as an insurance,
+use MaxAllowed aligned with the allocatable resources of the largest worker.
+
 ## Topology-Aware Traffic Routing
 
 Refer to the [Topology-Aware Traffic Routing documentation](./topology_aware_routing.md) as this document contains the documentation for the topology-aware routing Seed setting.

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -214,10 +214,6 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		minAllowed          = corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("200M"),
 		}
-		maxAllowed = corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("4"),
-			corev1.ResourceMemory: resource.MustParse("28G"),
-		}
 	)
 
 	if e.values.Class == ClassImportant {
@@ -424,7 +420,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		if err := kubernetesutils.DeleteObjects(ctx, e.client, hvpa); err != nil {
 			return err
 		}
-		if err := e.reconcileVerticalPodAutoscaler(ctx, vpa, minAllowed, maxAllowed); err != nil {
+		if err := e.reconcileVerticalPodAutoscaler(ctx, vpa, minAllowed); err != nil {
 			return err
 		}
 	} else if e.values.HVPAEnabled {
@@ -537,7 +533,6 @@ func (e *etcd) Deploy(ctx context.Context) error {
 								{
 									ContainerName:    containerNameEtcd,
 									MinAllowed:       minAllowed,
-									MaxAllowed:       maxAllowed,
 									ControlledValues: &controlledValues,
 								},
 								{
@@ -951,7 +946,7 @@ func (e *etcd) emptyVerticalPodAutoscaler() *vpaautoscalingv1.VerticalPodAutosca
 	return &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: e.etcd.Name, Namespace: e.namespace}}
 }
 
-func (e *etcd) reconcileVerticalPodAutoscaler(ctx context.Context, vpa *vpaautoscalingv1.VerticalPodAutoscaler, minAllowed, maxAllowed corev1.ResourceList) error {
+func (e *etcd) reconcileVerticalPodAutoscaler(ctx context.Context, vpa *vpaautoscalingv1.VerticalPodAutoscaler, minAllowed corev1.ResourceList) error {
 	vpaUpdateMode := vpaautoscalingv1.UpdateModeAuto
 	containerPolicyOff := vpaautoscalingv1.ContainerScalingModeOff
 	containerPolicyAuto := vpaautoscalingv1.ContainerScalingModeAuto
@@ -989,7 +984,6 @@ func (e *etcd) reconcileVerticalPodAutoscaler(ctx context.Context, vpa *vpaautos
 					{
 						ContainerName:    containerNameEtcd,
 						MinAllowed:       minAllowed,
-						MaxAllowed:       maxAllowed,
 						ControlledValues: &controlledValues,
 						Mode:             &containerPolicyAuto,
 					},

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -456,10 +456,6 @@ var _ = Describe("Etcd", func() {
 											MinAllowed: corev1.ResourceList{
 												corev1.ResourceMemory: resource.MustParse("200M"),
 											},
-											MaxAllowed: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("4"),
-												corev1.ResourceMemory: resource.MustParse("28G"),
-											},
 											ControlledValues: &controlledValues,
 										},
 										{
@@ -513,12 +509,8 @@ var _ = Describe("Etcd", func() {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName: "etcd",
-							MinAllowed:    corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200M")},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("4"),
-								corev1.ResourceMemory: resource.MustParse("28G"),
-							},
+							ContainerName:    "etcd",
+							MinAllowed:       corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200M")},
 							ControlledValues: &controlledValues,
 							Mode:             &containerPolicyAuto,
 						},

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -435,10 +435,6 @@ var _ = Describe("KubeAPIServer", func() {
 								corev1.ResourceCPU:    resource.MustParse("20m"),
 								corev1.ResourceMemory: resource.MustParse("200M"),
 							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("7"),
-								corev1.ResourceMemory: resource.MustParse("28G"),
-							},
 						},
 					},
 				),
@@ -455,10 +451,6 @@ var _ = Describe("KubeAPIServer", func() {
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("20m"),
 								corev1.ResourceMemory: resource.MustParse("200M"),
-							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("7"),
-								corev1.ResourceMemory: resource.MustParse("28G"),
 							},
 						},
 						{
@@ -488,10 +480,6 @@ var _ = Describe("KubeAPIServer", func() {
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("20m"),
 								corev1.ResourceMemory: resource.MustParse("200M"),
-							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("7"),
-								corev1.ResourceMemory: resource.MustParse("28G"),
 							},
 						},
 					},
@@ -573,10 +561,6 @@ var _ = Describe("KubeAPIServer", func() {
 						ContainerName: "kube-apiserver",
 						MinAllowed: corev1.ResourceList{
 							"memory": resource.MustParse("200M"),
-						},
-						MaxAllowed: corev1.ResourceList{
-							"cpu":    resource.MustParse("8"),
-							"memory": resource.MustParse("25G"),
 						},
 						ControlledValues: &controlledValues,
 					},

--- a/pkg/component/kubernetes/apiserver/hvpa.go
+++ b/pkg/component/kubernetes/apiserver/hvpa.go
@@ -52,10 +52,6 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 		kubeAPIServerMinAllowed = corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("200M"),
 		}
-		kubeAPIServerMaxAllowed = corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("8"),
-			corev1.ResourceMemory: resource.MustParse("25G"),
-		}
 		weightBasedScalingIntervals = []hvpav1alpha1.WeightBasedScalingInterval{
 			{
 				VpaWeight:         hvpav1alpha1.VpaOnly,
@@ -165,7 +161,7 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 				},
 				Spec: hvpav1alpha1.VpaTemplateSpec{
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-						ContainerPolicies: k.computeVerticalPodAutoscalerContainerResourcePolicies(kubeAPIServerMinAllowed, kubeAPIServerMaxAllowed),
+						ContainerPolicies: k.computeVerticalPodAutoscalerContainerResourcePolicies(kubeAPIServerMinAllowed),
 					},
 				},
 			},
@@ -181,13 +177,12 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 	return err
 }
 
-func (k *kubeAPIServer) computeVerticalPodAutoscalerContainerResourcePolicies(kubeAPIServerMinAllowed, kubeAPIServerMaxAllowed corev1.ResourceList) []vpaautoscalingv1.ContainerResourcePolicy {
+func (k *kubeAPIServer) computeVerticalPodAutoscalerContainerResourcePolicies(kubeAPIServerMinAllowed corev1.ResourceList) []vpaautoscalingv1.ContainerResourcePolicy {
 	var (
 		vpaContainerResourcePolicies = []vpaautoscalingv1.ContainerResourcePolicy{
 			{
 				ContainerName:    ContainerNameKubeAPIServer,
 				MinAllowed:       kubeAPIServerMinAllowed,
-				MaxAllowed:       kubeAPIServerMaxAllowed,
 				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 			},
 		}

--- a/pkg/component/kubernetes/apiserver/verticalpodautoscaler.go
+++ b/pkg/component/kubernetes/apiserver/verticalpodautoscaler.go
@@ -64,11 +64,6 @@ func (k *kubeAPIServer) reconcileVerticalPodAutoscalerInVPAAndHPAMode(ctx contex
 		corev1.ResourceCPU:    resource.MustParse("20m"),
 		corev1.ResourceMemory: resource.MustParse("200M"),
 	}
-	kubeAPIServerMaxAllowed := corev1.ResourceList{
-		// The CPU and memory are aligned to the machine ration of 1:4.
-		corev1.ResourceCPU:    resource.MustParse("7"),
-		corev1.ResourceMemory: resource.MustParse("28G"),
-	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client.Client(), verticalPodAutoscaler, func() error {
 		verticalPodAutoscaler.Spec = vpaautoscalingv1.VerticalPodAutoscalerSpec{
@@ -81,7 +76,7 @@ func (k *kubeAPIServer) reconcileVerticalPodAutoscalerInVPAAndHPAMode(ctx contex
 				UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
 			},
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-				ContainerPolicies: k.computeVerticalPodAutoscalerContainerResourcePolicies(kubeAPIServerMinAllowed, kubeAPIServerMaxAllowed),
+				ContainerPolicies: k.computeVerticalPodAutoscalerContainerResourcePolicies(kubeAPIServerMinAllowed),
 			},
 		}
 

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -83,8 +83,6 @@ type Values struct {
 	ScrapeTimeout monitoringv1.Duration
 	// VPAMinAllowed defines the resource list for the minAllowed field for the prometheus container resource policy.
 	VPAMinAllowed *corev1.ResourceList
-	// VPAMaxAllowed defines the resource list for the maxAllowed field for the prometheus container resource policy.
-	VPAMaxAllowed *corev1.ResourceList
 	// ExternalLabels is the set of external labels for the Prometheus configuration.
 	ExternalLabels map[string]string
 	// AdditionalPodLabels is a map containing additional labels for the created pods.

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -338,10 +338,6 @@ honor_labels: true`
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("1000M"),
 							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("4"),
-								corev1.ResourceMemory: resource.MustParse("28G"),
-							},
 							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 						},
 						{

--- a/pkg/component/observability/monitoring/prometheus/vpa.go
+++ b/pkg/component/observability/monitoring/prometheus/vpa.go
@@ -42,10 +42,6 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 						MinAllowed: ptr.Deref(p.values.VPAMinAllowed, corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1000M"),
 						}),
-						MaxAllowed: ptr.Deref(p.values.VPAMaxAllowed, corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("28G"),
-						}),
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},
 					{

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1224,10 +1224,6 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 		ScrapeTimeout:     "50s", // This is intentionally smaller than the scrape interval of 1m.
 		RuntimeVersion:    r.RuntimeVersion,
 		ExternalLabels:    map[string]string{"landscape": garden.Spec.VirtualCluster.Gardener.ClusterIdentity},
-		VPAMaxAllowed: &corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("4"),
-			corev1.ResourceMemory: resource.MustParse("50G"),
-		},
 		AdditionalPodLabels: map[string]string{
 			v1beta1constants.LabelNetworkPolicyToPublicNetworks:                                                v1beta1constants.LabelNetworkPolicyAllowed,
 			v1beta1constants.LabelNetworkPolicyToPrivateNetworks:                                               v1beta1constants.LabelNetworkPolicyAllowed,
@@ -1279,10 +1275,6 @@ func (r *Reconciler) newPrometheusLongTerm(log logr.Logger, garden *operatorv1al
 		RetentionSize:     "80GB",
 		ScrapeTimeout:     "50s", // This is intentionally smaller than the scrape interval of 1m.
 		RuntimeVersion:    r.RuntimeVersion,
-		VPAMaxAllowed: &corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("4"),
-			corev1.ResourceMemory: resource.MustParse("50G"),
-		},
 		AdditionalPodLabels: map[string]string{
 			gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
 		},


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Abandons the use of VerticalPodAutoscaler MaxAllowed for `kube-apiserver`, Etcd, and Prometheus. Motivation is to enable containers to scale beyond the current MaxAllowed level, and make use of potential larger nodes.

**Special notes for your reviewer**:
This change removes the VPA MaxAllowed for the garden control plane components as well. This opens the possibility for such a pod to be made unschedulable by VPA (requests > max node allocatable). However, such unschedulable pod is likely to actually suffer from resource exhaustion (e.g. be in an OOMkill loop). Therefore, the MaxAllowed is an unreliable short-term mitigation at best, and is unlikely to be in use by a productive garden cluster.

It is possible to make an exception and keep the MaxAllowed for garden CP components, at the cost of extra code complexity. It is not the path this PR currently takes, but is still an open option.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
VPA MaxAllowed is no longer hard-coded to fixed values (4/7/8 cores and 25/28G) for `kube-apiserver`, `etcd`, and `prometheus`. Operators must ensure sufficiently large worker pools for control plane components. For details, see [this document](https://github.com/gardener/gardener/blob/master/docs/operations/seed_settings.md#vertical-pod-autoscaler).
```