### PR TITLE
Fix ETCD dashboards

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-backup-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-backup-dashboard.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 16,
+  "id": 25,
   "links": [],
   "panels": [
     {
@@ -34,72 +34,59 @@
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
       "datasource": "prometheus",
       "description": "Timestamp of the latest snapshot successfully uploaded to the snapstore.",
-      "editable": true,
-      "error": false,
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeAsUS"
+        },
         "overrides": []
       },
-      "format": "dateTimeAsUS",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
       "gridPos": {
-        "h": 5,
+        "h": 2,
         "w": 11,
         "x": 0,
         "y": 1
       },
       "id": 2,
       "interval": null,
-      "isNew": true,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "span": 3,
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
@@ -114,87 +101,64 @@
           "step": 20
         }
       ],
-      "thresholds": "",
       "title": "Latest Snapshot Timestamp",
-      "type": "singlestat",
-      "valueFontSize": "200%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
       "datasource": "prometheus",
       "description": "Maximum duration worth of possible data loss in the event that etcd data gets corrupted at this moment.",
-      "editable": true,
-      "error": false,
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
         "overrides": []
       },
-      "format": "dtdurations",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
       "gridPos": {
-        "h": 5,
+        "h": 2,
         "w": 6,
         "x": 11,
         "y": 1
       },
       "id": 36,
       "interval": null,
-      "isNew": true,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "span": 3,
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
@@ -209,87 +173,64 @@
           "step": 20
         }
       ],
-      "thresholds": "",
       "title": "Maximum Possible Data Loss",
-      "type": "singlestat",
-      "valueFontSize": "200%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
       "datasource": "prometheus",
       "description": "Latest revision of the data from the latest snapshot uploaded to the snapstore.",
-      "editable": true,
-      "error": false,
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
         "overrides": []
       },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
       "gridPos": {
-        "h": 5,
-        "w": 7,
+        "h": 2,
+        "w": 6,
         "x": 17,
         "y": 1
       },
       "id": 35,
       "interval": null,
-      "isNew": true,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "span": 3,
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
@@ -304,18 +245,8 @@
           "step": 20
         }
       ],
-      "thresholds": "",
       "title": "Latest Snapshot Revision",
-      "type": "singlestat",
-      "valueFontSize": "200%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "aliasColors": {
@@ -341,7 +272,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 6
+        "y": 3
       },
       "hiddenSeries": false,
       "id": 4,
@@ -371,7 +302,7 @@
       "spaceLength": 10,
       "span": 5,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
@@ -417,6 +348,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:787",
           "decimals": 0,
           "format": "none",
           "label": null,
@@ -426,6 +358,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:788",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -463,7 +396,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 6
+        "y": 3
       },
       "hiddenSeries": false,
       "id": 37,
@@ -493,7 +426,7 @@
       "spaceLength": 10,
       "span": 5,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
@@ -539,6 +472,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:735",
           "decimals": 0,
           "format": "none",
           "label": null,
@@ -548,6 +482,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:736",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -585,7 +520,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 11
+        "y": 8
       },
       "hiddenSeries": false,
       "id": 12,
@@ -656,6 +591,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:683",
           "decimals": 0,
           "format": "none",
           "label": null,
@@ -665,6 +601,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:684",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -702,7 +639,7 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 11
+        "y": 8
       },
       "hiddenSeries": false,
       "id": 38,
@@ -732,7 +669,7 @@
       "spaceLength": 10,
       "span": 4,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
@@ -775,6 +712,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:839",
           "decimals": 0,
           "format": "none",
           "label": null,
@@ -784,6 +722,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:840",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -818,7 +757,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 11
+        "y": 8
       },
       "hiddenSeries": false,
       "id": 39,
@@ -848,7 +787,7 @@
       "spaceLength": 10,
       "span": 4,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
@@ -893,6 +832,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:941",
           "decimals": null,
           "format": "s",
           "label": null,
@@ -902,6 +842,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:942",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -939,7 +880,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 13
       },
       "hiddenSeries": false,
       "id": 40,
@@ -969,7 +910,7 @@
       "spaceLength": 10,
       "span": 5,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
@@ -1016,6 +957,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1045",
           "decimals": 0,
           "format": "none",
           "label": null,
@@ -1025,6 +967,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1046",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1062,7 +1005,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 13
       },
       "hiddenSeries": false,
       "id": 41,
@@ -1092,7 +1035,7 @@
       "spaceLength": 10,
       "span": 5,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
@@ -1139,6 +1082,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:993",
           "decimals": 0,
           "format": "none",
           "label": null,
@@ -1148,6 +1092,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:994",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1168,7 +1113,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 18
       },
       "id": 30,
       "panels": [],
@@ -1196,7 +1141,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 42,
@@ -1226,7 +1171,7 @@
       "spaceLength": 10,
       "span": 5,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "expr": "process_resident_memory_bytes{job=\"kube-etcd3-backup-restore-main\"}",
@@ -1259,6 +1204,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:631",
           "decimals": 0,
           "format": "decbytes",
           "label": null,
@@ -1268,6 +1214,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:632",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1302,7 +1249,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 43,
@@ -1332,7 +1279,7 @@
       "spaceLength": 10,
       "span": 5,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "expr": "rate(process_cpu_seconds_total{job=\"kube-etcd3-backup-restore-main\"}[$__rate_interval]) * 100",
@@ -1365,6 +1312,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1147",
           "decimals": 0,
           "format": "percent",
           "label": null,
@@ -1374,6 +1322,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1148",
           "format": "short",
           "label": null,
           "logBase": 1,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-backup-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-backup-dashboard.json
@@ -1,11 +1,21 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
+  "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
-  "iteration": 1542111230310,
+  "id": 16,
   "links": [],
   "panels": [
     {
@@ -35,6 +45,10 @@
       "description": "Timestamp of the latest snapshot successfully uploaded to the snapstore.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "dateTimeAsUS",
       "gauge": {
         "maxValue": 100,
@@ -67,7 +81,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -89,9 +102,11 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(etcdbr_snapshot_latest_timestamp{role=\"main\"})*1000",
+          "exemplar": true,
+          "expr": "max(etcdbr_snapshot_latest_timestamp{role=\"etcd-main\"})*1000",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "etcdbr_snapshot_latest_timestamp",
@@ -125,6 +140,10 @@
       "description": "Maximum duration worth of possible data loss in the event that etcd data gets corrupted at this moment.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "dtdurations",
       "gauge": {
         "maxValue": 100,
@@ -157,7 +176,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -179,9 +197,11 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time()-max(etcdbr_snapshot_latest_timestamp{role=\"main\"})",
+          "exemplar": true,
+          "expr": "time()-max(etcdbr_snapshot_latest_timestamp{role=\"etcd-main\"})",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "etcdbr_snapshot_latest_timestamp",
@@ -215,6 +235,10 @@
       "description": "Latest revision of the data from the latest snapshot uploaded to the snapstore.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -247,7 +271,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -269,9 +292,11 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(etcdbr_snapshot_latest_revision{role=\"main\"})",
+          "exemplar": true,
+          "expr": "max(etcdbr_snapshot_latest_revision{role=\"etcd-main\"})",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "etcdbr_snapshot_latest_revision",
@@ -294,8 +319,8 @@
     },
     {
       "aliasColors": {
-          "Succeeded": "green",
-          "Failed": "red"
+        "Failed": "red",
+        "Succeeded": "green"
       },
       "bars": false,
       "dashLength": 10,
@@ -304,6 +329,12 @@
       "description": "Total number of full snapshots successfully uploaded to the snapstore, as well as total number of failed attempts for the same, over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -329,9 +360,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -342,8 +374,10 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "etcdbr_snapshot_duration_seconds_count{role=\"main\",kind=\"Full\",succeeded=\"true\"}",
+          "exemplar": true,
+          "expr": "etcdbr_snapshot_duration_seconds_count{role=\"etcd-main\",kind=\"Full\",succeeded=\"true\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} Succeeded",
           "metric": "etcdbr_snapshot_duration_seconds_count",
@@ -351,8 +385,10 @@
           "step": 2
         },
         {
-          "expr": "etcdbr_snapshot_duration_seconds_count{role=\"main\",kind=\"Full\",succeeded=\"false\"}",
+          "exemplar": true,
+          "expr": "etcdbr_snapshot_duration_seconds_count{role=\"etcd-main\",kind=\"Full\",succeeded=\"false\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} Failed",
           "metric": "etcdbr_snapshot_duration_seconds_count",
@@ -405,8 +441,8 @@
     },
     {
       "aliasColors": {
-          "Succeeded": "green",
-          "Failed": "red"
+        "Failed": "red",
+        "Succeeded": "green"
       },
       "bars": false,
       "dashLength": 10,
@@ -415,6 +451,12 @@
       "description": "Total number of delta snapshots successfully uploaded to the snapstore, as well as total number of failed attempts for the same, over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -440,9 +482,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -453,8 +496,10 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "etcdbr_snapshot_duration_seconds_count{role=\"main\",kind=\"Incr\",succeeded=\"true\"}",
+          "exemplar": true,
+          "expr": "etcdbr_snapshot_duration_seconds_count{role=\"etcd-main\",kind=\"Incr\",succeeded=\"true\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} Succeeded",
           "metric": "etcdbr_snapshot_duration_seconds_count",
@@ -462,8 +507,10 @@
           "step": 2
         },
         {
-          "expr": "etcdbr_snapshot_duration_seconds_count{role=\"main\",kind=\"Incr\",succeeded=\"false\"}",
+          "exemplar": true,
+          "expr": "etcdbr_snapshot_duration_seconds_count{role=\"etcd-main\",kind=\"Incr\",succeeded=\"false\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} Failed",
           "metric": "etcdbr_snapshot_duration_seconds_count",
@@ -516,8 +563,8 @@
     },
     {
       "aliasColors": {
-          "Succeeded": "green",
-          "Failed": "red"
+        "Failed": "red",
+        "Succeeded": "green"
       },
       "bars": false,
       "dashLength": 10,
@@ -526,6 +573,12 @@
       "description": "Total number of snapshots successfully garbage-collected from the snapstore, as well as total number of failed attempts for the same, over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -551,9 +604,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -564,7 +618,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(etcdbr_snapshot_gc_total{role=\"main\",succeeded=\"true\",kind=~\"Full|Incr\"})",
+          "exemplar": true,
+          "expr": "sum(etcdbr_snapshot_gc_total{role=\"etcd-main\",succeeded=\"true\",kind=~\"Full|Incr\"})",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Succeeded",
           "metric": "etcdbr_snapshot_gc_total",
@@ -572,7 +628,9 @@
           "step": 4
         },
         {
-          "expr": "sum(etcdbr_snapshot_gc_total{role=\"main\",succeeded=\"false\",kind=~\"Full|Incr\"})",
+          "exemplar": true,
+          "expr": "sum(etcdbr_snapshot_gc_total{role=\"etcd-main\",succeeded=\"false\",kind=~\"Full|Incr\"})",
+          "interval": "",
           "legendFormat": "Failed",
           "refId": "B"
         }
@@ -622,8 +680,8 @@
     },
     {
       "aliasColors": {
-          "Succeeded": "green",
-          "Failed": "red"
+        "Failed": "red",
+        "Succeeded": "green"
       },
       "bars": false,
       "dashLength": 10,
@@ -632,6 +690,12 @@
       "description": "Total number of successful and failed attempts to defragment the etcd data store over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -657,9 +721,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -670,8 +735,10 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "etcdbr_defragmentation_duration_seconds_count{role=\"main\",succeeded=\"true\"}",
+          "exemplar": true,
+          "expr": "etcdbr_defragmentation_duration_seconds_count{role=\"etcd-main\",succeeded=\"true\"}",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} Succeeded",
           "metric": "etcdbr_defragmentation_duration_seconds_count",
@@ -679,8 +746,10 @@
           "step": 4
         },
         {
-          "expr": "etcdbr_defragmentation_duration_seconds_count{role=\"main\",succeeded=\"false\"}",
+          "exemplar": true,
+          "expr": "etcdbr_defragmentation_duration_seconds_count{role=\"etcd-main\",succeeded=\"false\"}",
           "instant": false,
+          "interval": "",
           "legendFormat": "{{pod}} Failed",
           "refId": "B"
         }
@@ -737,6 +806,12 @@
       "description": "Duration of taking full and delta snapshots over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -762,9 +837,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -775,9 +851,11 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_snapshot_duration_seconds_bucket{role=\"main\",kind=\"Full\"}[$__rate_interval])) by (le))",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_snapshot_duration_seconds_bucket{role=\"etcd-main\",kind=\"Full\"}[$__rate_interval])) by (le))",
           "hide": false,
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Full",
           "metric": "etcdbr_snapshot_duration_seconds_bucket",
@@ -785,9 +863,11 @@
           "step": 4
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_snapshot_duration_seconds_bucket{role=\"main\",kind=\"Incr\"}[$__rate_interval])) by (le))",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_snapshot_duration_seconds_bucket{role=\"etcd-main\",kind=\"Incr\"}[$__rate_interval])) by (le))",
           "hide": false,
           "instant": false,
+          "interval": "",
           "legendFormat": "Delta",
           "refId": "B"
         }
@@ -837,8 +917,8 @@
     },
     {
       "aliasColors": {
-          "Succeeded": "green",
-          "Failed": "red"
+        "Failed": "red",
+        "Succeeded": "green"
       },
       "bars": false,
       "dashLength": 10,
@@ -847,6 +927,12 @@
       "description": "Total number of successful and failed attempts at etcd data validations over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -872,9 +958,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -885,8 +972,10 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "etcdbr_validation_duration_seconds_count{role=\"main\",succeeded=\"true\"}",
+          "exemplar": true,
+          "expr": "etcdbr_validation_duration_seconds_count{role=\"etcd-main\",succeeded=\"true\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} Succeeded",
           "metric": "etcdbr_validation_duration_seconds_count",
@@ -894,9 +983,11 @@
           "step": 2
         },
         {
-          "expr": "etcdbr_validation_duration_seconds_count{role=\"main\",succeeded=\"false\"}",
+          "exemplar": true,
+          "expr": "etcdbr_validation_duration_seconds_count{role=\"etcd-main\",succeeded=\"false\"}",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} Failed",
           "metric": "etcdbr_validation_duration_seconds_count",
@@ -949,8 +1040,8 @@
     },
     {
       "aliasColors": {
-          "Succeeded": "green",
-          "Failed": "red"
+        "Failed": "red",
+        "Succeeded": "green"
       },
       "bars": false,
       "dashLength": 10,
@@ -959,6 +1050,12 @@
       "description": "Total number of successful and failed attempts at etcd data restorations over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -984,9 +1081,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -997,8 +1095,10 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "etcdbr_restoration_duration_seconds_count{role=\"main\",succeeded=\"true\"}",
+          "exemplar": true,
+          "expr": "etcdbr_restoration_duration_seconds_count{role=\"etcd-main\",succeeded=\"true\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} {{restore}} Succeeded",
           "metric": "etcdbr_restoration_duration_seconds_count",
@@ -1006,9 +1106,11 @@
           "step": 2
         },
         {
-          "expr": "etcdbr_restoration_duration_seconds_count{role=\"main\",succeeded=\"false\"}",
+          "exemplar": true,
+          "expr": "etcdbr_restoration_duration_seconds_count{role=\"etcd-main\",succeeded=\"false\"}",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} {{restore}} Failed",
           "metric": "etcdbr_restoration_duration_seconds_count",
@@ -1082,6 +1184,12 @@
       "description": "Memory consumed by etcd-backup-restore process over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -1107,9 +1215,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1181,6 +1290,12 @@
       "description": "Total CPU usage by etcd-backup-restore process as a percentage of total available CPU to the container, over time.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -1206,9 +1321,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1272,12 +1388,9 @@
       }
     }
   ],
-  "schemaVersion": 21,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": [
-    "controlplane",
-    "seed"
-  ],
+  "tags": ["controlplane", "seed"],
   "templating": {
     "list": []
   },
@@ -1286,16 +1399,7 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h"
-    ],
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"],
     "time_options": [
       "5m",
       "15m",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 9,
-  "iteration": 1542111230310,
+  "id": 11,
+  "iteration": 1722590655607,
   "links": [],
   "panels": [
     {
@@ -70,20 +70,18 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcdbr_cluster_size{job=\"kube-etcd3-backup-restore-$cluster\",pod=~\".*$cluster-$member\"}",
+          "expr": "etcdbr_cluster_size{job=\"kube-etcd3-backup-restore-$role\",pod=~\".*$role-$member\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -131,20 +129,18 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(up{job=\"kube-etcd3-backup-restore-$cluster\"})",
+          "expr": "sum(up{job=\"kube-etcd3-backup-restore-$role\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -191,20 +187,18 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(etcd_server_has_leader{job=\"kube-etcd3-$cluster\"})",
+          "expr": "sum(etcd_server_has_leader{job=\"kube-etcd3-$role\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -284,27 +278,25 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcd_server_is_leader{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}*2 + etcd_server_is_learner{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}",
+          "expr": "etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}*2 + etcd_server_is_learner{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "\"etcd-$cluster-$member\" Membership Status",
+      "title": "\"etcd-$role-$member\" Membership Status",
       "type": "stat"
     },
     {
@@ -366,27 +358,25 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcd_server_has_leader{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}",
+          "expr": "etcd_server_has_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "\"etcd-$cluster-$member\" Member Health Status",
+      "title": "\"etcd-$role-$member\" Member Health Status",
       "type": "stat"
     },
     {
@@ -440,7 +430,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -451,7 +441,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(etcd_server_leader_changes_seen_total{job=\"kube-etcd3-$cluster\"}[1d])",
+          "expr": "increase(etcd_server_leader_changes_seen_total{job=\"kube-etcd3-$role\"}[1d])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -537,7 +527,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -548,7 +538,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_server_heartbeat_send_failures_total{job=\"kube-etcd3-$cluster\"}[$__rate_interval])",
+          "expr": "rate(etcd_server_heartbeat_send_failures_total{job=\"kube-etcd3-$role\"}[$__rate_interval])",
           "instant": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -639,7 +629,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -650,7 +640,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(etcd_server_proposals_failed_total{role=~\"$cluster\"}[$__rate_interval]))",
+          "exemplar": true,
+          "expr": "sum(rate(etcd_server_proposals_failed_total{role=~\"etcd-$role\"}[$__rate_interval]))",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Proposal Failure Rate",
           "metric": "etcd_server_proposals_failed_total",
@@ -658,7 +650,9 @@
           "step": 2
         },
         {
-          "expr": "sum(etcd_server_proposals_pending{role=~\"$cluster\"})",
+          "exemplar": true,
+          "expr": "sum(etcd_server_proposals_pending{role=~\"etcd-$role\"})",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Proposal Pending",
           "metric": "etcd_server_proposals_pending",
@@ -666,7 +660,9 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(etcd_server_proposals_committed_total{role=~\"$cluster\"}[$__rate_interval]))",
+          "exemplar": true,
+          "expr": "sum(rate(etcd_server_proposals_committed_total{role=~\"etcd-$role\"}[$__rate_interval]))",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Proposal Commit Rate",
           "metric": "etcd_server_proposals_committed_total",
@@ -674,7 +670,9 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(etcd_server_proposals_applied_total{role=~\"$cluster\"}[$__rate_interval]))",
+          "exemplar": true,
+          "expr": "sum(rate(etcd_server_proposals_applied_total{role=~\"etcd-$role\"}[$__rate_interval]))",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Proposal Apply Rate",
           "refId": "D",
@@ -702,6 +700,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:118",
           "format": "short",
           "label": "",
           "logBase": 1,
@@ -710,6 +709,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:119",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -760,7 +760,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -771,9 +771,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_add_learner_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$cluster\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_add_learner_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\"}[$__rate_interval])) by (le))",
           "interval": "",
-          "legendFormat": "etcd-$cluster",
+          "legendFormat": "etcd-$role",
           "refId": "A"
         }
       ],
@@ -857,7 +857,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -868,7 +868,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcd_server_learner_promote_successes{job=\"kube-etcd3-$cluster\"}",
+          "expr": "etcd_server_learner_promote_successes{job=\"kube-etcd3-$role\"}",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -954,7 +954,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -965,10 +965,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_member_remove_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$cluster\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_member_remove_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\"}[$__rate_interval])) by (le))",
           "instant": false,
           "interval": "",
-          "legendFormat": "etcd-$cluster",
+          "legendFormat": "etcd-$role",
           "refId": "A"
         }
       ],
@@ -1075,27 +1075,25 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(etcd_network_active_peers{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"})",
+          "expr": "sum(etcd_network_active_peers{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "\"etcd-$cluster-$member\" Active Peers",
+      "title": "\"etcd-$role-$member\" Active Peers",
       "type": "stat"
     },
     {
@@ -1135,7 +1133,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1146,9 +1144,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"kube-etcd3-$cluster\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"kube-etcd3-$role\"}[$__rate_interval])) by (le))",
           "interval": "",
-          "legendFormat": "etcd-$cluster",
+          "legendFormat": "etcd-$role",
           "refId": "A"
         }
       ],
@@ -1232,7 +1230,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1243,7 +1241,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}[5m])",
+          "expr": "rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}[5m])",
           "interval": "",
           "legendFormat": "{{To}}",
           "refId": "A"
@@ -1329,7 +1327,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1340,7 +1338,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}[5m])",
+          "expr": "rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}[5m])",
           "interval": "",
           "legendFormat": "{{From}}",
           "refId": "A"
@@ -1440,7 +1438,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1451,7 +1449,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_server_slow_apply_total{job=\"kube-etcd3-$cluster\"}[$__rate_interval])",
+          "expr": "rate(etcd_server_slow_apply_total{job=\"kube-etcd3-$role\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -1537,7 +1535,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1548,7 +1546,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_server_slow_read_indexes_total{job=\"kube-etcd3-$cluster\"}[$__rate_interval])",
+          "expr": "rate(etcd_server_slow_read_indexes_total{job=\"kube-etcd3-$role\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -1600,16 +1598,13 @@
   ],
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [
-    "controlplane",
-    "seed"
-  ],
+  "tags": ["controlplane", "seed"],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
-          "tags": [],
+          "selected": true,
           "text": "main",
           "value": "main"
         },
@@ -1619,7 +1614,7 @@
         "includeAll": false,
         "label": null,
         "multi": false,
-        "name": "cluster",
+        "name": "role",
         "options": [
           {
             "selected": true,
@@ -1633,6 +1628,7 @@
           }
         ],
         "query": "main, events",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -1679,16 +1675,7 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h"
-    ],
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"],
     "time_options": [
       "5m",
       "15m",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-dashboard.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 29,
-  "iteration": 1720599800346,
+  "iteration": 1722495993188,
   "links": [],
   "panels": [
     {
@@ -103,7 +103,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(etcd_server_has_leader{role=~\"etcd-$cluster\"})",
+          "expr": "sum(etcd_server_has_leader{role=~\"etcd-$role\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -178,7 +178,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(grpc_server_started_total{role=~\"etcd-$cluster\",grpc_type=\"unary\"}[$__rate_interval]))",
+          "expr": "sum(rate(grpc_server_started_total{role=~\"etcd-$role\",grpc_type=\"unary\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -189,7 +189,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(rate(grpc_server_handled_total{role=~\"etcd-$cluster\",grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval]))",
+          "expr": "sum(rate(grpc_server_handled_total{role=~\"etcd-$role\",grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -293,7 +293,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(grpc_server_started_total{role=~\"etcd-$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{role=~\"etcd-$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
+          "expr": "sum(grpc_server_started_total{role=~\"etcd-$role\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{role=~\"etcd-$role\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -304,7 +304,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(grpc_server_started_total{role=~\"etcd-$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{role=~\"etcd-$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
+          "expr": "sum(grpc_server_started_total{role=~\"etcd-$role\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{role=~\"etcd-$role\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -408,7 +408,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "process_resident_memory_bytes{job=\"kube-etcd3-$cluster\"}",
+          "expr": "process_resident_memory_bytes{job=\"kube-etcd3-$role\"}",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} Resident Memory",
@@ -438,7 +438,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:69",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -447,7 +446,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:70",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -514,7 +512,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcd_mvcc_db_total_size_in_bytes{role=~\"etcd-$cluster\"}",
+          "expr": "etcd_mvcc_db_total_size_in_bytes{role=~\"etcd-$role\"}",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -616,7 +614,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{role=~\"etcd-$cluster\"}[$__rate_interval])) by (instance, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{role=~\"etcd-$role\"}[$__rate_interval])) by (instance, le))",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -627,7 +625,7 @@
         },
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{role=~\"etcd-$cluster\"}[$__rate_interval])) by (instance, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{role=~\"etcd-$role\"}[$__rate_interval])) by (instance, le))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} DB fsync",
@@ -728,7 +726,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_network_client_grpc_received_bytes_total{role=~\"etcd-$cluster\"}[$__rate_interval])",
+          "expr": "rate(etcd_network_client_grpc_received_bytes_total{role=~\"etcd-$role\"}[$__rate_interval])",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} Client Traffic In",
@@ -831,7 +829,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_network_client_grpc_sent_bytes_total{role=~\"etcd-$cluster\"}[$__rate_interval])",
+          "expr": "rate(etcd_network_client_grpc_sent_bytes_total{role=~\"etcd-$role\"}[$__rate_interval])",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} Client Traffic Out",
@@ -944,8 +942,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[$__rate_interval])) by(pod, container)",
+          "exemplar": true,
+          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${role:pipe}).*\"}[$__rate_interval])) by(pod, container)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} / {{container}}",
           "refId": "A"
@@ -1040,8 +1040,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[$__rate_interval])) by(pod, container)",
+          "exemplar": true,
+          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${role:pipe}).*\"}[$__rate_interval])) by(pod, container)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} / {{container}}",
           "refId": "A"
@@ -1101,14 +1103,19 @@
           "text": "main",
           "value": "main"
         },
-        "description": "",
+        "description": null,
         "error": null,
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": null,
         "multi": false,
-        "name": "cluster",
+        "name": "role",
         "options": [
+          {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
           {
             "selected": true,
             "text": "main",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-dashboard.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 29,
-  "iteration": 1722495993188,
+  "id": 33,
+  "iteration": 1722523016807,
   "links": [],
   "panels": [
     {
@@ -288,7 +288,7 @@
       "seriesOverrides": [],
       "spaceLength": 10,
       "span": 4,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -335,6 +335,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:126",
           "format": "short",
           "label": "",
           "logBase": 1,
@@ -343,6 +344,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:127",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -438,6 +440,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:178",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -446,6 +449,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:179",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -543,6 +547,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:230",
           "format": "bytes",
           "logBase": 1,
           "max": null,
@@ -550,6 +555,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:231",
           "format": "short",
           "logBase": 1,
           "max": null,
@@ -610,7 +616,7 @@
       "spaceLength": 10,
       "span": 4,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
@@ -655,6 +661,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:278",
           "format": "s",
           "logBase": 1,
           "max": null,
@@ -662,6 +669,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:279",
           "format": "short",
           "logBase": 1,
           "max": null,
@@ -756,6 +764,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:327",
           "format": "Bps",
           "label": null,
           "logBase": 1,
@@ -764,6 +773,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:328",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -971,6 +981,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:380",
           "format": "decbytes",
           "label": "",
           "logBase": 1,
@@ -979,6 +990,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:381",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1069,6 +1081,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:429",
           "format": "decbytes",
           "label": "",
           "logBase": 1,
@@ -1077,6 +1090,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:430",
           "format": "short",
           "label": null,
           "logBase": 1,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-dashboard.json
@@ -1,15 +1,27 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
+  "gnetId": null,
   "graphTooltip": 0,
-  "id": 9,
-  "iteration": 1542111230310,
+  "id": 29,
+  "iteration": 1720599800346,
   "links": [],
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -33,6 +45,10 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -86,8 +102,10 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(etcd_server_has_leader{role=~\"$cluster\"})",
+          "exemplar": true,
+          "expr": "sum(etcd_server_has_leader{role=~\"etcd-$cluster\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
           "metric": "etcd_server_has_leader",
@@ -116,13 +134,19 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 9,
         "x": 5,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 4,
       "isNew": true,
       "legend": {
@@ -138,7 +162,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -149,8 +177,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(grpc_server_started_total{role=~\"$cluster\",grpc_type=\"unary\"}[$__rate_interval]))",
+          "exemplar": true,
+          "expr": "sum(rate(grpc_server_started_total{role=~\"etcd-$cluster\",grpc_type=\"unary\"}[$__rate_interval]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "RPC Rate",
           "metric": "grpc_server_started_total",
@@ -158,8 +188,10 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(grpc_server_handled_total{role=~\"$cluster\",grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval]))",
+          "exemplar": true,
+          "expr": "sum(rate(grpc_server_handled_total{role=~\"etcd-$cluster\",grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "RPC Failed Rate",
           "metric": "grpc_server_handled_total",
@@ -169,6 +201,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "RPC Rate",
       "tooltip": {
@@ -216,13 +249,19 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 10,
         "x": 14,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 6,
       "isNew": true,
       "legend": {
@@ -238,7 +277,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -249,8 +292,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(grpc_server_started_total{role=~\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{role=~\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
+          "exemplar": true,
+          "expr": "sum(grpc_server_started_total{role=~\"etcd-$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{role=~\"etcd-$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Watch Streams",
           "metric": "grpc_server_handled_total",
@@ -258,8 +303,10 @@
           "step": 4
         },
         {
-          "expr": "sum(grpc_server_started_total{role=~\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{role=~\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
+          "exemplar": true,
+          "expr": "sum(grpc_server_started_total{role=~\"etcd-$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{role=~\"etcd-$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Lease Streams",
           "metric": "grpc_server_handled_total",
@@ -269,6 +316,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Active Streams",
       "tooltip": {
@@ -316,13 +364,19 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 8,
         "x": 0,
         "y": 6
       },
+      "hiddenSeries": false,
       "id": 12,
       "isNew": true,
       "legend": {
@@ -338,7 +392,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -349,7 +407,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "process_resident_memory_bytes{job=\"kube-etcd3-$cluster\"}",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} Resident Memory",
           "metric": "process_resident_memory_bytes",
@@ -359,6 +419,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory",
       "tooltip": {
@@ -377,6 +438,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:69",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -385,6 +447,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:70",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -407,7 +470,12 @@
       "decimals": null,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 5,
@@ -415,6 +483,7 @@
         "x": 8,
         "y": 6
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -429,7 +498,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -440,7 +513,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "etcd_mvcc_db_total_size_in_bytes{role=~\"$cluster\"}",
+          "exemplar": true,
+          "expr": "etcd_mvcc_db_total_size_in_bytes{role=~\"etcd-$cluster\"}",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -452,6 +526,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "DB Size",
       "tooltip": {
@@ -497,7 +572,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 5,
@@ -505,6 +585,7 @@
         "x": 16,
         "y": 6
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": false,
@@ -519,7 +600,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -530,8 +615,10 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{role=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{role=~\"etcd-$cluster\"}[$__rate_interval])) by (instance, le))",
           "hide": false,
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} WAL fsync",
           "metric": "etcd_disk_wal_fsync_duration_seconds_bucket",
@@ -539,7 +626,9 @@
           "step": 4
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{role=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{role=~\"etcd-$cluster\"}[$__rate_interval])) by (instance, le))",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} DB fsync",
           "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
@@ -549,6 +638,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Sync Duration",
       "tooltip": {
@@ -594,13 +684,19 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 14,
       "isNew": true,
       "legend": {
@@ -616,7 +712,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -627,7 +727,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(etcd_network_client_grpc_received_bytes_total{role=~\"$cluster\"}[$__rate_interval])",
+          "exemplar": true,
+          "expr": "rate(etcd_network_client_grpc_received_bytes_total{role=~\"etcd-$cluster\"}[$__rate_interval])",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} Client Traffic In",
           "metric": "etcd_network_client_grpc_received_bytes_total",
@@ -637,6 +739,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Client Traffic In",
       "tooltip": {
@@ -684,13 +787,19 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 16,
       "isNew": true,
       "legend": {
@@ -706,7 +815,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -717,7 +830,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(etcd_network_client_grpc_sent_bytes_total{role=~\"$cluster\"}[$__rate_interval])",
+          "exemplar": true,
+          "expr": "rate(etcd_network_client_grpc_sent_bytes_total{role=~\"etcd-$cluster\"}[$__rate_interval])",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} Client Traffic Out",
           "metric": "etcd_network_client_grpc_sent_bytes_total",
@@ -727,6 +842,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Client Traffic Out",
       "tooltip": {
@@ -768,6 +884,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -786,13 +903,19 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "One minute rates for all filesystem read operations executed within the container(s).\n\nThe data has the following designation scheme: <pod-name> / <container-name>",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 12,
         "x": 0,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 33,
       "legend": {
         "avg": false,
@@ -807,11 +930,16 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
+      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
@@ -825,6 +953,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Container Disk Read Operations (2m rate)",
       "tooltip": {
@@ -870,13 +999,19 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "One minute rates for all filesystem write operations executed within the container(s).\n\nThe data has the following designation scheme: <pod-name> / <container-name>",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 12,
         "x": 12,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 34,
       "legend": {
         "avg": false,
@@ -891,11 +1026,16 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.32",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
+      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
@@ -909,6 +1049,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Container Disk Write Operations (2m rate)",
       "tooltip": {
@@ -948,32 +1089,26 @@
       }
     }
   ],
-  "schemaVersion": 16,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": [
-    "controlplane",
-    "seed"
-  ],
+  "tags": ["controlplane", "seed"],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
-          "tags": [],
+          "selected": true,
           "text": "main",
           "value": "main"
         },
+        "description": "",
+        "error": null,
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "label": null,
         "multi": false,
         "name": "cluster",
         "options": [
-          {
-            "selected": false,
-            "text": "All",
-            "value": "$__all"
-          },
           {
             "selected": true,
             "text": "main",
@@ -986,6 +1121,7 @@
           }
         ],
         "query": "main, events",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       }
@@ -996,16 +1132,7 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h"
-    ],
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"],
     "time_options": [
       "5m",
       "15m",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
Three etcd dashboards were broken because the label values on etcd metrics had changed: From `role: <main/events>` to `role: etcd-<main/events>`. I also took the liberty of renaming the `$cluster` variable to be in line with the label name.

For the decision to un-stack and un-staircase various panels, I've attached some screenshots for easier comparison:
<details>
<summary>etcd dashboard</summary>

![Screenshot 2024-08-01 at 16 45 38](https://github.com/user-attachments/assets/38ccf20a-836a-4331-b854-42d670a7f3b0)  ![Screenshot 2024-08-01 at 16 45 32](https://github.com/user-attachments/assets/2ae8fc47-2ed1-42cd-a37c-12e5f3235330)

</details>

<details>
<summary>etcd backup/restore dashboard</summary>

![Screenshot 2024-08-01 at 16 45 48](https://github.com/user-attachments/assets/ebd9cd5d-b8ef-48ac-bf69-920432117100)
![Screenshot 2024-08-01 at 16 44 46](https://github.com/user-attachments/assets/00051abf-bfcd-4547-9ac5-12fbca87d97e)

</details>

<details>
<summary>etcd cluster details dashboard</summary>

![Screenshot 2024-08-02 at 13 38 20](https://github.com/user-attachments/assets/b948200f-1988-4201-83a2-dfc40f564c2b)
![Screenshot 2024-08-02 at 13 38 06](https://github.com/user-attachments/assets/99003ea6-0243-4622-9b3c-de6e373f9311)


</details>




**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @gardener/monitoring-maintainers 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user bugfix
The 'etcd', 'etcd backup/restore', and 'etcd cluster details' dashboards now display data again.
```
