### PR TITLE
Nit: Add an empty line before the `// Deprecated:` comment

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1269,6 +1269,8 @@ spec:
                               clientAuthentication:
                                 description: |-
                                   ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+
+
                                   Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
                                   It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
                                   TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -4459,8 +4459,8 @@ kubeconfig that is handed out to end-users. This field is immutable.</p>
 <td>
 <em>(Optional)</em>
 <p>Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
-not a default domain is used.
-Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
+not a default domain is used.</p>
+<p>Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
 Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.</p>
 </td>
 </tr>
@@ -4537,8 +4537,8 @@ DNSIncludeExclude
 </td>
 <td>
 <em>(Optional)</em>
-<p>Domains contains information about which domains shall be included/excluded for this provider.
-Deprecated: This field is deprecated and will be removed in a future release.
+<p>Domains contains information about which domains shall be included/excluded for this provider.</p>
+<p>Deprecated: This field is deprecated and will be removed in a future release.
 Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.</p>
 </td>
 </tr>
@@ -4551,8 +4551,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Primary indicates that this DNSProvider is used for shoot related domains.
-Deprecated: This field is deprecated and will be removed in a future release.
+<p>Primary indicates that this DNSProvider is used for shoot related domains.</p>
+<p>Deprecated: This field is deprecated and will be removed in a future release.
 Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.</p>
 </td>
 </tr>
@@ -4594,8 +4594,8 @@ DNSIncludeExclude
 </td>
 <td>
 <em>(Optional)</em>
-<p>Zones contains information about which hosted zones shall be included/excluded for this provider.
-Deprecated: This field is deprecated and will be removed in a future release.
+<p>Zones contains information about which hosted zones shall be included/excluded for this provider.</p>
+<p>Deprecated: This field is deprecated and will be removed in a future release.
 Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.</p>
 </td>
 </tr>
@@ -6381,8 +6381,8 @@ KubeletConfigReserved
 <td>
 <em>(Optional)</em>
 <p>SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
-When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
-Deprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31.
+When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.</p>
+<p>Deprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31.
 Please merge existing resource reservations into the kubeReserved field.
 TODO(MichaelEischer): Drop this field after support for Kubernetes 1.30 is dropped.</p>
 </td>
@@ -8700,8 +8700,8 @@ OpenIDConnectClientAuthentication
 </td>
 <td>
 <em>(Optional)</em>
-<p>ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
-Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
+<p>ClientAuthentication can optionally contain client configuration used for kubeconfig generation.</p>
+<p>Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
 It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
 TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.</p>
 </td>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4593,8 +4593,8 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <em>(Optional)</em>
 <p>UserData is a base64-encoded string that contains the data that is sent to the provider&rsquo;s APIs
 when a new machine/VM that is part of this worker pool shall be spawned.
-Either this or UserDataSecretRef must be provided.
-Deprecated: This field will be removed in future release.
+Either this or UserDataSecretRef must be provided.</p>
+<p>Deprecated: This field will be removed in future release.
 TODO(rfranzke): Remove this field after v1.104 has been released.</p>
 </td>
 </tr>

--- a/docs/api-reference/seedmanagement.md
+++ b/docs/api-reference/seedmanagement.md
@@ -659,8 +659,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>VPA specifies whether to enable VPA for gardenlet. Defaults to true.
-Deprecated: This field is deprecated and has no effect anymore. It will be removed in the future.
+<p>VPA specifies whether to enable VPA for gardenlet. Defaults to true.</p>
+<p>Deprecated: This field is deprecated and has no effect anymore. It will be removed in the future.
 TODO(rfranzke): Remove this field after v1.110 has been released.</p>
 </td>
 </tr>

--- a/docs/api-reference/settings.md
+++ b/docs/api-reference/settings.md
@@ -201,8 +201,8 @@ OpenIDConnectClientAuthentication
 <p>Client contains the configuration used for client OIDC authentication
 of Shoot clusters.
 This configuration is not overwriting any existing OpenID Connect
-client authentication already set on the Shoot object.
-Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
+client authentication already set on the Shoot object.</p>
+<p>Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
 It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
 TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.</p>
 </td>
@@ -518,8 +518,8 @@ OpenIDConnectClientAuthentication
 <p>Client contains the configuration used for client OIDC authentication
 of Shoot clusters.
 This configuration is not overwriting any existing OpenID Connect
-client authentication already set on the Shoot object.
-Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
+client authentication already set on the Shoot object.</p>
+<p>Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
 It&rsquo;s use was planned for genereting OIDC kubeconfig <a href="https://github.com/gardener/gardener/issues/1433">https://github.com/gardener/gardener/issues/1433</a>
 TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.</p>
 </td>

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1269,6 +1269,8 @@ spec:
                               clientAuthentication:
                                 description: |-
                                   ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+
+
                                   Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
                                   It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
                                   TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -292,6 +292,8 @@ spec:
                         UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
                         when a new machine/VM that is part of this worker pool shall be spawned.
                         Either this or UserDataSecretRef must be provided.
+
+
                         Deprecated: This field will be removed in future release.
                         TODO(rfranzke): Remove this field after v1.104 has been released.
                       format: byte

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -361,6 +361,7 @@ type DNS struct {
 	Domain *string
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.
+	//
 	// Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
 	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.
 	Providers []DNSProvider
@@ -371,10 +372,12 @@ type DNS struct {
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
 	// Domains contains information about which domains shall be included/excluded for this provider.
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
 	Domains *DNSIncludeExclude
 	// Primary indicates that this DNSProvider is used for shoot related domains.
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.
 	Primary *bool
@@ -387,6 +390,7 @@ type DNSProvider struct {
 	// this shoot.
 	Type *string
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
 	Zones *DNSIncludeExclude
@@ -703,6 +707,7 @@ type OIDCConfig struct {
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.
 	CABundle *string
 	// ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+	//
 	// Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
 	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
@@ -915,6 +920,7 @@ type KubeletConfig struct {
 	KubeReserved *KubeletConfigReserved
 	// SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
+	//
 	// Deprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31.
 	// Please merge existing resource reservations into the kubeReserved field.
 	// TODO(MichaelEischer): Drop this field after support for Kubernetes 1.30 is dropped.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -477,6 +477,7 @@ const (
 	LabelNetworkPolicyToPublicNetworks = "networking.gardener.cloud/to-public-networks"
 	// LabelNetworkPolicyToSeedAPIServer allows Egress from pods labeled with 'networking.gardener.cloud/to-seed-apiserver=allowed' to Seed's Kubernetes
 	// API Server.
+	//
 	// Deprecated: Use LabelNetworkPolicyToRuntimeAPIServer instead.
 	LabelNetworkPolicyToSeedAPIServer = "networking.gardener.cloud/to-seed-apiserver"
 	// LabelNetworkPolicyToRuntimeAPIServer allows Egress from pods labeled with 'networking.gardener.cloud/to-runtime-apiserver=allowed' to runtime Kubernetes
@@ -484,6 +485,7 @@ const (
 	LabelNetworkPolicyToRuntimeAPIServer = "networking.gardener.cloud/to-runtime-apiserver"
 	// LabelNetworkPolicyFromPrometheus allows Ingress from Prometheus to pods labeled with 'networking.gardener.cloud/from-prometheus=allowed' and ports
 	// named 'metrics' in the PodSpecification.
+	//
 	// Deprecated: This label is deprecated and will be removed in a future version. Components in shoot namespaces
 	//  which need to be scraped by Prometheus need to annotate their Services with
 	//  `networking.resources.gardener.cloud/from-policy-pod-label-selector=all-scrape-targets` and

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -728,6 +728,7 @@ message DNS {
 
   // Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
   // not a default domain is used.
+  //
   // Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
   // Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.
   // +patchMergeKey=type
@@ -750,12 +751,14 @@ message DNSIncludeExclude {
 // DNSProvider contains information about a DNS provider.
 message DNSProvider {
   // Domains contains information about which domains shall be included/excluded for this provider.
+  //
   // Deprecated: This field is deprecated and will be removed in a future release.
   // Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
   // +optional
   optional DNSIncludeExclude domains = 1;
 
   // Primary indicates that this DNSProvider is used for shoot related domains.
+  //
   // Deprecated: This field is deprecated and will be removed in a future release.
   // Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.
   // +optional
@@ -773,6 +776,7 @@ message DNSProvider {
   optional string type = 4;
 
   // Zones contains information about which hosted zones shall be included/excluded for this provider.
+  //
   // Deprecated: This field is deprecated and will be removed in a future release.
   // Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
   // +optional
@@ -1350,6 +1354,7 @@ message KubeletConfig {
 
   // SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
   // When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
+  //
   // Deprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31.
   // Please merge existing resource reservations into the kubeReserved field.
   // TODO(MichaelEischer): Drop this field after support for Kubernetes 1.30 is dropped.
@@ -2008,6 +2013,7 @@ message OIDCConfig {
   optional string caBundle = 1;
 
   // ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+  //
   // Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
   // It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
   // TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -449,6 +449,7 @@ type DNS struct {
 	Domain *string `json:"domain,omitempty" protobuf:"bytes,1,opt,name=domain"`
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.
+	//
 	// Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
 	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.
 	// +patchMergeKey=type
@@ -462,11 +463,13 @@ type DNS struct {
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
 	// Domains contains information about which domains shall be included/excluded for this provider.
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
 	// +optional
 	Domains *DNSIncludeExclude `json:"domains,omitempty" protobuf:"bytes,1,opt,name=domains"`
 	// Primary indicates that this DNSProvider is used for shoot related domains.
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.
 	// +optional
@@ -482,6 +485,7 @@ type DNSProvider struct {
 	Type *string `json:"type,omitempty" protobuf:"bytes,4,opt,name=type"`
 
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
 	// +optional
@@ -921,6 +925,7 @@ type OIDCConfig struct {
 	// +optional
 	CABundle *string `json:"caBundle,omitempty" protobuf:"bytes,1,opt,name=caBundle"`
 	// ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+	//
 	// Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
 	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
@@ -1188,6 +1193,7 @@ type KubeletConfig struct {
 	KubeReserved *KubeletConfigReserved `json:"kubeReserved,omitempty" protobuf:"bytes,14,opt,name=kubeReserved"`
 	// SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
+	//
 	// Deprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31.
 	// Please merge existing resource reservations into the kubeReserved field.
 	// TODO(MichaelEischer): Drop this field after support for Kubernetes 1.30 is dropped.

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -137,6 +137,7 @@ type WorkerPool struct {
 	// UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
 	// when a new machine/VM that is part of this worker pool shall be spawned.
 	// Either this or UserDataSecretRef must be provided.
+	//
 	// Deprecated: This field will be removed in future release.
 	// TODO(rfranzke): Remove this field after v1.104 has been released.
 	// +optional

--- a/pkg/apis/seedmanagement/types_managedseed.go
+++ b/pkg/apis/seedmanagement/types_managedseed.go
@@ -102,6 +102,7 @@ type GardenletDeployment struct {
 	// Env is the list of environment variables to set in the gardenlet container.
 	Env []corev1.EnvVar
 	// VPA specifies whether to enable VPA for gardenlet. Defaults to true.
+	//
 	// Deprecated: This field is deprecated and has no effect anymore. It will be removed in the future.
 	// TODO(rfranzke): Remove this field after v1.110 has been released.
 	VPA *bool

--- a/pkg/apis/seedmanagement/v1alpha1/generated.proto
+++ b/pkg/apis/seedmanagement/v1alpha1/generated.proto
@@ -101,6 +101,7 @@ message GardenletDeployment {
   repeated k8s.io.api.core.v1.EnvVar env = 10;
 
   // VPA specifies whether to enable VPA for gardenlet. Defaults to true.
+  //
   // Deprecated: This field is deprecated and has no effect anymore. It will be removed in the future.
   // TODO(rfranzke): Remove this field after v1.110 has been released.
   // +optional

--- a/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
@@ -128,6 +128,7 @@ type GardenletDeployment struct {
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty" protobuf:"bytes,10,rep,name=env"`
 	// VPA specifies whether to enable VPA for gardenlet. Defaults to true.
+	//
 	// Deprecated: This field is deprecated and has no effect anymore. It will be removed in the future.
 	// TODO(rfranzke): Remove this field after v1.110 has been released.
 	// +optional

--- a/pkg/apis/settings/types_shared.go
+++ b/pkg/apis/settings/types_shared.go
@@ -21,6 +21,7 @@ type OpenIDConnectPresetSpec struct {
 	// of Shoot clusters.
 	// This configuration is not overwriting any existing OpenID Connect
 	// client authentication already set on the Shoot object.
+	//
 	// Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
 	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.

--- a/pkg/apis/settings/v1alpha1/generated.proto
+++ b/pkg/apis/settings/v1alpha1/generated.proto
@@ -135,6 +135,7 @@ message OpenIDConnectPresetSpec {
   // of Shoot clusters.
   // This configuration is not overwriting any existing OpenID Connect
   // client authentication already set on the Shoot object.
+  //
   // Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
   // It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
   // TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.

--- a/pkg/apis/settings/v1alpha1/types_shared.go
+++ b/pkg/apis/settings/v1alpha1/types_shared.go
@@ -28,6 +28,7 @@ type OpenIDConnectPresetSpec struct {
 	// of Shoot clusters.
 	// This configuration is not overwriting any existing OpenID Connect
 	// client authentication already set on the Shoot object.
+	//
 	// Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31.
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
 	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -3024,7 +3024,7 @@ func schema_pkg_apis_core_v1beta1_DNS(ref common.ReferenceCallback) common.OpenA
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if not a default domain is used. Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.",
+							Description: "Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if not a default domain is used.\n\nDeprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -3096,13 +3096,13 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"domains": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domains contains information about which domains shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.",
+							Description: "Domains contains information about which domains shall be included/excluded for this provider.\n\nDeprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
 						},
 					},
 					"primary": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Primary indicates that this DNSProvider is used for shoot related domains. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.",
+							Description: "Primary indicates that this DNSProvider is used for shoot related domains.\n\nDeprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -3123,7 +3123,7 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 					},
 					"zones": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Zones contains information about which hosted zones shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.",
+							Description: "Zones contains information about which hosted zones shall be included/excluded for this provider.\n\nDeprecated: This field is deprecated and will be removed in a future release. Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
 						},
 					},
@@ -4473,7 +4473,7 @@ func schema_pkg_apis_core_v1beta1_KubeletConfig(ref common.ReferenceCallback) co
 					},
 					"systemReserved": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald). When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied. Deprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31. Please merge existing resource reservations into the kubeReserved field.",
+							Description: "SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald). When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.\n\nDeprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31. Please merge existing resource reservations into the kubeReserved field.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.KubeletConfigReserved"),
 						},
 					},
@@ -6089,7 +6089,7 @@ func schema_pkg_apis_core_v1beta1_OIDCConfig(ref common.ReferenceCallback) commo
 					},
 					"clientAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClientAuthentication can optionally contain client configuration used for kubeconfig generation. Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "ClientAuthentication can optionally contain client configuration used for kubeconfig generation.\n\nDeprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.OpenIDConnectClientAuthentication"),
 						},
 					},
@@ -10711,7 +10711,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_GardenletDeployment(ref common.Refe
 					},
 					"vpa": {
 						SchemaProps: spec.SchemaProps{
-							Description: "VPA specifies whether to enable VPA for gardenlet. Defaults to true. Deprecated: This field is deprecated and has no effect anymore. It will be removed in the future.",
+							Description: "VPA specifies whether to enable VPA for gardenlet. Defaults to true.\n\nDeprecated: This field is deprecated and has no effect anymore. It will be removed in the future.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -10914,7 +10914,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_GardenletSelfDeployment(ref common.
 					},
 					"vpa": {
 						SchemaProps: spec.SchemaProps{
-							Description: "VPA specifies whether to enable VPA for gardenlet. Defaults to true. Deprecated: This field is deprecated and has no effect anymore. It will be removed in the future.",
+							Description: "VPA specifies whether to enable VPA for gardenlet. Defaults to true.\n\nDeprecated: This field is deprecated and has no effect anymore. It will be removed in the future.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -11750,7 +11750,7 @@ func schema_pkg_apis_settings_v1alpha1_ClusterOpenIDConnectPresetSpec(ref common
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object.\n\nDeprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},
@@ -12026,7 +12026,7 @@ func schema_pkg_apis_settings_v1alpha1_OpenIDConnectPresetSpec(ref common.Refere
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object. Deprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object.\n\nDeprecated: The OpenID Connect configuration this field specifies is not used and will be forbidden starting from Kubernetes 1.31. It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -294,6 +294,8 @@ spec:
                         UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
                         when a new machine/VM that is part of this worker pool shall be spawned.
                         Either this or UserDataSecretRef must be provided.
+
+
                         Deprecated: This field will be removed in future release.
                         TODO(rfranzke): Remove this field after v1.104 has been released.
                       format: byte

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
@@ -23,6 +23,7 @@ var (
 type initializer struct{}
 
 // NewInitializer returns a new containerd initializer component.
+//
 // Deprecated: The containerd initializer is deprecated and will be removed in a future version. Please don't change or add content to the init script.
 // TODO(timuthy): Remove Initializer after Gardener v1.114 was released.
 func NewInitializer() *initializer {

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -200,6 +200,7 @@ const (
 	// ShootProjectSecretSuffixKubeconfig is a constant for a shoot project secret with suffix 'kubeconfig'.
 	ShootProjectSecretSuffixKubeconfig = "kubeconfig"
 	// ShootProjectSecretSuffixCACluster is a constant for a shoot project secret with suffix 'ca-cluster'.
+	//
 	// Deprecated: This constant is deprecated in favor of ShootProjectConfigMapSuffixCACluster
 	ShootProjectSecretSuffixCACluster = "ca-cluster"
 	// ShootProjectSecretSuffixCAClient is a constant for a shoot project secret with suffix 'ca-client'.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
It looks like VS Code strikes trough a deprecated field/func when there is an empty line before the `// Deprecated:` comment.

For example, for the ClientAuthentication field in the OIDCConfig struct:
https://github.com/gardener/gardener/blob/0b0333c46bc02d3a13a54a59d7b25177cc5f485c/pkg/apis/core/types_shoot.go#L705-L709

Before:
![Screenshot 2024-09-02 at 12 41 49](https://github.com/user-attachments/assets/53a46b96-5cf4-443e-bb80-9b8baa62fdc7)

After:
![Screenshot 2024-09-02 at 12 43 48](https://github.com/user-attachments/assets/d2934124-0c88-4e71-a7f2-ed6eccd4957d)

The empty line also helps to visually separate the fields doc string from the deprecation doc string.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
I have no problems to close the PR if the strike through functionality works out of the box in goland. At the end it is an opinionated cosmetic change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
