### PR TITLE
maintenance controller: Fix a corner case in the 1.29 -> 1.30 forceful upgrade where the worker pool swapBehavior is not mutated

### DIFF
--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -211,14 +211,14 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 
 		for i := range maintainedShoot.Spec.Provider.Workers {
 			if maintainedShoot.Spec.Provider.Workers[i].Kubernetes != nil && maintainedShoot.Spec.Provider.Workers[i].Kubernetes.Kubelet != nil {
-				kubeletVersion := ptr.Deref(maintainedShoot.Spec.Provider.Workers[i].Kubernetes.Version, shoot.Spec.Kubernetes.Version)
+				kubeletVersion := ptr.Deref(maintainedShoot.Spec.Provider.Workers[i].Kubernetes.Version, maintainedShoot.Spec.Kubernetes.Version)
 				kubeletSemverVersion, err := semver.NewVersion(kubeletVersion)
 				if err != nil {
 					return fmt.Errorf("error parsing kubelet version for worker pool %q: %w", maintainedShoot.Spec.Provider.Workers[i].Name, err)
 				}
 
 				if versionutils.ConstraintK8sGreaterEqual130.Check(kubeletSemverVersion) {
-					operations = append(operations, setLimitedSwap(maintainedShoot.Spec.Provider.Workers[i].Kubernetes.Kubelet, fmt.Sprintf("spec.provider.workers[%d].kubernetes.kubelet.meomrySwap.swapBehavior", i))...)
+					operations = append(operations, setLimitedSwap(maintainedShoot.Spec.Provider.Workers[i].Kubernetes.Kubelet, fmt.Sprintf("spec.provider.workers[%d].kubernetes.kubelet.memorySwap.swapBehavior", i))...)
 				}
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/blob/30fb645b569c4582c3fa228eec21f62b7af80a16/pkg/controllermanager/controller/shoot/maintenance/reconciler.go#L214 is wrong as `shoot.Spec.Kubernetes.Version` points to the old Shoot's K8s version and during K8s 1.29 -> 1.30 forceful upgrade it will evaluate to 1.29 and the logic below won't execute the needed migration code for updating the `swapBehavior` field which will later on prevent the Shoot update request to fail.

Steps to reproduce:
1. Create a K8s 1.29.0 Shoot with a worker pool that specifies `swapBehavior=UnlimitedSwap`

```yaml
spec:
  provider:
    type: local
    workers:
    - name: local
      machine:
        type: local
      cri:
        name: containerd
      minimum: 1
      maximum: 2
      maxSurge: 1
      maxUnavailable: 0
      kubernetes:
        kubelet:
          failSwapOn: false
          featureGates:
            NodeSwap: true
          memorySwap:
            swapBehavior: UnlimitedSwap
  kubernetes:
    version: 1.29.0
```

2. Expire K8s 1.29.0 in the CloudProfile and maintain the Shoot

3. Make sure that Shoot maintenance fails with:
```yaml
    lastMaintenance:
      description: Maintenance failed
      failureReason: 'Updates to the Shoot failed to be applied: Shoot.core.gardener.cloud
        "local" is invalid: spec.provider.workers[0].kubernetes.kubelet.memorySwap.swapBehavior:
        Unsupported value: "UnlimitedSwap": supported values: "NoSwap", "LimitedSwap"'
      state: Failed
      triggeredTime: "2024-09-02T13:44:42Z"
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-controller-manager: A corner case issue in the maintenance controller that prevented forceful minor K8s version update from K8s 1.29 to K8s 1.30 is now resolved.
```
