### PR TITLE
Deprecate `gardener/controlplane` Helm chart in favor of `gardener-operator`

### DIFF
--- a/charts/gardener/controlplane/Chart.yaml
+++ b/charts/gardener/controlplane/Chart.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 description: A Helm chart to deploy the Gardener controlplane (API server, controller-manager, scheduler, admission-controller)
 name: controlplane
 version: 0.1.0
+deprecated: true

--- a/charts/gardener/controlplane/README.md
+++ b/charts/gardener/controlplane/README.md
@@ -1,0 +1,8 @@
+# `gardener/controlplane` Helm Chart
+
+> [!CAUTION]
+> This Helm chart has been marked as "deprecated".
+> It will be removed at after v1.135 of Gardener has been released (around beginning of 2026).
+>
+> We urge you to switch to a [`gardener-operator`](../../../docs/concepts/operator.md)-based installation.
+> Read all about it [here](../../../docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).

--- a/charts/gardener/controlplane/README.md
+++ b/charts/gardener/controlplane/README.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION]
 > This Helm chart has been marked as "deprecated".
-> It will be removed at after v1.135 of Gardener has been released (around beginning of 2026).
+> It will be removed after v1.135 of Gardener has been released (around beginning of 2026).
 >
 > We urge you to switch to a [`gardener-operator`](../../../docs/concepts/operator.md)-based installation.
 > Read all about it [here](../../../docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -12,7 +12,7 @@ Please always make sure that you use the Helm chart version that matches the Gar
 In order to deploy the control plane components, please first deploy [`gardener-operator`](../concepts/operator.md#deployment) and create a [`Garden` resource](../concepts/operator.md#garden-resources).
 
 > [!CAUTION]
-> Below approach is deprecated and will be removed at after v1.135 of Gardener has been released (around beginning of 2026).
+> Below approach is deprecated and will be removed after v1.135 of Gardener has been released (around beginning of 2026).
 
 The [configuration values](../../charts/gardener/controlplane/values.yaml) depict the various options to configure the different components.
 Please consult [Gardener Configuration and Usage](../operations/configuration.md) for component specific configurations and [Authentication of Gardener Control Plane Components Against the Garden Cluster](./authentication_gardener_control_plane.md) for authentication related specifics.

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -9,6 +9,11 @@ Please always make sure that you use the Helm chart version that matches the Gar
 
 ## Deploying the Gardener Control Plane (API Server, Admission Controller, Controller Manager, Scheduler)
 
+In order to deploy the control plane components, please first deploy [`gardener-operator`](../concepts/operator.md#deployment) and create a [`Garden` resource](../concepts/operator.md#garden-resources).
+
+> [!CAUTION]
+> Below approach is deprecated and will be removed at after v1.135 of Gardener has been released (around beginning of 2026).
+
 The [configuration values](../../charts/gardener/controlplane/values.yaml) depict the various options to configure the different components.
 Please consult [Gardener Configuration and Usage](../operations/configuration.md) for component specific configurations and [Authentication of Gardener Control Plane Components Against the Garden Cluster](./authentication_gardener_control_plane.md) for authentication related specifics.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source dev-productivity
/kind enhancement

**What this PR does / why we need it**:
We should only support one approach to reduce operational (and development) complexity. With `gardener-operator`, we have a better way of managing the Gardener control plane, which follows best practises and learnings for operating Gardener from the past 6-7 years.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `gardener/controlplane` Helm chart has been deprecated and will be removed after `v1.135` has been released (around beginning of 2026). We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation. Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).
```
