### PR TITLE
Fix `kube-state-metrics` migration to `ManagedResource` on managed seeds

### DIFF
--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
@@ -237,11 +237,6 @@ func (k *kubeStateMetrics) Deploy(ctx context.Context) error {
 			return err
 		}
 
-		// TODO(vicwicker): Remove after Gardener v1.104 got released.
-		if err := managedresources.WaitUntilHealthyAndNotProgressing(ctx, k.client, k.namespace, k.managedResourceName()); err != nil {
-			return err
-		}
-
 		return managedresources.CreateForShootWithLabels(
 			ctx,
 			k.client,


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

https://github.com/gardener/gardener/pull/9941 migrates kube-state-metrics to managed resources. This change re-uses the already existing `shoot-core-kube-state-metrics` managed resource to deploy the kube-state-metrics resources in the shoot's control-plane namespace (e.g., kube-state-metrics deployment, config maps, services...). Previously, it deployed the cluster role and cluster role binding required by kube-state-metrics in the shoot. These cluster role and cluster role binding are now managed by a new `shoot-core-kube-state-metrics-target` managed resource.

During the migration, `shoot-core-kube-state-metrics` wants to delete the cluster role and cluster role binding that it does not manage anymore. However, because it's used now to deploy resources in the seed cluster, its class changed to seed. The cluster role and cluster role binding deletion is therefore attempted in the seed cluster, which is incorrect. This problem is specific to seeds that are also shoots (i.e., managed seeds) where there is a cluster role and cluster role binding because they are shoots. In non managed seeds, there is no such cluster role and cluster role bindings.

The fix is to delete the `shoot-core-kube-state-metrics` managed resource and wait for the deletion to complete. Then it can be recreated with the same name but different class. This way, the Gardener resource manager is not confused to delete the cluster role and cluster role binding in the seed.

**Special notes for your reviewer**:

/cc @istvanballok @plkokanov

**Release note**:

```other operator
NONE
```
