### PR TITLE
Pin valitail version to v2.2.15

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -161,6 +161,7 @@
     },
     {
       // Do not use docker for images from gardener registry except those which do not work with github-releases.
+      // Exclude valitail updates due to hard dependency on glibc version of the target nodes.
       "matchDatasources": ["docker"],
       "matchFileNames": ["imagevector/**"],
       "matchPackagePatterns": [
@@ -168,7 +169,8 @@
       ],
       "excludePackagePatterns": [
         "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/alpine",
-        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubernetesui\/.+"
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubernetesui\/.+",
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/credativ\/valitail"
       ],
       "enabled": false
     },

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -565,7 +565,7 @@ images:
 - name: valitail
   sourceRepository: github.com/credativ/vali
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/valitail
-  tag: "v2.2.17"
+  tag: "v2.2.15"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind bug

**What this PR does / why we need it**:
This PR pins valitail to version 2.2.15 to solve issues when the target OS does not provide matching or newer glibc version.
Since valitail is installed as a systemd service on the target cluster nodes the glibc version on the node matters. For example valitail version build against glibc version 2.36 cannot run on target node which provides only glibc version 2.32. For time being maintaing the valitail version requires manual update after ensuring that supported cluster nodes OSes provide the requried glibc version.

```bugfix operator
Valitail is now pinned to v2.2.15 (depends on glibc 2.32)
```
