### PR TITLE
Ignore completed `Pod`s in health check

### DIFF
--- a/pkg/utils/kubernetes/health/deployment.go
+++ b/pkg/utils/kubernetes/health/deployment.go
@@ -146,7 +146,7 @@ func DeploymentHasExactNumberOfPods(ctx context.Context, reader client.Reader, d
 
 	var numberOfRelevantPods int32
 	for _, pod := range podList.Items {
-		if !IsPodStale(pod.Status.Reason) {
+		if !IsPodStale(pod.Status.Reason) && !IsPodCompleted(pod.Status.Conditions) {
 			numberOfRelevantPods++
 		}
 	}

--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -326,5 +326,18 @@ var _ = Describe("Deployment", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeTrue())
 		})
+
+		It("should consider the deployment as updated even though there are still completed pods", func() {
+			p1 := pod.DeepCopy()
+			p1.Status.Conditions = []corev1.PodCondition{{Type: "Ready", Status: "PodCompleted"}}
+			Expect(fakeClient.Create(ctx, p1)).To(Succeed())
+
+			p2 := pod.DeepCopy()
+			Expect(fakeClient.Create(ctx, p2)).To(Succeed())
+
+			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
 	})
 })

--- a/pkg/utils/kubernetes/health/pod.go
+++ b/pkg/utils/kubernetes/health/pod.go
@@ -67,3 +67,13 @@ func IsPodStale(reason string) bool {
 		strings.Contains(reason, "NodeAffinity") ||
 		strings.Contains(reason, "NodeLost")
 }
+
+// IsPodCompleted returns true when the pod ready condition indicates completeness.
+func IsPodCompleted(conditions []corev1.PodCondition) bool {
+	for _, condition := range conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == "PodCompleted"
+		}
+	}
+	return false
+}

--- a/pkg/utils/kubernetes/health/pod.go
+++ b/pkg/utils/kubernetes/health/pod.go
@@ -8,6 +8,7 @@ package health
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -70,10 +71,7 @@ func IsPodStale(reason string) bool {
 
 // IsPodCompleted returns true when the pod ready condition indicates completeness.
 func IsPodCompleted(conditions []corev1.PodCondition) bool {
-	for _, condition := range conditions {
-		if condition.Type == corev1.PodReady {
-			return condition.Status == "PodCompleted"
-		}
-	}
-	return false
+	return slices.ContainsFunc(conditions, func(condition corev1.PodCondition) bool {
+		return condition.Type == corev1.PodReady && condition.Status == "PodCompleted"
+	})
 }

--- a/pkg/utils/kubernetes/health/pod_test.go
+++ b/pkg/utils/kubernetes/health/pod_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Pod", func() {
 		Entry("Foo", "Foo", BeFalse()),
 	)
 
-	DescribeTable("#IsPodCompleeted",
+	DescribeTable("#IsPodCompleted",
 		func(conditions []corev1.PodCondition, matcher types.GomegaMatcher) {
 			Expect(health.IsPodCompleted(conditions)).To(matcher)
 		},

--- a/pkg/utils/kubernetes/health/pod_test.go
+++ b/pkg/utils/kubernetes/health/pod_test.go
@@ -50,4 +50,15 @@ var _ = Describe("Pod", func() {
 		Entry("NodeLost", "NodeLost", BeTrue()),
 		Entry("Foo", "Foo", BeFalse()),
 	)
+
+	DescribeTable("#IsPodCompleeted",
+		func(conditions []corev1.PodCondition, matcher types.GomegaMatcher) {
+			Expect(health.IsPodCompleted(conditions)).To(matcher)
+		},
+
+		Entry("No conditions", nil, BeFalse()),
+		Entry("No ready condition", []corev1.PodCondition{{}}, BeFalse()),
+		Entry("Not completed", []corev1.PodCondition{{Type: "Ready"}}, BeFalse()),
+		Entry("Completed", []corev1.PodCondition{{Type: "Ready", Status: "PodCompleted"}}, BeTrue()),
+	)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
A deployment should be considered healthy even if it has completed pods of the previous replicaset. 

There were earlier occurrences where changed node attributes (e.g. `maxPods`) led to an immediate eviction and old `Pod`s remained as completed.

**Special notes for your reviewer**:
We should not reuse the [IsPodStale](https://github.com/gardener/gardener/blob/26e6e7b49713f7a39f85349405d9837fddf2b029/pkg/utils/kubernetes/health/pod.go#L64) function as this would lead to their deletion through the Care controller. This is often unwanted, esp. if completed pods belong to `Job`s.

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `gardener-resource-manager` does not mark `Deployment`s as progressing when there are still completed `Pod`s in the system.
```
