### PR TITLE
Deflake `operator/gardenlet` integration test

### DIFF
--- a/test/integration/operator/gardenlet/gardenlet_test.go
+++ b/test/integration/operator/gardenlet/gardenlet_test.go
@@ -185,6 +185,10 @@ var _ = Describe("Gardenlet controller test", func() {
 
 			verifyGardenletDeployment(true)
 
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(seed), seed)
+			}).Should(Succeed())
+
 			By("Update some value")
 			patch := client.MergeFrom(gardenlet.DeepCopy())
 			gardenlet.Spec.Deployment.RevisionHistoryLimit = ptr.To[int32](1337)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:

This PR aims to fix the flaky test, which can be observed in:

- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10645/pull-gardener-integration/1849412821922615296
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10706/pull-gardener-integration/1849406964413501440

The flaking test seems to be: [`should deploy gardenlet and no longer touch it when Seed object got created`](https://github.com/gardener/gardener/blob/master/test/integration/operator/gardenlet/gardenlet_test.go#L180-L199).

The cause appears to be a caching issue of the controller manager client in the test, which fails to recognize that the seed object is present.

In the test, the `testClient` [creates](https://github.com/gardener/gardener/blob/master/test/integration/operator/gardenlet/gardenlet_test.go#L184) the seed object for the corresponding gardenlet.

In the test scenario, the operator uses the `mgrClient` to [check whether a corresponding seed exists or not](https://github.com/gardener/gardener/blob/master/pkg/operator/controller/gardenlet/add.go#L96).

Under load, it could happen that the `mgrClient` has an invalid cache, therefore reconciling, which leads to the gardenlet deployment to be modified.

This change waits until the `mgrClient` is aware of the seed (or timing out) before updating the gardenlet. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
