### PR TITLE
[GEP-27] Add CloudProfile Bastion Validation

### DIFF
--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -244,6 +244,7 @@ func validateCloudProfileRegions(regions []core.Region, fldPath *field.Path) fie
 
 	return allErrs
 }
+
 func validateCloudProfileBastion(spec *core.CloudProfileSpec, fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs     field.ErrorList

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -244,7 +244,6 @@ func validateCloudProfileRegions(regions []core.Region, fldPath *field.Path) fie
 
 	return allErrs
 }
-
 func validateCloudProfileBastion(spec *core.CloudProfileSpec, fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs     field.ErrorList

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -1043,7 +1043,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					}))))
 				})
 
-				It("should forbid preview image if version is not specified", func() {
+				It("should forbid preview image", func() {
 					cloudProfile.Spec.Bastion = &core.Bastion{
 						MachineImage: &core.BastionMachineImage{Name: "some-machineimage"},
 					}
@@ -1084,20 +1084,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					Expect(errorList).To(BeEmpty())
 				})
 
-				It("should allow preview image if version is defined", func() {
-					cloudProfile.Spec.Bastion = &core.Bastion{
-						MachineImage: &core.BastionMachineImage{
-							Name:    "some-machineimage",
-							Version: ptr.To("1.2.3"),
-						},
-					}
-					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &previewClassification
-					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{"amd64"}
-
-					errorList := ValidateCloudProfile(cloudProfile)
-					Expect(errorList).To(BeEmpty())
-				})
-
 				It("should allow matching arch of machineType and machineImage", func() {
 					cloudProfile.Spec.Bastion = &core.Bastion{
 						MachineType: &core.BastionMachineType{Name: machineType.Name},
@@ -1106,7 +1092,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 							Version: ptr.To("1.2.3"),
 						},
 					}
-					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &previewClassification
+					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &supportedClassification
 					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{*machineType.Architecture}
 
 					errorList := ValidateCloudProfile(cloudProfile)

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -996,6 +996,132 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 				})
 			})
 
+			Context("bastion validation", func() {
+				It("should forbid unknown machineType", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineType: &core.BastionMachineType{Name: "unknown"},
+					}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.bastion.machineType.name"),
+					}))))
+				})
+
+				It("should allow known machineType", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineType: &core.BastionMachineType{Name: machineType.Name},
+					}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should forbid unknown machineImage", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineImage: &core.BastionMachineImage{Name: "unknown"},
+					}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.bastion.machineImage.name"),
+					}))))
+				})
+
+				It("should forbid preview image if version is not specified", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineImage: &core.BastionMachineImage{Name: "some-machineimage"},
+					}
+					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &previewClassification
+					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{"amd64"}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.bastion.machineImage.name"),
+					}))))
+				})
+
+				It("should forbid no arch images", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineImage: &core.BastionMachineImage{Name: "some-machineimage"},
+					}
+					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &supportedClassification
+					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.bastion.machineImage.name"),
+					}))))
+				})
+
+				It("should allow images with supported classification and architecture specification", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineImage: &core.BastionMachineImage{Name: "some-machineimage"},
+					}
+					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &supportedClassification
+					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{"amd64"}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should allow preview image if version is defined", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineImage: &core.BastionMachineImage{
+							Name:    "some-machineimage",
+							Version: ptr.To("1.2.3"),
+						},
+					}
+					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &previewClassification
+					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{"amd64"}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should allow matching arch of machineType and machineImage", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineType: &core.BastionMachineType{Name: machineType.Name},
+						MachineImage: &core.BastionMachineImage{
+							Name:    "some-machineimage",
+							Version: ptr.To("1.2.3"),
+						},
+					}
+					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &previewClassification
+					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{*machineType.Architecture}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should forbid different arch of machineType and machineImage", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineType: &core.BastionMachineType{Name: machineType.Name},
+						MachineImage: &core.BastionMachineImage{
+							Name:    "some-machineimage",
+							Version: ptr.To("1.2.3"),
+						},
+					}
+					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &supportedClassification
+					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{"arm64"}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.bastion.machineImage.version"),
+					}))))
+				})
+			})
+
 			It("should forbid unsupported seed selectors", func() {
 				cloudProfile.Spec.SeedSelector.MatchLabels["foo"] = "no/slash/allowed"
 

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -1117,6 +1117,22 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 						"Field": Equal("spec.bastion.machineImage.version"),
 					}))))
 				})
+
+				It("should allow any image architecture if machineType is nil", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{
+						MachineType: nil,
+						MachineImage: &core.BastionMachineImage{
+							Name:    "some-machineimage",
+							Version: ptr.To("1.2.3"),
+						},
+					}
+					cloudProfile.Spec.MachineImages[0].Versions[0].Classification = &supportedClassification
+					// architectures must be one of arm64 or amd64
+					cloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{"arm64"}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+					Expect(errorList).To(BeEmpty())
+				})
 			})
 
 			It("should forbid unsupported seed selectors", func() {

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -997,6 +997,17 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 			})
 
 			Context("bastion validation", func() {
+				It("should forbid empty bastion", func() {
+					cloudProfile.Spec.Bastion = &core.Bastion{}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.bastion"),
+					}))))
+				})
+
 				It("should forbid unknown machineType", func() {
 					cloudProfile.Spec.Bastion = &core.Bastion{
 						MachineType: &core.BastionMachineType{Name: "unknown"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR adds validation for the recently [introduced](https://github.com/gardener/gardener/pull/10233) bastion section of the CloudProfile as part of [GEP-27](https://github.com/gardener/gardener/pull/9935).
It checks for example that the chosen machineImage and machineType of the bastion do exist in the cloudProfile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Adds `CloudProfile` validation for the recently introduced `.spec.bastion` section.
```
