### PR TITLE
Fix local operator setup to use host arch for shoot images instead of always amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,9 +397,9 @@ operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 operator-seed-up: $(SKAFFOLD) $(HELM) $(KUBECTL) operator-up
 	$(SKAFFOLD) run -m garden -f=skaffold-operator-garden.yaml
 	$(SKAFFOLD) run -m garden-config -f=skaffold-operator-garden.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
-		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64
+		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
 	$(SKAFFOLD) run -m gardenlet -p operator -f=skaffold.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
-		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64
+		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
 
 operator-seed-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/operator-seed-down.sh --path-kind-kubeconfig $(KUBECONFIG) --path-garden-kubeconfig $(VIRTUAL_GARDEN_KUBECONFIG)

--- a/Makefile
+++ b/Makefile
@@ -396,8 +396,10 @@ operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 
 operator-seed-up: $(SKAFFOLD) $(HELM) $(KUBECTL) operator-up
 	$(SKAFFOLD) run -m garden -f=skaffold-operator-garden.yaml
-	$(SKAFFOLD) run -m garden-config -f=skaffold-operator-garden.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) --status-check=false # deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/
-	$(SKAFFOLD) run -m gardenlet -p operator -f=skaffold.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) --status-check=false # deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/
+	$(SKAFFOLD) run -m garden-config -f=skaffold-operator-garden.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
+		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64
+	$(SKAFFOLD) run -m gardenlet -p operator -f=skaffold.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
+		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64
 
 operator-seed-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/operator-seed-down.sh --path-kind-kubeconfig $(KUBECONFIG) --path-garden-kubeconfig $(VIRTUAL_GARDEN_KUBECONFIG)

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -401,6 +401,13 @@ build:
         ldflags:
           - '{{.LD_FLAGS}}'
         main: ./cmd/gardener-resource-manager
+      hooks:
+        after:
+          - command:
+              - bash
+              - hack/generate-kustomize-patch-gardenlet.sh
+              - image
+              - gardener-resource-manager
     - image: local-skaffold/gardener-apiserver
       ko:
         dependencies:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1385,6 +1385,13 @@ build:
         ldflags:
           - '{{.LD_FLAGS}}'
         main: ./cmd/gardener-resource-manager
+      hooks:
+        after:
+          - command:
+              - bash
+              - hack/generate-kustomize-patch-gardenlet.sh
+              - image
+              - gardener-resource-manager
     - image: local-skaffold/gardener-node-agent
       ko:
         dependencies:
@@ -1625,15 +1632,6 @@ profiles:
                 - bash
                 - hack/generate-kustomize-patch-gardenlet.sh
                 - helm
-      - op: add
-        path: /build/artifacts/2/hooks
-        value:
-          after:
-            - command:
-                - bash
-                - hack/generate-kustomize-patch-gardenlet.sh
-                - image
-                - gardener-resource-manager
       - op: add
         path: /build/artifacts/3/hooks
         value:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1267,6 +1267,9 @@ build:
             - pkg/utils/workloadidentity
             - third_party/gopkg.in/yaml.v2
             - VERSION
+        ldflags:
+          - '{{.LD_FLAGS}}'
+        main: ./cmd/gardenlet
       hooks:
         after:
           - command:
@@ -1274,9 +1277,6 @@ build:
               - hack/generate-kustomize-patch-gardenlet.sh
               - image
               - gardenlet
-        ldflags:
-          - '{{.LD_FLAGS}}'
-        main: ./cmd/gardenlet
     - image: local-skaffold/gardenlet/chart
       custom:
         dependencies:
@@ -1504,6 +1504,9 @@ build:
             - pkg/utils/version
             - third_party/gopkg.in/yaml.v2
             - VERSION
+        ldflags:
+          - '{{.LD_FLAGS}}'
+        main: ./cmd/gardener-node-agent
       hooks:
         after:
           - command:
@@ -1511,9 +1514,6 @@ build:
               - hack/generate-kustomize-patch-gardenlet.sh
               - image
               - gardener-node-agent
-        ldflags:
-          - '{{.LD_FLAGS}}'
-        main: ./cmd/gardener-node-agent
 deploy:
   helm:
     releases:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1267,6 +1267,13 @@ build:
             - pkg/utils/workloadidentity
             - third_party/gopkg.in/yaml.v2
             - VERSION
+      hooks:
+        after:
+          - command:
+              - bash
+              - hack/generate-kustomize-patch-gardenlet.sh
+              - image
+              - gardenlet
         ldflags:
           - '{{.LD_FLAGS}}'
         main: ./cmd/gardenlet
@@ -1280,6 +1287,12 @@ build:
       requires:
         - image: local-skaffold/gardenlet
           alias: IMG
+      hooks:
+        after:
+          - command:
+              - bash
+              - hack/generate-kustomize-patch-gardenlet.sh
+              - helm
     - image: local-skaffold/gardener-resource-manager
       ko:
         dependencies:
@@ -1491,6 +1504,13 @@ build:
             - pkg/utils/version
             - third_party/gopkg.in/yaml.v2
             - VERSION
+      hooks:
+        after:
+          - command:
+              - bash
+              - hack/generate-kustomize-patch-gardenlet.sh
+              - image
+              - gardener-node-agent
         ldflags:
           - '{{.LD_FLAGS}}'
         main: ./cmd/gardener-node-agent
@@ -1615,32 +1635,6 @@ profiles:
     patches:
       - op: remove
         path: /deploy/helm
-      - op: add
-        path: /build/artifacts/0/hooks
-        value:
-          after:
-            - command:
-                - bash
-                - hack/generate-kustomize-patch-gardenlet.sh
-                - image
-                - gardenlet
-      - op: add
-        path: /build/artifacts/1/hooks
-        value:
-          after:
-            - command:
-                - bash
-                - hack/generate-kustomize-patch-gardenlet.sh
-                - helm
-      - op: add
-        path: /build/artifacts/3/hooks
-        value:
-          after:
-            - command:
-                - bash
-                - hack/generate-kustomize-patch-gardenlet.sh
-                - image
-                - gardener-node-agent
     manifests:
       kustomize:
         paths:


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fix local operator setup to use host arch for shoot images instead of always amd64

Skaffold [uses the kubernetes cluster](https://skaffold.dev/docs/workflows/handling-platforms/#skaffold-can-set-the-image-architecture-automatically) to automatically determine for what platform to build the images for. Because the virtual cluster has no nodes, it is defaulting to `linux/amd64` but this is causing issues on ARM hosts where the kubelet of the shoot fails to start with 
```bash
$ k -n shoot--local--local exec -it machine-shoot--local--local-local-859c8-ljlwn -- /opt/bin/kubelet --version
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
 command terminated with exit code 133
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
