### PR TITLE
Grant read permissions to CRD for authenticated users in the virtual cluster

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -230,6 +230,15 @@ rules:
   - get
   - list
   - watch
+# allow shoot owners to use kube-state-metrics with a custom resource state configuration to expose metrics about e.g. shoots
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -301,15 +301,23 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gardener.cloud:system:read-global-resources",
 			},
-			Rules: []rbacv1.PolicyRule{{
-				APIGroups: []string{gardencorev1beta1.GroupName},
-				Resources: []string{
-					"cloudprofiles",
-					"exposureclasses",
-					"seeds",
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{gardencorev1beta1.GroupName},
+					Resources: []string{
+						"cloudprofiles",
+						"exposureclasses",
+						"seeds",
+					},
+					Verbs: []string{"get", "list", "watch"},
 				},
-				Verbs: []string{"get", "list", "watch"},
-			}},
+				{
+					// allow shoot owners to use kube-state-metrics with a custom resource state configuration to expose metrics about e.g. shoots
+					APIGroups: []string{apiextensionsv1.GroupName},
+					Resources: []string{"customresourcedefinitions"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			},
 		}
 		clusterRoleBindingReadGlobalResources = &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -321,15 +321,22 @@ var _ = Describe("Virtual", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gardener.cloud:system:read-global-resources",
 			},
-			Rules: []rbacv1.PolicyRule{{
-				APIGroups: []string{"core.gardener.cloud"},
-				Resources: []string{
-					"cloudprofiles",
-					"exposureclasses",
-					"seeds",
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"core.gardener.cloud"},
+					Resources: []string{
+						"cloudprofiles",
+						"exposureclasses",
+						"seeds",
+					},
+					Verbs: []string{"get", "list", "watch"},
 				},
-				Verbs: []string{"get", "list", "watch"},
-			}},
+				{
+					APIGroups: []string{"apiextensions.k8s.io"},
+					Resources: []string{"customresourcedefinitions"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			},
 		}
 		clusterRoleBindingReadGlobalResources = &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR grants list, watch and get permissions to custom resource definitions in the virtual cluster for any authenticated user. This way, shoot owners can use kube-state-metrics with [custom resource state](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md) configurations to generate their own shoot metrics. These permissions are required by kube-state-metrics even though shoots are part of the aggregation layer and do not have a custom resource definition (see [here](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md#rbac-enabled-clusters)).

Shoot owners will need to provide the `--namespaces` flag when running kube-state-metrics to avoid trying to access namespaces that are forbidden for them. Otherwise kube-state-metrics won't produce metrics and will log errors.

During the preparation of this PR, we found a bug in kube-state-metrics worth mentioning. Metrics from custom resources defined in the aggregation layer are only generated if at least a custom resource definition exists in the virtual cluster. Therefore, this feature might not work out of the box for Gardener installations where the virtual cluster has no custom resource definitions (e.g., the local setup). We opened an [issue](https://github.com/kubernetes/kube-state-metrics/issues/2471) to upstream for this.

**Special notes for your reviewer**:

/cc @istvanballok @chrkl @petersutter @rfranzke 

**Release note**:

```other user
Grant get, list and watch permissions to the `customresourcedefinitions` resource in the virtual cluster for authenticated users. Shoot owners can now generate their own shoot metrics using custom resource state configurations by kube-state-metrics.
```
