### PR TITLE
Fix: Forbid creation Shoot clusters with not valid/ empty oidc settings

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1289,7 +1289,7 @@ spec:
                                 type: object
                               clientID:
                                 description: The client ID for the OpenID Connect
-                                  client, must be set if oidc-issuer-url is set.
+                                  client, must be set.
                                 type: string
                               groupsClaim:
                                 description: If provided, the name of a custom OpenID
@@ -1305,8 +1305,8 @@ spec:
                                 type: string
                               issuerURL:
                                 description: The URL of the OpenID issuer, only HTTPS
-                                  scheme will be accepted. If set, it will be used
-                                  to verify the OIDC JSON Web Token (JWT).
+                                  scheme will be accepted. Used to verify the OIDC
+                                  JSON Web Token (JWT).
                                 type: string
                               requiredClaims:
                                 additionalProperties:

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8715,7 +8715,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.</p>
+<p>The client ID for the OpenID Connect client, must be set.</p>
 </td>
 </tr>
 <tr>
@@ -8751,7 +8751,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).</p>
+<p>The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).</p>
 </td>
 </tr>
 <tr>

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1289,7 +1289,7 @@ spec:
                                 type: object
                               clientID:
                                 description: The client ID for the OpenID Connect
-                                  client, must be set if oidc-issuer-url is set.
+                                  client, must be set.
                                 type: string
                               groupsClaim:
                                 description: If provided, the name of a custom OpenID
@@ -1305,8 +1305,8 @@ spec:
                                 type: string
                               issuerURL:
                                 description: The URL of the OpenID issuer, only HTTPS
-                                  scheme will be accepted. If set, it will be used
-                                  to verify the OIDC JSON Web Token (JWT).
+                                  scheme will be accepted. Used to verify the OIDC
+                                  JSON Web Token (JWT).
                                 type: string
                               requiredClaims:
                                 additionalProperties:

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -712,13 +712,13 @@ type OIDCConfig struct {
 	// It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
 	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
 	ClientAuthentication *OpenIDConnectClientAuthentication
-	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+	// The client ID for the OpenID Connect client, must be set.
 	ClientID *string
 	// If provided, the name of a custom OpenID Connect claim for specifying user groups. The claim value is expected to be a string or array of strings. This flag is experimental, please see the authentication documentation for further details.
 	GroupsClaim *string
 	// If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.
 	GroupsPrefix *string
-	// The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+	// The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).
 	IssuerURL *string
 	// key=value pairs that describes a required claim in the ID Token. If set, the claim is verified to be present in the ID Token with a matching value.
 	RequiredClaims map[string]string

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2020,7 +2020,7 @@ message OIDCConfig {
   // +optional
   optional OpenIDConnectClientAuthentication clientAuthentication = 2;
 
-  // The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+  // The client ID for the OpenID Connect client, must be set.
   // +optional
   optional string clientID = 3;
 
@@ -2032,7 +2032,7 @@ message OIDCConfig {
   // +optional
   optional string groupsPrefix = 5;
 
-  // The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+  // The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).
   // +optional
   optional string issuerURL = 6;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -931,7 +931,7 @@ type OIDCConfig struct {
 	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.30 is dropped.
 	// +optional
 	ClientAuthentication *OpenIDConnectClientAuthentication `json:"clientAuthentication,omitempty" protobuf:"bytes,2,opt,name=clientAuthentication"`
-	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+	// The client ID for the OpenID Connect client, must be set.
 	// +optional
 	ClientID *string `json:"clientID,omitempty" protobuf:"bytes,3,opt,name=clientID"`
 	// If provided, the name of a custom OpenID Connect claim for specifying user groups. The claim value is expected to be a string or array of strings. This flag is experimental, please see the authentication documentation for further details.
@@ -940,7 +940,7 @@ type OIDCConfig struct {
 	// If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.
 	// +optional
 	GroupsPrefix *string `json:"groupsPrefix,omitempty" protobuf:"bytes,5,opt,name=groupsPrefix"`
-	// The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+	// The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).
 	// +optional
 	IssuerURL *string `json:"issuerURL,omitempty" protobuf:"bytes,6,opt,name=issuerURL"`
 	// key=value pairs that describes a required claim in the ID Token. If set, the claim is verified to be present in the ID Token with a matching value.

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -6095,7 +6095,7 @@ func schema_pkg_apis_core_v1beta1_OIDCConfig(ref common.ReferenceCallback) commo
 					},
 					"clientID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.",
+							Description: "The client ID for the OpenID Connect client, must be set.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6116,7 +6116,7 @@ func schema_pkg_apis_core_v1beta1_OIDCConfig(ref common.ReferenceCallback) commo
 					},
 					"issuerURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).",
+							Description: "The URL of the OpenID issuer, only HTTPS scheme will be accepted. Used to verify the OIDC JSON Web Token (JWT).",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -715,6 +715,8 @@ func (c *validationContext) validateAdmissionPlugins(a admission.Attributes, sec
 	return allErrs
 }
 
+// For backwards-compatibility, we want to validate the oidc config only for newly created Shoot clusters.
+// There is additional oidc config validation in the static API validation.
 func (c *validationContext) validateOIDCConfig(a admission.Attributes) field.ErrorList {
 	var (
 		allErrs field.ErrorList

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1915,10 +1915,7 @@ var _ = Describe("validator", func() {
 
 				DescribeTable("do not validate oidc config when operation is not create", func(admissionOperation admission.Operation, operationOptions runtime.Object) {
 					oldShoot := shoot.DeepCopy()
-					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = &core.OIDCConfig{
-						ClientID:  ptr.To("someClientID"),
-						IssuerURL: ptr.To("https://issuer.com"),
-					}
+					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = &core.OIDCConfig{}
 
 					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
@@ -1929,7 +1926,7 @@ var _ = Describe("validator", func() {
 					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admissionOperation, operationOptions, false, nil)
 					err := admissionHandler.Admit(ctx, attrs, nil)
 
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				},
 					Entry("should allow invalid oidcConfig on shoot update", admission.Update, &metav1.UpdateOptions{}),
 					Entry("should allow invalid oidcConfig on shoot delete", admission.Delete, &metav1.DeleteOptions{}),

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1909,8 +1909,30 @@ var _ = Describe("validator", func() {
 					Entry("should allow when oidcConfig is valid", ptr.To("someClientID"), ptr.To("https://issuer.com"), BeNil()),
 					Entry("should forbid when oidcConfig clientID is nil", nil, ptr.To("https://issuer.com"), BeForbiddenError()),
 					Entry("should forbid when oidcConfig clientID is empty string", ptr.To(""), ptr.To("https://issuer.com"), BeForbiddenError()),
-					Entry("should forbid when oidcConfig IssuerURL is nil", ptr.To("someClientID"), nil, BeForbiddenError()),
-					Entry("should forbid when oidcConfig IssuerURL is empty string", ptr.To("someClientID"), ptr.To(""), BeForbiddenError()),
+					Entry("should forbid when oidcConfig issuerURL is nil", ptr.To("someClientID"), nil, BeForbiddenError()),
+					Entry("should forbid when oidcConfig issuerURL is empty string", ptr.To("someClientID"), ptr.To(""), BeForbiddenError()),
+				)
+
+				DescribeTable("do not validate oidc config when operation is not create", func(admissionOperation admission.Operation, operationOptions runtime.Object) {
+					oldShoot := shoot.DeepCopy()
+					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = &core.OIDCConfig{
+						ClientID:  ptr.To("someClientID"),
+						IssuerURL: ptr.To("https://issuer.com"),
+					}
+
+					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+					Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admissionOperation, operationOptions, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(BeNil())
+				},
+					Entry("should allow invalid oidcConfig on shoot update", admission.Update, &metav1.UpdateOptions{}),
+					Entry("should allow invalid oidcConfig on shoot delete", admission.Delete, &metav1.DeleteOptions{}),
 				)
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR fixes a bug in the `Shoot` spec which allowed configuring the `spec.kubernetes.kubeAPIServer.oidcConfig` field with setting which would cause the kube-apiserver to be stuck in Error state.

All setting in `oidcConfig` are set as `--oidc-*` flags in the kube-apiserver [ref](https://github.com/gardener/gardener/blob/d17322a5ff9f960aac1e1236dd2ea327353dcbb7/pkg/component/kubernetes/apiserver/deployment.go#L891-L947) (except for spec.kubernetes.kubeAPIServer.oidcConfig.clientAuthentication which does not have any use https://github.com/gardener/gardener/issues/1433). However, setting any `--oidc-*` flag without setting `oidc-issuer-url` and `oidc-client-id` would [lead to an error](https://github.com/kubernetes/kubernetes/blob/4e4a18878ce330fefda1dc46acca88ba355e9ce7/pkg/kubeapiserver/options/authentication.go#L664-L666).

This PR improves the validation of `spec.kubernetes.kubeAPIServer.oidcConfig` by validating that `issuerURL` and `clientID` are also set when `oidcConfig` is set.

This PR is similar to https://github.com/gardener/gardener/pull/10252 with the difference that the validation is done on shoot create to be backwards compatible

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
A bug has been fixed which was allowing users to set `Shoot` oidc configurations for the `kube-apiserver` without setting the `clientID` and `issuerURL` fields in `spec.kubernetes.kubeAPIServer.oidcConfig`, which would lead to the `kube-apiserver` stuck in a `Error` state. gardener-apiserver now requires both `clientID` and `issuerURL` fields to be set when the `spec.kubernetes.kubeAPIServer.oidcConfig` field is specified.
```


