### PR TITLE
provider-extensions setup: Disable Seed VPA by default

### DIFF
--- a/example/provider-extensions/gardenlet/values.yaml.tmpl
+++ b/example/provider-extensions/gardenlet/values.yaml.tmpl
@@ -51,4 +51,6 @@ config:
         scheduling:
           visible: true
         verticalPodAutoscaler:
-          enabled: true
+          # If using a Gardener shoot, make sure that the shoot cluster has VPA enabled. Otherwise, enable VPA below in the seed spec.
+          # Don't enable VPA for both the shoot control plane and the seed. 2 VPA deployments acting on the same cluster cause endless VPA eviction loops.
+          enabled: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Folks are usually using Shoot clusters as Seeds. Shoot clusters by default have VPA enabled (due to the `ShootVPAEnabledByDefault` admission plugin). Having VPA enabled in the Shoot control plane and in the Seed spec causes 2 VPA stacks to act on the same cluster and cause endless eviction loops.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
provider-extensions setup: Seed VPA is disabled by default to avoid two VPA deployments to act on the same cluster causing endless eviction loops.
```
