### PR TITLE
Adapt test definition for shoot creation

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -18,7 +18,7 @@ spec:
     -seed-kubecfg-path=$TM_KUBECONFIG_PATH/seed.config
     -shoot-kubecfg-path=$TM_KUBECONFIG_PATH/shoot.config
     -shoot-name=$SHOOT_NAME
-    -cloud-profile=$CLOUDPROFILE
+    -cloud-profile-name=$CLOUDPROFILE
     -seed=$SEED
     -secret-binding=$SECRET_BINDING
     -provider-type=$PROVIDER_TYPE

--- a/docs/development/testmachinery_tests.md
+++ b/docs/development/testmachinery_tests.md
@@ -249,7 +249,7 @@ go test  -timeout=0 ./test/testmachinery/system/shoot_creation \
   --v -ginkgo.v -ginkgo.show-node-events \
   -kubecfg=$HOME/.kube/config \
   -shoot-name=$SHOOT_NAME \
-  -cloud-profile=$CLOUDPROFILE \
+  -cloud-profile-name=$CLOUDPROFILE \
   -seed=$SEED \
   -secret-binding=$SECRET_BINDING \
   -provider-type=$PROVIDER_TYPE \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind api-change

**What this PR does / why we need it**:
Test definition for Shoot creation changed in https://github.com/gardener/gardener/pull/10266 ([ref](https://github.com/gardener/gardener/pull/10266/files#diff-0c5fc2d4d1cea0541004c8163ef28b926d4ba2702fdc4c143115ecfa992127adL309-R315)).
Shoot creation now takes parameter `-cloud-profile-name` instead of `-cloud-profile`. See also: https://github.com/gardener/gardener/blob/10186a5ed1a1a7c9d5fc18df9a7c89be433807e3/test/framework/shootcreationframework.go#L314.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @oliver-goetz @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
