### PR TITLE
Fix race-condition during kube-state-metrics cleanup

### DIFF
--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
@@ -94,6 +94,12 @@ func (k *kubeStateMetrics) Deploy(ctx context.Context) error {
 		if err := component.DestroyResourceConfigs(ctx, k.client, k.namespace, k.values.ClusterType, managedResourceName, k.getResourceConfigs("", nil)); client.IgnoreNotFound(err) != nil {
 			return err
 		}
+
+		timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+		defer cancel()
+		if err := managedresources.WaitUntilDeleted(timeoutCtx, k.client, k.namespace, managedResourceName); client.IgnoreNotFound(err) != nil {
+			return err
+		}
 	}
 
 	if k.values.ClusterType == component.ClusterTypeShoot {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
PR #10062 renamed the kube-state-metrics ManagedResouce (MR) to kube-state-metrics-runtime or kube-state-metrics-seed. Both the old and new MR contain the same Prometheus ScrapeConfigs. In the case that the new MR and their contained resources are created before the old MR was fully deleted, a situation might occur where the ScrapeConfigs are deleted again and the new MR is unhealthy until the next reconciliation.

**Which issue(s) this PR fixes**:
Fixes a race-condition during the resource cleanup that was introduced in PR #10062

**Special notes for your reviewer**:
/cc @istvanballok @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other bugfix
NONE
```
