### PR TITLE
[GEP-26] CredentialsBinding.CredentialsRef is now immutable

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2067,8 +2067,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>CredentialsBindingName is the name of the a CredentialsBinding that has a reference to the provider credentials.
-The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.
-This field is immutable.</p>
+The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.</p>
 </td>
 </tr>
 </table>
@@ -11980,8 +11979,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>CredentialsBindingName is the name of the a CredentialsBinding that has a reference to the provider credentials.
-The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.
-This field is immutable.</p>
+The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.</p>
 </td>
 </tr>
 </tbody>
@@ -12680,8 +12678,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>CredentialsBindingName is the name of the a CredentialsBinding that has a reference to the provider credentials.
-The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.
-This field is immutable.</p>
+The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.</p>
 </td>
 </tr>
 </table>

--- a/docs/api-reference/security.md
+++ b/docs/api-reference/security.md
@@ -85,7 +85,8 @@ Kubernetes core/v1.ObjectReference
 </td>
 <td>
 <p>CredentialsRef is a reference to a resource holding the credentials.
-Accepted resources are core/v1.Secret and security.gardener.cloud/v1alpha1.WorkloadIdentity</p>
+Accepted resources are core/v1.Secret and security.gardener.cloud/v1alpha1.WorkloadIdentity
+This field is immutable.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -106,7 +106,6 @@ type ShootSpec struct {
 	CloudProfile *CloudProfileReference
 	// CredentialsBindingName is the name of the a CredentialsBinding that has a reference to the provider credentials.
 	// The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.
-	// This field is immutable.
 	CredentialsBindingName *string
 }
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2991,7 +2991,6 @@ message ShootSpec {
 
   // CredentialsBindingName is the name of the a CredentialsBinding that has a reference to the provider credentials.
   // The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.
-  // This field is immutable.
   // +optional
   optional string credentialsBindingName = 23;
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -135,7 +135,6 @@ type ShootSpec struct {
 	CloudProfile *CloudProfileReference `json:"cloudProfile,omitempty" protobuf:"bytes,22,opt,name=cloudProfile"`
 	// CredentialsBindingName is the name of the a CredentialsBinding that has a reference to the provider credentials.
 	// The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.
-	// This field is immutable.
 	// +optional
 	CredentialsBindingName *string `json:"credentialsBindingName,omitempty" protobuf:"bytes,23,opt,name=credentialsBindingName"`
 }

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -321,14 +321,17 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Region, oldSpec.Region, fldPath.Child("region"))...)
 	allErrs = append(allErrs, ValidateCloudProfileReference(newSpec.CloudProfile, oldSpec.CloudProfile, newSpec.CloudProfileName, oldSpec.CloudProfileName, fldPath.Child("cloudProfile"))...)
+
+	if oldSpec.CredentialsBindingName != nil && len(ptr.Deref(newSpec.CredentialsBindingName, "")) == 0 {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsBindingName"), "once set this field cannot be set to empty"))
+	}
+
 	// allow removing the value of SecretBindingName when
 	// old secret binding existed, but new is set to nil
 	// and new credentials binding also exists
 	migrationFromSecBindingToCredBinding := oldSpec.SecretBindingName != nil && newSpec.SecretBindingName == nil && len(ptr.Deref(newSpec.CredentialsBindingName, "")) > 0
-	migrationFromCredBindingToSecBinding := oldSpec.CredentialsBindingName != nil && newSpec.CredentialsBindingName == nil && len(ptr.Deref(newSpec.SecretBindingName, "")) > 0
-	if !migrationFromSecBindingToCredBinding && !migrationFromCredBindingToSecBinding {
+	if !migrationFromSecBindingToCredBinding {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SecretBindingName, oldSpec.SecretBindingName, fldPath.Child("secretBindingName"))...)
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.CredentialsBindingName, oldSpec.CredentialsBindingName, fldPath.Child("credentialsBindingName"))...)
 	}
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.ExposureClassName, oldSpec.ExposureClassName, fldPath.Child("exposureClassName"))...)
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -323,7 +323,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	allErrs = append(allErrs, ValidateCloudProfileReference(newSpec.CloudProfile, oldSpec.CloudProfile, newSpec.CloudProfileName, oldSpec.CloudProfileName, fldPath.Child("cloudProfile"))...)
 
 	if oldSpec.CredentialsBindingName != nil && len(ptr.Deref(newSpec.CredentialsBindingName, "")) == 0 {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsBindingName"), "once set this field cannot be set to empty"))
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsBindingName"), "the field cannot be unset"))
 	}
 
 	// allow removing the value of SecretBindingName when

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -893,7 +893,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			))
 		})
 
-		It("should forbid updating credentialsBindingName when not migrating to secretBindingName", func() {
+		It("should allow updating credentialsBindingName", func() {
 			shoot.Spec.SecretBindingName = nil
 			shoot.Spec.CredentialsBindingName = ptr.To("foo")
 			newShoot := prepareShootForUpdate(shoot)
@@ -901,12 +901,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			errorList := ValidateShootUpdate(newShoot, shoot)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.credentialsBindingName"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
 		It("should allow switching from secretBindingName to credentialsBindingName", func() {
@@ -919,7 +914,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should allow switching from credentialsBindingName to secretBindingName", func() {
+		It("should not allow switching from credentialsBindingName to secretBindingName", func() {
 			shoot.Spec.SecretBindingName = nil
 			shoot.Spec.CredentialsBindingName = ptr.To("another-reference")
 			newShoot := prepareShootForUpdate(shoot)
@@ -928,7 +923,18 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			errorList := ValidateShootUpdate(newShoot, shoot)
 
-			Expect(errorList).To(BeEmpty())
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.secretBindingName"),
+					"Detail": Equal("field is immutable"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.credentialsBindingName"),
+					"Detail": Equal("once set this field cannot be set to empty"),
+				})),
+			))
 		})
 
 		Context("seed selector", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -932,7 +932,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.credentialsBindingName"),
-					"Detail": Equal("once set this field cannot be set to empty"),
+					"Detail": Equal("the field cannot be unset"),
 				})),
 			))
 		})

--- a/pkg/apis/security/types_credentialsbinding.go
+++ b/pkg/apis/security/types_credentialsbinding.go
@@ -22,6 +22,7 @@ type CredentialsBinding struct {
 	Provider CredentialsBindingProvider
 	// CredentialsRef is a reference to a resource holding the credentials.
 	// Accepted resources are core/v1.Secret and security.gardener.cloud/v1alpha1.WorkloadIdentity
+	// This field is immutable.
 	CredentialsRef corev1.ObjectReference
 	// Quotas is a list of references to Quota objects in the same or another namespace.
 	// This field is immutable.

--- a/pkg/apis/security/v1alpha1/generated.proto
+++ b/pkg/apis/security/v1alpha1/generated.proto
@@ -47,6 +47,7 @@ message CredentialsBinding {
 
   // CredentialsRef is a reference to a resource holding the credentials.
   // Accepted resources are core/v1.Secret and security.gardener.cloud/v1alpha1.WorkloadIdentity
+  // This field is immutable.
   optional k8s.io.api.core.v1.ObjectReference credentialsRef = 3;
 
   // Quotas is a list of references to Quota objects in the same or another namespace.

--- a/pkg/apis/security/v1alpha1/types_credentialsbinding.go
+++ b/pkg/apis/security/v1alpha1/types_credentialsbinding.go
@@ -23,6 +23,7 @@ type CredentialsBinding struct {
 	Provider CredentialsBindingProvider `json:"provider" protobuf:"bytes,2,opt,name=provider"`
 	// CredentialsRef is a reference to a resource holding the credentials.
 	// Accepted resources are core/v1.Secret and security.gardener.cloud/v1alpha1.WorkloadIdentity
+	// This field is immutable.
 	CredentialsRef corev1.ObjectReference `json:"credentialsRef" protobuf:"bytes,3,name=credentialsRef"`
 	// Quotas is a list of references to Quota objects in the same or another namespace.
 	// This field is immutable.

--- a/pkg/apis/security/validation/credentialsbinding.go
+++ b/pkg/apis/security/validation/credentialsbinding.go
@@ -37,6 +37,7 @@ func ValidateCredentialsBindingUpdate(newBinding, oldBinding *security.Credentia
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBinding.ObjectMeta, &oldBinding.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newBinding.CredentialsRef, oldBinding.CredentialsRef, field.NewPath("credentialsRef"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newBinding.Quotas, oldBinding.Quotas, field.NewPath("quotas"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newBinding.Provider, oldBinding.Provider, field.NewPath("provider"))...)
 

--- a/pkg/apis/security/validation/credentialsbinding_test.go
+++ b/pkg/apis/security/validation/credentialsbinding_test.go
@@ -268,6 +268,26 @@ var _ = Describe("CredentialsBinding Validation Tests", func() {
 			}
 		})
 
+		It("should forbid updating the CredentialsBinding credentialsRef field", func() {
+			newCredentialsBinding := prepareCredentialsBindingForUpdate(credentialsBinding)
+			newCredentialsBinding.CredentialsRef = corev1.ObjectReference{
+				APIVersion: "security.gardener.cloud/v1alpha1",
+				Kind:       "WorkloadIdentity",
+				Name:       "new-workloadidentity",
+				Namespace:  "my-namespace",
+			}
+
+			errorList := ValidateCredentialsBindingUpdate(newCredentialsBinding, credentialsBinding)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("credentialsRef"),
+					"Detail": Equal("field is immutable"),
+				})),
+			))
+		})
+
 		It("should forbid updating the CredentialsBinding quota fields", func() {
 			newCredentialsBinding := prepareCredentialsBindingForUpdate(credentialsBinding)
 			newCredentialsBinding.Quotas = append(newCredentialsBinding.Quotas, corev1.ObjectReference{
@@ -279,8 +299,9 @@ var _ = Describe("CredentialsBinding Validation Tests", func() {
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("quotas"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("quotas"),
+					"Detail": Equal("field is immutable"),
 				})),
 			))
 		})

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -8771,7 +8771,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"credentialsBindingName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CredentialsBindingName is the name of the a CredentialsBinding that has a reference to the provider credentials. The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName. This field is immutable.",
+							Description: "CredentialsBindingName is the name of the a CredentialsBinding that has a reference to the provider credentials. The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -10073,7 +10073,7 @@ func schema_pkg_apis_security_v1alpha1_CredentialsBinding(ref common.ReferenceCa
 					},
 					"credentialsRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CredentialsRef is a reference to a resource holding the credentials. Accepted resources are core/v1.Secret and security.gardener.cloud/v1alpha1.WorkloadIdentity",
+							Description: "CredentialsRef is a reference to a resource holding the credentials. Accepted resources are core/v1.Secret and security.gardener.cloud/v1alpha1.WorkloadIdentity This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -706,7 +706,9 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 		Name:            credentialsName,
 		ResourceRequest: true,
 	}
-	if decision, _, _ := r.authorizer.Authorize(ctx, readAttributes); decision != authorizer.DecisionAllow {
+	if decision, _, err := r.authorizer.Authorize(ctx, readAttributes); err != nil {
+		return fmt.Errorf("could not authorize read request for credentials: %w", err)
+	} else if decision != authorizer.DecisionAllow {
 		return fmt.Errorf("%s cannot reference a %s you are not allowed to read", binding.GetObjectKind().GroupVersionKind().Kind, credentialsKind)
 	}
 
@@ -742,7 +744,9 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 			ResourceRequest: true,
 			Path:            "",
 		}
-		if decision, _, _ := r.authorizer.Authorize(ctx, readAttributes); decision != authorizer.DecisionAllow {
+		if decision, _, err := r.authorizer.Authorize(ctx, readAttributes); err != nil {
+			return fmt.Errorf("could not authorize read request for quota: %w", err)
+		} else if decision != authorizer.DecisionAllow {
 			return fmt.Errorf("%s cannot reference a quota you are not allowed to read", binding.GetObjectKind().GroupVersionKind().Kind)
 		}
 
@@ -836,7 +840,9 @@ func (r *ReferenceManager) ensureShootReferences(ctx context.Context, attributes
 				Name:            resource.ResourceRef.Name,
 				ResourceRequest: true,
 			}
-			if decision, _, _ := r.authorizer.Authorize(ctx, readAttributes); decision != authorizer.DecisionAllow {
+			if decision, _, err := r.authorizer.Authorize(ctx, readAttributes); err != nil {
+				return fmt.Errorf("could not authorize read request for shoot resource reference: %w", err)
+			} else if decision != authorizer.DecisionAllow {
 				return errors.New("shoot cannot reference a resource you are not allowed to read")
 			}
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -701,7 +701,9 @@ func (c *validationContext) validateCredentialsBindingChange(
 	}
 
 	// Prevent users from changing the credentials binding unless they have read permissions for both old and new credentials.
-	// This ensures that if a user has access to a cluster
+	// This ensures that if a user has access to a shoot that references a binding in another namespace controlled by another party
+	// the said user cannot reference another binding and potentially change the underlying cloud provider account
+	// and leave orphaned resources in the other party's account.
 	if c.oldShoot.Spec.CredentialsBindingName != nil && c.shoot.Spec.CredentialsBindingName != nil &&
 		*c.oldShoot.Spec.CredentialsBindingName != *c.shoot.Spec.CredentialsBindingName {
 		oldCredentialsBinding, err := credentialsBindingLister.CredentialsBindings(c.oldShoot.Namespace).Get(*c.oldShoot.Spec.CredentialsBindingName)

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1175,6 +1175,117 @@ var _ = Describe("validator", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 			})
+
+		})
+
+		Context("changing shoot.spec.credentialsBindingName", func() {
+			var (
+				oldShoot *core.Shoot
+			)
+			BeforeEach(func() {
+				auth = mockauthorizer.NewMockAuthorizer(ctrl)
+
+				shoot.Spec.SecretBindingName = nil
+				oldShoot = shoot.DeepCopy()
+				shoot.Spec.CredentialsBindingName = ptr.To("new-credentialsbinding")
+
+				credentialsBinding.CredentialsRef = corev1.ObjectReference{
+					Namespace:  shoot.Namespace,
+					Name:       "secret1",
+					Kind:       "Secret",
+					APIVersion: corev1.SchemeGroupVersion.String(),
+				}
+
+				newCredentialsBinding := credentialsBinding.DeepCopy()
+				newCredentialsBinding.Name = "new-credentialsbinding"
+				newCredentialsBinding.CredentialsRef.Name = "new-secret"
+
+				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(newCredentialsBinding)).To(Succeed())
+			})
+
+			It("should deny the change if user has no permissions to read old credentials", func() {
+				authorizeAttributes := authorizer.AttributesRecord{
+					User:            userInfo,
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "secrets",
+					Namespace:       shoot.Namespace,
+					Name:            "secret1",
+					Verb:            "get",
+					ResourceRequest: true,
+				}
+
+				auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
+
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+				Expect(err).To(BeForbiddenError())
+				Expect(err).To(MatchError(ContainSubstring("user %q is not allowed to read the previously referenced Secret %q", userInfo.Name, shoot.Namespace+"/secret1")))
+			})
+
+			It("should deny the change if user has no permissions to read new credentials", func() {
+				oldAuthorizeAttributes := authorizer.AttributesRecord{
+					User:            userInfo,
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "secrets",
+					Namespace:       shoot.Namespace,
+					Name:            "secret1",
+					Verb:            "get",
+					ResourceRequest: true,
+				}
+				auth.EXPECT().Authorize(ctx, oldAuthorizeAttributes).Return(authorizer.DecisionAllow, "", nil)
+
+				newAuthorizeAttributes := authorizer.AttributesRecord{
+					User:            userInfo,
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "secrets",
+					Namespace:       shoot.Namespace,
+					Name:            "new-secret",
+					Verb:            "get",
+					ResourceRequest: true,
+				}
+				auth.EXPECT().Authorize(ctx, newAuthorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
+
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+				Expect(err).To(BeForbiddenError())
+				Expect(err).To(MatchError(ContainSubstring("user %q is not allowed to read the newly referenced Secret %q", userInfo.Name, shoot.Namespace+"/new-secret")))
+			})
+
+			It("should allow the change if user has permissions to read both old and new credentials", func() {
+				oldAuthorizeAttributes := authorizer.AttributesRecord{
+					User:            userInfo,
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "secrets",
+					Namespace:       shoot.Namespace,
+					Name:            "secret1",
+					Verb:            "get",
+					ResourceRequest: true,
+				}
+				auth.EXPECT().Authorize(ctx, oldAuthorizeAttributes).Return(authorizer.DecisionAllow, "", nil)
+
+				newAuthorizeAttributes := authorizer.AttributesRecord{
+					User:            userInfo,
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "secrets",
+					Namespace:       shoot.Namespace,
+					Name:            "new-secret",
+					Verb:            "get",
+					ResourceRequest: true,
+				}
+				auth.EXPECT().Authorize(ctx, newAuthorizeAttributes).Return(authorizer.DecisionAllow, "", nil)
+
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+			})
 		})
 
 		Context("tests deploy task", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security ipcei
/kind enhancement
/label ipcei/workload-identity

**What this PR does / why we need it**:
This PR makes `credentialsBinding.credentialsRef` immutable. `shoot.spec.credentialsBindingName` becomes mutable and users will be able to change it only if they can read both the old and new credential that is referenced by the `CredentialsBinding`. Migration from `shoot.spec.secretBindingName` to `shoot.spec.credentialsBindingName` will only be possible if the referenced credential is preserved and not changed during the process.

See justification for these changes in https://github.com/gardener/gardener/issues/9586#issuecomment-2297997424

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

Addresses https://github.com/gardener/gardener/issues/9586#issuecomment-2297997424

**Special notes for your reviewer**:
cc @vpnachev @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`credentialsBinding.credentialsRef` is now an immutable field.
```

```noteworthy user
Users can migrate from `shoot.spec.secretBindingName` to `shoot.spec.credentialsBindingName` only if the referenced credential remains the same and is not changed during the process.
```

```noteworthy user
Users are allowed to change `shoot.spec.credentialsBindingName` and reference another `CredentialsBinding` only if they have the permissions to read both the old and newly referenced credential.
```