### PR TITLE
Clean up the stale alertmanager VPA resources

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -133,14 +133,9 @@ func deleteStaleAlertmanagerVPAs(ctx context.Context, log logr.Logger, seedClien
 	}
 
 	return utilclient.ApplyToObjects(ctx, vpas, func(ctx context.Context, obj client.Object) error {
-		vpa, ok := obj.(*vpaautoscalingv1.VerticalPodAutoscaler)
-		if !ok {
-			return fmt.Errorf("expected *vpaautoscalingv1.VerticalPodAutoscaler but got %T", obj)
-		}
-
-		if vpa.Name == "alertmanager-vpa" {
-			if err := kubernetesutils.DeleteObject(ctx, seedClient, vpa); err != nil {
-				return fmt.Errorf("failed to delete VPA %s: %w", client.ObjectKeyFromObject(vpa), err)
+		if obj.GetName() == "alertmanager-vpa" {
+			if err := kubernetesutils.DeleteObject(ctx, seedClient, obj); err != nil {
+				return fmt.Errorf("failed to delete VPA %s: %w", client.ObjectKeyFromObject(obj), err)
 			}
 		}
 

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -11,17 +11,26 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/utils/flow"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	utilclient "github.com/gardener/gardener/pkg/utils/kubernetes/client"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
 	log.Info("Migrating deprecated failure-domain.beta.kubernetes.io labels to topology.kubernetes.io")
 	if err := migrateDeprecatedTopologyLabels(ctx, log, g.mgr.GetClient(), g.mgr.GetConfig()); err != nil {
+		return err
+	}
+
+	log.Info("Deleting stale alertmanager VPAs")
+	if err := deleteStaleAlertmanagerVPAs(ctx, log, g.mgr.GetClient()); err != nil {
 		return err
 	}
 
@@ -105,4 +114,36 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 	}
 
 	return flow.Parallel(taskFns...)(ctx)
+}
+
+// deleteStaleAlertmanagerVPAs deletes VPAs with name "alertmanager-vpa" in the Seed cluster.
+// In https://github.com/gardener/gardener/pull/9257/files#diff-31f2d707167e32b68a064c12fe955a5f2e7d6668e4de445ea9bf6b4e125e6091R95-R103 we forgot to delete
+// the VPA related to the old alertmanager deployment (https://github.com/gardener/gardener/pull/9257/files#diff-48abc7fddac745815a412837ac95081265c7ffcd80d5cbf3b2ec1454b2a4068aL160-L175).
+//
+// TODO(ialidzhikov): Remove this function after v1.106 has been released.
+func deleteStaleAlertmanagerVPAs(ctx context.Context, log logr.Logger, seedClient client.Client) error {
+	vpas := &vpaautoscalingv1.VerticalPodAutoscalerList{}
+	if err := seedClient.List(ctx, vpas); err != nil {
+		if meta.IsNoMatchError(err) {
+			log.Info("Received a 'no match error' while trying to list VPAs. Will assume that the VPA CRD is not yet installed (for example new Seed creation) and will skip cleaning up stale alertmanager VPAs")
+			return nil
+		}
+
+		return err
+	}
+
+	return utilclient.ApplyToObjects(ctx, vpas, func(ctx context.Context, obj client.Object) error {
+		vpa, ok := obj.(*vpaautoscalingv1.VerticalPodAutoscaler)
+		if !ok {
+			return fmt.Errorf("expected *vpaautoscalingv1.VerticalPodAutoscaler but got %T", obj)
+		}
+
+		if vpa.Name == "alertmanager-vpa" {
+			if err := kubernetesutils.DeleteObject(ctx, seedClient, vpa); err != nil {
+				return fmt.Errorf("failed to delete VPA %s: %w", client.ObjectKeyFromObject(vpa), err)
+			}
+		}
+
+		return nil
+	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/pull/9257/files#diff-31f2d707167e32b68a064c12fe955a5f2e7d6668e4de445ea9bf6b4e125e6091R95-R103 we forgot to delete the VPA related to the old alertmanager deployment (https://github.com/gardener/gardener/pull/9257/files#diff-48abc7fddac745815a412837ac95081265c7ffcd80d5cbf3b2ec1454b2a4068aL160-L175).

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/10367

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A stale VPA related to the old alertmanager deployment was not cleaned up by gardenlet. Now, gardenlet on startup cleans up the these stale alertmanager VPAs.
```
