### PR TITLE
Clean up unused `--seed-kubecfg-path` flag from the Shoot creation framework

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -15,7 +15,6 @@ spec:
     --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
     -verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
-    -seed-kubecfg-path=$TM_KUBECONFIG_PATH/seed.config
     -shoot-kubecfg-path=$TM_KUBECONFIG_PATH/shoot.config
     -shoot-name=$SHOOT_NAME
     -cloud-profile-name=$CLOUDPROFILE

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -28,7 +28,6 @@ type ShootCreationConfig struct {
 	GardenerConfig *GardenerConfig
 
 	shootKubeconfigPath          string
-	seedKubeconfigPath           string
 	testShootName                string
 	testShootPrefix              string
 	shootMachineImageName        string
@@ -183,10 +182,6 @@ func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreati
 		base.shootKubeconfigPath = overwrite.shootKubeconfigPath
 	}
 
-	if StringSet(overwrite.seedKubeconfigPath) {
-		base.seedKubeconfigPath = overwrite.seedKubeconfigPath
-	}
-
 	if StringSet(overwrite.testShootName) {
 		base.testShootName = overwrite.testShootName
 	}
@@ -305,7 +300,6 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	newCfg := &ShootCreationConfig{}
 
 	flag.StringVar(&newCfg.shootKubeconfigPath, "shoot-kubecfg-path", "", "the path to where the Kubeconfig of the Shoot cluster will be downloaded to. The kubeconfig expires in 6 hours.")
-	flag.StringVar(&newCfg.seedKubeconfigPath, "seed-kubecfg-path", "", "the path to where the Kubeconfig of the Seed cluster will be downloaded to.")
 	flag.StringVar(&newCfg.testShootName, "shoot-name", "", "unique name to use for test shoots. Used by test-machinery.")
 	flag.StringVar(&newCfg.testShootPrefix, "prefix", "", "prefix for generated shoot name. Usually used locally to auto generate a unique name.")
 	flag.StringVar(&newCfg.shootAnnotations, "annotations", "", "annotations to be added to the test shoot. Expected format is key1=val1,key2=val2 (similar to kubectl --selector).")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/8833/files#diff-0c5fc2d4d1cea0541004c8163ef28b926d4ba2702fdc4c143115ecfa992127adL437-L446 the `--seed-kubecfg-path` flag is no longer used by the Shoot creation framework.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
See https://github.com/gardener/test-infra/issues/533

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
