### PR TITLE
Fix Authenticationconfig admission webhook and use `v1beta1`

### DIFF
--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -160,7 +160,7 @@ metadata:
   namespace: garden-my-project
 data:
   config.yaml: |
-    apiVersion: apiserver.config.k8s.io/v1alpha1
+    apiVersion: apiserver.config.k8s.io/v1beta1
     kind: AuthenticationConfiguration
     jwt:
     - issuer:
@@ -180,8 +180,7 @@ data:
         message: "the hosted domain name must be example.com"
 ```
 
-Currently, only `apiVersion: apiserver.config.k8s.io/v1alpha1` is supported.
-The user is resposible for the validity of the configured `JWTAuthenticator`s.
+The user is responsible for the validity of the configured `JWTAuthenticator`s.
 
 ## Static Token kubeconfig
 

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler.go
@@ -97,10 +97,6 @@ func (h *Handler) admitShoot(ctx context.Context, request admission.Request) adm
 		return admissionwebhook.Allowed("shoot is already marked for deletion")
 	}
 
-	var (
-		authenticationConfigurationConfigMapName string
-	)
-
 	if request.Operation == admissionv1.Update {
 		oldShoot := &gardencore.Shoot{}
 		if err := runtime.DecodeInto(internalDecoder, request.OldObject.Raw, oldShoot); err != nil {
@@ -113,8 +109,8 @@ func (h *Handler) admitShoot(ctx context.Context, request admission.Request) adm
 			return admissionwebhook.Allowed("shoot spec was not changed")
 		}
 	}
-	authenticationConfigurationConfigMapName = gardencorehelper.GetShootAuthenticationConfigurationConfigMapName(shoot.Spec.Kubernetes.KubeAPIServer)
 
+	authenticationConfigurationConfigMapName := gardencorehelper.GetShootAuthenticationConfigurationConfigMapName(shoot.Spec.Kubernetes.KubeAPIServer)
 	if authenticationConfigurationConfigMapName == "" {
 		return admissionwebhook.Allowed("shoot resource is not specifying any authentication configuration")
 	}

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler.go
@@ -103,8 +103,8 @@ func (h *Handler) admitShoot(ctx context.Context, request admission.Request) adm
 		newAuthenticationConfigurationConfigMapName string
 		oldShootKubernetesVersion                   string
 		newShootKubernetesVersion                   string
-		oldServiceAccountConfigIssuer               *string
-		newServiceAccountConfigIssuer               *string
+		oldServiceAccountIssuer                     *string
+		newServiceAccountIssuer                     *string
 		oldServiceAccountAcceptedIssuers            []string
 		newServiceAccountAcceptedIssuers            []string
 	)
@@ -123,12 +123,12 @@ func (h *Handler) admitShoot(ctx context.Context, request admission.Request) adm
 
 		oldShootKubernetesVersion = oldShoot.Spec.Kubernetes.Version
 		oldAuthenticationConfigurationConfigMapName = gardencorehelper.GetShootAuthenticationConfigurationConfigMapName(oldShoot.Spec.Kubernetes.KubeAPIServer)
-		oldServiceAccountConfigIssuer = gardencorehelper.GetShootServiceAccountConfigIssuer(oldShoot.Spec.Kubernetes.KubeAPIServer)
+		oldServiceAccountIssuer = gardencorehelper.GetShootServiceAccountConfigIssuer(oldShoot.Spec.Kubernetes.KubeAPIServer)
 		oldServiceAccountAcceptedIssuers = gardencorehelper.GetShootServiceAccountConfigAcceptedIssuers(oldShoot.Spec.Kubernetes.KubeAPIServer)
 	}
 	newShootKubernetesVersion = shoot.Spec.Kubernetes.Version
 	newAuthenticationConfigurationConfigMapName = gardencorehelper.GetShootAuthenticationConfigurationConfigMapName(shoot.Spec.Kubernetes.KubeAPIServer)
-	newServiceAccountConfigIssuer = gardencorehelper.GetShootServiceAccountConfigIssuer(shoot.Spec.Kubernetes.KubeAPIServer)
+	newServiceAccountIssuer = gardencorehelper.GetShootServiceAccountConfigIssuer(shoot.Spec.Kubernetes.KubeAPIServer)
 	newServiceAccountAcceptedIssuers = gardencorehelper.GetShootServiceAccountConfigAcceptedIssuers(shoot.Spec.Kubernetes.KubeAPIServer)
 
 	if newAuthenticationConfigurationConfigMapName == "" {
@@ -141,7 +141,7 @@ func (h *Handler) admitShoot(ctx context.Context, request admission.Request) adm
 	// disallowed for the authentication configuration
 	if oldAuthenticationConfigurationConfigMapName == newAuthenticationConfigurationConfigMapName &&
 		oldShootKubernetesVersion == newShootKubernetesVersion &&
-		equalOrNil(oldServiceAccountConfigIssuer, newServiceAccountConfigIssuer) &&
+		equalOrNil(oldServiceAccountIssuer, newServiceAccountIssuer) &&
 		slices.Equal(oldServiceAccountAcceptedIssuers, newServiceAccountAcceptedIssuers) {
 		return admissionwebhook.Allowed("authentication configuration configmap was not changed")
 	}

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler_test.go
@@ -248,12 +248,6 @@ jwt:
 				test(admissionv1.Create, nil, shootv1beta1, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
 			})
 
-			It("referenced authenticationConfiguration name was not changed (UPDATE)", func() {
-				newShoot := shootv1beta1.DeepCopy()
-				newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{{Name: "some-plugin"}}
-				test(admissionv1.Update, shootv1beta1, newShoot, true, statusCodeAllowed, "authentication configuration configmap was not changed", "")
-			})
-
 			It("authenticationConfiguration name was added (UPDATE)", func() {
 				returnedCm := corev1.ConfigMap{
 					Data: map[string]string{"config.yaml": validAuthenticationConfiguration},

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler_test.go
@@ -63,7 +63,7 @@ var _ = Describe("handler", func() {
 
 		validAuthenticationConfiguration = `
 ---
-apiVersion: apiserver.config.k8s.io/v1alpha1
+apiVersion: apiserver.config.k8s.io/v1beta1
 kind: AuthenticationConfiguration
 jwt:
 - issuer:
@@ -77,7 +77,7 @@ jwt:
 `
 		anotherValidAuthenticationConfiguration = `
 ---
-apiVersion: apiserver.config.k8s.io/v1alpha1
+apiVersion: apiserver.config.k8s.io/v1beta1
 kind: AuthenticationConfiguration
 jwt:
 - issuer:
@@ -99,7 +99,7 @@ jwt:
 `
 		missingKeyConfiguration = `
 ---
-apiVersion: apiserver.config.k8s.io/v1alpha1
+apiVersion: apiserver.config.k8s.io/v1beta1
 kind: AuthenticationConfiguration
 jwt:
 - issuer:
@@ -113,7 +113,7 @@ jwt:
 `
 		invalidAuthenticationConfiguration = `
 ---
-apiVersion: apiserver.config.k8s.io/v1alpha1
+apiVersion: apiserver.config.k8s.io/v1beta1
 kind: AuthenticationConfiguration
 jwt:
 - issuer:
@@ -126,7 +126,7 @@ jwt:
 
 		invalidIssuerUrl = `
 ---
-apiVersion: apiserver.config.k8s.io/v1alpha1
+apiVersion: apiserver.config.k8s.io/v1beta1
 kind: AuthenticationConfiguration
 jwt:
 - issuer:
@@ -269,6 +269,19 @@ jwt:
 				test(admissionv1.Update, shootv1beta1, newShoot, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
 			})
 
+			It("serviceAccountConfig is nil (UPDATE)", func() {
+				returnedCm := corev1.ConfigMap{
+					Data: map[string]string{"config.yaml": validAuthenticationConfiguration},
+				}
+				newShoot := shootv1beta1.DeepCopy()
+				newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = nil
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = returnedCm
+					return nil
+				})
+				test(admissionv1.Update, shootv1beta1, newShoot, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
+			})
+
 			It("referenced authenticationConfiguration name was changed (UPDATE)", func() {
 				returnedCm := corev1.ConfigMap{
 					Data: map[string]string{"config.yaml": validAuthenticationConfiguration},
@@ -360,15 +373,13 @@ jwt:
 
 			It("contains disallowed issuers in the service account config", func() {
 				returnedCm := corev1.ConfigMap{
-					Data: map[string]string{"config.yaml": validAuthenticationConfiguration},
+					Data: map[string]string{"config.yaml": invalidIssuerUrl},
 				}
-				newShoot := shootv1beta1.DeepCopy()
-				newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.Issuer = ptr.To("https://foo.com")
 				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: shootNamespace, Name: cmName}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
-				test(admissionv1.Create, nil, newShoot, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://foo.com\": URL must not overlap with disallowed issuers:", "")
+				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://abc.com\": URL must not overlap with disallowed issuers:", "")
 			})
 		})
 	})

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -352,6 +352,24 @@ func GetShootAuthenticationConfigurationConfigMapName(apiServerConfig *core.Kube
 	return ""
 }
 
+// GetShootServiceAccountConfigIssuer returns the Shoot's ServiceAccountConfig Issuer.
+func GetShootServiceAccountConfigIssuer(apiServerConfig *core.KubeAPIServerConfig) *string {
+	if apiServerConfig != nil &&
+		apiServerConfig.ServiceAccountConfig != nil {
+		return apiServerConfig.ServiceAccountConfig.Issuer
+	}
+	return nil
+}
+
+// GetShootServiceAccountConfigAcceptedIssuers returns the Shoot's ServiceAccountConfig AcceptedIssuers.
+func GetShootServiceAccountConfigAcceptedIssuers(apiServerConfig *core.KubeAPIServerConfig) []string {
+	if apiServerConfig != nil &&
+		apiServerConfig.ServiceAccountConfig != nil {
+		return apiServerConfig.ServiceAccountConfig.AcceptedIssuers
+	}
+	return nil
+}
+
 // HibernationIsEnabled checks if the given shoot's desired state is hibernated.
 func HibernationIsEnabled(shoot *core.Shoot) bool {
 	return shoot.Spec.Hibernation != nil && ptr.Deref(shoot.Spec.Hibernation.Enabled, false)

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -501,6 +501,42 @@ var _ = Describe("helper", func() {
 		}, "foo"),
 	)
 
+	DescribeTable("#GetShootServiceAccountConfigIssuer",
+		func(kubeAPIServerConfig *core.KubeAPIServerConfig, expectedIssuer *string) {
+			Issuer := GetShootServiceAccountConfigIssuer(kubeAPIServerConfig)
+			Expect(Issuer).To(Equal(expectedIssuer))
+		},
+
+		Entry("KubeAPIServerConfig = nil", nil, nil),
+		Entry("ServiceAccountConfig = nil", &core.KubeAPIServerConfig{}, nil),
+		Entry("Issuer not set", &core.KubeAPIServerConfig{
+			ServiceAccountConfig: &core.ServiceAccountConfig{},
+		}, nil),
+		Entry("Issuer set", &core.KubeAPIServerConfig{
+			ServiceAccountConfig: &core.ServiceAccountConfig{
+				Issuer: ptr.To("foo"),
+			},
+		}, ptr.To("foo")),
+	)
+
+	DescribeTable("#GetShootServiceAccountConfigAcceptedIssuers",
+		func(kubeAPIServerConfig *core.KubeAPIServerConfig, expectedAcceptedIssuers []string) {
+			AcceptedIssuers := GetShootServiceAccountConfigAcceptedIssuers(kubeAPIServerConfig)
+			Expect(AcceptedIssuers).To(Equal(expectedAcceptedIssuers))
+		},
+
+		Entry("KubeAPIServerConfig = nil", nil, nil),
+		Entry("ServiceAccountConfig = nil", &core.KubeAPIServerConfig{}, nil),
+		Entry("AcceptedIssuers not set", &core.KubeAPIServerConfig{
+			ServiceAccountConfig: &core.ServiceAccountConfig{},
+		}, nil),
+		Entry("AcceptedIssuers set", &core.KubeAPIServerConfig{
+			ServiceAccountConfig: &core.ServiceAccountConfig{
+				AcceptedIssuers: []string{"foo", "bar"},
+			},
+		}, []string{"foo", "bar"}),
+	)
+
 	DescribeTable("#HibernationIsEnabled",
 		func(shoot *core.Shoot, hibernated bool) {
 			Expect(HibernationIsEnabled(shoot)).To(Equal(hibernated))

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -2234,7 +2234,7 @@ rules:
 							UsernamePrefix: ptr.To("some-username-prefix"),
 						}
 						version              = semver.MustParse("1.30.0")
-						authenticationConfig = `apiVersion: apiserver.config.k8s.io/v1alpha1
+						authenticationConfig = `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups:
@@ -2294,7 +2294,7 @@ kind: AuthenticationConfiguration
 						IssuerURL:   ptr.To("https://issuer.url.com"),
 					}
 					version              = semver.MustParse("1.30.0")
-					authenticationConfig = `apiVersion: apiserver.config.k8s.io/v1alpha1
+					authenticationConfig = `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups:
@@ -2349,7 +2349,7 @@ kind: AuthenticationConfiguration
 						UsernamePrefix: ptr.To("-"),
 					}
 					version              = semver.MustParse("1.30.0")
-					authenticationConfig = `apiVersion: apiserver.config.k8s.io/v1alpha1
+					authenticationConfig = `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups: {}
@@ -3818,7 +3818,7 @@ kind: AuthenticationConfiguration
 							IssuerURL: ptr.To("https://issuer.url.com"),
 						}
 						version              = semver.MustParse("1.30.0")
-						authenticationConfig = `apiVersion: apiserver.config.k8s.io/v1alpha1
+						authenticationConfig = `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups: {}

--- a/pkg/component/kubernetes/apiserver/authentication.go
+++ b/pkg/component/kubernetes/apiserver/authentication.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -66,13 +66,12 @@ func (k *kubeAPIServer) reconcileConfigMapAuthenticationConfig(ctx context.Conte
 
 // ComputeAuthenticationConfigRawConfig computes a AuthenticationConfiguration from oidcConfiguration.
 func ComputeAuthenticationConfigRawConfig(oidc *gardencorev1beta1.OIDCConfig) (string, error) {
-	authenticationConfiguration := &apiserverv1alpha1.AuthenticationConfiguration{
+	authenticationConfiguration := &apiserverv1beta1.AuthenticationConfiguration{
 		TypeMeta: metav1.TypeMeta{
-			// TODO(AleksandarSavchev): use v1beta1 when kubernetes packages are updated to version >= v1.30
-			APIVersion: apiserverv1alpha1.ConfigSchemeGroupVersion.String(),
+			APIVersion: apiserverv1beta1.ConfigSchemeGroupVersion.String(),
 			Kind:       "AuthenticationConfiguration",
 		},
-		JWT: []apiserverv1alpha1.JWTAuthenticator{{}},
+		JWT: []apiserverv1beta1.JWTAuthenticator{{}},
 	}
 
 	if v := oidc.CABundle; v != nil {
@@ -108,7 +107,7 @@ func ComputeAuthenticationConfigRawConfig(oidc *gardencorev1beta1.OIDCConfig) (s
 	}
 
 	for key, value := range oidc.RequiredClaims {
-		claimValidationRule := apiserverv1alpha1.ClaimValidationRule{
+		claimValidationRule := apiserverv1beta1.ClaimValidationRule{
 			Claim:         key,
 			RequiredValue: value,
 		}

--- a/pkg/component/kubernetes/apiserver/authentication_test.go
+++ b/pkg/component/kubernetes/apiserver/authentication_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Authentication", func() {
 				},
 				UsernameClaim:  ptr.To("some-user-claim"),
 				UsernamePrefix: ptr.To("some-user-prefix"),
-			}, `apiVersion: apiserver.config.k8s.io/v1alpha1
+			}, `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups:
@@ -57,7 +57,7 @@ kind: AuthenticationConfiguration
 			Entry("should retrun configuration with defaulted username values", &gardencorev1beta1.OIDCConfig{
 				ClientID:  ptr.To("some-client-id"),
 				IssuerURL: ptr.To("https://issuer.url.com"),
-			}, `apiVersion: apiserver.config.k8s.io/v1alpha1
+			}, `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups: {}
@@ -76,7 +76,7 @@ kind: AuthenticationConfiguration
 				IssuerURL:      ptr.To("https://issuer.url.com"),
 				UsernameClaim:  ptr.To("claim"),
 				UsernamePrefix: ptr.To("-"),
-			}, `apiVersion: apiserver.config.k8s.io/v1alpha1
+			}, `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups: {}
@@ -95,7 +95,7 @@ kind: AuthenticationConfiguration
 				IssuerURL:      ptr.To("https://issuer.url.com"),
 				UsernameClaim:  ptr.To("email"),
 				UsernamePrefix: ptr.To(""),
-			}, `apiVersion: apiserver.config.k8s.io/v1alpha1
+			}, `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups: {}
@@ -113,7 +113,7 @@ kind: AuthenticationConfiguration
 				ClientID:    ptr.To("some-client-id"),
 				IssuerURL:   ptr.To("https://issuer.url.com"),
 				GroupsClaim: ptr.To("some-groups-claim"),
-			}, `apiVersion: apiserver.config.k8s.io/v1alpha1
+			}, `apiVersion: apiserver.config.k8s.io/v1beta1
 jwt:
 - claimMappings:
     groups:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR fixes bugs introduced with #10459 to the authenticationconfig admission webhook. There are 3 bugs fixed:
- `Nil` pointers were not handled correctly in the `getDisallowedIssuers` function https://github.com/gardener/gardener/blob/7e15081b9feefe9315973000894429666c19c977/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler.go#L262-L266
- Having 0 disallowed issuers is a viable configuration
https://github.com/gardener/gardener/blob/7e15081b9feefe9315973000894429666c19c977/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler.go#L267-L270
- Changes to `ServiceAccountConfig` need to taken into account on Shoot `Update` for revalidation here:
https://github.com/gardener/gardener/blob/7e15081b9feefe9315973000894429666c19c977/pkg/admissioncontroller/webhook/admission/authenticationconfig/handler.go#L129-L134 

This PR also replaces `AuthenticationConfiguration` version `apiserver.config.k8s.io/v1alpha1` with `apiserver.config.k8s.io/v1beta1` for the computed configuration from `oidcConfiguration` since it is now supported with #10459.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
No bug fix release note is added since #10459 has not been released yet.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
