### PR TITLE
Re-allow `gardenlet` to patch `PersistentVolume`s

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -32,6 +32,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumes
+  verbs:
+  # This is currently necessary to migrate deprecated topology labels on PVs, ref: https://github.com/gardener/gardener/blob/e542bc4794473fcec1742ed751a2d420169c8326/cmd/gardenlet/app/migration.go#L27-L30.
+  # TODO(plkokanov): It can potentially be dropped once the requiring code is removed.
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - list

--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -35,7 +35,7 @@ rules:
   - persistentvolumes
   verbs:
   # This is currently necessary to migrate deprecated topology labels on PVs, ref: https://github.com/gardener/gardener/blob/e542bc4794473fcec1742ed751a2d420169c8326/cmd/gardenlet/app/migration.go#L27-L30.
-  # TODO(plkokanov): It can potentially be dropped once the requiring code is removed.
+  # TODO(plkokanov): Remove this RBAC rule when the requiring code is removed (when Kubernetes 1.27 support gets dropped).
   - patch
 - apiGroups:
   - ""

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -139,6 +139,11 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{""},
+				Resources: []string{"persistentvolumes"},
+				Verbs:     []string{"patch"},
+			},
+			{
+				APIGroups: []string{""},
 				Resources: []string{"nodes"},
 				Verbs:     []string{"list", "watch"},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind regression

**What this PR does / why we need it**:
This PR allows `gardenlet` to patch `PersistentVolume`s by adding the necessary rules in its `ClusterRole` as this is still required to migrate deprecated `failure-domain.beta.kubernetes.io` labels to `topology.kubernetes.io`: https://github.com/gardener/gardener/blob/e542bc4794473fcec1742ed751a2d420169c8326/cmd/gardenlet/app/migration.go#L40-L117

The rule to patch `PersistentVolume`s was removed in https://github.com/gardener/gardener/pull/10220, however, it was actually still required. 

We noticed this when starting `gardenlet` in landscapes that still had PVs with the old deprecated labels - namely it happened in a cluster created by ACK where the alicloud csi driver was still setting the deprecated labels.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a regression that caused `gardenlet` to not be able to migrate deprecated `failure-domain.beta.kubernetes.io` labels to `topology.kubernetes.io` due to a removed RBAC rule required to patch `PersistentVolume`s.
```
