### PR TITLE
[release-v1.104] [GEP-26] Fix bug where shoot care controller uses outdated credentials config

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/types.go
+++ b/pkg/gardenlet/controller/shoot/care/types.go
@@ -164,6 +164,6 @@ var defaultNewOperationFunc = func(
 		WithSecrets(secrets).
 		WithGardenFrom(gardenClient, shoot.Namespace).
 		WithSeedFrom(gardenClient, *shoot.Spec.SeedName).
-		WithShootFromCluster(gardenClient, seedClientSet, shoot).
+		WithShootFromCluster(seedClientSet, shoot).
 		Build(ctx, gardenClient, seedClientSet, shootClientMap)
 }

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -142,7 +142,8 @@ func (b *Builder) WithShoot(s *shootpkg.Shoot) *Builder {
 
 // WithShootFromCluster sets the shootFunc attribute at the Builder which will build a new Shoot object constructed from the cluster resource.
 // The shoot status is still taken from the passed `shoot`, though.
-func (b *Builder) WithShootFromCluster(gardenClient client.Client, seedClientSet kubernetes.Interface, s *gardencorev1beta1.Shoot) *Builder {
+// The credentials in the Shoot object are always set to `nil`.
+func (b *Builder) WithShootFromCluster(seedClientSet kubernetes.Interface, s *gardencorev1beta1.Shoot) *Builder {
 	b.shootFunc = func(ctx context.Context, c client.Reader, gardenObj *garden.Garden, seedObj *seed.Seed, serviceAccountIssuerConfig *corev1.Secret) (*shootpkg.Shoot, error) {
 		shootNamespace := gardenerutils.ComputeTechnicalID(gardenObj.Project.Name, s)
 
@@ -150,7 +151,7 @@ func (b *Builder) WithShootFromCluster(gardenClient client.Client, seedClientSet
 			NewBuilder().
 			WithShootObjectFromCluster(seedClientSet, shootNamespace).
 			WithCloudProfileObjectFromCluster(seedClientSet, shootNamespace).
-			WithShootCredentialsFrom(gardenClient).
+			WithoutShootCredentials().
 			WithSeedObject(seedObj.GetInfo()).
 			WithProjectName(gardenObj.Project.Name).
 			WithInternalDomain(gardenObj.InternalDomain).

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -164,9 +164,9 @@ func (b *Builder) WithShootCredentialsFrom(c client.Reader) *Builder {
 	return b
 }
 
-// WithoutShootCredentials sets the shootCredentialsFunc attribute at the builder to return `nil` as credentials.
+// WithoutShootCredentials sets the shootCredentialsFunc attribute at the builder to return empty Secret as credentials.
 func (b *Builder) WithoutShootCredentials() *Builder {
-	b.shootCredentialsFunc = func(context.Context, string, string, bool) (client.Object, error) { return nil, nil }
+	b.shootCredentialsFunc = func(context.Context, string, string, bool) (client.Object, error) { return &corev1.Secret{}, nil }
 	return b
 }
 

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -164,6 +164,12 @@ func (b *Builder) WithShootCredentialsFrom(c client.Reader) *Builder {
 	return b
 }
 
+// WithoutShootCredentials sets the shootCredentialsFunc attribute at the builder to return `nil` as credentials.
+func (b *Builder) WithoutShootCredentials() *Builder {
+	b.shootCredentialsFunc = func(context.Context, string, string, bool) (client.Object, error) { return nil, nil }
+	return b
+}
+
 // WithProjectName sets the projectName attribute at the Builder.
 func (b *Builder) WithProjectName(projectName string) *Builder {
 	b.projectName = projectName


### PR DESCRIPTION
/area ipcei security
/kind bug
/label ipcei/workload-identity


This is a manual partial cherry-pick of #10672 and #10681

```bugfix operator
Fix a bug where the shoot care controller cannot reconcile shoots with `spec.maintenance.confineSpecUpdateRollout=true` and migrated between `secretBindingName` and `credentialsBindingName` until the shoot is reconciled..
```
