### PR TITLE
Allow `skip-readiness` annotation to work with network status changes

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -92,7 +92,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 	var (
 		allowBackup                     = o.Seed.GetInfo().Spec.Backup != nil
-		staticNodesCIDR                 = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil && o.Shoot.GetInfo().Status.Networking != nil
+		staticNodesCIDR                 = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil && (o.Shoot.GetInfo().Status.Networking != nil || skipReadiness)
 		useDNS                          = botanist.ShootUsesDNS()
 		generation                      = o.Shoot.GetInfo().Generation
 		requestControlPlanePodsRestart  = controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area quality
/area robustness
/kind bug

**What this PR does / why we need it**:

Allow `skip-readiness` annotation to work with network status changes.

When a shoot was annotated with `shoot.gardener.cloud/skip-readiness: "true"` gardenlet crashed with the following error:

```
goroutine 2222 [running]:
github.com/gardener/gardener/pkg/gardenlet/operation/botanist.(*Botanist).setAPIServerServiceClusterIP(0x0?, {0xc0045de560?, 0xe?})
        github.com/gardener/gardener/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go:71 +0x30
github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure.(*service).Deploy(0xc0001ba540, {0x3364940, 0xc001522af0})
        github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure/service.go:176 +0x15a
github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot.(*Reconciler).runReconcileShootFlow.TaskFn.RetryUntilTimeout.func48.1({0x3364940?, 0xc001522af0?})
        github.com/gardener/gardener/pkg/utils/flow/taskfn.go:46 +0x22
github.com/gardener/gardener/pkg/utils/retry.UntilFor({0x3364940, 0xc001522af0}, 0xc007346ca0, {0x3359ef0, 0xc006aa6040}, 0xc006aa6030)
        github.com/gardener/gardener/pkg/utils/retry/retry.go:132 +0x49
github.com/gardener/gardener/pkg/utils/retry.(*ops).Until(0xc0000b86c0, {0x3364940, 0xc001522af0}, 0x2567e40?, 0xc006aa6030)
        github.com/gardener/gardener/pkg/utils/retry/retry.go:176 +0x6f
github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot.(*Reconciler).runReconcileShootFlow.TaskFn.RetryUntilTimeout.func48({0x3364898?, 0xc0041a9140?})
        github.com/gardener/gardener/pkg/utils/flow/taskfn.go:45 +0xb2
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func2()
        github.com/gardener/gardener/pkg/utils/flow/flow.go:226 +0x165
created by github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode in goroutine 1110
        github.com/gardener/gardener/pkg/utils/flow/flow.go:222 +0x4f0
```

This was a miss in #9998 as `skip-readiness` handling was not adapted accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The alternative solution to remove the `skipReadiness` condition in the `Waiting until shoot infrastructure has been reconciled` step would require to adapt a lot more dependencies and reduce the performance improvement of setting the annotation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixes a bug preventing shoot clusters with annotation `shoot.gardener.cloud/skip-readiness: "true"` to be created.
```

Thanks to @plkokanov for finding the issue.