### PR TITLE
e2e tests: Bump the Shoot Kubernetes version to 1.31.1

### DIFF
--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -66,7 +66,7 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 				Name: "local",
 			},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.30.0",
+				Version:                     "1.31.1",
 				EnableStaticTokenKubeconfig: ptr.To(false),
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: ptr.To(false),
@@ -131,7 +131,7 @@ func DefaultWorkerlessShoot(name string) *gardencorev1beta1.Shoot {
 				Name: "local",
 			},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.30.0",
+				Version:                     "1.31.1",
 				EnableStaticTokenKubeconfig: ptr.To(false),
 				KubeAPIServer:               &gardencorev1beta1.KubeAPIServerConfig{},
 			},

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -39,7 +39,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 		// explicitly use one version below the latest supported minor version so that Kubernetes version update test can be
 		// performed
-		f.Shoot.Spec.Kubernetes.Version = "1.29.0"
+		f.Shoot.Spec.Kubernetes.Version = "1.30.0"
 
 		if !v1beta1helper.IsWorkerless(f.Shoot) {
 			// create two additional worker pools which explicitly specify the kubernetes version
@@ -48,7 +48,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			pool2.Name += "2"
 			pool2.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: &f.Shoot.Spec.Kubernetes.Version}
 			pool3.Name += "3"
-			pool3.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: ptr.To("1.28.2")}
+			pool3.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: ptr.To("1.29.0")}
 			f.Shoot.Spec.Provider.Workers = append(f.Shoot.Spec.Provider.Workers, *pool2, *pool3)
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Since https://github.com/gardener/gardener/pull/10472, Gardener supports Kubernetes v1.31. This PR updates the Shoot Kubernetes version in the e2e test to use v1.31.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10286
Follow-up after https://github.com/gardener/gardener/pull/10472

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
