### PR TITLE
Update relabeled namespace on the shoot's ETCD dashboard disk operation panels

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-dashboard.json
@@ -953,7 +953,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${role:pipe}).*\"}[$__rate_interval])) by(pod, container)",
+          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"shoot-control-plane\", pod=~\"etcd-(${role:pipe}).*\"}[$__rate_interval])) by(pod, container)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1053,7 +1053,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${role:pipe}).*\"}[$__rate_interval])) by(pod, container)",
+          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"shoot-control-plane\", pod=~\"etcd-(${role:pipe}).*\"}[$__rate_interval])) by(pod, container)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
bebad97 broke two panels on the shoot ETCD dashboard by changing the metric relabel config to relabel the kubelet metrics' namespace as "shoot-control-plane". However, because the dashboard contains the hardcoded namespace in the query, this caused the panels to show no data.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @etiennnr @shafeeqes 
FYI @vicwicker 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed disk read/write panel in the shoot's etcd dashboards
```
