### PR TITLE
Display `GardenletReconciled` condition in `Gardenlet` table

### DIFF
--- a/pkg/apis/seedmanagement/types_gardenlet.go
+++ b/pkg/apis/seedmanagement/types_gardenlet.go
@@ -80,3 +80,8 @@ type GardenletStatus struct {
 	// Gardenlet's generation, which is updated on mutation by the API Server.
 	ObservedGeneration int64
 }
+
+const (
+	// GardenletReconciled is a condition type for indicating whether the Gardenlet's has been reconciled.
+	GardenletReconciled gardencore.ConditionType = "GardenletReconciled"
+)

--- a/pkg/apis/seedmanagement/types_gardenlet.go
+++ b/pkg/apis/seedmanagement/types_gardenlet.go
@@ -82,6 +82,6 @@ type GardenletStatus struct {
 }
 
 const (
-	// GardenletReconciled is a condition type for indicating whether the Gardenlet's has been reconciled.
+	// GardenletReconciled is a condition type for indicating whether the Gardenlet has been reconciled.
 	GardenletReconciled gardencore.ConditionType = "GardenletReconciled"
 )

--- a/pkg/apis/seedmanagement/v1alpha1/types_gardenlet.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_gardenlet.go
@@ -95,6 +95,6 @@ type GardenletStatus struct {
 }
 
 const (
-	// GardenletReconciled is a condition type for indicating whether the Gardenlet's has been reconciled.
+	// GardenletReconciled is a condition type for indicating whether the Gardenlet has been reconciled.
 	GardenletReconciled gardencorev1beta1.ConditionType = "GardenletReconciled"
 )

--- a/pkg/apiserver/registry/seedmanagement/gardenlet/storage/tableconvertor.go
+++ b/pkg/apiserver/registry/seedmanagement/gardenlet/storage/tableconvertor.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	"github.com/gardener/gardener/pkg/apis/core/helper"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 )
 
@@ -28,6 +29,7 @@ func newTableConvertor() rest.TableConvertor {
 		headers: []metav1beta1.TableColumnDefinition{
 			{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
 			{Name: "OCI Repository", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["ociRepository"]},
+			{Name: "Reconciled", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["reconciled"]},
 			{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
 		},
 	}
@@ -58,6 +60,11 @@ func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runt
 		)
 		cells = append(cells, gardenlet.Name)
 		cells = append(cells, gardenlet.Spec.Deployment.Helm.OCIRepository.GetURL())
+		if cond := helper.GetCondition(gardenlet.Status.Conditions, seedmanagement.GardenletReconciled); cond != nil {
+			cells = append(cells, cond.Status)
+		} else {
+			cells = append(cells, "<unknown>")
+		}
 		cells = append(cells, metatable.ConvertToHumanReadableDateType(gardenlet.CreationTimestamp))
 		return cells, nil
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Before:
```shell
$ kubectl -n garden get gardenlet
NAME       OCI REPOSITORY                      AGE
foo        some-oci-repository:some-tag        23h
```

Now:

```shell
$ kubectl -n garden get gardenlet
NAME       OCI REPOSITORY                      RECONCILED        AGE
foo        some-oci-repository:some-tag        True              23h
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
