### PR TITLE
Adapt VPA resources

### DIFF
--- a/pkg/component/autoscaling/vpa/admissioncontroller.go
+++ b/pkg/component/autoscaling/vpa/admissioncontroller.go
@@ -216,11 +216,8 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 					LivenessProbe: newDefaultLivenessProbe(),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("30m"),
-							corev1.ResourceMemory: resource.MustParse("200Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("3Gi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("30Mi"),
 						},
 					},
 					Ports: []corev1.ContainerPort{
@@ -297,24 +294,18 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 }
 
 func (v *vpa) reconcileAdmissionControllerVPA(vpa *vpaautoscalingv1.VerticalPodAutoscaler, deployment *appsv1.Deployment) {
-	updateMode := vpaautoscalingv1.UpdateModeAuto
-	controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-
 	vpa.Spec = vpaautoscalingv1.VerticalPodAutoscalerSpec{
 		TargetRef: &autoscalingv1.CrossVersionObjectReference{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 			Name:       deployment.Name,
 		},
-		UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{UpdateMode: &updateMode},
+		UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto)},
 		ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 				{
 					ContainerName:    "*",
-					ControlledValues: &controlledValues,
-					MinAllowed: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("100Mi"),
-					},
+					ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 				},
 			},
 		},

--- a/pkg/component/autoscaling/vpa/updater.go
+++ b/pkg/component/autoscaling/vpa/updater.go
@@ -207,11 +207,8 @@ func (v *vpa) reconcileUpdaterDeployment(deployment *appsv1.Deployment, serviceA
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("30m"),
-							corev1.ResourceMemory: resource.MustParse("200Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("15Mi"),
 						},
 					},
 				}},
@@ -235,24 +232,18 @@ func (v *vpa) reconcileUpdaterDeployment(deployment *appsv1.Deployment, serviceA
 }
 
 func (v *vpa) reconcileUpdaterVPA(vpa *vpaautoscalingv1.VerticalPodAutoscaler, deployment *appsv1.Deployment) {
-	updateMode := vpaautoscalingv1.UpdateModeAuto
-	controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-
 	vpa.Spec = vpaautoscalingv1.VerticalPodAutoscalerSpec{
 		TargetRef: &autoscalingv1.CrossVersionObjectReference{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 			Name:       deployment.Name,
 		},
-		UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{UpdateMode: &updateMode},
+		UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto)},
 		ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 				{
 					ContainerName:    "*",
-					ControlledValues: &controlledValues,
-					MinAllowed: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("50Mi"),
-					},
+					ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 				},
 			},
 		},

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -385,11 +385,8 @@ var _ = Describe("VPA", func() {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("30m"),
-										corev1.ResourceMemory: resource.MustParse("200Mi"),
-									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("4Gi"),
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("15Mi"),
 									},
 								},
 							}},
@@ -450,9 +447,6 @@ var _ = Describe("VPA", func() {
 						{
 							ContainerName:    "*",
 							ControlledValues: &vpaControlledValues,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-							},
 						},
 					},
 				},
@@ -684,8 +678,8 @@ var _ = Describe("VPA", func() {
 			var cpuRequest string
 			var memoryRequest string
 			if clusterType == component.ClusterTypeShoot {
-				cpuRequest = "30m"
-				memoryRequest = "200Mi"
+				cpuRequest = "10m"
+				memoryRequest = "15Mi"
 			} else {
 				cpuRequest = "200m"
 				memoryRequest = "800M"
@@ -760,9 +754,6 @@ var _ = Describe("VPA", func() {
 										corev1.ResourceCPU:    resource.MustParse(cpuRequest),
 										corev1.ResourceMemory: resource.MustParse(memoryRequest),
 									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("4Gi"),
-									},
 								},
 							}},
 						},
@@ -814,9 +805,6 @@ var _ = Describe("VPA", func() {
 						{
 							ContainerName:    "*",
 							ControlledValues: &vpaControlledValues,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("40Mi"),
-							},
 						},
 					},
 				},
@@ -1032,11 +1020,8 @@ var _ = Describe("VPA", func() {
 								LivenessProbe: livenessProbeVpa,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("30m"),
-										corev1.ResourceMemory: resource.MustParse("200Mi"),
-									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("3Gi"),
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("30Mi"),
 									},
 								},
 								Ports: []corev1.ContainerPort{
@@ -1150,9 +1135,6 @@ var _ = Describe("VPA", func() {
 						{
 							ContainerName:    "*",
 							ControlledValues: &vpaControlledValues,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("100Mi"),
-							},
 						},
 					},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
* Drop `minAllowed` values: we don't need to set higher settings than the global `minAllowed` configured for VPA globally.
* Drop limits: we don't have good indication that VPA isn't working correctly, if these limits are crossed
* Lower initial resource requests: As the VPA components are under VPA control as well, we can start with lower initial resources, which should be sufficient for the majority of all cases and rely on autoscaling to increase the requests where necessary.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
VPA resource settings are now adapted - memory limits are removed and initial resource requests are lowered.
```
