### PR TITLE
Fix SSH-keypair rotation

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser/component.go
@@ -82,6 +82,15 @@ EnvironmentFile=/etc/environment
 ExecStart=` + pathScript + `
 `),
 			},
+			{
+				Name:   "gardener-user.path",
+				Enable: ptr.To(true),
+				Content: ptr.To(`[Path]
+PathChanged=` + pathAuthorizedSSHKeys + `
+[Install]
+WantedBy=multi-user.target
+`),
+			},
 		},
 		[]extensionsv1alpha1.File{
 			{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser/component_test.go
@@ -52,6 +52,15 @@ EnvironmentFile=/etc/environment
 ExecStart=/var/lib/gardener-user/run.sh
 `),
 				},
+				extensionsv1alpha1.Unit{
+					Name:   "gardener-user.path",
+					Enable: ptr.To(true),
+					Content: ptr.To(`[Path]
+PathChanged=/var/lib/gardener-user-authorized-keys
+[Install]
+WantedBy=multi-user.target
+`),
+				},
 			))
 			Expect(files).To(ConsistOf(
 				extensionsv1alpha1.File{

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -27,22 +27,15 @@ import (
 	rotationutils "github.com/gardener/gardener/test/utils/rotation"
 )
 
-func testCredentialRotation(ctx context.Context, v rotationutils.Verifiers, f *framework.ShootCreationFramework) {
-	DeferCleanup(func() {
-		ctx, cancel := context.WithTimeout(parentCtx, 2*time.Minute)
-		defer cancel()
-
-		v.Cleanup(ctx)
-	})
+func testCredentialRotation(ctx context.Context, v rotationutils.Verifiers, f *framework.ShootCreationFramework, rotationAnnotation string) {
+	By("Start credentials rotation")
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+	defer cancel()
 
 	v.Before(ctx)
 
-	By("Start credentials rotation")
-	ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
-	defer cancel()
-
 	patch := client.MergeFrom(f.Shoot.DeepCopy())
-	metav1.SetMetaDataAnnotation(&f.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.OperationRotateCredentialsStart)
+	metav1.SetMetaDataAnnotation(&f.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, rotationAnnotation)
 	EventuallyWithOffset(1, func() error {
 		return f.GardenClient.Client().Patch(ctx, f.Shoot, patch)
 	}).Should(Succeed())
@@ -61,29 +54,37 @@ func testCredentialRotation(ctx context.Context, v rotationutils.Verifiers, f *f
 
 	v.AfterPrepared(ctx)
 
-	By("Complete credentials rotation")
-	ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
-	defer cancel()
+	if rotationAnnotation == v1beta1constants.OperationRotateCredentialsStart {
+		By("Complete credentials rotation")
+		ctx, cancel = context.WithTimeout(ctx, 20*time.Minute)
+		defer cancel()
 
-	patch = client.MergeFrom(f.Shoot.DeepCopy())
-	metav1.SetMetaDataAnnotation(&f.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.OperationRotateCredentialsComplete)
-	EventuallyWithOffset(1, func() error {
-		return f.GardenClient.Client().Patch(ctx, f.Shoot, patch)
-	}).Should(Succeed())
+		patch = client.MergeFrom(f.Shoot.DeepCopy())
+		metav1.SetMetaDataAnnotation(&f.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.OperationRotateCredentialsComplete)
+		EventuallyWithOffset(1, func() error {
+			return f.GardenClient.Client().Patch(ctx, f.Shoot, patch)
+		}).Should(Succeed())
 
-	EventuallyWithOffset(1, func(g Gomega) {
-		g.ExpectWithOffset(1, f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)).To(Succeed())
-		g.ExpectWithOffset(1, f.Shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
-		v.ExpectCompletingStatus(g)
-	}).Should(Succeed())
-
+		EventuallyWithOffset(1, func(g Gomega) {
+			g.ExpectWithOffset(1, f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)).To(Succeed())
+			g.ExpectWithOffset(1, f.Shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+			v.ExpectCompletingStatus(g)
+		}).Should(Succeed())
+	}
 	ExpectWithOffset(1, f.WaitForShootToBeReconciled(ctx, f.Shoot)).To(Succeed())
 
-	EventuallyWithOffset(1, func(g Gomega) {
-		g.ExpectWithOffset(1, f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)).To(Succeed())
+	EventuallyWithOffset(1, func() error {
+		return f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)
 	}).Should(Succeed())
 
 	v.AfterCompleted(ctx)
+
+	func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cleanupCancel()
+
+		v.Cleanup(cleanupCtx)
+	}()
 }
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
@@ -105,6 +106,11 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			By("Create Shoot")
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
+
+			// isolated test for ssh key rotation (does not trigger node rolling update)
+			if !v1beta1helper.IsWorkerless(f.Shoot) {
+				testCredentialRotation(parentCtx, rotationutils.Verifiers{&rotation.SSHKeypairVerifier{ShootCreationFramework: f}}, f, v1beta1constants.ShootOperationRotateSSHKeypair)
+			}
 
 			v := rotationutils.Verifiers{
 				// basic verifiers checking secrets
@@ -143,7 +149,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 				// advanced verifiers testing things from the user's perspective
 				&rotationutils.EncryptedDataVerifier{
-					NewTargetClientFunc: func() (kubernetes.Interface, error) {
+					NewTargetClientFunc: func(ctx context.Context) (kubernetes.Interface, error) {
 						return access.CreateShootClientFromAdminKubeconfig(ctx, f.GardenClient, f.Shoot)
 					},
 					Resources: []rotationutils.EncryptedResource{
@@ -166,12 +172,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			}
 
 			// test rotation for every rotation type
-			testCredentialRotation(ctx, v, f)
-
-			// isolated test for ssh key rotation (does not trigger node rolling update)
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				testCredentialRotation(ctx, rotationutils.Verifiers{&rotation.SSHKeypairVerifier{ShootCreationFramework: f}}, f)
-			}
+			testCredentialRotation(parentCtx, v, f, v1beta1constants.OperationRotateCredentialsStart)
 
 			By("Delete Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/operator/garden/create_rotate_delete.go
+++ b/test/e2e/operator/garden/create_rotate_delete.go
@@ -124,7 +124,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 
 			// advanced verifiers testing things from the user's perspective
 			&rotationutils.EncryptedDataVerifier{
-				NewTargetClientFunc: func() (kubernetes.Interface, error) {
+				NewTargetClientFunc: func(ctx context.Context) (kubernetes.Interface, error) {
 					return kubernetes.NewClientFromSecret(ctx, runtimeClient, namespace, "gardener",
 						kubernetes.WithDisabledCachedClient(),
 						kubernetes.WithClientOptions(client.Options{Scheme: operatorclient.VirtualScheme}),

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	componentbaseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -74,6 +75,7 @@ func (f *GardenerFramework) BeforeEach() {
 	validateGardenerConfig(f.Config)
 	gardenClient, err := kubernetes.NewClientFromFile("", f.Config.GardenerKubeconfig,
 		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
+		kubernetes.WithClientConnectionOptions(componentbaseconfig.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
 		kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
 		kubernetes.WithDisabledCachedClient(),
 	)

--- a/test/utils/access/adminkubeconfig.go
+++ b/test/utils/access/adminkubeconfig.go
@@ -6,6 +6,7 @@ package access
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,7 +55,7 @@ func RequestAdminKubeconfigForShoot(ctx context.Context, gardenClient kubernetes
 		},
 	}
 	if err := gardenClient.Client().SubResource("adminkubeconfig").Create(ctx, shoot, adminKubeconfigRequest); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create admin kubeconfig request for shoot %s: %w", client.ObjectKeyFromObject(shoot), err)
 	}
 
 	return adminKubeconfigRequest.Status.Kubeconfig, nil

--- a/test/utils/rotation/encrypted_data.go
+++ b/test/utils/rotation/encrypted_data.go
@@ -22,7 +22,7 @@ type EncryptedResource struct {
 
 // EncryptedDataVerifier creates and reads encrypted data in the cluster to verify correct configuration of etcd encryption.
 type EncryptedDataVerifier struct {
-	NewTargetClientFunc func() (kubernetes.Interface, error)
+	NewTargetClientFunc func(ctx context.Context) (kubernetes.Interface, error)
 	Resources           []EncryptedResource
 }
 
@@ -57,7 +57,7 @@ func (v *EncryptedDataVerifier) verifyEncryptedData(ctx context.Context) {
 	)
 
 	Eventually(func(g Gomega) {
-		targetClient, err = v.NewTargetClientFunc()
+		targetClient, err = v.NewTargetClientFunc(ctx)
 		g.Expect(err).NotTo(HaveOccurred())
 	}).Should(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

Currently, when only the SSH keypairs of a shoot are rotated, the correct keys are written to `/var/lib/gardener-user-ssh.key`, but the `gardener-user.service` systemd unit that copies the keys to `/home/gardener/.ssh/authorized_keys` is not executed because the systemd unit itself has not changed.
Only when the nodes are rolled will the correct keys be written to the `authorized_keys` file.

This PR adds a path unit that watches the `/var/lib/gardener-user-ssh.key` file for changes and runs the `gardener-user.service` unit, setting the correct keys, without the nodes needing to be rolled.

**Which issue(s) this PR fixes**:
Fixes #9966

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug where SSH key rotations for `Shoot`s did not properly update the authorized keys on the worker nodes (hence, the new key was unusable until a node restart or rollout).
```
