### PR TITLE
`WithoutShootCredentials` uses empty secret instead of nil object

### DIFF
--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -149,9 +149,9 @@ func (b *Builder) WithShootCredentialsFrom(c client.Reader) *Builder {
 	return b
 }
 
-// WithoutShootCredentials sets the shootCredentialsFunc attribute at the builder to return `nil` as credentials.
+// WithoutShootCredentials sets the shootCredentialsFunc attribute at the builder to return empty Secret as credentials.
 func (b *Builder) WithoutShootCredentials() *Builder {
-	b.shootCredentialsFunc = func(context.Context, string, string, bool) (client.Object, error) { return nil, nil }
+	b.shootCredentialsFunc = func(context.Context, string, string, bool) (client.Object, error) { return &corev1.Secret{}, nil }
 	return b
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
`WithoutShootCredentials` uses empty secret instead of nil object, see https://github.com/gardener/gardener/pull/10673#discussion_r1806443749 for details.

/cc @timuthy 
/area quality
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Follow-up on #10672 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
