### PR TITLE
set correct IPFamilies value for vpn-client apiserver sidecar

### DIFF
--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -859,6 +859,7 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 
 	if len(k.values.VPN.IPFamilies) > 0 {
 		container.Env = append(container.Env, corev1.EnvVar{
+			// IP_FAMILIES of seed
 			Name:  "IP_FAMILIES",
 			Value: string(k.values.VPN.IPFamilies[0]),
 		})

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -44,7 +44,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 		vpnConfig.HighAvailabilityNumberOfSeedServers = b.Shoot.VPNHighAvailabilityNumberOfSeedServers
 		vpnConfig.HighAvailabilityNumberOfShootClients = b.Shoot.VPNHighAvailabilityNumberOfShootClients
 		// Pod/service/node network CIDRs are set on deployment to handle dynamic network CIDRs
-		vpnConfig.IPFamilies = b.Shoot.GetInfo().Spec.Networking.IPFamilies
+		vpnConfig.IPFamilies = b.Seed.GetInfo().Spec.Networks.IPFamilies
 		vpnConfig.DisableNewVPN = !b.Shoot.UsesNewVPN
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Set correct IPFamilies value for `vpn-client-x` sidecar in the apiserver pod in case HA controlplane is enabled.
Until now was the IPFamilies for the shoot specified which breaks the setup in case an IPv6 shoot runs on an IPv4 Seed (OpenVPN in sidecar tries to resolve hostname via AAAA record instead of A record).

See:

```
2024-10-07 12:41:14 RESOLVE: Cannot resolve host address: vpn-seed-server-1:1194 (Name has no usable address)
2024-10-07 12:41:14 RESOLVE: Cannot resolve host address: vpn-seed-server-1:1194 (Name has no usable address)
2024-10-07 12:41:14 Could not determine IPv4/IPv6 protocol
2024-10-07 12:41:14 SIGUSR1[soft,Could not determine IPv4/IPv6 protocol] received, process restarting
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
HA-VPN works if seed and shoot have different IPFamilies.
```
