### PR TITLE
Allow Control Plane Migration with empty Networking Status.

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -951,7 +951,8 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 					workerless,
 				)...)
 
-				if c.shoot.Status.Networking != nil {
+				// validate network disjointedness with seed networking if networking status is non-empty
+				if c.shoot.Status.Networking != nil && !apiequality.Semantic.DeepEqual(c.shoot.Status.Networking, &core.NetworkingStatus{}) {
 					allErrs = append(allErrs, cidrvalidation.ValidateMultiNetworkDisjointedness(
 						field.NewPath("status", "networking"),
 						c.shoot.Status.Networking.Nodes,

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -951,7 +951,7 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 					workerless,
 				)...)
 
-				// validate network disjointedness with seed networking if networking status is non-empty
+				// validate network disjointedness with seed networks if networking status is non-empty
 				if c.shoot.Status.Networking != nil && !apiequality.Semantic.DeepEqual(c.shoot.Status.Networking, &core.NetworkingStatus{}) {
 					allErrs = append(allErrs, cidrvalidation.ValidateMultiNetworkDisjointedness(
 						field.NewPath("status", "networking"),

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -5162,7 +5162,7 @@ var _ = Describe("validator", func() {
 				Entry("should allow nil networking status", nil, Not(HaveOccurred())),
 				Entry("should allow empty networking status", &core.NetworkingStatus{}, Not(HaveOccurred())),
 				Entry("should allow correct networking status", &core.NetworkingStatus{Nodes: []string{nodesCIDR}, Pods: []string{podsCIDR}, Services: []string{servicesCIDR}}, Not(HaveOccurred())),
-				Entry("should reject networking status with seed values", &core.NetworkingStatus{Nodes: []string{seedNodesCIDR}, Pods: []string{seedPodsCIDR}, Services: []string{seedServicesCIDR}}, BeForbiddenError()),
+				Entry("should reject networking status if it is not disjoint with seed network", &core.NetworkingStatus{Nodes: []string{seedNodesCIDR}, Pods: []string{seedPodsCIDR}, Services: []string{seedServicesCIDR}}, BeForbiddenError()),
 			)
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

Allow Control Plane Migration with empty Networking Status.

PR #10240 changed the setting of the networking status. Now, the networking status will always be created. It may be empty, though. This caused issues in the validation of control plane migration.

This change makes the control plane migration possible again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
