### PR TITLE
Update CA image for k8s v1.25 and v1.26

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -169,12 +169,12 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.26.2"
+  tag: "v1.26.3"
   targetVersion: "1.26.x"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.25.3"
+  tag: "v1.25.4"
   targetVersion: "1.25.x"
 - name: vpn-seed-server
   sourceRepository: github.com/gardener/vpn2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Update CA images for k8s v1.25 and v1.26. 
cc @ccwienk 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The following dependencies have been updated:
- europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler: v1.25.3 -> v1.25.4 (for Kubernetes v1.25)
- europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler: v1.26.2 -> v1.26.3 (for Kubernetes v1.26)
```
