### PR TITLE
Do not overwrite machine state with nil data

### DIFF
--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -141,11 +141,15 @@ func computeGardenerData(
 		return nil, fmt.Errorf("failed compressing machine state data: %w", err)
 	}
 
-	return append(secretsToPersist, gardencorev1beta1.GardenerResourceData{
-		Name: v1beta1constants.DataTypeMachineState,
-		Type: v1beta1constants.DataTypeMachineState,
-		Data: runtime.RawExtension{Raw: machineStateJSONCompressed},
-	}), nil
+	if machineStateJSONCompressed != nil {
+		return append(secretsToPersist, gardencorev1beta1.GardenerResourceData{
+			Name: v1beta1constants.DataTypeMachineState,
+			Type: v1beta1constants.DataTypeMachineState,
+			Data: runtime.RawExtension{Raw: machineStateJSONCompressed},
+		}), nil
+	}
+
+	return secretsToPersist, nil
 }
 
 func computeSecretsToPersist(

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -142,11 +142,11 @@ func computeGardenerData(
 	}
 
 	if machineStateJSONCompressed != nil {
-		return append(secretsToPersist, gardencorev1beta1.GardenerResourceData{
+		secretsToPersist = append(secretsToPersist, gardencorev1beta1.GardenerResourceData{
 			Name: v1beta1constants.DataTypeMachineState,
 			Type: v1beta1constants.DataTypeMachineState,
 			Data: runtime.RawExtension{Raw: machineStateJSONCompressed},
-		}), nil
+		})
 	}
 
 	return secretsToPersist, nil

--- a/test/integration/gardenlet/shoot/state/state_test.go
+++ b/test/integration/gardenlet/shoot/state/state_test.go
@@ -29,8 +29,6 @@ var _ = Describe("Shoot State controller tests", func() {
 		secret     *corev1.Secret
 
 		lastOperation *gardencorev1beta1.LastOperation
-
-		emptyMachineState = gardencorev1beta1.GardenerResourceData{Name: "machine-state", Type: "machine-state"}
 	)
 
 	BeforeEach(func() {
@@ -141,7 +139,7 @@ var _ = Describe("Shoot State controller tests", func() {
 			By("Ensure ShootState is newly created")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
-				g.Expect(shootState.Spec.Gardener).To(ConsistOf(emptyMachineState))
+				g.Expect(shootState.Spec.Gardener).To(BeEmpty())
 			}).Should(Succeed())
 
 			By("Create secret for next backup")
@@ -162,7 +160,7 @@ var _ = Describe("Shoot State controller tests", func() {
 			By("Ensure ShootState is not updated")
 			Consistently(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
-				g.Expect(shootState.Spec.Gardener).To(ConsistOf(emptyMachineState))
+				g.Expect(shootState.Spec.Gardener).To(BeEmpty())
 			}).Should(Succeed())
 		})
 	})
@@ -235,7 +233,7 @@ var _ = Describe("Shoot State controller tests", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 				lastBackup = shootState.Annotations["gardener.cloud/timestamp"]
-				g.Expect(shootState.Spec.Gardener).To(ConsistOf(emptyMachineState))
+				g.Expect(shootState.Spec.Gardener).To(BeEmpty())
 			}).Should(Succeed())
 
 			By("Create secret for next backup")
@@ -245,7 +243,7 @@ var _ = Describe("Shoot State controller tests", func() {
 			Consistently(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 				g.Expect(shootState.Annotations).To(HaveKeyWithValue("gardener.cloud/timestamp", lastBackup))
-				g.Expect(shootState.Spec.Gardener).To(ConsistOf(emptyMachineState))
+				g.Expect(shootState.Spec.Gardener).To(BeEmpty())
 			}).Should(Succeed())
 
 			By("Step clock")
@@ -255,7 +253,7 @@ var _ = Describe("Shoot State controller tests", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 				g.Expect(shootState.Annotations).To(HaveKeyWithValue("gardener.cloud/timestamp", Not(Equal(lastBackup))))
-				g.Expect(shootState.Spec.Gardener).To(HaveLen(2))
+				g.Expect(shootState.Spec.Gardener).To(HaveLen(1))
 			}).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue which was causing the `machine-state` to be overwritten with nil data if the `migrate` phase of control plane migration errored and was retried after the `MachineDeployment`, `MachineSet` and `Machine` resources were deleted.

The issue would occur because the computed [`machineState`](https://github.com/gardener/gardener/blob/3d9c6bbc9557f36ad346efae7073b7184745420f/pkg/utils/gardener/shootstate/machines.go#L37) is empty if there are no machine objects. This would then result in a nil [`machineStateJSONCompressed `](https://github.com/gardener/gardener/blob/3d9c6bbc9557f36ad346efae7073b7184745420f/pkg/utils/gardener/shootstate/shootstate.go#L139) and this nil data is added as a `machine-state` entry in the gardener data list [here](https://github.com/gardener/gardener/blob/3d9c6bbc9557f36ad346efae7073b7184745420f/pkg/utils/gardener/shootstate/shootstate.go#L144-L147). The `nil` data then overwrites the existing machine-state data in the `ShootState` when [`gardenerData.Upsert(...)`](https://github.com/gardener/gardener/blob/3d9c6bbc9557f36ad346efae7073b7184745420f/pkg/utils/gardener/shootstate/shootstate.go#L58) is called.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue that would cause the entry for the `machine-state` in the `ShootState` to be overwritten with nil data during control plane migration, if the `migrate` phase errored and was retried after the `MachineDeployment`, `MachineSet` and `Machine` objects were deleted, which would result in the Shoot's nodes to be recreated during Control Plane Migration.
```
