### PR TITLE
Add kube-system namespace requirement to node-readiness docs

### DIFF
--- a/docs/usage/advanced/node-readiness.md
+++ b/docs/usage/advanced/node-readiness.md
@@ -21,7 +21,7 @@ For this, Gardener follows the proposed solution by the Kubernetes community and
 gardener-resource-manager's [`Node` controller](../../concepts/resource-manager.md#node-controller) reacts on newly created `Node` objects that have this taint.
 The controller removes the taint once all node-critical Pods are ready (determined by checking the Pods' `Ready` conditions).
 
-The `Node` controller considers all `DaemonSets` and `Pods` with the label `node.gardener.cloud/critical-component=true` as node-critical.
+The `Node` controller considers all `DaemonSets` and `Pods` with the label `node.gardener.cloud/critical-component=true` and located in the `kube-system` namespace as node-critical.
 If there are `DaemonSets` that contain the `node.gardener.cloud/critical-component=true` label in their metadata and in their Pod template, the `Node` controller waits for corresponding daemon Pods to be scheduled and to get ready before removing the taint.
 
 Additionally, the `Node` controller checks for the readiness of `csi-driver-node` components if a respective Pod indicates that it uses such a driver.
@@ -38,6 +38,7 @@ To make use of this feature, node-critical DaemonSets and Pods need to:
 
 - Tolerate the `node.gardener.cloud/critical-components-not-ready` `NoSchedule` taint.
 - Be labelled with `node.gardener.cloud/critical-component=true`.
+- Be placed in the `kube-system` namespace.
 
 `csi-driver-node` Pods additionally need to:
 

--- a/docs/usage/advanced/node-readiness.md
+++ b/docs/usage/advanced/node-readiness.md
@@ -21,7 +21,7 @@ For this, Gardener follows the proposed solution by the Kubernetes community and
 gardener-resource-manager's [`Node` controller](../../concepts/resource-manager.md#node-controller) reacts on newly created `Node` objects that have this taint.
 The controller removes the taint once all node-critical Pods are ready (determined by checking the Pods' `Ready` conditions).
 
-The `Node` controller considers all `DaemonSets` and `Pods` with the label `node.gardener.cloud/critical-component=true` and located in the `kube-system` namespace as node-critical.
+The `Node` controller considers all `DaemonSets` and `Pods` as node-critical which run in the `kube-system` namespace and are labeled with `node.gardener.cloud/critical-component=true`.
 If there are `DaemonSets` that contain the `node.gardener.cloud/critical-component=true` label in their metadata and in their Pod template, the `Node` controller waits for corresponding daemon Pods to be scheduled and to get ready before removing the taint.
 
 Additionally, the `Node` controller checks for the readiness of `csi-driver-node` components if a respective Pod indicates that it uses such a driver.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Add the information that customizing the node-readiness via usage of the `node.gardener.cloud/critical-component` label additionally requires placement of the resp. DS/Pod in the `kube-system` namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
