### PR TITLE
Remove etcd proposal alerts.

### DIFF
--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -755,22 +755,6 @@ func (e *etcd) Deploy(ctx context.Context) error {
 								"description": "Etcd3 cluster " + e.values.Role + " has no leader. Possible network partition in the etcd cluster.",
 							},
 						},
-						// etcd proposal alerts
-						// alert if there are several failed proposals within an hour
-						{
-							Alert: "KubeEtcd3" + role + "HighNumberOfFailedProposals",
-							Expr:  intstr.FromString(`increase(etcd_server_proposals_failed_total{job="` + serviceMonitorJobNameEtcd + `"}[1h]) > 5`),
-							Labels: map[string]string{
-								"service":    "etcd",
-								"severity":   "warning",
-								"type":       "seed",
-								"visibility": "operator",
-							},
-							Annotations: map[string]string{
-								"summary":     "High number of failed etcd proposals",
-								"description": "Etcd3 " + e.values.Role + " pod {{ $labels.pod }} has seen {{ $value }} proposal failures within the last hour.",
-							},
-						},
 						{
 							Alert: "KubeEtcd3" + role + "HighMemoryConsumption",
 							Expr:  intstr.FromString(`sum(container_memory_working_set_bytes{pod="etcd-` + e.values.Role + `-0",container="` + containerNameEtcd + `"}) / sum(kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed{container="` + containerNameEtcd + `", targetName="etcd-` + e.values.Role + `", resource="memory"}) > .5`),

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -670,20 +670,6 @@ var _ = Describe("Etcd", func() {
 								},
 							},
 							{
-								Alert: "KubeEtcd3" + testROLE + "HighNumberOfFailedProposals",
-								Expr:  intstr.FromString(`increase(etcd_server_proposals_failed_total{job="` + jobNameEtcd + `"}[1h]) > 5`),
-								Labels: map[string]string{
-									"service":    "etcd",
-									"severity":   "warning",
-									"type":       "seed",
-									"visibility": "operator",
-								},
-								Annotations: map[string]string{
-									"summary":     "High number of failed etcd proposals",
-									"description": "Etcd3 " + testRole + " pod {{ $labels.pod }} has seen {{ $value }} proposal failures within the last hour.",
-								},
-							},
-							{
 								Alert: "KubeEtcd3" + testROLE + "HighMemoryConsumption",
 								Expr:  intstr.FromString(`sum(container_memory_working_set_bytes{pod="etcd-` + testRole + `-0",container="etcd"}) / sum(kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed{container="etcd", targetName="etcd-` + testRole + `", resource="memory"}) > .5`),
 								For:   ptr.To(monitoringv1.Duration("15m")),

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-important-multinode-with-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-important-multinode-with-backup.prometheusrule.test.yaml
@@ -12,9 +12,6 @@ tests:
   # KubeEtcd3MainNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-main"}'
     values: '0+0x20'
-  # KubeEtcd3MainHighNumberOfFailedProposals
-  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-main", pod="etcd"}'
-    values: '0+1x6 6+0x115'
   # KubeEtcd3MainDbSizeLimitApproaching
   # KubeEtcd3MainDbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"}'
@@ -59,19 +56,6 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 main has no leader.
-  - eval_time: 1h
-    alertname: KubeEtcd3MainHighNumberOfFailedProposals
-    exp_alerts:
-    - exp_labels:
-        service: etcd
-        severity: warning
-        type: seed
-        visibility: operator
-        pod: etcd
-        job: kube-etcd3-main
-      exp_annotations:
-        description: Etcd3 main pod etcd has seen 6 proposal failures within the last hour.
-        summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3MainDbSizeLimitApproaching
     exp_alerts:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-important-multinode-without-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-important-multinode-without-backup.prometheusrule.test.yaml
@@ -12,9 +12,6 @@ tests:
   # KubeEtcd3MainNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-main"}'
     values: '0+0x20'
-  # KubeEtcd3MainHighNumberOfFailedProposals
-  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-main", pod="etcd"}'
-    values: '0+1x6 6+0x115'
   # KubeEtcd3MainDbSizeLimitApproaching
   # KubeEtcd3MainDbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"}'
@@ -42,19 +39,6 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 main has no leader.
-  - eval_time: 1h
-    alertname: KubeEtcd3MainHighNumberOfFailedProposals
-    exp_alerts:
-    - exp_labels:
-        service: etcd
-        severity: warning
-        type: seed
-        visibility: operator
-        pod: etcd
-        job: kube-etcd3-main
-      exp_annotations:
-        description: Etcd3 main pod etcd has seen 6 proposal failures within the last hour.
-        summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3MainDbSizeLimitApproaching
     exp_alerts:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-important-singlenode-with-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-important-singlenode-with-backup.prometheusrule.test.yaml
@@ -12,9 +12,6 @@ tests:
   # KubeEtcd3MainNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-main"}'
     values: '0+0x20'
-  # KubeEtcd3MainHighNumberOfFailedProposals
-  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-main", pod="etcd"}'
-    values: '0+1x6 6+0x115'
   # KubeEtcd3MainDbSizeLimitApproaching
   # KubeEtcd3MainDbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"}'
@@ -59,19 +56,6 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 main has no leader.
-  - eval_time: 1h
-    alertname: KubeEtcd3MainHighNumberOfFailedProposals
-    exp_alerts:
-    - exp_labels:
-        service: etcd
-        severity: warning
-        type: seed
-        visibility: operator
-        pod: etcd
-        job: kube-etcd3-main
-      exp_annotations:
-        description: Etcd3 main pod etcd has seen 6 proposal failures within the last hour.
-        summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3MainDbSizeLimitApproaching
     exp_alerts:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-important-singlenode-without-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-important-singlenode-without-backup.prometheusrule.test.yaml
@@ -12,9 +12,6 @@ tests:
   # KubeEtcd3MainNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-main"}'
     values: '0+0x20'
-  # KubeEtcd3MainHighNumberOfFailedProposals
-  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-main", pod="etcd"}'
-    values: '0+1x6 6+0x115'
   # KubeEtcd3MainDbSizeLimitApproaching
   # KubeEtcd3MainDbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"}'
@@ -42,19 +39,6 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 main has no leader.
-  - eval_time: 1h
-    alertname: KubeEtcd3MainHighNumberOfFailedProposals
-    exp_alerts:
-    - exp_labels:
-        service: etcd
-        severity: warning
-        type: seed
-        visibility: operator
-        pod: etcd
-        job: kube-etcd3-main
-      exp_annotations:
-        description: Etcd3 main pod etcd has seen 6 proposal failures within the last hour.
-        summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3MainDbSizeLimitApproaching
     exp_alerts:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-normal-multinode-with-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-normal-multinode-with-backup.prometheusrule.test.yaml
@@ -13,9 +13,6 @@ tests:
   # KubeEtcd3MainNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-main"}'
     values: '0+0x30'
-  # KubeEtcd3MainHighNumberOfFailedProposals
-  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-main", pod="etcd"}'
-    values: '0+1x6 6+0x115'
   # KubeEtcd3MainDbSizeLimitApproaching
   # KubeEtcd3MainDbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"}'
@@ -65,19 +62,6 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 main has no leader.
-  - eval_time: 1h
-    alertname: KubeEtcd3MainHighNumberOfFailedProposals
-    exp_alerts:
-    - exp_labels:
-        service: etcd
-        severity: warning
-        type: seed
-        visibility: operator
-        pod: etcd
-        job: kube-etcd3-main
-      exp_annotations:
-        description: Etcd3 main pod etcd has seen 6 proposal failures within the last hour.
-        summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3MainDbSizeLimitApproaching
     exp_alerts:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-normal-multinode-without-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-normal-multinode-without-backup.prometheusrule.test.yaml
@@ -12,9 +12,6 @@ tests:
   # KubeEtcd3MainNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-main"}'
     values: '0+0x30'
-  # KubeEtcd3MainHighNumberOfFailedProposals
-  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-main", pod="etcd"}'
-    values: '0+1x6 6+0x115'
   # KubeEtcd3MainDbSizeLimitApproaching
   # KubeEtcd3MainDbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"}'
@@ -42,19 +39,6 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 main has no leader.
-  - eval_time: 1h
-    alertname: KubeEtcd3MainHighNumberOfFailedProposals
-    exp_alerts:
-    - exp_labels:
-        service: etcd
-        severity: warning
-        type: seed
-        visibility: operator
-        pod: etcd
-        job: kube-etcd3-main
-      exp_annotations:
-        description: Etcd3 main pod etcd has seen 6 proposal failures within the last hour.
-        summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3MainDbSizeLimitApproaching
     exp_alerts:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-normal-singlenode-with-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-normal-singlenode-with-backup.prometheusrule.test.yaml
@@ -13,9 +13,6 @@ tests:
   # KubeEtcd3MainNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-main"}'
     values: '0+0x30'
-  # KubeEtcd3MainHighNumberOfFailedProposals
-  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-main", pod="etcd"}'
-    values: '0+1x6 6+0x115'
   # KubeEtcd3MainDbSizeLimitApproaching
   # KubeEtcd3MainDbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"}'
@@ -65,19 +62,6 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 main has no leader.
-  - eval_time: 1h
-    alertname: KubeEtcd3MainHighNumberOfFailedProposals
-    exp_alerts:
-    - exp_labels:
-        service: etcd
-        severity: warning
-        type: seed
-        visibility: operator
-        pod: etcd
-        job: kube-etcd3-main
-      exp_annotations:
-        description: Etcd3 main pod etcd has seen 6 proposal failures within the last hour.
-        summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3MainDbSizeLimitApproaching
     exp_alerts:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-normal-singlenode-without-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-normal-singlenode-without-backup.prometheusrule.test.yaml
@@ -12,9 +12,6 @@ tests:
   # KubeEtcd3MainNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-main"}'
     values: '0+0x30'
-  # KubeEtcd3MainHighNumberOfFailedProposals
-  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-main", pod="etcd"}'
-    values: '0+1x6 6+0x115'
   # KubeEtcd3MainDbSizeLimitApproaching
   # KubeEtcd3MainDbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"}'
@@ -42,19 +39,6 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 main has no leader.
-  - eval_time: 1h
-    alertname: KubeEtcd3MainHighNumberOfFailedProposals
-    exp_alerts:
-    - exp_labels:
-        service: etcd
-        severity: warning
-        type: seed
-        visibility: operator
-        pod: etcd
-        job: kube-etcd3-main
-      exp_annotations:
-        description: Etcd3 main pod etcd has seen 6 proposal failures within the last hour.
-        summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3MainDbSizeLimitApproaching
     exp_alerts:

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
@@ -100,23 +100,6 @@ spec:
         description: >-
           Virtual garden etcd events has no leader. Possible network partition in the etcd cluster.
 
-    - alert: EtcdHighNumberOfFailedProposals
-      expr: |
-        increase(
-          etcd_server_proposals_failed_total{job="virtual-garden-etcd"}[1h]
-        ) > 80
-      labels:
-        severity: info
-        topology: garden
-        service: VirtualGardenEtcd
-      annotations:
-        summary: >-
-          High number of failed virtual garden etcd {{$labels.role}} proposals in
-          landscape {{$externalLabels.landscape}}.
-        description: >-
-          Virtual garden etcd {{$labels.role}} has seen {{$value}} proposal
-          failures within the last hour.
-
     - record: virtual_garden:apiserver_storage_objects:max_by_resource
       expr: |
         max by (resource) (


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind cleanup

**What this PR does / why we need it**:

Removes alerts which are built on the `proposals_failed_total` metric of etcd.

The information that these alerts currently convey are already conveyed to the operator through other means, and there is no action an operator can take to fix the issue that raises these alerts (primarily leader election among members of the etcd cluster). See #10514 for more information.

**Which issue(s) this PR fixes**:

Fixes #10514 

**Special notes for your reviewer**:

/cc @shreyas-s-rao @ashwani2k @vicwicker @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Alerts based on the `proposals_failed_total` metric of the etcd cluster are not raised anymore.
```
