### PR TITLE
Allow Blackbox exporter to scrape admission webhooks

### DIFF
--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
@@ -21,61 +21,9 @@ const (
 	httpKubeAPIServerRootCAsModuleName    = "http_kube_apiserver_root_cas"
 	httpGardenerDashboardModuleName       = "http_gardener_dashboard"
 	httpGardenerDiscoveryServerModuleName = "http_gardener_discovery_server"
-	httpWebhookServerModuleName           = "http_webhooks"
-	// As we want to only check tls certificates for webhooks and don't care
-	// for the rest of the response, all of the following should be treated as OK.
-	// 5XX are excluded as they indicate that the returned result is not reliable
-)
 
-var (
-	WebhooksOKStatusCodes = []int{
-		http.StatusOK,                           // 200
-		http.StatusCreated,                      // 201
-		http.StatusAccepted,                     // 202
-		http.StatusNonAuthoritativeInfo,         // 203
-		http.StatusNoContent,                    // 204
-		http.StatusResetContent,                 // 205
-		http.StatusPartialContent,               // 206
-		http.StatusMultiStatus,                  // 207
-		http.StatusAlreadyReported,              // 208
-		http.StatusIMUsed,                       // 226
-		http.StatusMultipleChoices,              // 300
-		http.StatusMovedPermanently,             // 301
-		http.StatusFound,                        // 302
-		http.StatusSeeOther,                     // 303
-		http.StatusNotModified,                  // 304
-		http.StatusUseProxy,                     // 305
-		http.StatusTemporaryRedirect,            // 307
-		http.StatusPermanentRedirect,            // 308
-		http.StatusBadRequest,                   // 400
-		http.StatusUnauthorized,                 // 401
-		http.StatusPaymentRequired,              // 402
-		http.StatusForbidden,                    // 403
-		http.StatusNotFound,                     // 404
-		http.StatusMethodNotAllowed,             // 405
-		http.StatusNotAcceptable,                // 406
-		http.StatusProxyAuthRequired,            // 407
-		http.StatusRequestTimeout,               // 408
-		http.StatusConflict,                     // 409
-		http.StatusGone,                         // 410
-		http.StatusLengthRequired,               // 411
-		http.StatusPreconditionFailed,           // 412
-		http.StatusRequestEntityTooLarge,        // 413
-		http.StatusRequestURITooLong,            // 414
-		http.StatusUnsupportedMediaType,         // 415
-		http.StatusRequestedRangeNotSatisfiable, // 416
-		http.StatusExpectationFailed,            // 417
-		http.StatusTeapot,                       // 418
-		http.StatusMisdirectedRequest,           // 421
-		http.StatusUnprocessableEntity,          // 422
-		http.StatusLocked,                       // 423
-		http.StatusFailedDependency,             // 424
-		http.StatusUpgradeRequired,              // 426
-		http.StatusPreconditionRequired,         // 428
-		http.StatusTooManyRequests,              // 429
-		http.StatusRequestHeaderFieldsTooLarge,  // 431
-		http.StatusUnavailableForLegalReasons,   // 451
-	}
+	// Name of the module to be used for scraping of webhooks
+	HttpWebhookServerModuleName = "http_webhooks"
 )
 
 // Config returns the blackbox-exporter config for the garden use-case.
@@ -93,6 +41,58 @@ func Config(isDashboardCertificateIssuedByGardener, isGardenerDiscoveryServerEna
 					IPProtocol: "ipv4",
 				},
 			}
+		}
+
+		// As we want to only check tls certificates for webhooks and don't care
+		// for the rest of the response, all of the following should be treated as OK.
+		// 5XX are excluded as they indicate that the returned result is not reliable
+		webhookOKStatusCodes = []int{
+			http.StatusOK,                           // 200
+			http.StatusCreated,                      // 201
+			http.StatusAccepted,                     // 202
+			http.StatusNonAuthoritativeInfo,         // 203
+			http.StatusNoContent,                    // 204
+			http.StatusResetContent,                 // 205
+			http.StatusPartialContent,               // 206
+			http.StatusMultiStatus,                  // 207
+			http.StatusAlreadyReported,              // 208
+			http.StatusIMUsed,                       // 226
+			http.StatusMultipleChoices,              // 300
+			http.StatusMovedPermanently,             // 301
+			http.StatusFound,                        // 302
+			http.StatusSeeOther,                     // 303
+			http.StatusNotModified,                  // 304
+			http.StatusUseProxy,                     // 305
+			http.StatusTemporaryRedirect,            // 307
+			http.StatusPermanentRedirect,            // 308
+			http.StatusBadRequest,                   // 400
+			http.StatusUnauthorized,                 // 401
+			http.StatusPaymentRequired,              // 402
+			http.StatusForbidden,                    // 403
+			http.StatusNotFound,                     // 404
+			http.StatusMethodNotAllowed,             // 405
+			http.StatusNotAcceptable,                // 406
+			http.StatusProxyAuthRequired,            // 407
+			http.StatusRequestTimeout,               // 408
+			http.StatusConflict,                     // 409
+			http.StatusGone,                         // 410
+			http.StatusLengthRequired,               // 411
+			http.StatusPreconditionFailed,           // 412
+			http.StatusRequestEntityTooLarge,        // 413
+			http.StatusRequestURITooLong,            // 414
+			http.StatusUnsupportedMediaType,         // 415
+			http.StatusRequestedRangeNotSatisfiable, // 416
+			http.StatusExpectationFailed,            // 417
+			http.StatusTeapot,                       // 418
+			http.StatusMisdirectedRequest,           // 421
+			http.StatusUnprocessableEntity,          // 422
+			http.StatusLocked,                       // 423
+			http.StatusFailedDependency,             // 424
+			http.StatusUpgradeRequired,              // 426
+			http.StatusPreconditionRequired,         // 428
+			http.StatusTooManyRequests,              // 429
+			http.StatusRequestHeaderFieldsTooLarge,  // 431
+			http.StatusUnavailableForLegalReasons,   // 451
 		}
 
 		httpGardenerAPIServerModule       = defaultModuleConfig()
@@ -113,7 +113,7 @@ func Config(isDashboardCertificateIssuedByGardener, isGardenerDiscoveryServerEna
 	httpKubeAPIServerRootCAsModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
 	// Webhooks are using this certificate as CA
 	httpWebhookServerModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathGardenerAPIServerCABundle
-	httpWebhookServerModule.HTTP.ValidStatusCodes = WebhooksOKStatusCodes
+	httpWebhookServerModule.HTTP.ValidStatusCodes = webhookOKStatusCodes
 
 	if isDashboardCertificateIssuedByGardener {
 		httpGardenerDashboardModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathGardenerAPIServerCABundle
@@ -124,7 +124,7 @@ func Config(isDashboardCertificateIssuedByGardener, isGardenerDiscoveryServerEna
 		httpKubeAPIServerModuleName:        httpKubeAPIServerModule,
 		httpKubeAPIServerRootCAsModuleName: httpKubeAPIServerRootCAsModule,
 		httpGardenerDashboardModuleName:    httpGardenerDashboardModule,
-		httpWebhookServerModuleName:        httpWebhookServerModule,
+		HttpWebhookServerModuleName:        httpWebhookServerModule,
 	}}
 
 	if isGardenerDiscoveryServerEnabled {

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config.go
@@ -12,6 +12,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"net/http"
 )
 
 const (
@@ -20,6 +21,61 @@ const (
 	httpKubeAPIServerRootCAsModuleName    = "http_kube_apiserver_root_cas"
 	httpGardenerDashboardModuleName       = "http_gardener_dashboard"
 	httpGardenerDiscoveryServerModuleName = "http_gardener_discovery_server"
+	httpWebhookServerModuleName           = "http_webhooks"
+	// As we want to only check tls certificates for webhooks and don't care
+	// for the rest of the response, all of the following should be treated as OK.
+	// 5XX are excluded as they indicate that the returned result is not reliable
+)
+
+var (
+	WebhooksOKStatusCodes = []int{
+		http.StatusOK,                           // 200
+		http.StatusCreated,                      // 201
+		http.StatusAccepted,                     // 202
+		http.StatusNonAuthoritativeInfo,         // 203
+		http.StatusNoContent,                    // 204
+		http.StatusResetContent,                 // 205
+		http.StatusPartialContent,               // 206
+		http.StatusMultiStatus,                  // 207
+		http.StatusAlreadyReported,              // 208
+		http.StatusIMUsed,                       // 226
+		http.StatusMultipleChoices,              // 300
+		http.StatusMovedPermanently,             // 301
+		http.StatusFound,                        // 302
+		http.StatusSeeOther,                     // 303
+		http.StatusNotModified,                  // 304
+		http.StatusUseProxy,                     // 305
+		http.StatusTemporaryRedirect,            // 307
+		http.StatusPermanentRedirect,            // 308
+		http.StatusBadRequest,                   // 400
+		http.StatusUnauthorized,                 // 401
+		http.StatusPaymentRequired,              // 402
+		http.StatusForbidden,                    // 403
+		http.StatusNotFound,                     // 404
+		http.StatusMethodNotAllowed,             // 405
+		http.StatusNotAcceptable,                // 406
+		http.StatusProxyAuthRequired,            // 407
+		http.StatusRequestTimeout,               // 408
+		http.StatusConflict,                     // 409
+		http.StatusGone,                         // 410
+		http.StatusLengthRequired,               // 411
+		http.StatusPreconditionFailed,           // 412
+		http.StatusRequestEntityTooLarge,        // 413
+		http.StatusRequestURITooLong,            // 414
+		http.StatusUnsupportedMediaType,         // 415
+		http.StatusRequestedRangeNotSatisfiable, // 416
+		http.StatusExpectationFailed,            // 417
+		http.StatusTeapot,                       // 418
+		http.StatusMisdirectedRequest,           // 421
+		http.StatusUnprocessableEntity,          // 422
+		http.StatusLocked,                       // 423
+		http.StatusFailedDependency,             // 424
+		http.StatusUpgradeRequired,              // 426
+		http.StatusPreconditionRequired,         // 428
+		http.StatusTooManyRequests,              // 429
+		http.StatusRequestHeaderFieldsTooLarge,  // 431
+		http.StatusUnavailableForLegalReasons,   // 451
+	}
 )
 
 // Config returns the blackbox-exporter config for the garden use-case.
@@ -44,6 +100,7 @@ func Config(isDashboardCertificateIssuedByGardener, isGardenerDiscoveryServerEna
 		httpKubeAPIServerRootCAsModule    = defaultModuleConfig()
 		httpGardenerDashboardModule       = defaultModuleConfig()
 		httpGardenerDiscoveryServerModule = defaultModuleConfig()
+		httpWebhookServerModule           = defaultModuleConfig()
 
 		pathGardenerAPIServerCABundle = blackboxexporter.VolumeMountPathGardenerCA + "/" + secretsutils.DataKeyCertificateBundle
 		pathKubeAPIServerCABundle     = blackboxexporter.VolumeMountPathClusterAccess + "/" + secretsutils.DataKeyCertificateBundle
@@ -54,6 +111,9 @@ func Config(isDashboardCertificateIssuedByGardener, isGardenerDiscoveryServerEna
 	httpKubeAPIServerModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathKubeAPIServerCABundle
 	httpKubeAPIServerModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
 	httpKubeAPIServerRootCAsModule.HTTP.HTTPClientConfig.BearerTokenFile = pathToken
+	// Webhooks are using this certificate as CA
+	httpWebhookServerModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathGardenerAPIServerCABundle
+	httpWebhookServerModule.HTTP.ValidStatusCodes = WebhooksOKStatusCodes
 
 	if isDashboardCertificateIssuedByGardener {
 		httpGardenerDashboardModule.HTTP.HTTPClientConfig.TLSConfig.CAFile = pathGardenerAPIServerCABundle
@@ -64,6 +124,7 @@ func Config(isDashboardCertificateIssuedByGardener, isGardenerDiscoveryServerEna
 		httpKubeAPIServerModuleName:        httpKubeAPIServerModule,
 		httpKubeAPIServerRootCAsModuleName: httpKubeAPIServerRootCAsModule,
 		httpGardenerDashboardModuleName:    httpGardenerDashboardModule,
+		httpWebhookServerModuleName:        httpWebhookServerModule,
 	}}
 
 	if isGardenerDiscoveryServerEnabled {

--- a/pkg/component/observability/monitoring/blackboxexporter/garden/config_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/garden/config_test.go
@@ -84,6 +84,25 @@ var _ = Describe("Config", func() {
 						IPProtocol: "ipv4",
 					},
 				},
+				HttpWebhookServerModuleName: {
+					Prober:  "http",
+					Timeout: 10 * time.Second,
+					HTTP: blackboxexporterconfig.HTTPProbe{
+						Headers: map[string]string{
+							"Accept":          "*/*",
+							"Accept-Language": "en-US",
+						},
+						HTTPClientConfig: prometheuscommonconfig.HTTPClientConfig{
+							TLSConfig: prometheuscommonconfig.TLSConfig{CAFile: "/var/run/secrets/blackbox_exporter/gardener-ca/bundle.crt"},
+						},
+						ValidStatusCodes: []int{
+							200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+							300, 301, 302, 303, 304, 305, 307, 308,
+							400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 421, 422, 423, 424, 426, 428, 429, 431, 451,
+						},
+						IPProtocol: "ipv4",
+					},
+				},
 			}}))
 		})
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1329,6 +1329,7 @@ func (r *Reconciler) newBlackboxExporter(garden *operatorv1alpha1.Garden, secret
 				gardenerutils.NetworkPolicyLabel(v1beta1constants.LabelNetworkPolicyIstioIngressNamespaceAlias+"-"+v1beta1constants.DefaultSNIIngressServiceName, 9443): v1beta1constants.LabelNetworkPolicyAllowed,
 				gardenerutils.NetworkPolicyLabel(gardenerapiserver.DeploymentName, 8443):                                                                                v1beta1constants.LabelNetworkPolicyAllowed,
 				gardenerutils.NetworkPolicyLabel(gardenerdiscoveryserver.ServiceName, 8081):                                                                             v1beta1constants.LabelNetworkPolicyAllowed,
+				"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyWebhookTargets:                                                           v1beta1constants.LabelNetworkPolicyAllowed,
 			},
 			PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem100,
 			Config:            gardenblackboxexporter.Config(isDashboardCertificateIssuedByGardener, garden.Spec.VirtualCluster.Gardener.DiscoveryServer != nil),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
PR configures blackbox exporter with `http_webhooks` module that allows a configurations like:
```yaml
apiVersion: monitoring.coreos.com/v1alpha1
kind: ScrapeConfig
metadata:
  annotations:
    resources.gardener.cloud/origin: garden/blackbox-exporter
  labels:
    prometheus: garden
    resources.gardener.cloud/managed-by: gardener
  name: garden-blackbox-gardener-admission-controller
  namespace: garden
spec:
  metricRelabelings:
  - action: keep
    regex: ^(probe_success|probe_http_status_code|probe_http_duration_seconds|probe_ssl_earliest_cert_expiry)$
    sourceLabels:
    - __name__
  metricsPath: /probe
  params:
    module:
    - http_webhooks
  relabelings:
  - action: replace
    regex: (.*)
    replacement: $1
    separator: ;
    sourceLabels:
    - __address__
    targetLabel: __param_target
  - action: replace
    regex: (.*)
    replacement: $1
    separator: ;
    sourceLabels:
    - __param_target
    targetLabel: instance
  - action: replace
    regex: (.*)
    replacement: blackbox-exporter:9115
    separator: ;
    targetLabel: __address__
  - action: replace
    replacement: gardener-admission-controller
    targetLabel: job
  staticConfigs:
  - labels:
      purpose: availability
    targets:
    - https://gardener-admission-controller.garden.svc/
```
and have monitoring for the certificate expiration (among other things).

**Which issue(s) this PR fixes**:
Makes it easier to add CA certificates monitoring on https://github.com/gardener/gardener/issues/10394

**Special notes for your reviewer**:
/cc @istvanballok @rickardsjp @vicwicker @chrkl

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Admission webhooks on the runtime cluster can now define scrape configs for blackbox exporter with module `http_webhooks` and will be scraped with success probes for HTTP codes 2XX - 4XX
```
