### PR TITLE
Backdate generated certificates slightly (1 min) to allow a certain clock skew of clients.

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -147,17 +147,17 @@ var _ = Describe("Actuator", func() {
 		checksums = map[string]string{
 			v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 			cloudProviderConfigName:                  "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
-			caNameControlPlane:                       "7c7f437f14009f27cd74756cebb86555d35cc45bf92f85fe2285f5a4190f7b58",
-			"cloud-controller-manager":               "70e8dfa39f8feedcc3ed93c35499f94f851d3304ed1919e9a8c73ef8213728dd",
+			caNameControlPlane:                       "3e6425b85bb75f33df7c16387b6999eb0f2d3c3e0a81afb4739626c69a79887b",
+			"cloud-controller-manager":               "47448ddc1d8c7b02d20125b4f0914acf8402ee9d763d5bdd48634fcbf8d75b1d",
 		}
 		checksumsNoConfig = map[string]string{
 			v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
-			caNameControlPlane:                       "7c7f437f14009f27cd74756cebb86555d35cc45bf92f85fe2285f5a4190f7b58",
-			"cloud-controller-manager":               "70e8dfa39f8feedcc3ed93c35499f94f851d3304ed1919e9a8c73ef8213728dd",
+			caNameControlPlane:                       "3e6425b85bb75f33df7c16387b6999eb0f2d3c3e0a81afb4739626c69a79887b",
+			"cloud-controller-manager":               "47448ddc1d8c7b02d20125b4f0914acf8402ee9d763d5bdd48634fcbf8d75b1d",
 		}
 		exposureChecksums = map[string]string{
-			caNameControlPlaneExposure: "dc1f6bc41dedab9e06650fa5a19e677a8ea1f47d6667d066c33601ab2e85ff36",
-			"lb-readvertiser":          "d640460979ef9e3ff08ffeff15486a0c8ed6222be4c4f9ce1e10a7dd62b967a6",
+			caNameControlPlaneExposure: "98637da60735fb6f44615e032c30b3f5fc12d0af5df057fa2741aa97554db9a3",
+			"lb-readvertiser":          "c9157ced4dfc92686c2bf62e2f1a9f0d12f6d9ac1d835b877d9651b126b56e67",
 		}
 
 		configChartValues = map[string]any{
@@ -492,8 +492,8 @@ webhooks:
 			Expect(err).NotTo(HaveOccurred())
 
 			expectSecretsManagedBySecretsManager(fakeClient, "wanted secrets should get created",
-				"ca-provider-test-controlplane-05334c48", "ca-provider-test-controlplane-bundle-4e0a1191",
-				"cloud-controller-manager-bd8ec11d",
+				"ca-provider-test-controlplane-05334c48", "ca-provider-test-controlplane-bundle-bdc12448",
+				"cloud-controller-manager-bc446deb",
 			)
 		},
 		Entry("should deploy secrets and apply charts with correct parameters", cloudProviderConfigName, checksums, &admissionregistrationv1.MutatingWebhookConfiguration{Webhooks: []admissionregistrationv1.MutatingWebhook{{}}}, true),
@@ -672,8 +672,8 @@ webhooks:
 			Expect(err).NotTo(HaveOccurred())
 
 			expectSecretsManagedBySecretsManager(fakeClient, "wanted secrets should get created",
-				"ca-provider-test-controlplane-exposure-3dcf5fed", "ca-provider-test-controlplane-exposure-bundle-3b7e0d50",
-				"lb-readvertiser-335cd873",
+				"ca-provider-test-controlplane-exposure-3dcf5fed", "ca-provider-test-controlplane-exposure-bundle-20af429f",
+				"lb-readvertiser-aa3c2451",
 			)
 		},
 		Entry("should deploy secrets and apply charts with correct parameters"),

--- a/extensions/pkg/util/secret/manager/manager_test.go
+++ b/extensions/pkg/util/secret/manager/manager_test.go
@@ -241,9 +241,9 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 				Expect(sm.Cleanup(ctx)).To(Succeed())
 
 				expectSecrets(fakeClient,
-					"my-extension-ca-013c464d", "my-extension-ca-bundle-d563c0b7",
-					"my-extension-ca-2-673cf9ab", "my-extension-ca-2-bundle-086fe2a7",
-					"some-server-7388feb3", "some-secret-4b8f9d51")
+					"my-extension-ca-013c464d", "my-extension-ca-bundle-d9cdd23a",
+					"my-extension-ca-2-673cf9ab", "my-extension-ca-2-bundle-d54d5be6",
+					"some-server-fb949f01", "some-secret-4b8f9d51")
 			})
 		})
 
@@ -265,9 +265,9 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 					Expect(sm.Cleanup(ctx)).To(Succeed())
 
 					expectSecrets(fakeClient,
-						"my-extension-ca-013c464d", "my-extension-ca-bundle-7c9e4d64",
-						"my-extension-ca-2-673cf9ab", "my-extension-ca-2-bundle-97af5249",
-						"some-server-70ec0461", "some-secret-4b8f9d51")
+						"my-extension-ca-013c464d", "my-extension-ca-bundle-857457c0",
+						"my-extension-ca-2-673cf9ab", "my-extension-ca-2-bundle-42155530",
+						"some-server-2a71a28a", "some-secret-4b8f9d51")
 				})
 			})
 
@@ -290,9 +290,9 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 					Expect(sm.Cleanup(ctx)).To(Succeed())
 
 					expectSecrets(fakeClient,
-						"my-extension-ca-013c464d", "my-extension-ca-013c464d-431ab", "my-extension-ca-bundle-e595315e",
-						"my-extension-ca-2-673cf9ab", "my-extension-ca-2-673cf9ab-431ab", "my-extension-ca-2-bundle-fb324296",
-						"some-server-70ec0461", "some-secret-4b8f9d51")
+						"my-extension-ca-013c464d", "my-extension-ca-013c464d-431ab", "my-extension-ca-bundle-d0017688",
+						"my-extension-ca-2-673cf9ab", "my-extension-ca-2-673cf9ab-431ab", "my-extension-ca-2-bundle-d904c5b9",
+						"some-server-2a71a28a", "some-secret-4b8f9d51")
 				})
 			})
 
@@ -315,9 +315,9 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 					Expect(sm.Cleanup(ctx)).To(Succeed())
 
 					expectSecrets(fakeClient,
-						"my-extension-ca-013c464d-431ab", "my-extension-ca-bundle-0efe4bf3",
-						"my-extension-ca-2-673cf9ab-431ab", "my-extension-ca-2-bundle-11a56f33",
-						"some-server-bbe4c0f9", "some-secret-4b8f9d51")
+						"my-extension-ca-013c464d-431ab", "my-extension-ca-bundle-3455131c",
+						"my-extension-ca-2-673cf9ab-431ab", "my-extension-ca-2-bundle-8ceaf6ac",
+						"some-server-58b5baa2", "some-secret-4b8f9d51")
 				})
 			})
 		})

--- a/pkg/apiserver/registry/core/shoot/storage/kubeconfig_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/kubeconfig_test.go
@@ -310,7 +310,7 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 			Expect(cert.Subject.CommonName).To(Equal(userName))
 			Expect(cert.Subject.Organization).To(organizationMatcher)
 			Expect(cert.NotAfter.Unix()).To(Equal(getExpirationTimestamp(actual).Time.Unix())) // certificates do not have nano seconds in them
-			Expect(cert.NotBefore.UTC()).To(Equal(time.Unix(10, 0).UTC()))
+			Expect(cert.NotBefore.UTC()).To(Equal(secretsutils.AdjustToClockSkew(time.Unix(10, 0).UTC())))
 			Expect(cert.Issuer.CommonName).To(Equal(clientCACertName))
 		})
 	})

--- a/pkg/utils/secrets/certificate.go
+++ b/pkg/utils/secrets/certificate.go
@@ -48,6 +48,11 @@ const (
 	PKCS8
 )
 
+const (
+	// allowedClockSkew is the offset to allow with regards to certificate creation/usage difference.
+	allowedClockSkew = 1 * time.Minute
+)
+
 // CertificateSecretConfig contains the specification a to-be-generated CA, server, or client certificate.
 // It always contains a 3072-bit RSA private key.
 type CertificateSecretConfig struct {
@@ -219,7 +224,7 @@ func (s *CertificateSecretConfig) generateCertificateTemplate() *x509.Certificat
 			BasicConstraintsValid: true,
 			IsCA:                  isCA,
 			SerialNumber:          serialNumber,
-			NotBefore:             now,
+			NotBefore:             AdjustToClockSkew(now),
 			NotAfter:              expiration,
 			KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 			Subject: pkix.Name{
@@ -308,4 +313,9 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.
 	}
 
 	return certificate, caCertificate, tempDir, nil
+}
+
+// AdjustToClockSkew adjusts the given time by the maximum allowed clock skew.
+func AdjustToClockSkew(t time.Time) time.Time {
+	return t.Add(-1 * allowedClockSkew)
 }

--- a/pkg/utils/secrets/certificate.go
+++ b/pkg/utils/secrets/certificate.go
@@ -315,7 +315,7 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.
 	return certificate, caCertificate, tempDir, nil
 }
 
-// AdjustToClockSkew adjusts the given time by the maximum allowed clock skew.
+// AdjustToClockSkew adjusts the given time by the maximum allowed clock skew as clock skew can cause non-trivial errors.
 func AdjustToClockSkew(t time.Time) time.Time {
 	return t.Add(-1 * allowedClockSkew)
 }

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -405,7 +405,7 @@ var _ = Describe("Generate", func() {
 
 				By("Verify labels")
 				Expect(foundSecret.Labels).To(And(
-					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
+					HaveKeyWithValue("issued-at-time", strconv.FormatInt(secretsutils.AdjustToClockSkew(fakeClock.Now()).Unix(), 10)),
 					HaveKeyWithValue("valid-until-time", strconv.FormatInt(fakeClock.Now().AddDate(10, 0, 0).Unix(), 10)),
 				))
 			})
@@ -423,7 +423,7 @@ var _ = Describe("Generate", func() {
 
 				By("Verify labels")
 				Expect(foundSecret.Labels).To(And(
-					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
+					HaveKeyWithValue("issued-at-time", strconv.FormatInt(secretsutils.AdjustToClockSkew(fakeClock.Now()).Unix(), 10)),
 					HaveKeyWithValue("valid-until-time", strconv.FormatInt(fakeClock.Now().AddDate(10, 0, 0).Unix(), 10)),
 				))
 			})
@@ -613,7 +613,7 @@ var _ = Describe("Generate", func() {
 
 				By("Verify labels")
 				Expect(foundSecret.Labels).To(And(
-					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
+					HaveKeyWithValue("issued-at-time", strconv.FormatInt(secretsutils.AdjustToClockSkew(fakeClock.Now()).Unix(), 10)),
 					HaveKeyWithValue("valid-until-time", strconv.FormatInt(fakeClock.Now().AddDate(10, 0, 0).Unix(), 10)),
 				))
 			})
@@ -637,7 +637,7 @@ var _ = Describe("Generate", func() {
 
 				By("Verify labels")
 				Expect(foundSecret.Labels).To(And(
-					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
+					HaveKeyWithValue("issued-at-time", strconv.FormatInt(secretsutils.AdjustToClockSkew(fakeClock.Now()).Unix(), 10)),
 					HaveKeyWithValue("valid-until-time", strconv.FormatInt(fakeClock.Now().AddDate(10, 0, 0).Unix(), 10)),
 				))
 			})
@@ -783,7 +783,7 @@ var _ = Describe("Generate", func() {
 
 				By("Verify labels")
 				Expect(serverSecret.Labels).To(And(
-					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
+					HaveKeyWithValue("issued-at-time", strconv.FormatInt(secretsutils.AdjustToClockSkew(fakeClock.Now()).Unix(), 10)),
 					HaveKeyWithValue("valid-until-time", strconv.FormatInt(fakeClock.Now().Add(*serverConfig.Validity).Unix(), 10)),
 				))
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area ops-productivity
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Backdate generated certificates slightly (1 min) to allow a certain clock skew of clients.

In the real worlds, clocks are not always in sync. Clock skew is real and may cause trouble in a distributed system.
For example, if a user creates a kubeconfig via the garden cluster it should be valid also for the shoot cluster's api server, which may run on a different infrastructure and hence may use different time servers for synchronisation.
Backdating the certificates slightly allows some clock skew and prevents confusing errors.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

While I did not find official documentation on this, it seems let's encrypt backdates its certificates by even one hour, e.g. see https://community.letsencrypt.org/t/issued-cert-date-shows-gmt-1-instead-of-gmt/12832/3 and https://community.letsencrypt.org/t/certificates-issued-one-hour-too-early/166647. Therefore, backdating by 1 minute should be fine. It will not handle larger clock skew, but it should work for almost all cases.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener generated certificates are valid 1 minute before issuance to handle some amount of clock skew.
```
