### PR TITLE
Reapply "Drop deprecated .spec.pools[].userData from `extensions.gardener.cloud/v1alpha1.Worker` API"

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4584,22 +4584,6 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 </tr>
 <tr>
 <td>
-<code>userData</code></br>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UserData is a base64-encoded string that contains the data that is sent to the provider&rsquo;s APIs
-when a new machine/VM that is part of this worker pool shall be spawned.
-Either this or UserDataSecretRef must be provided.</p>
-<p>Deprecated: This field will be removed in future release.
-TODO(rfranzke): Remove this field after v1.104 has been released.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>userDataSecretRef</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core">
@@ -4608,10 +4592,8 @@ Kubernetes core/v1.SecretKeySelector
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider&rsquo;s APIs when
-a new machine/VM that is part of this worker pool shall be spawned.
-Either this or UserData must be provided.</p>
+a new machine/VM that is part of this worker pool shall be spawned.</p>
 </td>
 </tr>
 <tr>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -287,22 +287,10 @@ spec:
                         - key
                         type: object
                       type: array
-                    userData:
-                      description: |-
-                        UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
-                        when a new machine/VM that is part of this worker pool shall be spawned.
-                        Either this or UserDataSecretRef must be provided.
-
-
-                        Deprecated: This field will be removed in future release.
-                        TODO(rfranzke): Remove this field after v1.104 has been released.
-                      format: byte
-                      type: string
                     userDataSecretRef:
                       description: |-
                         UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
                         a new machine/VM that is part of this worker pool shall be spawned.
-                        Either this or UserData must be provided.
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -355,6 +343,7 @@ spec:
                   - maximum
                   - minimum
                   - name
+                  - userDataSecretRef
                   type: object
                 type: array
               providerConfig:

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -251,19 +251,15 @@ func ErrorMachineImageNotFound(name, version string, opt ...string) error {
 
 // FetchUserData fetches the user data for a worker pool.
 func FetchUserData(ctx context.Context, c client.Client, namespace string, pool extensionsv1alpha1.WorkerPool) ([]byte, error) {
-	if pool.UserDataSecretRef != nil {
-		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pool.UserDataSecretRef.Name, Namespace: namespace}}
-		if err := c.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
-			return nil, fmt.Errorf("failed fetching user data secret %s referenced in worker pool %s: %w", pool.UserDataSecretRef.Name, pool.Name, err)
-		}
-
-		userData, ok := secret.Data[pool.UserDataSecretRef.Key]
-		if !ok || len(userData) == 0 {
-			return nil, fmt.Errorf("user data secret %s for worker pool %s has no %s field or it's empty", pool.UserDataSecretRef.Name, pool.Name, pool.UserDataSecretRef.Key)
-		}
-
-		return userData, nil
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pool.UserDataSecretRef.Name, Namespace: namespace}}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+		return nil, fmt.Errorf("failed fetching user data secret %s referenced in worker pool %s: %w", pool.UserDataSecretRef.Name, pool.Name, err)
 	}
 
-	return pool.UserData, nil
+	userData, ok := secret.Data[pool.UserDataSecretRef.Key]
+	if !ok || len(userData) == 0 {
+		return nil, fmt.Errorf("user data secret %s for worker pool %s has no %s field or it's empty", pool.UserDataSecretRef.Name, pool.Name, pool.UserDataSecretRef.Key)
+	}
+
+	return userData, nil
 }

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -204,13 +204,6 @@ set_seed_name
 $(dirname "${0}")/download_gardener_source_code.sh --gardener-version $GARDENER_PREVIOUS_RELEASE --download-path $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases
 export GARDENER_PREVIOUS_VERSION="$(cat $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/VERSION)"
 
-# TODO(MartinWeindel): Temporary fix of addresses in previous release for e2e upgrade tests (remove this after v1.102 has been released).
-sed -i -e 's/hostIP: "127.0.0.1"/hostIP: "172.18.255.1"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
-sed -i -e 's/zone0IP: "127.0.0.10"/zone0IP: "172.18.255.10"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
-sed -i -e 's/zone1IP: "127.0.0.11"/zone1IP: "172.18.255.11"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
-sed -i -e 's/zone2IP: "127.0.0.12"/zone2IP: "172.18.255.12"/' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/charts/gardener/provider-local/values.yaml
-sed -i -e 's/- 127.0.0./- 172.18.255./' $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE/example/gardener-local/kind/ha-multi-zone/values.yaml
-
 # test setup
 kind_up
 

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -134,19 +134,9 @@ type WorkerPool struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty"`
-	// UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
-	// when a new machine/VM that is part of this worker pool shall be spawned.
-	// Either this or UserDataSecretRef must be provided.
-	//
-	// Deprecated: This field will be removed in future release.
-	// TODO(rfranzke): Remove this field after v1.104 has been released.
-	// +optional
-	UserData []byte `json:"userData,omitempty"`
 	// UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
 	// a new machine/VM that is part of this worker pool shall be spawned.
-	// Either this or UserData must be provided.
-	// +optional
-	UserDataSecretRef *corev1.SecretKeySelector `json:"userDataSecretRef,omitempty"`
+	UserDataSecretRef corev1.SecretKeySelector `json:"userDataSecretRef"`
 	// Volume contains information about the root disks that should be used for this worker pool.
 	// +optional
 	Volume *Volume `json:"volume,omitempty"`

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1893,16 +1893,7 @@ func (in *WorkerPool) DeepCopyInto(out *WorkerPool) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.UserData != nil {
-		in, out := &in.UserData, &out.UserData
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
-	if in.UserDataSecretRef != nil {
-		in, out := &in.UserDataSecretRef, &out.UserDataSecretRef
-		*out = new(v1.SecretKeySelector)
-		(*in).DeepCopyInto(*out)
-	}
+	in.UserDataSecretRef.DeepCopyInto(&out.UserDataSecretRef)
 	if in.Volume != nil {
 		in, out := &in.Volume, &out.Volume
 		*out = new(Volume)

--- a/pkg/apis/extensions/validation/worker.go
+++ b/pkg/apis/extensions/validation/worker.go
@@ -83,10 +83,6 @@ func ValidateWorkerPools(pools []extensionsv1alpha1.WorkerPool, fldPath *field.P
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "field is required"))
 		}
 
-		if pool.UserData == nil && pool.UserDataSecretRef == nil {
-			allErrs = append(allErrs, field.Required(idxPath.Child("userData"), "either userData or userDataSecretRef must be provided"))
-		}
-
 		if pool.NodeTemplate != nil {
 			for resourceName, value := range pool.NodeTemplate.Capacity {
 				allErrs = append(allErrs, kubernetescorevalidation.ValidateResourceQuantityValue(string(resourceName), value, idxPath.Child("nodeTemplate", "capacity", string(resourceName)))...)

--- a/pkg/apis/extensions/validation/worker_test.go
+++ b/pkg/apis/extensions/validation/worker_test.go
@@ -47,7 +47,6 @@ var _ = Describe("Worker validation tests", func() {
 						},
 						Name:         "pool1",
 						Architecture: ptr.To("amd64"),
-						UserData:     []byte("bootstrap data"),
 					},
 				},
 			},
@@ -106,34 +105,12 @@ var _ = Describe("Worker validation tests", func() {
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("spec.pools[0].name"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.pools[0].userData"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.pools[0].nodeTemplate.capacity.cpu"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("spec.pools[0].architecture"),
 			}))))
-		})
-
-		It("should complain Worker resources without user data", func() {
-			workerCopy := worker.DeepCopy()
-
-			workerCopy.Spec.Pools[0].UserData = nil
-
-			Expect(ValidateWorker(workerCopy)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.pools[0].userData"),
-			}))))
-		})
-
-		It("should allow Worker resources with user data secret ref", func() {
-			workerCopy := worker.DeepCopy()
-
-			workerCopy.Spec.Pools[0].UserDataSecretRef = &corev1.SecretKeySelector{}
-
-			Expect(ValidateWorker(workerCopy)).To(BeEmpty())
 		})
 
 		It("should allow valid worker resources", func() {
@@ -210,9 +187,9 @@ var _ = Describe("Worker validation tests", func() {
 						Name:    "image2",
 						Version: "version2",
 					},
-					Name:         "pool2",
-					Architecture: ptr.To("amd64"),
-					UserData:     []byte("new bootstrap data"),
+					Name:              "pool2",
+					Architecture:      ptr.To("amd64"),
+					UserDataSecretRef: corev1.SecretKeySelector{Key: "new-bootstrap-data-key"},
 				},
 			}
 

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -697,12 +697,6 @@ func (e *etcd) Deploy(ctx context.Context) error {
 
 	// etcd deployed for shoot cluster
 	if e.values.NamePrefix == "" {
-		// TODO(rickardsjp, chrkl, istvanballok): Remove after v1.102
-		err := kubernetesutils.DeleteObject(ctx, e.client, e.emptyScrapeConfig())
-		if client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("could not delete etcd scrape config in namespace %v: %w", e.namespace, err)
-		}
-
 		// TODO: The PrometheusRules for the garden cluster case are maintained in a separate file located here:
 		//  pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
 		//  These rules highly overlap with those for the shoots maintained here. They should be merged in the future.

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -955,7 +955,6 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1030,7 +1029,6 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, existingReplicas, false)))
@@ -1110,7 +1108,6 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, existingReplicas, false)))
@@ -1178,7 +1175,6 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1245,7 +1241,6 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1343,7 +1338,6 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 				}),
-				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1438,7 +1432,6 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1506,7 +1499,6 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1565,7 +1557,6 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, *replicas, true)))
@@ -1632,7 +1623,6 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, *replicas, true)))
@@ -1694,7 +1684,6 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", clientSecretName)))
 					}),
-					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, *replicas, false)))
@@ -1896,7 +1885,6 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(serviceMonitor("shoot", clientSecretName)))
 						}),
-						c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -1946,7 +1934,6 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(serviceMonitor("shoot", clientSecretName)))
 						}),
-						c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
@@ -2013,7 +2000,6 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
 					}),
-					c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -289,22 +289,10 @@ spec:
                         - key
                         type: object
                       type: array
-                    userData:
-                      description: |-
-                        UserData is a base64-encoded string that contains the data that is sent to the provider's APIs
-                        when a new machine/VM that is part of this worker pool shall be spawned.
-                        Either this or UserDataSecretRef must be provided.
-
-
-                        Deprecated: This field will be removed in future release.
-                        TODO(rfranzke): Remove this field after v1.104 has been released.
-                      format: byte
-                      type: string
                     userDataSecretRef:
                       description: |-
                         UserDataSecretRef references a Secret and a data key containing the data that is sent to the provider's APIs when
                         a new machine/VM that is part of this worker pool shall be spawned.
-                        Either this or UserData must be provided.
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -357,6 +345,7 @@ spec:
                   - maximum
                   - minimum
                   - name
+                  - userDataSecretRef
                   type: object
                 type: array
               providerConfig:

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -208,10 +208,7 @@ type OperatingSystemConfigs struct {
 type Data struct {
 	// Object is the plain OperatingSystemConfig object.
 	Object *extensionsv1alpha1.OperatingSystemConfig
-	// Content is the actual cloud-config user data.
-	// TODO(rfranzke): Remove this Content field after v1.140 is released.
-	Content string
-	// IncludeSecretNameInWorkerPool states whether an extensionsv1alpha1.WorkerPool must include the GardenerNodeAgentSecretName
+	// IncludeSecretNameInWorkerPool states whether a extensionsv1alpha1.WorkerPool must include the GardenerNodeAgentSecretName
 	IncludeSecretNameInWorkerPool bool
 	// GardenerNodeAgentSecretName is the name of the secret storing the gardener node agent configuration in the shoot cluster.
 	GardenerNodeAgentSecretName string
@@ -435,7 +432,6 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 
 				data := Data{
 					Object:                        osc,
-					Content:                       string(secret.Data[extensionsv1alpha1.OperatingSystemConfigSecretDataKey]),
 					IncludeSecretNameInWorkerPool: hashVersion > 1,
 					GardenerNodeAgentSecretName:   oscKey,
 					SecretName:                    &secret.Name,

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -963,13 +963,11 @@ var _ = Describe("OperatingSystemConfig", func() {
 				exp := map[string]*OperatingSystemConfigs{
 					worker1Name: {
 						Init: Data{
-							Content:                     "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-init",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker1Name + "-77ac3",
 							SecretName:                  ptr.To("cc-" + expected[0].Name),
 							Object:                      worker1OSCDownloader,
 						},
 						Original: Data{
-							Content:                     "foobar-gardener-node-agent-" + worker1Name + "-77ac3-type1-original",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker1Name + "-77ac3",
 							SecretName:                  ptr.To("cc-" + expected[1].Name),
 							Object:                      worker1OSCOriginal,
@@ -977,13 +975,11 @@ var _ = Describe("OperatingSystemConfig", func() {
 					},
 					worker2Name: {
 						Init: Data{
-							Content:                     "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-init",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker2Name + "-d9e53",
 							SecretName:                  ptr.To("cc-" + expected[2].Name),
 							Object:                      worker2OSCDownloader,
 						},
 						Original: Data{
-							Content:                     "foobar-gardener-node-agent-" + worker2Name + "-d9e53-type2-original",
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker2Name + "-d9e53",
 							SecretName:                  ptr.To("cc-" + expected[3].Name),
 							Object:                      worker2OSCOriginal,

--- a/pkg/component/extensions/worker/worker_test.go
+++ b/pkg/component/extensions/worker/worker_test.go
@@ -72,7 +72,6 @@ var _ = Describe("Worker", func() {
 		worker1MachineImageName               = "worker1machineimage"
 		worker1MachineImageVersion            = "worker1machineimagev1"
 		worker1MCMSettings                    = &gardencorev1beta1.MachineControllerManagerSettings{}
-		worker1UserData                       = []byte("bootstrap-me")
 		worker1UserDataKeyName                = "user-data-key-name-w1"
 		worker1UserDataSecretName             = "user-data-secret-name-w1"
 		worker1VolumeName                     = "worker1volumename"
@@ -99,7 +98,6 @@ var _ = Describe("Worker", func() {
 		worker2MachineType               = "worker2machinetype"
 		worker2MachineImageName          = "worker2machineimage"
 		worker2MachineImageVersion       = "worker2machineimagev1"
-		worker2UserData                  = []byte("bootstrap-me-now")
 		worker2UserDataKeyName           = "user-data-key-name-w2"
 		worker2UserDataSecretName        = "user-data-secret-name-w2"
 		worker2Arch                      = ptr.To("arm64")
@@ -166,14 +164,12 @@ var _ = Describe("Worker", func() {
 			WorkerPoolNameToOperatingSystemConfigsMap: map[string]*operatingsystemconfig.OperatingSystemConfigs{
 				worker1Name: {
 					Init: operatingsystemconfig.Data{
-						Content:                     string(worker1UserData),
 						GardenerNodeAgentSecretName: worker1UserDataKeyName,
 						SecretName:                  &worker1UserDataSecretName,
 					},
 				},
 				worker2Name: {
 					Init: operatingsystemconfig.Data{
-						Content:                     string(worker2UserData),
 						GardenerNodeAgentSecretName: worker2UserDataKeyName,
 						SecretName:                  &worker2UserDataSecretName,
 					},
@@ -292,8 +288,7 @@ var _ = Describe("Worker", func() {
 						Version: worker1MachineImageVersion,
 					},
 					ProviderConfig:    worker1ProviderConfig,
-					UserData:          worker1UserData,
-					UserDataSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker1UserDataSecretName}, Key: "cloud_config"},
+					UserDataSecretRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker1UserDataSecretName}, Key: "cloud_config"},
 					Volume: &extensionsv1alpha1.Volume{
 						Name:      &worker1VolumeName,
 						Type:      &worker1VolumeType,
@@ -337,8 +332,7 @@ var _ = Describe("Worker", func() {
 						Version: worker2MachineImageVersion,
 					},
 					KubernetesVersion: &workerKubernetesVersion,
-					UserData:          worker2UserData,
-					UserDataSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker2UserDataSecretName}, Key: "cloud_config"},
+					UserDataSecretRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: worker2UserDataSecretName}, Key: "cloud_config"},
 					NodeTemplate:      workerPool2NodeTemplate,
 					Architecture:      worker2Arch,
 					ClusterAutoscaler: emptyAutoscalerOptions,

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -197,12 +197,10 @@ var _ = Describe("operatingsystemconfig", func() {
 		var (
 			namespace = "shoot--foo--bar"
 
-			worker1Name            = "worker1"
-			worker1OriginalContent = "w1content"
-			worker1Key             = operatingsystemconfig.KeyV1(worker1Name, semver.MustParse(kubernetesVersion), nil)
+			worker1Name = "worker1"
+			worker1Key  = operatingsystemconfig.KeyV1(worker1Name, semver.MustParse(kubernetesVersion), nil)
 
 			worker2Name                  = "worker2"
-			worker2OriginalContent       = "w2content"
 			worker2KubernetesVersion     = "4.5.6"
 			worker2Key                   = operatingsystemconfig.KeyV1(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
 			worker2KubeletDataVolumeName = "vol"
@@ -211,7 +209,6 @@ var _ = Describe("operatingsystemconfig", func() {
 				worker1Name: {
 					Original: operatingsystemconfig.Data{
 						GardenerNodeAgentSecretName: worker1Key,
-						Content:                     worker1OriginalContent,
 						Object: &extensionsv1alpha1.OperatingSystemConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: worker1Name + "-original",
@@ -226,7 +223,6 @@ var _ = Describe("operatingsystemconfig", func() {
 				worker2Name: {
 					Original: operatingsystemconfig.Data{
 						GardenerNodeAgentSecretName: worker2Key,
-						Content:                     worker2OriginalContent,
 						Object: &extensionsv1alpha1.OperatingSystemConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: worker2Name + "-original",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
This commit reverts https://github.com/gardener/gardener/pull/10285 and cleans up two more small TODOs.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/9545

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The limitation of having at maximum ~80 worker pools in `Shoot`s has been lifted. Much higher numbers should be possible now (concrete limit depends on the amount of configuration within the pools (e.g., labels, taints, annotations, etc.)).
```
