### PR TITLE
Default cloud profile kind to `CloudProfile` when building reference.

### DIFF
--- a/pkg/utils/gardener/cloudprofile.go
+++ b/pkg/utils/gardener/cloudprofile.go
@@ -52,7 +52,11 @@ func BuildCloudProfileReference(shoot *gardencorev1beta1.Shoot) *gardencorev1bet
 		return nil
 	}
 	if shoot.Spec.CloudProfile != nil {
-		return shoot.Spec.CloudProfile
+		cloudProfileReference := shoot.Spec.CloudProfile.DeepCopy()
+		if len(cloudProfileReference.Kind) == 0 {
+			cloudProfileReference.Kind = constants.CloudProfileReferenceKindCloudProfile
+		}
+		return cloudProfileReference
 	}
 	if len(ptr.Deref(shoot.Spec.CloudProfileName, "")) > 0 {
 		return &gardencorev1beta1.CloudProfileReference{

--- a/pkg/utils/gardener/cloudprofile_test.go
+++ b/pkg/utils/gardener/cloudprofile_test.go
@@ -100,6 +100,17 @@ var _ = Describe("CloudProfile", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("returns the CloudProfile from the cloudProfile reference with empty kind field", func() {
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			shoot.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{
+				Name: cloudProfileName,
+			}
+			res, err := gardenerutils.GetCloudProfile(ctx, fakeClient, shoot)
+			Expect(res).To(Equal(cloudProfile))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("returns NamespacedCloudProfile", func() {
 			Expect(fakeClient.Create(ctx, namespacedCloudProfile)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/area usability
/kind enhancement

**What this PR does / why we need it**:
Building cloud profile references should provide a fallback to cloud profile kind `CloudProfile` for empty kind field in cloud profile reference. See also: https://github.com/gardener/gardener/pull/10478.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
