### PR TITLE
[extensions] Add option to disable all webhooks

### DIFF
--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -90,8 +90,12 @@ func (w *ServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&w.Namespace, NamespaceFlag, w.Namespace, "The webhook config namespace for 'service' mode.")
 }
 
-// DisableFlag is the name of the command line flag to disable individual webhooks.
-const DisableFlag = "disable-webhooks"
+const (
+	// DisableFlag is the name of the command line flag to disable individual webhooks.
+	DisableFlag = "disable-webhooks"
+	// disableAllWildcard is the wildcard to disable all webhooks.
+	disableAllWildcard = "*"
+)
 
 // NameToFactory binds a specific name to a webhook's factory function.
 type NameToFactory struct {
@@ -123,6 +127,9 @@ func (w *SwitchOptions) AddFlags(fs *pflag.FlagSet) {
 func (w *SwitchOptions) Complete() error {
 	disabled := sets.New[string]()
 	for _, disabledName := range w.Disabled {
+		if disabledName == disableAllWildcard {
+			return nil
+		}
 		if _, ok := w.nameToWebhookFactory[disabledName]; !ok {
 			return fmt.Errorf("cannot disable unknown webhook %q", disabledName)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR adds support for disabling all extension webhooks via `--disable-webhooks="*"`.  This is required as part of #9635, where we plan to disable all webhooks for provider extensions which are responsible for resources of the `garden` cluster. It becomes particularly important when the Garden-Runtime cluster is registered as Seed.

**Which issue(s) this PR fixes**:
Part of #9635

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
A wildcard option was added to the [SwitchOptions](https://github.com/gardener/gardener/blob/d810cfcdc030f0ff8dcb952c6a12f4fdc16dc290/extensions/pkg/webhook/cmd/options.go#L103) to disable all webhooks at once via `--disable-webhooks="*"`
```
