### PR TITLE
Revert "Drop deprecated .spec.pools[].userData from `extensions.gardener.cloud/v1alpha1.Worker` API"

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4491,7 +4491,7 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 when a new machine/VM that is part of this worker pool shall be spawned.
 Either this or UserDataSecretRef must be provided.
 Deprecated: This field will be removed in future release.
-TODO(rfranzke): Remove this field after v1.100 has been released.</p>
+TODO(rfranzke): Remove this field after v1.104 has been released.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4480,6 +4480,22 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 </tr>
 <tr>
 <td>
+<code>userData</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UserData is a base64-encoded string that contains the data that is sent to the provider&rsquo;s APIs
+when a new machine/VM that is part of this worker pool shall be spawned.
+Either this or UserDataSecretRef must be provided.
+Deprecated: This field will be removed in future release.
+TODO(rfranzke): Remove this field after v1.100 has been released.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>userDataSecretRef</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core">
@@ -4488,8 +4504,10 @@ Kubernetes core/v1.SecretKeySelector
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider&rsquo;s APIs when
-a new machine/VM that is part of this worker pool shall be spawned.</p>
+a new machine/VM that is part of this worker pool shall be spawned.
+Either this or UserData must be provided.</p>
 </td>
 </tr>
 <tr>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -287,10 +287,20 @@ spec:
                         - key
                         type: object
                       type: array
+                    userData:
+                      description: |-
+                        UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
+                        when a new machine/VM that is part of this worker pool shall be spawned.
+                        Either this or UserDataSecretRef must be provided.
+                        Deprecated: This field will be removed in future release.
+                        TODO(rfranzke): Remove this field after v1.100 has been released.
+                      format: byte
+                      type: string
                     userDataSecretRef:
                       description: |-
                         UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
                         a new machine/VM that is part of this worker pool shall be spawned.
+                        Either this or UserData must be provided.
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -343,7 +353,6 @@ spec:
                   - maximum
                   - minimum
                   - name
-                  - userDataSecretRef
                   type: object
                 type: array
               providerConfig:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -293,7 +293,7 @@ spec:
                         when a new machine/VM that is part of this worker pool shall be spawned.
                         Either this or UserDataSecretRef must be provided.
                         Deprecated: This field will be removed in future release.
-                        TODO(rfranzke): Remove this field after v1.100 has been released.
+                        TODO(rfranzke): Remove this field after v1.104 has been released.
                       format: byte
                       type: string
                     userDataSecretRef:

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -251,15 +251,19 @@ func ErrorMachineImageNotFound(name, version string, opt ...string) error {
 
 // FetchUserData fetches the user data for a worker pool.
 func FetchUserData(ctx context.Context, c client.Client, namespace string, pool extensionsv1alpha1.WorkerPool) ([]byte, error) {
-	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pool.UserDataSecretRef.Name, Namespace: namespace}}
-	if err := c.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
-		return nil, fmt.Errorf("failed fetching user data secret %s referenced in worker pool %s: %w", pool.UserDataSecretRef.Name, pool.Name, err)
+	if pool.UserDataSecretRef != nil {
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pool.UserDataSecretRef.Name, Namespace: namespace}}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+			return nil, fmt.Errorf("failed fetching user data secret %s referenced in worker pool %s: %w", pool.UserDataSecretRef.Name, pool.Name, err)
+		}
+
+		userData, ok := secret.Data[pool.UserDataSecretRef.Key]
+		if !ok || len(userData) == 0 {
+			return nil, fmt.Errorf("user data secret %s for worker pool %s has no %s field or it's empty", pool.UserDataSecretRef.Name, pool.Name, pool.UserDataSecretRef.Key)
+		}
+
+		return userData, nil
 	}
 
-	userData, ok := secret.Data[pool.UserDataSecretRef.Key]
-	if !ok || len(userData) == 0 {
-		return nil, fmt.Errorf("user data secret %s for worker pool %s has no %s field or it's empty", pool.UserDataSecretRef.Name, pool.Name, pool.UserDataSecretRef.Key)
-	}
-
-	return userData, nil
+	return pool.UserData, nil
 }

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -168,8 +168,12 @@ var _ = Describe("Machines", func() {
 				p.Name = "different-name"
 			})
 
+			It("when changing user-data", func() {
+				p.UserData = []byte("new-data")
+			})
+
 			It("when changing user-data secret ref", func() {
-				p.UserDataSecretRef = corev1.SecretKeySelector{Key: "foo"}
+				p.UserDataSecretRef = &corev1.SecretKeySelector{}
 			})
 
 			It("when changing zones", func() {
@@ -424,10 +428,6 @@ var _ = Describe("Machines", func() {
 			namespace = "some-namespace"
 			pool      extensionsv1alpha1.WorkerPool
 			userData  = []byte("some-user-data")
-
-			secretName = "some-secret-name"
-			key        = "the-key"
-			secret     *corev1.Secret
 		)
 
 		BeforeEach(func() {
@@ -435,44 +435,64 @@ var _ = Describe("Machines", func() {
 			fakeClient = fakeclient.NewClientBuilder().Build()
 		})
 
-		BeforeEach(func() {
-			pool.UserDataSecretRef = corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
-				Key:                  key,
-			}
-			secret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace}}
+		When("user data secret reference is used", func() {
+			var (
+				secretName = "some-secret-name"
+				key        = "the-key"
+				secret     *corev1.Secret
+			)
+
+			BeforeEach(func() {
+				pool.UserDataSecretRef = &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  key,
+				}
+				secret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace}}
+			})
+
+			It("should fail because the referenced secret is not found", func() {
+				result, err := FetchUserData(ctx, fakeClient, namespace, pool)
+				Expect(err).To(MatchError(ContainSubstring("failed fetching user data secret")))
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail because the referenced secret does not contain key", func() {
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+				result, err := FetchUserData(ctx, fakeClient, namespace, pool)
+				Expect(err).To(MatchError(ContainSubstring("field or it's empty")))
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail because the referenced secret's key is empty", func() {
+				secret.Data = map[string][]byte{key: nil}
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+				result, err := FetchUserData(ctx, fakeClient, namespace, pool)
+				Expect(err).To(MatchError(ContainSubstring("field or it's empty")))
+				Expect(result).To(BeNil())
+			})
+
+			It("should return the user data because the referenced secret's key is set", func() {
+				secret.Data = map[string][]byte{key: userData}
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+				result, err := FetchUserData(ctx, fakeClient, namespace, pool)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(userData))
+			})
 		})
 
-		It("should fail because the referenced secret is not found", func() {
-			result, err := FetchUserData(ctx, fakeClient, namespace, pool)
-			Expect(err).To(MatchError(ContainSubstring("failed fetching user data secret")))
-			Expect(result).To(BeNil())
-		})
+		When("user data is inlined", func() {
+			BeforeEach(func() {
+				pool.UserData = userData
+			})
 
-		It("should fail because the referenced secret does not contain key", func() {
-			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
-
-			result, err := FetchUserData(ctx, fakeClient, namespace, pool)
-			Expect(err).To(MatchError(ContainSubstring("field or it's empty")))
-			Expect(result).To(BeNil())
-		})
-
-		It("should fail because the referenced secret's key is empty", func() {
-			secret.Data = map[string][]byte{key: nil}
-			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
-
-			result, err := FetchUserData(ctx, fakeClient, namespace, pool)
-			Expect(err).To(MatchError(ContainSubstring("field or it's empty")))
-			Expect(result).To(BeNil())
-		})
-
-		It("should return the user data because the referenced secret's key is set", func() {
-			secret.Data = map[string][]byte{key: userData}
-			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
-
-			result, err := FetchUserData(ctx, fakeClient, namespace, pool)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(userData))
+			It("should return the inlined user data", func() {
+				result, err := FetchUserData(ctx, fakeClient, namespace, pool)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(userData))
+			})
 		})
 	})
 })

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -138,7 +138,7 @@ type WorkerPool struct {
 	// when a new machine/VM that is part of this worker pool shall be spawned.
 	// Either this or UserDataSecretRef must be provided.
 	// Deprecated: This field will be removed in future release.
-	// TODO(rfranzke): Remove this field after v1.100 has been released.
+	// TODO(rfranzke): Remove this field after v1.104 has been released.
 	// +optional
 	UserData []byte `json:"userData,omitempty"`
 	// UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -134,9 +134,18 @@ type WorkerPool struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty"`
+	// UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
+	// when a new machine/VM that is part of this worker pool shall be spawned.
+	// Either this or UserDataSecretRef must be provided.
+	// Deprecated: This field will be removed in future release.
+	// TODO(rfranzke): Remove this field after v1.100 has been released.
+	// +optional
+	UserData []byte `json:"userData,omitempty"`
 	// UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
 	// a new machine/VM that is part of this worker pool shall be spawned.
-	UserDataSecretRef corev1.SecretKeySelector `json:"userDataSecretRef"`
+	// Either this or UserData must be provided.
+	// +optional
+	UserDataSecretRef *corev1.SecretKeySelector `json:"userDataSecretRef,omitempty"`
 	// Volume contains information about the root disks that should be used for this worker pool.
 	// +optional
 	Volume *Volume `json:"volume,omitempty"`

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1849,7 +1849,16 @@ func (in *WorkerPool) DeepCopyInto(out *WorkerPool) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	in.UserDataSecretRef.DeepCopyInto(&out.UserDataSecretRef)
+	if in.UserData != nil {
+		in, out := &in.UserData, &out.UserData
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
+	if in.UserDataSecretRef != nil {
+		in, out := &in.UserDataSecretRef, &out.UserDataSecretRef
+		*out = new(v1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Volume != nil {
 		in, out := &in.Volume, &out.Volume
 		*out = new(Volume)

--- a/pkg/apis/extensions/validation/worker.go
+++ b/pkg/apis/extensions/validation/worker.go
@@ -83,6 +83,10 @@ func ValidateWorkerPools(pools []extensionsv1alpha1.WorkerPool, fldPath *field.P
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "field is required"))
 		}
 
+		if pool.UserData == nil && pool.UserDataSecretRef == nil {
+			allErrs = append(allErrs, field.Required(idxPath.Child("userData"), "either userData or userDataSecretRef must be provided"))
+		}
+
 		if pool.NodeTemplate != nil {
 			for resourceName, value := range pool.NodeTemplate.Capacity {
 				allErrs = append(allErrs, kubernetescorevalidation.ValidateResourceQuantityValue(string(resourceName), value, idxPath.Child("nodeTemplate", "capacity", string(resourceName)))...)

--- a/pkg/apis/extensions/validation/worker_test.go
+++ b/pkg/apis/extensions/validation/worker_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Worker validation tests", func() {
 						},
 						Name:         "pool1",
 						Architecture: ptr.To("amd64"),
+						UserData:     []byte("bootstrap data"),
 					},
 				},
 			},
@@ -105,12 +106,34 @@ var _ = Describe("Worker validation tests", func() {
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("spec.pools[0].name"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.pools[0].userData"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.pools[0].nodeTemplate.capacity.cpu"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("spec.pools[0].architecture"),
 			}))))
+		})
+
+		It("should complain Worker resources without user data", func() {
+			workerCopy := worker.DeepCopy()
+
+			workerCopy.Spec.Pools[0].UserData = nil
+
+			Expect(ValidateWorker(workerCopy)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.pools[0].userData"),
+			}))))
+		})
+
+		It("should allow Worker resources with user data secret ref", func() {
+			workerCopy := worker.DeepCopy()
+
+			workerCopy.Spec.Pools[0].UserDataSecretRef = &corev1.SecretKeySelector{}
+
+			Expect(ValidateWorker(workerCopy)).To(BeEmpty())
 		})
 
 		It("should allow valid worker resources", func() {
@@ -187,9 +210,9 @@ var _ = Describe("Worker validation tests", func() {
 						Name:    "image2",
 						Version: "version2",
 					},
-					Name:              "pool2",
-					Architecture:      ptr.To("amd64"),
-					UserDataSecretRef: corev1.SecretKeySelector{Key: "new-bootstrap-data-key"},
+					Name:         "pool2",
+					Architecture: ptr.To("amd64"),
+					UserData:     []byte("new bootstrap data"),
 				},
 			}
 

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -289,10 +289,20 @@ spec:
                         - key
                         type: object
                       type: array
+                    userData:
+                      description: |-
+                        UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
+                        when a new machine/VM that is part of this worker pool shall be spawned.
+                        Either this or UserDataSecretRef must be provided.
+                        Deprecated: This field will be removed in future release.
+                        TODO(rfranzke): Remove this field after v1.100 has been released.
+                      format: byte
+                      type: string
                     userDataSecretRef:
                       description: |-
                         UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
                         a new machine/VM that is part of this worker pool shall be spawned.
+                        Either this or UserData must be provided.
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -345,7 +355,6 @@ spec:
                   - maximum
                   - minimum
                   - name
-                  - userDataSecretRef
                   type: object
                 type: array
               providerConfig:

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -295,7 +295,7 @@ spec:
                         when a new machine/VM that is part of this worker pool shall be spawned.
                         Either this or UserDataSecretRef must be provided.
                         Deprecated: This field will be removed in future release.
-                        TODO(rfranzke): Remove this field after v1.100 has been released.
+                        TODO(rfranzke): Remove this field after v1.104 has been released.
                       format: byte
                       type: string
                     userDataSecretRef:

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -204,6 +204,9 @@ type OperatingSystemConfigs struct {
 type Data struct {
 	// Object is the plain OperatingSystemConfig object.
 	Object *extensionsv1alpha1.OperatingSystemConfig
+	// Content is the actual cloud-config user data.
+	// TODO(rfranzke): Remove this Content field after v1.100 is released.
+	Content string
 	// IncludeSecretNameInWorkerPool states whether a extensionsv1alpha1.WorkerPool must include the GardenerNodeAgentSecretName
 	IncludeSecretNameInWorkerPool bool
 	// GardenerNodeAgentSecretName is the name of the secret storing the gardener node agent configuration in the shoot cluster.
@@ -428,6 +431,7 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 
 				data := Data{
 					Object:                        osc,
+					Content:                       string(secret.Data[extensionsv1alpha1.OperatingSystemConfigSecretDataKey]),
 					IncludeSecretNameInWorkerPool: hashVersion > 1,
 					GardenerNodeAgentSecretName:   oscKey,
 					SecretName:                    &secret.Name,

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -205,9 +205,9 @@ type Data struct {
 	// Object is the plain OperatingSystemConfig object.
 	Object *extensionsv1alpha1.OperatingSystemConfig
 	// Content is the actual cloud-config user data.
-	// TODO(rfranzke): Remove this Content field after v1.100 is released.
+	// TODO(rfranzke): Remove this Content field after v1.140 is released.
 	Content string
-	// IncludeSecretNameInWorkerPool states whether a extensionsv1alpha1.WorkerPool must include the GardenerNodeAgentSecretName
+	// IncludeSecretNameInWorkerPool states whether an extensionsv1alpha1.WorkerPool must include the GardenerNodeAgentSecretName
 	IncludeSecretNameInWorkerPool bool
 	// GardenerNodeAgentSecretName is the name of the secret storing the gardener node agent configuration in the shoot cluster.
 	GardenerNodeAgentSecretName string

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -963,11 +963,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 				exp := map[string]*OperatingSystemConfigs{
 					worker1Name: {
 						Init: Data{
+							Content:                     "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker1Name + "-77ac3",
 							SecretName:                  ptr.To("cc-" + expected[0].Name),
 							Object:                      worker1OSCDownloader,
 						},
 						Original: Data{
+							Content:                     "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker1Name + "-77ac3",
 							SecretName:                  ptr.To("cc-" + expected[1].Name),
 							Object:                      worker1OSCOriginal,
@@ -975,11 +977,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 					},
 					worker2Name: {
 						Init: Data{
+							Content:                     "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker2Name + "-d9e53",
 							SecretName:                  ptr.To("cc-" + expected[2].Name),
 							Object:                      worker2OSCDownloader,
 						},
 						Original: Data{
+							Content:                     "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker2Name + "-d9e53",
 							SecretName:                  ptr.To("cc-" + expected[3].Name),
 							Object:                      worker2OSCOriginal,

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -175,7 +175,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			return nil, fmt.Errorf("missing secret name for worker pool %v", workerPool.Name)
 		}
 
-		// TODO(rfranzke): Remove userData after v1.100 has been released.
+		// TODO(rfranzke): Remove userData after v1.104 has been released.
 		userData := []byte(oscConfig.Init.Content)
 		userDataSecretRef := &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{Name: *oscConfig.Init.SecretName},
@@ -247,7 +247,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			NodeTemplate:        nodeTemplate,
 			NodeAgentSecretName: nodeAgentSecretName,
 			ProviderConfig:      pConfig,
-			// TODO(rfranzke): Remove usage of UserData field after v1.100 has been released.
+			// TODO(rfranzke): Remove usage of UserData field after v1.104 has been released.
 			UserData:                         userData,
 			UserDataSecretRef:                userDataSecretRef,
 			Volume:                           volume,

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -170,17 +170,18 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 		if !ok {
 			return nil, fmt.Errorf("missing operating system config for worker pool %v", workerPool.Name)
 		}
+
 		if oscConfig.Init.SecretName == nil {
 			return nil, fmt.Errorf("missing secret name for worker pool %v", workerPool.Name)
 		}
 
-		var (
-			gardenerNodeAgentSecretName = oscConfig.Init.GardenerNodeAgentSecretName
-			nodeAgentSecretName         *string
-		)
-		if oscConfig.Init.IncludeSecretNameInWorkerPool {
-			nodeAgentSecretName = &gardenerNodeAgentSecretName
+		// TODO(rfranzke): Remove userData after v1.100 has been released.
+		userData := []byte(oscConfig.Init.Content)
+		userDataSecretRef := &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: *oscConfig.Init.SecretName},
+			Key:                  extensionsv1alpha1.OperatingSystemConfigSecretDataKey,
 		}
+		gardenerNodeAgentSecretName := oscConfig.Init.GardenerNodeAgentSecretName
 
 		workerPoolKubernetesVersion := w.values.KubernetesVersion.String()
 		if workerPool.Kubernetes != nil && workerPool.Kubernetes.Version != nil {
@@ -224,6 +225,11 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			}
 		}
 
+		var nodeAgentSecretName *string
+		if oscConfig.Init.IncludeSecretNameInWorkerPool {
+			nodeAgentSecretName = &oscConfig.Init.GardenerNodeAgentSecretName
+		}
+
 		pools = append(pools, extensionsv1alpha1.WorkerPool{
 			Name:           workerPool.Name,
 			Minimum:        workerPool.Minimum,
@@ -241,10 +247,9 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			NodeTemplate:        nodeTemplate,
 			NodeAgentSecretName: nodeAgentSecretName,
 			ProviderConfig:      pConfig,
-			UserDataSecretRef: corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: *oscConfig.Init.SecretName},
-				Key:                  extensionsv1alpha1.OperatingSystemConfigSecretDataKey,
-			},
+			// TODO(rfranzke): Remove usage of UserData field after v1.100 has been released.
+			UserData:                         userData,
+			UserDataSecretRef:                userDataSecretRef,
 			Volume:                           volume,
 			DataVolumes:                      dataVolumes,
 			KubeletDataVolumeName:            workerPool.KubeletDataVolumeName,

--- a/pkg/component/extensions/worker/worker_test.go
+++ b/pkg/component/extensions/worker/worker_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Worker", func() {
 		worker1MachineImageName               = "worker1machineimage"
 		worker1MachineImageVersion            = "worker1machineimagev1"
 		worker1MCMSettings                    = &gardencorev1beta1.MachineControllerManagerSettings{}
+		worker1UserData                       = []byte("bootstrap-me")
 		worker1UserDataKeyName                = "user-data-key-name-w1"
 		worker1UserDataSecretName             = "user-data-secret-name-w1"
 		worker1VolumeName                     = "worker1volumename"
@@ -98,6 +99,7 @@ var _ = Describe("Worker", func() {
 		worker2MachineType               = "worker2machinetype"
 		worker2MachineImageName          = "worker2machineimage"
 		worker2MachineImageVersion       = "worker2machineimagev1"
+		worker2UserData                  = []byte("bootstrap-me-now")
 		worker2UserDataKeyName           = "user-data-key-name-w2"
 		worker2UserDataSecretName        = "user-data-secret-name-w2"
 		worker2Arch                      = ptr.To("arm64")
@@ -164,12 +166,14 @@ var _ = Describe("Worker", func() {
 			WorkerPoolNameToOperatingSystemConfigsMap: map[string]*operatingsystemconfig.OperatingSystemConfigs{
 				worker1Name: {
 					Init: operatingsystemconfig.Data{
+						Content:                     string(worker1UserData),
 						GardenerNodeAgentSecretName: worker1UserDataKeyName,
 						SecretName:                  &worker1UserDataSecretName,
 					},
 				},
 				worker2Name: {
 					Init: operatingsystemconfig.Data{
+						Content:                     string(worker2UserData),
 						GardenerNodeAgentSecretName: worker2UserDataKeyName,
 						SecretName:                  &worker2UserDataSecretName,
 					},
@@ -288,7 +292,8 @@ var _ = Describe("Worker", func() {
 						Version: worker1MachineImageVersion,
 					},
 					ProviderConfig:    worker1ProviderConfig,
-					UserDataSecretRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker1UserDataSecretName}, Key: "cloud_config"},
+					UserData:          worker1UserData,
+					UserDataSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker1UserDataSecretName}, Key: "cloud_config"},
 					Volume: &extensionsv1alpha1.Volume{
 						Name:      &worker1VolumeName,
 						Type:      &worker1VolumeType,
@@ -332,7 +337,8 @@ var _ = Describe("Worker", func() {
 						Version: worker2MachineImageVersion,
 					},
 					KubernetesVersion: &workerKubernetesVersion,
-					UserDataSecretRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker2UserDataSecretName}, Key: "cloud_config"},
+					UserData:          worker2UserData,
+					UserDataSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker2UserDataSecretName}, Key: "cloud_config"},
 					NodeTemplate:      workerPool2NodeTemplate,
 					Architecture:      worker2Arch,
 					ClusterAutoscaler: emptyAutoscalerOptions,

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -197,10 +197,12 @@ var _ = Describe("operatingsystemconfig", func() {
 		var (
 			namespace = "shoot--foo--bar"
 
-			worker1Name = "worker1"
-			worker1Key  = operatingsystemconfig.KeyV1(worker1Name, semver.MustParse(kubernetesVersion), nil)
+			worker1Name            = "worker1"
+			worker1OriginalContent = "w1content"
+			worker1Key             = operatingsystemconfig.KeyV1(worker1Name, semver.MustParse(kubernetesVersion), nil)
 
 			worker2Name                  = "worker2"
+			worker2OriginalContent       = "w2content"
 			worker2KubernetesVersion     = "4.5.6"
 			worker2Key                   = operatingsystemconfig.KeyV1(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
 			worker2KubeletDataVolumeName = "vol"
@@ -209,6 +211,7 @@ var _ = Describe("operatingsystemconfig", func() {
 				worker1Name: {
 					Original: operatingsystemconfig.Data{
 						GardenerNodeAgentSecretName: worker1Key,
+						Content:                     worker1OriginalContent,
 						Object: &extensionsv1alpha1.OperatingSystemConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: worker1Name + "-original",
@@ -223,6 +226,7 @@ var _ = Describe("operatingsystemconfig", func() {
 				worker2Name: {
 					Original: operatingsystemconfig.Data{
 						GardenerNodeAgentSecretName: worker2Key,
+						Content:                     worker2OriginalContent,
 						Object: &extensionsv1alpha1.OperatingSystemConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: worker2Name + "-original",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Revert "Drop deprecated .spec.pools[].userData from `extensions.gardener.cloud/v1alpha1.Worker` API" (https://github.com/gardener/gardener/pull/10220/commits/33c21432e994dad38a3a39086e4b15c125177beb from https://github.com/gardener/gardener/pull/10220).

`provider-alicloud` was adapted with https://github.com/gardener/gardener-extension-provider-alicloud/pull/727, but it was not released since then. Let's give the maintainers a bit more time.

Removal deadline has been increased to `v1.104` now (another 3 releases).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
