### PR TITLE
local setup: Disable the HVPA feature gates

### DIFF
--- a/charts/gardener/operator/values.yaml
+++ b/charts/gardener/operator/values.yaml
@@ -56,7 +56,6 @@ config:
     enableContentionProfiling: false
   featureGates:
     DefaultSeccompProfile: true
-    HVPA: true
   controllers:
     garden:
       concurrentSyncs: 1

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -443,8 +443,6 @@ spec:
         concurrentSyncs: 0
     featureGates:
       DefaultSeccompProfile: true
-      HVPA: true
-      HVPAForShootedSeed: true
       IPv6SingleStack: true
       ShootManagedIssuer: true
     etcdConfig:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -115,8 +115,6 @@ debugging:
   enableProfiling: false
   enableContentionProfiling: false
 featureGates:
-  HVPA: true
-  HVPAForShootedSeed: true
   DefaultSeccompProfile: true
   # Enable IPv6SingleStack to allow creating IPv6 seed clusters without changing the config.
   # This feature gate doesn't change gardenlet's default behavior, it only allows setting `ipFamilies=[IPv6]` in the

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -36,8 +36,6 @@ config:
     shootState:
       concurrentSyncs: 0 # we don't need the shootstate controller locally, and enabling it would even distort the results of CPM e2e tests
   featureGates:
-    HVPA: true
-    HVPAForShootedSeed: true
     DefaultSeccompProfile: true
     # Enable IPv6SingleStack to allow creating IPv6 seed clusters without changing the config.
     # This feature gate doesn't change gardenlet's default behavior, it only allows setting `ipFamilies=[IPv6]` in the

--- a/example/operator/10-componentconfig.yaml
+++ b/example/operator/10-componentconfig.yaml
@@ -29,7 +29,6 @@ debugging:
   enableContentionProfiling: false
 featureGates:
   DefaultSeccompProfile: true
-  HVPA: true
 controllers:
   garden:
     concurrentSyncs: 1

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -89,7 +89,6 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(runtimeClient.List(ctx, managedResourceList, client.InNamespace(namespace))).To(Succeed())
 			g.Expect(managedResourceList.Items).To(ConsistOf(
-				healthyManagedResource("hvpa"),
 				healthyManagedResource("vpa"),
 				healthyManagedResource("etcd-druid"),
 				healthyManagedResource("kube-state-metrics-runtime"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
The etcd and kube-apiserver are the only 2 components left that can use HVPA for autoscaling. However, with the promotion  of the `VPAForETCD` and and `VPAAndHPAForAPIServer` features gates to beta and their enablement by default, HVPA is no longer used (unless it is explicitly requested by the configuration of the feature gates).
Current, when the `VPAForETCD` and and `VPAAndHPAForAPIServer` are enabled (which is the default) and when the HVPA feature gate is enabled then the HVPA CRD and the hvpa-controller are unnecessarily deployed.
This PR disables the HVPA feature gate in local setups so that the HVPA CRD and the hvpa-controller are NOT unnecessarily deployed.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The gardener operator chart (`charts/gardener/operator`) does no longer enable the `HVPA` feature gate in its default `values.yaml`.
```

```other developer
The HVPA features gates (`HVPA` and `HVPAForShootedSeed`) are no longer enabled in local setups.
```
