### PR TITLE
Improve unhealthy nodes overview

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
@@ -826,7 +826,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Shows the number of nodes having issues for more than 5 mins in the cluster over a period of 30 mins.",
+      "description": "Shows the number of nodes having issues for more than 5 mins in the cluster.",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -868,9 +868,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count_over_time((sum by (node) (kube_node_spec_taint{effect=\"NoSchedule\", key!=\"deployment.machine.sapcloud.io/prefer-no-schedule\", key!=\"ToBeDeletedByClusterAutoscaler\", key!=\"node.gardener.cloud/critical-components-not-ready\"}))[30m:]) > 5",
+          "expr": "count_over_time(kube_node_spec_taint{effect=\"NoSchedule\", key=~\"node.kubernetes.io/.*\", node=~\".*$worker_group.*\"}[5m]) >= 5",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{node}} - {{key}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR improves the unhealthy nodes in the Node/Worker Pool overview dashboard. Earlier, the query considered nodes with custom taints of `NoSchedule` effect which distorts the view of finding unready nodes over time, esp. if custom taints are used by users.

The new query follows the [taint based eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions) approach and extracts all nodes/taint pairs that have the `node.kubernetes.io/` taint being set for at least 5 minutes (default toleration time for such taints).

**Special notes for your reviewer**:
/cc @rickardsjp @vicwicker @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Displaying unhealthy nodes in the shoot Plutono dashboard was improved to show nodes with taints used for [taint based eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions). Earlier, nodes with custom `NoSchedule` taints distorted this view, as actual healthy nodes were shown as problematic.
```
