### PR TITLE
Fix `provider-local`'s machine-controller-manager driver implementation with regards to listing of machines.

### DIFF
--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -6,6 +6,7 @@ package local
 
 import (
 	"context"
+	"strings"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
@@ -21,6 +22,7 @@ const (
 	labelKeyApp       = "app"
 	labelKeyProvider  = "machine-provider"
 	labelValueMachine = "machine"
+	machinePrefix     = "machine-"
 )
 
 // NewDriver returns an empty AWSDriver object
@@ -69,7 +71,11 @@ func userDataSecretForMachine(machine *machinev1alpha1.Machine, machineClass *ma
 }
 
 func podName(machineName string) string {
-	return "machine-" + machineName
+	return machinePrefix + machineName
+}
+
+func machineName(podName string) string {
+	return strings.TrimPrefix(podName, machinePrefix)
 }
 
 // TODO(scheererj): Remove the empty namespace mitigation after https://github.com/gardener/machine-controller-manager/pull/932 has been adopted

--- a/pkg/provider-local/machine-provider/local/list_machines.go
+++ b/pkg/provider-local/machine-provider/local/list_machines.go
@@ -33,7 +33,7 @@ func (d *localDriver) ListMachines(ctx context.Context, req *driver.ListMachines
 
 	machineList := make(map[string]string, len(podList.Items))
 	for _, pod := range podList.Items {
-		machineList[pod.Name] = pod.Name
+		machineList[pod.Name] = machineName(pod.Name)
 	}
 
 	return &driver.ListMachinesResponse{MachineList: machineList}, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area testing
/kind bug

**What this PR does / why we need it**:

Fix `provider-local`'s machine-controller-manager driver implementation with regards to listing of machines.

The machine-controller-manager assumes to get a map of provider IDs to machine names when listing machines. However, `provider-local`'s implementation had the subtle bug that it returned a map of provider IDs to pod/node names instead. The resulting values had an additional 'machine-' prefix.
This caused the safety controller in machine-controller-manager to act incorrectly, trying to delete machines and failing to do so. In #10176 and #10222, some of the existing issues were addressed, but now it became obvious that the real issue is that `provider-local`'s implementation did not conform to the expected interface.

The error message showing the duplicate prefix in the logs is the following:

```
2024-07-30T12:46:20.818891752Z stderr F E0730 12:46:20.818723       1 machine_safety.go:288] SafetyController: Error while trying to DELETE VM on CP - machine codes error: code = [NotFound] message = [pods "machine-machine-shoot--local--e2e-default-local-7b5cc-dpzzb" not found]. Shall retry in next safety controller sync.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
