### PR TITLE
Deflake extensionclusterrole integration test

### DIFF
--- a/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_suite_test.go
+++ b/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_suite_test.go
@@ -43,6 +43,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Reader
 
 	testRunID = "test-" + gardenerutils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 )
@@ -87,6 +88,7 @@ var _ = BeforeSuite(func() {
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("Register controller")
 	Expect((&extensionclusterrole.Reconciler{}).AddToManager(ctx, mgr)).To(Succeed())

--- a/test/integration/scheduler/shoot/shoot_suite_test.go
+++ b/test/integration/scheduler/shoot/shoot_suite_test.go
@@ -115,7 +115,7 @@ var _ = BeforeSuite(func() {
 		Expect(client.IgnoreNotFound(testClient.Delete(ctx, project))).To(Succeed())
 	})
 
-	By("Create SecretBinding")
+	By("Create Secret")
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-",
@@ -130,6 +130,7 @@ var _ = BeforeSuite(func() {
 		Expect(client.IgnoreNotFound(testClient.Delete(ctx, secret))).To(Succeed())
 	})
 
+	By("Create SecretBinding")
 	testSecretBinding = &gardencorev1beta1.SecretBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Deflake extensionclusterrole integration test.

Previously, deleting the ClusterRoleBinding was in a different `DeferCleanup` which gets executed before the deletion of ClusterRole. This could cause it to again get recreated and hence fail the `NotFound` check.
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10161/pull-gardener-integration/1816803358925656064
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10107/pull-gardener-integration/1812887318739030016

The Consistently at line 306 could get executed before the ClusterRoleBinding is created and hence can fail.
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10006/pull-gardener-integration/1815367885061623808
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10139/pull-gardener-integration/1813277774979272704


Before,
```
❯ stress -ignore "unable to grab random port" -p 48 ./test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole.test  --ginkgo.vv
...
2m10s: 108 runs so far, 3 failures (2.78%)
2m15s: 113 runs so far, 3 failures (2.65%)
2m20s: 121 runs so far, 3 failures (2.48%)
2m25s: 128 runs so far, 3 failures (2.34%)
2m30s: 129 runs so far, 3 failures (2.33%)
```

After:
```
❯ stress -ignore "unable to grab random port" -p 48 ./test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole.test  --ginkgo.vv
...
13m10s: 887 runs so far, 0 failures
13m15s: 892 runs so far, 0 failures
13m20s: 895 runs so far, 0 failures
13m25s: 904 runs so far, 0 failures
13m30s: 910 runs so far, 0 failures
13m35s: 917 runs so far, 0 failures
13m40s: 920 runs so far, 0 failures
13m45s: 926 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
