### PR TITLE
Reduced etcd container requests and VPA minAllowed

### DIFF
--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -8,7 +8,7 @@ set -e
 
 operation="${1:-check}"
 
-echo "> ${operation^} Skaffold Dependencies"
+echo "> ${operation} Skaffold Dependencies"
 
 success=true
 repo_root="$(git rev-parse --show-toplevel)"

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -212,7 +212,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		metrics             = druidv1alpha1.Basic
 		volumeClaimTemplate = e.etcd.Name
 		minAllowed          = corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("200M"),
+			corev1.ResourceMemory: resource.MustParse("60M"),
 		}
 	)
 
@@ -220,10 +220,16 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		if !e.values.HighAvailabilityEnabled {
 			annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
 		}
+		resourcesBackupRestore = &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("80Mi"),
+			},
+		}
 		metrics = druidv1alpha1.Extensive
 		volumeClaimTemplate = e.values.Role + "-" + strings.TrimSuffix(e.etcd.Name, "-"+e.values.Role)
 		minAllowed = corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("700M"),
+			corev1.ResourceMemory: resource.MustParse("300M"),
 		}
 	}
 
@@ -1142,8 +1148,8 @@ func (e *etcd) computeContainerResources(existingSts *appsv1.StatefulSet) (*core
 		}
 		resourcesBackupRestore = &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("23m"),
-				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("40Mi"),
 			},
 		}
 	)

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -153,8 +153,8 @@ var _ = Describe("Etcd", func() {
 
 			resourcesContainerBackupRestore := &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("23m"),
-					corev1.ResourceMemory: resource.MustParse("128Mi"),
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("40Mi"),
 				},
 			}
 			if existingResourcesContainerBackupRestore != nil {
@@ -269,6 +269,12 @@ var _ = Describe("Etcd", func() {
 			if class == ClassImportant {
 				if replicas == 1 {
 					obj.Spec.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
+				}
+				obj.Spec.Backup.Resources = &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("80Mi"),
+					},
 				}
 				obj.Spec.Etcd.Metrics = &metricsExtensive
 				obj.Spec.VolumeClaimTemplate = ptr.To(testRole + "-etcd")
@@ -456,7 +462,7 @@ var _ = Describe("Etcd", func() {
 										{
 											ContainerName: "etcd",
 											MinAllowed: corev1.ResourceList{
-												corev1.ResourceMemory: resource.MustParse("200M"),
+												corev1.ResourceMemory: resource.MustParse("60M"),
 											},
 											ControlledValues: &controlledValues,
 										},
@@ -487,7 +493,7 @@ var _ = Describe("Etcd", func() {
 
 			if class == ClassImportant {
 				obj.Spec.Vpa.Template.Spec.ResourcePolicy.ContainerPolicies[0].MinAllowed = corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("700M"),
+					corev1.ResourceMemory: resource.MustParse("300M"),
 				}
 			}
 
@@ -512,7 +518,7 @@ var _ = Describe("Etcd", func() {
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
 							ContainerName:    "etcd",
-							MinAllowed:       corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200M")},
+							MinAllowed:       corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("60M")},
 							ControlledValues: &controlledValues,
 							Mode:             &containerPolicyAuto,
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area cost
/kind enhancement

**What this PR does / why we need it**:
Adapt backup-restore container resource requests, as well as etcd container VPA minAllowed values as per recommendations from https://github.com/gardener/etcd-druid/issues/783

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-druid/issues/783

**Special notes for your reviewer**:
/cc @vlerenc @shreyas-s-rao @ashwani2k 
The fix was originally submitted as part of https://github.com/gardener/gardener/pull/10526. However there are some issues identified which will need some time to fix. This small change which optimises node utilisation should not be blocked and hence a separate PR. This will be removed from #10526.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improved node utilisation by reducing requests for etcd-druid managed pods.
```
