### PR TITLE
Allow control plane migration across seeds w/ different provider types

### DIFF
--- a/docs/operations/control_plane_migration.md
+++ b/docs/operations/control_plane_migration.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-Also, the involved Seeds need to have enabled `BackupBucket`s.
+The `Seed`s involved in the control plane migration must have backups enabled - their `.spec.backup` fields cannot be nil.
 
 ## ShootState
 
@@ -10,7 +10,7 @@ Also, the involved Seeds need to have enabled `BackupBucket`s.
 
 ## Shoot Control Plane Migration
 
-Triggering the migration is done by changing the `Shoot`'s `.spec.seedName` to a `Seed` that differs from the `.status.seedName`, we call this `Seed` a `"Destination Seed"`. This action can only be performed by an operator with the necessary RBAC. If the Destination `Seed` does not have a backup and restore configuration, the change to `spec.seedName` is rejected. Additionally, this Seed must not be set for deletion and must be healthy.
+Triggering the migration is done by changing the `Shoot`'s `.spec.seedName` to a `Seed` that differs from the `.status.seedName`, we call this `Seed` a `"Destination Seed"`. This action can only be performed by an operator with the necessary RBAC. If the `Destination Seed` does not have a backup and restore configuration, the change to `spec.seedName` is rejected. Additionally, this Seed must not be set for deletion and must be healthy.
 
 If the `Shoot` has different `.spec.seedName` and `.status.seedName`, a process is started to prepare the Control Plane for migration:
 
@@ -24,11 +24,38 @@ The etcd backups will be copied over to the `BackupBucket` of the `Destination S
 
 ## Triggering the Migration
 
-For controlplane migration, operators with the necessary RBAC can use the [`shoots/binding`](../concepts/scheduler.md#shootsbinding-subresource) subresource to change the `.spec.seedName`, with the following commands:
+For control plane migration, operators with the necessary RBAC can use the [`shoots/binding`](../concepts/scheduler.md#shootsbinding-subresource) subresource to change the `.spec.seedName`, with the following commands:
 
 ```bash
 NAMESPACE=my-namespace
 SHOOT_NAME=my-shoot
 DEST_SEED_NAME=destination-seed
+
 kubectl get --raw /apis/core.gardener.cloud/v1beta1/namespaces/${NAMESPACE}/shoots/${SHOOT_NAME} | jq -c '.spec.seedName = "'${DEST_SEED_NAME}'"' | kubectl replace --raw /apis/core.gardener.cloud/v1beta1/namespaces/${NAMESPACE}/shoots/${SHOOT_NAME}/binding -f - | jq -r '.spec.seedName'
 ```
+
+
+> [!NOTE]
+> When migrating `Shoot`s to a `Destination Seed` with different provider type from the `Source Seed`, make sure of the following:
+>
+> Pods running in the `Destination Seed` must have network connectivity to the backup storage provider of the `Source Seed` so that etcd backups can be copied successfully. Otherwise, the `Restore` operation will get stuck at the `Waiting until etcd backups are copied` step. However, if you do end up in this case, you can still finish the control plane migration by following the [guide to manually copy etcd backups](#copying-etcd-backups-manually-during-the-restore-operation).
+>
+> The nodes of your `Shoot` cluster must have network connectivity to the `Shoot`'s `kube-apiserver` and the `vpn-seed-server` once they are migrated to the `Destination Seed`. Otherwise, the `Restore` operation will get stuck at the `Waiting until the Kubernetes API server can connect to the Shoot workers` step. However, if you do end up in this case and cannot allow network traffic from the nodes to the `Shoot`'s control plane, you can annotate the `Shoot` with the `shoot.gardener.cloud/skip-readiness` annotation so that the `Restore` operation finishes, and then use the [`shoots/binding`](../concepts/scheduler.md#shootsbinding-subresource) subresource to migrate the control plane back to the `Source Seed`.
+
+
+## Copying ETCD Backups Manually During the `Restore` Operation
+
+Following is a workaround that can be used to copy etcd backups manually in situations where a `Shoot`'s control plane has been moved to a `Destination Seed` and the pods running in it lack network connectivity to the `Source Seed`s storage provider:
+
+1. Follow the instructions in the [`etcd-backup-restore` getting started documentation](https://github.com/gardener/etcd-backup-restore/blob/master/docs/deployment/getting_started.md#getting-started) on how to run the `etcdbrctl` command locally or in a container.
+1. Follow the instructions in the [passing-credentials guide](https://github.com/gardener/etcd-backup-restore/blob/master/docs/deployment/getting_started.md#passing-credentials) on how to set up the required credentials for the copy operation depending on the storage providers for which you want to perform it.
+1. Use the `etcdbrctl copy` command to copy the backups by following the instructions in the [`etcdbrctl copy` guide](https://github.com/gardener/etcd-backup-restore/blob/master/docs/deployment/getting_started.md#etcdbrctl-copy)
+1. After you have successfully copied the etcd backups, wait for the `EtcdCopyBackupsTask` custom resource to be created in the `Shoot`'s control plane on the `Destination Seed`, if it does not already exist. Afterwards, mark it as successful by patching it using the following command:
+    ```
+    SHOOT_NAME=my-shoot
+    PROJECT_NAME=my-project
+
+    kubectl patch -n shoot--${PROJECT_NAME}--${SHOOT_NAME} etcdcopybackupstask ${SHOOT_NAME} --subresource status --type merge -p "{\"status\":{\"conditions\":[{\"type\":\"Succeeded\",\"status\":\"True\",\"reason\":\"manual copy successful\",\"message\":\"manual copy successful\",\"lastTransitionTime\":\"$(date -Iseconds)\",\"lastUpdateTime\":\"$(date -Iseconds)\"}]}}"
+    ```
+1. After the `main-etcd` becomes `Ready`, remove the finalizer on the source `extensions.gardener.cloud/v1alpha1.BackupEntry` (the resource has `source-` as a prefix in its name) in the `Destination Seed` so that it can be deleted successfully. This is necessary as the `Destination Seed` will not have network connectivity to perform the actual deletion of the source backup directory.
+1. Once the control plane migration has finished successfully, make sure to manually clean up the source backup directory in the `Source Seed`'s storage provider.

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -83,8 +84,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	backupBucketList := &gardencorev1beta1.BackupBucketList{}
-	if err := r.Client.List(ctx, backupBucketList, client.MatchingFields{core.BackupBucketSeedName: seed.Name}); err != nil {
+	if err := r.Client.List(ctx, backupBucketList); err != nil {
 		return reconcile.Result{}, err
+	}
+	backupBucketsMap := make(map[string]*gardencorev1beta1.BackupBucket, len(backupBucketList.Items))
+	for _, backupBucket := range backupBucketList.Items {
+		backupBucketsMap[backupBucket.Name] = &backupBucket
 	}
 
 	backupEntryList := &gardencorev1beta1.BackupEntryList{}
@@ -118,10 +123,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	var (
 		controllerRegistrations = computeControllerRegistrationMaps(controllerRegistrationList)
 
-		wantedKindTypeCombinationForBackupBuckets, buckets = computeKindTypesForBackupBuckets(backupBucketList)
-		wantedKindTypeCombinationForBackupEntries          = computeKindTypesForBackupEntries(log, backupEntryList, buckets)
-		wantedKindTypeCombinationForShoots                 = computeKindTypesForShoots(ctx, log, r.Client, shootList, seed, controllerRegistrationList, internalDomain, defaultDomains)
-		wantedKindTypeCombinationForSeed                   = computeKindTypesForSeed(seed)
+		wantedKindTypeCombinationForBackupBuckets = computeKindTypesForBackupBuckets(backupBucketsMap, seed.Name)
+		wantedKindTypeCombinationForBackupEntries = computeKindTypesForBackupEntries(log, backupEntryList, backupBucketsMap)
+		wantedKindTypeCombinationForShoots        = computeKindTypesForShoots(ctx, log, r.Client, shootList, seed, controllerRegistrationList, internalDomain, defaultDomains)
+		wantedKindTypeCombinationForSeed          = computeKindTypesForSeed(seed)
 
 		wantedKindTypeCombinations = sets.
 						New[string]().
@@ -155,22 +160,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 // computeKindTypesForBackupBucket computes the list of wanted kind/type combinations for extension resources based on the
 // the list of existing BackupBucket resources.
 func computeKindTypesForBackupBuckets(
-	backupBucketList *gardencorev1beta1.BackupBucketList,
-) (
-	sets.Set[string],
-	map[string]gardencorev1beta1.BackupBucket,
-) {
-	var (
-		wantedKindTypeCombinations = sets.New[string]()
-		buckets                    = make(map[string]gardencorev1beta1.BackupBucket)
-	)
+	backupBucketsMap map[string]*gardencorev1beta1.BackupBucket,
+	seedName string,
+) sets.Set[string] {
+	wantedKindTypeCombinations := sets.New[string]()
 
-	for _, backupBucket := range backupBucketList.Items {
-		buckets[backupBucket.Name] = backupBucket
-		wantedKindTypeCombinations.Insert(gardenerutils.ExtensionsID(extensionsv1alpha1.BackupBucketResource, backupBucket.Spec.Provider.Type))
+	for _, backupBucket := range backupBucketsMap {
+		if ptr.Deref(backupBucket.Spec.SeedName, "") == seedName {
+			wantedKindTypeCombinations.Insert(gardenerutils.ExtensionsID(extensionsv1alpha1.BackupBucketResource, backupBucket.Spec.Provider.Type))
+		}
 	}
 
-	return wantedKindTypeCombinations, buckets
+	return wantedKindTypeCombinations
 }
 
 // computeKindTypesForBackupEntries computes the list of wanted kind/type combinations for extension resources based on the
@@ -178,7 +179,7 @@ func computeKindTypesForBackupBuckets(
 func computeKindTypesForBackupEntries(
 	log logr.Logger,
 	backupEntryList *gardencorev1beta1.BackupEntryList,
-	buckets map[string]gardencorev1beta1.BackupBucket,
+	buckets map[string]*gardencorev1beta1.BackupBucket,
 ) sets.Set[string] {
 	wantedKindTypeCombinations := sets.New[string]()
 

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -341,11 +341,7 @@ func (r *Reconciler) deleteBackupEntry(
 			},
 		}
 
-		if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return reconcile.Result{}, err
-			}
-		} else if err == nil {
+		if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err == nil {
 			if lastError := extensionBackupEntry.Status.LastError; lastError != nil {
 				r.Recorder.Event(backupEntry, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastError.Description)
 
@@ -356,6 +352,8 @@ func (r *Reconciler) deleteBackupEntry(
 			}
 			log.Info("Extension BackupEntry not yet deleted", "extensionBackupEntry", client.ObjectKeyFromObject(extensionBackupEntry))
 			return reconcile.Result{RequeueAfter: RequeueDurationWhenResourceDeletionStillPresent}, nil
+		} else if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
 		}
 
 		if err := client.IgnoreNotFound(r.SeedClient.Delete(seedCtx, extensionSecret)); err != nil {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -490,10 +490,6 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 		if c.seed.Spec.Backup == nil {
 			return admission.NewForbidden(a, fmt.Errorf("cannot change seed name because backup is not configured for seed %q", c.seed.Name))
 		}
-
-		if oldSeed.Spec.Provider.Type != c.seed.Spec.Provider.Type {
-			return admission.NewForbidden(a, fmt.Errorf("cannot change seed because cloud provider for new seed (%s) is not equal to cloud provider for old seed (%s)", c.seed.Spec.Provider.Type, oldSeed.Spec.Provider.Type))
-		}
 	} else if !reflect.DeepEqual(c.oldShoot.Spec, c.shoot.Spec) {
 		if wasShootRescheduledToNewSeed(c.shoot) {
 			return admission.NewForbidden(a, fmt.Errorf("shoot spec cannot be changed because shoot has been rescheduled to a new seed"))

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -4868,15 +4868,14 @@ var _ = Describe("validator", func() {
 					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("backup is not configured for old seed %q", seedName)))
 				})
 
-				It("should reject update of binding, because cloud provider for new Seed is not equal to cloud provider for old Seed", func() {
+				It("should allow update of binding to Seed with different provider type", func() {
 					seed.Spec.Provider.Type = "gcp"
 					newSeed.Spec.Provider.Type = "aws"
 
 					attrs := admission.NewAttributesRecord(&shoot, &oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, nil)
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("cannot change seed because cloud provider for new seed (%s) is not equal to cloud provider for old seed (%s)", newSeed.Spec.Provider.Type, seed.Spec.Provider.Type))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
This PR allows migration of Shoot control planes across Seeds with different provider types.
It also adds warnings and workarounds regarding problems that could occur due to lack of network connectivity:
1. When pods in the Destination Seed do not have network connectivity to the storage provider of the Source Seeds, meaning that it will be impossible to automatically copy etcd backups during the `Restore` operation
2. When the Shoot's nodes do not have network connectivity to the control plane after it is moved to the Destination Seed

Additionally, required provider extensions for source `BackupEntry`s will now be correctly installed in the Destination Seed during control plane migration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Performing control plane migration across `Seed`s with different provider types is now possible.  Before triggering the migration, make sure that pods in the `Shoot`'s control plane, once it is moved to the `Destination Seed`, will have network connectivity to the storage provider of the `Source Seed` (so that ETCD backups can be copied automatically). Additionally, make sure that the `Shoot`'s nodes will have network connectivity to the `Shoot`'s control plane after it is moved to the `Destination Seed`.
```