### PR TITLE
Move seed garbage collection to `seed-care`, ignore stale `Pod`s when checking for updated `Deployment`s

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/garbage_collection.go
+++ b/pkg/gardenlet/controller/shoot/care/garbage_collection.go
@@ -8,22 +8,18 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/hashicorp/go-multierror"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
 // GarbageCollection contains required information for shoot and seed garbage collection.
@@ -79,7 +75,7 @@ func (g *GarbageCollection) Collect(ctx context.Context) {
 
 // PerformGarbageCollectionSeed performs garbage collection in the Shoot namespace in the Seed cluster
 func (g *GarbageCollection) performGarbageCollectionSeed(ctx context.Context) error {
-	return g.deleteStalePods(ctx, g.seedClient, g.shoot.SeedNamespace)
+	return kubernetesutils.DeleteStalePods(ctx, g.log, g.seedClient, client.InNamespace(g.shoot.SeedNamespace))
 }
 
 // PerformGarbageCollectionShoot performs garbage collection in the kube-system namespace in the Shoot
@@ -94,7 +90,7 @@ func (g *GarbageCollection) performGarbageCollectionShoot(ctx context.Context, s
 		namespace = metav1.NamespaceAll
 	}
 
-	return g.deleteStalePods(ctx, shootClient, namespace)
+	return kubernetesutils.DeleteStalePods(ctx, g.log, shootClient, client.InNamespace(namespace))
 }
 
 // See https://github.com/gardener/gardener/issues/8749 and https://github.com/kubernetes/kubernetes/issues/109777.
@@ -131,52 +127,4 @@ func (g *GarbageCollection) deleteOrphanedNodeLeases(ctx context.Context, c clie
 	}
 
 	return flow.ParallelN(100, taskFns...)(ctx)
-}
-
-// GardenerDeletionGracePeriod is the default grace period for Gardener's force deletion methods.
-const GardenerDeletionGracePeriod = 5 * time.Minute
-
-func (g *GarbageCollection) deleteStalePods(ctx context.Context, c client.Client, namespace string) error {
-	podList := &corev1.PodList{}
-	if err := c.List(ctx, podList, client.InNamespace(namespace)); err != nil {
-		return err
-	}
-
-	var result error
-
-	for _, pod := range podList.Items {
-		log := g.log.WithValues("pod", client.ObjectKeyFromObject(&pod))
-
-		if health.IsPodStale(pod.Status.Reason) {
-			log.V(1).Info("Deleting stale pod", "reason", pod.Status.Reason)
-			if err := c.Delete(ctx, &pod, kubernetes.DefaultDeleteOptions...); client.IgnoreNotFound(err) != nil {
-				result = multierror.Append(result, err)
-			}
-
-			continue
-		}
-
-		if shouldObjectBeRemoved(&pod, GardenerDeletionGracePeriod) {
-			g.log.V(1).Info("Deleting stuck terminating pod")
-			if err := c.Delete(ctx, &pod, kubernetes.ForceDeleteOptions...); client.IgnoreNotFound(err) != nil {
-				result = multierror.Append(result, err)
-			}
-		}
-	}
-
-	return result
-}
-
-// shouldObjectBeRemoved determines whether the given object should be gone now.
-// This is calculated by first checking the deletion timestamp of an object: If the deletion timestamp
-// is unset, the object should not be removed - i.e. this returns false.
-// Otherwise, it is checked whether the deletionTimestamp is before the current time minus the
-// grace period.
-func shouldObjectBeRemoved(obj metav1.Object, gracePeriod time.Duration) bool {
-	deletionTimestamp := obj.GetDeletionTimestamp()
-	if deletionTimestamp == nil {
-		return false
-	}
-
-	return deletionTimestamp.Time.Before(time.Now().Add(-gracePeriod))
 }

--- a/pkg/utils/kubernetes/health/deployment.go
+++ b/pkg/utils/kubernetes/health/deployment.go
@@ -11,7 +11,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -140,11 +139,17 @@ func IsDeploymentUpdated(reader client.Reader, deployment *appsv1.Deployment) fu
 // DeploymentHasExactNumberOfPods returns true when there are exactly as many pods as the .spec.replicas field of the
 // deployment mandates.
 func DeploymentHasExactNumberOfPods(ctx context.Context, reader client.Reader, deployment *appsv1.Deployment) (bool, error) {
-	podList := &metav1.PartialObjectMetadataList{}
-	podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
+	podList := &corev1.PodList{}
 	if err := reader.List(ctx, podList, client.InNamespace(deployment.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)); err != nil {
 		return false, err
 	}
 
-	return int32(len(podList.Items)) == ptr.Deref(deployment.Spec.Replicas, 1), nil
+	var numberOfRelevantPods int32
+	for _, pod := range podList.Items {
+		if !IsPodStale(pod.Status.Reason) {
+			numberOfRelevantPods++
+		}
+	}
+
+	return numberOfRelevantPods == ptr.Deref(deployment.Spec.Replicas, 1), nil
 }

--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -315,15 +315,16 @@ var _ = Describe("Deployment", func() {
 		})
 
 		It("should consider the deployment as updated even though there are still stale pods", func() {
-			for i := 0; i < 2; i++ {
-				p := pod.DeepCopy()
-				p.Status.Reason = "Evicted"
-				Expect(fakeClient.Create(ctx, p)).To(Succeed())
-			}
+			p1 := pod.DeepCopy()
+			p1.Status.Reason = "Evicted"
+			Expect(fakeClient.Create(ctx, p1)).To(Succeed())
+
+			p2 := pod.DeepCopy()
+			Expect(fakeClient.Create(ctx, p2)).To(Succeed())
 
 			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ok).To(BeFalse())
+			Expect(ok).To(BeTrue())
 		})
 	})
 })

--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -313,5 +313,17 @@ var _ = Describe("Deployment", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeFalse())
 		})
+
+		It("should consider the deployment as updated even though there are still stale pods", func() {
+			for i := 0; i < 2; i++ {
+				p := pod.DeepCopy()
+				p.Status.Reason = "Evicted"
+				Expect(fakeClient.Create(ctx, p)).To(Succeed())
+			}
+
+			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
 	})
 })

--- a/pkg/utils/kubernetes/health/pod.go
+++ b/pkg/utils/kubernetes/health/pod.go
@@ -64,5 +64,6 @@ func CheckPod(pod *corev1.Pod) error {
 func IsPodStale(reason string) bool {
 	return strings.Contains(reason, "Evicted") ||
 		strings.HasPrefix(reason, "OutOf") ||
-		strings.Contains(reason, "NodeAffinity")
+		strings.Contains(reason, "NodeAffinity") ||
+		strings.Contains(reason, "NodeLost")
 }

--- a/pkg/utils/kubernetes/health/pod.go
+++ b/pkg/utils/kubernetes/health/pod.go
@@ -8,6 +8,7 @@ package health
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -57,4 +58,11 @@ func CheckPod(pod *corev1.Pod) error {
 	}
 
 	return fmt.Errorf("pod is in invalid phase %q (expected one of %q)", pod.Status.Phase, healthyPodPhases)
+}
+
+// IsPodStale returns true when the pod reason indicates staleness.
+func IsPodStale(reason string) bool {
+	return strings.Contains(reason, "Evicted") ||
+		strings.HasPrefix(reason, "OutOf") ||
+		strings.Contains(reason, "NodeAffinity")
 }

--- a/pkg/utils/kubernetes/health/pod_test.go
+++ b/pkg/utils/kubernetes/health/pod_test.go
@@ -14,27 +14,39 @@ import (
 )
 
 var _ = Describe("Pod", func() {
-	Describe("#CheckPod", func() {
-		DescribeTable("pods",
-			func(pod *corev1.Pod, matcher types.GomegaMatcher) {
-				err := health.CheckPod(pod)
-				Expect(err).To(matcher)
+	DescribeTable("#CheckPod",
+		func(pod *corev1.Pod, matcher types.GomegaMatcher) {
+			err := health.CheckPod(pod)
+			Expect(err).To(matcher)
+		},
+
+		Entry("pending", &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
 			},
-			Entry("pending", &corev1.Pod{
-				Status: corev1.PodStatus{
-					Phase: corev1.PodPending,
-				},
-			}, HaveOccurred()),
-			Entry("running", &corev1.Pod{
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-				},
-			}, BeNil()),
-			Entry("succeeded", &corev1.Pod{
-				Status: corev1.PodStatus{
-					Phase: corev1.PodSucceeded,
-				},
-			}, BeNil()),
-		)
-	})
+		}, HaveOccurred()),
+		Entry("running", &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		}, BeNil()),
+		Entry("succeeded", &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodSucceeded,
+			},
+		}, BeNil()),
+	)
+
+	DescribeTable("#IsPodStale",
+		func(reason string, matcher types.GomegaMatcher) {
+			Expect(health.IsPodStale(reason)).To(matcher)
+		},
+
+		Entry("Evicted", "Evicted", BeTrue()),
+		Entry("OutOfCpu", "OutOfCpu", BeTrue()),
+		Entry("OutOfMemory", "OutOfMemory", BeTrue()),
+		Entry("OutOfDisk", "OutOfDisk", BeTrue()),
+		Entry("NodeAffinity", "NodeAffinity", BeTrue()),
+		Entry("Foo", "Foo", BeFalse()),
+	)
 })

--- a/pkg/utils/kubernetes/health/pod_test.go
+++ b/pkg/utils/kubernetes/health/pod_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Pod", func() {
 		Entry("OutOfMemory", "OutOfMemory", BeTrue()),
 		Entry("OutOfDisk", "OutOfDisk", BeTrue()),
 		Entry("NodeAffinity", "NodeAffinity", BeTrue()),
+		Entry("NodeLost", "NodeLost", BeTrue()),
 		Entry("Foo", "Foo", BeFalse()),
 	)
 })

--- a/pkg/utils/kubernetes/pod.go
+++ b/pkg/utils/kubernetes/pod.go
@@ -8,7 +8,10 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-multierror"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
@@ -19,6 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
 // VisitPodSpec calls the given visitor for the PodSpec contained in the given object. The visitor may mutate the
@@ -186,4 +192,53 @@ func GetDeploymentForPod(ctx context.Context, reader client.Reader, namespace st
 	}
 
 	return deployment, nil
+}
+
+// DeleteStalePods deletes stale pods.
+func DeleteStalePods(ctx context.Context, log logr.Logger, c client.Client, listOptions ...client.ListOption) error {
+	podList := &corev1.PodList{}
+	if err := c.List(ctx, podList, listOptions...); err != nil {
+		return err
+	}
+
+	var result error
+
+	for _, pod := range podList.Items {
+		logger := log.WithValues("pod", client.ObjectKeyFromObject(&pod))
+
+		if health.IsPodStale(pod.Status.Reason) {
+			logger.V(1).Info("Deleting stale pod", "reason", pod.Status.Reason)
+			if err := c.Delete(ctx, &pod, kubernetes.DefaultDeleteOptions...); client.IgnoreNotFound(err) != nil {
+				result = multierror.Append(result, err)
+			}
+
+			continue
+		}
+
+		if shouldObjectBeRemoved(&pod) {
+			logger.V(1).Info("Deleting stuck terminating pod")
+			if err := c.Delete(ctx, &pod, kubernetes.ForceDeleteOptions...); client.IgnoreNotFound(err) != nil {
+				result = multierror.Append(result, err)
+			}
+		}
+	}
+
+	return result
+}
+
+// shouldObjectBeRemoved determines whether the given object should be gone now.
+// This is calculated by first checking the deletion timestamp of an object: If the deletion timestamp
+// is unset, the object should not be removed - i.e. this returns false.
+// Otherwise, it is checked whether the deletionTimestamp is before the current time minus the
+// grace period.
+func shouldObjectBeRemoved(obj metav1.Object) bool {
+	// gardenerDeletionGracePeriod is the default grace period for Gardener's force deletion methods.
+	const gardenerDeletionGracePeriod = 5 * time.Minute
+
+	deletionTimestamp := obj.GetDeletionTimestamp()
+	if deletionTimestamp == nil {
+		return false
+	}
+
+	return deletionTimestamp.Time.Before(time.Now().Add(-gardenerDeletionGracePeriod))
 }

--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -495,12 +495,13 @@ var _ = Describe("Pod Utils", func() {
 		It("should delete the stale pods", func() {
 			var (
 				normalPod = &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{Name: "normal", Namespace: "default"},
 				}
 				stalePod = &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{Name: "stale", Namespace: "default"},
 					Status:     corev1.PodStatus{Reason: "Evicted"},
 				}
+				pods = []corev1.Pod{*normalPod, *stalePod}
 				// There is no good way with the fake client to test the deletion of the pods stuck in termination
 				// We'd have to use a mock client, but we actually want to avoid its usage.
 			)
@@ -508,7 +509,7 @@ var _ = Describe("Pod Utils", func() {
 			Expect(fakeClient.Create(ctx, normalPod)).To(Succeed())
 			Expect(fakeClient.Create(ctx, stalePod)).To(Succeed())
 
-			Expect(DeleteStalePods(ctx, logr.Discard(), fakeClient)).To(Succeed())
+			Expect(DeleteStalePods(ctx, logr.Discard(), fakeClient, pods)).To(Succeed())
 
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(normalPod), &corev1.Pod{})).To(Succeed())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(stalePod), &corev1.Pod{})).To(BeNotFoundError())

--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -7,6 +7,7 @@ package kubernetes_test
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,12 +24,20 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Pod Utils", func() {
-	var podSpec corev1.PodSpec
+	var (
+		ctx        = context.TODO()
+		fakeClient client.Client
+
+		podSpec corev1.PodSpec
+	)
 
 	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+
 		podSpec = corev1.PodSpec{
 			InitContainers: []corev1.Container{
 				{
@@ -434,16 +443,11 @@ var _ = Describe("Pod Utils", func() {
 
 	Describe("#GetDeploymentForPod", func() {
 		var (
-			ctx        = context.TODO()
-			fakeClient client.Client
-
 			deployment *appsv1.Deployment
 			replicaSet *appsv1.ReplicaSet
 		)
 
 		BeforeEach(func() {
-			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
-
 			deployment = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment", Namespace: namespace}}
 			replicaSet = &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "replicaset", Namespace: namespace, OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: deployment.Name}}}}
 		})
@@ -484,6 +488,30 @@ var _ = Describe("Pod Utils", func() {
 			deployment, err := GetDeploymentForPod(ctx, fakeClient, namespace, []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: replicaSet.Name}})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(deployment).To(Equal(deployment))
+		})
+	})
+
+	Describe("#DeleteStalePods", func() {
+		It("should delete the stale pods", func() {
+			var (
+				normalPod = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Namespace: "default"},
+				}
+				stalePod = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Namespace: "default"},
+					Status:     corev1.PodStatus{Reason: "Evicted"},
+				}
+				// There is no good way with the fake client to test the deletion of the pods stuck in termination
+				// We'd have to use a mock client, but we actually want to avoid its usage.
+			)
+
+			Expect(fakeClient.Create(ctx, normalPod)).To(Succeed())
+			Expect(fakeClient.Create(ctx, stalePod)).To(Succeed())
+
+			Expect(DeleteStalePods(ctx, logr.Discard(), fakeClient)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(normalPod), &corev1.Pod{})).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(stalePod), &corev1.Pod{})).To(BeNotFoundError())
 		})
 	})
 })

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -571,6 +571,7 @@ build:
             - pkg/utils/flow
             - pkg/utils/gardener
             - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/health
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/time
@@ -798,6 +799,7 @@ build:
             - pkg/utils/flow
             - pkg/utils/gardener
             - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/health
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/timewindow
@@ -879,6 +881,7 @@ build:
             - pkg/utils/gardener
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/bootstraptoken
+            - pkg/utils/kubernetes/health
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/timewindow

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -190,6 +190,7 @@ build:
             - pkg/utils/flow
             - pkg/utils/gardener
             - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/health
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/time
@@ -417,6 +418,7 @@ build:
             - pkg/utils/flow
             - pkg/utils/gardener
             - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/health
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/timewindow
@@ -498,6 +500,7 @@ build:
             - pkg/utils/gardener
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/bootstraptoken
+            - pkg/utils/kubernetes/health
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/timewindow

--- a/test/integration/gardenlet/seed/care/care_test.go
+++ b/test/integration/gardenlet/seed/care/care_test.go
@@ -194,7 +194,9 @@ var _ = Describe("Seed Care controller tests", func() {
 			Expect(testClient.Create(ctx, pod2)).To(Succeed())
 
 			pod1.Status.Reason = "Evicted"
+			pod2.Status.Reason = "Evicted"
 			Expect(testClient.Status().Update(ctx, pod1)).To(Succeed())
+			Expect(testClient.Status().Update(ctx, pod2)).To(Succeed())
 
 			Eventually(func() error {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(pod1), &corev1.Pod{})

--- a/test/integration/gardenlet/seed/care/care_test.go
+++ b/test/integration/gardenlet/seed/care/care_test.go
@@ -177,6 +177,33 @@ var _ = Describe("Seed Care controller tests", func() {
 				WithMessageSubstrings("All system components are healthy."),
 			))
 		})
+
+		It("should delete stale pods in all namespaces except kube-system", func() {
+			var (
+				pod1 = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Namespace: testNamespace.Name},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "foo-container", Image: "foo"}}},
+				}
+				pod2 = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Namespace: metav1.NamespaceSystem},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "foo-container", Image: "foo"}}},
+				}
+			)
+
+			Expect(testClient.Create(ctx, pod1)).To(Succeed())
+			Expect(testClient.Create(ctx, pod2)).To(Succeed())
+
+			pod1.Status.Reason = "Evicted"
+			Expect(testClient.Status().Update(ctx, pod1)).To(Succeed())
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(pod1), &corev1.Pod{})
+			}).Should(BeNotFoundError())
+
+			Consistently(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(pod2), &corev1.Pod{})
+			}).Should(Succeed())
+		})
 	})
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR addresses the concerns mentioned in #10476:

1. Stale `Pod`s (e.g., those still existing in `Evicted` or other stale statuses) are ignored when checking whether a `Deployment` rollout succeeded (i.e., whether all `Pod`s belonging to older `ReplicaSet`s have been terminated).
2. For legacy reasons, the seed garbage collection was part of `shoot-care` controller. Hence, it was only active in shoot namespaces in the seed cluster. Now, we have moved this part to the `seed-care` controller. It will be active in all namespaces in the seed except for `kube-system`. If the seed is a managed seed (i.e., a shoot cluster), then the still existing garbage collection in the `shoot-care` controller will take care of it. If it is an unmanaged seed, it is out of the responsibility of `gardenlet`.

**Which issue(s) this PR fixes**:
Fixes #10476

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardenlet` now performs garbage collection of stale `Pod`s in all namespaces (except `kube-system`) in the seed cluster.
```
```bugfix operator
When checking whether a `Deployment` rollout is complete, stale `Pod`s are now ignored and no longer counted.
```