### PR TITLE
Remove the addition of the annotation: `cluster-autoscaler.kubernetes.io/safe-to-evict: false` from the HA configuration of etcd-main.

### DIFF
--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -221,7 +221,9 @@ func (e *etcd) Deploy(ctx context.Context) error {
 	)
 
 	if e.values.Class == ClassImportant {
-		annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
+		if !e.values.HighAvailabilityEnabled {
+			annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
+		}
 		metrics = druidv1alpha1.Extensive
 		volumeClaimTemplate = e.values.Role + "-" + strings.TrimSuffix(e.etcd.Name, "-"+e.values.Role)
 		minAllowed = corev1.ResourceList{

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -267,7 +267,9 @@ var _ = Describe("Etcd", func() {
 			}
 
 			if class == ClassImportant {
-				obj.Spec.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
+				if replicas == 1 {
+					obj.Spec.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
+				}
 				obj.Spec.Etcd.Metrics = &metricsExtensive
 				obj.Spec.VolumeClaimTemplate = ptr.To(testRole + "-etcd")
 			}


### PR DESCRIPTION
/area high-availability
/area etcd
/kind enhancement

**What this PR does / why we need it**:
Currently, annotation: `cluster-autoscaler.kubernetes.io/safe-to-evict: false` is being added to etcd-main (both HA and non-HA). This PR is to remove this adding of annotation `cluster-autoscaler.kubernetes.io/safe-to-evict: false` to etcd-main HA to improve node utilization.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/etcd-druid/issues/766 Point 2

**Special notes for your reviewer**:
https://github.com/gardener/etcd-druid/issues/766#issuecomment-2084895795

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Removed the addition of the annotation: `cluster-autoscaler.kubernetes.io/safe-to-evict: false` for the HA etcd-main to improve node utilization.
```
