### PR TITLE
Allow `machine-controller-manager-provider-local` to delete VMs in the safety controller.

### DIFF
--- a/pkg/provider-local/machine-provider/local/create_machine.go
+++ b/pkg/provider-local/machine-provider/local/create_machine.go
@@ -68,7 +68,7 @@ func (d *localDriver) applyPod(
 	*corev1.Pod,
 	error,
 ) {
-	pod := podForMachine(req.Machine)
+	pod := podForMachine(req.Machine, req.MachineClass)
 	pod.Annotations = map[string]string{}
 
 	if providerSpec.IPPoolNameV4 != "" {

--- a/pkg/provider-local/machine-provider/local/delete_machine.go
+++ b/pkg/provider-local/machine-provider/local/delete_machine.go
@@ -34,7 +34,7 @@ func (d *localDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachi
 		return nil, status.Error(codes.Unknown, fmt.Sprintf("error deleting user data secret: %s", err.Error()))
 	}
 
-	pod := podForMachine(req.Machine)
+	pod := podForMachine(req.Machine, req.MachineClass)
 	if err := d.client.Delete(ctx, pod); err != nil {
 		if !apierrors.IsNotFound(err) {
 			// Unknown leads to short retry in machine controller

--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -42,7 +42,13 @@ func (_ *localDriver) InitializeMachine(context.Context, *driver.InitializeMachi
 	return nil, status.Error(codes.Unimplemented, "InitializeMachine is not yet implemented")
 }
 
-func podForMachine(machine *machinev1alpha1.Machine) *corev1.Pod {
+func podForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) *corev1.Pod {
+	// TODO(scheererj): Remove the empty namespace mitigation after https://github.com/gardener/machine-controller-manager/pull/932 has been adopted
+	namespace := machine.Namespace
+	// machine.Namespace may be empty due to machine controller manager omitting namespace
+	if namespace == "" {
+		namespace = machineClass.Namespace
+	}
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -50,7 +56,7 @@ func podForMachine(machine *machinev1alpha1.Machine) *corev1.Pod {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName(machine.Name),
-			Namespace: machine.Namespace,
+			Namespace: namespace,
 		},
 	}
 }

--- a/pkg/provider-local/machine-provider/local/get_machine_status.go
+++ b/pkg/provider-local/machine-provider/local/get_machine_status.go
@@ -26,7 +26,7 @@ func (d *localDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 	klog.V(3).Infof("Machine status request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine status request has been processed for %q", req.Machine.Name)
 
-	pod := podForMachine(req.Machine)
+	pod := podForMachine(req.Machine, req.MachineClass)
 	if err := d.client.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Error(codes.NotFound, err.Error())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

Allow `machine-controller-manager-provider-local` to delete VMs in the safety controller.

In #10176, the first step was taken to allow provider-local to delete virtual machines in machine-controller-manager's safety controller. Unfortunately, while the deletion of the user data secret succeeded, the deletion of the pod itself still failed.
This change is a simple addon to the previous pull request and should finally resolve this issue.

After #10176, the error message looks like the following:

```
2024-07-26T19:53:08.035791866Z stderr F E0726 19:53:08.035249       1 machine_safety.go:288] SafetyController: Error while trying to DELETE VM on CP - machine codes error: code = [Unknown] message = [error deleting pod: an empty namespace may not be set when a resource name is provided]. Shall retry in next safety controller sync.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
