### PR TITLE
Collect `gardener_operator_garden_condition` metric

### DIFF
--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gardener/gardener/pkg/operator/apis/config"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/operator/controller"
+	"github.com/gardener/gardener/pkg/operator/metrics"
 	"github.com/gardener/gardener/pkg/operator/webhook"
 )
 
@@ -197,6 +198,11 @@ func run(ctx context.Context, log logr.Logger, cfg *config.OperatorConfiguration
 	}
 	if err := mgr.Add(gardenClientMap); err != nil {
 		return err
+	}
+
+	log.Info("Adding custom metrics to manager")
+	if err := metrics.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed adding metrics to manager: %w", err)
 	}
 
 	log.Info("Adding controllers to manager")

--- a/pkg/operator/metrics/garden.go
+++ b/pkg/operator/metrics/garden.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+)
+
+const gardenSubsystem = "garden"
+
+type gardenCollector struct {
+	runtimeClient client.Reader
+	log           logr.Logger
+
+	gardenConditions *prometheus.Desc
+}
+
+func newGardenCollector(k8sClient client.Reader, log logr.Logger) *gardenCollector {
+	c := &gardenCollector{
+		runtimeClient: k8sClient,
+		log:           log,
+	}
+	c.setMetricDefinitions()
+	return c
+}
+
+func (c *gardenCollector) setMetricDefinitions() {
+	c.gardenConditions = prometheus.NewDesc(
+		prometheus.BuildFQName(metricPrefix, gardenSubsystem, "condition"),
+		"Condition state of the Garden. Possible values: -1=Unknown|0=Unhealthy|1=Healthy|2=Progressing",
+		[]string{
+			"name",
+			"condition",
+			"operation",
+		},
+		nil,
+	)
+}
+
+func (c *gardenCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.gardenConditions
+}
+
+func (c *gardenCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	gardenList := &operatorv1alpha1.GardenList{}
+	if err := c.runtimeClient.List(ctx, gardenList); err != nil {
+		c.log.Error(err, "Failed to list gardens")
+		return
+	}
+
+	for i := range gardenList.Items {
+		garden := gardenList.Items[i]
+		if garden.Status.LastOperation == nil {
+			continue
+		}
+		lastOperation := string(garden.Status.LastOperation.Type)
+
+		for i := range garden.Status.Conditions {
+			condition := garden.Status.Conditions[i]
+			if condition.Type == "" {
+				continue
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.gardenConditions,
+				prometheus.GaugeValue,
+				mapConditionStatus(condition.Status),
+				[]string{
+					garden.Name,
+					string(condition.Type),
+					lastOperation,
+				}...,
+			)
+		}
+	}
+}

--- a/pkg/operator/metrics/garden_test.go
+++ b/pkg/operator/metrics/garden_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+)
+
+var _ = Describe("Garden metrics", func() {
+	var (
+		ctx       context.Context
+		k8sClient client.Client
+		c         prometheus.Collector
+	)
+
+	BeforeEach(func() {
+		testScheme := runtime.NewScheme()
+		Expect(operatorv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		k8sClient = fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithStatusSubresource(&operatorv1alpha1.Garden{}).
+			Build()
+
+		c = newGardenCollector(k8sClient, logr.Discard())
+	})
+
+	It("should collect condition metrics", func() {
+		garden := &operatorv1alpha1.Garden{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		}
+		Expect(k8sClient.Create(ctx, garden)).To(Succeed())
+
+		garden.Status = operatorv1alpha1.GardenStatus{
+			LastOperation: &gardencorev1beta1.LastOperation{
+				Type: gardencorev1beta1.LastOperationTypeReconcile,
+			},
+			Conditions: []gardencorev1beta1.Condition{
+				{Type: operatorv1alpha1.RuntimeComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
+				{Type: operatorv1alpha1.VirtualComponentsHealthy, Status: gardencorev1beta1.ConditionFalse},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, garden)).To(Succeed())
+
+		Expect(
+			testutil.CollectAndCompare(c, strings.NewReader(`# HELP gardener_operator_garden_condition Condition state of the Garden. Possible values: -1=Unknown|0=Unhealthy|1=Healthy|2=Progressing
+# TYPE gardener_operator_garden_condition gauge
+gardener_operator_garden_condition{condition="RuntimeComponentsHealthy",name="foo",operation="Reconcile"} 1
+gardener_operator_garden_condition{condition="VirtualComponentsHealthy",name="foo",operation="Reconcile"} 0
+`), "gardener_operator_garden_condition"),
+		).To(Succeed())
+	})
+})

--- a/pkg/operator/metrics/metrics.go
+++ b/pkg/operator/metrics/metrics.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+const (
+	metricPrefix = "gardener_operator"
+)
+
+type runnable struct {
+	gardenCollector *gardenCollector
+}
+
+// AddToManager adds the custom metrics collectors to the metrics registry. This is done "inside" a `manager.Runnable`,
+// because that guarantees that the cache informers are synced, before the metrics are added / scraped for the first
+// time.
+func AddToManager(_ context.Context, mgr manager.Manager) error {
+	k8sClient := mgr.GetClient()
+	return mgr.Add(&runnable{
+		gardenCollector: newGardenCollector(k8sClient, mgr.GetLogger().WithName("operator-metrics")),
+	})
+}
+
+func (r *runnable) Start(_ context.Context) error {
+	runtimemetrics.Registry.MustRegister(r.gardenCollector)
+	return nil
+}
+
+func mapConditionStatus(status gardencorev1beta1.ConditionStatus) float64 {
+	switch status {
+	case gardencorev1beta1.ConditionTrue:
+		return 1
+	case gardencorev1beta1.ConditionFalse:
+		return 0
+	case gardencorev1beta1.ConditionProgressing:
+		return 2
+	default:
+		return -1
+	}
+}

--- a/pkg/operator/metrics/metrics_suite_test.go
+++ b/pkg/operator/metrics/metrics_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Metrics Suite")
+}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -239,6 +239,7 @@ build:
             - pkg/operator/controller/garden/reference
             - pkg/operator/controller/gardenlet
             - pkg/operator/features
+            - pkg/operator/metrics
             - pkg/operator/predicate
             - pkg/operator/webhook
             - pkg/operator/webhook/defaulting


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Start collecting metrics about resources managed by the gardener-operator.

Currently, `gardener/gardener` barely exports any custom resource metrics, since that is handled by the [gardener-metrics-exporter](https://github.com/gardener/gardener-metrics-exporter). This component, however, only watches resources in the `virtualGarden` cluster, but the resources managed by the operator are not in that cluster. I therefore propose to start exporting the metrics here.

I started with only one condition, `gardener_operator_garden_condition` which is similar to the `shoot_condition` metric [here](https://github.com/gardener/gardener-metrics-exporter/blob/master/pkg/metrics/metrics.go#L106) (just with fewer labels)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` now collects the metric `gardener_operator_garden_condition`
```
