### PR TITLE
Disable cloud profile field sync if `Shoot` is being deleted

### DIFF
--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -290,6 +290,16 @@ var _ = Describe("Strategy", func() {
 
 				Expect(newShoot.Spec.CredentialsBindingName).To(Equal(ptr.To("binding")))
 			})
+
+			It("should not mutate shoots being deleted (cloud profile sync)", func() {
+				oldShoot.Spec.CloudProfileName = ptr.To("profile")
+				oldShoot.DeletionTimestamp = ptr.To(metav1.Now())
+				newShoot = oldShoot.DeepCopy()
+
+				strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
+
+				Expect(newShoot.Spec).To(Equal(oldShoot.Spec))
+			})
 		})
 
 		Context("seedName change", func() {

--- a/plugin/pkg/utils/cloudprofile.go
+++ b/plugin/pkg/utils/cloudprofile.go
@@ -115,6 +115,10 @@ func BuildCloudProfileReference(shoot *core.Shoot) *gardencorev1beta1.CloudProfi
 // SyncCloudProfileFields handles the coexistence of a Shoot Spec's cloudProfileName and cloudProfile
 // by making sure both fields are synced correctly and appropriate fallback cases are handled.
 func SyncCloudProfileFields(oldShoot, newShoot *core.Shoot) {
+	if newShoot.DeletionTimestamp != nil {
+		return
+	}
+
 	// clear cloudProfile if namespacedCloudProfile is newly provided but feature toggle is disabled
 	if newShoot.Spec.CloudProfile != nil && newShoot.Spec.CloudProfile.Kind == constants.CloudProfileReferenceKindNamespacedCloudProfile && !utilfeature.DefaultFeatureGate.Enabled(features.UseNamespacedCloudProfile) &&
 		(oldShoot == nil || oldShoot.Spec.CloudProfile == nil || oldShoot.Spec.CloudProfile.Kind != constants.CloudProfileReferenceKindNamespacedCloudProfile) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
An issue showed that if shoots are being deleted while the Gardener version is updated to `v1.101.0` (including changes from https://github.com/gardener/gardener/pull/10093), this leads to errors as the new automatic cloud profile field synchonization mechanism conflicts with the admission validation of an immutable `Shoot` spec on deletion.
This PR fixes the issue by not syncing the cloud profile fields for `Shoot`s being deleted.

**Special notes for your reviewer**:
/fyi @ScheererJ @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Disable cloud profile field sync if `Shoot` is being deleted.
```
