### PR TITLE
Allow disablement of VPA for VPN components.

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -315,6 +315,9 @@ const (
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaControlPlaneHAVPN = "alpha.control-plane.shoot.gardener.cloud/high-availability-vpn"
+	// ShootAlphaControlPlaneVPNVPAUpdateEnabled is a constant for an annotation on the Shoot resource to enforce
+	// enabling/disabling the vertical pod autoscaler update resources related to the VPN connection.
+	ShootAlphaControlPlaneVPNVPAUpdateEnabled = "alpha.control-plane.shoot.gardener.cloud/vpn-vpa-update-enabled"
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -315,9 +315,9 @@ const (
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaControlPlaneHAVPN = "alpha.control-plane.shoot.gardener.cloud/high-availability-vpn"
-	// ShootAlphaControlPlaneVPNVPAUpdateEnabled is a constant for an annotation on the Shoot resource to enforce
-	// enabling/disabling the vertical pod autoscaler update resources related to the VPN connection.
-	ShootAlphaControlPlaneVPNVPAUpdateEnabled = "alpha.control-plane.shoot.gardener.cloud/vpn-vpa-update-enabled"
+	// ShootAlphaControlPlaneVPNVPAUpdateDisabled is a constant for an annotation on the Shoot resource to enforce
+	// disabling the vertical pod autoscaler update resources related to the VPN connection.
+	ShootAlphaControlPlaneVPNVPAUpdateDisabled = "alpha.control-plane.shoot.gardener.cloud/vpn-vpa-update-disabled"
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -131,6 +131,8 @@ type Values struct {
 	HighAvailabilityNumberOfSeedServers int
 	// HighAvailabilityNumberOfShootClients is the number of VPN shoot clients used for HA
 	HighAvailabilityNumberOfShootClients int
+	// VPAUpdateDisabled indicates whether the vertical pod autoscaler update should be disabled.
+	VPAUpdateDisabled bool
 }
 
 // New creates a new instance of DeployWaiter for the vpn-seed-server.
@@ -874,6 +876,10 @@ func (v *vpnSeedServer) deployVPA(ctx context.Context) error {
 	targetRefKind := "Deployment"
 	if v.values.HighAvailabilityEnabled {
 		targetRefKind = "StatefulSet"
+	}
+
+	if v.values.VPAUpdateDisabled {
+		vpaUpdateMode = vpaautoscalingv1.UpdateModeOff
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, v.client, vpa, func() error {

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -696,7 +696,7 @@ var _ = Describe("VpnSeedServer", func() {
 			return svc
 		}
 
-		expectedVPAFor = func(highAvailabilityEnabled bool, udpateMode *vpaautoscalingv1.UpdateMode) *vpaautoscalingv1.VerticalPodAutoscaler {
+		expectedVPAFor = func(highAvailabilityEnabled bool, updateMode *vpaautoscalingv1.UpdateMode) *vpaautoscalingv1.VerticalPodAutoscaler {
 			targetKindRef := "Deployment"
 			if highAvailabilityEnabled {
 				targetKindRef = "StatefulSet"
@@ -715,7 +715,7 @@ var _ = Describe("VpnSeedServer", func() {
 						Name:       "vpn-seed-server",
 					},
 					UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-						UpdateMode: udpateMode,
+						UpdateMode: updateMode,
 					},
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -63,7 +63,6 @@ var _ = Describe("VpnSeedServer", func() {
 		istioNamespaceFunc = func() string { return istioNamespace }
 
 		vpaUpdateMode    = vpaautoscalingv1.UpdateModeAuto
-		vpaUpdateModeOff = vpaautoscalingv1.UpdateModeOff
 		controlledValues = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 		namespaceUID     = types.UID("123456")
 
@@ -819,7 +818,7 @@ var _ = Describe("VpnSeedServer", func() {
 				actualVPA := &vpaautoscalingv1.VerticalPodAutoscaler{}
 				updateMode := vpaUpdateMode
 				if values.VPAUpdateDisabled {
-					updateMode = vpaUpdateModeOff
+					updateMode = vpaautoscalingv1.UpdateModeOff
 				}
 				expectedVPA := expectedVPAFor(values.HighAvailabilityEnabled, &updateMode)
 				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVPA.Namespace, Name: expectedVPA.Name}, actualVPA)).To(Succeed())
@@ -891,7 +890,7 @@ var _ = Describe("VpnSeedServer", func() {
 
 				It("should successfully deploy vpa with update mode set to off", func() {
 					actualVPA := &vpaautoscalingv1.VerticalPodAutoscaler{}
-					expectedVPA := expectedVPAFor(values.HighAvailabilityEnabled, &vpaUpdateModeOff)
+					expectedVPA := expectedVPAFor(values.HighAvailabilityEnabled, ptr.To(vpaautoscalingv1.UpdateModeOff))
 					Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVPA.Namespace, Name: expectedVPA.Name}, actualVPA)).To(Succeed())
 					Expect(actualVPA).To(DeepEqual(expectedVPA))
 				})
@@ -951,7 +950,7 @@ var _ = Describe("VpnSeedServer", func() {
 				actualVPA := &vpaautoscalingv1.VerticalPodAutoscaler{}
 				updateMode := vpaUpdateMode
 				if values.VPAUpdateDisabled {
-					updateMode = vpaUpdateModeOff
+					updateMode = vpaautoscalingv1.UpdateModeOff
 				}
 				expectedVPA := expectedVPAFor(values.HighAvailabilityEnabled, &updateMode)
 				Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVPA.Namespace, Name: expectedVPA.Name}, actualVPA)).To(Succeed())
@@ -1001,7 +1000,7 @@ var _ = Describe("VpnSeedServer", func() {
 
 				It("should successfully deploy vpa with update mode set to off", func() {
 					actualVPA := &vpaautoscalingv1.VerticalPodAutoscaler{}
-					expectedVPA := expectedVPAFor(values.HighAvailabilityEnabled, &vpaUpdateModeOff)
+					expectedVPA := expectedVPAFor(values.HighAvailabilityEnabled, ptr.To(vpaautoscalingv1.UpdateModeOff))
 					Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedVPA.Namespace, Name: expectedVPA.Name}, actualVPA)).To(Succeed())
 					Expect(actualVPA).To(DeepEqual(expectedVPA))
 				})

--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -86,6 +86,8 @@ type Values struct {
 	PodAnnotations map[string]string
 	// VPAEnabled marks whether VerticalPodAutoscaler is enabled for the shoot.
 	VPAEnabled bool
+	// VPAUpdateDisabled indicates whether the vertical pod autoscaler update should be disabled.
+	VPAUpdateDisabled bool
 	// ReversedVPN contains the configuration values for the ReversedVPN.
 	ReversedVPN ReversedVPNValues
 	// HighAvailabilityEnabled marks whether HA is enabled for VPN.
@@ -459,6 +461,9 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 
 	if v.values.VPAEnabled {
 		vpaUpdateMode := vpaautoscalingv1.UpdateModeAuto
+		if v.values.VPAUpdateDisabled {
+			vpaUpdateMode = vpaautoscalingv1.UpdateModeOff
+		}
 		controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 		kind := "Deployment"
 		if _, ok := deploymentOrStatefulSet.(*appsv1.StatefulSet); ok {

--- a/pkg/gardenlet/operation/botanist/vpnseedserver.go
+++ b/pkg/gardenlet/operation/botanist/vpnseedserver.go
@@ -38,7 +38,7 @@ func (b *Botanist) DefaultVPNSeedServer() (vpnseedserver.Interface, error) {
 		HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,
 		HighAvailabilityNumberOfSeedServers:  b.Shoot.VPNHighAvailabilityNumberOfSeedServers,
 		HighAvailabilityNumberOfShootClients: b.Shoot.VPNHighAvailabilityNumberOfShootClients,
-		VPAUpdateDisabled:                    !b.Shoot.VPNVPAUpdateEnabled,
+		VPAUpdateDisabled:                    b.Shoot.VPNVPAUpdateDisabled,
 	}
 
 	if b.ShootUsesDNS() {

--- a/pkg/gardenlet/operation/botanist/vpnseedserver.go
+++ b/pkg/gardenlet/operation/botanist/vpnseedserver.go
@@ -38,6 +38,7 @@ func (b *Botanist) DefaultVPNSeedServer() (vpnseedserver.Interface, error) {
 		HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,
 		HighAvailabilityNumberOfSeedServers:  b.Shoot.VPNHighAvailabilityNumberOfSeedServers,
 		HighAvailabilityNumberOfShootClients: b.Shoot.VPNHighAvailabilityNumberOfShootClients,
+		VPAUpdateDisabled:                    !b.Shoot.VPNVPAUpdateEnabled,
 	}
 
 	if b.ShootUsesDNS() {

--- a/pkg/gardenlet/operation/botanist/vpnshoot.go
+++ b/pkg/gardenlet/operation/botanist/vpnshoot.go
@@ -20,8 +20,9 @@ func (b *Botanist) DefaultVPNShoot() (component.DeployWaiter, error) {
 	}
 
 	values := vpnshoot.Values{
-		Image:      image.String(),
-		VPAEnabled: b.Shoot.WantsVerticalPodAutoscaler,
+		Image:             image.String(),
+		VPAEnabled:        b.Shoot.WantsVerticalPodAutoscaler,
+		VPAUpdateDisabled: !b.Shoot.VPNVPAUpdateEnabled,
 		ReversedVPN: vpnshoot.ReversedVPNValues{
 			Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
 			Endpoint:    b.outOfClusterAPIServerFQDN(),

--- a/pkg/gardenlet/operation/botanist/vpnshoot.go
+++ b/pkg/gardenlet/operation/botanist/vpnshoot.go
@@ -22,7 +22,7 @@ func (b *Botanist) DefaultVPNShoot() (component.DeployWaiter, error) {
 	values := vpnshoot.Values{
 		Image:             image.String(),
 		VPAEnabled:        b.Shoot.WantsVerticalPodAutoscaler,
-		VPAUpdateDisabled: !b.Shoot.VPNVPAUpdateEnabled,
+		VPAUpdateDisabled: b.Shoot.VPNVPAUpdateDisabled,
 		ReversedVPN: vpnshoot.ReversedVPNValues{
 			Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
 			Endpoint:    b.outOfClusterAPIServerFQDN(),

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -280,6 +280,10 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	}
 	shoot.VPNHighAvailabilityNumberOfSeedServers = vpnseedserver.HighAvailabilityReplicaCount
 	shoot.VPNHighAvailabilityNumberOfShootClients = vpnseedserver.HighAvailabilityReplicaCount
+	shoot.VPNVPAUpdateEnabled = true
+	if vpnVPAUpdateEnabled, err := strconv.ParseBool(shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneVPNVPAUpdateEnabled]); err == nil {
+		shoot.VPNVPAUpdateEnabled = vpnVPAUpdateEnabled
+	}
 
 	needsClusterAutoscaler, err := v1beta1helper.ShootWantsClusterAutoscaler(shootObject)
 	if err != nil {

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -280,9 +280,8 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	}
 	shoot.VPNHighAvailabilityNumberOfSeedServers = vpnseedserver.HighAvailabilityReplicaCount
 	shoot.VPNHighAvailabilityNumberOfShootClients = vpnseedserver.HighAvailabilityReplicaCount
-	shoot.VPNVPAUpdateEnabled = true
-	if vpnVPAUpdateEnabled, err := strconv.ParseBool(shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneVPNVPAUpdateEnabled]); err == nil {
-		shoot.VPNVPAUpdateEnabled = vpnVPAUpdateEnabled
+	if vpnVPAUpdateDisabled, err := strconv.ParseBool(shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneVPNVPAUpdateDisabled]); err == nil {
+		shoot.VPNVPAUpdateDisabled = vpnVPAUpdateDisabled
 	}
 
 	needsClusterAutoscaler, err := v1beta1helper.ShootWantsClusterAutoscaler(shootObject)

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -90,6 +90,7 @@ type Shoot struct {
 	VPNHighAvailabilityEnabled              bool
 	VPNHighAvailabilityNumberOfSeedServers  int
 	VPNHighAvailabilityNumberOfShootClients int
+	VPNVPAUpdateEnabled                     bool
 	NodeLocalDNSEnabled                     bool
 	TopologyAwareRoutingEnabled             bool
 	Networks                                *Networks

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -90,7 +90,7 @@ type Shoot struct {
 	VPNHighAvailabilityEnabled              bool
 	VPNHighAvailabilityNumberOfSeedServers  int
 	VPNHighAvailabilityNumberOfShootClients int
-	VPNVPAUpdateEnabled                     bool
+	VPNVPAUpdateDisabled                    bool
 	NodeLocalDNSEnabled                     bool
 	TopologyAwareRoutingEnabled             bool
 	Networks                                *Networks


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:

Allow disablement of VPA for VPN components.

In some scenarios, the availability of the VPN is crucial and disruptions due to autoscaling are not desired. This change allows to disable the autoscaling of the VPN components in shoot/seed per cluster.

This is not meant as a general solution and will never be the standard for various reasons. However, in certain scenarios it may help to be able to disable autoscaling to prevent undesired disruptions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
