### PR TITLE
Fix vpn-seed-server VPA's targerRef when HA is enabled

### DIFF
--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -870,10 +870,16 @@ func (v *vpnSeedServer) deployVPA(ctx context.Context) error {
 		vpaUpdateMode    = vpaautoscalingv1.UpdateModeAuto
 		controlledValues = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 	)
+
+	targetRefKind := "Deployment"
+	if v.values.HighAvailabilityEnabled {
+		targetRefKind = "StatefulSet"
+	}
+
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, v.client, vpa, func() error {
 		vpa.Spec.TargetRef = &autoscalingv1.CrossVersionObjectReference{
 			APIVersion: appsv1.SchemeGroupVersion.String(),
-			Kind:       "Deployment",
+			Kind:       targetRefKind,
 			Name:       deploymentName,
 		}
 		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
vpa-recommender logs are full with logs of type:
```
{"log":"Cannot get target selector from VPA's targetRef. Reason: Deployment shoot--foo--bar/vpn-seed-server does not exist","pid":"1","severity":"ERR","source":"cluster_feeder.go:532"}
```

The reason is that for non-HA Shoots the vpn-seed-server is a Deployent, for HA ones - StatefulSet. See https://github.com/gardener/gardener/blob/5ed6ddbc750d160e818c4d6781bf609d6944ddf6/pkg/component/networking/vpn/seedserver/seedserver.go#L211-L249

However, the VPA's targetRef always points to the Deployment: https://github.com/gardener/gardener/blob/5ed6ddbc750d160e818c4d6781bf609d6944ddf6/pkg/component/networking/vpn/seedserver/seedserver.go#L874-L878

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the vpn-seed-server VPA's to be created with wrong targetRef for highly available Shoots is now fixed.
```
