### PR TITLE
  Allow overlapping ranges in case of single stack IPv6.

### DIFF
--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -71,8 +71,10 @@ func ValidateNetworkSpec(spec *extensionsv1alpha1.NetworkSpec, fldPath *field.Pa
 
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(cidrs...)...)
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDRIPFamily(cidrs, string(primaryIPFamily))...)
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(cidrs, false)...)
 
+	if !(len(spec.IPFamilies) == 1 && spec.IPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6) {
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(cidrs, false)...)
+	}
 	return allErrs
 }
 

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -162,17 +162,6 @@ var _ = Describe("Network validation tests", func() {
 					"Field": Equal("spec.serviceCIDR"),
 				}))))
 			})
-
-			It("should forbid Network with overlapping pod and service CIDRs", func() {
-				network.Spec.ServiceCIDR = "2001:db8:3::/48"
-				network.Spec.PodCIDR = network.Spec.ServiceCIDR
-
-				errorList := ValidateNetwork(network)
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.serviceCIDR"),
-				}))))
-			})
 		})
 	})
 

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -162,6 +162,14 @@ var _ = Describe("Network validation tests", func() {
 					"Field": Equal("spec.serviceCIDR"),
 				}))))
 			})
+
+			It("should allow Network with overlapping pod and service CIDRs", func() {
+				network.Spec.ServiceCIDR = "2001:db8:3::/48"
+				network.Spec.PodCIDR = network.Spec.ServiceCIDR
+
+				errorList := ValidateNetwork(network)
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow overlapping network ranges in case of single stack IPv6.
```
