### PR TITLE
Since GNA the annotations to restart services have changed a little

### DIFF
--- a/docs/usage/shoot_operations.md
+++ b/docs/usage/shoot_operations.md
@@ -48,7 +48,7 @@ The annotation is not set on the `Shoot` resource but directly on the `Node` obj
 For example, the following will restart both the `kubelet` and the `containerd` services:
 
 ```bash
-kubectl annotate node <node-name> worker.gardener.cloud/restart-systemd-services=kubelet,containerd
+kubectl annotate node <node-name> worker.gardener.cloud/restart-systemd-services=kubelet.service,containerd.service
 ```
 
 It may take up to a minute until the service is restarted.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:

Since GNA the annotation to restart certain systemd services on a node have changed slightly, fix this in the documentation.

Just noticed that in the very recent gardener releases, the `.service` extension is added in the node-agent if not present. So maybe this PR is not needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
