### PR TITLE
Utilization Improvements for `kube-{controller-manager,scheduler}`, `gardener-resource-manager`, `plutono-dashboard-refresher`, `vali`, `blackbox-exporter`, `prometheus-shoot`, `machine-controller-manager`, `cluster-autoscaler`

### DIFF
--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -110,10 +110,6 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 		podDisruptionBudget = c.emptyPodDisruptionBudget()
 		serviceMonitor      = c.emptyServiceMonitor()
 		prometheusRule      = c.emptyPrometheusRule()
-
-		vpaUpdateMode    = vpaautoscalingv1.UpdateModeAuto
-		controlledValues = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-		command          = c.computeCommand()
 	)
 
 	genericTokenKubeconfigSecret, found := c.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
@@ -205,7 +201,7 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 						Name:            containerName,
 						Image:           c.image,
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Command:         command,
+						Command:         c.computeCommand(),
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          portNameMetrics,
@@ -263,18 +259,13 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 			Name:       v1beta1constants.DeploymentNameClusterAutoscaler,
 		}
 		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{
-			UpdateMode: &vpaUpdateMode,
+			UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
 		}
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
-			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-				{
-					ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
-					MinAllowed: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("50Mi"),
-					},
-					ControlledValues: &controlledValues,
-				},
-			},
+			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+				ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+			}},
 		}
 		return nil
 	}); err != nil {

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -221,8 +221,8 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("300Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("30M"),
 							},
 						},
 					},

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -346,8 +346,8 @@ var _ = Describe("ClusterAutoscaler", func() {
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("100m"),
-											corev1.ResourceMemory: resource.MustParse("300Mi"),
+											corev1.ResourceCPU:    resource.MustParse("5m"),
+											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},
 								},

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -112,9 +112,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 		deploymentName                   = "cluster-autoscaler"
 		managedResourceName              = "shoot-core-cluster-autoscaler"
 
-		vpaUpdateMode    = vpaautoscalingv1.UpdateModeAuto
-		controlledValues = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-		vpa              = &vpaautoscalingv1.VerticalPodAutoscaler{
+		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{Name: vpaName, Namespace: namespace, ResourceVersion: "1"},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 				TargetRef: &autoscalingv1.CrossVersionObjectReference{
@@ -123,18 +121,13 @@ var _ = Describe("ClusterAutoscaler", func() {
 					Name:       deploymentName,
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-					UpdateMode: &vpaUpdateMode,
+					UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-						{
-							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-							},
-							ControlledValues: &controlledValues,
-						},
-					},
+					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+						ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					}},
 				},
 			},
 		}

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -298,8 +298,6 @@ type Values struct {
 	WatchedNamespace *string
 	// RuntimeKubernetesVersion is the Kubernetes version of the runtime cluster.
 	RuntimeKubernetesVersion *semver.Version
-	// VPA contains information for configuring VerticalPodAutoscaler settings for the gardener-resource-manager deployment.
-	VPA *VPAConfig
 	// SchedulingProfile is the kube-scheduler profile configured for the Shoot.
 	SchedulingProfile *gardencorev1beta1.SchedulingProfile
 	// DefaultSeccompProfileEnabled specifies if the defaulting seccomp profile webhook of GRM should be enabled or not.
@@ -324,13 +322,6 @@ type Values struct {
 	// operating system configs on nodes. When this is provided, the respective controller is enabled in
 	// resource-manager.
 	NodeAgentReconciliationMaxDelay *metav1.Duration
-}
-
-// VPAConfig contains information for configuring VerticalPodAutoscaler settings for the gardener-resource-manager deployment.
-type VPAConfig struct {
-	// MinAllowed specifies the minimal amount of resources that will be recommended
-	// for the container.
-	MinAllowed corev1.ResourceList
 }
 
 func (r *resourceManager) Deploy(ctx context.Context) error {
@@ -1059,8 +1050,6 @@ func (r *resourceManager) emptyServiceAccount() *corev1.ServiceAccount {
 
 func (r *resourceManager) ensureVPA(ctx context.Context) error {
 	vpa := r.emptyVPA()
-	vpaUpdateMode := vpaautoscalingv1.UpdateModeAuto
-	controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.client, vpa, func() error {
 		vpa.Labels = r.getLabels()
@@ -1070,20 +1059,13 @@ func (r *resourceManager) ensureVPA(ctx context.Context) error {
 			Name:       r.values.NamePrefix + v1beta1constants.DeploymentNameGardenerResourceManager,
 		}
 		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{
-			UpdateMode: &vpaUpdateMode,
+			UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
 		}
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
-			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-				{
-					ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
-					MinAllowed:    r.values.VPA.MinAllowed,
-					MaxAllowed: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4"),
-						corev1.ResourceMemory: resource.MustParse("10G"),
-					},
-					ControlledValues: &controlledValues,
-				},
-			},
+			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+				ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+			}},
 		}
 		return nil
 	})

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -837,8 +837,8 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("23m"),
-								corev1.ResourceMemory: resource.MustParse("47Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("30M"),
 							},
 						},
 						LivenessProbe: &corev1.Probe{

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -587,8 +587,8 @@ var _ = Describe("ResourceManager", func() {
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("23m"),
-											corev1.ResourceMemory: resource.MustParse("47Mi"),
+											corev1.ResourceCPU:    resource.MustParse("5m"),
+											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},
 									VolumeMounts: []corev1.VolumeMount{

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -130,8 +130,6 @@ var _ = Describe("ResourceManager", func() {
 		secret                              *corev1.Secret
 		service                             *corev1.Service
 		serviceAccount                      *corev1.ServiceAccount
-		updateMode                          = vpaautoscalingv1.UpdateModeAuto
-		controlledValues                    = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 		pdb                                 *policyv1.PodDisruptionBudget
 		serviceMonitorFor                   func(string) *monitoringv1.ServiceMonitor
 		vpa                                 *vpaautoscalingv1.VerticalPodAutoscaler
@@ -330,14 +328,9 @@ var _ = Describe("ResourceManager", func() {
 				{Key: "b"},
 				{Key: "c"},
 			},
-			TargetDiffersFromSourceCluster: true,
-			TargetDisableCache:             &targetDisableCache,
-			WatchedNamespace:               &watchedNamespace,
-			VPA: &VPAConfig{
-				MinAllowed: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("30Mi"),
-				},
-			},
+			TargetDiffersFromSourceCluster:      true,
+			TargetDisableCache:                  &targetDisableCache,
+			WatchedNamespace:                    &watchedNamespace,
 			SchedulingProfile:                   &binPackingSchedulingProfile,
 			DefaultSeccompProfileEnabled:        false,
 			EndpointSliceHintsEnabled:           false,
@@ -821,22 +814,13 @@ var _ = Describe("ResourceManager", func() {
 					Name:       "gardener-resource-manager",
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-					UpdateMode: &updateMode,
+					UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-						{
-							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("30Mi"),
-							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("4"),
-								corev1.ResourceMemory: resource.MustParse("10G"),
-							},
-							ControlledValues: &controlledValues,
-						},
-					},
+					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+						ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					}},
 				},
 			},
 		}

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -463,14 +463,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		}
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-				ContainerName: containerName,
-				MinAllowed: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("50Mi"),
-				},
-				MaxAllowed: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("4"),
-					corev1.ResourceMemory: resource.MustParse("10G"),
-				},
+				ContainerName:    containerName,
 				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 			}},
 		}

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -351,8 +351,8 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("128Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("30M"),
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -187,14 +187,7 @@ var _ = Describe("KubeControllerManager", func() {
 					},
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-							ContainerName: "kube-controller-manager",
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("4"),
-								corev1.ResourceMemory: resource.MustParse("10G"),
-							},
+							ContainerName:    "kube-controller-manager",
 							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 						}},
 					},

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -388,8 +388,8 @@ var _ = Describe("KubeControllerManager", func() {
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("100m"),
-											corev1.ResourceMemory: resource.MustParse("128Mi"),
+											corev1.ResourceCPU:    resource.MustParse("5m"),
+											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},
 									VolumeMounts: []corev1.VolumeMount{

--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -169,12 +169,10 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 		serviceMonitor      = k.emptyServiceMonitor()
 		prometheusRule      = k.emptyPrometheusRule()
 
-		vpaUpdateMode          = vpaautoscalingv1.UpdateModeAuto
-		controlledValues       = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-		port             int32 = 10259
-		probeURIScheme         = corev1.URISchemeHTTPS
-		env                    = k.computeEnvironmentVariables()
-		command                = k.computeCommand(port)
+		port           int32 = 10259
+		probeURIScheme       = corev1.URISchemeHTTPS
+		env                  = k.computeEnvironmentVariables()
+		command              = k.computeCommand(port)
 	)
 
 	if err := k.client.Create(ctx, configMap); client.IgnoreAlreadyExists(err) != nil {
@@ -359,22 +357,13 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 			Name:       v1beta1constants.DeploymentNameKubeScheduler,
 		}
 		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{
-			UpdateMode: &vpaUpdateMode,
+			UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
 		}
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
-			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-				{
-					ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
-					MinAllowed: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("50Mi"),
-					},
-					MaxAllowed: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4"),
-						corev1.ResourceMemory: resource.MustParse("10G"),
-					},
-					ControlledValues: &controlledValues,
-				},
-			},
+			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+				ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+			}},
 		}
 		return nil
 	}); err != nil {

--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -263,8 +263,8 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 						Env: env,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("23m"),
-								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("30M"),
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{

--- a/pkg/component/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/component/kubernetes/scheduler/scheduler_test.go
@@ -143,9 +143,7 @@ var _ = Describe("KubeScheduler", func() {
 			return pdb
 		}
 
-		vpaUpdateMode    = vpaautoscalingv1.UpdateModeAuto
-		controlledValues = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-		vpa              = &vpaautoscalingv1.VerticalPodAutoscaler{
+		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{Name: vpaName, Namespace: namespace, ResourceVersion: "1"},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 				TargetRef: &autoscalingv1.CrossVersionObjectReference{
@@ -154,22 +152,13 @@ var _ = Describe("KubeScheduler", func() {
 					Name:       deploymentName,
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-					UpdateMode: &vpaUpdateMode,
+					UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-						{
-							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("4"),
-								corev1.ResourceMemory: resource.MustParse("10G"),
-							},
-							ControlledValues: &controlledValues,
-						},
-					},
+					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+						ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					}},
 				},
 			},
 		}

--- a/pkg/component/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/component/kubernetes/scheduler/scheduler_test.go
@@ -272,8 +272,8 @@ var _ = Describe("KubeScheduler", func() {
 									Env: env,
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("23m"),
-											corev1.ResourceMemory: resource.MustParse("64Mi"),
+											corev1.ResourceCPU:    resource.MustParse("5m"),
+											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},
 									VolumeMounts: []corev1.VolumeMount{

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -244,9 +244,6 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 							corev1.ResourceCPU:    resource.MustParse("5m"),
 							corev1.ResourceMemory: resource.MustParse("20M"),
 						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("1024Mi"),
-						},
 					}},
 				},
 				PriorityClassName:             v1beta1constants.PriorityClassNameShootControlPlane300,

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -241,8 +241,8 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 					}},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("31m"),
-							corev1.ResourceMemory: resource.MustParse("70Mi"),
+							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceMemory: resource.MustParse("20M"),
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1024Mi"),

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -106,9 +106,6 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 		vpa                 = m.emptyVPA()
 		prometheusRule      = m.emptyPrometheusRule()
 		serviceMonitor      = m.emptyServiceMonitor()
-
-		vpaUpdateMode       = vpaautoscalingv1.UpdateModeAuto
-		vpaControlledValues = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 	)
 
 	genericTokenKubeconfigSecret, found := m.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
@@ -285,18 +282,11 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 			Kind:       "Deployment",
 			Name:       deployment.Name,
 		}
-		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{UpdateMode: &vpaUpdateMode}
+		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto)}
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
 				ContainerName:    containerName,
-				ControlledValues: &vpaControlledValues,
-				MinAllowed: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("70Mi"),
-				},
-				MaxAllowed: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("2"),
-					corev1.ResourceMemory: resource.MustParse("5G"),
-				},
+				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 			}},
 		}
 		return nil

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -295,13 +295,6 @@ var _ = Describe("MachineControllerManager", func() {
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
 						ContainerName:    "machine-controller-manager",
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-						MinAllowed: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("70Mi"),
-						},
-						MaxAllowed: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("2"),
-							corev1.ResourceMemory: resource.MustParse("5G"),
-						},
 					}},
 				},
 			},

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -240,9 +240,6 @@ var _ = Describe("MachineControllerManager", func() {
 									corev1.ResourceCPU:    resource.MustParse("5m"),
 									corev1.ResourceMemory: resource.MustParse("20M"),
 								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("1Gi"),
-								},
 							},
 						}},
 						PriorityClassName:             "gardener-system-300",

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -237,8 +237,8 @@ var _ = Describe("MachineControllerManager", func() {
 							}},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("31m"),
-									corev1.ResourceMemory: resource.MustParse("70Mi"),
+									corev1.ResourceCPU:    resource.MustParse("5m"),
+									corev1.ResourceMemory: resource.MustParse("20M"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("1Gi"),

--- a/pkg/component/nodemanagement/machinecontrollermanager/provider.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/provider.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/ptr"
 
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -70,13 +71,10 @@ func ProviderSidecarContainer(namespace, providerName, image string) corev1.Cont
 // ProviderSidecarVPAContainerPolicy returns a vpaautoscalingv1.ContainerResourcePolicy object which can be injected
 // into the machine-controller-manager-vpa VPA managed by the gardenlet. This function can be used in provider-specific
 // control plane webhook implementations when the standard container policy for the sidecar is required.
-func ProviderSidecarVPAContainerPolicy(providerName string, minAllowed, maxAllowed corev1.ResourceList) vpaautoscalingv1.ContainerResourcePolicy {
-	ccv := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
+func ProviderSidecarVPAContainerPolicy(providerName string) vpaautoscalingv1.ContainerResourcePolicy {
 	return vpaautoscalingv1.ContainerResourcePolicy{
 		ContainerName:    providerSidecarContainerName(providerName),
-		ControlledValues: &ccv,
-		MinAllowed:       minAllowed,
-		MaxAllowed:       maxAllowed,
+		ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 	}
 }
 

--- a/pkg/component/nodemanagement/machinecontrollermanager/provider_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/provider_test.go
@@ -8,9 +8,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
 )
@@ -69,17 +69,9 @@ var _ = Describe("Provider", func() {
 	})
 
 	It("should return a default VPA container policy object for the provider-specific sidecar container", func() {
-		var (
-			ccv        = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-			minAllowed = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1M")}
-			maxAllowed = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5M")}
-		)
-
-		Expect(ProviderSidecarVPAContainerPolicy(provider, minAllowed, maxAllowed)).To(Equal(vpaautoscalingv1.ContainerResourcePolicy{
+		Expect(ProviderSidecarVPAContainerPolicy(provider)).To(Equal(vpaautoscalingv1.ContainerResourcePolicy{
 			ContainerName:    "machine-controller-manager-" + provider,
-			ControlledValues: &ccv,
-			MinAllowed:       minAllowed,
-			MaxAllowed:       maxAllowed,
+			ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 		}))
 	})
 })

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -575,8 +575,8 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("20m"),
-										corev1.ResourceMemory: resource.MustParse("300Mi"),
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("100M"),
 									},
 								},
 								SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -297,14 +297,7 @@ func (v *vali) getVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 					{
-						ContainerName: valiName,
-						MinAllowed: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("200M"),
-						},
-						MaxAllowed: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("800m"),
-							corev1.ResourceMemory: resource.MustParse("3Gi"),
-						},
+						ContainerName:    valiName,
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},
 					{

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -578,9 +578,6 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 										corev1.ResourceCPU:    resource.MustParse("20m"),
 										corev1.ResourceMemory: resource.MustParse("300Mi"),
 									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("3Gi"),
-									},
 								},
 								SecurityContext: &corev1.SecurityContext{
 									RunAsUser:              ptr.To(valiUserAndGroupId),
@@ -613,9 +610,6 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("5m"),
 										corev1.ResourceMemory: resource.MustParse("15Mi"),
-									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("700Mi"),
 									},
 								},
 								SecurityContext: &corev1.SecurityContext{
@@ -681,9 +675,6 @@ func (v *vali) getStatefulSet(valiConfigMapName, telegrafConfigMapName, genericT
 						corev1.ResourceCPU:    resource.MustParse("5m"),
 						corev1.ResourceMemory: resource.MustParse("30Mi"),
 					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("150Mi"),
-					},
 				},
 				Ports: []corev1.ContainerPort{{
 					Name:          kubeRBACProxyName,
@@ -713,9 +704,6 @@ wait
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("5m"),
 						corev1.ResourceMemory: resource.MustParse("45Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("350Mi"),
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -1020,14 +1020,7 @@ func getVPA(isRBACProxyEnabled bool) *vpaautoscalingv1.VerticalPodAutoscaler {
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 					{
-						ContainerName: valiName,
-						MinAllowed: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("200M"),
-						},
-						MaxAllowed: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("800m"),
-							corev1.ResourceMemory: resource.MustParse("3Gi"),
-						},
+						ContainerName:    valiName,
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},
 					{

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -1199,8 +1199,8 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("20m"),
-									corev1.ResourceMemory: resource.MustParse("300Mi"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("100M"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -1202,9 +1202,6 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 									corev1.ResourceCPU:    resource.MustParse("20m"),
 									corev1.ResourceMemory: resource.MustParse("300Mi"),
 								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("3Gi"),
-								},
 							},
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:              ptr.To[int64](10001),
@@ -1241,9 +1238,6 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("5m"),
 									corev1.ResourceMemory: resource.MustParse("15Mi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("700Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
@@ -1309,9 +1303,6 @@ func getStatefulSet(isRBACProxyEnabled bool) *appsv1.StatefulSet {
 						corev1.ResourceCPU:    resource.MustParse("5m"),
 						corev1.ResourceMemory: resource.MustParse("30Mi"),
 					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("150Mi"),
-					},
 				},
 				Ports: []corev1.ContainerPort{
 					{
@@ -1350,9 +1341,6 @@ wait
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("5m"),
 						corev1.ResourceMemory: resource.MustParse("45Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("350Mi"),
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
@@ -246,7 +246,6 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("10m"),
 										corev1.ResourceMemory: resource.MustParse("25Mi"),
 									},
 								},

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
@@ -246,7 +246,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("25Mi"),
+										corev1.ResourceMemory: resource.MustParse("15M"),
 									},
 								},
 								Ports: []corev1.ContainerPort{

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
@@ -364,8 +364,9 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
-							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+							ContainerName:       vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ControlledValues:    ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+							ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 						},
 					},
 				},

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
@@ -328,6 +328,8 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: '*'
+      controlledResources:
+      - memory
       controlledValues: RequestsOnly
   targetRef:
     apiVersion: apps/v1

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
@@ -201,7 +201,6 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 10m
             memory: 25Mi
         volumeMounts:
         - mountPath: /etc/blackbox_exporter

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter_test.go
@@ -201,7 +201,7 @@ spec:
           protocol: TCP
         resources:
           requests:
-            memory: 25Mi
+            memory: 15M
         volumeMounts:
         - mountPath: /etc/blackbox_exporter
           name: blackbox-exporter-config`

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -104,6 +104,8 @@ type Values struct {
 	AdditionalAlertRelabelConfigs []monitoringv1.RelabelConfig
 	// RestrictToNamespace controls whether the Prometheus instance should only scrape its targets in its own namespace.
 	RestrictToNamespace bool
+	// ResourceRequests defines the initial resource requests
+	ResourceRequests *corev1.ResourceList
 }
 
 // CentralConfigs contains configuration for this Prometheus instance that is created together with it. This should

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -52,10 +52,10 @@ func (p *prometheus) prometheus(cortexConfigMap *corev1.ConfigMap) *monitoringv1
 				ImagePullPolicy:   corev1.PullIfNotPresent,
 				Version:           p.values.Version,
 				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
+					Requests: ptr.Deref(p.values.ResourceRequests, corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("300m"),
 						corev1.ResourceMemory: resource.MustParse("1000Mi"),
-					},
+					}),
 				},
 				ServiceAccountName: p.name(),
 				SecurityContext:    &corev1.PodSecurityContext{RunAsUser: ptr.To[int64](0)},

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -336,7 +336,7 @@ honor_labels: true`
 						{
 							ContainerName: "prometheus",
 							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("1000M"),
+								corev1.ResourceMemory: resource.MustParse("100M"),
 							},
 							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 						},

--- a/pkg/component/observability/monitoring/prometheus/vpa.go
+++ b/pkg/component/observability/monitoring/prometheus/vpa.go
@@ -40,7 +40,7 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 					{
 						ContainerName: "prometheus",
 						MinAllowed: ptr.Deref(p.values.VPAMinAllowed, corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("1000M"),
+							corev1.ResourceMemory: resource.MustParse("100M"),
 						}),
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},

--- a/pkg/component/observability/monitoring/prometheusoperator/deployment.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/deployment.go
@@ -52,9 +52,9 @@ func (p *prometheusOperator) deployment() *appsv1.Deployment {
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								fmt.Sprintf("--prometheus-config-reloader=%s", p.values.ImageConfigReloader),
-								"--config-reloader-cpu-request=10m",
+								"--config-reloader-cpu-request=0",
 								"--config-reloader-cpu-limit=0",
-								"--config-reloader-memory-request=25Mi",
+								"--config-reloader-memory-request=20M",
 								"--config-reloader-memory-limit=0",
 								"--enable-config-reloader-probes=false",
 							},

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -154,9 +154,9 @@ var _ = Describe("PrometheusOperator", func() {
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Args: []string{
 									"--prometheus-config-reloader=" + imageReloader,
-									"--config-reloader-cpu-request=10m",
+									"--config-reloader-cpu-request=0",
 									"--config-reloader-cpu-limit=0",
-									"--config-reloader-memory-request=25Mi",
+									"--config-reloader-memory-request=20M",
 									"--config-reloader-memory-limit=0",
 									"--enable-config-reloader-probes=false",
 								},

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -634,7 +634,7 @@ func (p *plutono) getDeployment(providerConfigMap, dataSourceConfigMap *corev1.C
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("5m"),
-									corev1.ResourceMemory: resource.MustParse("64Mi"),
+									corev1.ResourceMemory: resource.MustParse("85M"),
 								},
 							},
 						},

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -380,7 +380,7 @@ metadata:
 										Resources: corev1.ResourceRequirements{
 											Requests: corev1.ResourceList{
 												corev1.ResourceCPU:    resource.MustParse("5m"),
-												corev1.ResourceMemory: resource.MustParse("64Mi"),
+												corev1.ResourceMemory: resource.MustParse("85M"),
 											},
 										},
 									},

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/component-base/version"
@@ -94,12 +93,7 @@ func NewRuntimeGardenerResourceManager(
 		SecretNameServerCA:                  secretNameServerCA,
 		SyncPeriod:                          &metav1.Duration{Duration: time.Hour},
 		RuntimeKubernetesVersion:            runtimeVersion,
-		VPA: &resourcemanager.VPAConfig{
-			MinAllowed: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("64Mi"),
-			},
-		},
-		Zones: zones,
+		Zones:                               zones,
 	}), nil
 }
 
@@ -160,15 +154,10 @@ func NewTargetGardenerResourceManager(
 		TargetDiffersFromSourceCluster:       true,
 		TargetNamespaces:                     targetNamespaces,
 		RuntimeKubernetesVersion:             kubernetesVersion,
-		VPA: &resourcemanager.VPAConfig{
-			MinAllowed: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("30Mi"),
-			},
-		},
-		WatchedNamespace:                &namespaceName,
-		TopologyAwareRoutingEnabled:     topologyAwareRoutingEnabled,
-		IsWorkerless:                    isWorkerless,
-		NodeAgentReconciliationMaxDelay: nodeAgentReconciliationMaxDelay,
+		WatchedNamespace:                     &namespaceName,
+		TopologyAwareRoutingEnabled:          topologyAwareRoutingEnabled,
+		IsWorkerless:                         isWorkerless,
+		NodeAgentReconciliationMaxDelay:      nodeAgentReconciliationMaxDelay,
 	}
 
 	return resourcemanager.New(

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
@@ -91,6 +92,10 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		Retention:           ptr.To(monitoringv1.Duration("30d")),
 		RetentionSize:       "15GB",
 		RestrictToNamespace: true,
+		ResourceRequests: &corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("400M"),
+		},
 		AdditionalPodLabels: map[string]string{
 			"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyScrapeTargets:  v1beta1constants.LabelNetworkPolicyAllowed,
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.GardenNamespace+"-prometheus-cache", 9090):  v1beta1constants.LabelNetworkPolicyAllowed,

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -12,8 +12,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/ptr"
@@ -56,19 +54,9 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(_ context.Context, _ 
 
 // EnsureMachineControllerManagerVPA ensures that the machine-controller-manager VPA conforms to the provider requirements.
 func (e *ensurer) EnsureMachineControllerManagerVPA(_ context.Context, _ extensionscontextwebhook.GardenContext, newObj, _ *vpaautoscalingv1.VerticalPodAutoscaler) error {
-	var (
-		minAllowed = corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
-		}
-		maxAllowed = corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("2"),
-			corev1.ResourceMemory: resource.MustParse("5G"),
-		}
-	)
-
 	newObj.Spec.ResourcePolicy.ContainerPolicies = webhook.EnsureVPAContainerResourcePolicyWithName(
 		newObj.Spec.ResourcePolicy.ContainerPolicies,
-		machinecontrollermanager.ProviderSidecarVPAContainerPolicy(local.Name, minAllowed, maxAllowed),
+		machinecontrollermanager.ProviderSidecarVPAContainerPolicy(local.Name),
 	)
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost auto-scaling
/kind enhancement

**What this PR does / why we need it**:
As requested by @vlerenc:

##### `kube-scheduler`, `kube-controller-manager`, `gardener-resource-manager`

> Can we please drop `{min|max}Allowed`? `minAllowed` is sometimes higher than usage (evident from the data), so we waste resources. `maxAllowed` is generally not good (risk of under-cross-charging and under-reservations leading to less revenue and noisy neighbors/outages). Even today, we see it happens already for `gardener-resource-manager` for memory, so we already under-cross-charge (less revenue) and under-reserve (noisy neighbor problem) memory.

> While we are at it, can we please also change the initial resource requests to the observed 5th usage percentile, which is round-about 2m/30M, let's say 5m/30M.

##### `plutono-dashboard-refresher`

> Can we please change the resource requests for plutono--dashboard-refresher from 64Mi to 85M as we are underprovisioning this container (requested 390G, but used 460G) and not charging our end users accordingly.

##### `vali`

> Can we please drop {min|max}Allowed from the vali--vali container? minAllowed is often higher than usage, so we waste resources. maxAllowed is generally not good (risk of under-cross-charging and under-reservations leading to less revenue and noisy neighbors/outages), whether it happens today or not (it may happen tomorrow).

> Can we please also right-size the initial requests further? Starting at the 5th usage percentile appears sufficient also for other components. For the vali--vali container that would mean 1m and 80MB. Since 1m is below VPA's smallest resolution/slice of 10m/10M, and adding some buffer to memory, this would mean 10m and 100M, please.

> Can you please also consider dropping the memory limit? It can make sense to have a memory limit if we know what the value should reasonably be, but since the load varies between clusters, having a limit may result in OOM loops or at least reduce the availability of the logging stack.

##### `blackbox-exporter`

> Can we please drop the CPU requests completely from container resource requests and VPA? CPU usage is on average 0 and maximum 3m while VPA's smallest slice technically is 10m/10M. Consequently, CPU requests are always 10m for all clusters in all landscapes.
> Orienting at the 5th usage percentile, initial memory requests can be rather 10M or 15M.

##### `prometheus` and `config-reloader`

> - `prometheus` 5th CPU and memory usage percentile is dramatically below initial requests and its minimum memory usage is dramatically below VPA `minAllowed`, so we waste a lot of resources
> - `config-reloader` has an average CPU usage of 0m and max CPU usage of 0m and 95th memory usage of 18M with only little spread, so it's not worth having it under VPA as VPA's smallest slice/resolution is 10m/10M and any (tiny) resizing leads to pod eviction/disruption; furthermore these side cars are usually dwarfed by their main container that VPA usually overprovisioned for by 5%-15%

##### `machine-controller-manager` and `cluster-autoscaler`

> Can we please drop `{min|max}Allowed`? `minAllowed` is sometimes higher than usage (evident from the data), so we waste resources. `maxAllowed` is generally not good (risk of under-cross-charging and under-reservations leading to less revenue and noisy neighbors/outages). While we are at it, can we please also change the initial resource requests to the observed 5th usage percentile?
> 
> - `cluster-autoscaler`
>   - `minAllowed` dropped
>   - (Initial) resource requests changed from 100m/300Mi to 5m/30M
> - `machine-controller-manager`:
>   - `{min|max}Allowed` dropped
>   - (Initial) resource requests changed from 31m/70Mi to 5m/20M
>   - Memory limits dropped (if reasonable/insufficient confidence that 1G is the right limit)
> - `machine-controller-manager-provider-*`:
>   - `{min|max}Allowed` dropped

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
