### PR TITLE
Introduce integration test for `node-agent-authorizer` webhook

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -195,8 +195,10 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 					Name:       "node-agent-authorizer",
 					Kubeconfig: kubeconfig,
 					WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
-						AuthorizedTTL:                            metav1.Duration{Duration: 0},
-						UnauthorizedTTL:                          metav1.Duration{Duration: 0},
+						// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
+						// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
+						AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
+						UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
 						Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
 						FailurePolicy:                            apiserverv1beta1.FailurePolicyDeny,
 						SubjectAccessReviewVersion:               "v1",

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -587,8 +587,10 @@ func (r *Reconciler) newKubeAPIServer(
 			Name:       "seed-authorizer",
 			Kubeconfig: kubeconfig,
 			WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
-				AuthorizedTTL:                            metav1.Duration{Duration: time.Duration(0)},
-				UnauthorizedTTL:                          metav1.Duration{Duration: time.Duration(0)},
+				// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
+				// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
+				AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
+				UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
 				Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
 				FailurePolicy:                            apiserverv1beta1.FailurePolicyDeny,
 				SubjectAccessReviewVersion:               "v1",

--- a/test/integration/resourcemanager/csrapprover/csrapprover_suite_test.go
+++ b/test/integration/resourcemanager/csrapprover/csrapprover_suite_test.go
@@ -110,7 +110,6 @@ var _ = BeforeSuite(func() {
 			&rest.Config{QPS: 1000.0, Burst: 2000.0},
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(user).NotTo(BeNil())
 
 		testClient, err := client.New(user.Config(), client.Options{Scheme: resourcemanagerclient.CombinedScheme})
 		Expect(err).NotTo(HaveOccurred())

--- a/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_suite_test.go
+++ b/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_suite_test.go
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagentauthorizer_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
+	resourcemanagerclient "github.com/gardener/gardener/pkg/resourcemanager/client"
+	"github.com/gardener/gardener/pkg/resourcemanager/webhook/nodeagentauthorizer"
+	"github.com/gardener/gardener/pkg/utils"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/test/framework"
+)
+
+func TestNodeAgentAuthorizer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration ResourceManager NodeAgentAuthorizer Suite")
+}
+
+const testID = "nodeagentauthorizer-webhook-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	sourceRestConfig *rest.Config
+	sourceEnv        *envtest.Environment
+	sourceClient     client.Client
+
+	targetRestConfig          *rest.Config
+	targetRestConfigNodeAgent *rest.Config
+	targetEnv                 *envtest.Environment
+	targetClient              client.Client
+	targetClientNodeAgent     client.Client
+
+	testRunID     string
+	testNamespace *corev1.Namespace
+
+	machineName       string
+	userNameNodeAgent string
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+	testRunID = utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:16]
+
+	// determine a unique namespace name for test environment
+	testNamespaceName := testID + "-" + testRunID[:8]
+
+	By("Start source environment")
+	seedCRDs := filepath.Join("..", "..", "..", "..", "example", "seed-crds")
+	sourceEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join(seedCRDs, "10-crd-machine.sapcloud.io_machines.yaml"),
+			},
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	sourceRestConfig, err = sourceEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(sourceRestConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop source environment")
+		Expect(sourceEnv.Stop()).To(Succeed())
+	})
+
+	By("Create source client")
+	sourceClient, err = client.New(sourceRestConfig, client.Options{Scheme: resourcemanagerclient.CombinedScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Create test Namespace")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
+			Name: testNamespaceName,
+		},
+	}
+	Expect(sourceClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created test Namespace in source cluster", "namespaceName", testNamespace.Name)
+
+	DeferCleanup(func() {
+		By("Delete test Namespace from source cluster")
+		Expect(sourceClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("Create kubeconfig file for source cluster")
+	kubeconfigFileName, err := createKubeconfigFileForAuthorizationWebhook(sourceEnv.WebhookInstallOptions)
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		By("Delete kubeconfig file for source cluster")
+		Expect(os.Remove(kubeconfigFileName)).To(Succeed())
+	})
+
+	By("Start target environment")
+	Expect(framework.FileExists(kubeconfigFileName)).To(BeTrue())
+	testAPIServer := &envtest.APIServer{}
+	testAPIServer.Configure().
+		Set("authorization-mode", "RBAC", "Webhook").
+		Set("authorization-webhook-config-file", kubeconfigFileName).
+		Set("authorization-webhook-cache-authorized-ttl", "0").
+		Set("authorization-webhook-cache-unauthorized-ttl", "0")
+
+	targetEnv = &envtest.Environment{
+		ControlPlane: envtest.ControlPlane{
+			APIServer: testAPIServer,
+		},
+	}
+
+	targetRestConfig, err = targetEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(targetRestConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop target environment")
+		Expect(targetEnv.Stop()).To(Succeed())
+	})
+
+	By("Create target clients")
+	targetClient, err = client.New(targetRestConfig, client.Options{Scheme: resourcemanagerclient.CombinedScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	machineName = "machine-" + testRunID
+	userNameNodeAgent = "gardener.cloud:node-agent:machine:" + machineName
+
+	createClient := func(userName string) (client.Client, *rest.Config) {
+		user, err := targetEnv.AddUser(
+			envtest.User{Name: userName, Groups: []string{v1beta1constants.NodeAgentsGroup}},
+			&rest.Config{QPS: 1000.0, Burst: 2000.0},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(user).NotTo(BeNil())
+
+		testClient, err := client.New(user.Config(), client.Options{Scheme: resourcemanagerclient.CombinedScheme})
+		Expect(err).NotTo(HaveOccurred())
+		return testClient, user.Config()
+	}
+
+	targetClientNodeAgent, targetRestConfigNodeAgent = createClient(userNameNodeAgent)
+
+	By("Setup manager")
+	mgr, err := manager.New(sourceRestConfig, manager.Options{
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port:    sourceEnv.WebhookInstallOptions.LocalServingPort,
+			Host:    sourceEnv.WebhookInstallOptions.LocalServingHost,
+			CertDir: sourceEnv.WebhookInstallOptions.LocalServingCertDir,
+		}),
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{testNamespace.Name: {}},
+		},
+		Controller: controllerconfig.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Register webhook")
+	Expect((&nodeagentauthorizer.Webhook{
+		Logger: log,
+		Config: config.NodeAgentAuthorizerWebhookConfig{
+			Enabled:          true,
+			MachineNamespace: testNamespaceName,
+		},
+	}).AddToManager(mgr, sourceClient, targetClient)).To(Succeed())
+
+	By("Start manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	// Wait for the webhook server to start
+	Eventually(func() error {
+		checker := mgr.GetWebhookServer().StartedChecker()
+		return checker(&http.Request{})
+	}).Should(Succeed())
+
+	DeferCleanup(func() {
+		By("Stop manager")
+		mgrCancel()
+	})
+})
+
+func createKubeconfigFileForAuthorizationWebhook(webhookInstallOptions envtest.WebhookInstallOptions) (string, error) {
+	clusters := make(map[string]*clientcmdapi.Cluster)
+	clusters["authorization-webhook"] = &clientcmdapi.Cluster{
+		Server:                   fmt.Sprintf("https://%s:%d%s", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort, nodeagentauthorizer.WebhookPath),
+		CertificateAuthorityData: webhookInstallOptions.LocalServingCAData,
+	}
+	contexts := make(map[string]*clientcmdapi.Context)
+	contexts["authorization-webhook"] = &clientcmdapi.Context{
+		Cluster:  "authorization-webhook",
+		AuthInfo: "authorization-webhook",
+	}
+	authinfos := make(map[string]*clientcmdapi.AuthInfo)
+	clientConfig := clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: "authorization-webhook",
+		AuthInfos:      authinfos,
+	}
+	kubeConfigFile, err := os.CreateTemp("", "kubeconfig-nodeagentauthorizer-")
+	if err != nil {
+		return "", err
+	}
+	if err := clientcmd.WriteToFile(clientConfig, kubeConfigFile.Name()); err != nil {
+		return "", err
+	}
+	return kubeConfigFile.Name(), nil
+}

--- a/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_test.go
+++ b/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_test.go
@@ -127,7 +127,7 @@ var _ = Describe("NodeAgentAuthorizer tests", func() {
 			})
 		})
 
-		It("should be able to create a CertificateSigningRequest, get it but not change and delete it", func() {
+		It("should be able to create a CertificateSigningRequest, get it but not change or delete it", func() {
 			Expect(targetClientNodeAgent.Create(ctx, csr)).To(Succeed())
 
 			Expect(targetClientNodeAgent.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
@@ -164,7 +164,6 @@ var _ = Describe("NodeAgentAuthorizer tests", func() {
 		It("should forbid to list CertificateSigningRequests", func() {
 			Expect(targetClientNodeAgent.List(ctx, &certificatesv1.CertificateSigningRequestList{})).To(BeForbiddenError())
 		})
-
 	})
 
 	Describe("#Events", func() {
@@ -639,7 +638,7 @@ var _ = Describe("NodeAgentAuthorizer tests", func() {
 })
 
 func createNodeForMachine(node *corev1.Node, machine *machinev1alpha1.Machine) {
-	Expect(targetClient.Create(ctx, node)).To(Succeed())
+	ExpectWithOffset(1, targetClient.Create(ctx, node)).To(Succeed())
 	machine.SetLabels(map[string]string{machinev1alpha1.NodeLabelKey: node.Name})
-	Expect(sourceClient.Update(ctx, machine)).To(Succeed())
+	ExpectWithOffset(1, sourceClient.Update(ctx, machine)).To(Succeed())
 }

--- a/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_test.go
+++ b/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_test.go
@@ -199,7 +199,7 @@ var _ = Describe("NodeAgentAuthorizer tests", func() {
 
 		It("should be able to create and patch an event", func() {
 			// Recording the same event multiple times in a short period makes the event recorder patching the event.
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				recorder.Event(node, "Normal", "test-reason", "test-message")
 			}
 

--- a/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_test.go
+++ b/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_test.go
@@ -1,0 +1,645 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagentauthorizer_test
+
+import (
+	"crypto/rand"
+	"crypto/x509/pkix"
+	"fmt"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	certutil "k8s.io/client-go/util/cert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("NodeAgentAuthorizer tests", func() {
+	const (
+		machineSecretName      = "foo-machine-secret"
+		nodeName               = "foo-node"
+		otherMachineName       = "bar-machine"
+		otherMachineSecretName = "bar-machine-secret"
+		valitailSecretName     = "gardener-valitail"
+	)
+
+	var (
+		machine      *machinev1alpha1.Machine
+		otherMachine *machinev1alpha1.Machine
+		node         *corev1.Node
+	)
+
+	BeforeEach(func() {
+		machine = &machinev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      machineName,
+				Namespace: testNamespace.Name,
+			},
+			Spec: machinev1alpha1.MachineSpec{
+				NodeTemplateSpec: machinev1alpha1.NodeTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName: machineSecretName},
+					},
+				},
+			},
+		}
+		Expect(sourceClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(func() {
+			By("Delete Machine")
+			Expect(sourceClient.Delete(ctx, machine)).To(Or(Succeed(), BeNotFoundError()))
+		})
+
+		otherMachine = &machinev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      otherMachineName,
+				Namespace: testNamespace.Name,
+			},
+			Spec: machinev1alpha1.MachineSpec{
+				NodeTemplateSpec: machinev1alpha1.NodeTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName: otherMachineSecretName},
+					},
+				},
+			},
+		}
+		Expect(sourceClient.Create(ctx, otherMachine)).To(Succeed())
+		DeferCleanup(func() {
+			By("Delete other Machine")
+			Expect(sourceClient.Delete(ctx, otherMachine)).To(Or(Succeed(), BeNotFoundError()))
+		})
+
+		node = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   nodeName,
+				Labels: map[string]string{"node.gardener.cloud/machine-name": machineName},
+			},
+		}
+		DeferCleanup(func() {
+			By("Delete Node")
+			Expect(targetClient.Delete(ctx, node)).To(Or(Succeed(), BeNotFoundError()))
+		})
+	})
+
+	Describe("#CertificateSigningRequests", func() {
+		var (
+			csr *certificatesv1.CertificateSigningRequest
+		)
+
+		BeforeEach(func() {
+			certificateSubject := &pkix.Name{
+				CommonName: "nodeagent-authorizer-test",
+			}
+			privateKey, err := secretsutils.FakeGenerateKey(rand.Reader, 4096)
+			Expect(err).ToNot(HaveOccurred())
+			csrData, err := certutil.MakeCSR(privateKey, certificateSubject, nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			csr = &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-request"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageClientAuth,
+					},
+					Request:    csrData,
+					SignerName: certificatesv1.KubeAPIServerClientSignerName,
+				},
+			}
+
+			DeferCleanup(func() {
+				By("Delete CertificateSigningRequest")
+				Expect(targetClient.Delete(ctx, csr)).To(Or(Succeed(), BeNotFoundError()))
+			})
+		})
+
+		It("should be able to create a CertificateSigningRequest, get it but not change and delete it", func() {
+			Expect(targetClientNodeAgent.Create(ctx, csr)).To(Succeed())
+
+			Expect(targetClientNodeAgent.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
+
+			csrUpdate := csr.DeepCopy()
+			csrUpdate.SetLabels(map[string]string{"foo": "bar"})
+			Expect(targetClientNodeAgent.Update(ctx, csrUpdate)).To(BeForbiddenError())
+
+			patch := client.MergeFrom(csr)
+			csrPatch := csr.DeepCopy()
+			csrPatch.SetLabels(map[string]string{"foo": "bar"})
+			Expect(targetClientNodeAgent.Patch(ctx, csrPatch, patch)).To(BeForbiddenError())
+
+			Expect(targetClientNodeAgent.Delete(ctx, csr)).To(BeForbiddenError())
+		})
+
+		It("should forbid to access a CertificateSigningRequest created by a different user", func() {
+			Expect(targetClient.Create(ctx, csr)).To(Succeed())
+
+			Expect(targetClientNodeAgent.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(BeForbiddenError())
+
+			csrUpdate := csr.DeepCopy()
+			csrUpdate.SetLabels(map[string]string{"foo": "bar"})
+			Expect(targetClientNodeAgent.Update(ctx, csrUpdate)).To(BeForbiddenError())
+
+			patch := client.MergeFrom(csr)
+			csrPatch := csr.DeepCopy()
+			csrPatch.SetLabels(map[string]string{"foo": "bar"})
+			Expect(targetClientNodeAgent.Patch(ctx, csrPatch, patch)).To(BeForbiddenError())
+
+			Expect(targetClientNodeAgent.Delete(ctx, csr)).To(BeForbiddenError())
+		})
+
+		It("should forbid to list CertificateSigningRequests", func() {
+			Expect(targetClientNodeAgent.List(ctx, &certificatesv1.CertificateSigningRequestList{})).To(BeForbiddenError())
+		})
+
+	})
+
+	Describe("#Events", func() {
+		var (
+			recorder record.EventRecorder
+		)
+
+		BeforeEach(func() {
+			corev1Client, err := corev1client.NewForConfig(targetRestConfigNodeAgent)
+			Expect(err).ToNot(HaveOccurred())
+			broadcaster := record.NewBroadcaster()
+			broadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: corev1Client.Events("")})
+			recorder = broadcaster.NewRecorder(targetClientNodeAgent.Scheme(), corev1.EventSource{Component: "nodeagentauthorizer-test"})
+
+			node.Name = fmt.Sprintf("event-node-%s", utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:16])
+			createNodeForMachine(node, machine)
+		})
+
+		It("should be able to create an event", func() {
+			recorder.Event(node, "Normal", "test-reason", "test-message")
+
+			Eventually(func(g Gomega) {
+				eventList := &corev1.EventList{}
+				g.Expect(targetClient.List(ctx, eventList, client.MatchingFields{"involvedObject.name": node.Name})).To(Succeed())
+				g.Expect(eventList.Items).To(HaveLen(1))
+				g.Expect(eventList.Items[0].Type).To(Equal("Normal"))
+				g.Expect(eventList.Items[0].Reason).To(Equal("test-reason"))
+				g.Expect(eventList.Items[0].Message).To(Equal("test-message"))
+				g.Expect(eventList.Items[0].Count).To(Equal(int32(1)))
+			}).Should(Succeed())
+		})
+
+		It("should be able to create and patch an event", func() {
+			// Recording the same event multiple times in a short period makes the event recorder patching the event.
+			for i := 0; i < 3; i++ {
+				recorder.Event(node, "Normal", "test-reason", "test-message")
+			}
+
+			Eventually(func(g Gomega) {
+				eventList := &corev1.EventList{}
+				g.Expect(targetClient.List(ctx, eventList, client.MatchingFields{"involvedObject.name": node.Name})).To(Succeed())
+				g.Expect(eventList.Items).To(HaveLen(1))
+				g.Expect(eventList.Items[0].Type).To(Equal("Normal"))
+				g.Expect(eventList.Items[0].Reason).To(Equal("test-reason"))
+				g.Expect(eventList.Items[0].Message).To(Equal("test-message"))
+				g.Expect(eventList.Items[0].Count).To(Equal(int32(3)))
+			}).Should(Succeed())
+		})
+
+		It("should forbid to list events", func() {
+			Expect(targetClientNodeAgent.List(ctx, &corev1.EventList{})).To(BeForbiddenError())
+		})
+
+		It("should forbid to update an event", func() {
+			Expect(targetClientNodeAgent.Update(ctx, &corev1.Event{ObjectMeta: metav1.ObjectMeta{Name: "foo-event", Namespace: "default"}})).To(BeForbiddenError())
+		})
+
+		It("should forbid to delete an event", func() {
+			Expect(targetClientNodeAgent.Delete(ctx, &corev1.Event{ObjectMeta: metav1.ObjectMeta{Name: "foo-event", Namespace: "default"}})).To(BeForbiddenError())
+		})
+	})
+
+	Describe("#Leases", func() {
+		const (
+			otherNodeName           = "bar-node"
+			nodeAgentLeaseName      = "gardener-node-agent-" + nodeName
+			otherNodeAgentLeaseName = "gardener-node-agent-" + otherNodeName
+		)
+
+		var otherNode *corev1.Node
+
+		BeforeEach(func() {
+			otherNode = &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   otherNodeName,
+					Labels: map[string]string{"node.gardener.cloud/machine-name": otherMachineName},
+				},
+			}
+			DeferCleanup(func() {
+				By("Delete other Node")
+				Expect(targetClient.Delete(ctx, otherNode)).To(Or(Succeed(), BeNotFoundError()))
+			})
+			createNodeForMachine(otherNode, otherMachine)
+		})
+
+		DescribeTable("#get",
+			func(name, namespace string, createNode, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+				if createNode {
+					createNodeForMachine(node, machine)
+				}
+				lease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+				}
+				Expect(targetClient.Create(ctx, lease)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(targetClient.Delete(ctx, lease)).To(Or(Succeed(), BeNotFoundError()))
+				})
+				Expect(targetClientNodeAgent.Get(ctx, client.ObjectKeyFromObject(lease), &coordinationv1.Lease{})).To(matcher)
+			},
+			Entry("allow own gardener-node-agent", nodeAgentLeaseName, "kube-system", true, true),
+			Entry("forbid if no own node", nodeAgentLeaseName, "kube-system", false, false),
+			Entry("forbid other gardener-node-agent", otherNodeAgentLeaseName, "kube-system", true, false),
+			Entry("forbid other gardener-node-agent if no own node", otherNodeAgentLeaseName, "kube-system", false, false),
+			Entry("forbid in default namespace", "foo-bar", "default", true, false),
+			Entry("forbid in default namespace without node", "foo-bar", "default", false, false),
+		)
+
+		DescribeTable("#update",
+			func(name, namespace string, createNode, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+				if createNode {
+					createNodeForMachine(node, machine)
+				}
+				lease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+				}
+				Expect(targetClient.Create(ctx, lease)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(targetClient.Delete(ctx, lease)).To(Or(Succeed(), BeNotFoundError()))
+				})
+				lease.SetLabels(map[string]string{"foo": "bar"})
+				Expect(targetClientNodeAgent.Update(ctx, lease.DeepCopy())).To(matcher)
+			},
+			Entry("allow own gardener-node-agent", nodeAgentLeaseName, "kube-system", true, true),
+			Entry("forbid if no own node", nodeAgentLeaseName, "kube-system", false, false),
+			Entry("forbid other gardener-node-agent", otherNodeAgentLeaseName, "kube-system", true, false),
+			Entry("forbid other gardener-node-agent if no own node", otherNodeAgentLeaseName, "kube-system", false, false),
+			Entry("forbid in default namespace", "foo-bar", "default", true, false),
+			Entry("forbid in default namespace without node", "foo-bar", "default", false, false),
+		)
+
+		DescribeTable("#patch",
+			func(name, namespace string, createNode bool) {
+				if createNode {
+					createNodeForMachine(node, machine)
+				}
+				lease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+				}
+				Expect(targetClient.Create(ctx, lease)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(targetClient.Delete(ctx, lease)).To(Or(Succeed(), BeNotFoundError()))
+				})
+				patch := client.MergeFrom(lease)
+				lease.SetLabels(map[string]string{"foo": "bar"})
+				Expect(targetClientNodeAgent.Patch(ctx, lease.DeepCopy(), patch)).To(BeForbiddenError())
+			},
+			Entry("forbid own gardener-node-agent", nodeAgentLeaseName, "kube-system", true),
+			Entry("forbid if no own node", nodeAgentLeaseName, "kube-system", false),
+			Entry("forbid other gardener-node-agent", otherNodeAgentLeaseName, "kube-system", true),
+			Entry("forbid other gardener-node-agent if no own node", otherNodeAgentLeaseName, "kube-system", false),
+			Entry("forbid in default namespace", "foo-bar", "default", true),
+			Entry("forbid in default namespace without node", "foo-bar", "default", false),
+		)
+
+		DescribeTable("#delete",
+			func(name, namespace string, createNode bool) {
+				if createNode {
+					createNodeForMachine(node, machine)
+				}
+				lease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+				}
+				Expect(targetClient.Create(ctx, lease)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(targetClient.Delete(ctx, lease)).To(Or(Succeed(), BeNotFoundError()))
+				})
+				Expect(targetClientNodeAgent.Delete(ctx, lease.DeepCopy())).To(BeForbiddenError())
+			},
+			Entry("forbid own gardener-node-agent", nodeAgentLeaseName, "kube-system", true),
+			Entry("forbid if no own node", nodeAgentLeaseName, "kube-system", false),
+			Entry("forbid other gardener-node-agent", otherNodeAgentLeaseName, "kube-system", true),
+			Entry("forbid other gardener-node-agent if no own node", otherNodeAgentLeaseName, "kube-system", false),
+			Entry("forbid in default namespace", "foo-bar", "default", true),
+			Entry("forbid in default namespace without node", "foo-bar", "default", false),
+		)
+
+		DescribeTable("#list",
+			func(name, namespace string, createNode, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+				if createNode {
+					createNodeForMachine(node, machine)
+				}
+				var listOptions []client.ListOption
+				if name != "" {
+					listOptions = append(listOptions, client.MatchingFields{"metadata.name": name})
+				}
+				if namespace != "" {
+					listOptions = append(listOptions, client.InNamespace(namespace))
+				}
+				Expect(targetClientNodeAgent.List(ctx, &coordinationv1.LeaseList{}, listOptions...)).To(matcher)
+			},
+			Entry("allow own gardener-node-agent", nodeAgentLeaseName, "kube-system", true, true),
+			Entry("forbid if no own node", nodeAgentLeaseName, "kube-system", false, false),
+			Entry("forbid other gardener-node-agent", otherNodeAgentLeaseName, "kube-system", true, false),
+			Entry("forbid other gardener-node-agent if no own node", otherNodeAgentLeaseName, "kube-system", false, false),
+			Entry("forbid in default namespace", "foo-bar", "default", true, false),
+			Entry("forbid in default namespace without node", "foo-bar", "default", false, false),
+			Entry("forbid whole kube-system namespace", "", "kube-system", true, false),
+			Entry("forbid whole kube-system namespace if no own node", "", "kube-system", false, false),
+			Entry("forbid cluster wide", "", "", true, false),
+			Entry("forbid cluster wide if no own node", "", "", false, false),
+		)
+
+		DescribeTable("#create",
+			func(name, namespace string, createNode, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+				if createNode {
+					createNodeForMachine(node, machine)
+				}
+				lease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+				}
+				Expect(targetClientNodeAgent.Create(ctx, lease)).To(matcher)
+				DeferCleanup(func() {
+					Expect(targetClient.Delete(ctx, lease)).To(Or(Succeed(), BeNotFoundError()))
+				})
+			},
+			Entry("allow own gardener-node-agent", nodeAgentLeaseName, "kube-system", true, true),
+			Entry("forbid if no own node", nodeAgentLeaseName, "kube-system", false, false),
+			Entry("allow other gardener-node-agent - we cannot avoid this", otherNodeAgentLeaseName, "kube-system", true, true),
+			Entry("forbid other gardener-node-agent if no own node", otherNodeAgentLeaseName, "kube-system", false, false),
+			Entry("forbid in default namespace", "foo-bar", "default", true, false),
+			Entry("forbid in default namespace without node", "foo-bar", "default", false, false),
+		)
+	})
+
+	Describe("#Nodes", func() {
+		const otherNodeName = "bar-node"
+
+		var otherNode *corev1.Node
+
+		BeforeEach(func() {
+			otherNode = &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   otherNodeName,
+					Labels: map[string]string{"node.gardener.cloud/machine-name": otherMachineName},
+				},
+			}
+			DeferCleanup(func() {
+				By("Delete other Node")
+				Expect(targetClient.Delete(ctx, otherNode)).To(Or(Succeed(), BeNotFoundError()))
+			})
+			createNodeForMachine(otherNode, otherMachine)
+		})
+
+		DescribeTable("#get",
+			func(name string, createNode, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+				if createNode {
+					createNodeForMachine(node, machine)
+				}
+				Expect(targetClientNodeAgent.Get(ctx, client.ObjectKey{Name: name}, &corev1.Node{})).To(matcher)
+			},
+			Entry("allow own node", nodeName, true, true),
+			Entry("forbid if no own node", nodeName, false, false),
+			Entry("forbid other node", otherNodeName, true, false),
+			Entry("forbid other node if no own node", otherNodeName, false, false),
+		)
+
+		DescribeTable("#update",
+			func(name string, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+
+				createNodeForMachine(node, machine)
+
+				testNode := &corev1.Node{}
+				Expect(targetClient.Get(ctx, client.ObjectKey{Name: name}, testNode)).To(Succeed())
+				testNode.Labels["foo"] = "bar"
+				Expect(targetClientNodeAgent.Update(ctx, testNode)).To(matcher)
+			},
+			Entry("allow own node", nodeName, true),
+			Entry("forbid other node", otherNodeName, false),
+		)
+
+		DescribeTable("#patch",
+			func(name string, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+
+				createNodeForMachine(node, machine)
+
+				testNode := &corev1.Node{}
+				Expect(targetClient.Get(ctx, client.ObjectKey{Name: name}, testNode)).To(Succeed())
+				patch := client.MergeFrom(testNode)
+				testNode.Labels["foo"] = "bar"
+				Expect(targetClientNodeAgent.Patch(ctx, testNode, patch)).To(matcher)
+			},
+			Entry("allow own node", nodeName, true),
+			Entry("forbid other node", otherNodeName, false),
+		)
+
+		DescribeTable("#delete",
+			func(name string) {
+				createNodeForMachine(node, machine)
+
+				testNode := &corev1.Node{}
+				Expect(targetClient.Get(ctx, client.ObjectKey{Name: name}, testNode)).To(Succeed())
+				Expect(targetClientNodeAgent.Delete(ctx, testNode)).To(BeForbiddenError())
+			},
+			Entry("forbid own node", nodeName),
+			Entry("forbid other node", otherNodeName),
+		)
+
+		It("should allow listing nodes unconditionally", func() {
+			Expect(targetClientNodeAgent.List(ctx, &corev1.NodeList{})).To(Succeed())
+		})
+	})
+
+	Describe("#Secrets", func() {
+		BeforeEach(func() {
+			machineSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machineSecretName,
+					Namespace: "kube-system",
+				},
+			}
+			Expect(targetClient.Create(ctx, machineSecret)).To(Succeed())
+			DeferCleanup(func() {
+				By("Delete machine Secret")
+				Expect(targetClient.Delete(ctx, machineSecret)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			otherMachineSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      otherMachineSecretName,
+					Namespace: "kube-system",
+				},
+			}
+			Expect(targetClient.Create(ctx, otherMachineSecret)).To(Succeed())
+			DeferCleanup(func() {
+				By("Delete other machine Secret")
+				Expect(targetClient.Delete(ctx, otherMachineSecret)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			valitailSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      valitailSecretName,
+					Namespace: "kube-system",
+				},
+			}
+			Expect(targetClient.Create(ctx, valitailSecret)).To(Succeed())
+			DeferCleanup(func() {
+				By("Delete valitail Secret")
+				Expect(targetClient.Delete(ctx, valitailSecret)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			fooSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			}
+			Expect(targetClient.Create(ctx, fooSecret)).To(Succeed())
+			DeferCleanup(func() {
+				By("Delete foo Secret")
+				Expect(targetClient.Delete(ctx, fooSecret)).To(Or(Succeed(), BeNotFoundError()))
+			})
+		})
+
+		DescribeTable("#get",
+			func(name, namespace string, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+				Expect(targetClientNodeAgent.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &corev1.Secret{})).To(matcher)
+			},
+			Entry("allow valitail secret", valitailSecretName, "kube-system", true),
+			Entry("allow machine secret", machineSecretName, "kube-system", true),
+			Entry("forbid foo secret", "foo", "default", false),
+			Entry("forbid other machine secret", otherMachineSecretName, "kube-system", false),
+		)
+
+		DescribeTable("#update",
+			func(name, namespace string) {
+				secret := &corev1.Secret{}
+				Expect(targetClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret)).To(Succeed())
+				secret.SetLabels(map[string]string{"foo": "bar"})
+				Expect(targetClientNodeAgent.Update(ctx, secret)).To(BeForbiddenError())
+			},
+			Entry("forbid valitail secret", valitailSecretName, "kube-system"),
+			Entry("forbid machine secret", machineSecretName, "kube-system"),
+			Entry("forbid foo secret", "foo", "default"),
+			Entry("forbid other machine secret", otherMachineSecretName, "kube-system"),
+		)
+
+		DescribeTable("#patch",
+			func(name, namespace string) {
+				secret := &corev1.Secret{}
+				Expect(targetClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret)).To(Succeed())
+				patch := client.MergeFrom(secret.DeepCopy())
+				secret.SetLabels(map[string]string{"foo": "bar"})
+				Expect(targetClientNodeAgent.Patch(ctx, secret, patch)).To(BeForbiddenError())
+			},
+			Entry("forbid valitail secret", valitailSecretName, "kube-system"),
+			Entry("forbid machine secret", machineSecretName, "kube-system"),
+			Entry("forbid foo secret", "foo", "default"),
+			Entry("forbid other machine secret", otherMachineSecretName, "kube-system"),
+		)
+
+		DescribeTable("#delete",
+			func(name, namespace string) {
+				secret := &corev1.Secret{}
+				Expect(targetClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret)).To(Succeed())
+				Expect(targetClientNodeAgent.Delete(ctx, secret)).To(BeForbiddenError())
+			},
+			Entry("forbid valitail secret", valitailSecretName, "kube-system"),
+			Entry("forbid machine secret", machineSecretName, "kube-system"),
+			Entry("forbid foo secret", "foo", "default"),
+			Entry("forbid other machine secret", otherMachineSecretName, "kube-system"),
+		)
+
+		DescribeTable("#list",
+			func(name, namespace string, allow bool) {
+				matcher := BeForbiddenError()
+				if allow {
+					matcher = Succeed()
+				}
+				var listOptions []client.ListOption
+				if name != "" {
+					listOptions = append(listOptions, client.MatchingFields{"metadata.name": name})
+				}
+				if namespace != "" {
+					listOptions = append(listOptions, client.InNamespace(namespace))
+				}
+				Expect(targetClientNodeAgent.List(ctx, &corev1.SecretList{}, listOptions...)).To(matcher)
+			},
+			Entry("allow valitail secret", valitailSecretName, "kube-system", true),
+			Entry("allow machine secret", machineSecretName, "kube-system", true),
+			Entry("forbid default namespace", "", "default", false),
+			Entry("forbid kube-system namespace", "", "kube-system", false),
+			Entry("forbid cluster wide", "", "", false),
+		)
+	})
+})
+
+func createNodeForMachine(node *corev1.Node, machine *machinev1alpha1.Machine) {
+	Expect(targetClient.Create(ctx, node)).To(Succeed())
+	machine.SetLabels(map[string]string{machinev1alpha1.NodeLabelKey: node.Name})
+	Expect(sourceClient.Update(ctx, machine)).To(Succeed())
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This is a follow-up to PR #10535. It introduces an integration test for the new `node-agent-authorizer` webhook.

**Which issue(s) this PR fixes**:
Part of #10505 

**Special notes for your reviewer**:
/cc @rfranzke @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`seed-authorizer` and structured authorization webhooks of shoot kube-apiservers no longer use the default TTL for `AuthorizedTTL` and `UnauthorizedTTL`.
```
