### PR TITLE
Improve `istio-ingressgateway` resource requests and maxReplicas

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -77,10 +77,10 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 250m
-              memory: 1Gi
+              cpu: 300m
+              memory: 600Mi
             limits:
-              memory: 8Gi
+              memory: 4800Mi
           env:
           - name: JWT_POLICY
             value: third-party-jwt

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
@@ -24,7 +24,7 @@ ingressVersion: "1.21.5"
 #externalTrafficPolicy: Cluster
 replicas: 2
 minReplicas: 2
-maxReplicas: 5
+maxReplicas: 9
 enforceSpreadAcrossHosts: false
 
 # Istio Ingress Configuration Resources

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -62,7 +62,7 @@ var _ = Describe("istiod", func() {
 		renderer chartrenderer.Interface
 
 		minReplicas = 2
-		maxReplicas = 5
+		maxReplicas = 9
 
 		externalTrafficPolicy corev1.ServiceExternalTrafficPolicyType
 
@@ -139,7 +139,7 @@ var _ = Describe("istiod", func() {
 		istioIngressAutoscaler = func(min *int, max *int) string {
 			data, _ := os.ReadFile("./test_charts/ingress_autoscaler.yaml")
 			str := strings.ReplaceAll(string(data), "<MIN_REPLICAS>", strconv.Itoa(ptr.Deref(min, 2)))
-			str = strings.ReplaceAll(str, "<MAX_REPLICAS>", strconv.Itoa(ptr.Deref(max, 5)))
+			str = strings.ReplaceAll(str, "<MAX_REPLICAS>", strconv.Itoa(ptr.Deref(max, 9)))
 			return str
 		}
 

--- a/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
@@ -74,10 +74,10 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 250m
-              memory: 1Gi
+              cpu: 300m
+              memory: 600Mi
             limits:
-              memory: 8Gi
+              memory: 4800Mi
           env:
           - name: JWT_POLICY
             value: third-party-jwt

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -75,7 +75,7 @@ func NewIstio(
 		// zonal load balancer is exposed individually via its own IP address. Therefore, having
 		// just one replica may negatively affect availability.
 		minReplicas = ptr.To(len(zones) * 2)
-		// The default configuration without availability zones has 5 as the maximum amount of
+		// The default configuration without availability zones has 9 as the maximum amount of
 		// replicas, which apparently works in all known Gardener scenarios. Reducing it to less
 		// per zone gives some room for autoscaling while it is assumed to never reach the maximum.
 		maxReplicas = ptr.To(len(zones) * 6)

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -78,7 +78,7 @@ func NewIstio(
 		// The default configuration without availability zones has 5 as the maximum amount of
 		// replicas, which apparently works in all known Gardener scenarios. Reducing it to less
 		// per zone gives some room for autoscaling while it is assumed to never reach the maximum.
-		maxReplicas = ptr.To(len(zones) * 4)
+		maxReplicas = ptr.To(len(zones) * 6)
 	}
 
 	policyLabels := commonIstioIngressNetworkPolicyLabels(vpnEnabled)

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -85,7 +85,7 @@ func checkIstio(istioDeploy istio.Interface, testValues istioTestValues) {
 
 	if zoneSize := len(testValues.zones); zoneSize > 1 {
 		minReplicas = ptr.To(zoneSize * 2)
-		maxReplicas = ptr.To(zoneSize * 4)
+		maxReplicas = ptr.To(zoneSize * 6)
 	}
 
 	networkPolicyLabels := map[string]string{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR changes the CPU and memory resource requests of the `istio-proxy` container of the `istio-ingressgateway` deployment to `300m` and `600Mi`, respectfully. Additionally, max replicas for the `istio-ingressgateway` deployed for single zones is increased from 5 to 9. The max replicas for multiple zones is increased from 4 to 6 per zone.

I have kept the ratio of memory limits to memory requests to be 8, so the new memory limits for the `istio-proxy` container are `4800Mi`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This change is motivated by the current resource usage of `istio-ingressgateway` on our landscapes.
/cc @ScheererJ @DockToFuture 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The CPU and memory resource requests of the `istio-proxy` container for the `istio-ingressgateway` deployment have been changed to `300m` and `600Mi`, respectively.
The HPA `maxReplicas` for the `istio-ingressgateway` deployment have been increased from 5 to 9. When deployed for multiple zones, the `maxReplicas` are increased from 4 to 6 per zone.
```
