### PR TITLE
Install `go` in the remote local setup from the `go` download site

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -24,11 +24,14 @@ spec:
           ln -s ~/.cache/apk /etc/apk/cache
           apk add apache2-utils bash bash-completion bat bind-tools conntrack-tools coreutils curl \
                   diffutils dnsmasq docker-bash-completion findutils fzf g++ gawk gcompat git      \
-                  git-prompt go grep helm inotify-tools jq k9s less lsof make mandoc mc moreutils  \
+                  git-prompt grep helm inotify-tools jq k9s less lsof make mandoc mc moreutils     \
                   mount ncurses neovim parallel procps sed strace tar tcpdump tmux tmux-doc tzdata \
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
+          echo golang          && wget -N "https://go.dev/dl/$(curl -sL https://golang.org/VERSION?m=text | awk 'NR==1{print}').linux-amd64.tar.gz" && tar -C /usr/local -xzf go1.*.linux-amd64.tar.gz \
+                               && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+                               && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
           echo gardenlogin     && wget -N "https://github.com/gardener/gardenlogin/releases/download/$(curl -sL https://raw.githubusercontent.com/gardener/gardenlogin/master/LATEST)/gardenlogin_linux_amd64" && mv gardenlogin_linux_amd64 /usr/local/bin/gardenlogin && chmod +x /usr/local/bin/gardenlogin \
                                && ln -s "$(which gardenlogin)" /usr/local/bin/kubectl-gardenlogin
           echo gardenctl       && wget -N "https://github.com/gardener/gardenctl-v2/releases/download/$(curl -sL https://raw.githubusercontent.com/gardener/gardenctl-v2/master/LATEST)/gardenctl_v2_linux_amd64" && mv gardenctl_v2_linux_amd64 /usr/local/bin/gardenctl && chmod +x /usr/local/bin/gardenctl \


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR installs `go` in the remote local setup from the `go` download site. Installing go via `apk` was a mistake because Gardener updates its `go` version faster than the `apk` repositories, which might lead to compilation errors as the following:

```
# nice make kind-ha-multi-zone-down kind-ha-multi-zone-up && kubectl wait --for=condition=ready pod -A --all --timeout=-1s
go: go.mod requires go >= 1.23.0 (running go 1.22.7; GOTOOLCHAIN=local)
...
```

When the remote local setup was first introduced in commit [583ce9a](https://github.com/gardener/gardener/commit/583ce9a075f06228223ace8354e31576a8c82a3d), it already installed `go` from its download site but this was changed in commit [e80591f](https://github.com/gardener/gardener/commit/e80591fa667e763a936d544b806689aba96fd951).

**Special notes for your reviewer**:

/cc @istvanballok

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Install go in the remote local setup from the go download site instead of using the apk package manager.
```
