### PR TITLE
Deprecate `Shoot`'s `.oidcConfig.clientAuthentication` field

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1267,8 +1267,11 @@ spec:
                                   be used.
                                 type: string
                               clientAuthentication:
-                                description: ClientAuthentication can optionally contain
-                                  client configuration used for kubeconfig generation.
+                                description: |-
+                                  ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+                                  Deprecated: This field has no implemented use.
+                                  It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+                                  TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
                                 properties:
                                   extraConfig:
                                     additionalProperties:

--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1269,9 +1269,9 @@ spec:
                               clientAuthentication:
                                 description: |-
                                   ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
-                                  Deprecated: This field has no implemented use.
+                                  Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
                                   It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
-                                  TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
+                                  TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
                                 properties:
                                   extraConfig:
                                     additionalProperties:

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8538,7 +8538,10 @@ OpenIDConnectClientAuthentication
 </td>
 <td>
 <em>(Optional)</em>
-<p>ClientAuthentication can optionally contain client configuration used for kubeconfig generation.</p>
+<p>ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+Deprecated: This field has no implemented use.
+It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
+TODO(AleksandarSavchev): Drop this field after v1.102 has been released.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8539,9 +8539,9 @@ OpenIDConnectClientAuthentication
 <td>
 <em>(Optional)</em>
 <p>ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
-Deprecated: This field has no implemented use.
+Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
 It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
-TODO(AleksandarSavchev): Drop this field after v1.102 has been released.</p>
+TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/settings.md
+++ b/docs/api-reference/settings.md
@@ -201,7 +201,10 @@ OpenIDConnectClientAuthentication
 <p>Client contains the configuration used for client OIDC authentication
 of Shoot clusters.
 This configuration is not overwriting any existing OpenID Connect
-client authentication already set on the Shoot object.</p>
+client authentication already set on the Shoot object.
+Deprecated: The OpenID Connect configuration this field specifies is not used.
+It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
+TODO(AleksandarSavchev): Drop this field after v1.102 has been released.</p>
 </td>
 </tr>
 <tr>
@@ -515,7 +518,10 @@ OpenIDConnectClientAuthentication
 <p>Client contains the configuration used for client OIDC authentication
 of Shoot clusters.
 This configuration is not overwriting any existing OpenID Connect
-client authentication already set on the Shoot object.</p>
+client authentication already set on the Shoot object.
+Deprecated: The OpenID Connect configuration this field specifies is not used.
+It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
+TODO(AleksandarSavchev): Drop this field after v1.102 has been released.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/settings.md
+++ b/docs/api-reference/settings.md
@@ -202,9 +202,9 @@ OpenIDConnectClientAuthentication
 of Shoot clusters.
 This configuration is not overwriting any existing OpenID Connect
 client authentication already set on the Shoot object.
-Deprecated: The OpenID Connect configuration this field specifies is not used.
+Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
 It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
-TODO(AleksandarSavchev): Drop this field after v1.102 has been released.</p>
+TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.</p>
 </td>
 </tr>
 <tr>
@@ -519,9 +519,9 @@ OpenIDConnectClientAuthentication
 of Shoot clusters.
 This configuration is not overwriting any existing OpenID Connect
 client authentication already set on the Shoot object.
-Deprecated: The OpenID Connect configuration this field specifies is not used.
+Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
 It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
-TODO(AleksandarSavchev): Drop this field after v1.102 has been released.</p>
+TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.</p>
 </td>
 </tr>
 <tr>

--- a/docs/usage/openidconnect-presets.md
+++ b/docs/usage/openidconnect-presets.md
@@ -56,11 +56,6 @@ spec:
     - RS256
     requiredClaims:
       key: value
-  client:
-    secret: oidc-client-secret
-    extraConfig:
-      extra-scopes: "email,offline_access,profile"
-      foo: bar
   weight: 90
 ```
 
@@ -119,11 +114,6 @@ spec:
   kubernetes:
     kubeAPIServer:
       oidcConfig:
-        clientAuthentication:
-          extraConfig:
-            extra-scopes: email,offline_access,profile
-            foo: bar
-          secret: oidc-client-secret
         clientID: test-1
         groupsClaim: groups-claim
         groupsPrefix: groups-prefix
@@ -200,11 +190,6 @@ spec:
     - RS256
     requiredClaims:
       key: value
-  client:
-    secret: oidc-client-secret
-    extraConfig:
-      extra-scopes: "email,offline_access,profile"
-      foo: bar
   weight: 90
 ```
 
@@ -261,11 +246,6 @@ spec:
   kubernetes:
     kubeAPIServer:
       oidcConfig:
-        clientAuthentication:
-          extraConfig:
-            extra-scopes: email,offline_access,profile
-            foo: bar
-          secret: oidc-client-secret
         clientID: cluster-preset
         groupsClaim: groups-claim
         groupsPrefix: groups-prefix

--- a/example/10-clusteropenidconnectpreset.yaml
+++ b/example/10-clusteropenidconnectpreset.yaml
@@ -26,9 +26,4 @@ spec:
     # - RS256
     # requiredClaims:
     #   key: value
-  client:
-    secret: oidc-client-secret
-    extraConfig:
-      extra-scopes: email,offline_access,profile
-      foo: bar
   weight: 90 # value from 1 to 100

--- a/example/10-openidconnectpreset.yaml
+++ b/example/10-openidconnectpreset.yaml
@@ -24,9 +24,4 @@ spec:
     # - RS256
     # requiredClaims:
     #   key: value
-  client:
-    secret: oidc-client-secret
-    extraConfig:
-      extra-scopes: email,offline_access,profile
-      foo: bar
   weight: 90 # value from 1 to 100

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1267,8 +1267,11 @@ spec:
                                   be used.
                                 type: string
                               clientAuthentication:
-                                description: ClientAuthentication can optionally contain
-                                  client configuration used for kubeconfig generation.
+                                description: |-
+                                  ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+                                  Deprecated: This field has no implemented use.
+                                  It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+                                  TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
                                 properties:
                                   extraConfig:
                                     additionalProperties:

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1269,9 +1269,9 @@ spec:
                               clientAuthentication:
                                 description: |-
                                   ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
-                                  Deprecated: This field has no implemented use.
+                                  Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
                                   It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
-                                  TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
+                                  TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
                                 properties:
                                   extraConfig:
                                     additionalProperties:

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -678,9 +678,9 @@ type OIDCConfig struct {
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.
 	CABundle *string
 	// ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
-	// Deprecated: This field has no implemented use.
+	// Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
-	// TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
+	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
 	ClientAuthentication *OpenIDConnectClientAuthentication
 	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
 	ClientID *string

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -678,6 +678,9 @@ type OIDCConfig struct {
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.
 	CABundle *string
 	// ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+	// Deprecated: This field has no implemented use.
+	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+	// TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
 	ClientAuthentication *OpenIDConnectClientAuthentication
 	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
 	ClientID *string

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1972,6 +1972,9 @@ message OIDCConfig {
   optional string caBundle = 1;
 
   // ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+  // Deprecated: This filed has no implemented use.
+  // It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+  // TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
   // +optional
   optional OpenIDConnectClientAuthentication clientAuthentication = 2;
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1972,9 +1972,9 @@ message OIDCConfig {
   optional string caBundle = 1;
 
   // ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
-  // Deprecated: This field has no implemented use.
+  // Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
   // It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
-  // TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
+  // TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
   // +optional
   optional OpenIDConnectClientAuthentication clientAuthentication = 2;
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1972,7 +1972,7 @@ message OIDCConfig {
   optional string caBundle = 1;
 
   // ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
-  // Deprecated: This filed has no implemented use.
+  // Deprecated: This field has no implemented use.
   // It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
   // TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
   // +optional

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -879,9 +879,9 @@ type OIDCConfig struct {
 	// +optional
 	CABundle *string `json:"caBundle,omitempty" protobuf:"bytes,1,opt,name=caBundle"`
 	// ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
-	// Deprecated: This field has no implemented use.
+	// Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
-	// TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
+	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
 	// +optional
 	ClientAuthentication *OpenIDConnectClientAuthentication `json:"clientAuthentication,omitempty" protobuf:"bytes,2,opt,name=clientAuthentication"`
 	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -879,6 +879,9 @@ type OIDCConfig struct {
 	// +optional
 	CABundle *string `json:"caBundle,omitempty" protobuf:"bytes,1,opt,name=caBundle"`
 	// ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+	// Deprecated: This field has no implemented use.
+	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+	// TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
 	// +optional
 	ClientAuthentication *OpenIDConnectClientAuthentication `json:"clientAuthentication,omitempty" protobuf:"bytes,2,opt,name=clientAuthentication"`
 	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1295,6 +1295,11 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 				allErrs = append(allErrs, field.Invalid(oidcPath.Child("caBundle"), *oidc.CABundle, "caBundle is not a valid PEM-encoded certificate"))
 			}
 		}
+		// TODO(AleksandarSavchev): Remove this check as soon as v1.31 is the least supported Kubernetes version in Gardener.
+		k8sGreaterEqual131, _ := versionutils.CheckVersionMeetsConstraint(version, ">= 1.31")
+		if oidc.ClientAuthentication != nil && k8sGreaterEqual131 {
+			allErrs = append(allErrs, field.Invalid(oidcPath.Child("clientAuthentication"), *oidc.ClientAuthentication, "for Kubernetes versions >= 1.31, clientAuthentication field is no longer supported"))
+		}
 		if oidc.GroupsClaim != nil && len(*oidc.GroupsClaim) == 0 {
 			allErrs = append(allErrs, field.Invalid(oidcPath.Child("groupsClaim"), *oidc.GroupsClaim, "groupsClaim cannot be empty when key is provided"))
 		}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1851,6 +1851,19 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Entry("should add error if issuerURL is set but clientID is nil", 1, nil),
 					Entry("should add error if issuerURL is set but clientID is empty string ", 2, ptr.To("")),
 				)
+
+				It("should forbid setting clinetAuthentication from kubernetes version 1.31", func() {
+					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.ClientAuthentication = &core.OpenIDConnectClientAuthentication{}
+					shoot.Spec.Kubernetes.Version = "1.31"
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(HaveLen(1))
+					Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.kubernetes.kubeAPIServer.oidcConfig.clientAuthentication"),
+					}))
+				})
 			})
 
 			Context("admission plugin validation", func() {

--- a/pkg/apis/settings/types_shared.go
+++ b/pkg/apis/settings/types_shared.go
@@ -21,6 +21,9 @@ type OpenIDConnectPresetSpec struct {
 	// of Shoot clusters.
 	// This configuration is not overwriting any existing OpenID Connect
 	// client authentication already set on the Shoot object.
+	// Deprecated: The OpenID Connect configuration this field specifies is not used.
+	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+	// TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
 	Client *OpenIDConnectClientAuthentication
 
 	// ShootSelector decides whether to apply the configuration if the

--- a/pkg/apis/settings/types_shared.go
+++ b/pkg/apis/settings/types_shared.go
@@ -21,9 +21,9 @@ type OpenIDConnectPresetSpec struct {
 	// of Shoot clusters.
 	// This configuration is not overwriting any existing OpenID Connect
 	// client authentication already set on the Shoot object.
-	// Deprecated: The OpenID Connect configuration this field specifies is not used.
+	// Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
-	// TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
+	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
 	Client *OpenIDConnectClientAuthentication
 
 	// ShootSelector decides whether to apply the configuration if the

--- a/pkg/apis/settings/v1alpha1/generated.proto
+++ b/pkg/apis/settings/v1alpha1/generated.proto
@@ -135,6 +135,9 @@ message OpenIDConnectPresetSpec {
   // of Shoot clusters.
   // This configuration is not overwriting any existing OpenID Connect
   // client authentication already set on the Shoot object.
+  // Deprecated: The OpenID Connect configuration this filed specifies is not used.
+  // It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+  // TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
   // +optional
   optional OpenIDConnectClientAuthentication client = 2;
 

--- a/pkg/apis/settings/v1alpha1/generated.proto
+++ b/pkg/apis/settings/v1alpha1/generated.proto
@@ -135,9 +135,9 @@ message OpenIDConnectPresetSpec {
   // of Shoot clusters.
   // This configuration is not overwriting any existing OpenID Connect
   // client authentication already set on the Shoot object.
-  // Deprecated: The OpenID Connect configuration this field specifies is not used.
+  // Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
   // It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
-  // TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
+  // TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
   // +optional
   optional OpenIDConnectClientAuthentication client = 2;
 

--- a/pkg/apis/settings/v1alpha1/generated.proto
+++ b/pkg/apis/settings/v1alpha1/generated.proto
@@ -135,7 +135,7 @@ message OpenIDConnectPresetSpec {
   // of Shoot clusters.
   // This configuration is not overwriting any existing OpenID Connect
   // client authentication already set on the Shoot object.
-  // Deprecated: The OpenID Connect configuration this filed specifies is not used.
+  // Deprecated: The OpenID Connect configuration this field specifies is not used.
   // It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
   // TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
   // +optional

--- a/pkg/apis/settings/v1alpha1/types_shared.go
+++ b/pkg/apis/settings/v1alpha1/types_shared.go
@@ -28,6 +28,9 @@ type OpenIDConnectPresetSpec struct {
 	// of Shoot clusters.
 	// This configuration is not overwriting any existing OpenID Connect
 	// client authentication already set on the Shoot object.
+	// Deprecated: The OpenID Connect configuration this field specifies is not used.
+	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+	// TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
 	// +optional
 	Client *OpenIDConnectClientAuthentication `json:"client,omitempty" protobuf:"bytes,2,opt,name=client"`
 

--- a/pkg/apis/settings/v1alpha1/types_shared.go
+++ b/pkg/apis/settings/v1alpha1/types_shared.go
@@ -28,9 +28,9 @@ type OpenIDConnectPresetSpec struct {
 	// of Shoot clusters.
 	// This configuration is not overwriting any existing OpenID Connect
 	// client authentication already set on the Shoot object.
-	// Deprecated: The OpenID Connect configuration this field specifies is not used.
+	// Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
-	// TODO(AleksandarSavchev): Drop this field after v1.102 has been released.
+	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
 	// +optional
 	Client *OpenIDConnectClientAuthentication `json:"client,omitempty" protobuf:"bytes,2,opt,name=client"`
 

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -5995,7 +5995,7 @@ func schema_pkg_apis_core_v1beta1_OIDCConfig(ref common.ReferenceCallback) commo
 					},
 					"clientAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClientAuthentication can optionally contain client configuration used for kubeconfig generation.",
+							Description: "ClientAuthentication can optionally contain client configuration used for kubeconfig generation. Deprecated: This filed has no implemented use. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.OpenIDConnectClientAuthentication"),
 						},
 					},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -5995,7 +5995,7 @@ func schema_pkg_apis_core_v1beta1_OIDCConfig(ref common.ReferenceCallback) commo
 					},
 					"clientAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClientAuthentication can optionally contain client configuration used for kubeconfig generation. Deprecated: This field has no implemented use. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "ClientAuthentication can optionally contain client configuration used for kubeconfig generation. Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.OpenIDConnectClientAuthentication"),
 						},
 					},
@@ -11599,7 +11599,7 @@ func schema_pkg_apis_settings_v1alpha1_ClusterOpenIDConnectPresetSpec(ref common
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this field specifies is not used. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},
@@ -11875,7 +11875,7 @@ func schema_pkg_apis_settings_v1alpha1_OpenIDConnectPresetSpec(ref common.Refere
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this field specifies is not used. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -5995,7 +5995,7 @@ func schema_pkg_apis_core_v1beta1_OIDCConfig(ref common.ReferenceCallback) commo
 					},
 					"clientAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClientAuthentication can optionally contain client configuration used for kubeconfig generation. Deprecated: This filed has no implemented use. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "ClientAuthentication can optionally contain client configuration used for kubeconfig generation. Deprecated: This field has no implemented use. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.OpenIDConnectClientAuthentication"),
 						},
 					},
@@ -11599,7 +11599,7 @@ func schema_pkg_apis_settings_v1alpha1_ClusterOpenIDConnectPresetSpec(ref common
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this filed specifies is not used. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this field specifies is not used. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},
@@ -11875,7 +11875,7 @@ func schema_pkg_apis_settings_v1alpha1_OpenIDConnectPresetSpec(ref common.Refere
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this filed specifies is not used. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this field specifies is not used. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -11599,7 +11599,7 @@ func schema_pkg_apis_settings_v1alpha1_ClusterOpenIDConnectPresetSpec(ref common
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object.",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this filed specifies is not used. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},
@@ -11875,7 +11875,7 @@ func schema_pkg_apis_settings_v1alpha1_OpenIDConnectPresetSpec(ref common.Refere
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object.",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this filed specifies is not used. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
This PR deprecates the unused field `spec.kubernetes.kubeAPIServer.oidcConfig.clientAuthentication` from the `Shoot` specification. The field was added 5 years ago in [this PR](https://github.com/gardener/gardener/pull/1394), its use was planned to be followed by #1433, which has been closed for 3 years.

This PR also deprecates the respective fields in the `OpenIDConnectPreset` and `ClusterOpenIDConnectPreset` API.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The `spec.kubernetes.kubeAPIServer.oidcConfig.clientAuthentication` field in the `Shoot` API is deprecated and will be removed after support for Kubernetes 1.30 is dropped.
```
```noteworthy user
The `spec.client` field in the `{Cluster}OpenIDConnectPreset` APIs is deprecated and will be removed after support for Kubernetes 1.30 is dropped.
```