### PR TITLE
[Node-Agent] Ensure that local CA certificate directory has files before start copying.

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -87,7 +87,7 @@ if [[ -f "/etc/debian_version" ]]; then
     # Copy certificates from default "localcertsdir" because /usr is mounted read-only in Garden Linux.
     # See https://github.com/gardenlinux/gardenlinux/issues/1490
     mkdir -p "/var/lib/ca-certificates-local"
-    if [[ -d "/usr/local/share/ca-certificates" ]]; then
+    if [[ -d "/usr/local/share/ca-certificates" && -n "$(ls -A '/usr/local/share/ca-certificates')" ]]; then
         cp -af /usr/local/share/ca-certificates/* "/var/lib/ca-certificates-local"
     fi
     # localcertsdir is supported on Debian based OS only

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
@@ -8,7 +8,7 @@ if [[ -f "/etc/debian_version" ]]; then
     # Copy certificates from default "localcertsdir" because /usr is mounted read-only in Garden Linux.
     # See https://github.com/gardenlinux/gardenlinux/issues/1490
     mkdir -p "{{ .pathLocalSSLCerts }}"
-    if [[ -d "/usr/local/share/ca-certificates" ]]; then
+    if [[ -d "/usr/local/share/ca-certificates" && -n "$(ls -A '/usr/local/share/ca-certificates')" ]]; then
         cp -af /usr/local/share/ca-certificates/* "{{ .pathLocalSSLCerts }}"
     fi
     # localcertsdir is supported on Debian based OS only


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

Ensure that local CA certificate directory has files before start copying.

In case there are no files in the directory the `cp` operation will fail when trying to `stat` the files.

`gardener-node-agent` fails with:

```
Jul 30 12:38:20 machine-shoot--local--e2e-default-local3-696db-8dpjq gardener-node-agent[349]: {"level":"error","ts":"2024-07-30T12:38:20.167Z","msg":"Reconciler error","controller":"operatingsystemconfig","namespace":"kube-system","name":"gardener-node-agent-local3-b8f97ee2fd9a4297","reconcileID":"67ae7bd7-6150-48d0-a59a-9681ef7846e1","error":"failed executing unit commands: 1 error occurred:\n\t* unable to restart unit \"updatecacerts.service\": restart failed for updatecacerts.service, due failed\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:227"}
```

`updatecacerts.service` fails with:

```
Aug 01 08:58:47 machine-shoot--local--local-local-79987-jh8pl systemd[1]: Starting updatecacerts.service - Update local certificate authorities...
Aug 01 08:58:47 machine-shoot--local--local-local-79987-jh8pl update-local-ca-certificates.sh[440]: cp: cannot stat '/usr/local/share/ca-certificates/*': No such file or directory
Aug 01 08:58:47 machine-shoot--local--local-local-79987-jh8pl systemd[1]: updatecacerts.service: Main process exited, code=exited, status=1/FAILURE
Aug 01 08:58:47 machine-shoot--local--local-local-79987-jh8pl systemd[1]: updatecacerts.service: Failed with result 'exit-code'.
Aug 01 08:58:47 machine-shoot--local--local-local-79987-jh8pl systemd[1]: Failed to start updatecacerts.service - Update local certificate authorities.
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/10171

**Special notes for your reviewer**:

This seems to be more relevant to local setup and end-to-end tests. The result of this issue is that `kubelet` and `containerd` are started and shortly after restarted on any new node. This can lead to "lost" containers, which we saw especially with some critical components in the local setup, e.g. `apiserver-proxy`, where an init container might or might not be started, but there is no follow-up and no logs. `apiserver-proxy` may be especially effected as it has an init container with a very short runtime.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`updatecacerts.service` systemd unit on nodes with Debian OS does not fail anymore if `/usr/local/share/ca-certificates` directory is empty.
```
