### PR TITLE
🧹 Cleanup `TODO` concerning Istio zone migration code

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -7,7 +7,6 @@ package seed
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
 	proberapi "github.com/gardener/dependency-watchdog/api/prober"
@@ -358,66 +357,6 @@ func (r *Reconciler) newIstio(ctx context.Context, seed *seedpkg.Seed, isGardenC
 					seed.GetZonalLoadBalancerServiceProxyProtocolTermination(zone),
 				); err != nil {
 					return nil, nil, "", err
-				}
-			}
-		}
-	}
-
-	// TODO(scheererj): Remove this after v1.102 has been released.
-	// Allow temporary creation of ingress gateway copy to easy migration
-
-	// Map all ingress gateway namespace names to the corresponding gateway values for easier access
-	namespaceToGatewayValues := map[string]istio.IngressGatewayValues{}
-	for _, values := range istioDeployer.GetValues().IngressGateway {
-		namespaceToGatewayValues[values.Namespace] = values
-	}
-
-	// Search for istio namespaces with an annotation to copy them and add them to the list with a different namespace
-	for _, label := range []string{"istio", v1beta1constants.LabelExposureClassHandlerName} {
-		namespaceList := &metav1.PartialObjectMetadataList{}
-		namespaceList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NamespaceList"))
-		if err := r.SeedClientSet.Client().List(ctx, namespaceList, client.HasLabels{label}); err != nil {
-			return nil, nil, "", err
-		}
-		for _, ns := range namespaceList.Items {
-			if targetNamespace, ok := ns.Annotations["alpha.istio-ingress.gardener.cloud/migrate-to"]; ok && targetNamespace != "" {
-				if gatewayValues, ok := namespaceToGatewayValues[ns.Name]; ok {
-					// Labels need to be adjusted to contain the correct zone => copy the source labels
-					gatewayLabels := utils.MergeStringMaps(gatewayValues.Labels, map[string]string{})
-					var zone *string
-					if len(gatewayValues.Zones) == 1 {
-						zone = ptr.To(gatewayValues.Zones[0])
-						// The expected migration is from <region>-<zone> to <zone>
-						if lastSeparator := strings.LastIndex(*zone, "-"); lastSeparator >= 0 {
-							newZone := (*zone)[lastSeparator+1:]
-							// Unfortunately, ordinary istio ingress gateways (first case) use different labels than exposure classes (second case)
-							if value, ok := gatewayLabels[istio.DefaultZoneKey]; ok {
-								gatewayLabels[istio.DefaultZoneKey] = strings.ReplaceAll(value, "--zone--"+*zone, "--zone--"+newZone)
-							} else if value, ok := gatewayLabels[v1beta1constants.GardenRole]; ok {
-								gatewayLabels[v1beta1constants.GardenRole] = strings.ReplaceAll(value, "--zone--"+*zone, "--zone--"+newZone)
-							}
-							zone = &newZone
-						}
-					}
-					proxyProtocolTermination := seed.GetLoadBalancerServiceProxyProtocolTermination()
-					if zone != nil {
-						proxyProtocolTermination = seed.GetZonalLoadBalancerServiceProxyProtocolTermination(*zone)
-					}
-					if err := sharedcomponent.AddIstioIngressGateway(
-						ctx,
-						r.SeedClientSet.Client(),
-						istioDeployer,
-						targetNamespace,
-						gatewayValues.Annotations,
-						gatewayLabels,
-						gatewayValues.ExternalTrafficPolicy,
-						nil,
-						zone,
-						seed.IsDualStack(),
-						proxyProtocolTermination,
-					); err != nil {
-						return nil, nil, "", err
-					}
 				}
 			}
 		}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -529,22 +529,6 @@ func cleanupOrphanExposureClassHandlerResources(
 		}
 	}
 
-	// TODO(scheererj): Remove this after v1.102 has been released.
-	// Allow temporary creation of ingress gateway copy to easy migration
-	migrationTargetToSource := map[string]string{}
-	for _, label := range []string{"istio", v1beta1constants.LabelExposureClassHandlerName} {
-		namespaceList := &metav1.PartialObjectMetadataList{}
-		namespaceList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NamespaceList"))
-		if err := c.List(ctx, namespaceList, client.HasLabels{label}); err != nil {
-			return err
-		}
-		for _, ns := range namespaceList.Items {
-			if targetNamespace, ok := ns.Annotations["alpha.istio-ingress.gardener.cloud/migrate-to"]; ok && targetNamespace != "" {
-				migrationTargetToSource[targetNamespace] = ns.Name
-			}
-		}
-	}
-
 	// Remove zonal, orphaned istio exposure class namespaces
 	zonalExposureClassHandlerNamespaces := &corev1.NamespaceList{}
 	if err := c.List(ctx, zonalExposureClassHandlerNamespaces, client.MatchingLabelsSelector{
@@ -557,9 +541,6 @@ func cleanupOrphanExposureClassHandlerResources(
 	for _, namespace := range zonalExposureClassHandlerNamespaces.Items {
 		if ok, zone := sharedcomponent.IsZonalIstioExtension(namespace.Labels); ok {
 			if err := cleanupOrphanIstioNamespace(ctx, log, c, namespace, true, func() bool {
-				if migrationTargetToSource[namespace.Name] != "" {
-					return true
-				}
 				if !zoneSet.Has(zone) {
 					return false
 				}
@@ -586,7 +567,7 @@ func cleanupOrphanExposureClassHandlerResources(
 	for _, namespace := range zonalIstioNamespaces.Items {
 		if ok, zone := sharedcomponent.IsZonalIstioExtension(namespace.Labels); ok {
 			if err := cleanupOrphanIstioNamespace(ctx, log, c, namespace, false, func() bool {
-				return zoneSet.Has(zone) || migrationTargetToSource[namespace.Name] != ""
+				return zoneSet.Has(zone)
 			}); err != nil {
 				return err
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

- Remove Istio zone migration code (from https://github.com/gardener/gardener/pull/9304 and https://github.com/gardener/gardener/pull/9457, released with `v1.91.0` and `v1.92.0`)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The code is no longer necessary and can be removed slightly ahead of schedule, i.e. it can already be removed from `v1.101` instead of only `v1.102` as stated in the removed code. The timeline was prolonged in #9885.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
