### PR TITLE
chore: Introduce Make target `operator-seed-dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,12 +395,14 @@ operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) delete
 
 operator-seed-up: SKAFFOLD_MODE=run
+operator-seed-up: SKAFFOLD_PROFILE=operator
 operator-seed-dev: SKAFFOLD_MODE=dev
+operator-seed-dev: SKAFFOLD_PROFILE=operator,operator-dev
 operator-seed-up operator-seed-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) operator-up
 	$(SKAFFOLD) run -m garden -f=skaffold-operator-garden.yaml
 	$(SKAFFOLD) run -m garden-config -f=skaffold-operator-garden.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
 		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
-	$(SKAFFOLD) $(SKAFFOLD_MODE) -m gardenlet -p operator -f=skaffold.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
+	$(SKAFFOLD) $(SKAFFOLD_MODE) -m gardenlet -p $(SKAFFOLD_PROFILE) -f=skaffold.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
 		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
 
 operator-seed-down: $(SKAFFOLD) $(HELM) $(KUBECTL)

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ test-e2e-local-ha-single-zone test-e2e-local-migration-ha-single-zone ci-e2e-kin
 kind2-ha-single-zone-up kind2-ha-single-zone-down gardenlet-kind2-ha-single-zone-up gardenlet-kind2-ha-single-zone-dev gardenlet-kind2-ha-single-zone-debug gardenlet-kind2-ha-single-zone-down: export KUBECONFIG = $(GARDENER_LOCAL2_HA_SINGLE_ZONE_KUBECONFIG)
 kind-ha-multi-zone-up kind-ha-multi-zone-down gardener-ha-multi-zone-up: export KUBECONFIG = $(GARDENER_LOCAL_HA_MULTI_ZONE_KUBECONFIG)
 test-e2e-local-ha-multi-zone ci-e2e-kind-ha-multi-zone ci-e2e-kind-ha-multi-zone-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_HA_MULTI_ZONE_KUBECONFIG)
-kind-operator-up kind-operator-down operator%up operator-dev operator-debug operator%down test-e2e-local-operator ci-e2e-kind-operator ci-e2e-kind-operator-seed: export KUBECONFIG = $(GARDENER_LOCAL_OPERATOR_KUBECONFIG)
+kind-operator-up kind-operator-down operator%up operator-dev operator-debug operator%down operator-seed-dev test-e2e-local-operator ci-e2e-kind-operator ci-e2e-kind-operator-seed: export KUBECONFIG = $(GARDENER_LOCAL_OPERATOR_KUBECONFIG)
 operator-seed-% test-e2e-local-operator-seed: export VIRTUAL_GARDEN_KUBECONFIG = $(REPO_ROOT)/example/operator/virtual-garden/kubeconfig
 test-e2e-local-operator-seed: export KUBECONFIG = $(VIRTUAL_GARDEN_KUBECONFIG)
 # CLUSTER_NAME
@@ -323,19 +323,19 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
-gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
-gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export SKAFFOLD_PUSH = true
-gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export SOURCE_DATE_EPOCH = $(shell date -d $(BUILD_DATE) +%s)
-gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export GARDENER_VERSION = $(VERSION)
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug operator-seed-dev: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug operator-seed-dev: export SKAFFOLD_PUSH = true
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug operator-seed-dev: export SOURCE_DATE_EPOCH = $(shell date -d $(BUILD_DATE) +%s)
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug operator-seed-dev: export GARDENER_VERSION = $(VERSION)
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 gardener%up gardener%dev gardener%debug gardener%down gardenlet%up gardenlet%dev gardenlet%debug gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
 # set ldflags for skaffold
-gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION Gardener $(BUILD_DATE))
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug operator-seed-dev: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION Gardener $(BUILD_DATE))
 # skaffold dev and debug clean up deployed modules by default, disable this
-gardener%dev gardener%debug gardenlet%dev gardenlet%debug operator-dev operator-debug: export SKAFFOLD_CLEANUP = false
+gardener%dev gardener%debug gardenlet%dev gardenlet%debug operator-dev operator-debug operator-seed-dev: export SKAFFOLD_CLEANUP = false
 # skaffold dev triggers new builds and deployments immediately on file changes by default,
 # this is too heavy in a large project like gardener, so trigger new builds and deployments manually instead.
-gardener%dev gardenlet%dev operator-dev: export SKAFFOLD_TRIGGER = manual
+gardener%dev gardenlet%dev operator-dev operator-seed-dev: export SKAFFOLD_TRIGGER = manual
 # Artifacts might be already built when you decide to start debugging.
 # However, these artifacts do not include the gcflags which `skaffold debug` sets automatically, so delve would not work.
 # Disabling the skaffold cache for debugging ensures that you run artifacts with gcflags required for debugging.
@@ -394,11 +394,13 @@ operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) delete garden --all --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete
 
-operator-seed-up: $(SKAFFOLD) $(HELM) $(KUBECTL) operator-up
+operator-seed-up: SKAFFOLD_MODE=run
+operator-seed-dev: SKAFFOLD_MODE=dev
+operator-seed-up operator-seed-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) operator-up
 	$(SKAFFOLD) run -m garden -f=skaffold-operator-garden.yaml
 	$(SKAFFOLD) run -m garden-config -f=skaffold-operator-garden.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
 		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
-	$(SKAFFOLD) run -m gardenlet -p operator -f=skaffold.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
+	$(SKAFFOLD) $(SKAFFOLD_MODE) -m gardenlet -p operator -f=skaffold.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
 		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
 
 operator-seed-down: $(SKAFFOLD) $(HELM) $(KUBECTL)

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -401,13 +401,25 @@ The one for the virtual garden is accessible at `./example/operator/virtual-gard
 > ```
 > When the shoot cluster is HA (i.e., `.spec.controlPlane.highAvailability.failureTolerance == zone`), then you can access it via `172.18.255.1`.
 
-Please use this command to tear down your environment:
+Similar as in the section _[Devleoping Gardener](#developing-gardener)_ it's possible to run a [Skaffold development loop](https://skaffold.dev/docs/workflows/dev/) as well using:
+```shell
+make operator-seed-dev
+```
+
+> :info: Please note that in this setup Skaffold is only watching for changes in the following components:
+> - [`gardenlet`](../concepts/gardenlet.md)
+> - `gardenlet/chart`
+> - [`gardener-resource-manager`](../concepts/resource-manager.md)
+> - [`gardener-node-agent`](../concepts/node-agent.md)
+
+Finally, please use this command to tear down your environment:
 
 ```shell
 make kind-operator-down
 ```
 
-This setup supports creating shoots and managed seeds the same way as explained in the previous chapters. However, the development and debugging setups are not working yet.
+This setup supports creating shoots and managed seeds the same way as explained in the previous chapters.
+However, the development loop has limitations and the debugging setup is not working yet.
 
 ## Remote Local Setup
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -401,7 +401,7 @@ The one for the virtual garden is accessible at `./example/operator/virtual-gard
 > ```
 > When the shoot cluster is HA (i.e., `.spec.controlPlane.highAvailability.failureTolerance == zone`), then you can access it via `172.18.255.1`.
 
-Similar as in the section _[Devleoping Gardener](#developing-gardener)_ it's possible to run a [Skaffold development loop](https://skaffold.dev/docs/workflows/dev/) as well using:
+Similar as in the section _[Developing Gardener](#developing-gardener)_ it's possible to run a [Skaffold development loop](https://skaffold.dev/docs/workflows/dev/) as well using:
 ```shell
 make operator-seed-dev
 ```

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -406,7 +406,7 @@ Similar as in the section _[Developing Gardener](#developing-gardener)_ it's pos
 make operator-seed-dev
 ```
 
-> :info: Please note that in this setup Skaffold is only watching for changes in the following components:
+> :information_source: Please note that in this setup Skaffold is only watching for changes in the following components:
 > - [`gardenlet`](../concepts/gardenlet.md)
 > - `gardenlet/chart`
 > - [`gardener-resource-manager`](../concepts/resource-manager.md)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -929,14 +929,14 @@ build:
     - garden.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
-      template: "{{.version}}-{{.timestamp}}"
+      template: "{{.version}}-{{.sha}}"
       components:
         - name: version
           envTemplate:
             template: "{{.GARDENER_VERSION}}"
-        - name: timestamp
-          dateTime:
-            format: "20060102150405"
+        - name: sha
+          gitCommit:
+            variant: AbbrevCommitSha
   artifacts:
     - image: local-skaffold/gardenlet
       ko:
@@ -1661,3 +1661,14 @@ profiles:
                   - bash
                   - -ec
                   - KUBECONFIG=$VIRTUAL_GARDEN_KUBECONFIG hack/usage/wait-for.sh seed local GardenletReady SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+  - name: operator-dev
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{.version}}-{{.timestamp}}"
+      - op: replace
+        path: /build/tagPolicy/customTemplate/components/1
+        value:
+          name: timestamp
+          dateTime:
+            format: "20060102150405"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -929,7 +929,7 @@ build:
     - garden.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
-      template: "{{.version}}-{{.sha}}"
+      template: "{{.version}}-{{.sha}}-{{.timestamp}}"
       components:
         - name: version
           envTemplate:
@@ -937,6 +937,9 @@ build:
         - name: sha
           gitCommit:
             variant: AbbrevCommitSha
+        - name: timestamp
+          dateTime:
+            format: "20060102150405"
   artifacts:
     - image: local-skaffold/gardenlet
       ko:
@@ -1661,3 +1664,8 @@ profiles:
                   - bash
                   - -ec
                   - KUBECONFIG=$VIRTUAL_GARDEN_KUBECONFIG hack/usage/wait-for.sh seed local GardenletReady SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+  - name: operator-debug
+    patches:
+      - op: add
+        path: /manifests/kustomize/paths/-
+        value: example/gardener-local/gardenlet/debug

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1664,8 +1664,3 @@ profiles:
                   - bash
                   - -ec
                   - KUBECONFIG=$VIRTUAL_GARDEN_KUBECONFIG hack/usage/wait-for.sh seed local GardenletReady SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
-  - name: operator-debug
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths/-
-        value: example/gardener-local/gardenlet/debug

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -929,14 +929,11 @@ build:
     - garden.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
-      template: "{{.version}}-{{.sha}}-{{.timestamp}}"
+      template: "{{.version}}-{{.timestamp}}"
       components:
         - name: version
           envTemplate:
             template: "{{.GARDENER_VERSION}}"
-        - name: sha
-          gitCommit:
-            variant: AbbrevCommitSha
         - name: timestamp
           dateTime:
             format: "20060102150405"


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind enhancement

**What this PR does / why we need it**:

This PR introduces a new Make target: `make operator-seed-dev`
Today, the [getting-started documentation for local development/deployment](https://gardener.cloud/docs/gardener/deployment/getting_started_locally/#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator) that uses the `gardener-operator` focuses on commands that setup/teardown the environment. While it's possible to launch the dev-loop for the `gardener-operator` using `make operator-dev` this does not exist yet for other Gardener components such as the `gardenlet`.

The new Make target `make operator-seed-dev` is based on `make operator-seed-up` with the difference that:
- It uses `skaffold dev` instead of `skaffold run`
- The Skaffold tag policy for the `gardenlet` has been changed to use a `timestamp` instead of the abbreviated Git commit hash (if the `operator-dev` Skaffold profile is used).

**Which issue(s) this PR fixes**:
_n.a._

**Special notes for your reviewer**:
Thanks to @LucaBernstein for the `Makefile` and Skaffold support 🧙‍♂️ 

**Release note**:
```other developer
Add Make target `make operator-seed-dev` for local development of the `gardenlet` in the operator setup.
```
