### PR TITLE
Update logging stack components

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -464,7 +464,7 @@ images:
 - name: fluent-operator
   sourceRepository: github.com/fluent/fluent-operator
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-operator
-  tag: "v2.9.0"
+  tag: "v3.1.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -481,7 +481,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-operator
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
-  tag: "v3.0.7"
+  tag: "v3.1.5"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -500,7 +500,7 @@ images:
     name: fluent-bit-to-vali
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-  tag: "v0.60.0"
+  tag: "v0.61.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -535,7 +535,7 @@ images:
 - name: vali-curator
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-  tag: "v0.60.0"
+  tag: "v0.61.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -590,7 +590,7 @@ images:
     name: telegraf-iptables
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-  tag: "v0.60.0"
+  tag: "v0.61.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -610,7 +610,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-  tag: "v0.60.0"
+  tag: "v0.61.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -627,7 +627,7 @@ images:
 - name: tune2fs
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-  tag: "v0.60.0"
+  tag: "v0.61.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind enhancement

This PR brings updates in logging stack components:
- fluent-operator v3.1.0
- fluent-bit v3.1.5
- gardener logging plugin v0.61.0

```other dependency
The `fluent-operator` image has been updated to `v3.10`. [Release Notes](https://redirect.github.com/fluent/fluent-operator/releases/tag/v3.1.0)
The `fluent-bit` image has been updated to `v3.1.5`. [Release Notes](https://redirect.github.com/fluent/fluent-bit/releases/tag/v3.1.5)
The `gardener/logging` image has been updated to `v0.61.0`. [Release Notes](https://redirect.github.com/gardener/logging/releases/tag/v0.61.0)
```
