### PR TITLE
Deprecate Shoot's `.kubeAPIServer.oidcConfig` field

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1281,8 +1281,12 @@ spec:
                                 type: integer
                             type: object
                           oidcConfig:
-                            description: OIDCConfig contains configuration settings
-                              for the OIDC provider.
+                            description: |-
+                              OIDCConfig contains configuration settings for the OIDC provider.
+
+                              Deprecated: This field is deprecated and will be forbidden starting from Kubernetes 1.32.
+                              Please configure and use structured authentication instead of oidc flags.
+                              For more information check https://github.com/gardener/gardener/issues/9858
                             properties:
                               caBundle:
                                 description: If set, the OpenID server's certificate

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -5753,6 +5753,10 @@ OIDCConfig
 <td>
 <em>(Optional)</em>
 <p>OIDCConfig contains configuration settings for the OIDC provider.</p>
+<p>Deprecated: This field is deprecated and will be forbidden starting from Kubernetes 1.32.
+Please configure and use structured authentication instead of oidc flags.
+For more information check <a href="https://github.com/gardener/gardener/issues/9858">https://github.com/gardener/gardener/issues/9858</a>
+TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.31 is dropped.</p>
 </td>
 </tr>
 <tr>

--- a/docs/usage/security/openidconnect-presets.md
+++ b/docs/usage/security/openidconnect-presets.md
@@ -4,7 +4,7 @@ title: OpenIDConnect Presets
 
 # ClusterOpenIDConnectPreset and OpenIDConnectPreset
 
-> **Note:** OpenID Connect is deprecated in favor of [Structured Authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`. 
+> **Note:** OpenID Connect is deprecated in favor of [Structured Authentication configuration](../shoot/shoot_access.md#structured-authentication). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`. 
 
 This page provides an overview of ClusterOpenIDConnectPresets and OpenIDConnectPresets, which are objects for injecting [OpenIDConnect Configuration](https://openid.net/connect/) into `Shoot` at creation time. The injected information contains configuration for the Kube API Server and optionally configuration for kubeconfig generation using said configuration.
 

--- a/docs/usage/security/openidconnect-presets.md
+++ b/docs/usage/security/openidconnect-presets.md
@@ -4,6 +4,8 @@ title: OpenIDConnect Presets
 
 # ClusterOpenIDConnectPreset and OpenIDConnectPreset
 
+> **Note:** OpenID Connect is deprecated in favor of [Structured Authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`. 
+
 This page provides an overview of ClusterOpenIDConnectPresets and OpenIDConnectPresets, which are objects for injecting [OpenIDConnect Configuration](https://openid.net/connect/) into `Shoot` at creation time. The injected information contains configuration for the Kube API Server and optionally configuration for kubeconfig generation using said configuration.
 
 ## OpenIDConnectPreset

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -110,6 +110,8 @@ The examples for other programming languages are similar to [the above](#shootsa
 
 ## OpenID Connect
 
+> **Note:** OpenID Connect is deprecated in favor of [Structured Authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`
+
 The `kube-apiserver` of shoot clusters can be provided with [OpenID Connect configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) via the Shoot spec:
 
 ```yaml

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -110,7 +110,7 @@ The examples for other programming languages are similar to [the above](#shootsa
 
 ## OpenID Connect
 
-> **Note:** OpenID Connect is deprecated in favor of [Structured Authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`
+> **Note:** OpenID Connect is deprecated in favor of [Structured Authentication configuration](#structured-authentication). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`
 
 The `kube-apiserver` of shoot clusters can be provided with [OpenID Connect configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) via the Shoot spec:
 

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1281,8 +1281,12 @@ spec:
                                 type: integer
                             type: object
                           oidcConfig:
-                            description: OIDCConfig contains configuration settings
-                              for the OIDC provider.
+                            description: |-
+                              OIDCConfig contains configuration settings for the OIDC provider.
+
+                              Deprecated: This field is deprecated and will be forbidden starting from Kubernetes 1.32.
+                              Please configure and use structured authentication instead of oidc flags.
+                              For more information check https://github.com/gardener/gardener/issues/9858
                             properties:
                               caBundle:
                                 description: If set, the OpenID server's certificate

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -596,6 +596,11 @@ type KubeAPIServerConfig struct {
 	// StructuredAuthentication contains configuration settings for structured authentication to the kube-apiserver.
 	StructuredAuthentication *StructuredAuthentication
 	// OIDCConfig contains configuration settings for the OIDC provider.
+	//
+	// Deprecated: This field is deprecated and will be forbidden starting from Kubernetes 1.32.
+	// Please configure and use structured authentication instead of oidc flags.
+	// For more information check https://github.com/gardener/gardener/issues/9858
+	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.31 is dropped.
 	OIDCConfig *OIDCConfig
 	// RuntimeConfig contains information about enabled or disabled APIs.
 	RuntimeConfig map[string]bool

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1150,6 +1150,11 @@ message KubeAPIServerConfig {
   optional AuditConfig auditConfig = 4;
 
   // OIDCConfig contains configuration settings for the OIDC provider.
+  //
+  // Deprecated: This field is deprecated and will be forbidden starting from Kubernetes 1.32.
+  // Please configure and use structured authentication instead of oidc flags.
+  // For more information check https://github.com/gardener/gardener/issues/9858
+  // TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.31 is dropped.
   // +optional
   optional OIDCConfig oidcConfig = 6;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -781,6 +781,11 @@ type KubeAPIServerConfig struct {
 	// EnableBasicAuthentication *bool `json:"enableBasicAuthentication,omitempty" protobuf:"varint,5,opt,name=enableBasicAuthentication"`
 
 	// OIDCConfig contains configuration settings for the OIDC provider.
+	//
+	// Deprecated: This field is deprecated and will be forbidden starting from Kubernetes 1.32.
+	// Please configure and use structured authentication instead of oidc flags.
+	// For more information check https://github.com/gardener/gardener/issues/9858
+	// TODO(AleksandarSavchev): Drop this field after support for Kubernetes 1.31 is dropped.
 	// +optional
 	OIDCConfig *OIDCConfig `json:"oidcConfig,omitempty" protobuf:"bytes,6,opt,name=oidcConfig"`
 	// RuntimeConfig contains information about enabled or disabled APIs.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1291,7 +1291,11 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 		return allErrs
 	}
 
-	if oidc := kubeAPIServer.OIDCConfig; oidc != nil {
+	// TODO(AleksandarSavchev): Remove this check as soon as v1.32 is the least supported Kubernetes version in Gardener.
+	k8sGreaterEqual132, _ := versionutils.CheckVersionMeetsConstraint(version, ">= 1.32")
+	if oidc := kubeAPIServer.OIDCConfig; k8sGreaterEqual132 && oidc != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("oidcConfig"), *oidc, "for Kubernetes versions >= 1.31, oidcConfig field is no longer supported"))
+	} else if oidc != nil {
 		oidcPath := fldPath.Child("oidcConfig")
 
 		if fieldNilOrEmptyString(oidc.ClientID) {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1765,6 +1765,17 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 		Context("KubeAPIServer validation", func() {
 			Context("OIDC validation", func() {
+				It("should forbid setting OIDC configuration from kubernetes version 1.32", func() {
+					shoot.Spec.Kubernetes.Version = "1.32"
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.kubernetes.kubeAPIServer.oidcConfig"),
+					}))))
+				})
+
 				It("should forbid unsupported OIDC configuration", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.CABundle = ptr.To("")
 					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.ClientID = ptr.To("")

--- a/pkg/apis/settings/types_cluster_openidconnect_preset.go
+++ b/pkg/apis/settings/types_cluster_openidconnect_preset.go
@@ -14,6 +14,11 @@ import (
 
 // ClusterOpenIDConnectPreset is a OpenID Connect configuration that is applied
 // to a Shoot objects cluster-wide.
+//
+// Deprecated: This resource is deprecated and will be removed after support for Kubernetes 1.31 is dropped.
+// Please configure and use structured authentication instead of oidc flags.
+// For more information check https://github.com/gardener/gardener/issues/9858
+// TODO(AleksandarSavchev): Remove this resource after support for Kubernetes 1.31 is dropped.
 type ClusterOpenIDConnectPreset struct {
 	metav1.TypeMeta
 	// Standard object metadata.

--- a/pkg/apis/settings/types_openidconnect_preset.go
+++ b/pkg/apis/settings/types_openidconnect_preset.go
@@ -13,6 +13,11 @@ import (
 
 // OpenIDConnectPreset is a OpenID Connect configuration that is applied
 // to a Shoot in a namespace.
+//
+// Deprecated: This resource is deprecated and will be removed after support for Kubernetes 1.31 is dropped.
+// Please configure and use structured authentication instead of oidc flags.
+// For more information check https://github.com/gardener/gardener/issues/9858
+// TODO(AleksandarSavchev): Remove this resource after support for Kubernetes 1.31 is dropped.
 type OpenIDConnectPreset struct {
 	metav1.TypeMeta
 	// Standard object metadata.

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -4146,7 +4146,7 @@ func schema_pkg_apis_core_v1beta1_KubeAPIServerConfig(ref common.ReferenceCallba
 					},
 					"oidcConfig": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OIDCConfig contains configuration settings for the OIDC provider.",
+							Description: "OIDCConfig contains configuration settings for the OIDC provider.\n\nDeprecated: This field is deprecated and will be forbidden starting from Kubernetes 1.32. Please configure and use structured authentication instead of oidc flags. For more information check https://github.com/gardener/gardener/issues/9858",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.OIDCConfig"),
 						},
 					},

--- a/pkg/component/kubernetes/apiserver/authentication.go
+++ b/pkg/component/kubernetes/apiserver/authentication.go
@@ -65,6 +65,7 @@ func (k *kubeAPIServer) reconcileConfigMapAuthenticationConfig(ctx context.Conte
 }
 
 // ComputeAuthenticationConfigRawConfig computes a AuthenticationConfiguration from oidcConfiguration.
+// TODO(AleksandarSavchev): Remove this functionality as soon as v1.32 is the least supported Kubernetes version in Gardener.
 func ComputeAuthenticationConfigRawConfig(oidc *gardencorev1beta1.OIDCConfig) (string, error) {
 	authenticationConfiguration := &apiserverv1beta1.AuthenticationConfiguration{
 		TypeMeta: metav1.TypeMeta{
@@ -149,6 +150,7 @@ func (k *kubeAPIServer) handleAuthenticationSettings(deployment *appsv1.Deployme
 	})
 }
 
+// TODO(AleksandarSavchev): Remove this functionality as soon as v1.32 is the least supported Kubernetes version in Gardener.
 func (k *kubeAPIServer) handleOIDCSettings(deployment *appsv1.Deployment, secretOIDCCABundle *corev1.Secret) {
 	if k.values.OIDC == nil {
 		return

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -184,7 +184,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 			if maintainedShoot.Spec.Kubernetes.KubeAPIServer != nil && maintainedShoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig != nil {
 				maintainedShoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = nil
 
-				reason := ".spec.kubernetes.kubeAPIServer.oidcConfig is set to nil. Reason: The field was no-op since its introduction and can no longer be enabled for Shoot clusters using Kubernetes version 1.32+"
+				reason := ".spec.kubernetes.kubeAPIServer.oidcConfig is set to nil. Reason: The field has been deprecated in favor of structured authentication and can no longer be enabled for Shoot clusters using Kubernetes version 1.32+"
 				operations = append(operations, reason)
 			}
 		}

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -175,6 +175,21 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 		}
 	}
 
+	// Set the .spec.kubernetes.kubeAPIServer.oidcConfig field to nil, when Shoot cluster is being forcefully updated to K8s >= 1.32.
+	// Gardener forbids setting the field for Shoots with K8s 1.32+. See https://github.com/gardener/gardener/pull/10666
+	{
+		oldK8sLess132, _ := versionutils.CheckVersionMeetsConstraint(oldShootKubernetesVersion.String(), "< 1.32")
+		newK8sGreaterEqual132, _ := versionutils.CheckVersionMeetsConstraint(shootKubernetesVersion.String(), ">= 1.32")
+		if oldK8sLess132 && newK8sGreaterEqual132 {
+			if maintainedShoot.Spec.Kubernetes.KubeAPIServer != nil && maintainedShoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig != nil {
+				maintainedShoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = nil
+
+				reason := ".spec.kubernetes.kubeAPIServer.oidcConfig is set to nil. Reason: The field was no-op since its introduction and can no longer be enabled for Shoot clusters using Kubernetes version 1.32+"
+				operations = append(operations, reason)
+			}
+		}
+	}
+
 	// Now it's time to update worker pool kubernetes version if specified
 	for i, pool := range maintainedShoot.Spec.Provider.Workers {
 		if pool.Kubernetes == nil || pool.Kubernetes.Version == nil {

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -1108,7 +1108,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 				Eventually(func(g Gomega) string {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot131), shoot131)).To(Succeed())
 					g.Expect(shoot131.Status.LastMaintenance).NotTo(BeNil())
-					g.Expect(shoot131.Status.LastMaintenance.Description).To(ContainSubstring("Control Plane: Updated Kubernetes version from \"1.31.0\" to \"1.32.0\". Reason: Kubernetes version expired - force update required, .spec.kubernetes.kubeAPIServer.oidcConfig is set to nil. Reason: The field was no-op since its introduction and can no longer be enabled for Shoot clusters using Kubernetes version 1.32+"))
+					g.Expect(shoot131.Status.LastMaintenance.Description).To(ContainSubstring("Control Plane: Updated Kubernetes version from \"1.31.0\" to \"1.32.0\". Reason: Kubernetes version expired - force update required, .spec.kubernetes.kubeAPIServer.oidcConfig is set to nil. Reason: The field has been deprecated in favor of structured authentication and can no longer be enabled for Shoot clusters using Kubernetes version 1.32+"))
 					g.Expect(shoot131.Status.LastMaintenance.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
 					g.Expect(shoot131.Status.LastMaintenance.TriggeredTime).To(Equal(metav1.Time{Time: fakeClock.Now()}))
 					g.Expect(shoot131.Spec.Kubernetes.KubeAPIServer.OIDCConfig).To(BeNil())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup

**What this PR does / why we need it**:
This PR deprecates the `spec.kubernetes.kubeAPIServer.oidcConfig` field from the Shoot specification and forbids it for clusters with Kubernetes `>= 1.32` in favour of structured authentication.

**Which issue(s) this PR fixes**:
Part of #9858

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The `spec.kubernetes.kubeAPIServer.oidcConfig` field in the `Shoot` API is deprecated and will be removed after support for Kubernetes 1.31 is dropped.
```
