### PR TITLE
Use `vpa-recommender` from the gardener fork of `kubernetes/autoscaler`

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -656,10 +656,15 @@ images:
         confidentiality_requirement: 'low'
         integrity_requirement: 'high'
         availability_requirement: 'high'
+# TODO(plkokanov): Use a forked version of the vpa-recommender for the following reasons:
+#   1. It includes a fix for the nil pointer exception in vpa-recommender 1.2.0 (check https://github.com/kubernetes/autoscaler/pull/7161 for more info)
+#   2. It adds verbose logging when the vpa-recommender estimates memory values which are less than or equal to the minAllowed defined in the
+# corresponding VPA resource. A new metric is also included which counts how many times such estimations have occurred for each VPA resource.
+# (check https://github.com/gardener/autoscaler/pull/322 for more info).
 - name: vpa-recommender
-  sourceRepository: github.com/kubernetes/autoscaler
-  repository: registry.k8s.io/autoscaling/vpa-recommender
-  tag: "1.2.0"
+  sourceRepository: github.com/gardener/autoscaler
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender
+  tag: "1.2.1"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -656,11 +656,13 @@ images:
         confidentiality_requirement: 'low'
         integrity_requirement: 'high'
         availability_requirement: 'high'
-# TODO(plkokanov): Use a forked version of the vpa-recommender for the following reasons:
+# We use a forked version of the vpa-recommender for the following reasons:
 #   1. It includes a fix for the nil pointer exception in vpa-recommender 1.2.0 (check https://github.com/kubernetes/autoscaler/pull/7161 for more info)
 #   2. It adds verbose logging when the vpa-recommender estimates memory values which are less than or equal to the minAllowed defined in the
 # corresponding VPA resource. A new metric is also included which counts how many times such estimations have occurred for each VPA resource.
 # (check https://github.com/gardener/autoscaler/pull/322 for more info).
+#
+# TODO(plkokanov): Switch back to the upstream vpa-recommender image when we no longer need to use the forked version.
 - name: vpa-recommender
   sourceRepository: github.com/gardener/autoscaler
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR replaces the `vpa-recommender` so that one built from https://github.com/gardener/autoscaler/tree/rel-vertical-pod-autoscaler is used.
This is done for the following reasons:
1. It includes a fix for a nil pointer exception in `vpa-recommender` 1.2.0 (check https://github.com/kubernetes/autoscaler/pull/7161 for more info) so that we do not have to wait for a hotfix release to be done
2. It adds verbose logging when the `vpa-recommender` estimates memory values which are less than or equal to the `minAllowed` defined in the corresponding VPA resource. A new metric is also included which counts how many times such estimations have occurred for each VPA resource. This logging will be helpful in investigating an issue which causes the `vpa-recommender` to set such low values and to never increase them afterwards, causing pods to get constantly OOMKilled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener now temporarily uses a `vpa-recommender` built from a [fork](https://github.com/gardener/autoscaler/tree/rel-vertical-pod-autoscaler) to add additional logging and metrics for debugging an issue where the `vpa-recommender` could recommend lower than `minAllowed` memory requests for pods that actually have high memory usage. 
```
