### PR TITLE
Only generate workload identity signing key if not already done

### DIFF
--- a/hack/generate-kustomize-patch-workload-identity-signing-key.sh
+++ b/hack/generate-kustomize-patch-workload-identity-signing-key.sh
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+if [ ! -e example/gardener-local/controlplane/workload-identity-signing-key ]; then
+  openssl genrsa -out example/gardener-local/controlplane/workload-identity-signing-key 4096
+fi

--- a/hack/generate-kustomize-patch-workload-identity-signing-key.sh
+++ b/hack/generate-kustomize-patch-workload-identity-signing-key.sh
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
-set -e
-
-if [ ! -e example/gardener-local/controlplane/workload-identity-signing-key ]; then
-  openssl genrsa -out example/gardener-local/controlplane/workload-identity-signing-key 4096
-fi

--- a/hack/generate-workload-identity-signing-key.sh
+++ b/hack/generate-workload-identity-signing-key.sh
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+signing_key_path="${1:-"example/gardener-local/controlplane/workload-identity-signing-key"}"
+
+if [ ! -e "$signing_key_path" ]; then
+  openssl genrsa -out "$signing_key_path" 4096
+fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -510,7 +510,7 @@ deploy:
         - host:
             command:
               - bash
-              - hack/generate-kustomize-patch-workload-identity-signing-key.sh
+              - hack/generate-workload-identity-signing-key.sh
       after:
         - host:
             command:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -509,11 +509,8 @@ deploy:
               - example/gardener-local/controlplane/networkpolicy.yaml
         - host:
             command:
-              - openssl
-              - genrsa
-              - -out
-              - example/gardener-local/controlplane/workload-identity-signing-key
-              - 4096
+              - bash
+              - hack/generate-kustomize-patch-workload-identity-signing-key.sh
       after:
         - host:
             command:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR prevents recreating the `gardener-apiserver` pod on each `make gardener-up`.

cc @ialidzhikov @vpnachev 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
