### PR TITLE
Exclude valitail update in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -161,7 +161,6 @@
     },
     {
       // Do not use docker for images from gardener registry except those which do not work with github-releases.
-      // Exclude valitail updates due to hard dependency on glibc version of the target nodes.
       "matchDatasources": ["docker"],
       "matchFileNames": ["imagevector/**"],
       "matchPackagePatterns": [
@@ -169,7 +168,15 @@
       ],
       "excludePackagePatterns": [
         "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/alpine",
-        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubernetesui\/.+",
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubernetesui\/.+"
+      ],
+      "enabled": false
+    },
+    {
+      // Exclude valitail updates due to hard dependency on glibc version of the target nodes.
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["imagevector/**"],
+      "matchPackagePatterns": [
         "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/credativ\/valitail"
       ],
       "enabled": false


### PR DESCRIPTION
/area impediment
/kind cleanup

This PR removes `valitail` component from renovate.
Follow-up on https://github.com/gardener/gardener/pull/10278 which didn't properly exclude valitail updates by rennovate: https://github.com/gardener/gardener/pull/10280

```other operator
NONE
```
