### PR TITLE
Harden Project controller integration tests with NamespacedCloudProfiles

### DIFF
--- a/test/integration/controllermanager/project/project/project_test.go
+++ b/test/integration/controllermanager/project/project/project_test.go
@@ -601,6 +601,8 @@ var _ = Describe("Project controller tests", func() {
 
 				By("Create NamespacedCloudProfile")
 				namespacedCloudProfile.Spec.Parent.Name = parentCloudProfile.Name
+				// Create the NamespacedCloudProfile using Eventually, as it may take time for the client and cache to
+				// have the parent CloudProfile available for reading.
 				Eventually(func() error {
 					return testClient.Create(ctx, namespacedCloudProfile)
 				}).Should(Succeed())

--- a/test/integration/controllermanager/project/project/project_test.go
+++ b/test/integration/controllermanager/project/project/project_test.go
@@ -601,10 +601,12 @@ var _ = Describe("Project controller tests", func() {
 
 				By("Create NamespacedCloudProfile")
 				namespacedCloudProfile.Spec.Parent.Name = parentCloudProfile.Name
-				Expect(testClient.Create(ctx, namespacedCloudProfile)).To(Succeed())
+				Eventually(func() error {
+					return testClient.Create(ctx, namespacedCloudProfile)
+				}).Should(Succeed())
 				By("Wait until NamespacedCloudProfile is reconciled")
 				Eventually(func(g Gomega) {
-					Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
 					g.Expect(namespacedCloudProfile.Status.ObservedGeneration).To(Equal(namespacedCloudProfile.Generation))
 				}).Should(Succeed())
 				DeferCleanup(func() {
@@ -652,7 +654,7 @@ var _ = Describe("Project controller tests", func() {
 				})
 				Expect(testClient.Patch(ctx, project, patch)).To(Succeed())
 
-				By("Ensure new admin has access to NamespacedCloudProfile")
+				By("Ensure viewer has access to NamespacedCloudProfile")
 				Eventually(func() error {
 					return testUserClient.Get(ctx, namespacedCloudProfileKey, &gardencorev1beta1.NamespacedCloudProfile{})
 				}).Should(Succeed())
@@ -710,7 +712,7 @@ var _ = Describe("Project controller tests", func() {
 				}
 				Expect(testUserClient.Update(ctx, namespacedCloudProfile)).To(Succeed())
 				Eventually(func(g Gomega) {
-					Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
 					g.Expect(namespacedCloudProfile.Status.ObservedGeneration).To(Equal(namespacedCloudProfile.Generation))
 				}).Should(Succeed())
 
@@ -777,7 +779,7 @@ var _ = Describe("Project controller tests", func() {
 					return testUserClient.Update(ctx, namespacedCloudProfile)
 				}).Should(Succeed())
 				Eventually(func(g Gomega) {
-					Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
 					g.Expect(namespacedCloudProfile.Status.ObservedGeneration).To(Equal(namespacedCloudProfile.Generation))
 				}).Should(Succeed())
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
A [flake](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10521/pull-gardener-integration/1834284023480848384) has been observed that should be solved by this fix.

**Which issue(s) this PR fixes**:
Contributes to #10519

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
