### PR TITLE
apiserverproxy: introduce self managed network interface

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -807,7 +807,7 @@ images:
     name: apiserver-proxy
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/apiserver-proxy
-  tag: "v0.17.0"
+  tag: "v0.18.0"
 - name: cert-management
   sourceRepository: github.com/gardener/cert-management
   repository: europe-docker.pkg.dev/gardener-project/releases/cert-controller-manager

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy.go
@@ -304,7 +304,7 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 								Args: []string{
 									fmt.Sprintf("--ip-address=%s", a.values.advertiseIPAddress),
 									"--daemon=false",
-									"--interface=lo",
+									"--interface=apiserverproxy0",
 								},
 								SecurityContext: &corev1.SecurityContext{
 									Capabilities: &corev1.Capabilities{
@@ -331,7 +331,7 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Args: []string{
 									fmt.Sprintf("--ip-address=%s", a.values.advertiseIPAddress),
-									"--interface=lo",
+									"--interface=apiserverproxy0",
 								},
 								SecurityContext: &corev1.SecurityContext{
 									Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/apiserver-proxy/pull/128 introduced changes to the apiserver-proxy component to manage it's own network interface to move away from loopback device `lo`

Reason is cilium ignoring the lo device when considering host addresses in eBPF datapath mode:
See https://github.com/gardener/gardener-extension-networking-cilium/issues/386 for additional information.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-networking-cilium/issues/386

**Special notes for your reviewer**:
During testing with the local setup the rollout of the new network interface did not interfere existing connections. 
Having the address bind to loopback and the new device did not raise any issues.
Cleanup is done when a node roll occurs anyway.

