### PR TITLE
guestbook test: Switch redis image repository to AR

### DIFF
--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -54,7 +54,8 @@ var _ = Describe("VpnSeedServer", func() {
 
 		ctx                      = context.TODO()
 		namespace                = "shoot--foo--bar"
-		vpnImage                 = "eu.gcr.io/gardener-project/gardener/vpn-seed-server:v1.2.3"
+		vpnSeedServerImage       = "some-image:some-tag"
+		apiServerProxyImage      = "some-image2:some-tag2"
 		values                   = Values{}
 		runtimeKubernetesVersion *semver.Version
 
@@ -98,7 +99,7 @@ var _ = Describe("VpnSeedServer", func() {
 					Containers: []corev1.Container{
 						{
 							Name:            "vpn-seed-server",
-							Image:           vpnImage,
+							Image:           vpnSeedServerImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Ports: []corev1.ContainerPort{
 								{
@@ -271,7 +272,7 @@ var _ = Describe("VpnSeedServer", func() {
 				template.Spec.Containers[0].VolumeMounts = append(template.Spec.Containers[0].VolumeMounts, mount)
 				template.Spec.Containers = append(template.Spec.Containers, corev1.Container{
 					Name:            "openvpn-exporter",
-					Image:           vpnImage,
+					Image:           vpnSeedServerImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command: []string{
 						"/openvpn-exporter",
@@ -328,7 +329,7 @@ var _ = Describe("VpnSeedServer", func() {
 			} else {
 				template.Spec.Containers = append(template.Spec.Containers, corev1.Container{
 					Name:            "envoy-proxy",
-					Image:           values.ImageAPIServerProxy,
+					Image:           apiServerProxyImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					SecurityContext: &corev1.SecurityContext{
 						Capabilities: &corev1.Capabilities{
@@ -735,8 +736,8 @@ var _ = Describe("VpnSeedServer", func() {
 		runtimeKubernetesVersion = semver.MustParse("1.25.0")
 
 		values = Values{
-			ImageAPIServerProxy: "envoyproxy/envoy:v4.5.6",
-			ImageVPNSeedServer:  vpnImage,
+			ImageAPIServerProxy: apiServerProxyImage,
+			ImageVPNSeedServer:  vpnSeedServerImage,
 			KubeAPIServerHost:   ptr.To("foo.bar"),
 			Network: NetworkValues{
 				PodCIDRs:     []net.IPNet{{IP: net.ParseIP("10.0.1.0"), Mask: net.CIDRMask(24, 32)}},

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -145,8 +145,8 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	// redis-slaves are not required for test success
 	values := map[string]any{
 		"image": map[string]any{
-			"registry":   "eu.gcr.io",
-			"repository": "gardener-project/3rd/redis",
+			"registry":   "europe-docker.pkg.dev",
+			"repository": "gardener-project/releases/3rd/redis",
 			"tag":        "5.0.8",
 		},
 		"cluster": map[string]any{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
We already copy the redis image from dockerhub to AR. See https://github.com/gardener/ci-infra/blob/10b1fd1f0aa7474c19b5b4b7c9d5569e49f590a5/config/images/images.yaml#L132-L137

This was somehow missed in https://github.com/gardener/gardener/pull/8968

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
