### PR TITLE
Add observability URLs to shoot observability secret

### DIFF
--- a/docs/usage/observability/logging.md
+++ b/docs/usage/observability/logging.md
@@ -52,7 +52,7 @@ The logs are accessible via Plutono. To access them:
 
   1. Authenticate via basic auth to gain access to Plutono.  
   The secret containing the credentials is stored in the project namespace following the naming pattern `<shoot-name>.monitoring`.
-  In this secret you can also find the Plutono URL in the `url-plutono` annotation.
+  In this secret you can also find the Plutono URL in the `plutono-url` annotation.
   For Gardener operators, the credentials are also stored in the control-plane (`shoot--<project-name>--<shoot-name>`) namespace in the `observability-ingress-users-<hash>` secret in the seed.
 
   1. Plutono contains several dashboards that aim to facilitate the work of operators and users.

--- a/docs/usage/observability/logging.md
+++ b/docs/usage/observability/logging.md
@@ -50,9 +50,9 @@ Also, in the shoot control plane an `event-logger` pod is deployed, which scrape
 
 The logs are accessible via Plutono. To access them:
 
-  1. Authenticate via basic auth to gain access to Plutono.
-  The Plutono URL can be found in the `Logging and Monitoring` section of a cluster in the Gardener Dashboard alongside the credentials.
+  1. Authenticate via basic auth to gain access to Plutono.  
   The secret containing the credentials is stored in the project namespace following the naming pattern `<shoot-name>.monitoring`.
+  In this secret you can also find the Plutono URL in the `url-plutono` annotation.
   For Gardener operators, the credentials are also stored in the control-plane (`shoot--<project-name>--<shoot-name>`) namespace in the `observability-ingress-users-<hash>` secret in the seed.
 
   1. Plutono contains several dashboards that aim to facilitate the work of operators and users.

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -305,11 +305,25 @@ func (b *Botanist) generateObservabilityIngressPassword(ctx context.Context) err
 		return err
 	}
 
+	// TODO(oliver-goetz): Remove `url` when Gardener v1.110 is released.
+	annotations := map[string]string{
+		"url":         "https://" + b.ComputePlutonoHost(),
+		"plutono-url": "https://" + b.ComputePlutonoHost(),
+	}
+
+	if b.IsShootMonitoringEnabled() {
+		annotations["prometheus-url"] = "https://" + b.ComputePrometheusHost()
+
+		if b.Shoot.WantsAlertmanager {
+			annotations["alertmanager-url"] = "https://" + b.ComputeAlertManagerHost()
+		}
+	}
+
 	return b.syncShootCredentialToGarden(
 		ctx,
 		gardenerutils.ShootProjectSecretSuffixMonitoring,
 		map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleMonitoring},
-		map[string]string{"url": "https://" + b.ComputePlutonoHost()},
+		annotations,
 		secret.Data,
 	)
 }

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -307,16 +307,13 @@ func (b *Botanist) generateObservabilityIngressPassword(ctx context.Context) err
 
 	// TODO(oliver-goetz): Remove `url` when Gardener v1.110 is released.
 	annotations := map[string]string{
-		"url":         "https://" + b.ComputePlutonoHost(),
-		"plutono-url": "https://" + b.ComputePlutonoHost(),
+		"url":            "https://" + b.ComputePlutonoHost(),
+		"plutono-url":    "https://" + b.ComputePlutonoHost(),
+		"prometheus-url": "https://" + b.ComputePrometheusHost(),
 	}
 
-	if b.IsShootMonitoringEnabled() {
-		annotations["prometheus-url"] = "https://" + b.ComputePrometheusHost()
-
-		if b.Shoot.WantsAlertmanager {
-			annotations["alertmanager-url"] = "https://" + b.ComputeAlertManagerHost()
-		}
+	if b.Shoot.WantsAlertmanager {
+		annotations["alertmanager-url"] = "https://" + b.ComputeAlertManagerHost()
 	}
 
 	return b.syncShootCredentialToGarden(

--- a/pkg/gardenlet/operation/botanist/secrets_test.go
+++ b/pkg/gardenlet/operation/botanist/secrets_test.go
@@ -293,6 +293,8 @@ var _ = Describe("Secrets", func() {
 
 			Context("observability credentials", func() {
 				It("should generate the password and sync it to the garden", func() {
+					botanist.Shoot.WantsAlertmanager = true
+
 					Expect(botanist.InitializeSecretsManagement(ctx)).To(Succeed())
 
 					secretList := &corev1.SecretList{}
@@ -314,6 +316,9 @@ var _ = Describe("Secrets", func() {
 					gardenSecret := &corev1.Secret{}
 					Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".monitoring"}, gardenSecret)).To(Succeed())
 					Expect(gardenSecret.Annotations).To(HaveKeyWithValue("url", "https://gu-foo--bar.example.com"))
+					Expect(gardenSecret.Annotations).To(HaveKeyWithValue("plutono-url", "https://gu-foo--bar.example.com"))
+					Expect(gardenSecret.Annotations).To(HaveKeyWithValue("prometheus-url", "https://p-foo--bar.example.com"))
+					Expect(gardenSecret.Annotations).To(HaveKeyWithValue("alertmanager-url", "https://au-foo--bar.example.com"))
 					Expect(gardenSecret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "monitoring"))
 					Expect(gardenSecret.Data).To(And(HaveKey("username"), HaveKey("password"), HaveKey("auth")))
 				})

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -56,7 +56,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 						return secret, f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(f.Shoot.Name, "monitoring")}, secret)
 					},
 					GetObservabilityEndpoint: func(secret *corev1.Secret) string {
-						return secret.Annotations["url"]
+						return secret.Annotations["plutono-url"]
 					},
 					GetObservabilityRotation: func() *gardencorev1beta1.ObservabilityRotation {
 						return f.Shoot.Status.Credentials.Rotation.Observability


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
The URLs of Shoot `plutono`, `prometheus` and `alertmanager` are now stored as annotations in `<shoot-name>.monitoring` secret in the project namespace.
This enables users to query the respective URLs without Gardener Dashboard being deployed.
The new annotations are: `plutono-url`, `prometheus-url` and `alertmanager-url`.

**Which issue(s) this PR fixes**:
Fixes #9867

**Special notes for your reviewer**:
cc @petersutter 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The URLs of Shoot `plutono`, `prometheus` and `alertmanager` are now stored as annotations in `<shoot-name>.monitoring` secret in the project namespace.
```
```breaking user
The `url` annotation in `<shoot-name>.monitoring` secrets in the project namespace is deprecated and will be removed soon. Please use the `plutono-url` annotation instead.
```
