### PR TITLE
When the command execution fails, return `stderr` as the response

### DIFF
--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -6,6 +6,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -74,12 +75,12 @@ func (e *rootPodExecutor) Execute(ctx context.Context, command string) ([]byte, 
 	command = fmt.Sprintf("chroot /hostroot %s", command)
 	reader, err := e.executor.Execute(ctx, e.Pod.Namespace, e.Pod.Name, e.Pod.Spec.Containers[0].Name, command)
 	if err != nil {
-		var response []byte
 		if reader != nil {
-			response, _ = io.ReadAll(reader)
+			response, readErr := io.ReadAll(reader)
+			return response, errors.Join(err, readErr)
 		}
 
-		return response, err
+		return nil, err
 	}
 	response, err := io.ReadAll(reader)
 	if err != nil {

--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -74,7 +74,12 @@ func (e *rootPodExecutor) Execute(ctx context.Context, command string) ([]byte, 
 	command = fmt.Sprintf("chroot /hostroot %s", command)
 	reader, err := e.executor.Execute(ctx, e.Pod.Namespace, e.Pod.Name, e.Pod.Spec.Containers[0].Name, command)
 	if err != nil {
-		return nil, err
+		var response []byte
+		if reader != nil {
+			response, _ = io.ReadAll(reader)
+		}
+
+		return response, err
 	}
 	response, err := io.ReadAll(reader)
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
When the command execution fails, return `stderr` as the response instead of nil. In this way, the root cause of the failure can be easily identified.
For example, if `cat` command is executed on a non-existent file, the execution fails with `command terminated with exit code 1` and an empty response. But if the response contains `stderr`, we'll have more context for the root cause: `cat: non-existent-file: No such file or directory`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
