### PR TITLE
Refine seed `STATUS` column

### DIFF
--- a/pkg/apiserver/registry/core/seed/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/core/seed/storage/tableconvertor.go
@@ -73,9 +73,9 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		if gardenletReadyCondition != nil && gardenletReadyCondition.Status == core.ConditionUnknown {
 			cells = append(cells, "Unknown")
 		} else if (gardenletReadyCondition == nil || gardenletReadyCondition.Status != core.ConditionTrue) ||
-			(extensionsReadyCondition == nil || extensionsReadyCondition.Status != core.ConditionTrue) ||
 			(backupBucketCondition != nil && backupBucketCondition.Status != core.ConditionTrue) ||
-			(seedSystemComponentsHealthyCondition != nil && seedSystemComponentsHealthyCondition.Status != core.ConditionTrue) {
+			(extensionsReadyCondition == nil || extensionsReadyCondition.Status == core.ConditionFalse || extensionsReadyCondition.Status == core.ConditionUnknown) ||
+			(seedSystemComponentsHealthyCondition != nil && (seedSystemComponentsHealthyCondition.Status == core.ConditionFalse || seedSystemComponentsHealthyCondition.Status == core.ConditionUnknown)) {
 			cells = append(cells, "NotReady")
 		} else {
 			cells = append(cells, "Ready")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
When seeds are listed via `kubectl`, the `STATUS` column identifies their readiness states.
Earlier, this identifier tend to oscillate because `SeedExtensionsReady` and  `SeedSystemComponentsHealthy` were considered as soon as they went into `progressing`, which esp. happens on larger landscapes, mainly because of auto-scaling actions. With this change, the mentioned conditions are only considered when they are `false`.

The evaluation of `SeedGardenletReady` and `SeedBackupBucketsReady` remain unchanged to reflect the view of `gardener-scheduler` [ref](https://github.com/gardener/gardener/blob/f9fe30f3a66785e9076da4e7b023f9b3c08820f7/pkg/scheduler/controller/shoot/reconciler.go#L538).

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `STATUS` column of `seed`s was improved, when they are listed via `kubectl`. Earlier the field tend to oscillated, especially when extensions and system components are scaled frequently.
```
