### PR TITLE
Add dual-stack support for coredns

### DIFF
--- a/pkg/component/networking/coredns/mock/mocks.go
+++ b/pkg/component/networking/coredns/mock/mocks.go
@@ -14,6 +14,7 @@ import (
 	net "net"
 	reflect "reflect"
 
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -79,6 +80,18 @@ func (m *MockInterface) SetClusterIPs(arg0 []net.IP) {
 func (mr *MockInterfaceMockRecorder) SetClusterIPs(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterIPs", reflect.TypeOf((*MockInterface)(nil).SetClusterIPs), arg0)
+}
+
+// SetIPFamilies mocks base method.
+func (m *MockInterface) SetIPFamilies(arg0 []v1beta1.IPFamily) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetIPFamilies", arg0)
+}
+
+// SetIPFamilies indicates an expected call of SetIPFamilies.
+func (mr *MockInterfaceMockRecorder) SetIPFamilies(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIPFamilies", reflect.TypeOf((*MockInterface)(nil).SetIPFamilies), arg0)
 }
 
 // SetNodeNetworkCIDRs mocks base method.

--- a/pkg/gardenlet/operation/botanist/coredns.go
+++ b/pkg/gardenlet/operation/botanist/coredns.go
@@ -67,6 +67,7 @@ func (b *Botanist) DeployCoreDNS(ctx context.Context) error {
 	b.Shoot.Components.SystemComponents.CoreDNS.SetPodNetworkCIDRs(b.Shoot.Networks.Pods)
 	b.Shoot.Components.SystemComponents.CoreDNS.SetClusterIPs(b.Shoot.Networks.CoreDNS)
 	b.Shoot.Components.SystemComponents.CoreDNS.SetPodAnnotations(restartedAtAnnotations)
+	b.Shoot.Components.SystemComponents.CoreDNS.SetIPFamilies(b.Shoot.GetInfo().Spec.Networking.IPFamilies)
 
 	return b.Shoot.Components.SystemComponents.CoreDNS.Deploy(ctx)
 }

--- a/pkg/gardenlet/operation/botanist/coredns_test.go
+++ b/pkg/gardenlet/operation/botanist/coredns_test.go
@@ -121,6 +121,13 @@ var _ = Describe("CoreDNS", func() {
 					CoreDNS: coreDNS,
 				},
 			}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+					},
+				},
+			})
 			botanist.Shoot.Networks = &shootpkg.Networks{
 				CoreDNS: []net.IP{net.ParseIP("18.19.20.21"), net.ParseIP("2001:db8::1")},
 				Pods:    []net.IPNet{{IP: net.ParseIP("22.23.24.25")}, {IP: net.ParseIP("2001:db8::2")}},
@@ -136,6 +143,7 @@ var _ = Describe("CoreDNS", func() {
 			kubernetesClient.EXPECT().Client().Return(c)
 
 			coreDNS.EXPECT().SetPodAnnotations(nil)
+			coreDNS.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4})
 			coreDNS.EXPECT().Deploy(ctx).Return(fakeErr)
 
 			Expect(botanist.DeployCoreDNS(ctx)).To(MatchError(fakeErr))
@@ -145,6 +153,7 @@ var _ = Describe("CoreDNS", func() {
 			kubernetesClient.EXPECT().Client().Return(c)
 
 			coreDNS.EXPECT().SetPodAnnotations(nil)
+			coreDNS.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4})
 			coreDNS.EXPECT().Deploy(ctx)
 
 			Expect(botanist.DeployCoreDNS(ctx)).To(Succeed())
@@ -161,6 +170,7 @@ var _ = Describe("CoreDNS", func() {
 			botanist.Shoot.SetInfo(shoot)
 
 			coreDNS.EXPECT().SetPodAnnotations(map[string]string{"gardener.cloud/restarted-at": nowFunc().Format(time.RFC3339)})
+			coreDNS.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4})
 			coreDNS.EXPECT().Deploy(ctx)
 
 			Expect(botanist.DeployCoreDNS(ctx)).To(Succeed())
@@ -185,6 +195,25 @@ var _ = Describe("CoreDNS", func() {
 			})).To(Succeed())
 
 			coreDNS.EXPECT().SetPodAnnotations(annotations)
+			coreDNS.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4})
+			coreDNS.EXPECT().Deploy(ctx)
+
+			Expect(botanist.DeployCoreDNS(ctx)).To(Succeed())
+		})
+
+		It("should successfully deploy with dual-stack enabled", func() {
+
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4, gardencorev1beta1.IPFamilyIPv6},
+					},
+				},
+			})
+			kubernetesClient.EXPECT().Client().Return(c)
+
+			coreDNS.EXPECT().SetPodAnnotations(nil)
+			coreDNS.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4, gardencorev1beta1.IPFamilyIPv6})
 			coreDNS.EXPECT().Deploy(ctx)
 
 			Expect(botanist.DeployCoreDNS(ctx)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Add dual-stack support for coredns. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add dual-stack support for coredns.
```
