### PR TITLE
[release-v1.100] Automated cherry pick of #10431: Prevent setting `net.netfilter.nf_conntrack_max` in case `kube-proxy` is deployed.

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -135,6 +135,8 @@ type OriginalValues struct {
 	// KubeletConfig is the default kubelet configuration for all worker pools. Individual worker pools might overwrite
 	// this configuration.
 	KubeletConfig *gardencorev1beta1.KubeletConfig
+	// KubeProxyEnabled indicates whether kube-proxy is enabled or not.
+	KubeProxyEnabled bool
 	// MachineTypes is a list of machine types.
 	MachineTypes []gardencorev1beta1.MachineType
 	// SSHPublicKeys is a list of public SSH keys.
@@ -781,6 +783,7 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 		kubeletConfigParameters: kubeletConfigParameters,
 		kubeletCLIFlags:         kubeletCLIFlags,
 		kubeletDataVolumeName:   worker.KubeletDataVolumeName,
+		kubeProxyEnabled:        o.values.KubeProxyEnabled,
 		kubernetesVersion:       kubernetesVersion,
 		sshPublicKeys:           o.values.SSHPublicKeys,
 		sshAccessEnabled:        o.values.SSHAccessEnabled,
@@ -845,6 +848,7 @@ type deployer struct {
 	kubeletConfigParameters components.ConfigurableKubeletConfigParameters
 	kubeletCLIFlags         components.ConfigurableKubeletCLIFlags
 	kubeletDataVolumeName   *string
+	kubeProxyEnabled        bool
 	kubernetesVersion       *semver.Version
 	sshPublicKeys           []string
 	sshAccessEnabled        bool
@@ -882,6 +886,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		KubeletConfigParameters: d.kubeletConfigParameters,
 		KubeletCLIFlags:         d.kubeletCLIFlags,
 		KubeletDataVolumeName:   d.kubeletDataVolumeName,
+		KubeProxyEnabled:        d.kubeProxyEnabled,
 		KubernetesVersion:       d.kubernetesVersion,
 		SSHPublicKeys:           d.sshPublicKeys,
 		SSHAccessEnabled:        d.sshAccessEnabled,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/components.go
@@ -33,6 +33,7 @@ type Context struct {
 	KubeletCLIFlags         ConfigurableKubeletCLIFlags
 	KubeletConfigParameters ConfigurableKubeletConfigParameters
 	KubeletDataVolumeName   *string
+	KubeProxyEnabled        bool
 	KubernetesVersion       *semver.Version
 	SSHPublicKeys           []string
 	SSHAccessEnabled        bool

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
@@ -36,6 +36,12 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		newData[key] = value
 	}
 
+	if !ctx.KubeProxyEnabled {
+		for key, value := range nonKubeProxyData {
+			newData[key] = value
+		}
+	}
+
 	if kubelet.ShouldProtectKernelDefaultsBeEnabled(&ctx.KubeletConfigParameters, ctx.KubernetesVersion) {
 		// Needed configuration by kubelet
 		// The kubelet sets these values but it is not able to when protectKernelDefaults=true
@@ -137,6 +143,10 @@ var data = map[string]string{
 	// See https://www.sap.com/developer/tutorials/hxe-ua-install-using-docker.html
 	"fs.aio-max-nr":                "262144",
 	"vm.memory_failure_early_kill": "1",
+}
+
+// Kube-proxy already sets the maximum conntrack size, but it may be useful for other scenarios.
+var nonKubeProxyData = map[string]string{
 	// A common problem on Linux systems is running out of space in the conntrack table,
 	// which can cause poor iptables performance.
 	// This can happen if you run a lot of workloads on a given host,

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -57,6 +57,11 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 		valitailEnabled, valiIngressHost = true, b.ComputeValiHost()
 	}
 
+	kubeProxyEnabled := true
+	if b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy != nil && b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy.Enabled != nil {
+		kubeProxyEnabled = *b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy.Enabled
+	}
+
 	return operatingsystemconfig.New(
 		b.Logger,
 		b.SeedClientSet.Client(),
@@ -69,6 +74,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				ClusterDomain:       gardencorev1beta1.DefaultDomain,
 				Images:              oscImages,
 				KubeletConfig:       b.Shoot.GetInfo().Spec.Kubernetes.Kubelet,
+				KubeProxyEnabled:    kubeProxyEnabled,
 				MachineTypes:        b.Shoot.CloudProfile.Spec.MachineTypes,
 				SSHAccessEnabled:    v1beta1helper.ShootEnablesSSHAccess(b.Shoot.GetInfo()),
 				ValitailEnabled:     valitailEnabled,


### PR DESCRIPTION
/kind enhancement
/area robustness
/area networking

Cherry pick of #10431 on release-v1.100.

#10431: Prevent setting `net.netfilter.nf_conntrack_max` in case `kube-proxy` is deployed.

**Release Notes:**
```other operator
Kernel setting `net.netfilter.nf_conntrack_max` is only set on nodes by `sysctl.d` if `kube-proxy` is disabled.
```