### PR TITLE
Shoot specification: require `clientID` and `issuerURL` when setting `oidcConfig`

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1284,7 +1284,7 @@ spec:
                                 type: object
                               clientID:
                                 description: The client ID for the OpenID Connect
-                                  client, must be set if oidc-issuer-url is set.
+                                  client, must be set.
                                 type: string
                               groupsClaim:
                                 description: If provided, the name of a custom OpenID
@@ -1300,8 +1300,8 @@ spec:
                                 type: string
                               issuerURL:
                                 description: The URL of the OpenID issuer, only HTTPS
-                                  scheme will be accepted. If set, it will be used
-                                  to verify the OIDC JSON Web Token (JWT).
+                                  scheme will be accepted. Used to verify the OIDC
+                                  JSON Web Token (JWT).
                                 type: string
                               requiredClaims:
                                 additionalProperties:

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8694,7 +8694,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.</p>
+<p>The client ID for the OpenID Connect client, must be set.</p>
 </td>
 </tr>
 <tr>
@@ -8730,7 +8730,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).</p>
+<p>The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).</p>
 </td>
 </tr>
 <tr>

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1284,7 +1284,7 @@ spec:
                                 type: object
                               clientID:
                                 description: The client ID for the OpenID Connect
-                                  client, must be set if oidc-issuer-url is set.
+                                  client, must be set.
                                 type: string
                               groupsClaim:
                                 description: If provided, the name of a custom OpenID
@@ -1300,8 +1300,8 @@ spec:
                                 type: string
                               issuerURL:
                                 description: The URL of the OpenID issuer, only HTTPS
-                                  scheme will be accepted. If set, it will be used
-                                  to verify the OIDC JSON Web Token (JWT).
+                                  scheme will be accepted. Used to verify the OIDC
+                                  JSON Web Token (JWT).
                                 type: string
                               requiredClaims:
                                 additionalProperties:

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -679,13 +679,13 @@ type OIDCConfig struct {
 	CABundle *string
 	// ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
 	ClientAuthentication *OpenIDConnectClientAuthentication
-	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+	// The client ID for the OpenID Connect client, must be set.
 	ClientID *string
 	// If provided, the name of a custom OpenID Connect claim for specifying user groups. The claim value is expected to be a string or array of strings. This flag is experimental, please see the authentication documentation for further details.
 	GroupsClaim *string
 	// If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.
 	GroupsPrefix *string
-	// The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+	// The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).
 	IssuerURL *string
 	// key=value pairs that describes a required claim in the ID Token. If set, the claim is verified to be present in the ID Token with a matching value.
 	RequiredClaims map[string]string

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2003,7 +2003,7 @@ message OIDCConfig {
   // +optional
   optional OpenIDConnectClientAuthentication clientAuthentication = 2;
 
-  // The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+  // The client ID for the OpenID Connect client, must be set.
   // +optional
   optional string clientID = 3;
 
@@ -2015,7 +2015,7 @@ message OIDCConfig {
   // +optional
   optional string groupsPrefix = 5;
 
-  // The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+  // The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).
   // +optional
   optional string issuerURL = 6;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -881,7 +881,7 @@ type OIDCConfig struct {
 	// ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
 	// +optional
 	ClientAuthentication *OpenIDConnectClientAuthentication `json:"clientAuthentication,omitempty" protobuf:"bytes,2,opt,name=clientAuthentication"`
-	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+	// The client ID for the OpenID Connect client, must be set.
 	// +optional
 	ClientID *string `json:"clientID,omitempty" protobuf:"bytes,3,opt,name=clientID"`
 	// If provided, the name of a custom OpenID Connect claim for specifying user groups. The claim value is expected to be a string or array of strings. This flag is experimental, please see the authentication documentation for further details.
@@ -890,7 +890,7 @@ type OIDCConfig struct {
 	// If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.
 	// +optional
 	GroupsPrefix *string `json:"groupsPrefix,omitempty" protobuf:"bytes,5,opt,name=groupsPrefix"`
-	// The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+	// The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).
 	// +optional
 	IssuerURL *string `json:"issuerURL,omitempty" protobuf:"bytes,6,opt,name=issuerURL"`
 	// key=value pairs that describes a required claim in the ID Token. If set, the claim is verified to be present in the ID Token with a matching value.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -887,10 +887,6 @@ func validateKubernetesForWorkerlessShoot(kubernetes core.Kubernetes, fldPath *f
 	return allErrs
 }
 
-func fieldNilOrEmptyString(field *string) bool {
-	return field == nil || len(*field) == 0
-}
-
 func validateNetworking(networking *core.Networking, workerless bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -1264,22 +1260,16 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 	if oidc := kubeAPIServer.OIDCConfig; oidc != nil {
 		oidcPath := fldPath.Child("oidcConfig")
 
-		if fieldNilOrEmptyString(oidc.ClientID) {
-			if oidc.ClientID != nil {
-				allErrs = append(allErrs, field.Invalid(oidcPath.Child("clientID"), oidc.ClientID, "clientID cannot be empty when key is provided"))
-			}
-			if !fieldNilOrEmptyString(oidc.IssuerURL) {
-				allErrs = append(allErrs, field.Invalid(oidcPath.Child("clientID"), oidc.ClientID, "clientID must be set when issuerURL is provided"))
-			}
+		if oidc.ClientID == nil {
+			allErrs = append(allErrs, field.Required(oidcPath.Child("clientID"), "clientID must be set when oidcConfig is provided"))
+		} else if len(*oidc.ClientID) == 0 {
+			allErrs = append(allErrs, field.Required(oidcPath.Child("clientID"), "clientID cannot be empty"))
 		}
 
-		if fieldNilOrEmptyString(oidc.IssuerURL) {
-			if oidc.IssuerURL != nil {
-				allErrs = append(allErrs, field.Invalid(oidcPath.Child("issuerURL"), oidc.IssuerURL, "issuerURL cannot be empty when key is provided"))
-			}
-			if !fieldNilOrEmptyString(oidc.ClientID) {
-				allErrs = append(allErrs, field.Invalid(oidcPath.Child("issuerURL"), oidc.IssuerURL, "issuerURL must be set when clientID is provided"))
-			}
+		if oidc.IssuerURL == nil {
+			allErrs = append(allErrs, field.Required(oidcPath.Child("issuerURL"), "issuerURL must be set when oidcConfig is provided"))
+		} else if len(*oidc.IssuerURL) == 0 {
+			allErrs = append(allErrs, field.Required(oidcPath.Child("issuerURL"), "issuerURL cannot be empty"))
 		} else {
 			issuer, err := url.Parse(*oidc.IssuerURL)
 			if err != nil || (issuer != nil && len(issuer.Host) == 0) {

--- a/pkg/apis/operator/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation_test.go
@@ -1645,7 +1645,14 @@ var _ = Describe("Validation Tests", func() {
 
 						It("should not complain when OIDC config is configured in both gardener-dashboard and kube-apiserver config", func() {
 							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{}}
-							garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{OIDCConfig: &gardencorev1beta1.OIDCConfig{}}}
+							garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{
+								KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{
+									OIDCConfig: &gardencorev1beta1.OIDCConfig{
+										ClientID:  ptr.To("someClientID"),
+										IssuerURL: ptr.To("https://issuer.com"),
+									},
+								},
+							}
 
 							Expect(ValidateGarden(garden)).To(BeEmpty())
 						})

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -6092,7 +6092,7 @@ func schema_pkg_apis_core_v1beta1_OIDCConfig(ref common.ReferenceCallback) commo
 					},
 					"clientID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.",
+							Description: "The client ID for the OpenID Connect client, must be set.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6113,7 +6113,7 @@ func schema_pkg_apis_core_v1beta1_OIDCConfig(ref common.ReferenceCallback) commo
 					},
 					"issuerURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).",
+							Description: "The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in the `Shoot` spec which allowed configuring the `spec.kubernetes.kubeAPIServer.oidcConfig` field with setting which would cause the `kube-apiserver` to be stuck in `Error` state.

All setting in `oidcConfig` are set as `--oidc-*` flags in the `kube-apiserver` [ref](https://github.com/gardener/gardener/blob/d17322a5ff9f960aac1e1236dd2ea327353dcbb7/pkg/component/kubernetes/apiserver/deployment.go#L891-L947) (except for `spec.kubernetes.kubeAPIServer.oidcConfig.clientAuthentication` which does not have any use [#1433](https://github.com/gardener/gardener/issues/1433)). However, setting any `--oidc-*` flag without setting `oidc-issuer-url` and `oidc-client-id` would [lead to an error](https://github.com/kubernetes/kubernetes/blob/4e4a18878ce330fefda1dc46acca88ba355e9ce7/pkg/kubeapiserver/options/authentication.go#L664-L666).

This PR improves the validation of `spec.kubernetes.kubeAPIServer.oidcConfig` by validating that `issuerURL` and `clientID` are also set when `oidcConfig` is set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which was allowing users to set `Shoot` oidc configurations for the `kube-apiserver` without setting the `issuerURL` and `clientID` fields in `spec.kubernetes.kubeAPIServer.oidcConfig`, which would lead to the `kube-apiserver` stuck in a `Error` state.
```
