### PR TITLE
[GEP-26] Fix cloudprovider secret deployment to not renew WorkloadIdentity token on shoot reconciliation

### DIFF
--- a/pkg/apis/security/v1alpha1/constants/constants.go
+++ b/pkg/apis/security/v1alpha1/constants/constants.go
@@ -23,6 +23,12 @@ const (
 	// AnnotationWorkloadIdentityTokenRenewTimestamp is an annotation key used to indicate the time when a workload identity token will be
 	AnnotationWorkloadIdentityTokenRenewTimestamp = WorkloadIdentityPrefix + "token-renew-timestamp"
 
+	// DataKeyToken is the data key of a secret whose value contains a workload identity token.
+	DataKeyToken = "token"
+
+	// DataKeyConfig is the data key of a secret whose value contains a workload identity provider configuration.
+	DataKeyConfig = "config"
+
 	// LabelPurpose is a label used to indicate the purpose of the labeled resource.
 	// Specific values might cause controllers to act on the said object.
 	LabelPurpose = groupName + "/purpose"

--- a/pkg/apis/security/v1alpha1/constants/constants.go
+++ b/pkg/apis/security/v1alpha1/constants/constants.go
@@ -20,12 +20,8 @@ const (
 	// the timestamp after which the workload identity token has to be renewed.
 	AnnotationWorkloadIdentityTokenRenewTimestamp = WorkloadIdentityPrefix + "token-renew-timestamp"
 
-	// AnnotationWorkloadIdentityTokenRenewTimestamp is an annotation key used to indicate the time when a workload identity token will be
-	AnnotationWorkloadIdentityTokenRenewTimestamp = WorkloadIdentityPrefix + "token-renew-timestamp"
-
 	// DataKeyToken is the data key of a secret whose value contains a workload identity token.
 	DataKeyToken = "token"
-
 	// DataKeyConfig is the data key of a secret whose value contains a workload identity provider configuration.
 	DataKeyConfig = "config"
 

--- a/pkg/apis/security/v1alpha1/constants/constants.go
+++ b/pkg/apis/security/v1alpha1/constants/constants.go
@@ -20,6 +20,9 @@ const (
 	// the timestamp after which the workload identity token has to be renewed.
 	AnnotationWorkloadIdentityTokenRenewTimestamp = WorkloadIdentityPrefix + "token-renew-timestamp"
 
+	// AnnotationWorkloadIdentityTokenRenewTimestamp is an annotation key used to indicate the time when a workload identity token will be
+	AnnotationWorkloadIdentityTokenRenewTimestamp = WorkloadIdentityPrefix + "token-renew-timestamp"
+
 	// LabelPurpose is a label used to indicate the purpose of the labeled resource.
 	// Specific values might cause controllers to act on the said object.
 	LabelPurpose = groupName + "/purpose"

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler.go
@@ -111,7 +111,7 @@ func (r *Reconciler) reconcileSecret(ctx context.Context, log logr.Logger, secre
 	if secret.Data == nil {
 		secret.Data = make(map[string][]byte, 1)
 	}
-	secret.Data["token"] = []byte(token)
+	secret.Data[securityv1alpha1constants.DataKeyToken] = []byte(token)
 
 	return r.SeedClient.Patch(ctx, secret, patch)
 }
@@ -122,7 +122,7 @@ func (r *Reconciler) shouldRequeue(secret *corev1.Secret) (bool, time.Duration, 
 		return false, 0, nil
 	}
 
-	if _, ok := secret.Data["token"]; !ok {
+	if _, ok := secret.Data[securityv1alpha1constants.DataKeyToken]; !ok {
 		return false, 0, nil
 	}
 

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -473,9 +473,9 @@ func (b *Botanist) DeployCloudProviderSecret(ctx context.Context) error {
 		secret, err := workloadidentity.NewSecret(
 			v1beta1constants.SecretNameCloudProvider,
 			b.Shoot.SeedNamespace,
-			workloadidentity.ForWorkloadIdentity(credentials.Name, credentials.Namespace, credentials.Spec.TargetSystem.Type),
-			workloadidentity.WithWorkloadIdentityProviderConfig(credentials.Spec.TargetSystem.ProviderConfig),
-			workloadidentity.WithWorkloadIdentityContextObject(shootMeta),
+			workloadidentity.For(credentials.Name, credentials.Namespace, credentials.Spec.TargetSystem.Type),
+			workloadidentity.WithProviderConfig(credentials.Spec.TargetSystem.ProviderConfig),
+			workloadidentity.WithContextObject(shootMeta),
 			workloadidentity.WithLabels(map[string]string{v1beta1constants.GardenerPurpose: v1beta1constants.SecretNameCloudProvider}),
 		)
 		if err != nil {

--- a/pkg/utils/workloadidentity/export_test.go
+++ b/pkg/utils/workloadidentity/export_test.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadidentity
+
+import "time"
+
+// Functions exported for testing.
+
+var (
+	GetKeyID       = getKeyID
+	GetSigner      = getSigner
+	GetRSASigner   = getRSASigner
+	GetECDSASigner = getECDSASigner
+)
+
+func SetNow(n func() time.Time) {
+	now = n
+}
+
+func Now() func() time.Time {
+	return now
+}

--- a/pkg/utils/workloadidentity/secret.go
+++ b/pkg/utils/workloadidentity/secret.go
@@ -99,20 +99,20 @@ func WithAnnotations(annotations map[string]string) SecretOption {
 	}
 }
 
-// ForWorkloadIdentity is an option that correlates the workload identity secret with a specific workload identity.
+// For is an option that correlates the workload identity secret with a specific workload identity.
 // This option is required upon creation of such secret.
-func ForWorkloadIdentity(name, namespace, providerType string) SecretOption {
+func For(workloadIdentityName, workloadIdentityNamespace, workloadIdentityProviderType string) SecretOption {
 	return func(s *Secret) error {
-		s.workloadIdentityName = name
-		s.workloadIdentityNamespace = namespace
-		s.workloadIdentityProviderType = providerType
+		s.workloadIdentityName = workloadIdentityName
+		s.workloadIdentityNamespace = workloadIdentityNamespace
+		s.workloadIdentityProviderType = workloadIdentityProviderType
 		return nil
 	}
 }
 
-// WithWorkloadIdentityProviderConfig is an option that can be used to store
+// WithProviderConfig is an option that can be used to store
 // provider specific information in the workload identity secret.
-func WithWorkloadIdentityProviderConfig(providerConfig *runtime.RawExtension) SecretOption {
+func WithProviderConfig(providerConfig *runtime.RawExtension) SecretOption {
 	return func(s *Secret) error {
 		data, err := json.Marshal(providerConfig)
 		if err != nil {
@@ -123,10 +123,10 @@ func WithWorkloadIdentityProviderConfig(providerConfig *runtime.RawExtension) Se
 	}
 }
 
-// WithWorkloadIdentityContextObject is an option that can be used
+// WithContextObject is an option that can be used
 // to indicate to the token requestor controller for workload identities
 // that requested tokens are going to be used in the context of the passed object.
-func WithWorkloadIdentityContextObject(contextObject securityv1alpha1.ContextObject) SecretOption {
+func WithContextObject(contextObject securityv1alpha1.ContextObject) SecretOption {
 	return func(s *Secret) error {
 		data, err := json.Marshal(contextObject)
 		if err != nil {

--- a/pkg/utils/workloadidentity/secret.go
+++ b/pkg/utils/workloadidentity/secret.go
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadidentity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+// SecretOption represents a function that is used to configure [Secret] during creation.
+type SecretOption func(*Secret) error
+
+// Secret wraps [*corev1.Secret] and represents an object which will be used by
+// workloads to request a token for a specific [securityv1alpha1.WorkloadIdentity].
+// The created secret is properly annotated and labeled so that the token requestor controller
+// for workload identities will pick it up and keep a valid workload identity token stored in it.
+type Secret struct {
+	secret *corev1.Secret
+
+	labels      map[string]string
+	annotations map[string]string
+
+	workloadIdentityName           string
+	workloadIdentityNamespace      string
+	workloadIdentityProviderType   string
+	workloadIdentityContextObject  []byte
+	workloadIdentityProviderConfig []byte
+}
+
+// NewSecret creates a new workload identity secret that will be recognized
+// by the token requestor controller for workload identities which will keep
+// a valid workload identity token stored in it.
+func NewSecret(name, namespace string, opts ...SecretOption) (*Secret, error) {
+	workloadIdentitySecret := &Secret{
+		secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Data: make(map[string][]byte),
+		},
+	}
+
+	var err error
+	for _, o := range opts {
+		if e := o(workloadIdentitySecret); err != nil {
+			err = errors.Join(err, e)
+		}
+	}
+
+	if len(workloadIdentitySecret.workloadIdentityName) == 0 {
+		err = errors.Join(err, errors.New("workload identity name is not set"))
+	}
+
+	if len(workloadIdentitySecret.workloadIdentityNamespace) == 0 {
+		err = errors.Join(err, errors.New("workload identity namespace is not set"))
+	}
+
+	if len(workloadIdentitySecret.workloadIdentityProviderType) == 0 {
+		err = errors.Join(err, errors.New("workload identity provider type is not set"))
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return workloadIdentitySecret, nil
+}
+
+// WithLabels is an option that can be used to set additional labels to the workload identity secret
+// which are not necessarily correlated with workload identity specific logic.
+func WithLabels(labels map[string]string) SecretOption {
+	return func(s *Secret) error {
+		s.labels = maps.Clone(labels)
+		return nil
+	}
+}
+
+// WithAnnotations is an option that can be used to set additional annotations to the workload identity secret
+// which are not necessarily correlated with workload identity specific logic.
+func WithAnnotations(annotations map[string]string) SecretOption {
+	return func(s *Secret) error {
+		s.annotations = maps.Clone(annotations)
+		return nil
+	}
+}
+
+// ForWorkloadIdentity is an option that correlates the workload identity secret with a specific workload identity.
+// This option is required upon creation of such secret.
+func ForWorkloadIdentity(name, namespace, providerType string) SecretOption {
+	return func(s *Secret) error {
+		s.workloadIdentityName = name
+		s.workloadIdentityNamespace = namespace
+		s.workloadIdentityProviderType = providerType
+		return nil
+	}
+}
+
+// WithWorkloadIdentityProviderConfig is an option that can be used to store
+// provider specific information in the workload identity secret.
+func WithWorkloadIdentityProviderConfig(providerConfig *runtime.RawExtension) SecretOption {
+	return func(s *Secret) error {
+		data, err := json.Marshal(providerConfig)
+		if err != nil {
+			return err
+		}
+		s.workloadIdentityProviderConfig = data
+		return nil
+	}
+}
+
+// WithWorkloadIdentityContextObject is an option that can be used
+// to indicate to the token requestor controller for workload identities
+// that requested tokens are going to be used in the context of the passed object.
+func WithWorkloadIdentityContextObject(contextObject securityv1alpha1.ContextObject) SecretOption {
+	return func(s *Secret) error {
+		data, err := json.Marshal(contextObject)
+		if err != nil {
+			return err
+		}
+		s.workloadIdentityContextObject = data
+		return nil
+	}
+}
+
+// Reconcile creates or patches the workload identity secret. Based on the struct configuration, it adds
+// annotations and labels that are recognized by the token requestor controller for workload identities.
+func (s *Secret) Reconcile(ctx context.Context, c client.Client) error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c, s.secret, func() error {
+		s.secret.Type = corev1.SecretTypeOpaque
+
+		// preserve the renew timestamp if present but overwrite all other annotations
+		if v, ok := s.secret.ObjectMeta.Annotations[securityv1alpha1constants.AnnotationWorkloadIdentityTokenRenewTimestamp]; ok {
+			s.secret.ObjectMeta.Annotations = utils.MergeStringMaps(s.annotations, map[string]string{
+				securityv1alpha1constants.AnnotationWorkloadIdentityTokenRenewTimestamp: v,
+			})
+		} else {
+			s.secret.ObjectMeta.Annotations = s.annotations
+		}
+
+		metav1.SetMetaDataAnnotation(&s.secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityNamespace, s.workloadIdentityNamespace)
+		metav1.SetMetaDataAnnotation(&s.secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityName, s.workloadIdentityName)
+		if len(s.workloadIdentityContextObject) > 0 {
+			metav1.SetMetaDataAnnotation(&s.secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityContextObject, string(s.workloadIdentityContextObject))
+		} else {
+			delete(s.secret.ObjectMeta.Annotations, securityv1alpha1constants.AnnotationWorkloadIdentityContextObject)
+		}
+
+		s.secret.Labels = utils.MergeStringMaps(s.labels, map[string]string{
+			securityv1alpha1constants.LabelPurpose:                  securityv1alpha1constants.LabelPurposeWorkloadIdentityTokenRequestor,
+			securityv1alpha1constants.LabelWorkloadIdentityProvider: s.workloadIdentityProviderType,
+		})
+
+		if s.secret.Data == nil {
+			s.secret.Data = make(map[string][]byte)
+		}
+
+		// preserve the data token key if present but overwrite all other data keys
+		if v, ok := s.secret.Data[securityv1alpha1constants.DataKeyToken]; ok {
+			s.secret.Data[securityv1alpha1constants.DataKeyToken] = v
+		}
+
+		if len(s.workloadIdentityProviderConfig) > 0 {
+			s.secret.Data[securityv1alpha1constants.DataKeyConfig] = s.workloadIdentityProviderConfig
+		} else {
+			delete(s.secret.Data, securityv1alpha1constants.DataKeyConfig)
+		}
+
+		return nil
+	},
+		// The token-requestor might concurrently update the secret token key to populate the token.
+		// Hence, we need to use optimistic locking here to ensure we don't accidentally overwrite the concurrent update.
+		// ref https://github.com/gardener/gardener/issues/6092#issuecomment-1156244514
+		controllerutils.MergeFromOption{MergeFromOption: client.MergeFromWithOptimisticLock{}})
+	return err
+}

--- a/pkg/utils/workloadidentity/secret_test.go
+++ b/pkg/utils/workloadidentity/secret_test.go
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadidentity
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+)
+
+var _ = Describe("#Secret", func() {
+	var (
+		fakeClient      client.Client
+		secretName      = "foo"
+		secretNamespace = "namespace"
+		ctx             context.Context
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		ctx = context.TODO()
+	})
+
+	It("should not be able to create a secret because workload identity info is not set", func() {
+		secret, err := NewSecret(secretName, secretNamespace)
+		Expect(err).To(HaveOccurred())
+		Expect(secret).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("workload identity name is not set"))
+		Expect(err.Error()).To(ContainSubstring("workload identity namespace is not set"))
+		Expect(err.Error()).To(ContainSubstring("workload identity provider type is not set"))
+	})
+
+	It("should correctly create the secret", func() {
+		secret, err := NewSecret(
+			secretName,
+			secretNamespace,
+			ForWorkloadIdentity("wi-foo", "wi-ns", "provider"),
+			WithWorkloadIdentityContextObject(securityv1alpha1.ContextObject{
+				Kind:       "Shoot",
+				APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+				Name:       "shoot-name",
+				Namespace:  ptr.To("shoot-namespace"),
+				UID:        "12345678-94af-4960-9774-0e9987654321",
+			}),
+			WithWorkloadIdentityProviderConfig(&runtime.RawExtension{
+				Raw: []byte(`{"foo":"bar"}`),
+			}),
+			WithLabels(map[string]string{
+				"foo":                    "bar",
+				"gardener.cloud/purpose": "cloudprovider",
+			}),
+			WithAnnotations(map[string]string{"foo": "bar"}),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(secret.Reconcile(ctx, fakeClient)).To(Succeed())
+		got := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+			},
+		}
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+		Expect(got).To(Equal(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+				Annotations: map[string]string{
+					"foo": "bar",
+					"workloadidentity.security.gardener.cloud/context-object": `{"kind":"Shoot","apiVersion":"core.gardener.cloud/v1beta1","name":"shoot-name","namespace":"shoot-namespace","uid":"12345678-94af-4960-9774-0e9987654321"}`,
+					"workloadidentity.security.gardener.cloud/name":           "wi-foo",
+					"workloadidentity.security.gardener.cloud/namespace":      "wi-ns",
+				},
+				Labels: map[string]string{
+					"security.gardener.cloud/purpose":                   "workload-identity-token-requestor",
+					"workloadidentity.security.gardener.cloud/provider": "provider",
+					"foo":                    "bar",
+					"gardener.cloud/purpose": "cloudprovider",
+				},
+				ResourceVersion: "1",
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"config": []byte(`{"foo":"bar"}`),
+			},
+		}))
+	})
+
+	It("should correctly patch an existing secret", func() {
+		existing := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+				Annotations: map[string]string{
+					"foo": "bar",
+					"workloadidentity.security.gardener.cloud/context-object": `{"kind":"Shoot","apiVersion":"core.gardener.cloud/v1beta1","name":"shoot-name","namespace":"shoot-namespace","uid":"12345678-94af-4960-9774-0e9987654321"}`,
+					"workloadidentity.security.gardener.cloud/name":           "wi-foo",
+					"workloadidentity.security.gardener.cloud/namespace":      "wi-ns",
+				},
+				Labels: map[string]string{
+					"security.gardener.cloud/purpose":                   "workload-identity-token-requestor",
+					"workloadidentity.security.gardener.cloud/provider": "provider",
+					"foo":                    "bar",
+					"gardener.cloud/purpose": "cloudprovider",
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"config": []byte(`{"foo":"bar"}`),
+				"token":  []byte("token"),
+			},
+		}
+
+		Expect(fakeClient.Create(ctx, existing)).To(Succeed())
+
+		secret, err := NewSecret(
+			secretName,
+			secretNamespace,
+			ForWorkloadIdentity("new-name", "new-namespace", "new-provider"),
+			WithLabels(map[string]string{"new-foo": "new-bar"}),
+			WithAnnotations(map[string]string{"new-foo": "new-bar"}),
+			WithWorkloadIdentityProviderConfig(&runtime.RawExtension{
+				Raw: []byte(`{"foo":"bar"}`),
+			}),
+			WithWorkloadIdentityContextObject(securityv1alpha1.ContextObject{
+				Kind:       "Shoot",
+				APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+				Name:       "new-name",
+				Namespace:  ptr.To("new-namespace"),
+				UID:        "12345678-94af-4960-9774-0e9987654321",
+			}),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(secret.Reconcile(ctx, fakeClient)).To(Succeed())
+		got := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+			},
+		}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+		Expect(got).To(Equal(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+				Annotations: map[string]string{
+					"new-foo": "new-bar",
+					"workloadidentity.security.gardener.cloud/context-object": `{"kind":"Shoot","apiVersion":"core.gardener.cloud/v1beta1","name":"new-name","namespace":"new-namespace","uid":"12345678-94af-4960-9774-0e9987654321"}`,
+					"workloadidentity.security.gardener.cloud/name":           "new-name",
+					"workloadidentity.security.gardener.cloud/namespace":      "new-namespace",
+				},
+				Labels: map[string]string{
+					"security.gardener.cloud/purpose":                   "workload-identity-token-requestor",
+					"workloadidentity.security.gardener.cloud/provider": "new-provider",
+					"new-foo": "new-bar",
+				},
+				ResourceVersion: "2",
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"config": []byte(`{"foo":"bar"}`),
+				"token":  []byte("token"),
+			},
+		}))
+	})
+
+	It("should remove unneeded info from an existing secret", func() {
+		existing := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+				Annotations: map[string]string{
+					"foo": "bar",
+					"workloadidentity.security.gardener.cloud/context-object": `{"kind":"Shoot","apiVersion":"core.gardener.cloud/v1beta1","name":"shoot-name","namespace":"shoot-namespace","uid":"12345678-94af-4960-9774-0e9987654321"}`,
+					"workloadidentity.security.gardener.cloud/name":           "wi-foo",
+					"workloadidentity.security.gardener.cloud/namespace":      "wi-ns",
+				},
+				Labels: map[string]string{
+					"security.gardener.cloud/purpose":                   "workload-identity-token-requestor",
+					"workloadidentity.security.gardener.cloud/provider": "provider",
+					"foo":                    "bar",
+					"gardener.cloud/purpose": "cloudprovider",
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"config": []byte(`{"foo":"bar"}`),
+				"token":  []byte("token"),
+			},
+		}
+
+		Expect(fakeClient.Create(ctx, existing)).To(Succeed())
+
+		secret, err := NewSecret(
+			secretName,
+			secretNamespace,
+			ForWorkloadIdentity("new-name", "new-namespace", "new-provider"),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(secret.Reconcile(ctx, fakeClient)).To(Succeed())
+		got := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+			},
+		}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+		Expect(got).To(Equal(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+				Annotations: map[string]string{
+					"workloadidentity.security.gardener.cloud/name":      "new-name",
+					"workloadidentity.security.gardener.cloud/namespace": "new-namespace",
+				},
+				Labels: map[string]string{
+					"security.gardener.cloud/purpose":                   "workload-identity-token-requestor",
+					"workloadidentity.security.gardener.cloud/provider": "new-provider",
+				},
+				ResourceVersion: "2",
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"token": []byte("token"),
+			},
+		}))
+	})
+})

--- a/pkg/utils/workloadidentity/secret_test.go
+++ b/pkg/utils/workloadidentity/secret_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package workloadidentity
+package workloadidentity_test
 
 import (
 	"context"
@@ -19,6 +19,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/workloadidentity"
 )
 
 var _ = Describe("#Secret", func() {
@@ -35,7 +36,7 @@ var _ = Describe("#Secret", func() {
 	})
 
 	It("should not be able to create a secret because workload identity info is not set", func() {
-		secret, err := NewSecret(secretName, secretNamespace)
+		secret, err := workloadidentity.NewSecret(secretName, secretNamespace)
 		Expect(err).To(HaveOccurred())
 		Expect(secret).To(BeNil())
 		Expect(err.Error()).To(And(
@@ -46,25 +47,25 @@ var _ = Describe("#Secret", func() {
 	})
 
 	It("should correctly create the secret", func() {
-		secret, err := NewSecret(
+		secret, err := workloadidentity.NewSecret(
 			secretName,
 			secretNamespace,
-			For("wi-foo", "wi-ns", "provider"),
-			WithContextObject(securityv1alpha1.ContextObject{
+			workloadidentity.For("wi-foo", "wi-ns", "provider"),
+			workloadidentity.WithContextObject(securityv1alpha1.ContextObject{
 				Kind:       "Shoot",
 				APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 				Name:       "shoot-name",
 				Namespace:  ptr.To("shoot-namespace"),
 				UID:        "12345678-94af-4960-9774-0e9987654321",
 			}),
-			WithProviderConfig(&runtime.RawExtension{
+			workloadidentity.WithProviderConfig(&runtime.RawExtension{
 				Raw: []byte(`{"foo":"bar"}`),
 			}),
-			WithLabels(map[string]string{
+			workloadidentity.WithLabels(map[string]string{
 				"foo":                    "bar",
 				"gardener.cloud/purpose": "cloudprovider",
 			}),
-			WithAnnotations(map[string]string{"foo": "bar"}),
+			workloadidentity.WithAnnotations(map[string]string{"foo": "bar"}),
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -129,16 +130,16 @@ var _ = Describe("#Secret", func() {
 
 		Expect(fakeClient.Create(ctx, existing)).To(Succeed())
 
-		secret, err := NewSecret(
+		secret, err := workloadidentity.NewSecret(
 			secretName,
 			secretNamespace,
-			For("new-name", "new-namespace", "new-provider"),
-			WithLabels(map[string]string{"new-foo": "new-bar"}),
-			WithAnnotations(map[string]string{"new-foo": "new-bar"}),
-			WithProviderConfig(&runtime.RawExtension{
+			workloadidentity.For("new-name", "new-namespace", "new-provider"),
+			workloadidentity.WithLabels(map[string]string{"new-foo": "new-bar"}),
+			workloadidentity.WithAnnotations(map[string]string{"new-foo": "new-bar"}),
+			workloadidentity.WithProviderConfig(&runtime.RawExtension{
 				Raw: []byte(`{"foo":"bar"}`),
 			}),
-			WithContextObject(securityv1alpha1.ContextObject{
+			workloadidentity.WithContextObject(securityv1alpha1.ContextObject{
 				Kind:       "Shoot",
 				APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 				Name:       "new-name",
@@ -208,10 +209,10 @@ var _ = Describe("#Secret", func() {
 
 		Expect(fakeClient.Create(ctx, existing)).To(Succeed())
 
-		secret, err := NewSecret(
+		secret, err := workloadidentity.NewSecret(
 			secretName,
 			secretNamespace,
-			For("new-name", "new-namespace", "new-provider"),
+			workloadidentity.For("new-name", "new-namespace", "new-provider"),
 		)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/utils/workloadidentity/secret_test.go
+++ b/pkg/utils/workloadidentity/secret_test.go
@@ -38,24 +38,26 @@ var _ = Describe("#Secret", func() {
 		secret, err := NewSecret(secretName, secretNamespace)
 		Expect(err).To(HaveOccurred())
 		Expect(secret).To(BeNil())
-		Expect(err.Error()).To(ContainSubstring("workload identity name is not set"))
-		Expect(err.Error()).To(ContainSubstring("workload identity namespace is not set"))
-		Expect(err.Error()).To(ContainSubstring("workload identity provider type is not set"))
+		Expect(err.Error()).To(And(
+			ContainSubstring("workload identity name is not set"),
+			ContainSubstring("workload identity namespace is not set"),
+			ContainSubstring("workload identity provider type is not set"),
+		))
 	})
 
 	It("should correctly create the secret", func() {
 		secret, err := NewSecret(
 			secretName,
 			secretNamespace,
-			ForWorkloadIdentity("wi-foo", "wi-ns", "provider"),
-			WithWorkloadIdentityContextObject(securityv1alpha1.ContextObject{
+			For("wi-foo", "wi-ns", "provider"),
+			WithContextObject(securityv1alpha1.ContextObject{
 				Kind:       "Shoot",
 				APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 				Name:       "shoot-name",
 				Namespace:  ptr.To("shoot-namespace"),
 				UID:        "12345678-94af-4960-9774-0e9987654321",
 			}),
-			WithWorkloadIdentityProviderConfig(&runtime.RawExtension{
+			WithProviderConfig(&runtime.RawExtension{
 				Raw: []byte(`{"foo":"bar"}`),
 			}),
 			WithLabels(map[string]string{
@@ -130,13 +132,13 @@ var _ = Describe("#Secret", func() {
 		secret, err := NewSecret(
 			secretName,
 			secretNamespace,
-			ForWorkloadIdentity("new-name", "new-namespace", "new-provider"),
+			For("new-name", "new-namespace", "new-provider"),
 			WithLabels(map[string]string{"new-foo": "new-bar"}),
 			WithAnnotations(map[string]string{"new-foo": "new-bar"}),
-			WithWorkloadIdentityProviderConfig(&runtime.RawExtension{
+			WithProviderConfig(&runtime.RawExtension{
 				Raw: []byte(`{"foo":"bar"}`),
 			}),
-			WithWorkloadIdentityContextObject(securityv1alpha1.ContextObject{
+			WithContextObject(securityv1alpha1.ContextObject{
 				Kind:       "Shoot",
 				APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 				Name:       "new-name",
@@ -209,7 +211,7 @@ var _ = Describe("#Secret", func() {
 		secret, err := NewSecret(
 			secretName,
 			secretNamespace,
-			ForWorkloadIdentity("new-name", "new-namespace", "new-provider"),
+			For("new-name", "new-namespace", "new-provider"),
 		)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/utils/workloadidentity/workloadidentity_suite_test.go
+++ b/pkg/utils/workloadidentity/workloadidentity_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package workloadidentity
+package workloadidentity_test
 
 import (
 	"testing"

--- a/pkg/utils/workloadidentity/workloadidentity_suite_test.go
+++ b/pkg/utils/workloadidentity/workloadidentity_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package workloadidentity_test
+package workloadidentity
 
 import (
 	"testing"

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -434,6 +434,7 @@ build:
             - pkg/apis/security
             - pkg/apis/security/install
             - pkg/apis/security/v1alpha1
+            - pkg/apis/security/v1alpha1/constants
             - pkg/apis/security/validation
             - pkg/apis/seedmanagement
             - pkg/apis/seedmanagement/encoding

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -64,6 +64,7 @@ build:
             - pkg/apis/security
             - pkg/apis/security/install
             - pkg/apis/security/v1alpha1
+            - pkg/apis/security/v1alpha1/constants
             - pkg/apis/security/validation
             - pkg/apis/seedmanagement
             - pkg/apis/seedmanagement/encoding
@@ -1254,6 +1255,7 @@ build:
             - pkg/utils/validation/kubernetes/core
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
+            - pkg/utils/workloadidentity
             - third_party/gopkg.in/yaml.v2
             - VERSION
         ldflags:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality ipcei
/kind bug
/label ipcei/workload-identity


**What this PR does / why we need it**:
Fix cloudprovider secret deployment to not renew WorkloadIdentity token on shoot reconciliation.
Currently, all already existing annotations, labels and data fields are removed on each shoot reconciliation, most of these changes triggers the workload identity token requestor controller to renew the token.

**Which issue(s) this PR fixes**:
Follow up on https://github.com/gardener/gardener/pull/10239
Part of https://github.com/gardener/gardener/issues/9586
Alternative of https://github.com/gardener/gardener/pull/10371

**Special notes for your reviewer**:
cc @rfranzke @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
