### PR TITLE
vpa-{updater,recommender}: Enable leader election unconditionally. Enable HA

### DIFF
--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -150,6 +150,10 @@ This document provides a checklist for them that you can walk through.
 
    To reduce costs and to improve the network traffic latency in multi-zone Seed clusters, consider making a `Service` topology-aware, if applicable. In short, when a `Service` is topology-aware, Kubernetes routes network traffic to the `Endpoint`s (`Pod`s) which are located in the same zone where the traffic originated from. In this way, the cross availability zone traffic is avoided. See [Topology-Aware Traffic Routing](../operations/topology_aware_routing.md).
 
+7. **Enable leader election unconditionally for controllers** ([example 1](https://github.com/gardener/gardener/blob/bd0a90854f0a8751d361e6f1cedd97ce5a746e3c/pkg/component/kubernetes/controllermanager/controllermanager.go#L677), [example 2](https://github.com/gardener/gardener/blob/bd0a90854f0a8751d361e6f1cedd97ce5a746e3c/pkg/component/kubernetes/scheduler/scheduler.go#L75-L76), [example 3](https://github.com/gardener/gardener/blob/bd0a90854f0a8751d361e6f1cedd97ce5a746e3c/pkg/component/gardener/resourcemanager/resource_manager.go#L519-L523))
+
+   Enable leader election unconditionally for controllers independently from the number of replicas or from the high availability configurations. Having leader election enabled even for a single replica Deployment prevents having two Pods active at the same time. Otherwise, there are some corner cases that can result in two active Pods - Deployment rolling update or kubelet stops running on a Node and is not able to terminate the old replica while kube-controller-manager creates a new replica to match the Deployment's desired replicas count.
+
 ## Scalability
 
 1. **Provide resource requirements** ([example](https://github.com/gardener/gardener/blob/b0de7db96ad436fe32c25daae5e8cb552dac351f/pkg/component/metricsserver/metrics_server.go#L345-L353))

--- a/pkg/component/autoscaling/vpa/admissioncontroller.go
+++ b/pkg/component/autoscaling/vpa/admissioncontroller.go
@@ -134,7 +134,7 @@ func (v *vpa) reconcileAdmissionControllerClusterRoleBinding(clusterRoleBinding 
 	clusterRoleBinding.Subjects = []rbacv1.Subject{{
 		Kind:      rbacv1.ServiceAccountKind,
 		Name:      serviceAccountName,
-		Namespace: v.serviceAccountNamespace(),
+		Namespace: v.namespaceForApplicationClassResource(),
 	}}
 }
 

--- a/pkg/component/autoscaling/vpa/general.go
+++ b/pkg/component/autoscaling/vpa/general.go
@@ -105,12 +105,12 @@ func (v *vpa) reconcileGeneralClusterRoleBindingActor(clusterRoleBinding *rbacv1
 		{
 			Kind:      rbacv1.ServiceAccountKind,
 			Name:      recommender,
-			Namespace: v.serviceAccountNamespace(),
+			Namespace: v.namespaceForApplicationClassResource(),
 		},
 		{
 			Kind:      rbacv1.ServiceAccountKind,
 			Name:      updater,
-			Namespace: v.serviceAccountNamespace(),
+			Namespace: v.namespaceForApplicationClassResource(),
 		},
 	}
 }
@@ -158,17 +158,17 @@ func (v *vpa) reconcileGeneralClusterRoleBindingTargetReader(clusterRoleBinding 
 		{
 			Kind:      rbacv1.ServiceAccountKind,
 			Name:      admissionController,
-			Namespace: v.serviceAccountNamespace(),
+			Namespace: v.namespaceForApplicationClassResource(),
 		},
 		{
 			Kind:      rbacv1.ServiceAccountKind,
 			Name:      recommender,
-			Namespace: v.serviceAccountNamespace(),
+			Namespace: v.namespaceForApplicationClassResource(),
 		},
 		{
 			Kind:      rbacv1.ServiceAccountKind,
 			Name:      updater,
-			Namespace: v.serviceAccountNamespace(),
+			Namespace: v.namespaceForApplicationClassResource(),
 		},
 	}
 }

--- a/pkg/component/autoscaling/vpa/recommender.go
+++ b/pkg/component/autoscaling/vpa/recommender.go
@@ -74,6 +74,8 @@ func (v *vpa) recommenderResourceConfigs() component.ResourceConfigs {
 		clusterRoleBindingCheckpointActor = v.emptyClusterRoleBinding("checkpoint-actor")
 		clusterRoleStatusActor            = v.emptyClusterRole("status-actor")
 		clusterRoleBindingStatusActor     = v.emptyClusterRoleBinding("status-actor")
+		roleLeaderLocking                 = v.emptyRole("leader-locking-vpa-recommender")
+		roleBindingLeaderLocking          = v.emptyRoleBinding("leader-locking-vpa-recommender")
 		service                           = v.emptyService(recommender)
 		deployment                        = v.emptyDeployment(recommender)
 		podMonitor                        = v.emptyPodMonitor(recommender)
@@ -91,6 +93,10 @@ func (v *vpa) recommenderResourceConfigs() component.ResourceConfigs {
 		{Obj: clusterRoleStatusActor, Class: component.Application, MutateFn: func() { v.reconcileRecommenderClusterRoleStatusActor(clusterRoleStatusActor) }},
 		{Obj: clusterRoleBindingStatusActor, Class: component.Application, MutateFn: func() {
 			v.reconcileRecommenderClusterRoleBinding(clusterRoleBindingStatusActor, clusterRoleStatusActor, recommender)
+		}},
+		{Obj: roleLeaderLocking, Class: component.Application, MutateFn: func() { v.reconcileRecommenderRoleLeaderLocking(roleLeaderLocking) }},
+		{Obj: roleBindingLeaderLocking, Class: component.Application, MutateFn: func() {
+			v.reconcileRecommenderRoleBindingLeaderLocking(roleBindingLeaderLocking, roleLeaderLocking, recommender)
 		}},
 		{Obj: service, Class: component.Runtime, MutateFn: func() { v.reconcileRecommenderService(service) }},
 	}
@@ -172,7 +178,38 @@ func (v *vpa) reconcileRecommenderClusterRoleBinding(clusterRoleBinding *rbacv1.
 	clusterRoleBinding.Subjects = []rbacv1.Subject{{
 		Kind:      rbacv1.ServiceAccountKind,
 		Name:      serviceAccountName,
-		Namespace: v.serviceAccountNamespace(),
+		Namespace: v.namespaceForApplicationClassResource(),
+	}}
+}
+
+func (v *vpa) reconcileRecommenderRoleLeaderLocking(role *rbacv1.Role) {
+	role.Labels = getRoleLabel()
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups:     []string{"coordination.k8s.io"},
+			Resources:     []string{"leases"},
+			ResourceNames: []string{"vpa-recommender"},
+			Verbs:         []string{"get", "watch", "update"},
+		},
+	}
+}
+
+func (v *vpa) reconcileRecommenderRoleBindingLeaderLocking(roleBinding *rbacv1.RoleBinding, role *rbacv1.Role, serviceAccountName string) {
+	roleBinding.Labels = getRoleLabel()
+	roleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+	roleBinding.Subjects = []rbacv1.Subject{{
+		Kind:      rbacv1.ServiceAccountKind,
+		Name:      serviceAccountName,
+		Namespace: v.namespaceForApplicationClassResource(),
 	}}
 }
 
@@ -226,6 +263,8 @@ func (v *vpa) reconcileRecommenderDeployment(deployment *appsv1.Deployment, serv
 						fmt.Sprintf("--target-memory-percentile=%f", ptr.Deref(v.values.Recommender.TargetMemoryPercentile, gardencorev1beta1.DefaultTargetMemoryPercentile)),
 						fmt.Sprintf("--recommendation-lower-bound-memory-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationLowerBoundMemoryPercentile, gardencorev1beta1.DefaultRecommendationLowerBoundMemoryPercentile)),
 						fmt.Sprintf("--recommendation-upper-bound-memory-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationUpperBoundMemoryPercentile, gardencorev1beta1.DefaultRecommendationUpperBoundMemoryPercentile)),
+						"--leader-elect=true",
+						fmt.Sprintf("--leader-elect-resource-namespace=%s", v.namespaceForApplicationClassResource()),
 					},
 					LivenessProbe: newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{

--- a/pkg/component/autoscaling/vpa/recommender.go
+++ b/pkg/component/autoscaling/vpa/recommender.go
@@ -196,7 +196,7 @@ func (v *vpa) reconcileRecommenderRoleLeaderLocking(role *rbacv1.Role) {
 		{
 			APIGroups:     []string{"coordination.k8s.io"},
 			Resources:     []string{"leases"},
-			ResourceNames: []string{"vpa-recommender"},
+			ResourceNames: []string{recommender},
 			Verbs:         []string{"get", "watch", "update"},
 		},
 	}

--- a/pkg/component/autoscaling/vpa/updater.go
+++ b/pkg/component/autoscaling/vpa/updater.go
@@ -56,15 +56,21 @@ type ValuesUpdater struct {
 
 func (v *vpa) updaterResourceConfigs() component.ResourceConfigs {
 	var (
-		clusterRole        = v.emptyClusterRole("evictioner")
-		clusterRoleBinding = v.emptyClusterRoleBinding("evictioner")
-		deployment         = v.emptyDeployment(updater)
-		vpa                = v.emptyVerticalPodAutoscaler(updater)
+		clusterRole              = v.emptyClusterRole("evictioner")
+		clusterRoleBinding       = v.emptyClusterRoleBinding("evictioner")
+		roleLeaderLocking        = v.emptyRole("leader-locking-vpa-updater")
+		roleBindingLeaderLocking = v.emptyRoleBinding("leader-locking-vpa-updater")
+		deployment               = v.emptyDeployment(updater)
+		vpa                      = v.emptyVerticalPodAutoscaler(updater)
 	)
 
 	configs := component.ResourceConfigs{
 		{Obj: clusterRole, Class: component.Application, MutateFn: func() { v.reconcileUpdaterClusterRole(clusterRole) }},
 		{Obj: clusterRoleBinding, Class: component.Application, MutateFn: func() { v.reconcileUpdaterClusterRoleBinding(clusterRoleBinding, clusterRole, updater) }},
+		{Obj: roleLeaderLocking, Class: component.Application, MutateFn: func() { v.reconcileUpdaterRoleLeaderLocking(roleLeaderLocking) }},
+		{Obj: roleBindingLeaderLocking, Class: component.Application, MutateFn: func() {
+			v.reconcileUpdaterRoleBindingLeaderLocking(roleBindingLeaderLocking, roleLeaderLocking, updater)
+		}},
 		{Obj: vpa, Class: component.Runtime, MutateFn: func() { v.reconcileUpdaterVPA(vpa, deployment) }},
 	}
 
@@ -115,7 +121,38 @@ func (v *vpa) reconcileUpdaterClusterRoleBinding(clusterRoleBinding *rbacv1.Clus
 	clusterRoleBinding.Subjects = []rbacv1.Subject{{
 		Kind:      rbacv1.ServiceAccountKind,
 		Name:      serviceAccountName,
-		Namespace: v.serviceAccountNamespace(),
+		Namespace: v.namespaceForApplicationClassResource(),
+	}}
+}
+
+func (v *vpa) reconcileUpdaterRoleLeaderLocking(role *rbacv1.Role) {
+	role.Labels = getRoleLabel()
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups:     []string{"coordination.k8s.io"},
+			Resources:     []string{"leases"},
+			ResourceNames: []string{"vpa-updater"},
+			Verbs:         []string{"get", "watch", "update"},
+		},
+	}
+}
+
+func (v *vpa) reconcileUpdaterRoleBindingLeaderLocking(roleBinding *rbacv1.RoleBinding, role *rbacv1.Role, serviceAccountName string) {
+	roleBinding.Labels = getRoleLabel()
+	roleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+	roleBinding.Subjects = []rbacv1.Subject{{
+		Kind:      rbacv1.ServiceAccountKind,
+		Name:      serviceAccountName,
+		Namespace: v.namespaceForApplicationClassResource(),
 	}}
 }
 
@@ -151,6 +188,8 @@ func (v *vpa) reconcileUpdaterDeployment(deployment *appsv1.Deployment, serviceA
 						"--v=2",
 						"--kube-api-qps=100",
 						"--kube-api-burst=120",
+						"--leader-elect=true",
+						fmt.Sprintf("--leader-elect-resource-namespace=%s", v.namespaceForApplicationClassResource()),
 					},
 					LivenessProbe: newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{

--- a/pkg/component/autoscaling/vpa/updater.go
+++ b/pkg/component/autoscaling/vpa/updater.go
@@ -139,7 +139,7 @@ func (v *vpa) reconcileUpdaterRoleLeaderLocking(role *rbacv1.Role) {
 		{
 			APIGroups:     []string{"coordination.k8s.io"},
 			Resources:     []string{"leases"},
-			ResourceNames: []string{"vpa-updater"},
+			ResourceNames: []string{updater},
 			Verbs:         []string{"get", "watch", "update"},
 		},
 	}

--- a/pkg/component/autoscaling/vpa/vpa.go
+++ b/pkg/component/autoscaling/vpa/vpa.go
@@ -220,6 +220,14 @@ func (v *vpa) emptyClusterRoleBinding(name string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: v.rbacNamePrefix() + name}}
 }
 
+func (v *vpa) emptyRole(name string) *rbacv1.Role {
+	return &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: v.rbacNamePrefix() + name, Namespace: v.namespaceForApplicationClassResource()}}
+}
+
+func (v *vpa) emptyRoleBinding(name string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: v.rbacNamePrefix() + name, Namespace: v.namespaceForApplicationClassResource()}}
+}
+
 func (v *vpa) emptyDeployment(name string) *appsv1.Deployment {
 	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: v.namespace}}
 }
@@ -263,7 +271,7 @@ func (v *vpa) rbacNamePrefix() string {
 	return prefix + "target:"
 }
 
-func (v *vpa) serviceAccountNamespace() string {
+func (v *vpa) namespaceForApplicationClassResource() string {
 	if v.values.ClusterType == component.ClusterTypeSeed {
 		return v.namespace
 	}

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -115,12 +115,14 @@ var _ = Describe("VPA", func() {
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
 
-		serviceAccountUpdater     *corev1.ServiceAccount
-		clusterRoleUpdater        *rbacv1.ClusterRole
-		clusterRoleBindingUpdater *rbacv1.ClusterRoleBinding
-		shootAccessSecretUpdater  *corev1.Secret
-		deploymentUpdaterFor      func(bool, *metav1.Duration, *metav1.Duration, *int32, *float64, *float64) *appsv1.Deployment
-		vpaUpdater                *vpaautoscalingv1.VerticalPodAutoscaler
+		serviceAccountUpdater           *corev1.ServiceAccount
+		clusterRoleUpdater              *rbacv1.ClusterRole
+		clusterRoleBindingUpdater       *rbacv1.ClusterRoleBinding
+		roleLeaderLockingUpdater        *rbacv1.Role
+		roleBindingLeaderLockingUpdater *rbacv1.RoleBinding
+		shootAccessSecretUpdater        *corev1.Secret
+		deploymentUpdaterFor            func(bool, *metav1.Duration, *metav1.Duration, *int32, *float64, *float64, string) *appsv1.Deployment
+		vpaUpdater                      *vpaautoscalingv1.VerticalPodAutoscaler
 
 		serviceAccountRecommender                    *corev1.ServiceAccount
 		clusterRoleRecommenderMetricsReader          *rbacv1.ClusterRole
@@ -129,9 +131,11 @@ var _ = Describe("VPA", func() {
 		clusterRoleBindingRecommenderCheckpointActor *rbacv1.ClusterRoleBinding
 		clusterRoleRecommenderStatusActor            *rbacv1.ClusterRole
 		clusterRoleBindingRecommenderStatusActor     *rbacv1.ClusterRoleBinding
+		roleLeaderLockingRecommender                 *rbacv1.Role
+		roleBindingLeaderLockingRecommender          *rbacv1.RoleBinding
 		serviceRecommenderFor                        func(component.ClusterType) *corev1.Service
 		shootAccessSecretRecommender                 *corev1.Secret
-		deploymentRecommenderFor                     func(bool, *metav1.Duration, *float64, component.ClusterType, *float64, *float64, *float64, *float64, *float64, *float64) *appsv1.Deployment
+		deploymentRecommenderFor                     func(bool, *metav1.Duration, *float64, component.ClusterType, *float64, *float64, *float64, *float64, *float64, *float64, string) *appsv1.Deployment
 		vpaRecommender                               *vpaautoscalingv1.VerticalPodAutoscaler
 		podMonitorRecommender                        *monitoringv1.PodMonitor
 
@@ -229,6 +233,47 @@ var _ = Describe("VPA", func() {
 				Namespace: namespace,
 			}},
 		}
+		roleLeaderLockingUpdater = &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener.cloud:vpa:target:leader-locking-vpa-updater",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"gardener.cloud/role": "vpa",
+				},
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups:     []string{"coordination.k8s.io"},
+					Resources:     []string{"leases"},
+					ResourceNames: []string{"vpa-updater"},
+					Verbs:         []string{"get", "watch", "update"},
+				},
+			},
+		}
+		roleBindingLeaderLockingUpdater = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener.cloud:vpa:target:leader-locking-vpa-updater",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"gardener.cloud/role": "vpa",
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "gardener.cloud:vpa:target:leader-locking-vpa-updater",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "vpa-updater",
+				Namespace: namespace,
+			}},
+		}
 		shootAccessSecretUpdater = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "shoot-access-vpa-updater",
@@ -251,6 +296,7 @@ var _ = Describe("VPA", func() {
 			evictionRateBurst *int32,
 			evictionRateLimit *float64,
 			evictionTolerance *float64,
+			leaderElectionNamespace string,
 		) *appsv1.Deployment {
 			var (
 				flagEvictionToleranceValue      = "0.500000"
@@ -320,6 +366,8 @@ var _ = Describe("VPA", func() {
 									"--v=2",
 									"--kube-api-qps=100",
 									"--kube-api-burst=120",
+									"--leader-elect=true",
+									fmt.Sprintf("--leader-elect-resource-namespace=%s", leaderElectionNamespace),
 								},
 								LivenessProbe: livenessProbeVpa,
 								Ports: []corev1.ContainerPort{
@@ -518,6 +566,47 @@ var _ = Describe("VPA", func() {
 				Name:     "gardener.cloud:vpa:target:status-actor",
 			},
 		}
+		roleLeaderLockingRecommender = &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener.cloud:vpa:target:leader-locking-vpa-recommender",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"gardener.cloud/role": "vpa",
+				},
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups:     []string{"coordination.k8s.io"},
+					Resources:     []string{"leases"},
+					ResourceNames: []string{"vpa-recommender"},
+					Verbs:         []string{"get", "watch", "update"},
+				},
+			},
+		}
+		roleBindingLeaderLockingRecommender = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener.cloud:vpa:target:leader-locking-vpa-recommender",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"gardener.cloud/role": "vpa",
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "gardener.cloud:vpa:target:leader-locking-vpa-recommender",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "vpa-recommender",
+				Namespace: namespace,
+			}},
+		}
 		serviceRecommenderFor = func(clusterType component.ClusterType) *corev1.Service {
 			obj := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -572,6 +661,7 @@ var _ = Describe("VPA", func() {
 			targetMemoryPercentile *float64,
 			recommendationLowerBoundMemoryPercentile *float64,
 			recommendationUpperBoundMemoryPercentile *float64,
+			leaderElectionNamespace string,
 		) *appsv1.Deployment {
 			var cpuRequest string
 			var memoryRequest string
@@ -632,6 +722,8 @@ var _ = Describe("VPA", func() {
 									fmt.Sprintf("--target-memory-percentile=%f", ptr.Deref(targetMemoryPercentile, 0.9)),
 									fmt.Sprintf("--recommendation-lower-bound-memory-percentile=%f", ptr.Deref(recommendationLowerBoundMemoryPercentile, 0.5)),
 									fmt.Sprintf("--recommendation-upper-bound-memory-percentile=%f", ptr.Deref(recommendationUpperBoundMemoryPercentile, 0.95)),
+									"--leader-elect=true",
+									fmt.Sprintf("--leader-elect-resource-namespace=%s", leaderElectionNamespace),
 								},
 								LivenessProbe: livenessProbeVpa,
 								Ports: []corev1.ContainerPort{
@@ -1310,14 +1402,19 @@ var _ = Describe("VPA", func() {
 					clusterRoleUpdater.Name = replaceTargetSubstrings(clusterRoleUpdater.Name)
 					clusterRoleBindingUpdater.Name = replaceTargetSubstrings(clusterRoleBindingUpdater.Name)
 					clusterRoleBindingUpdater.RoleRef.Name = replaceTargetSubstrings(clusterRoleBindingUpdater.RoleRef.Name)
+					roleLeaderLockingUpdater.Name = replaceTargetSubstrings(roleLeaderLockingUpdater.Name)
+					roleBindingLeaderLockingUpdater.Name = replaceTargetSubstrings(roleBindingLeaderLockingUpdater.Name)
+					roleBindingLeaderLockingUpdater.RoleRef.Name = replaceTargetSubstrings(roleBindingLeaderLockingUpdater.RoleRef.Name)
 
-					deploymentUpdater := deploymentUpdaterFor(true, nil, nil, nil, nil, nil)
+					deploymentUpdater := deploymentUpdaterFor(true, nil, nil, nil, nil, nil, namespace)
 					adaptNetworkPolicyLabelsForClusterTypeSeed(deploymentUpdater.Spec.Template.Labels)
 
 					expectedObjects = []client.Object{
 						serviceAccountUpdater,
 						clusterRoleUpdater,
 						clusterRoleBindingUpdater,
+						roleLeaderLockingUpdater,
+						roleBindingLeaderLockingUpdater,
 						deploymentUpdater,
 						vpaUpdater,
 					}
@@ -1332,8 +1429,11 @@ var _ = Describe("VPA", func() {
 					clusterRoleRecommenderStatusActor.Name = replaceTargetSubstrings(clusterRoleRecommenderStatusActor.Name)
 					clusterRoleBindingRecommenderStatusActor.Name = replaceTargetSubstrings(clusterRoleBindingRecommenderStatusActor.Name)
 					clusterRoleBindingRecommenderStatusActor.RoleRef.Name = replaceTargetSubstrings(clusterRoleBindingRecommenderStatusActor.RoleRef.Name)
+					roleLeaderLockingRecommender.Name = replaceTargetSubstrings(roleLeaderLockingRecommender.Name)
+					roleBindingLeaderLockingRecommender.Name = replaceTargetSubstrings(roleBindingLeaderLockingRecommender.Name)
+					roleBindingLeaderLockingRecommender.RoleRef.Name = replaceTargetSubstrings(roleBindingLeaderLockingRecommender.RoleRef.Name)
 
-					deploymentRecommender := deploymentRecommenderFor(true, nil, nil, component.ClusterTypeSeed, nil, nil, nil, nil, nil, nil)
+					deploymentRecommender := deploymentRecommenderFor(true, nil, nil, component.ClusterTypeSeed, nil, nil, nil, nil, nil, nil, namespace)
 					adaptNetworkPolicyLabelsForClusterTypeSeed(deploymentRecommender.Spec.Template.Labels)
 
 					expectedObjects = append(expectedObjects,
@@ -1344,6 +1444,8 @@ var _ = Describe("VPA", func() {
 						clusterRoleBindingRecommenderCheckpointActor,
 						clusterRoleRecommenderStatusActor,
 						clusterRoleBindingRecommenderStatusActor,
+						roleLeaderLockingRecommender,
+						roleBindingLeaderLockingRecommender,
 						deploymentRecommender,
 						serviceRecommenderFor(component.ClusterTypeSeed),
 						podMonitorRecommender,
@@ -1480,6 +1582,7 @@ var _ = Describe("VPA", func() {
 					valuesUpdater.EvictionRateBurst,
 					valuesUpdater.EvictionRateLimit,
 					valuesUpdater.EvictionTolerance,
+					namespace,
 				)
 				adaptNetworkPolicyLabelsForClusterTypeSeed(deploymentUpdater.Spec.Template.Labels)
 
@@ -1494,6 +1597,7 @@ var _ = Describe("VPA", func() {
 					valuesRecommender.TargetMemoryPercentile,
 					valuesRecommender.RecommendationLowerBoundMemoryPercentile,
 					valuesRecommender.RecommendationUpperBoundMemoryPercentile,
+					namespace,
 				)
 				adaptNetworkPolicyLabelsForClusterTypeSeed(deploymentRecommender.Spec.Template.Labels)
 
@@ -1549,8 +1653,16 @@ var _ = Describe("VPA", func() {
 
 					By("Verify vpa-updater application resources")
 					clusterRoleBindingUpdater.Subjects[0].Namespace = "kube-system"
+					roleLeaderLockingUpdater.Namespace = "kube-system"
+					roleBindingLeaderLockingUpdater.Namespace = "kube-system"
+					roleBindingLeaderLockingUpdater.Subjects[0].Namespace = "kube-system"
 
-					Expect(managedResource).To(contain(clusterRoleUpdater, clusterRoleBindingUpdater))
+					Expect(managedResource).To(contain(
+						clusterRoleUpdater,
+						clusterRoleBindingUpdater,
+						roleLeaderLockingUpdater,
+						roleBindingLeaderLockingUpdater,
+					))
 					Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
@@ -1562,7 +1674,7 @@ var _ = Describe("VPA", func() {
 
 					deployment := &appsv1.Deployment{}
 					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpa-updater"}, deployment)).To(Succeed())
-					deploymentUpdater := deploymentUpdaterFor(false, nil, nil, nil, nil, nil)
+					deploymentUpdater := deploymentUpdaterFor(false, nil, nil, nil, nil, nil, "kube-system")
 					deploymentUpdater.ResourceVersion = "1"
 					Expect(deployment).To(Equal(deploymentUpdater))
 
@@ -1574,12 +1686,20 @@ var _ = Describe("VPA", func() {
 					By("Verify vpa-recommender application resources")
 					clusterRoleBindingRecommenderMetricsReader.Subjects[0].Namespace = "kube-system"
 					clusterRoleBindingRecommenderCheckpointActor.Subjects[0].Namespace = "kube-system"
+					clusterRoleBindingRecommenderStatusActor.Subjects[0].Namespace = "kube-system"
+					roleLeaderLockingRecommender.Namespace = "kube-system"
+					roleBindingLeaderLockingRecommender.Namespace = "kube-system"
+					roleBindingLeaderLockingRecommender.Subjects[0].Namespace = "kube-system"
 
 					Expect(managedResource).To(contain(
 						clusterRoleRecommenderMetricsReader,
 						clusterRoleBindingRecommenderMetricsReader,
 						clusterRoleRecommenderCheckpointActor,
 						clusterRoleBindingRecommenderCheckpointActor,
+						clusterRoleRecommenderStatusActor,
+						clusterRoleBindingRecommenderStatusActor,
+						roleLeaderLockingRecommender,
+						roleBindingLeaderLockingRecommender,
 					))
 
 					By("Verify vpa-recommender runtime resources")
@@ -1590,7 +1710,7 @@ var _ = Describe("VPA", func() {
 
 					deployment = &appsv1.Deployment{}
 					Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "vpa-recommender"}, deployment)).To(Succeed())
-					deploymentRecommender := deploymentRecommenderFor(false, nil, nil, component.ClusterTypeShoot, nil, nil, nil, nil, nil, nil)
+					deploymentRecommender := deploymentRecommenderFor(false, nil, nil, component.ClusterTypeShoot, nil, nil, nil, nil, nil, nil, "kube-system")
 					deploymentRecommender.ResourceVersion = "1"
 					Expect(deployment).To(Equal(deploymentRecommender))
 
@@ -1744,11 +1864,11 @@ var _ = Describe("VPA", func() {
 				Expect(c.Create(ctx, managedResourceSecret)).To(Succeed())
 
 				By("Create vpa-updater runtime resources")
-				Expect(c.Create(ctx, deploymentUpdaterFor(true, nil, nil, nil, nil, nil))).To(Succeed())
+				Expect(c.Create(ctx, deploymentUpdaterFor(true, nil, nil, nil, nil, nil, "kube-system"))).To(Succeed())
 				Expect(c.Create(ctx, vpaUpdater)).To(Succeed())
 
 				By("Create vpa-recommender runtime resources")
-				Expect(c.Create(ctx, deploymentRecommenderFor(true, nil, nil, component.ClusterTypeShoot, nil, nil, nil, nil, nil, nil))).To(Succeed())
+				Expect(c.Create(ctx, deploymentRecommenderFor(true, nil, nil, component.ClusterTypeShoot, nil, nil, nil, nil, nil, nil, "kube-system"))).To(Succeed())
 				Expect(c.Create(ctx, serviceRecommenderFor(component.ClusterTypeShoot))).To(Succeed())
 				Expect(c.Create(ctx, vpaRecommender)).To(Succeed())
 
@@ -1764,11 +1884,11 @@ var _ = Describe("VPA", func() {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
 
 				By("Verify vpa-updater runtime resources")
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(deploymentUpdaterFor(true, nil, nil, nil, nil, nil)), &appsv1.Deployment{})).To(BeNotFoundError())
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(deploymentUpdaterFor(true, nil, nil, nil, nil, nil, "kube-system")), &appsv1.Deployment{})).To(BeNotFoundError())
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(vpaUpdater), &vpaautoscalingv1.VerticalPodAutoscaler{})).To(BeNotFoundError())
 
 				By("Verify vpa-recommender runtime resources")
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(deploymentRecommenderFor(true, nil, nil, component.ClusterTypeShoot, nil, nil, nil, nil, nil, nil)), &appsv1.Deployment{})).To(BeNotFoundError())
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(deploymentRecommenderFor(true, nil, nil, component.ClusterTypeShoot, nil, nil, nil, nil, nil, nil, "kube-system")), &appsv1.Deployment{})).To(BeNotFoundError())
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(serviceRecommenderFor(component.ClusterTypeShoot)), &appsv1.Deployment{})).To(BeNotFoundError())
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(vpaRecommender), &vpaautoscalingv1.VerticalPodAutoscaler{})).To(BeNotFoundError())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
HA was so far not enabled for vpa-{recommender,updater} because they didn't support leader election: https://github.com/gardener/gardener/blob/f1c5fc5d855dde57188a73aacd924d69449fccd9/pkg/component/autoscaling/vpa/updater.go#L123-L124 and https://github.com/gardener/gardener/blob/f1c5fc5d855dde57188a73aacd924d69449fccd9/pkg/component/autoscaling/vpa/recommender.go#L182-L183

In VPA v1.2.0, support for leader election was added to vpa-{recommender,updater} with https://github.com/kubernetes/autoscaler/pull/6985.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
One thing that is not so obvious today is that we run control plane controllers (kube-controller-manager, kube-scheduler, cloud-controller-manager, etc.) with leader election enabled even even though they run with single replica in some of the cases:
- kube-controller-manager: https://github.com/gardener/gardener/blob/db06a3ac88c23e212242d65d1f47418ad1e141d6/pkg/component/kubernetes/controllermanager/controllermanager.go#L677
- kube-scheduler: https://github.com/gardener/gardener/blob/37c4b728ebd3353e0b442add3727f5ca6bc7497a/pkg/component/kubernetes/scheduler/scheduler.go#L75-L76
- cloud-controller-manager: https://github.com/gardener/gardener-extension-provider-aws/blob/8a7e4b28837e2d5fe4fc4e8212de2809db57dce9/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml#L53
- gardener-resource-manager: https://github.com/gardener/gardener/blob/9f3b25415f3cd5ba9f44d5d0cf6c6b752af6f37f/pkg/component/gardener/resourcemanager/resource_manager.go#L519-L523
- ...

That's why I enabled leader election unconditionally for {vpa-updater,recommender} as well.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
vpa-updater and vpa-recommender components do now run with leader election enabled (unconditionally) and support running in HA mode.
```
