### PR TITLE
Allow empty pod and service ranges in shoot spec for IPv6 single stack.

### DIFF
--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -557,19 +557,19 @@ func ToNetworks(shoot *gardencorev1beta1.Shoot, workerless bool) (*Networks, err
 			return nil, fmt.Errorf("cannot parse shoot's pod cidr %w", err)
 		}
 		pods = append(pods, *p)
-	} else if !workerless {
+	} else if !workerless && !gardencorev1beta1.IsIPv6SingleStack(shoot.Spec.Networking.IPFamilies) {
 		return nil, fmt.Errorf("shoot's pods cidr is empty")
 	}
 
-	if shoot.Spec.Networking.Services == nil {
+	if shoot.Spec.Networking.Services != nil {
+		_, s, err := net.ParseCIDR(*shoot.Spec.Networking.Services)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse shoot's network cidr %w", err)
+		}
+		services = append(services, *s)
+	} else if !gardencorev1beta1.IsIPv6SingleStack(shoot.Spec.Networking.IPFamilies) {
 		return nil, fmt.Errorf("shoot's service cidr is empty")
 	}
-
-	_, s, err := net.ParseCIDR(*shoot.Spec.Networking.Services)
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse shoot's network cidr %w", err)
-	}
-	services = append(services, *s)
 
 	if shoot.Spec.Networking.Nodes != nil {
 		_, n, err := net.ParseCIDR(*shoot.Spec.Networking.Nodes)

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"reflect"
 	"slices"
 	"strconv"
@@ -877,6 +878,11 @@ func (c *validationContext) validateReferencedSecret(secretLister kubecorev1list
 	return nil
 }
 
+func cidrMatchesIPFamily(cidr string, ipfamilies []core.IPFamily) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return ip != nil && (ip.To4() != nil && slices.Contains(ipfamilies, core.IPFamilyIPv4) || ip.To4() == nil && slices.Contains(ipfamilies, core.IPFamilyIPv6))
+}
+
 func (c *validationContext) validateShootNetworks(a admission.Attributes, workerless bool) field.ErrorList {
 	var (
 		allErrs field.ErrorList
@@ -888,18 +894,22 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 	}
 
 	if c.seed != nil {
-		if c.shoot.Spec.Networking.Pods == nil && !workerless && slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
+		if c.shoot.Spec.Networking.Pods == nil && !workerless {
 			if c.seed.Spec.Networks.ShootDefaults != nil {
-				c.shoot.Spec.Networking.Pods = c.seed.Spec.Networks.ShootDefaults.Pods
-			} else {
+				if cidrMatchesIPFamily(*c.seed.Spec.Networks.ShootDefaults.Pods, c.shoot.Spec.Networking.IPFamilies) {
+					c.shoot.Spec.Networking.Pods = c.seed.Spec.Networks.ShootDefaults.Pods
+				}
+			} else if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
 				allErrs = append(allErrs, field.Required(path.Child("pods"), "pods is required"))
 			}
 		}
 
-		if c.shoot.Spec.Networking.Services == nil && slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
+		if c.shoot.Spec.Networking.Services == nil {
 			if c.seed.Spec.Networks.ShootDefaults != nil {
-				c.shoot.Spec.Networking.Services = c.seed.Spec.Networks.ShootDefaults.Services
-			} else {
+				if cidrMatchesIPFamily(*c.seed.Spec.Networks.ShootDefaults.Services, c.shoot.Spec.Networking.IPFamilies) {
+					c.shoot.Spec.Networking.Services = c.seed.Spec.Networks.ShootDefaults.Services
+				}
+			} else if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
 				allErrs = append(allErrs, field.Required(path.Child("services"), "services is required"))
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow empty pod and service ranges in shoot spec for IPv6 single stack.
```
