### PR TITLE
kind: Bump `kindest/node` image to v1.31.1

### DIFF
--- a/example/gardener-local/kind/cluster/templates/_kubeadm_config_patches.tpl
+++ b/example/gardener-local/kind/cluster/templates/_kubeadm_config_patches.tpl
@@ -1,12 +1,16 @@
 {{- define "kubeadmConfigPatches" -}}
 - |
+  # TODO(ialidzhikov): Use the kubeadm.k8s.io/v1beta4 API when kind supports it (ref https://github.com/kubernetes-sigs/kind/pull/3675).
+  # Currently kind accepts kubeadm.k8s.io/v1beta3 but the resulting kube-system/kubeadm-config ConfigMap uses kubeadm.k8s.io/v1beta4.
+  # The ConfigMap is patched in the kind-up.sh script.
+  apiVersion: kubeadm.k8s.io/v1beta3
   kind: ClusterConfiguration
   apiServer:
 {{- if .Values.gardener.apiserverRelay.deployed }}
     certSANs:
-      - localhost
-      - 127.0.0.1
-      - gardener-apiserver.relay.svc.cluster.local
+    - localhost
+    - 127.0.0.1
+    - gardener-apiserver.relay.svc.cluster.local
 {{- end }}
     extraArgs:
 {{- if or (not .Values.gardener.controlPlane.deployed) (not .Values.gardener.controlPlane.kindIsGardenCluster) }}

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -1,4 +1,4 @@
-image: kindest/node:v1.30.4
+image: kindest/node:v1.31.1
 
 gardener:
   apiserverRelay:

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -364,7 +364,7 @@ for node in $nodes; do
   docker exec "$node" sh -c "sysctl fs.inotify.max_user_instances=8192"
 done
 
-authorization_webhook_config_file=$(kubectl -n kube-system get configmap kubeadm-config -o yaml | yq e '.data.ClusterConfiguration' | yq e '.apiServer.extraVolumes[0].hostPath')
+authorization_webhook_config_file=$(kubectl -n kube-system get configmap kubeadm-config -o yaml | yq '.data.ClusterConfiguration' | yq '.apiServer.extraVolumes[0].hostPath')
 if [[ -n "$authorization_webhook_config_file" && "$authorization_webhook_config_file" != "null" ]]; then
   kubectl -n kube-system get configmap kubeadm-config -o yaml | \
     sed -e "s#value: RBAC,Node#value: RBAC,Node,Webhook\n      - name: authorization-webhook-config-file\n        value: $authorization_webhook_config_file#" | \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates the `kindest/node` image for the kind/garden cluster used in the various local setups.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10286

**Special notes for your reviewer**:
I had to adapt the logic that patches the `kube-system/kubeadm-config` ConfigMap introduced with https://github.com/gardener/gardener/pull/9155 as with the new `kindest/node` image the config inside now uses the `kubeadm.k8s.io/v1beta4` API. In `kubeadm.k8s.io/v1beta4` the way of passing `extraArgs` to components is changed.

`extraArgs` structure in `kubeadm.k8s.io/v1beta3`:
```yaml
apiVersion: kubeadm.k8s.io/v1beta3
kind: ClusterConfiguration
apisServer:
  extraArgs:
    authorization-mode: RBAC,Node,Webhook
    authorization-webhook-cache-authorized-ttl: "0"
    authorization-webhook-cache-unauthorized-ttl: "0"
    runtime-config: ""
```

`extraArgs` structure in `kubeadm.k8s.io/v1beta4`:
```yaml
apiVersion: kubeadm.k8s.io/v1beta3
kind: ClusterConfiguration
apisServer:
  extraArgs:
    - name: authorization-mode
      value: RBAC,Node,Webook
    - name: authorization-webhook-cache-authorized-ttl
      value: "0"
    - name: authorization-webhook-cache-unauthorized-ttl
      value: "0"
    - name: runtime-config
      value: ""
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
local setup: The kind cluster's node image is now updated to `kindest/node@v1.31.1`.
```
