### PR TITLE
Fix extracting the `go` binaries in the remote local setup

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,7 +29,9 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo golang          && wget -N "https://go.dev/dl/$(curl -sL https://golang.org/VERSION?m=text | awk 'NR==1{print}').linux-amd64.tar.gz" && tar -C /usr/local -xzf go1.*.linux-amd64.tar.gz \
+          echo golang          && VERSION=$(curl -sL https://golang.org/VERSION?m=text | awk 'NR==1{print}') \
+                               && wget -N "https://go.dev/dl/$VERSION.linux-amd64.tar.gz" \
+                               && tar -C /usr/local -xzf "$VERSION.linux-amd64.tar.gz" \
                                && ln -s /usr/local/go/bin/go /usr/local/bin/go \
                                && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
           echo gardenlogin     && wget -N "https://github.com/gardener/gardenlogin/releases/download/$(curl -sL https://raw.githubusercontent.com/gardener/gardenlogin/master/LATEST)/gardenlogin_linux_amd64" && mv gardenlogin_linux_amd64 /usr/local/bin/gardenlogin && chmod +x /usr/local/bin/gardenlogin \


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

https://github.com/gardener/gardener/pull/10502 reverted the remote local setup back to installing `go` via the official go download site instead of `apk`. However using the wildcard to extract the downloaded tar file leads to errors if there are multiple files matching the pattern, which appears to be the case when a newer go version is downloaded. The following example is a wrong `tar` command:

```
tar -C /usr/local -xzf go1.22.linux-amd64.tar.gz go1.23.linux-amd64.tar.gz
```

This PR fixes this issue by only extracting the latest version.

**Special notes for your reviewer**:

/cc @istvanballok 
/fyi @plkokanov 

**Release note**:

```other developer
Correctly extract and install the go binaries in the remote local setup
```
