### PR TITLE
Deprecate `HVPA` and `HVPAForShootedSeed` feature gates

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -20,8 +20,6 @@ The following tables are a summary of the feature gates that you can set on diff
 
 | Feature                   | Default | Stage   | Since   | Until   |
 |---------------------------|---------|---------|---------|---------|
-| HVPA                      | `false` | `Alpha` | `0.31`  |         |
-| HVPAForShootedSeed        | `false` | `Alpha` | `0.32`  |         |
 | DefaultSeccompProfile     | `false` | `Alpha` | `1.54`  |         |
 | IPv6SingleStack           | `false` | `Alpha` | `1.63`  |         |
 | ShootForceDeletion        | `false` | `Alpha` | `1.81`  | `1.90`  |
@@ -167,6 +165,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | VPAAndHPAForAPIServer                        | `false` | `Alpha`      | `1.95`  | `1.100` |
 | VPAAndHPAForAPIServer                        | `true`  | `Beta`       | `1.101` | `1.104` |
 | VPAAndHPAForAPIServer                        | `true`  | `GA`         | `1.105` |         |
+| HVPA                                         | `false` | `Alpha`      | `0.31`  | `1.105` |
+| HVPA                                         | `false` | `Deprecated` | `1.106` |         |
+| HVPAForShootedSeed                           | `false` | `Alpha`      | `0.32`  | `1.105` |
+| HVPAForShootedSeed                           | `false` | `Deprecated` | `1.106` |         |
 
 ## Using a Feature
 

--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -19,6 +19,9 @@ However, there are two supported autoscaling modes for the Garden or Shoot clust
 
    The `HVPA` mode is the used autoscaling mode when the `HVPA` feature gate is enabled and the `VPAForETCD` feature gate is disabled.
 
+> [!NOTE]
+> Starting with release `v1.106`, the `HVPA` feature gate is deprecated and locked to false.
+
 - `VPA`
 
    In `VPA` mode, the etcd is scaled by a native `VPA` resource.
@@ -62,6 +65,9 @@ There are three supported autoscaling modes for the Shoot Kubernetes API server.
    The API server's min replicas count is 2, the max replicas count - 3.
 
    The `HVPA` mode is the used autoscaling mode when the `HVPA` feature gate is enabled (and the `VPAAndHPAForAPIServer` feature gate is disabled).
+
+> [!NOTE]
+> Starting with release `v1.106`, the `HVPA` feature gate is deprecated and locked to false.
 
 - `VPAAndHPA`
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -18,16 +18,20 @@ const (
 	// MyFeature featuregate.Feature = "MyFeature"
 
 	// HVPA enables simultaneous horizontal and vertical scaling in Seed Clusters.
+	// Deprecated: The feature gate is deprecated and locked to false. It will be removed in a future release.
 	// owner @shreyas-s-rao @voelzmo
 	// alpha: v0.31.0
+	// deprecated: v1.106.0
 	HVPA featuregate.Feature = "HVPA"
 
 	// HVPAForShootedSeed enables simultaneous horizontal and vertical scaling in shooted seed Clusters.
+	// Deprecated: The feature gate is deprecated and locked to false. It will be removed in a future release.
 	// owner @shreyas-s-rao @voelzmo
 	// alpha: v0.32.0
+	// deprecated: v1.106.0
 	HVPAForShootedSeed featuregate.Feature = "HVPAForShootedSeed"
 
-	// VPAForETCD enables using plain VPA for etcd-main and etcd-events, even if HVPA is enabled for the other components.
+	// VPAForETCD enables using plain VPA for etcd-main and etcd-events.
 	// owner @voelzmo
 	// alpha: v1.94.0
 	// beta: v1.97.0
@@ -68,7 +72,6 @@ const (
 	// The pod-trashing cycle between VPA and HPA scaling on the same metric is avoided
 	// by configuring the HPA to scale on average usage (not on average utilization) and
 	// by picking the target average utilization values in sync with VPA's allowed maximums.
-	// The feature gate takes precedence over the `HVPA` feature gate when they are both enabled.
 	// owner: @ialidzhikov
 	// alpha: v1.95.0
 	// beta: v1.101.0
@@ -119,8 +122,8 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 
 // AllFeatureGates is the list of all feature gates.
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	HVPA:                      {Default: false, PreRelease: featuregate.Alpha},
-	HVPAForShootedSeed:        {Default: false, PreRelease: featuregate.Alpha},
+	HVPA:                      {Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true},
+	HVPAForShootedSeed:        {Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true},
 	VPAForETCD:                {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	DefaultSeccompProfile:     {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:           {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -16,8 +16,8 @@ var _ = Describe("Features", func() {
 	Describe("#GetFeatures", func() {
 		It("should return the spec for the given feature gate", func() {
 			Expect(GetFeatures("HVPA", "HVPAForShootedSeed", "Foo")).To(Equal(map[featuregate.Feature]featuregate.FeatureSpec{
-				HVPA:               {Default: false, PreRelease: featuregate.Alpha},
-				HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Alpha},
+				HVPA:               {Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true},
+				HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true},
 			}))
 		})
 	})

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -87,8 +87,6 @@ var _ = Describe("Etcd", func() {
 	})
 
 	Describe("#DefaultEtcd", func() {
-		var hvpaEnabled = true
-
 		BeforeEach(func() {
 			botanist.SecretsManager = sm
 			botanist.SeedClientSet = kubernetesClient
@@ -128,8 +126,6 @@ var _ = Describe("Etcd", func() {
 						purpose = shootPurpose
 					)
 					It(fmt.Sprintf("should successfully create an etcd interface: class = %q, purpose = %q", class, purpose), func() {
-						defer test.WithFeatureGate(features.DefaultFeatureGate, features.HVPA, hvpaEnabled)()
-
 						botanist.Shoot.Purpose = purpose
 
 						validator := &newEtcdValidator{
@@ -142,7 +138,6 @@ var _ = Describe("Etcd", func() {
 							expectedReplicas:                PointTo(Equal(int32(1))),
 							expectedStorageCapacity:         Equal("10Gi"),
 							expectedDefragmentationSchedule: Equal(ptr.To("34 12 */3 * *")),
-							expectedHVPAEnabled:             Equal(hvpaEnabled),
 							expectedMaintenanceTimeWindow:   Equal(maintenanceTimeWindow),
 							expectedScaleDownUpdateMode:     Equal(ptr.To(computeUpdateMode(class, purpose))),
 							expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
@@ -180,7 +175,6 @@ var _ = Describe("Etcd", func() {
 					expectedReplicas:                PointTo(Equal(int32(1))),
 					expectedStorageCapacity:         Equal("10Gi"),
 					expectedDefragmentationSchedule: Equal(ptr.To("34 12 * * *")),
-					expectedHVPAEnabled:             Equal(hvpaEnabled),
 					expectedMaintenanceTimeWindow:   Equal(maintenanceTimeWindow),
 					expectedScaleDownUpdateMode:     Equal(ptr.To(hvpav1alpha1.UpdateModeMaintenanceWindow)),
 					expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
@@ -198,8 +192,6 @@ var _ = Describe("Etcd", func() {
 			It("should successfully create an etcd interface (important class)", func() {
 				class := etcd.ClassImportant
 
-				defer test.WithFeatureGate(features.DefaultFeatureGate, features.HVPAForShootedSeed, hvpaForShootedSeedEnabled)()
-
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
 					expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
@@ -210,7 +202,6 @@ var _ = Describe("Etcd", func() {
 					expectedReplicas:                PointTo(Equal(int32(1))),
 					expectedStorageCapacity:         Equal("10Gi"),
 					expectedDefragmentationSchedule: Equal(ptr.To("34 12 * * *")),
-					expectedHVPAEnabled:             Equal(hvpaEnabled),
 					expectedMaintenanceTimeWindow:   Equal(maintenanceTimeWindow),
 					expectedScaleDownUpdateMode:     Equal(ptr.To(hvpav1alpha1.UpdateModeMaintenanceWindow)),
 					expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
@@ -227,7 +218,6 @@ var _ = Describe("Etcd", func() {
 		})
 
 		It("should return an error because the maintenance time window cannot be parsed", func() {
-			defer test.WithFeatureGate(features.DefaultFeatureGate, features.HVPA, true)()
 			botanist.Shoot.GetInfo().Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
 				Begin: "foobar",
 				End:   "barfoo",
@@ -536,7 +526,6 @@ type newEtcdValidator struct {
 	expectedStorageCapacity         gomegatypes.GomegaMatcher
 	expectedDefragmentationSchedule gomegatypes.GomegaMatcher
 	expectedHighAvailabilityEnabled gomegatypes.GomegaMatcher
-	expectedHVPAEnabled             gomegatypes.GomegaMatcher
 	expectedMaintenanceTimeWindow   gomegatypes.GomegaMatcher
 	expectedScaleDownUpdateMode     gomegatypes.GomegaMatcher
 }

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +35,6 @@ import (
 	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	mocketcd "github.com/gardener/gardener/pkg/component/etcd/etcd/mock"
-	"github.com/gardener/gardener/pkg/features"
 	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
@@ -44,7 +42,6 @@ import (
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
-	"github.com/gardener/gardener/pkg/utils/test"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -112,13 +109,6 @@ var _ = Describe("Etcd", func() {
 				botanist.ManagedSeed = nil
 			})
 
-			computeUpdateMode := func(class etcd.Class, purpose gardencorev1beta1.ShootPurpose) string {
-				if class == etcd.ClassImportant && (purpose == gardencorev1beta1.ShootPurposeProduction || purpose == gardencorev1beta1.ShootPurposeInfrastructure) {
-					return hvpav1alpha1.UpdateModeOff
-				}
-				return hvpav1alpha1.UpdateModeMaintenanceWindow
-			}
-
 			for _, etcdClass := range []etcd.Class{etcd.ClassNormal, etcd.ClassImportant} {
 				for _, shootPurpose := range []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation, gardencorev1beta1.ShootPurposeProduction, gardencorev1beta1.ShootPurposeInfrastructure} {
 					var (
@@ -139,7 +129,6 @@ var _ = Describe("Etcd", func() {
 							expectedStorageCapacity:         Equal("10Gi"),
 							expectedDefragmentationSchedule: Equal(ptr.To("34 12 */3 * *")),
 							expectedMaintenanceTimeWindow:   Equal(maintenanceTimeWindow),
-							expectedScaleDownUpdateMode:     Equal(ptr.To(computeUpdateMode(class, purpose))),
 							expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 						}
 
@@ -156,15 +145,11 @@ var _ = Describe("Etcd", func() {
 		})
 
 		Context("no HVPAShootedSeed feature gate", func() {
-			hvpaForShootedSeedEnabled := false
-
 			BeforeEach(func() {
 				botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
 			})
 
 			It("should successfully create an etcd interface (normal class)", func() {
-				defer test.WithFeatureGate(features.DefaultFeatureGate, features.HVPAForShootedSeed, hvpaForShootedSeedEnabled)()
-
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
 					expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
@@ -176,7 +161,6 @@ var _ = Describe("Etcd", func() {
 					expectedStorageCapacity:         Equal("10Gi"),
 					expectedDefragmentationSchedule: Equal(ptr.To("34 12 * * *")),
 					expectedMaintenanceTimeWindow:   Equal(maintenanceTimeWindow),
-					expectedScaleDownUpdateMode:     Equal(ptr.To(hvpav1alpha1.UpdateModeMaintenanceWindow)),
 					expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 				}
 
@@ -203,7 +187,6 @@ var _ = Describe("Etcd", func() {
 					expectedStorageCapacity:         Equal("10Gi"),
 					expectedDefragmentationSchedule: Equal(ptr.To("34 12 * * *")),
 					expectedMaintenanceTimeWindow:   Equal(maintenanceTimeWindow),
-					expectedScaleDownUpdateMode:     Equal(ptr.To(hvpav1alpha1.UpdateModeMaintenanceWindow)),
 					expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 				}
 
@@ -527,7 +510,6 @@ type newEtcdValidator struct {
 	expectedDefragmentationSchedule gomegatypes.GomegaMatcher
 	expectedHighAvailabilityEnabled gomegatypes.GomegaMatcher
 	expectedMaintenanceTimeWindow   gomegatypes.GomegaMatcher
-	expectedScaleDownUpdateMode     gomegatypes.GomegaMatcher
 }
 
 func (v *newEtcdValidator) NewEtcd(

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -205,48 +205,6 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabled:         false,
 					},
 				),
-				Entry("default behaviour, HVPA is enabled, VPAAndHPAForAPIServer is enabled",
-					nil,
-					map[featuregate.Feature]bool{
-						features.HVPA:                  true,
-						features.VPAAndHPAForAPIServer: true,
-					},
-					apiserver.AutoscalingConfig{
-						Mode: apiserver.AutoscalingModeVPAAndHPA,
-						APIServerResources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("250m"),
-								corev1.ResourceMemory: resource.MustParse("500Mi"),
-							},
-						},
-						MinReplicas:               2,
-						MaxReplicas:               6,
-						UseMemoryMetricForHvpaHPA: false,
-						ScaleDownDisabled:         false,
-					},
-				),
-				Entry("shoot disables scale down, HVPA is enabled, VPAAndHPAForAPIServer is enabled",
-					func() {
-						botanist.Shoot.GetInfo().Annotations = map[string]string{"alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled": "true"}
-					},
-					map[featuregate.Feature]bool{
-						features.HVPA:                  true,
-						features.VPAAndHPAForAPIServer: true,
-					},
-					apiserver.AutoscalingConfig{
-						Mode: apiserver.AutoscalingModeVPAAndHPA,
-						APIServerResources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("250m"),
-								corev1.ResourceMemory: resource.MustParse("500Mi"),
-							},
-						},
-						MinReplicas:               4,
-						MaxReplicas:               6,
-						UseMemoryMetricForHvpaHPA: false,
-						ScaleDownDisabled:         true,
-					},
-				),
 				Entry("shoot is a managed seed and HVPAForShootedSeed is disabled, VPAAndHPAForAPIServer is enabled",
 					func() {
 						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -205,6 +205,28 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabled:         false,
 					},
 				),
+				Entry("shoot disables scale down, HVPA is disabled, VPAAndHPAForAPIServer is enabled",
+					func() {
+						botanist.Shoot.GetInfo().Annotations = map[string]string{"alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled": "true"}
+					},
+					map[featuregate.Feature]bool{
+						features.HVPA:                  false,
+						features.VPAAndHPAForAPIServer: true,
+					},
+					apiserver.AutoscalingConfig{
+						Mode: apiserver.AutoscalingModeVPAAndHPA,
+						APIServerResources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("250m"),
+								corev1.ResourceMemory: resource.MustParse("500Mi"),
+							},
+						},
+						MinReplicas:               4,
+						MaxReplicas:               6,
+						UseMemoryMetricForHvpaHPA: false,
+						ScaleDownDisabled:         true,
+					},
+				),
 				Entry("shoot is a managed seed and HVPAForShootedSeed is disabled, VPAAndHPAForAPIServer is enabled",
 					func() {
 						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}

--- a/pkg/operator/controller/garden/care/health_test.go
+++ b/pkg/operator/controller/garden/care/health_test.go
@@ -26,10 +26,8 @@ import (
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/features"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	. "github.com/gardener/gardener/pkg/operator/controller/garden/care"
-	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -64,8 +62,6 @@ var _ = Describe("Garden health", func() {
 	)
 
 	BeforeEach(func() {
-		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.HVPA, true))
-
 		ctx = context.Background()
 		runtimeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	seedcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -190,7 +189,6 @@ var _ = Describe("Seed controller tests", func() {
 			&secretsutils.GenerateKey, secretsutils.FakeGenerateKey,
 			&resourcemanager.SkipWebhookDeployment, true,
 		))
-		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.HVPA, true))
 
 		By("Create DNS provider secret in garden namespace")
 		dnsProviderSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
@@ -544,8 +542,6 @@ var _ = Describe("Seed controller tests", func() {
 							// vertical-pod-autoscaler
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),
-							// hvpa-controller
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpas.autoscaling.k8s.io")})}),
 							// fluent-operator
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfilters.fluentbit.fluent.io")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfluentbitconfigs.fluentbit.fluent.io")})}),
@@ -661,7 +657,6 @@ var _ = Describe("Seed controller tests", func() {
 					if !seedIsGarden {
 						expectedManagedResources = append(expectedManagedResources,
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vpa")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpa")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-druid")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("nginx-ingress")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("plutono")})}),

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -51,7 +51,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/networking/nginxingress"
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/operator/apis/config"
 	gardencontroller "github.com/gardener/gardener/pkg/operator/controller/garden/garden"
@@ -78,7 +77,6 @@ var _ = Describe("Garden controller tests", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(test.WithVar(&secretsutils.GenerateKey, secretsutils.FakeGenerateKey))
-		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.HVPA, true))
 		DeferCleanup(test.WithVars(
 			&etcd.DefaultInterval, 100*time.Millisecond,
 			&etcd.DefaultTimeout, 500*time.Millisecond,
@@ -228,9 +226,6 @@ var _ = Describe("Garden controller tests", func() {
 						},
 					},
 				},
-				FeatureGates: map[string]bool{
-					"HVPA": true,
-				},
 			},
 			Identity:        &gardencorev1beta1.Gardener{Name: "test-gardener"},
 			GardenNamespace: testNamespace.Name,
@@ -350,7 +345,6 @@ spec:
 			return crdList.Items
 		}).Should(And(
 			ContainElements(
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpas.autoscaling.k8s.io")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
@@ -456,7 +450,6 @@ spec:
 		}).Should(ContainElements(
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden-system")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vpa")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpa")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-druid")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("nginx-ingress")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator")})}),
@@ -956,7 +949,6 @@ spec:
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
 			return crdList.Items
 		}).ShouldNot(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpas.autoscaling.k8s.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR is a continuation of #10599 and deprecates the `HVPA` and `HVPAForShootedSeed` feature gates. Additionally, it also locks them to false.
The related code will be cleaned up when the feature gates are completely removed (planned for the `v1.107` release).

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `HVPA` and `HVPAForShootedSeed` feature gates have been deprecated and locked to false. Disable the `HVPA` and `HVPAForShootedSeed` feature gates if you have them enabled before upgrading to this version of Gardener.
```
