### PR TITLE
📖 Update version skew policy, add developer guide for deprecations and backwards-compatibility

### DIFF
--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -30,15 +30,25 @@ Example:
 - newest `gardener-apiserver` is at **1.37**
 - other `gardener-apiserver` instances are supported at **1.37** and **1.36**
 
-#### gardener-controller-manager, gardener-scheduler, gardener-admission-controller, gardenlet
+#### gardener-controller-manager, gardener-scheduler, gardener-admission-controller
 
-`gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` must not be newer than the `gardener-apiserver` instances they communicate with.
+`gardener-controller-manager`, `gardener-scheduler`, and `gardener-admission-controller` must not be newer than the `gardener-apiserver` instances they communicate with.
 They are expected to match the `gardener-apiserver` minor version, but may be up to one minor version older (to allow live upgrades).
 
 Example:
 
 - `gardener-apiserver` is at **1.37**
-- `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` are supported at **1.37** and **1.36**
+- `gardener-controller-manager`, `gardener-scheduler`, and `gardener-admission-controller` are supported at **1.37** and **1.36**
+
+#### gardenlet
+
+- `gardenlet` must not be newer than `gardener-apiserver`
+- `gardenlet` may be up to two minor versions older than `gardener-apiserver`
+
+Example:
+
+- `gardener-apiserver` is at **1.37**
+- `gardenlet` is supported at **1.37**, **1.36**, and **1.35**
 
 #### gardener-operator
 
@@ -61,13 +71,14 @@ Prerequisites:
 
 - In a single-instance setup, the existing `gardener-apiserver` instance is **1.37**.
 - In a multi-instance setup, all `gardener-apiserver` instances are at **1.37** or **1.38** (this ensures maximum skew of 1 minor version between the oldest and newest `gardener-apiserver` instance).
-- The `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` instances that communicate with this `gardener-apiserver` are at version **1.37** (this ensures they are not newer than the existing API server version and are within 1 minor version of the new API server version).
+- The `gardener-controller-manager`, `gardener-scheduler`, and `gardener-admission-controller`
+- `gardenlet` instances on all seeds are at version **1.37** or **1.36** (this ensures they are not newer than the existing API server version and are within 2 minor versions of the new API server version).
 
 Actions:
 
 - Upgrade `gardener-apiserver` to **1.38**.
 
-#### gardener-controller-manager, gardener-scheduler, gardener-admission-controller, gardenlet
+#### gardener-controller-manager, gardener-scheduler, gardener-admission-controller
 
 Prerequisites:
 
@@ -75,7 +86,20 @@ Prerequisites:
 
 Actions:
 
-- Upgrade `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` to **1.38**
+- Upgrade `gardener-controller-manager`, `gardener-scheduler`, and `gardener-admission-controller` to **1.38**
+
+#### gardenlet
+
+Prerequisites:
+
+- The `gardener-apiserver` instances the `gardenlet` communicates with are at **1.38**.
+
+Actions:
+
+- Optionally upgrade `gardenlet` instances to **1.38** (or they can be left at **1.37** or **1.36**).
+
+> [!WARNING]
+> Running a landscape with `gardenlet` instances that are persistently two minor versions behind `gardener-apiserver` means they must be upgraded before the Gardener control plane can be upgraded.
 
 #### gardener-operator
 

--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -71,7 +71,7 @@ Prerequisites:
 
 - In a single-instance setup, the existing `gardener-apiserver` instance is **1.37**.
 - In a multi-instance setup, all `gardener-apiserver` instances are at **1.37** or **1.38** (this ensures maximum skew of 1 minor version between the oldest and newest `gardener-apiserver` instance).
-- The `gardener-controller-manager`, `gardener-scheduler`, and `gardener-admission-controller`
+- The `gardener-controller-manager`, `gardener-scheduler`, and `gardener-admission-controller` instances that communicate with this `gardener-apiserver` are at version **1.37** (this ensures they are not newer than the existing API server version and are within 1 minor version of the new API server version).
 - `gardenlet` instances on all seeds are at version **1.37** or **1.36** (this ensures they are not newer than the existing API server version and are within 2 minor versions of the new API server version).
 
 Actions:

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -8,6 +8,7 @@ This document describes how to contribute features or hotfixes, and how new Gard
     - [Release Validation](#release-validation)
   - [Contributing New Features or Fixes](#contributing-new-features-or-fixes)
     - [TODO Statements](#todo-statements)
+    - [Deprecations and Backwards-Compatibility](#deprecations-and-backwards-compatibility)
   - [Cherry Picks](#cherry-picks)
     - [Prerequisites](#prerequisites)
     - [Initiate a Cherry Pick](#initiate-a-cherry-pick)
@@ -151,7 +152,7 @@ Usually, the new release is triggered in the beginning of the second week if all
 ## Contributing New Features or Fixes
 
 Please refer to the [Gardener contributor guide](https://gardener.cloud/docs/contribute/).
-Besides a lot of a general information, it also provides a checklist for newly created pull requests that may help you to prepare your changes for an efficient review process.
+Besides a lot of general information, it also provides a checklist for newly created pull requests that may help you to prepare your changes for an efficient review process.
 If you are contributing a fix or major improvement, please take care to open cherry-pick PRs to all affected and still supported versions once the change is approved and merged in the `master` branch.
 
 :warning: Please ensure that your modifications pass the verification checks (linting, formatting, static code checks, tests, etc.) by executing
@@ -182,6 +183,29 @@ In order to properly follow-up with such TODOs and to prevent them from piling u
   ```
   The associated person should actively drive the implementation of the referenced issue (unless it cannot be done because of third-party dependencies or conditions) so that the TODO statement does not get stale.
 - TODO statements without actionable tasks or those that are unlikely to ever be implemented (maybe because of very low priorities) should not be specified in the first place. If a TODO is specified, the associated person should make sure to actively follow-up.
+
+### Deprecations and Backwards-Compatibility
+
+In case you have to remove functionality _relevant to end-users_ (e.g., a field or default value in the `Shoot` API), please **connect it with a Kubernetes minor version upgrade**.
+This way, end-users are forced to actively adapt their manifests when they perform their Kubernetes upgrades.
+For example, the `.spec.kubernetes.enableStaticTokenKubeconfig` field in the `Shoot` API is no longer allowed to be set for Kubernetes versions `>= 1.27`.
+
+In case you have to remove or change functionality _which cannot be directly connected with a Kubernetes version upgrade_, please consider introducing a feature gate.
+This way, landscape operators can announce the planned changes to their users and communicate a timeline when they plan to activate the feature gate.
+End-users can then prepare for it accordingly.
+For example, the fact that changes to `kubelet.kubeReserved` in the `Shoot` API will lead to a rolling update of the worker nodes (previously, these changes were updated in-place) is controlled via the `NewWorkerPoolHash` feature gate.
+
+In case you have to remove functionality _relevant to Gardener extensions_, please deprecate it first, and add a [TODO statement](#todo-statements) to remove it only after **at least 9 releases**.
+Do not forget to write a proper release note as part of your pull request.
+This gives extension developers enough time (~18 weeks) to adapt to the changes (and to release a new version of their extension) before Gardener finally removes the functionality.
+Examples are removing a field in the `extensions.gardener.cloud/v1alpha1` API group, or removing a controller in the extensions library.
+
+In case you have to run migration code (_which is mostly internal_), please add a [TODO statement](#todo-statements) to remove it only after **3 releases**.
+This way, we can ensure that the Gardener version skew policy is not violated.
+For example, the migration code for moving the Prometheus instances under management of `prometheus-operator` was running for three releases.
+
+> [!TIP]
+> Please revisit the [version skew policy](../deployment/version_skew_policy.md).
 
 ## Cherry Picks
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Some recent occurrences ([[1]](https://github.com/gardener/gardener/pull/10220#discussion_r1697977594), [[2]](https://github.com/gardener/gardener/pull/10285), [[3]](https://github.com/gardener/gardener/pull/10290)) indicate that we should refine our process regarding deprecations and backwards-compatibility (in fact, this wasn't even documented before).

On the way, I updated the version skew policy document to better explain the compatibility of `gardenlet` versions with the Gardener control plane.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
[This document](https://github.com/gardener/gardener/blob/master/docs/development/process.md) now contains a guide for developers how to handle deprecations and backwards-compatibility of changes.
```
```doc operator
[The version skew policy](https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md) was updated to better reflect how to handle `gardenlet` upgrades.
```
