### PR TITLE
Promote `VPAForETCD` and `VPAAndHPAForAPIServer` feature gates to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,12 +28,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootForceDeletion        | `true`  | `Beta`  | `1.91`  |         |
 | UseNamespacedCloudProfile | `false` | `Alpha` | `1.92`  |         |
 | ShootManagedIssuer        | `false` | `Alpha` | `1.93`  |         |
-| VPAForETCD                | `false` | `Alpha` | `1.94`  | `1.96`  |
-| VPAForETCD                | `true`  | `Beta`  | `1.97`  | `1.104` |
-| VPAForETCD                | `true`  | `GA`    | `1.105` |         |
-| VPAAndHPAForAPIServer     | `false` | `Alpha` | `1.95`  | `1.100` |
-| VPAAndHPAForAPIServer     | `true`  | `Beta`  | `1.101` | `1.104` |
-| VPAAndHPAForAPIServer     | `true`  | `GA`    | `1.105` |         |
 | ShootCredentialsBinding   | `false` | `Alpha` | `1.98`  |         |
 | NewWorkerPoolHash         | `false` | `Alpha` | `1.98`  |         |
 | NewVPN                    | `false` | `Alpha` | `1.104` |         |
@@ -42,9 +36,9 @@ The following tables are a summary of the feature gates that you can set on diff
 
 | Feature                                      | Default | Stage        | Since   | Until   |
 |----------------------------------------------|---------|--------------|---------|---------|
-| NodeLocalDNS                                 | `false` | `Alpha`      | `1.7`   |         |
+| NodeLocalDNS                                 | `false` | `Alpha`      | `1.7`   | `1.25`  |
 | NodeLocalDNS                                 |         | `Removed`    | `1.26`  |         |
-| KonnectivityTunnel                           | `false` | `Alpha`      | `1.6`   |         |
+| KonnectivityTunnel                           | `false` | `Alpha`      | `1.6`   | `1.26`  |
 | KonnectivityTunnel                           |         | `Removed`    | `1.27`  |         |
 | MountHostCADirectories                       | `false` | `Alpha`      | `1.11`  | `1.25`  |
 | MountHostCADirectories                       | `true`  | `Beta`       | `1.26`  | `1.27`  |
@@ -52,7 +46,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | MountHostCADirectories                       |         | `Removed`    | `1.30`  |         |
 | DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha`      | `1.28`  | `1.31`  |
 | DisallowKubeconfigRotationForShootInDeletion | `true`  | `Beta`       | `1.32`  | `1.35`  |
-| DisallowKubeconfigRotationForShootInDeletion | `true`  | `GA`         | `1.36`  |         |
+| DisallowKubeconfigRotationForShootInDeletion | `true`  | `GA`         | `1.36`  | `1.37`  |
 | DisallowKubeconfigRotationForShootInDeletion |         | `Removed`    | `1.38`  |         |
 | Logging                                      | `false` | `Alpha`      | `0.13`  | `1.40`  |
 | Logging                                      |         | `Removed`    | `1.41`  |         |
@@ -146,7 +140,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | ContainerdRegistryHostsDir                   |         | `Removed`    | `1.88`  |         |
 | WorkerlessShoots                             | `false` | `Alpha`      | `1.70`  | `1.78`  |
 | WorkerlessShoots                             | `true`  | `Beta`       | `1.79`  | `1.85`  |
-| WorkerlessShoots                             | `true`  | `GA`         | `1.86`  |         |
+| WorkerlessShoots                             | `true`  | `GA`         | `1.86`  | `1.87`  |
 | WorkerlessShoots                             |         | `Removed`    | `1.88`  |         |
 | MachineControllerManagerDeployment           | `false` | `Alpha`      | `1.73`  |         |
 | MachineControllerManagerDeployment           | `true`  | `Beta`       | `1.81`  | `1.81`  |
@@ -156,7 +150,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerFastRollout                         | `true`  | `GA`         | `1.90`  | `1.91`  |
 | APIServerFastRollout                         |         | `Removed`    | `1.92`  |         |
 | UseGardenerNodeAgent                         | `false` | `Alpha`      | `1.82`  | `1.88`  |
-| UseGardenerNodeAgent                         | `true`  | `Beta`       | `1.89`  |         |
+| UseGardenerNodeAgent                         | `true`  | `Beta`       | `1.89`  | `1.89`  |
 | UseGardenerNodeAgent                         | `true`  | `GA`         | `1.90`  | `1.91`  |
 | UseGardenerNodeAgent                         |         | `Removed`    | `1.92`  |         |
 | CoreDNSQueryRewriting                        | `false` | `Alpha`      | `1.55`  | `1.95`  |
@@ -167,6 +161,12 @@ The following tables are a summary of the feature gates that you can set on diff
 | MutableShootSpecNetworkingNodes              | `true`  | `Beta`       | `1.96`  | `1.96`  |
 | MutableShootSpecNetworkingNodes              | `true`  | `GA`         | `1.97`  | `1.100` |
 | MutableShootSpecNetworkingNodes              |         | `Removed`    | `1.101` |         |
+| VPAForETCD                                   | `false` | `Alpha`      | `1.94`  | `1.96`  |
+| VPAForETCD                                   | `true`  | `Beta`       | `1.97`  | `1.104` |
+| VPAForETCD                                   | `true`  | `GA`         | `1.105` |         |
+| VPAAndHPAForAPIServer                        | `false` | `Alpha`      | `1.95`  | `1.100` |
+| VPAAndHPAForAPIServer                        | `true`  | `Beta`       | `1.101` | `1.104` |
+| VPAAndHPAForAPIServer                        | `true`  | `GA`         | `1.105` |         |
 
 ## Using a Feature
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -29,9 +29,11 @@ The following tables are a summary of the feature gates that you can set on diff
 | UseNamespacedCloudProfile | `false` | `Alpha` | `1.92`  |         |
 | ShootManagedIssuer        | `false` | `Alpha` | `1.93`  |         |
 | VPAForETCD                | `false` | `Alpha` | `1.94`  | `1.96`  |
-| VPAForETCD                | `true`  | `Beta`  | `1.97`  |         |
+| VPAForETCD                | `true`  | `Beta`  | `1.97`  | `1.104` |
+| VPAForETCD                | `true`  | `GA`    | `1.105` |         |
 | VPAAndHPAForAPIServer     | `false` | `Alpha` | `1.95`  | `1.100` |
-| VPAAndHPAForAPIServer     | `true`  | `Beta`  | `1.101` |         |
+| VPAAndHPAForAPIServer     | `true`  | `Beta`  | `1.101` | `1.104` |
+| VPAAndHPAForAPIServer     | `true`  | `GA`    | `1.105` |         |
 | ShootCredentialsBinding   | `false` | `Alpha` | `1.98`  |         |
 | NewWorkerPoolHash         | `false` | `Alpha` | `1.98`  |         |
 | NewVPN                    | `false` | `Alpha` | `1.104` |         |

--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -23,10 +23,11 @@ However, there are two supported autoscaling modes for the Garden or Shoot clust
 
    In `VPA` mode, the etcd is scaled by a native `VPA` resource.
 
-   The `VPA` mode is the used autoscaling mode when the `VPAForETCD` feature gate is enabled (takes precedence over the `HVPA` feature gate). 
+   The `VPA` mode is the used autoscaling mode when the `VPAForETCD` feature gate is enabled (takes precedence over the `HVPA` feature gate).
 
 > [!NOTE]
 > Starting with release `v1.97`, the `VPAForETCD` feature gate is enabled by default.
+> Starting with release `v1.105`, the `VPAForETCD` feature gate is promoted to GA and locked to true.
 
 For both of the autoscaling modes downscaling is handled more pessimistically to prevent many subsequent etcd restarts. Thus, for `production` and `infrastructure` Shoot clusters (or all Garden clusters), downscaling is deactivated for the main etcd. For all other Shoot clusters, lower advertised requests/limits are only applied during the Shoot's maintenance time window.
 
@@ -77,6 +78,7 @@ There are three supported autoscaling modes for the Shoot Kubernetes API server.
 
 > [!NOTE]
 > Starting with release `v1.101`, the `VPAAndHPAForAPIServer` feature gate is enabled by default.
+> Starting with release `v1.105`, the `VPAAndHPAForAPIServer` feature gate is promoted to GA and locked to true.
 
 In all scaling modes the min replicas count of 2 is imposed by the [High Availability of Shoot Control Plane Components](../development/high-availability.md#control-plane-components).
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -31,6 +31,7 @@ const (
 	// owner @voelzmo
 	// alpha: v1.94.0
 	// beta: v1.97.0
+	// GA: v1.105.0
 	VPAForETCD featuregate.Feature = "VPAForETCD"
 
 	// DefaultSeccompProfile defaults the seccomp profile for Gardener managed workload in the seed to RuntimeDefault.
@@ -71,6 +72,7 @@ const (
 	// owner: @ialidzhikov
 	// alpha: v1.95.0
 	// beta: v1.101.0
+	// GA: v1.105.0
 	VPAAndHPAForAPIServer featuregate.Feature = "VPAAndHPAForAPIServer"
 
 	// ShootCredentialsBinding enables the usage of the CredentialsBindingName API in shoot spec.
@@ -119,13 +121,13 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPA:                      {Default: false, PreRelease: featuregate.Alpha},
 	HVPAForShootedSeed:        {Default: false, PreRelease: featuregate.Alpha},
-	VPAForETCD:                {Default: true, PreRelease: featuregate.Beta},
+	VPAForETCD:                {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	DefaultSeccompProfile:     {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:           {Default: false, PreRelease: featuregate.Alpha},
 	ShootManagedIssuer:        {Default: false, PreRelease: featuregate.Alpha},
 	ShootForceDeletion:        {Default: true, PreRelease: featuregate.Beta},
 	UseNamespacedCloudProfile: {Default: false, PreRelease: featuregate.Alpha},
-	VPAAndHPAForAPIServer:     {Default: true, PreRelease: featuregate.Beta},
+	VPAAndHPAForAPIServer:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ShootCredentialsBinding:   {Default: false, PreRelease: featuregate.Alpha},
 	NewWorkerPoolHash:         {Default: false, PreRelease: featuregate.Alpha},
 	NewVPN:                    {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR promotes the `VPAForETCD` and `VPAAndHPAForAPIServer` feature gates to GA and locks them to true. The related code is not cleaned up now as we agreed with @ialidzhikov to do it after we deprecate the `HVPA` and `HVPAForShootedSeed` feature gates  in `v1.106` and afterwards remove the feature gates, clean-up the related code and update the auto-scaling documentation in `v1.107`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `VPAForETCD` and `VPAAndHPAForAPIServer` feature gates have been promoted to GA and locked to `true`.
```
