### PR TITLE
Fix getting started locally docs to use the correct IP address

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -199,15 +199,15 @@ cat <<EOF | sudo tee -a /etc/hosts
 
 # Begin of Gardener local setup section
 # Shoot API server domains
-127.0.0.1 api.local.local.external.local.gardener.cloud
-127.0.0.1 api.local.local.internal.local.gardener.cloud
+172.18.255.1 api.local.local.external.local.gardener.cloud
+172.18.255.1 api.local.local.internal.local.gardener.cloud
 
 # Ingress
-127.0.0.1 p-seed.ingress.local.seed.local.gardener.cloud
-127.0.0.1 g-seed.ingress.local.seed.local.gardener.cloud
-127.0.0.1 gu-local--local.ingress.local.seed.local.gardener.cloud
-127.0.0.1 p-local--local.ingress.local.seed.local.gardener.cloud
-127.0.0.1 v-local--local.ingress.local.seed.local.gardener.cloud
+172.18.255.1 p-seed.ingress.local.seed.local.gardener.cloud
+172.18.255.1 g-seed.ingress.local.seed.local.gardener.cloud
+172.18.255.1 gu-local--local.ingress.local.seed.local.gardener.cloud
+172.18.255.1 p-local--local.ingress.local.seed.local.gardener.cloud
+172.18.255.1 v-local--local.ingress.local.seed.local.gardener.cloud
 
 # E2e tests
 172.18.255.1 api.e2e-managedseed.garden.external.local.gardener.cloud
@@ -335,7 +335,7 @@ make kind-down
 
 ## Alternative Way to Set Up Garden and Seed Leveraging `gardener-operator`
 
-Instead of starting Garden and Seed via `make kind-up gardener-up`, you can also use `gardener-operator` to create your local dev landscape.  
+Instead of starting Garden and Seed via `make kind-up gardener-up`, you can also use `gardener-operator` to create your local dev landscape.
 In this setup, the virtual garden cluster has its own load balancer, so you have to create an own DNS entry in your `/etc/hosts`:
 
 ```shell


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation dev-productivity 
/kind bug

**What this PR does / why we need it**:
After #10019 the `istio-ingressgateway` load balancer is no longer exposed on `127.0.0.1` but on `172.18.0.2` and `172.18.255.1`, if the `/etc/hosts` file is not updated with the new IP, accessing the api server of a local shoot or some of the ingress endpoints fails, e.g.

```sh
$ k get pod
E0806 16:12:34.200660   29865 memcache.go:265] couldn't get current server API group list: Get "https://api.local.local.external.local.gardener.cloud/api?timeout=32s": dial tcp 127.0.0.1:443: connect: connection refused
E0806 16:12:34.201691   29865 memcache.go:265] couldn't get current server API group list: Get "https://api.local.local.external.local.gardener.cloud/api?timeout=32s": dial tcp 127.0.0.1:443: connect: connection refused
E0806 16:12:34.202785   29865 memcache.go:265] couldn't get current server API group list: Get "https://api.local.local.external.local.gardener.cloud/api?timeout=32s": dial tcp 127.0.0.1:443: connect: connection refused
E0806 16:12:34.203688   29865 memcache.go:265] couldn't get current server API group list: Get "https://api.local.local.external.local.gardener.cloud/api?timeout=32s": dial tcp 127.0.0.1:443: connect: connection refused
E0806 16:12:34.204544   29865 memcache.go:265] couldn't get current server API group list: Get "https://api.local.local.external.local.gardener.cloud/api?timeout=32s": dial tcp 127.0.0.1:443: connect: connection refused
The connection to the server api.local.local.external.local.gardener.cloud was refused - did you specify the right host or port?
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
