### PR TITLE
Add label selector to ShootResourceReservation plugin

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -146,6 +146,8 @@ If `useGKEFormula: true` is set, then the plugin injects resource reservations b
 Already existing resource reservations are not modified; this also means that resource reservations are not automatically updated if the machine type for a worker pool is changed.
 If a shoot contains global resource reservations, then no per worker pool resource reservations are injected.
 
+By default, `useGKEFormula: true` applies to all Shoots. Operators can use the optional configuration `labelSelector` to limit which Shoots get worker specific resource reservations injected.
+
 ## `ShootVPAEnabledByDefault`
 
 _(disabled by default)_

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -146,7 +146,8 @@ If `useGKEFormula: true` is set, then the plugin injects resource reservations b
 Already existing resource reservations are not modified; this also means that resource reservations are not automatically updated if the machine type for a worker pool is changed.
 If a shoot contains global resource reservations, then no per worker pool resource reservations are injected.
 
-By default, `useGKEFormula: true` applies to all Shoots. Operators can use the optional configuration `labelSelector` to limit which Shoots get worker specific resource reservations injected.
+By default, `useGKEFormula: true` applies to all Shoots.
+Operators can provide an optional label selector via the `selector` field to limit which Shoots get worker specific resource reservations injected.
 
 ## `ShootVPAEnabledByDefault`
 

--- a/example/20-admissionconfig.yaml
+++ b/example/20-admissionconfig.yaml
@@ -24,3 +24,4 @@ plugins:
    apiVersion: shootresourcereservation.admission.gardener.cloud/v1alpha1
    kind: Configuration
    useGKEFormula: false
+#   labelSelector: shootresources.gardener.cloud/workerspecificreservations=true

--- a/example/20-admissionconfig.yaml
+++ b/example/20-admissionconfig.yaml
@@ -24,4 +24,6 @@ plugins:
    apiVersion: shootresourcereservation.admission.gardener.cloud/v1alpha1
    kind: Configuration
    useGKEFormula: false
-#   labelSelector: shootresources.gardener.cloud/workerspecificreservations=true
+#  selector:
+#    matchLabels:
+#      shoot.gardener.cloud/worker-specific-reservations: "true"

--- a/plugin/pkg/shoot/resourcereservation/admission.go
+++ b/plugin/pkg/shoot/resourcereservation/admission.go
@@ -12,6 +12,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
@@ -40,12 +41,12 @@ func Register(plugins *admission.Plugins) {
 			return nil, err
 		}
 
-		parsedLabelSelector, err := labels.Parse(cfg.LabelSelector)
+		selector, err := metav1.LabelSelectorAsSelector(cfg.Selector)
 		if err != nil {
 			return nil, err
 		}
 
-		return New(cfg.UseGKEFormula, parsedLabelSelector), nil
+		return New(cfg.UseGKEFormula, selector), nil
 	})
 }
 

--- a/plugin/pkg/shoot/resourcereservation/admission.go
+++ b/plugin/pkg/shoot/resourcereservation/admission.go
@@ -142,13 +142,8 @@ func (c *ResourceReservation) Admit(_ context.Context, a admission.Attributes, _
 		return nil
 	}
 
-	if !c.useGKEFormula {
+	if !c.useGKEFormula || !c.labelSelector.Matches(labels.Set(shoot.Labels)) {
 		setStaticResourceReservationDefaults(shoot)
-		return nil
-	}
-
-	// Pass if the Shoot doesn't match the label selector
-	if !c.labelSelector.Matches(labels.Set(shoot.Labels)) {
 		return nil
 	}
 

--- a/plugin/pkg/shoot/resourcereservation/admission_test.go
+++ b/plugin/pkg/shoot/resourcereservation/admission_test.go
@@ -103,7 +103,7 @@ var _ = Describe("resourcereservation", func() {
 		)
 
 		var parsedLabelSelector labels.Selector
-		var labelSelectorString string
+		var labelSelector = &metav1.LabelSelector{}
 		var typeDependentReservations bool
 
 		setupProfile := func(typeDependentReservations bool, selector labels.Selector) {
@@ -115,7 +115,7 @@ var _ = Describe("resourcereservation", func() {
 		}
 
 		JustBeforeEach(func() {
-			parsedLabelSelector, _ = labels.Parse(labelSelectorString)
+			parsedLabelSelector, _ = metav1.LabelSelectorAsSelector(labelSelector)
 			setupProfile(typeDependentReservations, parsedLabelSelector)
 		})
 
@@ -155,7 +155,7 @@ var _ = Describe("resourcereservation", func() {
 
 				Context("with a label selector configured", func() {
 					BeforeEach(func() {
-						labelSelectorString = "shoot.gardener.cloud/worker-specific-reservations=true"
+						labelSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"shoot.gardener.cloud/worker-specific-reservations": "true"}}
 					})
 
 					Context("when the Shoot label matches the label selector", func() {
@@ -211,7 +211,7 @@ var _ = Describe("resourcereservation", func() {
 
 				Context("with no label selector configured", func() {
 					BeforeEach(func() {
-						labelSelectorString = ""
+						labelSelector = &metav1.LabelSelector{}
 					})
 
 					It("should not overwrite worker pool resource reservations", func() {

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/types.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/types.go
@@ -16,4 +16,6 @@ type Configuration struct {
 	// UseGKEFormula enables the calculation of resource reservations based on
 	// the CPU and memory resources available for a machine type.
 	UseGKEFormula bool `json:"useGKEFormula"`
+	// LabelSelector optionally defines a label selector for which the GKE formula should be applied
+	LabelSelector string `json:"labelSelector,omitempty"`
 }

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/types.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/types.go
@@ -16,6 +16,6 @@ type Configuration struct {
 	// UseGKEFormula enables the calculation of resource reservations based on
 	// the CPU and memory resources available for a machine type.
 	UseGKEFormula bool `json:"useGKEFormula"`
-	// LabelSelector optionally defines a label selector for which the GKE formula should be applied
-	LabelSelector string `json:"labelSelector,omitempty"`
+	// Selector optionally defines a label selector for which the GKE formula should be applied.
+	Selector *metav1.LabelSelector
 }

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/types.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/types.go
@@ -17,5 +17,6 @@ type Configuration struct {
 	// the CPU and memory resources available for a machine type.
 	UseGKEFormula bool `json:"useGKEFormula"`
 	// Selector optionally defines a label selector for which the GKE formula should be applied.
+	// Defaults to empty LabelSelector, which matches everything.
 	Selector *metav1.LabelSelector
 }

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/defaults.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/defaults.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// SetDefaults_Configuration sets default values for the Configuration object.
 func SetDefaults_Configuration(obj *Configuration) {
 	if obj.Selector == nil {
 		obj.Selector = &metav1.LabelSelector{}

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/defaults.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/defaults.go
@@ -5,8 +5,15 @@
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+func SetDefaults_Configuration(obj *Configuration) {
+	if obj.Selector == nil {
+		obj.Selector = &metav1.LabelSelector{}
+	}
+}
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/defaults_test.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/defaults_test.go
@@ -1,0 +1,24 @@
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/gardener/gardener/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1"
+)
+
+var _ = Describe("Config defaulting", func() {
+	It("should default the selector to empty label selector", func() {
+		config := &Configuration{}
+
+		expectedConfiguration := &Configuration{
+			UseGKEFormula: false,
+			Selector:      &metav1.LabelSelector{},
+		}
+
+		SetObjectDefaults_Configuration(config)
+
+		Expect(config).To(Equal(expectedConfiguration))
+	})
+})

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/defaults_test.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/defaults_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1_test
 
 import (

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/types.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/types.go
@@ -16,6 +16,7 @@ type Configuration struct {
 	// UseGKEFormula enables the calculation of resource reservations based on
 	// the CPU and memory resources available for a machine type.
 	UseGKEFormula bool `json:"useGKEFormula"`
-	// LabelSelector optionally defines a label selector for which the GKE formula should be applied
-	LabelSelector string `json:"labelSelector,omitempty"`
+	// Selector optionally defines a label selector for which the GKE formula should be applied
+	// +optional
+	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 }

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/types.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/types.go
@@ -16,4 +16,6 @@ type Configuration struct {
 	// UseGKEFormula enables the calculation of resource reservations based on
 	// the CPU and memory resources available for a machine type.
 	UseGKEFormula bool `json:"useGKEFormula"`
+	// LabelSelector optionally defines a label selector for which the GKE formula should be applied
+	LabelSelector string `json:"labelSelector,omitempty"`
 }

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/types.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/types.go
@@ -16,7 +16,8 @@ type Configuration struct {
 	// UseGKEFormula enables the calculation of resource reservations based on
 	// the CPU and memory resources available for a machine type.
 	UseGKEFormula bool `json:"useGKEFormula"`
-	// Selector optionally defines a label selector for which the GKE formula should be applied
+	// Selector optionally defines a label selector for which the GKE formula should be applied.
+	// Defaults to empty LabelSelector, which matches everything.
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 }

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/v1alpha1_suite_test.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAPI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "APIs Settings V1alpha1 Suite")
+}

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/v1alpha1_suite_test.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/v1alpha1_suite_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestAPI(t *testing.T) {
+func TestV1alpha1(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "APIs Settings V1alpha1 Suite")
+	RunSpecs(t, "AdmissionPlugin Shoot ResourceReservation API v1alpha1 Suite")
 }

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/zz_generated.conversion.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/zz_generated.conversion.go
@@ -37,6 +37,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_Configuration_To_shootresourcereservation_Configuration(in *Configuration, out *shootresourcereservation.Configuration, s conversion.Scope) error {
 	out.UseGKEFormula = in.UseGKEFormula
+	out.LabelSelector = in.LabelSelector
 	return nil
 }
 
@@ -47,6 +48,7 @@ func Convert_v1alpha1_Configuration_To_shootresourcereservation_Configuration(in
 
 func autoConvert_shootresourcereservation_Configuration_To_v1alpha1_Configuration(in *shootresourcereservation.Configuration, out *Configuration, s conversion.Scope) error {
 	out.UseGKEFormula = in.UseGKEFormula
+	out.LabelSelector = in.LabelSelector
 	return nil
 }
 

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/zz_generated.conversion.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/zz_generated.conversion.go
@@ -10,7 +10,10 @@
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	shootresourcereservation "github.com/gardener/gardener/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -37,7 +40,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_Configuration_To_shootresourcereservation_Configuration(in *Configuration, out *shootresourcereservation.Configuration, s conversion.Scope) error {
 	out.UseGKEFormula = in.UseGKEFormula
-	out.LabelSelector = in.LabelSelector
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	return nil
 }
 
@@ -48,7 +51,7 @@ func Convert_v1alpha1_Configuration_To_shootresourcereservation_Configuration(in
 
 func autoConvert_shootresourcereservation_Configuration_To_v1alpha1_Configuration(in *shootresourcereservation.Configuration, out *Configuration, s conversion.Scope) error {
 	out.UseGKEFormula = in.UseGKEFormula
-	out.LabelSelector = in.LabelSelector
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	return nil
 }
 

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/zz_generated.deepcopy.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -17,6 +18,11 @@ import (
 func (in *Configuration) DeepCopyInto(out *Configuration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.Selector != nil {
+		in, out := &in.Selector, &out.Selector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/zz_generated.defaults.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1/zz_generated.defaults.go
@@ -17,5 +17,10 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&Configuration{}, func(obj interface{}) { SetObjectDefaults_Configuration(obj.(*Configuration)) })
 	return nil
+}
+
+func SetObjectDefaults_Configuration(in *Configuration) {
+	SetDefaults_Configuration(in)
 }

--- a/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/zz_generated.deepcopy.go
+++ b/plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@
 package shootresourcereservation
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -17,6 +18,11 @@ import (
 func (in *Configuration) DeepCopyInto(out *Configuration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.Selector != nil {
+		in, out := &in.Selector, &out.Selector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Add a label selector to the ShootResourceReservation plugin which was introduced with https://github.com/gardener/gardener/pull/9449 as part of https://github.com/gardener/gardener/issues/2590

With this optional configuration option, operators can choose to have the plugin apply to only a subset of Shoots. Shoot owners can opt-in to having their resource reservations being done by the plugin by adding the corresponding label to their Shoot.

**Which issue(s) this PR fixes**:
fixes https://github.com/gardener/gardener/issues/9965
 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add label selector to ShootResourceReservation plugin to control for which Shoots the ShootResourceReservation Plugin sets `kubeReserved` according to the GKE formula when `useGKEFormula: true` is set.
```
