### PR TITLE
chore(utils): add AppendUniqueDropIn

### DIFF
--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -82,6 +82,9 @@ type Ensurer interface {
 	// EnsureAdditionalProvisionFiles ensures additional systemd files for the 'provision' OSC
 	// "old" might be "nil" and must always be checked.
 	EnsureAdditionalProvisionFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *[]extensionsv1alpha1.File) error
+	// EnsureAdditionalProvisionDropIns ensures additional systemd files for the 'provision' OSC
+	// "old" might be "nil" and must always be checked.
+	EnsureAdditionalProvisionDropIns(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *[]extensionsv1alpha1.DropIn) error
 	// EnsureCRIConfig ensures the CRI config.
 	// "old" might be "nil" and must always be checked.
 	EnsureCRIConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *extensionsv1alpha1.CRIConfig) error

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -23,7 +23,7 @@ func LogMutation(logger logr.Logger, kind, namespace, name string) {
 	logger.Info("Mutating resource", "kind", kind, "namespace", namespace, "name", name)
 }
 
-// AppendUniqueUnit appens a unit only if it does not exist.
+// AppendUniqueUnit appends a unit only if it does not exist.
 func AppendUniqueUnit(units *[]extensionsv1alpha1.Unit, unit extensionsv1alpha1.Unit) {
 	for _, un := range *units {
 		if un.Name == unit.Name {
@@ -31,6 +31,16 @@ func AppendUniqueUnit(units *[]extensionsv1alpha1.Unit, unit extensionsv1alpha1.
 		}
 	}
 	*units = append(*units, unit)
+}
+
+// AppendUniqueDropIn appends a unit only if it does not exist.
+func AppendUniqueDropIn(dropins *[]extensionsv1alpha1.DropIn, dropin extensionsv1alpha1.DropIn) {
+	for _, un := range *dropins {
+		if un.Name == dropin.Name {
+			return
+		}
+	}
+	*dropins = append(*dropins, dropin)
 }
 
 // splitCommandLineRegex is used to split command line arguments by white space or "\".


### PR DESCRIPTION
**How to categorize this PR?**
/area usability
/kind enhancement

**What this PR does / why we need it**:
Since extensions like https://github.com/gardener/gardener-extension-provider-equinix-metal/blob/master/pkg/webhook/controlplane/ensurer.go#L154 make use of this util to append units, however it is not possible to also uniqueAppend DropIns like this

**Special notes for your reviewer**:
NONE
**Release note**:
NONE


