### PR TITLE
[GEP-26] Promote ShootCredentialsBinding to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,7 +26,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootForceDeletion        | `true`  | `Beta`  | `1.91`  |         |
 | UseNamespacedCloudProfile | `false` | `Alpha` | `1.92`  |         |
 | ShootManagedIssuer        | `false` | `Alpha` | `1.93`  |         |
-| ShootCredentialsBinding   | `false` | `Alpha` | `1.98`  |         |
+| ShootCredentialsBinding   | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding   | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash         | `false` | `Alpha` | `1.98`  |         |
 | NewVPN                    | `false` | `Alpha` | `1.104` |         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -27,6 +27,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | UseNamespacedCloudProfile | `false` | `Alpha` | `1.92`  |         |
 | ShootManagedIssuer        | `false` | `Alpha` | `1.93`  |         |
 | ShootCredentialsBinding   | `false` | `Alpha` | `1.98`  |         |
+| ShootCredentialsBinding   | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash         | `false` | `Alpha` | `1.98`  |         |
 | NewVPN                    | `false` | `Alpha` | `1.104` |         |
 

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -160,7 +160,6 @@ global:
     featureGates:
       IPv6SingleStack: true
       ShootForceDeletion: true
-      ShootCredentialsBinding: true
       UseNamespacedCloudProfile: true
     resources: {}
     podLabels:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -81,6 +81,7 @@ const (
 	// ShootCredentialsBinding enables the usage of the CredentialsBindingName API in shoot spec.
 	// owner: @vpnachev @dimityrmirchev
 	// alpha: v1.98.0
+	// beta: v1.107.0
 	ShootCredentialsBinding featuregate.Feature = "ShootCredentialsBinding"
 
 	// NewWorkerPoolHash enables a new calculation method for the worker pool hash. The new
@@ -131,7 +132,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ShootForceDeletion:        {Default: true, PreRelease: featuregate.Beta},
 	UseNamespacedCloudProfile: {Default: false, PreRelease: featuregate.Alpha},
 	VPAAndHPAForAPIServer:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	ShootCredentialsBinding:   {Default: false, PreRelease: featuregate.Alpha},
+	ShootCredentialsBinding:   {Default: true, PreRelease: featuregate.Beta},
 	NewWorkerPoolHash:         {Default: false, PreRelease: featuregate.Alpha},
 	NewVPN:                    {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei security
/kind enhancement
/label ipcei/workload-identity


**What this PR does / why we need it**:
Promotes `ShootCredentialsBinding` to beta.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

/cc @vpnachev 

Please hold this for the `v1.107.0` release.
/hold

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener API Server feature gate `ShootCredentialsBinding` has been promoted to beta and is enabled by default.
```
