### PR TITLE
[release-v1.104] update dependency gardener/etcd-druid to v0.22.7

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -68,7 +68,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
-  tag: "v0.22.5"
+  tag: "v0.22.7"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**What this PR does / why we need it**:
We have released etcd-druid `v0.22.6` followed by another patch release `v0.22.7` and both of images have been updated on g/g master with these PRs https://github.com/gardener/gardener/pull/10556 , https://github.com/gardener/gardener/pull/10570.
This PR is to update the etcd-druid `v0.22.5` -> `v0.22.7`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener/etcd-druid` image has been updated to `v0.22.7`. [Release Notes](https://redirect.github.com/gardener/etcd-druid/releases/tag/v0.22.7)
```
