### PR TITLE
CIS 4.1.5 ensure kubelet config has permissions set to 600

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -73,7 +73,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		},
 		{
 			Path:        PathKubeletConfig,
-			Permissions: ptr.To[int32](0644),
+			Permissions: ptr.To[int32](0600),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: fileContentKubeletConfig,
 			},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -259,7 +259,7 @@ func kubeletFiles(ctx components.Context, kubeletConfig, kubeletCABundleBase64 s
 		},
 		{
 			Path:        "/var/lib/kubelet/config/kubelet",
-			Permissions: ptr.To[int32](0644),
+			Permissions: ptr.To[int32](0600),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind enhancement

**What this PR does / why we need it**:

According to chapter 4.1.5 of the CIS Kubernetes Benchmark v1.10 the kubelet config permissions must be set to 600.
