### PR TITLE
Allow Service Account Managed Issuer feature for workerless shoots

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2641,10 +2641,6 @@ func validateShootManagedIssuer(shoot *core.Shoot) field.ErrorList {
 			kubeAPIServerConfig.ServiceAccountConfig.Issuer != nil {
 			allErrors = append(allErrors, field.Forbidden(field.NewPath("metadata", "annotations").Key(v1beta1constants.AnnotationAuthenticationIssuer), "managed shoot issuer cannot be enabled when .kubernetes.kubeAPIServer.serviceAccountConfig.issuer is set"))
 		}
-
-		if helper.IsWorkerless(shoot) {
-			allErrors = append(allErrors, field.Forbidden(field.NewPath("metadata", "annotations").Key(v1beta1constants.AnnotationAuthenticationIssuer), "managed shoot issuer cannot be enabled for workerless shoots"))
-		}
 	}
 
 	return allErrors

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1177,19 +1177,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
-			It("should not allow enabling it for workerless shoots", func() {
-				shoot.Annotations = map[string]string{
-					"authentication.gardener.cloud/issuer": "managed",
-				}
-				shoot.Spec.Provider.Workers = []core.Worker{}
-				errorList := ValidateShoot(shoot)
-				Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
-					"Field":  Equal("metadata.annotations[authentication.gardener.cloud/issuer]"),
-					"Detail": ContainSubstring("managed shoot issuer cannot be enabled for workerless shoots"),
-				}))))
-			})
-
 			It("should allow enabling it for shoots without configured issuer", func() {
 				shoot.Annotations = map[string]string{
 					"authentication.gardener.cloud/issuer": "managed",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
Lifts the restriction that was preventing workerless shoots to enable the Service Account Managed Issuer feature.

**Which issue(s) this PR fixes**:
Fixes #10687

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Service Account Managed Issuer can be now enabled for workerless shoot clusters.
```
