### PR TITLE
[GEP-26] Add CredentialsBinding controller documentation

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -103,6 +103,16 @@ This gets bound to all `ServiceAccount`s in seed namespaces whose labels match t
 
 You can read more about the purpose of this reconciler in [this document](../extensions/garden-api-access.md#additional-permissions).
 
+### [`CredentialsBinding` Controller](../../pkg/controllermanager/controller/credentialsbinding)
+
+`CredentialsBinding`s reference `Secret`s, `WorkloadIdentity`s and `Quota`s and are themselves referenced by `Shoot`s.
+
+The controller adds finalizers to the referenced objects to ensure they don't get deleted while still being referenced.
+Similarly, to ensure that `CredentialsBinding`s in-use are always present in the system until the last referring `Shoot` gets deleted, the controller adds a finalizer which is only released when there is no `Shoot` referencing the `CredentialsBinding` anymore.
+
+Referenced `Secret`s and `WorkloadIdentity`s will also be labeled with `provider.shoot.gardener.cloud/<type>=true`, where `<type>` is the value of the `.provider.type` of the `CredentialsBinding`.
+Also, all referenced `Secret`s and `WorkloadIdentity`s, as well as `Quota`s, will be labeled with `reference.gardener.cloud/credentialsbinding=true` to allow for easily filtering for objects referenced by `CredentialsBinding`s.
+
 ### [`Event` Controller](../../pkg/controllermanager/controller/event)
 
 With the Gardener Event Controller, you can prolong the lifespan of events related to Shoot clusters.
@@ -150,7 +160,7 @@ The `ManagedSeedSet` controller creates and deletes `ManagedSeed`s and `Shoot`s 
 
 `Quota` object limits the resources consumed by shoot clusters either per provider secret or per project/namespace.
 
-Consequently, to ensure that `Quota`s in-use are always present in the system until the last `SecretBinding` that references them gets deleted, the controller adds a finalizer which is only released when there is no `SecretBinding` referencing the `Quota` anymore.
+Consequently, to ensure that `Quota`s in-use are always present in the system until the last `SecretBinding` or `CredentialsBinding` that references them gets deleted, the controller adds a finalizer which is only released when there is no `SecretBinding` or `CredentialsBinding` referencing the `Quota` anymore.
 
 ### [`Project` Controller](../../pkg/controllermanager/controller/project)
 
@@ -170,7 +180,7 @@ These RBAC resources are prefixed with `gardener.cloud:system:project{-member,-v
 Gardener administrators and extension developers can define their own roles. For more information, see [Extending Project Roles](../extensions/project-roles.md) for more information.
 
 In addition, operators can configure the Project controller to maintain a default [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) for project namespaces.
-Quotas can especially limit the creation of user facing resources, e.g. `Shoots`, `SecretBindings`, `Secrets` and thus protect the garden cluster from massive resource exhaustion but also enable operators to align quotas with respective enterprise policies.
+Quotas can especially limit the creation of user facing resources, e.g. `Shoots`, `SecretBindings`, `CredentialsBinding`, `Secrets` and thus protect the garden cluster from massive resource exhaustion but also enable operators to align quotas with respective enterprise policies.
 
 > :warning: **Gardener itself is not exempted from configured quotas**. For example, Gardener creates `Secrets` for every shoot cluster in the project namespace and at the same time increases the available quota count. Please mind this additional resource consumption.
 
@@ -187,6 +197,7 @@ controllers:
           hard:
             count/shoots.core.gardener.cloud: "100"
             count/secretbindings.core.gardener.cloud: "10"
+            count/credentialsbindings.security.gardener.cloud: "10"
             count/secrets: "800"
       projectSelector: {}
 ```
@@ -216,8 +227,8 @@ This reconciler is enabled by default and works as follows:
 1. Projects are considered as "stale"/not actively used when all of the following conditions apply: The namespace associated with the `Project` does not have any...
     1. `Shoot` resources.
     1. `BackupEntry` resources.
-    1. `Secret` resources that are referenced by a `SecretBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
-    1. `Quota` resources that are referenced by a `SecretBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
+    1. `Secret` resources that are referenced by a `SecretBinding` or a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
+    1. `Quota` resources that are referenced by a `SecretBinding` or a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
     1. The time period when the project was used for the last time (`status.lastActivityTimestamp`) is longer than the configured `minimumLifetimeDays`
 
 If a project is considered "stale", then its `.status.staleSinceTimestamp` will be set to the time when it was first detected to be stale.
@@ -314,7 +325,7 @@ It could also add some operation or task annotations. For more information, see 
 
 #### ["Quota" Reconciler](../../pkg/controllermanager/controller/shoot/quota)
 
-This reconciler might auto-delete shoot clusters in case their referenced `SecretBinding` is itself referencing a `Quota` with `.spec.clusterLifetimeDays != nil`.
+This reconciler might auto-delete shoot clusters in case their referenced `SecretBinding` or `CredentialsBinding` is itself referencing a `Quota` with `.spec.clusterLifetimeDays != nil`.
 If the shoot cluster is older than the configured lifetime, then it gets deleted.
 It maintains the expiration time of the `Shoot` in the value of the `shoot.gardener.cloud/expiration-timestamp` annotation.
 This annotation might be overridden, however only by at most twice the value of the `.spec.clusterLifetimeDays`.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security ipcei
/kind enhancement
/ipcei workload-identity

**What this PR does / why we need it**:
Adds the relevant documentation copied from https://github.com/gardener/gardener/pull/10327 which was recently closed.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
