### PR TITLE
Clarify documentation regarding Managed Service Account Issuer enablement

### DIFF
--- a/docs/usage/shoot_serviceaccounts.md
+++ b/docs/usage/shoot_serviceaccounts.md
@@ -61,8 +61,9 @@ This ability removes the need for changing the `.spec.kubernetes.kubeAPIServer.s
 
 ### Prerequisites
 
-⚠️ Note: The following prerequisites are responsibility of the Gardener Administrators and are not something that end users can configure by themselves.
-If uncertain that these requirements are met, please contact your Gardener Administrator.
+> [!NOTE]
+> The following prerequisites are responsibility of the Gardener Administrators and are not something that end users can configure by themselves.
+> If uncertain that these requirements are met, please contact your Gardener Administrator.
 
 Prerequisites:
 - The Garden Cluster should have the Gardener Discovery Server deployed and configured.

--- a/docs/usage/shoot_serviceaccounts.md
+++ b/docs/usage/shoot_serviceaccounts.md
@@ -29,7 +29,8 @@ According to the [upstream specification](https://kubernetes.io/docs/reference/c
 By default, Gardener uses the internal cluster domain as issuer (e.g., `https://api.foo.bar.example.com`).
 If you specify the `issuer`, then this default issuer will always be part of the list of accepted issuers (you don't need to specify it yourself).
 
-> [!CAUTION] If you change from the default issuer to a custom `issuer`, all previously issued tokens will still be valid/accepted.
+> [!CAUTION]
+> If you change from the default issuer to a custom `issuer`, all previously issued tokens will still be valid/accepted.
 > However, if you change from a custom `issuer` `A` to another `issuer` `B` (custom or default), then you have to add `A` to the `acceptedIssuers` so that previously issued tokens are not invalidated.
 > Otherwise, the control plane components as well as system components and your workload pods might fail.
 > You can remove `A` from the `acceptedIssuers` when all currently active tokens have been issued solely by `B`.
@@ -49,7 +50,8 @@ It has the following specification:
 
 > The maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.
 
-> [!NOTE] The value for this field must be in the `[30d,90d]` range.
+> [!NOTE]
+> The value for this field must be in the `[30d,90d]` range.
 > The background for this limitation is that all Gardener components rely on the `TokenRequest` API and the Kubernetes service account token projection feature with short-lived, auto-rotating tokens.
 > Any values lower than `30d` risk impacting the SLO for shoot clusters, and any values above `90d` violate security best practices with respect to maximum validity of credentials before they must be rotated.
 > Given that the field just specifies the upper bound, end-users can still use lower values for their individual workload by specifying the `.spec.volumes[].projected.sources[].serviceAccountToken.expirationSeconds` in the `PodSpec`s.

--- a/docs/usage/shoot_serviceaccounts.md
+++ b/docs/usage/shoot_serviceaccounts.md
@@ -29,13 +29,13 @@ According to the [upstream specification](https://kubernetes.io/docs/reference/c
 By default, Gardener uses the internal cluster domain as issuer (e.g., `https://api.foo.bar.example.com`).
 If you specify the `issuer`, then this default issuer will always be part of the list of accepted issuers (you don't need to specify it yourself).
 
-⚠️ Caution: If you change from the default issuer to a custom `issuer`, all previously issued tokens will still be valid/accepted.
-However, if you change from a custom `issuer` `A` to another `issuer` `B` (custom or default), then you have to add `A` to the `acceptedIssuers` so that previously issued tokens are not invalidated.
-Otherwise, the control plane components as well as system components and your workload pods might fail.
-You can remove `A` from the `acceptedIssuers` when all currently active tokens have been issued solely by `B`.
-This can be ensured by using [projected token volumes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) with a short validity, or by rolling out all pods.
-Additionally, all [`ServiceAccount` token secrets](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets) should be recreated.
-Apart from this, you should wait for at least `12h` to make sure the control plane and system components have received a new token from Gardener.
+> [!CAUTION] If you change from the default issuer to a custom `issuer`, all previously issued tokens will still be valid/accepted.
+> However, if you change from a custom `issuer` `A` to another `issuer` `B` (custom or default), then you have to add `A` to the `acceptedIssuers` so that previously issued tokens are not invalidated.
+> Otherwise, the control plane components as well as system components and your workload pods might fail.
+> You can remove `A` from the `acceptedIssuers` when all currently active tokens have been issued solely by `B`.
+> This can be ensured by using [projected token volumes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) with a short validity, or by rolling out all pods.
+> Additionally, all [`ServiceAccount` token secrets](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets) should be recreated.
+> Apart from this, you should wait for at least `12h` to make sure the control plane and system components have received a new token from Gardener.
 
 ## Token Expirations
 
@@ -49,10 +49,10 @@ It has the following specification:
 
 > The maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.
 
-⚠️ Note that the value for this field must be in the `[30d,90d]` range.
-The background for this limitation is that all Gardener components rely on the `TokenRequest` API and the Kubernetes service account token projection feature with short-lived, auto-rotating tokens.
-Any values lower than `30d` risk impacting the SLO for shoot clusters, and any values above `90d` violate security best practices with respect to maximum validity of credentials before they must be rotated.
-Given that the field just specifies the upper bound, end-users can still use lower values for their individual workload by specifying the `.spec.volumes[].projected.sources[].serviceAccountToken.expirationSeconds` in the `PodSpec`s.
+> [!NOTE] The value for this field must be in the `[30d,90d]` range.
+> The background for this limitation is that all Gardener components rely on the `TokenRequest` API and the Kubernetes service account token projection feature with short-lived, auto-rotating tokens.
+> Any values lower than `30d` risk impacting the SLO for shoot clusters, and any values above `90d` violate security best practices with respect to maximum validity of credentials before they must be rotated.
+> Given that the field just specifies the upper bound, end-users can still use lower values for their individual workload by specifying the `.spec.volumes[].projected.sources[].serviceAccountToken.expirationSeconds` in the `PodSpec`s.
 
 ## Managed Service Account Issuer
 

--- a/docs/usage/shoot_serviceaccounts.md
+++ b/docs/usage/shoot_serviceaccounts.md
@@ -56,14 +56,18 @@ Given that the field just specifies the upper bound, end-users can still use low
 
 ## Managed Service Account Issuer
 
+Gardener also provides a way to manage the service account issuer of a shoot cluster as well as serving its OIDC discovery documents from a centrally managed server called [Gardener Discovery Server](https://github.com/gardener/gardener-discovery-server).
+This ability removes the need for changing the `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.issuer` and exposing it separately.
+
 ### Prerequisites
 
-Gardener also provides a way to manage the service account issuer of a shoot cluster as well as serving its OIDC discovery documents from a centrally managed server called [Gardener Discovery Server](https://github.com/gardener/gardener-discovery-server). This ability removes the need for changing the `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.issuer` and exposing it separately. The feature has the following prerequisites:
+⚠️ Note: The following prerequisites are responsibility of the Gardener Administrators and are not something that end users can configure by themselves.
+If uncertain that these requirements are met, please contact your Gardener Administrator.
+
+Prerequisites:
 - The Garden Cluster should have the Gardener Discovery Server deployed and configured.
   The easiest way to handle this is by using the [gardener-operator](../concepts/operator.md#gardener-discovery-server).
 - The [`ShootManagedIssuer`](../deployment/feature_gates.md#list-of-feature-gates) feature gate should be enabled.
-
-If uncertain that these prerequisites are met, please contact your Gardener Administrator.
 
 ### Enablement
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR tries to clarify the documentation around the Managed Service Account Issuer enablement. The current documentation might be unclear to some end users (see https://github.com/gardener/gardener/issues/10567).

cc @pre I hope that this makes things more clear

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
