### PR TITLE
Improve the SeedConditionFailing alert when nodes are rolled

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -301,16 +301,18 @@ spec:
           The seed cluster {{$labels.name}} in {{$externalLabels.landscape}}
           has a failing condition: {{$labels.condition}}.
 
+      # avoid alert noise for flapping conditions except for GardenletReady and APIServerUnavailable
     - alert: SeedConditionFailing
       expr: |
         max by (name, condition) (
-          last_over_time((
+          count_over_time((
             garden_seed_condition{condition != "GardenletReady"} <= 0
             or
             garden_shoot_condition{condition != "APIServerUnavailable",
                                    is_seed    = "true",
-                                   operation  = "Reconcile"} <= 0)[5m:]))
-      for: 30m # avoid alert noise for flapping conditions except for GardenletReady and APIServerUnavailable
+                                   operation  = "Reconcile"} <= 0)[8m:]) >= 4
+        )
+      for: 30m
       labels:
         severity: critical
         topology: seed

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -16,10 +16,10 @@ tests:
     input_series:
       - series: garden_seed_condition{condition = "ExtensionsReady",
                                       name      = "seed-flapping"}
-        values: 0 0 2 -1 2 0x25
+        values: 0x2 0 0 2 -1 2 0x24
       - series: garden_seed_condition{condition = "ExtensionsReady",
                                       name      = "seed-progressing-for-long"}
-        values: 2 2 0 0 2 2 0x24
+        values: 0x2 2 2 0 2 2 2 0x23
       - series: garden_seed_condition{condition = "GardenletReady",
                                       name      = "seed-flapping"}
         values: 0 0 2 -1 2 0 0 0 0 0
@@ -40,7 +40,7 @@ tests:
       landscape: landscape-unit-tests
     alert_rule_test:
       - alertname: SeedConditionFailing
-        eval_time: 30m
+        eval_time: 33m
         exp_alerts:
           - exp_labels:
               severity: critical
@@ -86,9 +86,9 @@ tests:
     interval: 1m
     input_series:
       - series: garden_shoot_condition{is_seed="true", operation="Reconcile", condition="SystemComponentsHealthy", name="seed-one"}
-        values: "0x30"
+        values: "0x32"
       - series: garden_seed_condition{condition="SeedSystemComponentsHealthy", name="seed-two"}
-        values: "0x30"
+        values: "0x32"
       - series: garden_seed_condition{condition = "GardenletReady",
                                       name      = "seed-three"}
         values: "0x10"
@@ -101,7 +101,7 @@ tests:
       landscape: landscape-unit-tests
     alert_rule_test:
       - alertname: SeedConditionFailing
-        eval_time: 30m
+        eval_time: 33m
         exp_alerts:
           - exp_labels:
               severity: critical

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -91,12 +91,12 @@ tests:
         values: "0x32"
       - series: garden_seed_condition{condition = "GardenletReady",
                                       name      = "seed-three"}
-        values: "0x10"
+        values: "0x9"
       - series: garden_shoot_condition{condition = "APIServerUnavailable",
                                        is_seed   = "true",
                                        operation = "Reconcile",
                                        name      = "seed-four"}
-        values: "0x10"
+        values: "0x9"
     external_labels:
       landscape: landscape-unit-tests
     alert_rule_test:


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR improves the `SeedConditionFailing` alert to prevent false positive alert notifications that we observed when the nodes of a seed are rolled. Rolling all the nodes might take very long and, during that time, the `SeedSystemComponentsHealthy` condition might fail temporarily during the first minutes of each new node when not all the daemonset pods (e.g. `egress-filter-applier`) are ready yet. This might fire as a false positive (or even flapping) alert, and thereby trigger multiple notifications.

The improvement extends the time window considered in the query from 5 to 8 minutes and asserts the number of unhealthy samples is at least 50%. This modified expression prevents the alert when the condition fails only once every few minutes, and hence reduces the false positive alert notifications. The alert still fires as expected when the condition fails consistently for a longer time, which is the intended behaviour.

**Special notes for your reviewer**:

/cc @istvanballok @rickardsjp @chrkl 
/fyi @ScheererJ 

**Release note**:

```other operator
NONE
```
