### PR TITLE
provider-local/node: Bump `kindest/node` image to v1.31.1

### DIFF
--- a/pkg/provider-local/node/Dockerfile
+++ b/pkg/provider-local/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM kindest/node:v1.30.4
+FROM kindest/node:v1.31.1
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Bump kindest/node image of `gardener-extension-provider-local-node`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10286

**Special notes for your reviewer**:
I will create a dedicated PR for bumping the `kindest/node` image of the kind cluster: https://github.com/gardener/gardener/blob/ad3c1d39ecbb8939e50c7a610013ba6eb3a093c8/example/gardener-local/kind/cluster/values.yaml#L1

There are adaptations that have to be performed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The base image of the `gardener-extension-provider-local-node` image is now updated to `kindest/node@v1.31.1`.
```
