### PR TITLE
ipv6 support for node-local-dns

### DIFF
--- a/pkg/component/networking/nodelocaldns/constants/constants.go
+++ b/pkg/component/networking/nodelocaldns/constants/constants.go
@@ -7,6 +7,8 @@ package constants
 const (
 	// IPVSAddress is the IPv4 address used by node-local-dns when IPVS is used.
 	IPVSAddress = "169.254.20.10"
+	// IPVSIPv6Address is the IPv6 address used by node-local-dns when IPVS is used.
+	IPVSIPv6Address = "fd30:1319:f1e:230b::1"
 	// LabelValue is the value of a label used for the identification of node-local-dns pods.
 	LabelValue = "node-local-dns"
 )

--- a/pkg/component/networking/nodelocaldns/mock/mocks.go
+++ b/pkg/component/networking/nodelocaldns/mock/mocks.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -90,6 +91,18 @@ func (m *MockInterface) SetDNSServers(arg0 []string) {
 func (mr *MockInterfaceMockRecorder) SetDNSServers(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDNSServers", reflect.TypeOf((*MockInterface)(nil).SetDNSServers), arg0)
+}
+
+// SetIPFamilies mocks base method.
+func (m *MockInterface) SetIPFamilies(arg0 []v1beta1.IPFamily) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetIPFamilies", arg0)
+}
+
+// SetIPFamilies indicates an expected call of SetIPFamilies.
+func (mr *MockInterfaceMockRecorder) SetIPFamilies(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIPFamilies", reflect.TypeOf((*MockInterface)(nil).SetIPFamilies), arg0)
 }
 
 // Wait mocks base method.

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -226,6 +227,7 @@ var _ = Describe("NodeLocalDNS", func() {
 		values = Values{
 			Image:             image,
 			KubernetesVersion: semver.MustParse("1.26.1"),
+			IPFamilies:        []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
 		}
 
 		managedResource = &resourcesv1alpha1.ManagedResource{
@@ -270,7 +272,7 @@ data:
                 ` + forceTcpToClusterDNS + `
         }
         prometheus :` + strconv.Itoa(prometheusPort) + `
-        health ` + ipvsAddress + `:` + strconv.Itoa(livenessProbePort) + `
+        health ` + healthAddress(values) + `:` + strconv.Itoa(livenessProbePort) + `
         }
     in-addr.arpa:53 {
         errors
@@ -620,7 +622,7 @@ status: {}
             ` + forceTcpToClusterDNS + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
-    health ` + ipvsAddress + `:` + strconv.Itoa(livenessProbePort) + `
+    health ` + healthAddress(values) + `:` + strconv.Itoa(livenessProbePort) + `
     }
 in-addr.arpa:53 {
     errors
@@ -892,7 +894,7 @@ ip6.arpa:53 {
             ` + forceTcpToClusterDNS + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
-    health ` + ipvsAddress + `:` + strconv.Itoa(livenessProbePort) + `
+    health ` + healthAddress(values) + `:` + strconv.Itoa(livenessProbePort) + `
     }
 in-addr.arpa:53 {
     errors
@@ -1110,6 +1112,57 @@ ip6.arpa:53 {
 						})
 					})
 				})
+
+				Context("With IPv6:", func() {
+					BeforeEach(func() {
+						values.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6}
+						values.Config = &gardencorev1beta1.NodeLocalDNS{Enabled: true,
+							ForceTCPToClusterDNS:        ptr.To(false),
+							ForceTCPToUpstreamDNS:       ptr.To(false),
+							DisableForwardToUpstreamDNS: ptr.To(false),
+						}
+						forceTcpToClusterDNS = "prefer_udp"
+						forceTcpToUpstreamDNS = "prefer_udp"
+						ipvsAddress = "fd30:1319:f1e:230b::1"
+					})
+
+					Context("w/o VPA", func() {
+						BeforeEach(func() {
+							values.VPAEnabled = false
+							values.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6}
+						})
+
+						It("should successfully deploy all resources", func() {
+							expectedManifests = nil
+							expectedManifests = append(expectedManifests, configMapYAMLFor())
+							Expect(manifests).To(ContainElements(expectedManifests))
+							managedResourceDaemonset, err := extractDaemonSet(manifests, kubernetes.ShootCodec.UniversalDeserializer())
+							Expect(err).ToNot(HaveOccurred())
+							daemonset := daemonSetYAMLFor()
+							utilruntime.Must(references.InjectAnnotations(daemonset))
+							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+						})
+					})
+
+					Context("w/ VPA", func() {
+						BeforeEach(func() {
+							values.VPAEnabled = true
+							values.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6}
+
+						})
+
+						It("should successfully deploy all resources", func() {
+							expectedManifests = append(expectedManifests, configMapYAMLFor(), vpaYAML)
+							Expect(manifests).To(ContainElements(expectedManifests))
+
+							managedResourceDaemonset, err := extractDaemonSet(manifests, kubernetes.ShootCodec.UniversalDeserializer())
+							Expect(err).ToNot(HaveOccurred())
+							daemonset := daemonSetYAMLFor()
+							utilruntime.Must(references.InjectAnnotations(daemonset))
+							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+						})
+					})
+				})
 			})
 		})
 	})
@@ -1231,18 +1284,52 @@ ip6.arpa:53 {
 
 })
 
-func bindIP(values Values) string {
-	if len(values.DNSServers) > 0 {
-		return "169.254.20.10 " + strings.Join(values.DNSServers, " ")
+func healthAddress(values Values) string {
+	ipFamiliesSet := sets.New[gardencorev1beta1.IPFamily](values.IPFamilies...)
+	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) {
+		return "169.254.20.10"
 	}
-	return "169.254.20.10"
+	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) {
+		if len(values.DNSServers) > 0 {
+			return "fd30:1319:f1e:230b::1 " + strings.Join(values.DNSServers, " ")
+		}
+		return "[fd30:1319:f1e:230b::1]"
+	}
+	return ""
+}
+
+func bindIP(values Values) string {
+	ipFamiliesSet := sets.New[gardencorev1beta1.IPFamily](values.IPFamilies...)
+	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) {
+		if len(values.DNSServers) > 0 {
+			return "169.254.20.10 " + strings.Join(values.DNSServers, " ")
+		}
+		return "169.254.20.10"
+	}
+	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) {
+		if len(values.DNSServers) > 0 {
+			return "fd30:1319:f1e:230b::1 " + strings.Join(values.DNSServers, " ")
+		}
+		return "fd30:1319:f1e:230b::1"
+	}
+	return ""
 }
 
 func containerArg(values Values) string {
-	if len(values.DNSServers) > 0 {
-		return "169.254.20.10," + strings.Join(values.DNSServers, ",")
+	ipFamiliesSet := sets.New[gardencorev1beta1.IPFamily](values.IPFamilies...)
+	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) {
+		if len(values.DNSServers) > 0 {
+			return "169.254.20.10," + strings.Join(values.DNSServers, ",")
+		}
+		return "169.254.20.10"
 	}
-	return "169.254.20.10"
+	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) {
+		if len(values.DNSServers) > 0 {
+			return "fd30:1319:f1e:230b::1," + strings.Join(values.DNSServers, ",")
+		}
+		return "fd30:1319:f1e:230b::1"
+	}
+	return ""
 }
 
 func extractDaemonSet(manifests []string, decoder runtime.Decoder) (*appsv1.DaemonSet, error) {

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -490,8 +490,14 @@ func (r *Reconciler) reconcileNetworkPolicyAllowToDNS(ctx context.Context, log l
 					// required for node local dns feature, allows egress traffic to node local dns cache
 					{
 						IPBlock: &networkingv1.IPBlock{
-							// node local dns feature is only supported for shoots with IPv4 single-stack networking
+							// node local dns feature is only supported for shoots with IPv4 or IPv6 single-stack networking
 							CIDR: fmt.Sprintf("%s/32", nodelocaldnsconstants.IPVSAddress),
+						},
+					},
+					{
+						IPBlock: &networkingv1.IPBlock{
+							// node local dns feature is only supported for shoots with IPv4 or IPv6 single-stack networking
+							CIDR: fmt.Sprintf("%s/128", nodelocaldnsconstants.IPVSIPv6Address),
 						},
 					},
 				},

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -55,7 +55,7 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 	}
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetClusterDNS(clusterDNS)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetDNSServers(dnsServers)
-
+	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetIPFamilies(b.Shoot.GetInfo().Spec.Networking.IPFamilies)
 	if b.Shoot.NodeLocalDNSEnabled {
 		return b.Shoot.Components.SystemComponents.NodeLocalDNS.Deploy(ctx)
 	}

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -123,7 +123,13 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 		// If IPVS is enabled then instruct the kubelet to create pods resolving DNS to the `nodelocaldns` network
 		// interface link-local ip address. For more information checkout the usage documentation under
 		// https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/.
-		clusterDNSAddresses = []string{nodelocaldnsconstants.IPVSAddress}
+		ipFamiliesSet := sets.New[gardencorev1beta1.IPFamily](b.Shoot.GetInfo().Spec.Networking.IPFamilies...)
+		if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) {
+			clusterDNSAddresses = []string{nodelocaldnsconstants.IPVSAddress}
+		}
+		if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) {
+			clusterDNSAddresses = []string{nodelocaldnsconstants.IPVSIPv6Address}
+		}
 	}
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetClusterDNSAddresses(clusterDNSAddresses)
 

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -113,6 +113,9 @@ var _ = Describe("operatingsystemconfig", func() {
 						{Name: "foo"},
 					},
 				},
+				Networking: &gardencorev1beta1.Networking{
+					IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+				},
 			},
 			Status: gardencorev1beta1.ShootStatus{
 				TechnicalID: "shoot--garden-testing",
@@ -150,6 +153,30 @@ var _ = Describe("operatingsystemconfig", func() {
 						},
 					},
 				}
+				operatingSystemConfig.EXPECT().SetCABundle(nil)
+
+				operatingSystemConfig.EXPECT().Deploy(ctx)
+				Expect(botanist.DeployOperatingSystemConfig(ctx)).To(Succeed())
+			})
+
+			It("should deploy successfully with ipFamiliy IPv6", func() {
+
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Provider: gardencorev1beta1.Provider{
+							Workers: []gardencorev1beta1.Worker{
+								{Name: "foo"},
+							},
+						},
+						Networking: &gardencorev1beta1.Networking{
+							IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6},
+						},
+					},
+					Status: gardencorev1beta1.ShootStatus{
+						TechnicalID: "shoot--garden-testing",
+					},
+				})
+				botanist.Shoot.Purpose = "development"
 				operatingSystemConfig.EXPECT().SetCABundle(nil)
 
 				operatingSystemConfig.EXPECT().Deploy(ctx)

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
@@ -517,6 +517,12 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 									CIDR: "169.254.20.10/32",
 								},
 							},
+							// required for node local dns feature, allows egress traffic to node local dns cache
+							{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "fd30:1319:f1e:230b::1/128",
+								},
+							},
 							// required for node local dns feature, allows egress traffic to CoreDNS
 							{
 								IPBlock: &networkingv1.IPBlock{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
The node-local-dns configuration in gardener does only support IPv4 shoot clusters. This PR extends the node-local-dns configuration to also support IPv6 shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
IPv6 support for `node-local-dns`.
```
