### PR TITLE
Allow viewers `pods/log` access

### DIFF
--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -443,8 +443,7 @@ func (s *shootSystem) shootInfoData() map[string]string {
 func (s *shootSystem) readOnlyRBACResources() []client.Object {
 	allowedSubResources := map[string]map[string][]string{
 		corev1.GroupName: {
-			"pods":  {"log"},
-			"nodes": {"proxy"},
+			"pods": {"log"},
 		},
 	}
 

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -554,6 +554,8 @@ var _ = Describe("ShootSystem", func() {
 								{Name: "secrets", Verbs: metav1.Verbs{"get", "list", "watch"}},
 								{Name: "configmaps", Verbs: metav1.Verbs{"get", "list", "watch"}},
 								{Name: "services", Verbs: metav1.Verbs{"get", "list", "watch"}},
+								{Name: "pods", Verbs: metav1.Verbs{"get", "list", "watch"}},
+								{Name: "nodes", Verbs: metav1.Verbs{"get", "list", "watch"}},
 							},
 						},
 						{
@@ -596,7 +598,7 @@ var _ = Describe("ShootSystem", func() {
 						Rules: []rbacv1.PolicyRule{
 							{
 								APIGroups: []string{""},
-								Resources: []string{"configmaps"},
+								Resources: []string{"configmaps", "nodes", "nodes/proxy", "pods", "pods/log"},
 								Verbs:     []string{"get", "list", "watch"},
 							},
 							{

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -598,7 +598,7 @@ var _ = Describe("ShootSystem", func() {
 						Rules: []rbacv1.PolicyRule{
 							{
 								APIGroups: []string{""},
-								Resources: []string{"configmaps", "nodes", "nodes/proxy", "pods", "pods/log"},
+								Resources: []string{"configmaps", "nodes", "pods", "pods/log"},
 								Verbs:     []string{"get", "list", "watch"},
 							},
 							{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Allow viewers `pods/log` ~~and `nodes/proxy`~~ access.

**Which issue(s) this PR fixes**:
related to https://github.com/gardener/gardener/issues/10618

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The viewer kubeconfigs for shoot clusters now allow the `pods/log` subresource.
```
