### PR TITLE
Enhance validation for operation annotations for Credential rotation

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2472,22 +2472,22 @@ func validateShootOperation(operation, maintenanceOperation string, shoot *core.
 	switch maintenanceOperation {
 	case v1beta1constants.OperationRotateCredentialsStart:
 		if sets.New(v1beta1constants.OperationRotateCAStart, v1beta1constants.OperationRotateServiceAccountKeyStart, v1beta1constants.OperationRotateETCDEncryptionKeyStart).Has(operation) {
-			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted when maintenance operation is 'rotate-credentials-start'", operation)))
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted when maintenance operation is '%s'", operation, maintenanceOperation)))
 		}
 	case v1beta1constants.OperationRotateCredentialsComplete:
 		if sets.New(v1beta1constants.OperationRotateCAComplete, v1beta1constants.OperationRotateServiceAccountKeyComplete, v1beta1constants.OperationRotateETCDEncryptionKeyComplete).Has(operation) {
-			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted when maintenance operation is 'rotate-credentials-complete'", operation)))
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted when maintenance operation is '%s'", operation, maintenanceOperation)))
 		}
 	}
 
 	switch operation {
 	case v1beta1constants.OperationRotateCredentialsStart:
 		if sets.New(v1beta1constants.OperationRotateCAStart, v1beta1constants.OperationRotateServiceAccountKeyStart, v1beta1constants.OperationRotateETCDEncryptionKeyStart).Has(maintenanceOperation) {
-			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation 'rotate-credentials-start' is not permitted when maintenance operation is '%s'", maintenanceOperation)))
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted when maintenance operation is '%s'", operation, maintenanceOperation)))
 		}
 	case v1beta1constants.OperationRotateCredentialsComplete:
 		if sets.New(v1beta1constants.OperationRotateCAComplete, v1beta1constants.OperationRotateServiceAccountKeyComplete, v1beta1constants.OperationRotateETCDEncryptionKeyComplete).Has(maintenanceOperation) {
-			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation 'rotate-credentials-complete' is not permitted when maintenance operation is '%s'", maintenanceOperation)))
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted when maintenance operation is '%s'", operation, maintenanceOperation)))
 		}
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2469,6 +2469,28 @@ func validateShootOperation(operation, maintenanceOperation string, shoot *core.
 		}
 	}
 
+	switch maintenanceOperation {
+	case v1beta1constants.OperationRotateCredentialsStart:
+		if sets.New(v1beta1constants.OperationRotateCAStart, v1beta1constants.OperationRotateServiceAccountKeyStart, v1beta1constants.OperationRotateETCDEncryptionKeyStart).Has(operation) {
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted when maintenance operation is 'rotate-credentials-start'", operation)))
+		}
+	case v1beta1constants.OperationRotateCredentialsComplete:
+		if sets.New(v1beta1constants.OperationRotateCAComplete, v1beta1constants.OperationRotateServiceAccountKeyComplete, v1beta1constants.OperationRotateETCDEncryptionKeyComplete).Has(operation) {
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted when maintenance operation is 'rotate-credentials-complete'", operation)))
+		}
+	}
+
+	switch operation {
+	case v1beta1constants.OperationRotateCredentialsStart:
+		if sets.New(v1beta1constants.OperationRotateCAStart, v1beta1constants.OperationRotateServiceAccountKeyStart, v1beta1constants.OperationRotateETCDEncryptionKeyStart).Has(maintenanceOperation) {
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation 'rotate-credentials-start' is not permitted when maintenance operation is '%s'", maintenanceOperation)))
+		}
+	case v1beta1constants.OperationRotateCredentialsComplete:
+		if sets.New(v1beta1constants.OperationRotateCAComplete, v1beta1constants.OperationRotateServiceAccountKeyComplete, v1beta1constants.OperationRotateETCDEncryptionKeyComplete).Has(maintenanceOperation) {
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation 'rotate-credentials-complete' is not permitted when maintenance operation is '%s'", maintenanceOperation)))
+		}
+	}
+
 	allErrs = append(allErrs, validateShootOperationContext(operation, shoot, fldPathOp)...)
 	if shoot.DeletionTimestamp == nil {
 		// Only validate maintenance operation context when shoot has no deletion timestamp. If it has such a timestamp,

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -4902,6 +4902,104 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(ValidateShoot(shoot)).To(BeEmpty())
 			})
 
+			DescribeTable("It should forbid setting certain operation annotations when shoot has a maintenance annotation",
+				func(maintenanceOpAnnotation, operationAnnotation string, errMatcher gomegatypes.GomegaMatcher) {
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", maintenanceOpAnnotation)
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", operationAnnotation)
+
+					shoot.Status = core.ShootStatus{
+						LastOperation: &core.LastOperation{
+							Type:  core.LastOperationTypeCreate,
+							State: core.LastOperationStateSucceeded,
+						},
+					}
+
+					if sets.New(v1beta1constants.OperationRotateCredentialsComplete, v1beta1constants.OperationRotateCAComplete, v1beta1constants.OperationRotateServiceAccountKeyComplete, v1beta1constants.OperationRotateETCDEncryptionKeyComplete).Has(maintenanceOpAnnotation) {
+						shoot.Status.Credentials = &core.ShootCredentials{
+							Rotation: &core.ShootCredentialsRotation{
+								CertificateAuthorities: &core.CARotation{
+									Phase: core.RotationPrepared,
+								},
+								ServiceAccountKey: &core.ServiceAccountKeyRotation{
+									Phase: core.RotationPrepared,
+								},
+								ETCDEncryptionKey: &core.ETCDEncryptionKeyRotation{
+									Phase: core.RotationPrepared,
+								},
+							},
+						}
+					}
+
+					Expect(ValidateShoot(shoot)).To(errMatcher)
+
+					delete(shoot.Annotations, "maintenance.gardener.cloud/operation")
+					delete(shoot.Annotations, "gardener.cloud/operation")
+				},
+				Entry("rotate-ca-start", "rotate-credentials-start", "rotate-ca-start", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-ca-start' is not permitted when maintenance operation is 'rotate-credentials-start'"),
+				})))),
+				Entry("rotate-serviceaccount-key-start", "rotate-credentials-start", "rotate-serviceaccount-key-start", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-serviceaccount-key-start' is not permitted when maintenance operation is 'rotate-credentials-start'"),
+				})))),
+				Entry("rotate-etcd-encryption-key-start", "rotate-credentials-start", "rotate-etcd-encryption-key-start", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-etcd-encryption-key-start' is not permitted when maintenance operation is 'rotate-credentials-start'"),
+				})))),
+
+				Entry("rotate-ca-complete", "rotate-credentials-complete", "rotate-ca-complete", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-ca-complete' is not permitted when maintenance operation is 'rotate-credentials-complete'"),
+				})))),
+				Entry("rotate-serviceaccount-key-complete", "rotate-credentials-complete", "rotate-serviceaccount-key-complete", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-serviceaccount-key-complete' is not permitted when maintenance operation is 'rotate-credentials-complete'"),
+				})))),
+				Entry("rotate-etcd-encryption-key-complete", "rotate-credentials-complete", "rotate-etcd-encryption-key-complete", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-etcd-encryption-key-complete' is not permitted when maintenance operation is 'rotate-credentials-complete'"),
+				})))),
+
+				Entry("rotate-credentials-start", "rotate-ca-start", "rotate-credentials-start", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-credentials-start' is not permitted when maintenance operation is 'rotate-ca-start'"),
+				})))),
+				Entry("rotate-credentials-start", "rotate-serviceaccount-key-start", "rotate-credentials-start", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-credentials-start' is not permitted when maintenance operation is 'rotate-serviceaccount-key-start'"),
+				})))),
+				Entry("rotate-credentials-start", "rotate-etcd-encryption-key-start", "rotate-credentials-start", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-credentials-start' is not permitted when maintenance operation is 'rotate-etcd-encryption-key-start'"),
+				})))),
+
+				Entry("rotate-credentials-complete", "rotate-ca-complete", "rotate-credentials-complete", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-credentials-complete' is not permitted when maintenance operation is 'rotate-ca-complete'"),
+				})))),
+				Entry("rotate-credentials-complete", "rotate-serviceaccount-key-complete", "rotate-credentials-complete", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-credentials-complete' is not permitted when maintenance operation is 'rotate-serviceaccount-key-complete'"),
+				})))),
+				Entry("rotate-credentials-complete", "rotate-etcd-encryption-key-complete", "rotate-credentials-complete", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring("operation 'rotate-credentials-complete' is not permitted when maintenance operation is 'rotate-etcd-encryption-key-complete'"),
+				})))),
+			)
+
 			DescribeTable("forbid certain rotation operations when shoot is hibernated",
 				func(operation string) {
 					shoot.Spec.Hibernation = &core.Hibernation{Enabled: ptr.To(true)}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -612,77 +612,79 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})))),
 		)
 
-		DescribeTable("addons validation",
-			func(purpose core.ShootPurpose, allowed bool) {
-				shootCopy := shoot.DeepCopy()
-				shootCopy.Spec.Purpose = &purpose
+		Context("Addons validation", func() {
+			DescribeTable("addons validation",
+				func(purpose core.ShootPurpose, allowed bool) {
+					shootCopy := shoot.DeepCopy()
+					shootCopy.Spec.Purpose = &purpose
 
-				errorList := ValidateShoot(shootCopy)
+					errorList := ValidateShoot(shootCopy)
 
-				if allowed {
-					Expect(errorList).To(BeEmpty())
-				} else {
-					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeForbidden),
-						"Field": Equal("spec.addons"),
-					}))))
-				}
-			},
-			Entry("should allow addons on evaluation shoots", core.ShootPurposeEvaluation, true),
-			Entry("should forbid addons on testing shoots", core.ShootPurposeTesting, false),
-			Entry("should forbid addons on development shoots", core.ShootPurposeDevelopment, false),
-			Entry("should forbid addons on production shoots", core.ShootPurposeProduction, false),
-		)
+					if allowed {
+						Expect(errorList).To(BeEmpty())
+					} else {
+						Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeForbidden),
+							"Field": Equal("spec.addons"),
+						}))))
+					}
+				},
+				Entry("should allow addons on evaluation shoots", core.ShootPurposeEvaluation, true),
+				Entry("should forbid addons on testing shoots", core.ShootPurposeTesting, false),
+				Entry("should forbid addons on development shoots", core.ShootPurposeDevelopment, false),
+				Entry("should forbid addons on production shoots", core.ShootPurposeProduction, false),
+			)
 
-		It("should forbid addon configuration if the shoot is workerless", func() {
-			shoot.Spec.Provider.Workers = []core.Worker{}
-			shoot.Spec.Addons = &core.Addons{}
-			shoot.Spec.Kubernetes.KubeControllerManager = nil
+			It("should forbid addon configuration if the shoot is workerless", func() {
+				shoot.Spec.Provider.Workers = []core.Worker{}
+				shoot.Spec.Addons = &core.Addons{}
+				shoot.Spec.Kubernetes.KubeControllerManager = nil
 
-			errorList := ValidateShoot(shoot)
+				errorList := ValidateShoot(shoot)
 
-			Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeForbidden),
-				"Field":  Equal("spec.addons"),
-				"Detail": ContainSubstring("addons cannot be enabled for Workerless Shoot clusters"),
-			}))))
-		})
+				Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.addons"),
+					"Detail": ContainSubstring("addons cannot be enabled for Workerless Shoot clusters"),
+				}))))
+			})
 
-		It("should forbid unsupported addon configuration", func() {
-			shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode = ptr.To("does-not-exist")
+			It("should forbid unsupported addon configuration", func() {
+				shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode = ptr.To("does-not-exist")
 
-			errorList := ValidateShoot(shoot)
+				errorList := ValidateShoot(shoot)
 
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeNotSupported),
-				"Field": Equal("spec.addons.kubernetesDashboard.authenticationMode"),
-			}))))
-		})
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("spec.addons.kubernetesDashboard.authenticationMode"),
+				}))))
+			})
 
-		It("should allow external traffic policies 'Cluster' for nginx-ingress", func() {
-			v := corev1.ServiceExternalTrafficPolicyCluster
-			shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
-			errorList := ValidateShoot(shoot)
-			Expect(errorList).To(BeEmpty())
-		})
+			It("should allow external traffic policies 'Cluster' for nginx-ingress", func() {
+				v := corev1.ServiceExternalTrafficPolicyCluster
+				shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
+				errorList := ValidateShoot(shoot)
+				Expect(errorList).To(BeEmpty())
+			})
 
-		It("should allow external traffic policies 'Local' for nginx-ingress", func() {
-			v := corev1.ServiceExternalTrafficPolicyLocal
-			shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
-			errorList := ValidateShoot(shoot)
-			Expect(errorList).To(BeEmpty())
-		})
+			It("should allow external traffic policies 'Local' for nginx-ingress", func() {
+				v := corev1.ServiceExternalTrafficPolicyLocal
+				shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
+				errorList := ValidateShoot(shoot)
+				Expect(errorList).To(BeEmpty())
+			})
 
-		It("should forbid unsupported external traffic policies for nginx-ingress", func() {
-			v := corev1.ServiceExternalTrafficPolicy("something-else")
-			shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
+			It("should forbid unsupported external traffic policies for nginx-ingress", func() {
+				v := corev1.ServiceExternalTrafficPolicy("something-else")
+				shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
 
-			errorList := ValidateShoot(shoot)
+				errorList := ValidateShoot(shoot)
 
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeNotSupported),
-				"Field": Equal("spec.addons.nginxIngress.externalTrafficPolicy"),
-			}))))
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("spec.addons.nginxIngress.externalTrafficPolicy"),
+				}))))
+			})
 		})
 
 		It("should forbid unsupported specification (provider independent)", func() {
@@ -725,83 +727,144 @@ var _ = Describe("Shoot Validation Tests", func() {
 			))
 		})
 
-		It("should forbid adding secretBindingName in case of workerless shoot", func() {
-			shoot.Spec.Provider.Workers = nil
-			shoot.Spec.SecretBindingName = ptr.To("foo")
+		Context("SecretBindingName/CredentialsBinding validation", func() {
 
-			errorList := ValidateShoot(shoot)
+			It("should forbid adding secretBindingName in case of workerless shoot", func() {
+				shoot.Spec.Provider.Workers = nil
+				shoot.Spec.SecretBindingName = ptr.To("foo")
 
-			Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeForbidden),
-				"Field":  Equal("spec.secretBindingName"),
-				"Detail": ContainSubstring("this field should not be set for workerless Shoot clusters"),
-			}))))
-		})
+				errorList := ValidateShoot(shoot)
 
-		It("should forbid adding credentialsBindingName in case of workerless shoot", func() {
-			shoot.Spec.Provider.Workers = nil
-			shoot.Spec.CredentialsBindingName = ptr.To("foo")
+				Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.secretBindingName"),
+					"Detail": ContainSubstring("this field should not be set for workerless Shoot clusters"),
+				}))))
+			})
 
-			errorList := ValidateShoot(shoot)
+			It("should forbid adding credentialsBindingName in case of workerless shoot", func() {
+				shoot.Spec.Provider.Workers = nil
+				shoot.Spec.CredentialsBindingName = ptr.To("foo")
 
-			Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeForbidden),
-				"Field":  Equal("spec.credentialsBindingName"),
-				"Detail": ContainSubstring("this field should not be set for workerless Shoot clusters"),
-			}))))
-		})
+				errorList := ValidateShoot(shoot)
 
-		It("should allow nil secretBindingName in case of workerless shoot", func() {
-			shoot.Spec.Provider.Workers = nil
-			shoot.Spec.Addons = nil
-			shoot.Spec.SecretBindingName = nil
-			shoot.Spec.Kubernetes.KubeControllerManager = nil
-			shoot.Spec.Networking = nil
-			shoot.Spec.Kubernetes.KubeControllerManager = nil
+				Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.credentialsBindingName"),
+					"Detail": ContainSubstring("this field should not be set for workerless Shoot clusters"),
+				}))))
+			})
 
-			errorList := ValidateShoot(shoot)
+			It("should allow nil secretBindingName in case of workerless shoot", func() {
+				shoot.Spec.Provider.Workers = nil
+				shoot.Spec.Addons = nil
+				shoot.Spec.SecretBindingName = nil
+				shoot.Spec.Kubernetes.KubeControllerManager = nil
+				shoot.Spec.Networking = nil
+				shoot.Spec.Kubernetes.KubeControllerManager = nil
 
-			Expect(errorList).To(BeEmpty())
-		})
+				errorList := ValidateShoot(shoot)
 
-		It("should allow nil credentialsBindingName in case of workerless shoot", func() {
-			shoot.Spec.Provider.Workers = nil
-			shoot.Spec.Addons = nil
-			shoot.Spec.SecretBindingName = nil
-			shoot.Spec.CredentialsBindingName = nil
-			shoot.Spec.Kubernetes.KubeControllerManager = nil
-			shoot.Spec.Networking = nil
-			shoot.Spec.Kubernetes.KubeControllerManager = nil
+				Expect(errorList).To(BeEmpty())
+			})
 
-			errorList := ValidateShoot(shoot)
+			It("should allow nil credentialsBindingName in case of workerless shoot", func() {
+				shoot.Spec.Provider.Workers = nil
+				shoot.Spec.Addons = nil
+				shoot.Spec.SecretBindingName = nil
+				shoot.Spec.CredentialsBindingName = nil
+				shoot.Spec.Kubernetes.KubeControllerManager = nil
+				shoot.Spec.Networking = nil
+				shoot.Spec.Kubernetes.KubeControllerManager = nil
 
-			Expect(errorList).To(BeEmpty())
-		})
+				errorList := ValidateShoot(shoot)
 
-		It("should forbid setting both secretBindingName and credentialsBindingName", func() {
-			shoot.Spec.SecretBindingName = ptr.To("foo")
-			shoot.Spec.CredentialsBindingName = ptr.To("foo")
+				Expect(errorList).To(BeEmpty())
+			})
 
-			errorList := ValidateShoot(shoot)
+			It("should forbid setting both secretBindingName and credentialsBindingName", func() {
+				shoot.Spec.SecretBindingName = ptr.To("foo")
+				shoot.Spec.CredentialsBindingName = ptr.To("foo")
 
-			Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeForbidden),
-				"Field":  Equal("spec.secretBindingName"),
-				"Detail": Equal("is incompatible with credentialsBindingName"),
-			}))))
-		})
+				errorList := ValidateShoot(shoot)
 
-		It("should forbid not setting at least one of secretBindingName or credentialsBindingName", func() {
-			shoot.Spec.SecretBindingName = nil
-			shoot.Spec.CredentialsBindingName = nil
+				Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.secretBindingName"),
+					"Detail": Equal("is incompatible with credentialsBindingName"),
+				}))))
+			})
 
-			errorList := ValidateShoot(shoot)
+			It("should forbid not setting at least one of secretBindingName or credentialsBindingName", func() {
+				shoot.Spec.SecretBindingName = nil
+				shoot.Spec.CredentialsBindingName = nil
 
-			Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeRequired),
-				"Field":  Equal("spec.secretBindingName"),
-				"Detail": Equal("must be set when credentialsBindingName is not"),
-			}))))
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("spec.secretBindingName"),
+					"Detail": Equal("must be set when credentialsBindingName is not"),
+				}))))
+			})
+
+			It("should forbid updating secretBindingName when not migrating to credentialsBindingName", func() {
+				newShoot := prepareShootForUpdate(shoot)
+				shoot.Spec.SecretBindingName = ptr.To("another-reference")
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.secretBindingName"),
+					})),
+				))
+			})
+
+			It("should allow updating credentialsBindingName", func() {
+				shoot.Spec.SecretBindingName = nil
+				shoot.Spec.CredentialsBindingName = ptr.To("foo")
+				newShoot := prepareShootForUpdate(shoot)
+				shoot.Spec.CredentialsBindingName = ptr.To("another-reference")
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should allow switching from secretBindingName to credentialsBindingName", func() {
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.SecretBindingName = nil
+				newShoot.Spec.CredentialsBindingName = ptr.To("another-reference")
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should not allow switching from credentialsBindingName to secretBindingName", func() {
+				shoot.Spec.SecretBindingName = nil
+				shoot.Spec.CredentialsBindingName = ptr.To("another-reference")
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.SecretBindingName = ptr.To("foo")
+				newShoot.Spec.CredentialsBindingName = nil
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.secretBindingName"),
+						"Detail": Equal("field is immutable"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.credentialsBindingName"),
+						"Detail": Equal("the field cannot be unset"),
+					})),
+				))
+			})
 		})
 
 		It("should forbid adding invalid/duplicate emails", func() {
@@ -879,64 +942,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 			))
 		})
 
-		It("should forbid updating secretBindingName when not migrating to credentialsBindingName", func() {
-			newShoot := prepareShootForUpdate(shoot)
-			shoot.Spec.SecretBindingName = ptr.To("another-reference")
-
-			errorList := ValidateShootUpdate(newShoot, shoot)
-
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.secretBindingName"),
-				})),
-			))
-		})
-
-		It("should allow updating credentialsBindingName", func() {
-			shoot.Spec.SecretBindingName = nil
-			shoot.Spec.CredentialsBindingName = ptr.To("foo")
-			newShoot := prepareShootForUpdate(shoot)
-			shoot.Spec.CredentialsBindingName = ptr.To("another-reference")
-
-			errorList := ValidateShootUpdate(newShoot, shoot)
-
-			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should allow switching from secretBindingName to credentialsBindingName", func() {
-			newShoot := prepareShootForUpdate(shoot)
-			newShoot.Spec.SecretBindingName = nil
-			newShoot.Spec.CredentialsBindingName = ptr.To("another-reference")
-
-			errorList := ValidateShootUpdate(newShoot, shoot)
-
-			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should not allow switching from credentialsBindingName to secretBindingName", func() {
-			shoot.Spec.SecretBindingName = nil
-			shoot.Spec.CredentialsBindingName = ptr.To("another-reference")
-			newShoot := prepareShootForUpdate(shoot)
-			newShoot.Spec.SecretBindingName = ptr.To("foo")
-			newShoot.Spec.CredentialsBindingName = nil
-
-			errorList := ValidateShootUpdate(newShoot, shoot)
-
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.secretBindingName"),
-					"Detail": Equal("field is immutable"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
-					"Field":  Equal("spec.credentialsBindingName"),
-					"Detail": Equal("the field cannot be unset"),
-				})),
-			))
-		})
-
 		Context("seed selector", func() {
 			seedSelector := &core.SeedSelector{LabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}
 
@@ -1005,150 +1010,155 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 		})
 
-		It("should forbid passing an extension w/o type information", func() {
-			extension := core.Extension{}
-			shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension)
+		Context("Extensions validation", func() {
 
-			errorList := ValidateShoot(shoot)
+			It("should forbid passing an extension w/o type information", func() {
+				extension := core.Extension{}
+				shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.extensions[0].type"),
-				}))))
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.extensions[0].type"),
+					}))))
+			})
+
+			It("should allow passing an extension w/ type information", func() {
+				extension := core.Extension{
+					Type: "arbitrary",
+				}
+				shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension)
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should forbid passing an extension of same type more than once", func() {
+				extension := core.Extension{
+					Type: "arbitrary",
+				}
+				shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension, extension)
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeDuplicate),
+						"Field": Equal("spec.extensions[1].type"),
+					}))))
+			})
+
+			It("should allow passing more than one extension of different type", func() {
+				extension := core.Extension{
+					Type: "arbitrary",
+				}
+				shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension, extension)
+				shoot.Spec.Extensions[1].Type = "arbitrary-2"
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 
-		It("should allow passing an extension w/ type information", func() {
-			extension := core.Extension{
-				Type: "arbitrary",
-			}
-			shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension)
+		Context("Resources validation", func() {
+			It("should forbid resources w/o names or w/ invalid references", func() {
+				ref := core.NamedResourceReference{}
+				shoot.Spec.Resources = append(shoot.Spec.Resources, ref)
 
-			errorList := ValidateShoot(shoot)
+				errorList := ValidateShoot(shoot)
 
-			Expect(errorList).To(BeEmpty())
-		})
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.resources[0].name"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.resources[0].resourceRef.kind"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.resources[0].resourceRef.name"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.resources[0].resourceRef.apiVersion"),
+					})),
+				))
+			})
 
-		It("should forbid passing an extension of same type more than once", func() {
-			extension := core.Extension{
-				Type: "arbitrary",
-			}
-			shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension, extension)
+			It("should forbid resources of kind other than Secret/ConfigMap", func() {
+				ref := core.NamedResourceReference{
+					Name: "test",
+					ResourceRef: autoscalingv1.CrossVersionObjectReference{
+						Kind:       "ServiceAccount",
+						Name:       "test-sa",
+						APIVersion: "v1",
+					},
+				}
+				shoot.Spec.Resources = append(shoot.Spec.Resources, ref)
 
-			errorList := ValidateShoot(shoot)
+				errorList := ValidateShoot(shoot)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeDuplicate),
-					"Field": Equal("spec.extensions[1].type"),
-				}))))
-		})
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":     Equal(field.ErrorTypeNotSupported),
+						"Field":    Equal("spec.resources[0].resourceRef.kind"),
+						"BadValue": Equal("ServiceAccount"),
+					})),
+				))
+			})
 
-		It("should allow passing more than one extension of different type", func() {
-			extension := core.Extension{
-				Type: "arbitrary",
-			}
-			shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension, extension)
-			shoot.Spec.Extensions[1].Type = "arbitrary-2"
+			It("should forbid resources with non-unique names", func() {
+				ref := core.NamedResourceReference{
+					Name: "test",
+					ResourceRef: autoscalingv1.CrossVersionObjectReference{
+						Kind:       "Secret",
+						Name:       "test-secret",
+						APIVersion: "v1",
+					},
+				}
+				shoot.Spec.Resources = append(shoot.Spec.Resources, ref, ref)
 
-			errorList := ValidateShoot(shoot)
+				errorList := ValidateShoot(shoot)
 
-			Expect(errorList).To(BeEmpty())
-		})
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeDuplicate),
+						"Field": Equal("spec.resources[1].name"),
+					})),
+				))
+			})
 
-		It("should forbid resources w/o names or w/ invalid references", func() {
-			ref := core.NamedResourceReference{}
-			shoot.Spec.Resources = append(shoot.Spec.Resources, ref)
+			It("should allow resources w/ names and valid references", func() {
+				ref := core.NamedResourceReference{
+					Name: "test",
+					ResourceRef: autoscalingv1.CrossVersionObjectReference{
+						Kind:       "Secret",
+						Name:       "test-secret",
+						APIVersion: "v1",
+					},
+				}
 
-			errorList := ValidateShoot(shoot)
+				ref2 := core.NamedResourceReference{
+					Name: "test-cm",
+					ResourceRef: autoscalingv1.CrossVersionObjectReference{
+						Kind:       "ConfigMap",
+						Name:       "test-cm",
+						APIVersion: "v1",
+					},
+				}
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.resources[0].name"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.resources[0].resourceRef.kind"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.resources[0].resourceRef.name"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.resources[0].resourceRef.apiVersion"),
-				})),
-			))
-		})
+				shoot.Spec.Resources = append(shoot.Spec.Resources, ref, ref2)
 
-		It("should forbid resources of kind other than Secret/ConfigMap", func() {
-			ref := core.NamedResourceReference{
-				Name: "test",
-				ResourceRef: autoscalingv1.CrossVersionObjectReference{
-					Kind:       "ServiceAccount",
-					Name:       "test-sa",
-					APIVersion: "v1",
-				},
-			}
-			shoot.Spec.Resources = append(shoot.Spec.Resources, ref)
+				errorList := ValidateShoot(shoot)
 
-			errorList := ValidateShoot(shoot)
-
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeNotSupported),
-					"Field":    Equal("spec.resources[0].resourceRef.kind"),
-					"BadValue": Equal("ServiceAccount"),
-				})),
-			))
-		})
-
-		It("should forbid resources with non-unique names", func() {
-			ref := core.NamedResourceReference{
-				Name: "test",
-				ResourceRef: autoscalingv1.CrossVersionObjectReference{
-					Kind:       "Secret",
-					Name:       "test-secret",
-					APIVersion: "v1",
-				},
-			}
-			shoot.Spec.Resources = append(shoot.Spec.Resources, ref, ref)
-
-			errorList := ValidateShoot(shoot)
-
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeDuplicate),
-					"Field": Equal("spec.resources[1].name"),
-				})),
-			))
-		})
-
-		It("should allow resources w/ names and valid references", func() {
-			ref := core.NamedResourceReference{
-				Name: "test",
-				ResourceRef: autoscalingv1.CrossVersionObjectReference{
-					Kind:       "Secret",
-					Name:       "test-secret",
-					APIVersion: "v1",
-				},
-			}
-
-			ref2 := core.NamedResourceReference{
-				Name: "test-cm",
-				ResourceRef: autoscalingv1.CrossVersionObjectReference{
-					Kind:       "ConfigMap",
-					Name:       "test-cm",
-					APIVersion: "v1",
-				},
-			}
-
-			shoot.Spec.Resources = append(shoot.Spec.Resources, ref, ref2)
-
-			errorList := ValidateShoot(shoot)
-
-			Expect(errorList).To(BeEmpty())
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 
 		It("should allow updating the seed if it has not been set previously", func() {
@@ -6856,9 +6866,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				Expect(errList).To(BeEmpty())
 			})
-
 		})
-
 	})
 
 	Describe("#ValidateHibernationSchedules", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
If someone annotates the shoot with an operation annotation while there is already a maintenance annotation for rotation present, for eg: `maintenance.gardener.cloud/operation: rotate-ca-start ` as well as `gardener.cloud/operation: rotate-credentials-start`, gardenlet can error with:
```
2024-10-27 09:29:14 | {"log":{"controller":"shoot","error":"Shoot.core.gardener.cloud \"shoot-new\" is invalid: metadata.annotations[maintenance.gardener.cloud/operation]: Forbidden: cannot start CA rotation if .status.credentials.rotation.certificateAuthorities.phase is not 'Completed'","level":"error","msg":"Reconciler error","name":"shoot-new","namespace":"garden-local","object":{"name":"shoot-new","namespace":"garden-local"},"reconcileID":"20f9c675-21c9-4f17-a34b-0c02cc6511fe","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.6/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.6/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.6/pkg/internal/controller/controller.go:227","ts":"2024-10-27T09:29:14.402Z"}}
```
or `maintenance.gardener.cloud/operation: rotate-credentials-start` with `gardener.cloud/operation: rotate-ca-start`

```
2024-10-28 12:21:53 | {"log":{"controller":"shoot","error":"Shoot.core.gardener.cloud \"shoot-new\" is invalid: metadata.annotations[maintenance.gardener.cloud/operation]: Forbidden: cannot start rotation of all credentials if .status.credentials.rotation.certificateAuthorities.phase is not 'Completed'","level":"error","msg":"Reconciler error","name":"shoot-new","namespace":"garden-local","object":{"name":"shoot-new","namespace":"garden-local"},"reconcileID":"1f0847c9-eb84-4aed-89e5-f5cbd43395e7","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224","ts":"2024-10-28T06:51:53.887Z"}}
```
Similarly for completion.
This PR enhances the validation for rotate operation annotations to cover these cases.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
