### PR TITLE
Fix flaky operator seed e2e tests

### DIFF
--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -110,8 +110,8 @@ Additionally, it generates the [`MachineClass`es](https://github.com/gardener/ma
 
 The gardenlet creates a wildcard DNS record for the Seed's ingress domain pointing to the `nginx-ingress-controller`'s LoadBalancer.
 This domain is commonly used by all `Ingress` objects created in the Seed for Seed and Shoot components.
-However, provider-local implements the `DNSRecord` extension API (see the [`DNSRecord`section](#dnsrecord)).
-To make `Ingress` domains resolvable on the host, this controller reconciles all `Ingresses` and creates `DNSRecords` of type `local` for each host included in `spec.rules`.
+As provider-local implements the `DNSRecord` extension API (see the [`DNSRecord`section](#dnsrecord)), this controller reconciles all `Ingress`s and creates `DNSRecord`s of type `local` for each host included in `spec.rules`.
+This only happens for shoot namespaces (`gardener.cloud/role=shoot` label) to make `Ingress` domains resolvable on the machine pods.
 
 #### `Service`
 

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -884,7 +884,6 @@ var _ = Describe("KubeStateMetrics", func() {
 					serviceFor(component.ClusterTypeSeed),
 					deploymentFor(component.ClusterTypeSeed),
 					vpaFor("-runtime"),
-					scrapeConfigCacheFor("-runtime"),
 					scrapeConfigGarden,
 				}
 

--- a/pkg/component/observability/monitoring/kubestatemetrics/resources.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/resources.go
@@ -66,11 +66,11 @@ func (k *kubeStateMetrics) getResourceConfigs(genericTokenKubeconfigSecretName s
 			component.ResourceConfig{Obj: clusterRoleBinding, Class: component.Application, MutateFn: func() { k.reconcileClusterRoleBinding(clusterRoleBinding, clusterRole, serviceAccount) }},
 			component.ResourceConfig{Obj: deployment, Class: component.Runtime, MutateFn: func() { k.reconcileDeployment(deployment, serviceAccount, "", nil) }},
 			component.ResourceConfig{Obj: pdb, Class: component.Runtime, MutateFn: func() { k.reconcilePodDisruptionBudget(pdb, deployment) }},
-			component.ResourceConfig{Obj: scrapeConfigCache, Class: component.Runtime, MutateFn: func() { k.reconcileScrapeConfigCache(scrapeConfigCache) }},
 		)
 
 		if k.values.NameSuffix == SuffixSeed {
 			configs = append(configs,
+				component.ResourceConfig{Obj: scrapeConfigCache, Class: component.Runtime, MutateFn: func() { k.reconcileScrapeConfigCache(scrapeConfigCache) }},
 				component.ResourceConfig{Obj: scrapeConfigSeed, Class: component.Runtime, MutateFn: func() { k.reconcileScrapeConfigSeed(scrapeConfigSeed) }},
 			)
 		}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -59,7 +59,7 @@ const finalizerName = "core.gardener.cloud/controllerinstallation"
 
 // RequeueDurationWhenResourceDeletionStillPresent is the duration used for requeueing when owned resources are still in
 // the process of being deleted when deleting a ControllerInstallation.
-var RequeueDurationWhenResourceDeletionStillPresent = 30 * time.Second
+var RequeueDurationWhenResourceDeletionStillPresent = 5 * time.Second
 
 // Reconciler reconciles ControllerInstallations and deploys them into the seed cluster.
 type Reconciler struct {

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -107,10 +107,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if seed.DeletionTimestamp != nil {
-		if err := r.delete(ctx, log, seedObj, seedIsGarden, isManagedSeed); err != nil {
-			return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
+		result, err := r.delete(ctx, log, seedObj, seedIsGarden, isManagedSeed)
+		if err != nil {
+			return result, r.updateStatusOperationError(ctx, seed, err, operationType)
 		}
-		return reconcile.Result{}, nil
+		return result, nil
 	}
 
 	if err := r.reconcile(ctx, log, seedObj, seedIsGarden, isManagedSeed); err != nil {

--- a/pkg/operator/controller/extension/virtualcluster/reconciler.go
+++ b/pkg/operator/controller/extension/virtualcluster/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/gardener/gardener/pkg/operator/apis/config"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -96,9 +95,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// check Garden's last operation status. If the last operation is a successful reconciliation, we can proceed to install the extensions to the virtual garden cluster.
 	switch lastOperation := garden.Status.LastOperation; {
 	case lastOperation == nil || (lastOperation.Type == gardencorev1beta1.LastOperationTypeReconcile && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded):
-		return reconcile.Result{}, &reconciler.RequeueAfterError{
-			RequeueAfter: requeueGardenResourceNotReady,
-		}
+		log.Info("Garden is not yet in 'Reconcile Succeeded' state, requeueing", "requeueAfter", requeueGardenResourceNotReady)
+		return reconcile.Result{RequeueAfter: requeueGardenResourceNotReady}, nil
 	case lastOperation.Type == gardencorev1beta1.LastOperationTypeDelete:
 		// if the last operation is a delete, then do nothing. Once the Garden resource is deleted, we will reconcile and remove the finalizers from the Extension.
 		return reconcile.Result{}, nil

--- a/pkg/provider-local/controller/ingress/add.go
+++ b/pkg/provider-local/controller/ingress/add.go
@@ -7,11 +7,16 @@ package ingress
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 // ControllerName is the name of the controller.
@@ -28,7 +33,7 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
+func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
 	opts.Controller.Reconciler = &reconciler{client: mgr.GetClient()}
 
 	ctrl, err := controller.New(ControllerName, mgr, opts.Controller)
@@ -36,10 +41,16 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 		return err
 	}
 
-	return ctrl.Watch(source.Kind(mgr.GetCache(), &networkingv1.Ingress{}), &handler.EnqueueRequestForObject{})
+	return ctrl.Watch(source.Kind(mgr.GetCache(), &networkingv1.Ingress{}), &handler.EnqueueRequestForObject{}, predicate.NewPredicateFuncs(func(object client.Object) bool {
+		namespace := &corev1.Namespace{}
+		if err := mgr.GetClient().Get(ctx, client.ObjectKey{Name: object.GetNamespace()}, namespace); err != nil {
+			ctrl.GetLogger().Error(err, "Unable to fetch namespace")
+		}
+		return namespace.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot
+	}))
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(_ context.Context, mgr manager.Manager) error {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
 }

--- a/pkg/provider-local/controller/ingress/reconciler.go
+++ b/pkg/provider-local/controller/ingress/reconciler.go
@@ -32,9 +32,8 @@ type reconciler struct {
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	key := req.NamespacedName
 	ingress := &networkingv1.Ingress{}
-	if err := r.client.Get(ctx, key, ingress); err != nil {
+	if err := r.client.Get(ctx, req.NamespacedName, ingress); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(1).Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil

--- a/skaffold-operator-garden.yaml
+++ b/skaffold-operator-garden.yaml
@@ -14,7 +14,7 @@ deploy:
             command:
               - bash
               - -ec
-              - hack/usage/wait-for.sh garden local VirtualGardenAPIServerAvailable VirtualComponentsHealthy
+              - hack/usage/wait-for.sh garden local VirtualGardenAPIServerAvailable RuntimeComponentsHealthy VirtualComponentsHealthy
         - host:
             command:
               - bash

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1589,7 +1589,7 @@ profiles:
   - name: operator
     patches:
       - op: remove
-        path: /deploy
+        path: /deploy/helm
       - op: add
         path: /build/artifacts/0/hooks
         value:
@@ -1629,3 +1629,12 @@ profiles:
       kustomize:
         paths:
           - example/gardener-local/gardenlet/operator
+    deploy:
+      kubectl:
+        hooks:
+          after:
+            - host:
+                command:
+                  - bash
+                  - -ec
+                  - KUBECONFIG=$VIRTUAL_GARDEN_KUBECONFIG hack/usage/wait-for.sh seed local GardenletReady SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
Please check the individual commits and their messages for reasoning and explanations what and why has changed.
After this PR is merged, the flakes in the e2e test should be removed (or at least improved 😉).

/cc @ScheererJ as CFO (chief flake officer 😁)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
