### PR TITLE
[GEP-26] Fix bug where shoot care controller uses outdated credentials config

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/types.go
+++ b/pkg/gardenlet/controller/shoot/care/types.go
@@ -164,6 +164,6 @@ var defaultNewOperationFunc = func(
 		WithSecrets(secrets).
 		WithGardenFrom(gardenClient, shoot.Namespace).
 		WithSeedFrom(gardenClient, *shoot.Spec.SeedName).
-		WithShootFromCluster(gardenClient, seedClientSet, shoot).
+		WithShootFromCluster(seedClientSet, shoot).
 		Build(ctx, gardenClient, seedClientSet, shootClientMap)
 }

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -142,7 +142,8 @@ func (b *Builder) WithShoot(s *shootpkg.Shoot) *Builder {
 
 // WithShootFromCluster sets the shootFunc attribute at the Builder which will build a new Shoot object constructed from the cluster resource.
 // The shoot status is still taken from the passed `shoot`, though.
-func (b *Builder) WithShootFromCluster(gardenClient client.Client, seedClientSet kubernetes.Interface, s *gardencorev1beta1.Shoot) *Builder {
+// The credentials in the Shoot object are always set to `nil`.
+func (b *Builder) WithShootFromCluster(seedClientSet kubernetes.Interface, s *gardencorev1beta1.Shoot) *Builder {
 	b.shootFunc = func(ctx context.Context, c client.Reader, gardenObj *garden.Garden, seedObj *seed.Seed, serviceAccountIssuerConfig *corev1.Secret) (*shootpkg.Shoot, error) {
 		shootNamespace := gardenerutils.ComputeTechnicalID(gardenObj.Project.Name, s)
 
@@ -150,7 +151,7 @@ func (b *Builder) WithShootFromCluster(gardenClient client.Client, seedClientSet
 			NewBuilder().
 			WithShootObjectFromCluster(seedClientSet, shootNamespace).
 			WithCloudProfileObjectFromCluster(seedClientSet, shootNamespace).
-			WithShootCredentialsFrom(gardenClient).
+			WithoutShootCredentials().
 			WithSeedObject(seedObj.GetInfo()).
 			WithProjectName(gardenObj.Project.Name).
 			WithInternalDomain(gardenObj.InternalDomain).

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -113,21 +113,6 @@ func (b *Builder) WithExposureClassObject(exposureClass *gardencorev1beta1.Expos
 	return b
 }
 
-// WithShootCredentials sets the shootCredentialsFunc attribute at the Builder.
-// If the credentials are not of type [*corev1.Secret] or [*securityv1alpha1.WorkloadIdentity]
-// the function will panic.
-func (b *Builder) WithShootCredentials(credentials client.Object) *Builder {
-	_, isSecret := credentials.(*corev1.Secret)
-	_, isWorkloadIdentity := credentials.(*securityv1alpha1.WorkloadIdentity)
-
-	if !isSecret && !isWorkloadIdentity {
-		panic("credentials must be of type [*corev1.Secret] or [*securityv1alpha1.WorkloadIdentity]")
-	}
-
-	b.shootCredentialsFunc = func(context.Context, string, string, bool) (client.Object, error) { return credentials, nil }
-	return b
-}
-
 // WithShootCredentialsFrom sets the shootCredentialsFunc attribute at the Builder after fetching it from the given reader.
 func (b *Builder) WithShootCredentialsFrom(c client.Reader) *Builder {
 	b.shootCredentialsFunc = func(ctx context.Context, namespace, bindingName string, fromSecretBinding bool) (client.Object, error) {

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -164,6 +164,12 @@ func (b *Builder) WithShootCredentialsFrom(c client.Reader) *Builder {
 	return b
 }
 
+// WithoutShootCredentials sets the shootCredentialsFunc attribute at the builder to return `nil` as credentials.
+func (b *Builder) WithoutShootCredentials() *Builder {
+	b.shootCredentialsFunc = func(context.Context, string, string, bool) (client.Object, error) { return nil, nil }
+	return b
+}
+
 // WithProjectName sets the projectName attribute at the Builder.
 func (b *Builder) WithProjectName(projectName string) *Builder {
 	b.projectName = projectName


### PR DESCRIPTION
**How to categorize this PR?**
/area ipcei security
/kind bug
/label ipcei/workload-identity


**What this PR does / why we need it**:
Shoot care controller fail to reconcile shoots using the `confineSpecUpdateRollout` feature after migration from secretBindingName to credentialsBindingName (or vice versa) until the next shoot reconciliation. This is because on reconciliation the care controller uses the now outdated shoot config from the `Cluster` resource while the seed authorizer respects the latest shoot spec, thus it does not allow gardenlet to read secretBinding while the shoot is already set use credentialsBinding.


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug where the shoot care controller cannot reconcile shoots with `spec.maintenance.confineSpecUpdateRollout=true` and migrated between `secretBindingName` and `credentialsBindingName` until the shoot is reconciled..
```

```breaking developer
The unused method `WithShootCredentials` have been removed from `github.com/gardener/gardener/pkg/gardenlet/operation/shoot.Builder`.
```
