### PR TITLE
Remove obsolete migration code from the monitoring component

### DIFF
--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
@@ -155,19 +155,6 @@ func (k *kubeStateMetrics) Deploy(ctx context.Context) error {
 		registry          = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 	)
 
-	// TODO(chrkl): Remove after release v1.103
-	if k.values.ClusterType == component.ClusterTypeSeed && k.values.NameSuffix != "" {
-		if err := component.DestroyResourceConfigs(ctx, k.client, k.namespace, k.values.ClusterType, managedResourceName, nil); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-
-		timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
-		defer cancel()
-		if err := managedresources.WaitUntilDeleted(timeoutCtx, k.client, k.namespace, managedResourceName); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-	}
-
 	if k.values.ClusterType == component.ClusterTypeShoot {
 		// TODO(vicwicker): Remove after release v1.104
 		mr := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameShoot, Namespace: k.namespace}}

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics.go
@@ -15,10 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -156,28 +154,6 @@ func (k *kubeStateMetrics) Deploy(ctx context.Context) error {
 	)
 
 	if k.values.ClusterType == component.ClusterTypeShoot {
-		// TODO(vicwicker): Remove after release v1.104
-		mr := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameShoot, Namespace: k.namespace}}
-		if err := k.client.Get(ctx, client.ObjectKeyFromObject(mr), mr); client.IgnoreNotFound(err) != nil {
-			return err
-		} else if err == nil && mr.Spec.Class == nil {
-			// spec.class nil means shoot
-
-			// remove the finalizer to prevent deleting the cluster role and cluster role binding in the shoot even when the GRM is not running
-			// in a hibernated control-plane. It is similar to "mr.Spec.KeepObjects = true", but it supports hibernated shoots as well.
-			// The cluster role and cluster role binding are going to be adopted by the new managed resource with the "-target" suffix.
-			if err := controllerutils.RemoveAllFinalizers(ctx, k.client, mr); err != nil {
-				return err
-			}
-
-			if err := managedresources.DeleteForShoot(ctx, k.client, k.namespace, managedResourceNameShoot); err != nil {
-				return err
-			}
-			if err := managedresources.WaitUntilDeleted(ctx, k.client, k.namespace, managedResourceNameShoot); err != nil {
-				return err
-			}
-		}
-
 		genericTokenKubeconfigSecret, found := k.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
 		if !found {
 			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -787,22 +787,6 @@ var _ = Describe("KubeStateMetrics", func() {
 					Record: "shoot:node_operating_system:sum",
 					Expr:   intstr.FromString(`sum(kube_node_info) by (os_image, kernel_version)`),
 				},
-				{
-					Record: "kube_pod_container_resource_limits_cpu_cores",
-					Expr:   intstr.FromString(`kube_pod_container_resource_limits{resource="cpu", unit="core"}`),
-				},
-				{
-					Record: "kube_pod_container_resource_requests_cpu_cores",
-					Expr:   intstr.FromString(`kube_pod_container_resource_requests{resource="cpu", unit="core"}`),
-				},
-				{
-					Record: "kube_pod_container_resource_limits_memory_bytes",
-					Expr:   intstr.FromString(`kube_pod_container_resource_limits{resource="memory", unit="byte"}`),
-				},
-				{
-					Record: "kube_pod_container_resource_requests_memory_bytes",
-					Expr:   intstr.FromString(`kube_pod_container_resource_requests{resource="memory", unit="byte"}`),
-				},
 			}
 
 			return &monitoringv1.PrometheusRule{

--- a/pkg/component/observability/monitoring/kubestatemetrics/resources.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/resources.go
@@ -669,24 +669,6 @@ func (k *kubeStateMetrics) prometheusRuleShoot() *monitoringv1.PrometheusRule {
 			Record: "shoot:node_operating_system:sum",
 			Expr:   intstr.FromString(`sum(kube_node_info) by (os_image, kernel_version)`),
 		},
-		// Mitigation for extension dashboards.
-		// TODO(istvanballok): Remove in a future version. For more details, see https://github.com/gardener/gardener/pull/6224.
-		{
-			Record: "kube_pod_container_resource_limits_cpu_cores",
-			Expr:   intstr.FromString(`kube_pod_container_resource_limits{resource="cpu", unit="core"}`),
-		},
-		{
-			Record: "kube_pod_container_resource_requests_cpu_cores",
-			Expr:   intstr.FromString(`kube_pod_container_resource_requests{resource="cpu", unit="core"}`),
-		},
-		{
-			Record: "kube_pod_container_resource_limits_memory_bytes",
-			Expr:   intstr.FromString(`kube_pod_container_resource_limits{resource="memory", unit="byte"}`),
-		},
-		{
-			Record: "kube_pod_container_resource_requests_memory_bytes",
-			Expr:   intstr.FromString(`kube_pod_container_resource_requests{resource="memory", unit="byte"}`),
-		},
 	}
 
 	prometheusRule.Labels = monitoringutils.Labels(shoot.Label)

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-dashboard.json
@@ -71,7 +71,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum({__name__=~\"kube(_customresource)?_verticalpodautoscaler_spec_updatepolicy_updatemode\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\"}) by (update_mode) > 0",
+          "expr": "sum({__name__=~\"kube_customresource_verticalpodautoscaler_spec_updatepolicy_updatemode\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\"}) by (update_mode) > 0",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -158,7 +158,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target{resource=\"memory\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -168,7 +168,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{resource=\"memory\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -178,7 +178,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{resource=\"memory\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -188,7 +188,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed{resource=\"memory\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_minallowed_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_minallowed_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -198,7 +198,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed{resource=\"memory\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -325,7 +325,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target{resource=\"memory\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"} or kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -448,7 +448,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target{resource=\"cpu\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -458,7 +458,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{resource=\"cpu\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -468,7 +468,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{resource=\"cpu\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -478,7 +478,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed{resource=\"cpu\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_minallowed_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_minallowed_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -488,7 +488,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed{resource=\"cpu\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"} or kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -614,7 +614,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target{resource=\"cpu\", namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"} or kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"})",
+          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR removes the following migration code from the monitoring component:

1. Migration code from appending the cluster type suffix to `kube-state-metrics`. Commit https://github.com/gardener/gardener/commit/1e3de9d9b7dcc39fb880a39f00286be38218f571 /cc @chrkl 
2. Migration code for the `kube-state-metrics` version upgrade. Commit https://github.com/gardener/gardener/commit/bebad977201009a83129b6b3bb679d4be2e437a5
3. Mitigation for extension dashboards. Commit https://github.com/gardener/gardener/commit/b85e48c364a7f375923c5b7e7132643e748b5fd8 /cc @istvanballok 

**Release note**:

```other operator
Clean up migration code from the monitoring component
```
