### PR TITLE
Clean up stale unit test. Update detail in Shoot purposes docs

### DIFF
--- a/docs/usage/shoot_purposes.md
+++ b/docs/usage/shoot_purposes.md
@@ -18,8 +18,7 @@ The `Shoot` resource contains a `.spec.purpose` field indicating how the shoot i
 The following enlists the differences in the way the shoot clusters are set up based on the selected purpose:
 
 * `testing` shoot clusters **do not** get a monitoring or a logging stack as part of their control planes.
-* `production` shoot clusters get at least two replicas of the `kube-apiserver` for their control planes.
-Auto-scaling scale down of the main ETCD is disabled for such clusters.
+* for `production` and `infrastructure` shoot clusters auto-scaling scale down of the main ETCD is disabled.
 
 There are also differences with respect to how `testing` shoots are scheduled after creation, please consult the [Scheduler documentation](../concepts/scheduler.md).
 

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -240,27 +240,6 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabled:         false,
 					},
 				),
-				Entry("shoot purpose production, VPAAndHPAForAPIServer is enabled",
-					func() {
-						botanist.Shoot.Purpose = gardencorev1beta1.ShootPurposeProduction
-					},
-					map[featuregate.Feature]bool{
-						features.VPAAndHPAForAPIServer: true,
-					},
-					apiserver.AutoscalingConfig{
-						Mode: apiserver.AutoscalingModeVPAAndHPA,
-						APIServerResources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("250m"),
-								corev1.ResourceMemory: resource.MustParse("500Mi"),
-							},
-						},
-						MinReplicas:               2,
-						MaxReplicas:               6,
-						UseMemoryMetricForHvpaHPA: false,
-						ScaleDownDisabled:         false,
-					},
-				),
 				Entry("shoot disables scale down, HVPA is enabled, VPAAndHPAForAPIServer is disabled",
 					func() {
 						botanist.Shoot.GetInfo().Annotations = map[string]string{"alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled": "true"}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
With the introduction of the HA webhooks we deploy components of type server (kube-apiserver is such) with 2 replicas at least no matter what is the purpose of the Shoot. See https://github.com/gardener/gardener/blob/901e117ffa2ea5c9c08f764fb3d37aa239a0db5f/docs/development/high-availability.md#control-plane-components

Hence, it is an outdated information that:
> * `production` shoot clusters get at least two replicas of the `kube-apiserver` for their control planes.

Shoot cluster with any purpose gets at least 2 replicas no matter HA or not.

For more context, in https://github.com/gardener/gardener/pull/9678/files#diff-6ec61cd169e81e73dd683a4c325e0c4bbb76e80ac8bd1de48d7e14aec0439317L98-L100 I cleaned up stale code for computing the kube-apiserver replicas. This PR also drops the unit test that was not cleaned up. 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
