### PR TITLE
Tag images with `garden.local.gardener.cloud` instead of `localhost` for local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
-gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export SKAFFOLD_DEFAULT_REPO = localhost:5001
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export SKAFFOLD_PUSH = true
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export SOURCE_DATE_EPOCH = $(shell date -d $(BUILD_DATE) +%s)
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export GARDENER_VERSION = $(VERSION)

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -50,7 +50,10 @@ All of the following steps assume that you are using this kubeconfig.
 
 Additionally, this command also deploys a local container registry to the cluster, as well as a few registry mirrors, that are set up as a pull-through cache for all upstream registries Gardener uses by default.
 This is done to speed up image pulls across local clusters.
-The local registry can be accessed as `garden.local.gardener.cloud:5001` for pushing and pulling.
+
+> You will need to add `127.0.0.1 garden.local.gardener.cloud` to your /etc/hosts.
+
+The local registry can now be accessed either via `localhost:5001` or `garden.local.gardener.cloud:5001` for pushing and pulling.
 The storage directories of the registries are mounted to the host machine under `dev/local-registry`.
 With this, mirrored images don't have to be pulled again after recreating the cluster.
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -50,7 +50,7 @@ All of the following steps assume that you are using this kubeconfig.
 
 Additionally, this command also deploys a local container registry to the cluster, as well as a few registry mirrors, that are set up as a pull-through cache for all upstream registries Gardener uses by default.
 This is done to speed up image pulls across local clusters.
-The local registry can be accessed as `localhost:5001` for pushing and pulling.
+The local registry can be accessed as `garden.local.gardener.cloud:5001` for pushing and pulling.
 The storage directories of the registries are mounted to the host machine under `dev/local-registry`.
 With this, mirrored images don't have to be pulled again after recreating the cluster.
 
@@ -66,7 +66,7 @@ First, ensure that your `/etc/hosts` file contains an entry resolving `localhost
 ```
 
 Typically, only `ip6-localhost` is mapped to `::1` on linux machines.
-However, we need `localhost` to resolve to both `127.0.0.1` and `::1` so that we can talk to our registry via a single address (`localhost:5001`).
+However, we need `garden.local.gardener.cloud` to resolve to both `127.0.0.1` and `::1` so that we can talk to our registry via a single address (`garden.local.gardener.cloud:5001`).
 
 Next, we need to configure NAT for outgoing traffic from the kind network to the internet.
 After executing `make kind-up IPFAMILY=ipv6`, execute the following command to set up the corresponding iptables rules:

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -37,6 +37,8 @@ In these cases, you might want to check out one of the following options that ru
 
 ```bash
 make kind-up
+```
+
 > If you want to setup an IPv6 KinD cluster, use `make kind-up IPFAMILY=ipv6` instead.
 
 This command sets up a new KinD cluster named `gardener-local` and stores the kubeconfig in the `./example/gardener-local/kind/local/kubeconfig` file.

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -37,8 +37,6 @@ In these cases, you might want to check out one of the following options that ru
 
 ```bash
 make kind-up
-```
-
 > If you want to setup an IPv6 KinD cluster, use `make kind-up IPFAMILY=ipv6` instead.
 
 This command sets up a new KinD cluster named `gardener-local` and stores the kubeconfig in the `./example/gardener-local/kind/local/kubeconfig` file.
@@ -62,10 +60,10 @@ Furthermore, it deploys the [metrics-server](https://github.com/kubernetes-sigs/
 
 ## Setting Up IPv6 Single-Stack Networking (optional)
 
-First, ensure that your `/etc/hosts` file contains an entry resolving `localhost` to the IPv6 loopback address:
+First, ensure that your `/etc/hosts` file contains an entry resolving `garden.local.gardener.cloud` to the IPv6 loopback address:
 
 ```text
-::1 localhost
+::1 garden.local.gardener.cloud
 ```
 
 Typically, only `ip6-localhost` is mapped to `::1` on linux machines.

--- a/docs/deployment/getting_started_locally_with_extensions.md
+++ b/docs/deployment/getting_started_locally_with_extensions.md
@@ -85,7 +85,10 @@ All of the following steps assume that you are using this kubeconfig.
 
 Additionally, this command deploys a local container registry to the cluster as well as a few registry mirrors that are set up as a pull-through cache for all upstream registries Gardener uses by default.
 This is done to speed up image pulls across local clusters.
-The local registry can be accessed as `localhost:5001` for pushing and pulling.
+
+> You will need to add `127.0.0.1 garden.local.gardener.cloud` to your /etc/hosts.
+
+The local registry can now be accessed either via `localhost:5001` or `garden.local.gardener.cloud:5001` for pushing and pulling.
 The storage directories of the registries are mounted to your machine under `dev/local-registry`.
 With this, mirrored images don't have to be pulled again after recreating the cluster.
 

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -90,3 +90,11 @@ clamp_mss_to_pmtu() {
     iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
   fi
 }
+
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+ensure_glgc_resolves_to_localhost() {
+  if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
+  fi
+}

--- a/hack/ci-e2e-kind-ha-multi-zone.sh
+++ b/hack/ci-e2e-kind-ha-multi-zone.sh
@@ -11,6 +11,11 @@ set -x
 
 source $(dirname "${0}")/ci-common.sh
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 clamp_mss_to_pmtu
 
 # test setup

--- a/hack/ci-e2e-kind-ha-multi-zone.sh
+++ b/hack/ci-e2e-kind-ha-multi-zone.sh
@@ -11,13 +11,9 @@ set -x
 
 source $(dirname "${0}")/ci-common.sh
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
-
 clamp_mss_to_pmtu
+
+ensure_glgc_resolves_to_localhost
 
 # test setup
 make kind-ha-multi-zone-up

--- a/hack/ci-e2e-kind-ha-multi-zone.sh
+++ b/hack/ci-e2e-kind-ha-multi-zone.sh
@@ -14,6 +14,7 @@ source $(dirname "${0}")/ci-common.sh
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 clamp_mss_to_pmtu

--- a/hack/ci-e2e-kind-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-ha-single-zone.sh
@@ -13,11 +13,7 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
+ensure_glgc_resolves_to_localhost
 
 # test setup
 make kind-ha-single-zone-up

--- a/hack/ci-e2e-kind-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-ha-single-zone.sh
@@ -16,6 +16,7 @@ clamp_mss_to_pmtu
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 # test setup

--- a/hack/ci-e2e-kind-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-ha-single-zone.sh
@@ -13,6 +13,11 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 # test setup
 make kind-ha-single-zone-up
 

--- a/hack/ci-e2e-kind-migration-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-migration-ha-single-zone.sh
@@ -15,6 +15,7 @@ clamp_mss_to_pmtu
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 # test setup

--- a/hack/ci-e2e-kind-migration-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-migration-ha-single-zone.sh
@@ -12,6 +12,11 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 # test setup
 make kind-ha-single-zone-up
 make kind2-ha-single-zone-up

--- a/hack/ci-e2e-kind-migration-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-migration-ha-single-zone.sh
@@ -12,11 +12,7 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
+ensure_glgc_resolves_to_localhost
 
 # test setup
 make kind-ha-single-zone-up

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -15,6 +15,7 @@ clamp_mss_to_pmtu
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 # test setup

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -12,11 +12,7 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
+ensure_glgc_resolves_to_localhost
 
 # test setup
 make kind-up

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -12,6 +12,11 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 # test setup
 make kind-up
 make kind2-up

--- a/hack/ci-e2e-kind-operator-seed.sh
+++ b/hack/ci-e2e-kind-operator-seed.sh
@@ -15,6 +15,7 @@ clamp_mss_to_pmtu
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 # test setup

--- a/hack/ci-e2e-kind-operator-seed.sh
+++ b/hack/ci-e2e-kind-operator-seed.sh
@@ -12,6 +12,11 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 # test setup
 make kind-operator-up
 

--- a/hack/ci-e2e-kind-operator-seed.sh
+++ b/hack/ci-e2e-kind-operator-seed.sh
@@ -12,11 +12,7 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
+ensure_glgc_resolves_to_localhost
 
 # test setup
 make kind-operator-up

--- a/hack/ci-e2e-kind-operator.sh
+++ b/hack/ci-e2e-kind-operator.sh
@@ -15,6 +15,7 @@ clamp_mss_to_pmtu
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 # test setup

--- a/hack/ci-e2e-kind-operator.sh
+++ b/hack/ci-e2e-kind-operator.sh
@@ -12,6 +12,11 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 # test setup
 make kind-operator-up
 

--- a/hack/ci-e2e-kind-operator.sh
+++ b/hack/ci-e2e-kind-operator.sh
@@ -12,11 +12,7 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
+ensure_glgc_resolves_to_localhost
 
 # test setup
 make kind-operator-up

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -17,6 +17,7 @@ SEED_NAME=""
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 # copy_kubeconfig_from_kubeconfig_env_var copies the kubeconfig to apporiate location based on kind setup

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -14,11 +14,7 @@ VERSION="$(cat VERSION)"
 CLUSTER_NAME=""
 SEED_NAME=""
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
+ensure_glgc_resolves_to_localhost
 
 # copy_kubeconfig_from_kubeconfig_env_var copies the kubeconfig to apporiate location based on kind setup
 function copy_kubeconfig_from_kubeconfig_env_var() {

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -14,6 +14,11 @@ VERSION="$(cat VERSION)"
 CLUSTER_NAME=""
 SEED_NAME=""
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 # copy_kubeconfig_from_kubeconfig_env_var copies the kubeconfig to apporiate location based on kind setup
 function copy_kubeconfig_from_kubeconfig_env_var() {
   case "$SHOOT_FAILURE_TOLERANCE_TYPE" in

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -15,6 +15,7 @@ clamp_mss_to_pmtu
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 # test setup

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -12,11 +12,7 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
+ensure_glgc_resolves_to_localhost
 
 # test setup
 make kind-up

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -12,6 +12,11 @@ source $(dirname "${0}")/ci-common.sh
 
 clamp_mss_to_pmtu
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 # test setup
 make kind-up
 

--- a/hack/gardener-extensions-up.sh
+++ b/hack/gardener-extensions-up.sh
@@ -43,7 +43,7 @@ fi
 echo "Configure seed cluster"
 "$SCRIPT_DIR"/../example/provider-extensions/seed/configure-seed.sh "$PATH_GARDEN_KUBECONFIG" "$PATH_SEED_KUBECONFIG" "$SEED_NAME"
 echo "Start bootstrapping Gardener"
-SKAFFOLD_DEFAULT_REPO=localhost:5001 SKAFFOLD_PUSH=true skaffold run -m etcd,controlplane,extensions-env -p extensions
+SKAFFOLD_DEFAULT_REPO=garden.local.gardener.cloud:5001 SKAFFOLD_PUSH=true skaffold run -m etcd,controlplane,extensions-env -p extensions
 echo "Configure admission controllers"
 "$SCRIPT_DIR"/../example/provider-extensions/garden/configure-admission.sh "$PATH_GARDEN_KUBECONFIG" apply
 echo "Registering controllers"

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -58,11 +58,11 @@ check_local_dns_records() {
   glgc_ip_address=""
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    if dscacheutil -q host -a name garden.local.gardener.cloud | grep -q "ip_address"; then
-        glgc_ip_address=$(dscacheutil -q host -a name garden.local.gardener.cloud | grep "ip_address" | head -n 1| cut -d' ' -f2)
-    fi
+    # Suppress exit code using "|| true"
+    glgc_ip_address=$(dscacheutil -q host -a name garden.local.gardener.cloud | grep "ip_address" | head -n 1| cut -d' ' -f2 || true)
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    glgc_ip_address=$(getent hosts garden.local.gardener.cloud | cut -d' ' -f1)
+    # Suppress exit code using "|| true"
+    glgc_ip_address="$(getent hosts garden.local.gardener.cloud | cut -d' ' -f1 || true)"
   else
     echo "Warning: Unknown OS. Make sure garden.local.gardener.cloud resolves to 127.0.0.1"
     return 0

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -58,7 +58,24 @@ parse_flags() {
 setup_kind_network() {
   # check if network already exists
   local existing_network_id
+  local glgc_ip_address
   existing_network_id="$(docker network list --filter=name=^kind$ --format='{{.ID}}')"
+  glgc_ip_address=""
+    
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    if dscacheutil -q host -a name garden.local.gardener.cloud | grep -q "ip_address"; then
+        glgc_ip_address=$(dscacheutil -q host -a name garden.local.gardener.cloud | grep "ip_address" | head -n 1| cut -d' ' -f2)
+    fi
+  elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    glgc_ip_address=$(getent hosts garden.local.gardener.cloud | cut -d' ' -f1)
+  else
+    echo "WARN: Unknown OS. Make sure garden.local.gardener.cloud resolves to 127.0.0.1"
+  fi
+
+  if [ "$glgc_ip_address" != "127.0.0.1" ]; then
+      echo "garden.local.gardener.cloud does not resolve to 127.0.0.1. Please add a line for it in /etc/hosts"
+      exit 1
+  fi
 
   if [ -n "$existing_network_id" ] ; then
     # ensure the network is configured correctly

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -62,13 +62,13 @@ check_local_dns_records() {
     glgc_ip_address=$(dscacheutil -q host -a name garden.local.gardener.cloud | grep "ip_address" | head -n 1| cut -d' ' -f2 || true)
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Suppress exit code using "|| true"
-    glgc_ip_address="$(getent hosts garden.local.gardener.cloud | cut -d' ' -f1 || true)"
+    glgc_ip_address="$(getent ahosts garden.local.gardener.cloud | cut -d' ' -f1 || true)"
   else
     echo "Warning: Unknown OS. Make sure garden.local.gardener.cloud resolves to 127.0.0.1"
     return 0
   fi
-
-  if [ "$glgc_ip_address" != "127.0.0.1" ]; then
+    
+  if ! echo "$glgc_ip_address" | grep "127.0.0.1" ; then
       echo "Error: garden.local.gardener.cloud does not resolve to 127.0.0.1. Please add a line for it in /etc/hosts"
       exit 1
   fi

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -68,7 +68,7 @@ check_local_dns_records() {
     return 0
   fi
     
-  if ! echo "$glgc_ip_address" | grep "127.0.0.1" ; then
+  if ! echo "$glgc_ip_address" | grep -q "127.0.0.1" ; then
       echo "Error: garden.local.gardener.cloud does not resolve to 127.0.0.1. Please add a line for it in /etc/hosts"
       exit 1
   fi

--- a/hack/push-helm.sh
+++ b/hack/push-helm.sh
@@ -30,5 +30,7 @@ yq -i "$image_ref |= \"$IMG\"" "$chart_dir/values.yaml"
 # valid dns name.
 yq -i ".name |= \"$name\"" "$chart_dir/Chart.yaml"
 
+
 helm package "$chart_dir" -d "$chart_dir" --version "$tag"
-helm push "$chart_dir/$name-$tag.tgz" "oci://$registry"
+helm push --plain-http "$chart_dir/$name-$tag.tgz" "oci://$registry"
+

--- a/hack/push-helm.sh
+++ b/hack/push-helm.sh
@@ -30,7 +30,5 @@ yq -i "$image_ref |= \"$IMG\"" "$chart_dir/values.yaml"
 # valid dns name.
 yq -i ".name |= \"$name\"" "$chart_dir/Chart.yaml"
 
-
 helm package "$chart_dir" -d "$chart_dir" --version "$tag"
 helm push --plain-http "$chart_dir/$name-$tag.tgz" "oci://$registry"
-

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -18,6 +18,7 @@ fi
 echo "> E2E Tests"
 
 source "$(dirname "$0")/test-e2e-local.env"
+source $(dirname "${0}")/ci-common.sh
 
 ginkgo_flags=
 
@@ -40,11 +41,7 @@ if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
   local_address_operator="::3"
 fi
 
-# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
-if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
-fi
+ensure_glgc_resolves_to_localhost
 
 # If we are running the gardener-operator tests then we have to make the virtual garden domains accessible.
 if [[ "$TYPE" == "operator" ]] || [[ "$TYPE" == "operator-seed" ]]; then

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -43,6 +43,7 @@ fi
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+    printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
 fi
 
 # If we are running the gardener-operator tests then we have to make the virtual garden domains accessible.

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -40,6 +40,11 @@ if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
   local_address_operator="::3"
 fi
 
+# If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
+if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
+fi
+
 # If we are running the gardener-operator tests then we have to make the virtual garden domains accessible.
 if [[ "$TYPE" == "operator" ]] || [[ "$TYPE" == "operator-seed" ]]; then
   if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -92,6 +92,11 @@ func (e *ensurer) EnsureAdditionalProvisionFiles(_ context.Context, _ extensions
 			UpstreamHost: "europe-docker.pkg.dev",
 			MirrorHost:   "http://garden.local.gardener.cloud:5008",
 		},
+		// Enable containerd to reach registry at garden.local.gardener.cloud:5001 via HTTP.
+		{
+			UpstreamHost: "garden.local.gardener.cloud:5001",
+			MirrorHost:   "http://garden.local.gardener.cloud:5001",
+		},
 	} {
 		*new = webhook.EnsureFileWithPath(*new, extensionsv1alpha1.File{
 			Path:        filepath.Join("/etc/containerd/certs.d", mirror.UpstreamHost, "hosts.toml"),

--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -89,14 +89,10 @@ func buildRef(oci *gardencorev1.OCIRepository) (name.Reference, error) {
 		name.StrictValidation,
 	}
 
-	// in the local setup, we need to replace the registry and configure that we don't want to use TLS
+	// in the local setup we don't want to use TLS
         if strings.Contains(ref, "garden.local.gardener.cloud:5001") {
 		opts = append(opts, name.Insecure)
         }
-	if strings.Contains(ref, localRegistry) {
-		ref = strings.Replace(ref, localRegistry, inKubernetesRegistry, 1)
-		opts = append(opts, name.Insecure)
-	}
 
 	return name.ParseReference(ref, opts...)
 }

--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -90,9 +90,9 @@ func buildRef(oci *gardencorev1.OCIRepository) (name.Reference, error) {
 	}
 
 	// in the local setup we don't want to use TLS
-        if strings.Contains(ref, "garden.local.gardener.cloud:5001") {
+	if strings.Contains(ref, "garden.local.gardener.cloud:5001") {
 		opts = append(opts, name.Insecure)
-        }
+	}
 
 	return name.ParseReference(ref, opts...)
 }

--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -90,6 +90,9 @@ func buildRef(oci *gardencorev1.OCIRepository) (name.Reference, error) {
 	}
 
 	// in the local setup, we need to replace the registry and configure that we don't want to use TLS
+        if strings.Contains(ref, "garden.local.gardener.cloud:5001") {
+		opts = append(opts, name.Insecure)
+        }
 	if strings.Contains(ref, localRegistry) {
 		ref = strings.Replace(ref, localRegistry, inKubernetesRegistry, 1)
 		opts = append(opts, name.Insecure)

--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -90,7 +90,7 @@ func buildRef(oci *gardencorev1.OCIRepository) (name.Reference, error) {
 	}
 
 	// in the local setup we don't want to use TLS
-	if strings.Contains(ref, "garden.local.gardener.cloud:5001") {
+	if strings.Contains(ref, inKubernetesRegistry) {
 		opts = append(opts, name.Insecure)
 	}
 

--- a/pkg/utils/oci/helmregistry_test.go
+++ b/pkg/utils/oci/helmregistry_test.go
@@ -143,8 +143,8 @@ var _ = Describe("buildRef", func() {
 			&gardencorev1.OCIRepository{Repository: ptr.To("oci://example.com/foo"), Tag: ptr.To("1.0.0"), Digest: ptr.To(digest)},
 			mustNewDigest("example.com/foo@"+digest),
 		),
-		Entry("replace registry and configure insecure in local setup",
-			&gardencorev1.OCIRepository{Ref: ptr.To("localhost:5001/foo:1.0.0")},
+		Entry("configure insecure in local setup when using garden.local.gardener.cloud",
+			&gardencorev1.OCIRepository{Ref: ptr.To("garden.local.gardener.cloud:5001/foo:1.0.0")},
 			name.MustParseReference("garden.local.gardener.cloud:5001/foo:1.0.0", name.Insecure),
 		),
 	)

--- a/skaffold-operator-garden.yaml
+++ b/skaffold-operator-garden.yaml
@@ -28,7 +28,6 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-    - localhost:5001
   artifacts:
     - image: local-skaffold/gardener-extension-provider-local-node
       context: pkg/provider-local/node

--- a/skaffold-operator-garden.yaml
+++ b/skaffold-operator-garden.yaml
@@ -26,6 +26,9 @@ kind: Config
 metadata:
   name: garden-config
 build:
+  insecureRegistries:
+    - garden.local.gardener.cloud:5001
+    - localhost:5001
   artifacts:
     - image: local-skaffold/gardener-extension-provider-local-node
       context: pkg/provider-local/node

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -5,7 +5,6 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"
@@ -924,7 +923,6 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -3,6 +3,9 @@ kind: Config
 metadata:
   name: gardener-operator
 build:
+  insecureRegistries:
+    - garden.local.gardener.cloud:5001
+    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"
@@ -919,6 +922,9 @@ kind: Config
 metadata:
   name: provider-local
 build:
+  insecureRegistries:
+    - garden.local.gardener.cloud:5001
+    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -21,7 +21,6 @@ requires:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"
@@ -600,7 +599,6 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"
@@ -915,7 +913,6 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -21,6 +21,7 @@ requires:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
+    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"
@@ -599,6 +600,7 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
+    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"
@@ -913,6 +915,7 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
+    - localhost:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -19,6 +19,8 @@ requires:
   - configs:
       - etcd
 build:
+  insecureRegistries:
+    - garden.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"
@@ -595,6 +597,8 @@ kind: Config
 metadata:
   name: provider-local
 build:
+  insecureRegistries:
+    - garden.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"
@@ -907,6 +911,8 @@ kind: Config
 metadata:
   name: gardenlet
 build:
+  insecureRegistries:
+    - garden.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Currently, all images that are built for the local setup are tagged with localhost:5001 as the registry.

This, however, makes it impossible for pods in the cluster to reach the registry since localhost:5001 routes differently for the pods. However, garden.local.gardener.cloud has been setup to route to the cluster node for every pod & node thus allowing pods to reach the registry at port 5001.

There are currently two use cases for this change:
- The Lakom controller needs to communicate with the local registry to pull in digests for every pod. This change will allow us to avoid code that specifically handles this edge case (E.g. when an image is tagged with localhost:5001 treat it as garden.local.gardener.cloud:5001)
- There is already code in gardener that handles this edge case. It can now be removed: https://github.com/gardener/gardener/blob/c5c2e3c613775785ac4056b7ee4e356f53a9f4b1/pkg/utils/oci/helmregistry.go#L92-L96

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
In the local development setup, the images are pushed to `garden.local.gardener.cloud:5001` instead of `localhost:5001` now. Please add `127.0.0.1 garden.local.gardener.cloud` to your `/etc/hosts`. 
```
