### PR TITLE
Fix cAdvisor network metric relabeling config

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
@@ -41,7 +41,7 @@ metric_relabel_configs:
   regex: POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_usage_bytes|container_fs_writes_bytes_total|container_last_seen|container_memory_cache|container_memory_mapped_file|container_memory_rss|container_memory_usage_bytes|container_memory_working_set_bytes|container_oom_events_total)
   action: drop
 - source_labels: [ __name__, container, interface, id ]
-  regex: container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*
+  regex: container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*
   action: keep
 - source_labels: [ __name__, container, interface ]
   regex: container_network.+;POD;(.{5,}|tun0|en.+)

--- a/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
@@ -61,7 +61,7 @@ metric_relabel_configs:
   regex: POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_usage_bytes|container_fs_writes_bytes_total|container_last_seen|container_memory_cache|container_memory_mapped_file|container_memory_rss|container_memory_usage_bytes|container_memory_working_set_bytes|container_oom_events_total)
   action: drop
 - source_labels: [ __name__, container, interface, id ]
-  regex: container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*
+  regex: container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*
   action: keep
 - source_labels: [ __name__, container, interface ]
   regex: container_network.+;POD;(.{5,}|tun0|en.+)
@@ -157,7 +157,7 @@ metric_relabel_configs:
   regex: POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_usage_bytes|container_fs_writes_bytes_total|container_last_seen|container_memory_cache|container_memory_mapped_file|container_memory_rss|container_memory_usage_bytes|container_memory_working_set_bytes|container_oom_events_total)
   action: drop
 - source_labels: [ __name__, container, interface, id ]
-  regex: container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*
+  regex: container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*
   action: keep
 - source_labels: [ __name__, container, interface ]
   regex: container_network.+;POD;(.{5,}|tun0|en.+)

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -277,7 +277,7 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 						{
 							SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface", "id"},
 							Action:       "keep",
-							Regex:        `container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*`,
+							Regex:        `container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*`,
 						},
 						{
 							SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface"},

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -253,7 +253,7 @@ var _ = Describe("ScrapeConfigs", func() {
 								{
 									SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface", "id"},
 									Action:       "keep",
-									Regex:        `container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*`,
+									Regex:        `container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*`,
 								},
 								{
 									SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
The cAdvisor relabeling config uses the name of the network interface to add a label to the scraped metrics if it is a node's host network. This happens for different devices, i.e. if overlay network is enabled, it also applies to the overlay network device (tunl0). Critically, nodes on AWS will name the device as specified here:
https://github.com/systemd/systemd/blob/ccddd104fc95e0e769142af6e1fe1edec5be70a6/src/udev/udev-builtin-net_id.c#L29 This leads to device names such as `enp39s0`, which were, prior to this commit, not matched by the regex.
In consequence, the `Node Details` dashboard's network throughput panel did not display data, as it filters for the metrics labeled `host_network="true"`.
So far, this was only an issue on AWS nodes. OpenStack, Aliyun, and GCP name devices `ens.+`, and Azure node network devices are named `eth0`. Therefore, adapting the regex in the relabling config to match ethernet devices (`en` prefix) will also populate the `Node Details` dashboard's network panel again.

**Which issue(s) this PR fixes**:
Fixes an issue in a Prometheus relabeling config that caused AWS nodes' network metrics to not get labeled as `host_network="true"`, which in turn broke some dashboard panels.

**Special notes for your reviewer**:
cc @istvanballok @vicwicker @chrkl @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes an issue with the network metrics relabeling config that caused the `Node Details` dashboard to not display data for AWS nodes.
```
