### PR TITLE
Add readiness probe to `kube-proxy`.

### DIFF
--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -590,6 +590,19 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 												Protocol:      corev1.ProtocolTCP,
 											},
 										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/healthz",
+													Port:   intstr.FromInt32(10256),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+											InitialDelaySeconds: 15,
+											TimeoutSeconds:      15,
+											SuccessThreshold:    1,
+											FailureThreshold:    2,
+										},
 										Resources: corev1.ResourceRequirements{
 											Requests: map[corev1.ResourceName]resource.Quantity{
 												corev1.ResourceCPU:    resource.MustParse("20m"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Add readiness probe to `kube-proxy`.

Node critical component handling relies on pods reporting their status via pod readiness. As `kube-proxy` did not have a readiness probe before, it was automatically assumed to be ready once it started running. This could have caused issues in case `kube-proxy` continuously crashed, but the node critical component controller assumed `kube-proxy` to be ready as its status reported to be ready. The end result would be workload being scheduled to a node without a properly running `kube-proxy` due to the node critical component controller removing the taint eventually. This should no longer happen with the readiness probe.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

Please note that this pull request explicitly does not add a liveness probe. This is based on the feedback from https://github.com/kubernetes/kubernetes/pull/75323 and https://github.com/kubernetes/enhancements/pull/3837/files#r1100590046, which push back on having a liveness probe for `kube-proxy` based on the health port. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`kube-proxy` now has a readiness probe so that a node will only become ready for workloads after `kube-proxy` was ready at least once.
```
