### PR TITLE
Fix registry hosts probing when OSC `criConfig.containerd.registries.hosts.caCerts` spec field is specified

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
@@ -6,12 +6,15 @@ package operatingsystemconfig
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	_ "embed"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"text/template"
 	"time"
 
@@ -312,15 +315,34 @@ func addRegistryToContainerdFunc(ctx context.Context, log logr.Logger, registryC
 	if !exists && ptr.Deref(registryConfig.ReadinessProbe, false) {
 		log.Info("Probing endpoints for image registry", "upstream", registryConfig.Upstream)
 		if err := retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
-			for _, registryHosts := range registryConfig.Hosts {
-				req, err := http.NewRequestWithContext(ctx, http.MethodGet, registryHosts.URL, nil)
+			for _, registryHost := range registryConfig.Hosts {
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, registryHost.URL, nil)
 				if err != nil {
-					return false, fmt.Errorf("failed to construct http request %s for upstream %s: %w", registryHosts.URL, registryConfig.Upstream, err)
+					return false, fmt.Errorf("failed to construct http request %s for upstream %s: %w", registryHost.URL, registryConfig.Upstream, err)
+				}
+
+				if len(registryHost.CACerts) > 0 {
+					caCertPool := x509.NewCertPool()
+					for _, caCert := range registryHost.CACerts {
+						if !filepath.IsAbs(caCert) {
+							caCert = filepath.Join(baseDir, caCert)
+						}
+						pemContent, err := fs.ReadFile(caCert)
+						if err != nil {
+							return false, fmt.Errorf("failed to read ca file %s for host %s and upstream %s: %w", caCert, registryHost.URL, registryConfig.Upstream, err)
+						}
+						caCertPool.AppendCertsFromPEM(pemContent)
+					}
+					httpClient.Transport = &http.Transport{
+						TLSClientConfig: &tls.Config{
+							RootCAs: caCertPool,
+						},
+					}
 				}
 
 				_, err = httpClient.Do(req)
 				if err != nil {
-					return false, fmt.Errorf("failed to reach registry %s for upstream %s: %w", registryHosts.URL, registryConfig.Upstream, err)
+					return false, fmt.Errorf("failed to reach registry %s for upstream %s: %w", registryHost.URL, registryConfig.Upstream, err)
 				}
 			}
 			return true, nil

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
@@ -335,7 +335,8 @@ func addRegistryToContainerdFunc(ctx context.Context, log logr.Logger, registryC
 					}
 					httpClient.Transport = &http.Transport{
 						TLSClientConfig: &tls.Config{
-							RootCAs: caCertPool,
+							RootCAs:    caCertPool,
+							MinVersion: tls.VersionTLS12,
 						},
 					}
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:

When probing registry hosts the following error may occurs if TLS is required:
```
last error: failed to reach registry https://10.4.193.97:5000 for upstream quay.io: Get \"https://10.4.193.97:5000\": tls: failed to verify certificate: x509: certificate signed by unknown authority
```
In case the OSC field `criConfig.containerd.registries.hosts.caCerts` is set, use the provided CAs so that the probe succeeds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue in gardener-node-agent causing registry hosts probe to fail when the `spec.criConfig.containerd.registries.hosts.caCerts` field of OperatingSystemConfig is set is now fixed.
```
