### PR TITLE
[kube-proxy daemon set] drop volume kube-proxy-mode and create file in script

### DIFF
--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -485,7 +485,7 @@ done
 				},
 			}
 
-			configMapCleanupScriptName = "kube-proxy-cleanup-script-a4263ada"
+			configMapCleanupScriptName = "kube-proxy-cleanup-script-1797a990"
 			configMapCleanupScript     = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      configMapCleanupScriptName,
@@ -501,7 +501,9 @@ done
 				Immutable: ptr.To(true),
 				Data: map[string]string{
 					"cleanup.sh": `#!/bin/sh -e
-OLD_KUBE_PROXY_MODE="$(cat "$1")"
+if [ -f "$1" ]; then
+  OLD_KUBE_PROXY_MODE="$(cat "$1")"
+fi
 if [ -z "${OLD_KUBE_PROXY_MODE}" ] || [ "${OLD_KUBE_PROXY_MODE}" = "${KUBE_PROXY_MODE}" ]; then
   echo "${KUBE_PROXY_MODE}" >"$1"
   echo "Nothing to cleanup - the mode didn't change."
@@ -649,7 +651,6 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 											{MountPath: "/script", Name: "kube-proxy-cleanup-script"},
 											{MountPath: "/lib/modules", Name: "kernel-modules"},
 											{MountPath: "/var/lib/kube-proxy", Name: "kube-proxy-dir"},
-											{MountPath: "/var/lib/kube-proxy/mode", Name: "kube-proxy-mode"},
 											{MountPath: "/var/lib/kube-proxy-kubeconfig", Name: "kubeconfig"},
 											{MountPath: "/var/lib/kube-proxy-config", Name: "kube-proxy-config"},
 										},
@@ -730,15 +731,6 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 											HostPath: &corev1.HostPathVolumeSource{
 												Path: "/var/lib/kube-proxy",
 												Type: ptr.To(corev1.HostPathDirectoryOrCreate),
-											},
-										},
-									},
-									{
-										Name: "kube-proxy-mode",
-										VolumeSource: corev1.VolumeSource{
-											HostPath: &corev1.HostPathVolumeSource{
-												Path: "/var/lib/kube-proxy/mode",
-												Type: ptr.To(corev1.HostPathFileOrCreate),
 											},
 										},
 									},

--- a/pkg/component/kubernetes/proxy/resources.go
+++ b/pkg/component/kubernetes/proxy/resources.go
@@ -49,11 +49,11 @@ const (
 	dataKeyConfig             = "config.yaml"
 	dataKeyConntrackFixScript = "conntrack_fix.sh"
 	dataKeyCleanupScript      = "cleanup.sh"
+	filenameMode              = "mode"
 
 	volumeMountPathKubeconfig         = "/var/lib/kube-proxy-kubeconfig"
 	volumeMountPathConfig             = "/var/lib/kube-proxy-config"
 	volumeMountPathDir                = "/var/lib/kube-proxy"
-	volumeMountPathMode               = "/var/lib/kube-proxy/mode"
 	volumeMountPathCleanupScript      = "/script"
 	volumeMountPathConntrackFixScript = "/script"
 	volumeMountPathKernelModules      = "/lib/modules"
@@ -63,7 +63,6 @@ const (
 	volumeNameKubeconfig         = "kubeconfig"
 	volumeNameConfig             = "kube-proxy-config"
 	volumeNameDir                = "kube-proxy-dir"
-	volumeNameMode               = "kube-proxy-mode"
 	volumeNameCleanupScript      = "kube-proxy-cleanup-script"
 	volumeNameConntrackFixScript = "conntrack-fix-script"
 	volumeNameKernelModules      = "kernel-modules"
@@ -199,7 +198,6 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 
 		directoryOrCreate  = corev1.HostPathDirectoryOrCreate
-		fileOrCreate       = corev1.HostPathFileOrCreate
 		k8sGreaterEqual129 = versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion)
 
 		daemonSet = &appsv1.DaemonSet{
@@ -334,15 +332,6 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 									HostPath: &corev1.HostPathVolumeSource{
 										Path: hostPathDir,
 										Type: &directoryOrCreate,
-									},
-								},
-							},
-							{
-								Name: volumeNameMode,
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: hostPathDir + "/mode",
-										Type: &fileOrCreate,
 									},
 								},
 							},
@@ -487,7 +476,7 @@ func (k *kubeProxy) getInitContainers(kubernetesVersion *semver.Version, image s
 			Command: []string{
 				"sh",
 				"-c",
-				fmt.Sprintf("%s/%s %s", volumeMountPathCleanupScript, dataKeyCleanupScript, volumeMountPathMode),
+				fmt.Sprintf("%s/%s %s/%s", volumeMountPathCleanupScript, dataKeyCleanupScript, volumeMountPathDir, filenameMode),
 			},
 			Env: []corev1.EnvVar{
 				{
@@ -510,10 +499,6 @@ func (k *kubeProxy) getInitContainers(kubernetesVersion *semver.Version, image s
 				{
 					Name:      volumeNameDir,
 					MountPath: volumeMountPathDir,
-				},
-				{
-					Name:      volumeNameMode,
-					MountPath: volumeMountPathMode,
 				},
 				{
 					Name:      volumeNameKubeconfig,

--- a/pkg/component/kubernetes/proxy/resources/cleanup.sh
+++ b/pkg/component/kubernetes/proxy/resources/cleanup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
-OLD_KUBE_PROXY_MODE="$(cat "$1")"
+if [ -f "$1" ]; then
+  OLD_KUBE_PROXY_MODE="$(cat "$1")"
+fi
 if [ -z "${OLD_KUBE_PROXY_MODE}" ] || [ "${OLD_KUBE_PROXY_MODE}" = "${KUBE_PROXY_MODE}" ]; then
   echo "${KUBE_PROXY_MODE}" >"$1"
   echo "Nothing to cleanup - the mode didn't change."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind flake

**What this PR does / why we need it**:
In very rare cases, the kube-proxy pod creation is stuck in the init container with the event 
```
MountVolume.SetUp failed for volume "kube-proxy-mode" : open /var/lib/kube-proxy/mode: no such file or directory
```

It seems to be related to the restarts of the containerd/kubelet units by the `gardener-node-agent` unit after node creation.

This PR is a guess/hope that it can be avoided by simplifying the volumes, i.e. by removing the `kube-proxy-mode` volume
```
  - hostPath:
      path: /var/lib/kube-proxy
      type: DirectoryOrCreate
    name: kube-proxy-dir
  - hostPath:
      path: /var/lib/kube-proxy/mode
      type: FileOrCreate
    name: kube-proxy-mode
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[kube-proxy daemon set] drop volume kube-proxy-mode and create file in script
```
