### PR TITLE
Fix/Add CABundle handling for flatcar

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -92,9 +92,18 @@ if [[ -f "/etc/debian_version" ]]; then
     fi
     # localcertsdir is supported on Debian based OS only
     /usr/sbin/update-ca-certificates --fresh --localcertsdir "/var/lib/ca-certificates-local"
-else
-    /usr/sbin/update-ca-certificates --fresh
+    exit
 fi
+
+if grep -q flatcar "/etc/os-release"; then
+    # Flatcar needs the file in /etc/ssl/certs/ with .pem file extension
+    cp "/var/lib/ca-certificates-local/ROOTcerts.crt" /etc/ssl/certs/ROOTcerts.pem
+    # Flatcar does not support --fresh
+    /usr/sbin/update-ca-certificates
+    exit
+fi
+
+/usr/sbin/update-ca-certificates --fresh
 `)),
 						},
 					},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
@@ -13,6 +13,15 @@ if [[ -f "/etc/debian_version" ]]; then
     fi
     # localcertsdir is supported on Debian based OS only
     /usr/sbin/update-ca-certificates --fresh --localcertsdir "{{ .pathLocalSSLCerts }}"
-else
-    /usr/sbin/update-ca-certificates --fresh
+    exit
 fi
+
+if grep -q flatcar "/etc/os-release"; then
+    # Flatcar needs the file in /etc/ssl/certs/ with .pem file extension
+    cp "{{ .pathLocalSSLCerts }}/ROOTcerts.crt" /etc/ssl/certs/ROOTcerts.pem
+    # Flatcar does not support --fresh
+    /usr/sbin/update-ca-certificates
+    exit
+fi
+
+/usr/sbin/update-ca-certificates --fresh


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:

The `CABundle` from `cloudprofile.spec.caBundle` and `shoot.spec.provider.workers.caBundle` is currently not working for `flatcar` linux.

This PR adds the handling for `flatcar` to `update-local-ca-certificates.sh` (Based on the description of flatcar: https://www.flatcar.org/docs/latest/setup/security/adding-certificate-authorities/)

I decided against putting the cert file directly to `/etc/ssl/certs/ROOTcerts.pem` via `OperatingSystemConfig`, as this is already present in `/var/lib/ca-certificates-local/ROOTcerts.crt`. In my opinion, the same applies to  `/etc/pki/trust/anchors/ROOTcerts.pem` which contains also the same and could be copied within the shell script.

I dont understeand the reason for `mkdir -p "{{ .pathLocalSSLCerts }}"`, as this is should be always there because of the files from `OperatingSystemConfig`. I cant check with the linked Issue (https://github.com/gardenlinux/gardenlinux/issues/1490) as this is not public accessible. 
https://github.com/gardener/gardener/blob/b4042f7fcf05978d2d81920e5d54c4044156c3a9/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh#L10

**Special notes for your reviewer**:

I tested it on our environmet with flatcar version 3815.2.3.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug operator
Fix CABundle from `cloudprofile.spec.caBundle` and `shoot.spec.provider.workers.caBundle` handling for flatcar
```
