### PR TITLE
[NewVPN] Enable IPv6 for HA if needed.

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -2931,6 +2931,9 @@ kind: AuthenticationConfiguration
 					MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
 					ReadOnly:  true,
 				})
+				if !disableNewVPN {
+					initContainer.SecurityContext.Privileged = ptr.To(true)
+				}
 				if disableNewVPN {
 					initContainer.Command = nil
 					initContainer.Env = append(initContainer.Env,

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -753,6 +753,11 @@ func (k *kubeAPIServer) vpnSeedClientInitContainer() *corev1.Container {
 		},
 	}...)
 
+	if !k.values.VPN.DisableNewVPN {
+		// may need to enable IPv6 in pod network (e.g. for GKE clusters)
+		container.SecurityContext.Privileged = ptr.To(true)
+	}
+
 	if k.values.VPN.DisableNewVPN {
 		container.Command = nil
 		container.Env = append(container.Env,

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -594,6 +594,29 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 			},
 		}
 
+		if !v.values.DisableNewVPN {
+			template.Spec.InitContainers = []corev1.Container{
+				{
+					Name:            "setup",
+					Image:           v.values.ImageVPNSeedServer,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command: []string{
+						"/bin/vpn-server",
+						"setup",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "IS_HA",
+							Value: "true",
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: ptr.To(true),
+					},
+				},
+			}
+		}
+
 		if v.values.DisableNewVPN {
 			statusPath := filepath.Join(volumeMountPathStatusDir, "openvpn.status")
 			exporterContainer.Command = []string{

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -323,6 +323,28 @@ var _ = Describe("VpnSeedServer", func() {
 					},
 					VolumeMounts: []corev1.VolumeMount{mount},
 				}
+				if !disableNewVPN {
+					template.Spec.InitContainers = []corev1.Container{
+						{
+							Name:            "setup",
+							Image:           vpnSeedServerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command: []string{
+								"/bin/vpn-server",
+								"setup",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "IS_HA",
+									Value: "true",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+						},
+					}
+				}
 				if disableNewVPN {
 					exporterContainer.Command = []string{
 						"/openvpn-exporter",


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
If the `NewVPN` feature gate is enabled, an IPv6 transport network is used by the VPN tunnel. In HA mode, an IPv6 address needs to be assigned to the bonding device for the vpn-client. An IPv6 address needs also to be set in the vpn-seed-server in this case. If IPv6 is disabled in the pod (e.g. seen for GKE clusters with IPv4 stack only), the init containers must enable IPv6 by changing a kernel setting.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Depends on #10640

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[NewVPN] Enable IPv6 for HA if needed.
```
