### PR TITLE
[operator] Fix Gardenlet deployment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -190,6 +190,7 @@
 * [Deploying Gardenlets](deployment/deploy_gardenlet.md)
   * [Automatic Deployment of Gardenlets](deployment/deploy_gardenlet_automatically.md)
   * [Deploy a Gardenlet Manually](deployment/deploy_gardenlet_manually.md)
+  * [Deploy a Gardenlet via Gardener Operator](deployment/deploy_gardenlet_via_operator.md)
   * [Scoped API Access for Gardenlets](deployment/gardenlet_api_access.md)
 * [Overwrite image vector](deployment/image_vector.md)
 * [Migration from Gardener `v0` to `v1`](deployment/migration_v0_to_v1.md)

--- a/docs/deployment/deploy_gardenlet_automatically.md
+++ b/docs/deployment/deploy_gardenlet_automatically.md
@@ -6,7 +6,7 @@ This procedure is the preferred way to add additional seed clusters, because sho
 
 ## Prerequisites
 
-The only prerequisite is to register an initial cluster as a seed cluster that already has a manually deployed gardenlet (for a step-by-step manual installation guide, see [Deploy a Gardenlet Manually](deploy_gardenlet_manually.md)).
+The only prerequisite is to register an initial cluster as a seed cluster that already has a deployed gardenlet (for available options see [Deploying Gardenlets](deploy_gardenlet.md)).
 
 > [!TIP]
 > The initial seed cluster can be the garden cluster itself, but for better separation of concerns, it is recommended to only register other clusters as seeds.

--- a/docs/deployment/deploy_gardenlet_via_operator.md
+++ b/docs/deployment/deploy_gardenlet_via_operator.md
@@ -127,5 +127,5 @@ spec:
 # ...
 ```
 
-After successful deployment of gardenlet, `gardener-operator` will delete the `remote-cluster-kubeconfig` `Secret` and set `.spec.kubeconfigSecretRef` to `nil`.
+After successful deployment of gardenlet and registration of the expected seed cluster, `gardener-operator` will delete the `remote-cluster-kubeconfig` `Secret`.
 This is because the kubeconfig will never ever be needed anymore (`gardener-operator` is only responsible for initial deployment, and gardenlet updates itself with an in-cluster kubeconfig).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
When deploying a Gardenlet to a remote cluster, it happened that the Kubeconfig reference was deleted from the `Gardenlet` object, but the `Seed` was not yet registered.
In the next reconciliation run, the controller tries to deploy the Gardenlet chart with the in-cluster Kubeconfig, i.e. to a totally different and undesired cluster.

This PR fixes said scenario. The controller does not remove `spec.kubeconfigSecretRef` anymore for this purpose.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ thanks for reporting
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue was fixed that cause `gardener-operator` to deploy the `gardenlet` into the runtime cluster instead of another intended remote cluster.
```
