### PR TITLE
Scrape `gardener-operator` metrics from `garden` prometheus

### DIFF
--- a/charts/gardener/operator/templates/deployment.yaml
+++ b/charts/gardener/operator/templates/deployment.yaml
@@ -46,9 +46,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/scheme: 'http'
-        prometheus.io/port: {{ required ".Values.config.server.metrics.port is required" .Values.config.server.metrics.port | quote }}
 {{ include "operator.deployment.annotations" . | indent 8 }}
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/charts/gardener/operator/templates/service.yaml
+++ b/charts/gardener/operator/templates/service.yaml
@@ -9,6 +9,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports: '[{"protocol":"TCP","port": {{ .Values.config.server.metrics.port }}}]'
 spec:
   selector:
     app: gardener

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -46,6 +47,7 @@ import (
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	gardenprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
@@ -180,6 +182,13 @@ func (r *Reconciler) reconcile(
 				return gardenerutils.ReconcileVPAForGardenerComponent(ctx, r.RuntimeClientSet.Client(), v1beta1constants.DeploymentNameGardenerOperator, r.GardenNamespace)
 			},
 			Dependencies: flow.NewTaskIDs(deployVPACRD),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying ServiceMonitor for gardener-operator",
+			Fn: func(ctx context.Context) error {
+				return r.deployOperatorServiceMonitor(ctx)
+			},
+			Dependencies: flow.NewTaskIDs(deployPrometheusCRD),
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name:         "Deploying and waiting for gardener-resource-manager to be healthy",
@@ -764,6 +773,33 @@ func (r *Reconciler) deployGardenPrometheus(ctx context.Context, log logr.Logger
 
 	prometheus.SetCentralScrapeConfigs(gardenprometheus.CentralScrapeConfigs(prometheusAggregateTargets, globalMonitoringSecretRuntime))
 	return prometheus.Deploy(ctx)
+}
+
+func (r *Reconciler) deployOperatorServiceMonitor(ctx context.Context) error {
+	sm := &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{
+		Name:      gardenprometheus.Label + "-" + v1beta1constants.DeploymentNameGardenerOperator,
+		Namespace: r.GardenNamespace,
+	}}
+
+	_, err := controllerutils.CreateOrGetAndMergePatch(ctx, r.RuntimeClientSet.Client(), sm, func() error {
+		sm.Labels = utils.MergeStringMaps(sm.Labels, monitoringutils.Labels(gardenprometheus.Label))
+
+		sm.Spec.Endpoints = []monitoringv1.Endpoint{{
+			Port: "metrics",
+			MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+				"rest_client_.+",
+				"controller_runtime_.+",
+				"workqueue_.+",
+				"go_.+",
+			)},
+		}
+		sm.Spec.Selector = metav1.LabelSelector{MatchLabels: map[string]string{
+			v1beta1constants.LabelApp:  v1beta1constants.LabelGardener,
+			v1beta1constants.LabelRole: "operator",
+		}}
+		return nil
+	})
+	return err
 }
 
 func (r *Reconciler) deployGardenerDashboard(ctx context.Context, dashboard gardenerdashboard.Interface, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, virtualGardenClient client.Client) error {

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -420,6 +421,11 @@ spec:
 		By("Verify that VPA was created for gardener-operator")
 		Eventually(func() error {
 			return testClient.Get(ctx, client.ObjectKey{Name: "gardener-operator-vpa", Namespace: testNamespace.Name}, &vpaautoscalingv1.VerticalPodAutoscaler{})
+		}).Should(Succeed())
+
+		By("Verify that ServiceMonitor was created for gardener-operator")
+		Eventually(func() error {
+			return testClient.Get(ctx, client.ObjectKey{Name: "garden-gardener-operator", Namespace: testNamespace.Name}, &monitoringv1.ServiceMonitor{})
 		}).Should(Succeed())
 
 		// The garden controller waits for the gardener-resource-manager Deployment to be healthy, so let's fake this here.


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Configures the `gardener-operator` metrics to be scraped by the `garden` Prometheus.

This also removes annotations used by the [Seed Prometheus](https://github.com/gardener/gardener/blob/master/docs/monitoring/README.md#seed-prometheus) service discovery. Currently, that scrape target is always down, because there is no network policy that allows it to scrape the metrics endpoint.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `gardener-operator` metrics are now automatically scraped by the `garden` Prometheus.
```
