### PR TITLE
Improve utilization for node-local-dns.

### DIFF
--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -361,7 +361,7 @@ ip6.arpa:53 {
 										corev1.ResourceMemory: resource.MustParse("25Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("100Mi"),
+										corev1.ResourceMemory: resource.MustParse("200Mi"),
 									},
 								},
 								Args: []string{
@@ -494,7 +494,8 @@ ip6.arpa:53 {
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					}},
 				},
 			},

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -493,18 +493,9 @@ ip6.arpa:53 {
 					UpdateMode: &vpaUpdateMode,
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-						{
-							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("20Mi"),
-							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("200Mi"),
-							},
-						},
-					},
+					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+					}},
 				},
 			},
 		}

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -412,7 +412,7 @@ status:
 										Image: values.Image,
 										Resources: corev1.ResourceRequirements{
 											Limits: corev1.ResourceList{
-												corev1.ResourceMemory: resource.MustParse("100Mi"),
+												corev1.ResourceMemory: resource.MustParse("200Mi"),
 											},
 											Requests: corev1.ResourceList{
 												corev1.ResourceCPU:    resource.MustParse("25m"),
@@ -538,6 +538,7 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: '*'
+      controlledValues: RequestsOnly
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -538,11 +538,6 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: '*'
-      maxAllowed:
-        cpu: 100m
-        memory: 200Mi
-      minAllowed:
-        memory: 20Mi
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:

Improve utilization for node-local-dns by removing VPA `(min|max)Allowed` settings.

`minAllowed` may cause wasted resources while `maxAllowed` may cause under-reservation and hence noisy neighbor issues. This change removes the settings for node-local-dns components.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Similar to https://github.com/gardener/gardener/pull/10555, but for `node-local-dns` component.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```

/cc @axel7born @DockToFuture 