### PR TITLE
[GEP-26] Allow quota scope to reference WorkloadIdentity

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1405,7 +1405,7 @@ Kubernetes core/v1.ObjectReference
 </em>
 </td>
 <td>
-<p>Scope is the scope of the Quota object, either &lsquo;project&rsquo; or &lsquo;secret&rsquo;. This field is immutable.</p>
+<p>Scope is the scope of the Quota object, either &lsquo;project&rsquo;, &lsquo;secret&rsquo; or &lsquo;workloadidentity&rsquo;. This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -9372,7 +9372,7 @@ Kubernetes core/v1.ObjectReference
 </em>
 </td>
 <td>
-<p>Scope is the scope of the Quota object, either &lsquo;project&rsquo; or &lsquo;secret&rsquo;. This field is immutable.</p>
+<p>Scope is the scope of the Quota object, either &lsquo;project&rsquo;, &lsquo;secret&rsquo; or &lsquo;workloadidentity&rsquo;. This field is immutable.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -49,7 +49,10 @@ func QuotaScope(scopeRef corev1.ObjectReference) (string, error) {
 		return "project", nil
 	}
 	if scopeRef.APIVersion == "v1" && scopeRef.Kind == "Secret" {
-		return "secret", nil
+		return "credentials", nil
+	}
+	if gvk := schema.FromAPIVersionAndKind(scopeRef.APIVersion, scopeRef.Kind); gvk.Group == "security.gardener.cloud" && gvk.Kind == "WorkloadIdentity" {
+		return "credentials", nil
 	}
 	return "", errors.New("unknown quota scope")
 }

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -59,7 +59,8 @@ var _ = Describe("helper", func() {
 		},
 
 		Entry("project", "core.gardener.cloud/v1beta1", "Project", "project", BeNil()),
-		Entry("secret", "v1", "Secret", "secret", BeNil()),
+		Entry("secret", "v1", "Secret", "credentials", BeNil()),
+		Entry("workloadidentity", "security.gardener.cloud/v1alpha1", "WorkloadIdentity", "credentials", BeNil()),
 		Entry("unknown", "v2", "Foo", "", HaveOccurred()),
 	)
 

--- a/pkg/apis/core/types_quota.go
+++ b/pkg/apis/core/types_quota.go
@@ -38,7 +38,7 @@ type QuotaSpec struct {
 	ClusterLifetimeDays *int32
 	// Metrics is a list of resources which will be put under constraints.
 	Metrics corev1.ResourceList
-	// Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.
+	// Scope is the scope of the Quota object, either 'project', 'secret' or 'workloadidentity'. This field is immutable.
 	Scope corev1.ObjectReference
 }
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2244,7 +2244,7 @@ message QuotaSpec {
   // Metrics is a list of resources which will be put under constraints.
   map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> metrics = 2;
 
-  // Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.
+  // Scope is the scope of the Quota object, either 'project', 'secret' or 'workloadidentity'. This field is immutable.
   optional k8s.io.api.core.v1.ObjectReference scope = 3;
 }
 

--- a/pkg/apis/core/v1beta1/types_quota.go
+++ b/pkg/apis/core/v1beta1/types_quota.go
@@ -42,6 +42,6 @@ type QuotaSpec struct {
 	ClusterLifetimeDays *int32 `json:"clusterLifetimeDays,omitempty" protobuf:"varint,1,opt,name=clusterLifetimeDays"`
 	// Metrics is a list of resources which will be put under constraints.
 	Metrics corev1.ResourceList `json:"metrics" protobuf:"bytes,2,rep,name=metrics,casttype=k8s.io/api/core/v1.ResourceList,castkey=k8s.io/api/core/v1.ResourceName"`
-	// Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.
-	Scope corev1.ObjectReference `json:"scope" protobuf:"bytes,3,opt,name=scope"`
+	// Scope is the scope of the Quota object, either 'project', 'secret' or 'workloadidentity'. This field is immutable.
+	Scope corev1.ObjectReference `json:"scope" protobuf:"bytes,3,opt,name=scope"` // TODO: When graduating the API to v1 consider reworking this field as described in https://github.com/gardener/gardener/issues/9773#issuecomment-2293340267
 }

--- a/pkg/apis/core/validation/quota.go
+++ b/pkg/apis/core/validation/quota.go
@@ -40,7 +40,7 @@ func ValidateQuotaSpec(quotaSpec *core.QuotaSpec, fldPath *field.Path) field.Err
 
 	scopeRef := quotaSpec.Scope
 	if _, err := helper.QuotaScope(scopeRef); err != nil {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scopeRef, []string{"project", "secret"}))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scopeRef, []string{"project", "secret", "workloadidentity"}))
 	}
 
 	metricsFldPath := fldPath.Child("metrics")

--- a/pkg/apis/core/validation/quota_test.go
+++ b/pkg/apis/core/validation/quota_test.go
@@ -119,5 +119,15 @@ var _ = Describe("Quota Validation Tests ", func() {
 				})),
 			))
 		})
+
+		It("should allow quota scope referencing WorkloadIdentity", func() {
+			quota.Spec.Scope = corev1.ObjectReference{
+				Kind:       "WorkloadIdentity",
+				APIVersion: "security.gardener.cloud/v1alpha1",
+			}
+			errorList := ValidateQuota(quota)
+
+			Expect(errorList).To(BeEmpty())
+		})
 	})
 })

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -6768,7 +6768,7 @@ func schema_pkg_apis_core_v1beta1_QuotaSpec(ref common.ReferenceCallback) common
 					},
 					"scope": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.",
+							Description: "Scope is the scope of the Quota object, either 'project', 'secret' or 'workloadidentity'. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -723,10 +723,9 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 		return fmt.Errorf("unknown credentials kind: %s", credentialsKind)
 	}
 
-	// TODO(dimityrmirchev): Extend quota scope to allow workload identities
 	var (
-		secretQuotaCount  int
-		projectQuotaCount int
+		credentialsQuotaCount int
+		projectQuotaCount     int
 	)
 
 	for _, quotaRef := range quotas {
@@ -759,11 +758,11 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 		if scope == "project" {
 			projectQuotaCount++
 		}
-		if scope == "secret" {
-			secretQuotaCount++
+		if scope == "credentials" {
+			credentialsQuotaCount++
 		}
-		if projectQuotaCount > 1 || secretQuotaCount > 1 {
-			return errors.New("only one quota per scope (project or secret) can be assigned")
+		if projectQuotaCount > 1 || credentialsQuotaCount > 1 {
+			return errors.New("only one quota per scope (project or credentials) can be assigned")
 		}
 	}
 

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -914,8 +914,22 @@ var _ = Describe("resourcereferencemanager", func() {
 					},
 					Spec: gardencorev1beta1.QuotaSpec{
 						Scope: corev1.ObjectReference{
-							APIVersion: "core.gardener.cloud/v1beta1",
-							Kind:       "Project",
+							APIVersion: "v1",
+							Kind:       "Secret",
+						},
+					},
+				}
+
+				quotaName3 := "quota-3"
+				quota3 := gardencorev1beta1.Quota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      quotaName3,
+						Namespace: namespace,
+					},
+					Spec: gardencorev1beta1.QuotaSpec{
+						Scope: corev1.ObjectReference{
+							APIVersion: securityv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "WorkloadIdentity",
 						},
 					},
 				}
@@ -924,13 +938,18 @@ var _ = Describe("resourcereferencemanager", func() {
 					Name:      quotaName2,
 					Namespace: namespace,
 				}
+				quota3Ref := corev1.ObjectReference{
+					Name:      quotaName3,
+					Namespace: namespace,
+				}
 				quotaRefList := securityCredentialsBindingRefWorkloadIdentity.Quotas
-				quotaRefList = append(quotaRefList, quota2Ref)
+				quotaRefList = append(quotaRefList, quota2Ref, quota3Ref)
 				securityCredentialsBindingRefWorkloadIdentity.Quotas = quotaRefList
 
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota2)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota3)).To(Succeed())
 
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security ipcei
/kind enhancement
/ipcei workload-identity

**What this PR does / why we need it**:
This PR allows `quota.scope` to reference `WorkloadIdentity`s. It also combines the logic w.r.t `Secret`s and `WorkloadIdentity`s references and treats them in the exact same way as "credentials".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Part of https://github.com/gardener/gardener/issues/9586

cc @vpnachev @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`Quota`s can now have scope of type `WorkloadIdentity`.
```
