### PR TITLE
docs: Document debugging in GoLand and VS Code

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -115,7 +115,7 @@ make gardener-debug
 ```
 
 This is using skaffold debugging features. In the Gardener case, Go debugging using [Delve](https://github.com/go-delve/delve) is the most relevant use case.
-Please see the [skaffold debugging documentation](https://skaffold.dev/docs/workflows/debug/) how to setup your IDE accordingly.
+Please see the [skaffold debugging documentation](https://skaffold.dev/docs/workflows/debug/) how to set up your IDE accordingly or check the examples below ([GoLand](#debugging-in-goland), [VS Code](#debugging-in-vs-code)).
 
 `SKAFFOLD_MODULE` environment variable is working the same way as described for [Developing Gardener](#developing-gardener). However, skaffold is not watching for changes when debugging,
 because it would like to avoid interrupting your debugging session.
@@ -141,6 +141,31 @@ This means that when a goroutine of gardenlet (or any other gardener-core compon
 Thus, leader election, health and readiness checks for `gardener-admission-controller`, `gardener-apiserver`, `gardener-controller-manager`, `gardener-scheduler`,`gardenlet` and `operator` are disabled when debugging.
 
 If you have similar problems with other components which are not deployed by skaffold, you could temporarily turn off the leader election and disable liveness and readiness probes there too.
+
+### Debugging in GoLand
+
+1. Edit your **Run/Debug Configurations**.
+2. Add a new **Go Remote** configuration.
+3. Set the port to `56268` (or any increment of it when debugging multiple components).
+4. _Recommended:_ Change the behavior of **On disconnect** to **Leave it running**.
+
+### Debugging in VS Code
+
+1. Create or edit your `.vscode/launch.json` configuration.
+2. Add the following configuration:
+
+```json5
+{
+  "name": "go remote",
+  "type": "go",
+  "request": "attach",
+  "mode": "remote",
+  "port": 56268, // or any increment of it when debugging multiple components
+  "host": "127.0.0.1"
+}
+```
+
+Since the [ko](https://skaffold.dev/docs/builders/builder-types/ko/) builder is used in Skaffold to build the images it's not necessary to specify the `cwd` and `remotePath` options as they match the workspace folder ([ref](https://skaffold.dev/docs/workflows/debug/#skaffold-debug-using-the-vs-code-go-extension)).
 
 ## Creating a `Shoot` Cluster
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -165,7 +165,7 @@ If you have similar problems with other components which are not deployed by ska
 }
 ```
 
-Since the [ko](https://skaffold.dev/docs/builders/builder-types/ko/) builder is used in Skaffold to build the images it's not necessary to specify the `cwd` and `remotePath` options as they match the workspace folder ([ref](https://skaffold.dev/docs/workflows/debug/#skaffold-debug-using-the-vs-code-go-extension)).
+Since the [ko](https://skaffold.dev/docs/builders/builder-types/ko/) builder is used in Skaffold to build the images, it's not necessary to specify the `cwd` and `remotePath` options as they match the workspace folder ([ref](https://skaffold.dev/docs/workflows/debug/#skaffold-debug-using-the-vs-code-go-extension)).
 
 ## Creating a `Shoot` Cluster
 


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/area documentation
/kind enhancement

**What this PR does / why we need it**:

The [Getting Started Locally](https://gardener.cloud/docs/gardener/deployment/getting_started_locally/#debugging-gardener) documentation has a section that describes how to debug Gardener locally.
Regarding IDE setup it links out to [Skaffold's debugging documentation](https://skaffold.dev/docs/workflows/debug/).

Skaffold recommends that the easiest way to debug is to install the [Cloud Code](https://cloud.google.com/code?hl=en) IDE extension/plugin, which I see as a push to use GCP and increase usage of Gemini. However, it also did not work for me when trying to debug in GoLand.

Using the inbuilt Go remote debugging capabilities of GoLand or VS Code is far easier. This PR provides minimal guides for setting up debugging in GoLand and VS Code. This could save new Gardener developers some time in the future.

👉 [Preview](https://github.com/marc1404/gardener/blob/5262c560fa28f8d72272533ab1174191c6805726/docs/deployment/getting_started_locally.md#debugging-gardener) of the debugging section.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @LucaBernstein 

**Release note**:

```other operator
NONE
```
