### PR TITLE
Prevent setting `net.netfilter.nf_conntrack_max` in case `kube-proxy` is deployed.

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -131,6 +131,8 @@ type OriginalValues struct {
 	// KubeletConfig is the default kubelet configuration for all worker pools. Individual worker pools might overwrite
 	// this configuration.
 	KubeletConfig *gardencorev1beta1.KubeletConfig
+	// KubeProxyEnabled indicates whether kube-proxy is enabled or not.
+	KubeProxyEnabled bool
 	// MachineTypes is a list of machine types.
 	MachineTypes []gardencorev1beta1.MachineType
 	// SSHPublicKeys is a list of public SSH keys.
@@ -735,6 +737,7 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 		kubeletConfigParameters: kubeletConfigParameters,
 		kubeletCLIFlags:         kubeletCLIFlags,
 		kubeletDataVolumeName:   worker.KubeletDataVolumeName,
+		kubeProxyEnabled:        o.values.KubeProxyEnabled,
 		kubernetesVersion:       kubernetesVersion,
 		sshPublicKeys:           o.values.SSHPublicKeys,
 		sshAccessEnabled:        o.values.SSHAccessEnabled,
@@ -800,6 +803,7 @@ type deployer struct {
 	kubeletConfigParameters components.ConfigurableKubeletConfigParameters
 	kubeletCLIFlags         components.ConfigurableKubeletCLIFlags
 	kubeletDataVolumeName   *string
+	kubeProxyEnabled        bool
 	kubernetesVersion       *semver.Version
 	sshPublicKeys           []string
 	sshAccessEnabled        bool
@@ -839,6 +843,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		KubeletConfigParameters: d.kubeletConfigParameters,
 		KubeletCLIFlags:         d.kubeletCLIFlags,
 		KubeletDataVolumeName:   d.kubeletDataVolumeName,
+		KubeProxyEnabled:        d.kubeProxyEnabled,
 		KubernetesVersion:       d.kubernetesVersion,
 		SSHPublicKeys:           d.sshPublicKeys,
 		SSHAccessEnabled:        d.sshAccessEnabled,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/components.go
@@ -35,6 +35,7 @@ type Context struct {
 	KubeletCLIFlags         ConfigurableKubeletCLIFlags
 	KubeletConfigParameters ConfigurableKubeletConfigParameters
 	KubeletDataVolumeName   *string
+	KubeProxyEnabled        bool
 	KubernetesVersion       *semver.Version
 	SSHPublicKeys           []string
 	SSHAccessEnabled        bool

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
@@ -36,6 +36,12 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		newData[key] = value
 	}
 
+	if !ctx.KubeProxyEnabled {
+		for key, value := range nonKubeProxyData {
+			newData[key] = value
+		}
+	}
+
 	if kubelet.ShouldProtectKernelDefaultsBeEnabled(&ctx.KubeletConfigParameters, ctx.KubernetesVersion) {
 		// Needed configuration by kubelet
 		// The kubelet sets these values but it is not able to when protectKernelDefaults=true
@@ -137,6 +143,10 @@ var data = map[string]string{
 	// See https://www.sap.com/developer/tutorials/hxe-ua-install-using-docker.html
 	"fs.aio-max-nr":                "262144",
 	"vm.memory_failure_early_kill": "1",
+}
+
+// Kube-proxy already sets the maximum conntrack size, but it may be useful for other scenarios.
+var nonKubeProxyData = map[string]string{
 	// A common problem on Linux systems is running out of space in the conntrack table,
 	// which can cause poor iptables performance.
 	// This can happen if you run a lot of workloads on a given host,

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -57,6 +57,11 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 		valitailEnabled, valiIngressHost = true, b.ComputeValiHost()
 	}
 
+	kubeProxyEnabled := true
+	if b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy != nil && b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy.Enabled != nil {
+		kubeProxyEnabled = *b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy.Enabled
+	}
+
 	return operatingsystemconfig.New(
 		b.Logger,
 		b.SeedClientSet.Client(),
@@ -69,6 +74,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				ClusterDomain:          gardencorev1beta1.DefaultDomain,
 				Images:                 oscImages,
 				KubeletConfig:          b.Shoot.GetInfo().Spec.Kubernetes.Kubelet,
+				KubeProxyEnabled:       kubeProxyEnabled,
 				MachineTypes:           b.Shoot.CloudProfile.Spec.MachineTypes,
 				SSHAccessEnabled:       v1beta1helper.ShootEnablesSSHAccess(b.Shoot.GetInfo()),
 				ValitailEnabled:        valitailEnabled,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Prevent setting `net.netfilter.nf_conntrack_max` in case `kube-proxy` is deployed.

Previously, the kernel setting `net.netfilter.nf_conntrack_max` was always set during node initialisation. In case `kube-proxy` was deployed to the nodes it also set the same kernel setting. However, the static initialisation by Gardener used a static value, but `kube-proxy` calculated a value based on the number cpu cores.
To reduce the permissions of `kube-proxy`, an init container was introduced, which set the kernel settings. However, the ordinary container also tries to do the same thing in case the value is not as expected. This can lead to an endless crash loop. In case the node initialisation is performed multiple times as can happen with gardener node agent.
A simple solution to the problem is to only set kernel setting `net.netfilter.nf_conntrack_max` in the node initialisation if `kube-proxy` is not enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Kernel setting `net.netfilter.nf_conntrack_max` is only set on nodes by `sysctl.d` if `kube-proxy` is disabled.
```
