### PR TITLE
Removed unnecessary pointer fields in `GardenletConfig` resource

### DIFF
--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -637,13 +637,13 @@ func ComputeExpectedGardenletConfiguration(
 				Burst: 130,
 			},
 		},
-		ShootClientConnection: &gardenletv1alpha1.ShootClientConnection{
+		ShootClientConnection: gardenletv1alpha1.ShootClientConnection{
 			ClientConnectionConfiguration: baseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   25,
 				Burst: 50,
 			},
 		},
-		Controllers: &gardenletv1alpha1.GardenletControllerConfiguration{
+		Controllers: gardenletv1alpha1.GardenletControllerConfiguration{
 			BackupBucket: &gardenletv1alpha1.BackupBucketControllerConfiguration{
 				ConcurrentSyncs: &twenty,
 			},
@@ -786,7 +786,7 @@ func ComputeExpectedGardenletConfiguration(
 		},
 		LogLevel:  logLevelInfo,
 		LogFormat: logFormatJson,
-		Logging: &gardenletv1alpha1.Logging{
+		Logging: gardenletv1alpha1.Logging{
 			Enabled: ptr.To(false),
 			Vali: &gardenletv1alpha1.Vali{
 				Enabled: ptr.To(false),
@@ -811,22 +811,22 @@ func ComputeExpectedGardenletConfiguration(
 			EnableContentionProfiling: ptr.To(false),
 		},
 		FeatureGates: featureGates,
-		Resources: &gardenletv1alpha1.ResourcesConfiguration{
+		Resources: gardenletv1alpha1.ResourcesConfiguration{
 			Capacity: corev1.ResourceList{
 				"shoots": resource.MustParse("250"),
 			},
 		},
-		SNI: &gardenletv1alpha1.SNI{Ingress: &gardenletv1alpha1.SNIIngress{
+		SNI: gardenletv1alpha1.SNI{Ingress: &gardenletv1alpha1.SNIIngress{
 			ServiceName: ptr.To(v1beta1constants.DefaultSNIIngressServiceName),
 			Namespace:   ptr.To(v1beta1constants.DefaultSNIIngressNamespace),
 			Labels:      map[string]string{"app": "istio-ingressgateway", "istio": "ingressgateway"},
 		}},
-		Monitoring: &gardenletv1alpha1.MonitoringConfig{
+		Monitoring: gardenletv1alpha1.MonitoringConfig{
 			Shoot: &gardenletv1alpha1.ShootMonitoringConfig{
 				Enabled: ptr.To(true),
 			},
 		},
-		ETCDConfig: &gardenletv1alpha1.ETCDConfig{
+		ETCDConfig: gardenletv1alpha1.ETCDConfig{
 			BackupCompactionController: &gardenletv1alpha1.BackupCompactionController{
 				EnableBackupCompaction:    ptr.To(false),
 				EventsThreshold:           ptr.To[int64](1000000),

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Defaults", func() {
 						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					Resources: &gardenletv1alpha1.ResourcesConfiguration{
+					Resources: gardenletv1alpha1.ResourcesConfiguration{
 						Capacity: corev1.ResourceList{
 							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 						},
@@ -76,7 +76,7 @@ var _ = Describe("Defaults", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: gardenletv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 							},
@@ -105,7 +105,7 @@ var _ = Describe("Defaults", func() {
 						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					Resources: &gardenletv1alpha1.ResourcesConfiguration{
+					Resources: gardenletv1alpha1.ResourcesConfiguration{
 						Capacity: corev1.ResourceList{
 							gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 						},
@@ -134,7 +134,7 @@ var _ = Describe("Defaults", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: gardenletv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -106,13 +106,8 @@ func setDefaultsGardenletConfig(config *runtime.RawExtension, name, namespace st
 }
 
 func setDefaultsGardenletConfiguration(obj *gardenletv1alpha1.GardenletConfiguration, name, namespace string) {
-	// Initialize resources
-	if obj.Resources == nil {
-		obj.Resources = &gardenletv1alpha1.ResourcesConfiguration{}
-	}
-
 	// Set resources defaults
-	setDefaultsResources(obj.Resources)
+	setDefaultsResources(&obj.Resources)
 
 	// Initialize seed config
 	if obj.SeedConfig == nil {

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Defaults", func() {
 						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					Resources: &gardenletv1alpha1.ResourcesConfiguration{
+					Resources: gardenletv1alpha1.ResourcesConfiguration{
 						Capacity: corev1.ResourceList{
 							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 						},
@@ -90,7 +90,7 @@ var _ = Describe("Defaults", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: gardenletv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 							},
@@ -120,7 +120,7 @@ var _ = Describe("Defaults", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: gardenletv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},
@@ -152,7 +152,7 @@ var _ = Describe("Defaults", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: gardenletv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},

--- a/pkg/controller/gardenletdeployer/valueshelper_test.go
+++ b/pkg/controller/gardenletdeployer/valueshelper_test.go
@@ -93,7 +93,7 @@ var _ = Describe("ValuesHelper", func() {
 				string("FooFeature"): true,
 				string("BarFeature"): true,
 			},
-			Logging: &config.Logging{
+			Logging: config.Logging{
 				Enabled: ptr.To(true),
 			},
 			SeedConfig: &config.SeedConfig{
@@ -192,7 +192,7 @@ var _ = Describe("ValuesHelper", func() {
 					string("FooFeature"): false,
 					string("BarFeature"): true,
 				},
-				Logging: &gardenletv1alpha1.Logging{
+				Logging: gardenletv1alpha1.Logging{
 					Enabled: ptr.To(true),
 				},
 			}
@@ -227,6 +227,13 @@ var _ = Describe("ValuesHelper", func() {
 						"qps":                float64(100),
 						"burst":              float64(130),
 					},
+					"shootClientConnection": map[string]any{
+						"kubeconfig":         "",
+						"acceptContentTypes": "",
+						"contentType":        "",
+						"qps":                float64(0),
+						"burst":              float64(0),
+					},
 					"seedClientConnection": map[string]any{
 						"kubeconfig":         "",
 						"acceptContentTypes": "application/json",
@@ -234,6 +241,11 @@ var _ = Describe("ValuesHelper", func() {
 						"qps":                float64(100),
 						"burst":              float64(130),
 					},
+					"etcdConfig":  map[string]any{},
+					"sni":         map[string]any{},
+					"controllers": map[string]any{},
+					"monitoring":  map[string]any{},
+					"resources":   map[string]any{},
 					"server": map[string]any{
 						"healthProbes": map[string]any{
 							"bindAddress": "0.0.0.0",
@@ -314,6 +326,7 @@ var _ = Describe("ValuesHelper", func() {
 			result, err := vh.GetGardenletChartValues(mergedDeployment, mergedGardenletConfig(false), "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(gardenletChartValues(false, "", 1, nil)))
+			//Expect(reflect.DeepEqual(result, gardenletChartValues(false, "", 1, nil))).To(BeTrue())
 		})
 	})
 })

--- a/pkg/gardenlet/apis/config/helper/helpers.go
+++ b/pkg/gardenlet/apis/config/helper/helpers.go
@@ -75,8 +75,7 @@ func ConvertGardenletConfigurationExternal(obj runtime.Object) (*gardenletv1alph
 
 // IsLoggingEnabled return true if the logging stack for clusters is enabled.
 func IsLoggingEnabled(c *config.GardenletConfiguration) bool {
-	if c != nil && c.Logging != nil &&
-		c.Logging.Enabled != nil {
+	if c != nil && c.Logging.Enabled != nil {
 		return *c.Logging.Enabled
 	}
 	return false
@@ -84,8 +83,7 @@ func IsLoggingEnabled(c *config.GardenletConfiguration) bool {
 
 // IsValiEnabled return true if the vali is enabled
 func IsValiEnabled(c *config.GardenletConfiguration) bool {
-	if c != nil && c.Logging != nil &&
-		c.Logging.Vali != nil && c.Logging.Vali.Enabled != nil {
+	if c != nil && c.Logging.Vali != nil && c.Logging.Vali.Enabled != nil {
 		return *c.Logging.Vali.Enabled
 	}
 	return true
@@ -93,7 +91,7 @@ func IsValiEnabled(c *config.GardenletConfiguration) bool {
 
 // IsEventLoggingEnabled returns true if the event-logging is enabled.
 func IsEventLoggingEnabled(c *config.GardenletConfiguration) bool {
-	return c != nil && c.Logging != nil &&
+	return c != nil &&
 		c.Logging.ShootEventLogging != nil &&
 		c.Logging.ShootEventLogging.Enabled != nil &&
 		*c.Logging.ShootEventLogging.Enabled
@@ -101,7 +99,7 @@ func IsEventLoggingEnabled(c *config.GardenletConfiguration) bool {
 
 // IsMonitoringEnabled returns true if the monitoring stack for shoot clusters is enabled. Default is enabled.
 func IsMonitoringEnabled(c *config.GardenletConfiguration) bool {
-	if c != nil && c.Monitoring != nil && c.Monitoring.Shoot != nil &&
+	if c != nil && c.Monitoring.Shoot != nil &&
 		c.Monitoring.Shoot.Enabled != nil {
 		return *c.Monitoring.Shoot.Enabled
 	}
@@ -110,7 +108,7 @@ func IsMonitoringEnabled(c *config.GardenletConfiguration) bool {
 
 // GetManagedResourceProgressingThreshold returns ManagedResourceProgressingThreshold if set otherwise it returns nil.
 func GetManagedResourceProgressingThreshold(c *config.GardenletConfiguration) *metav1.Duration {
-	if c != nil && c.Controllers != nil && c.Controllers.ShootCare != nil && c.Controllers.ShootCare.ManagedResourceProgressingThreshold != nil {
+	if c != nil && c.Controllers.ShootCare != nil && c.Controllers.ShootCare.ManagedResourceProgressingThreshold != nil {
 		return c.Controllers.ShootCare.ManagedResourceProgressingThreshold
 	}
 	return nil

--- a/pkg/gardenlet/apis/config/helper/helpers_test.go
+++ b/pkg/gardenlet/apis/config/helper/helpers_test.go
@@ -93,7 +93,7 @@ var _ = Describe("helper", func() {
 	Describe("#IsMonitoringEnabled", func() {
 		It("should return false when Monitoring.Shoot.Enabled is false", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Monitoring: &config.MonitoringConfig{
+				Monitoring: config.MonitoringConfig{
 					Shoot: &config.ShootMonitoringConfig{
 						Enabled: ptr.To(false),
 					},
@@ -104,7 +104,7 @@ var _ = Describe("helper", func() {
 
 		It("should return true when Monitoring.Shoot.Enabled is true", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Monitoring: &config.MonitoringConfig{
+				Monitoring: config.MonitoringConfig{
 					Shoot: &config.ShootMonitoringConfig{
 						Enabled: ptr.To(true),
 					},
@@ -120,14 +120,14 @@ var _ = Describe("helper", func() {
 
 		It("should return true when Monitoring.Shoot is nil", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Monitoring: &config.MonitoringConfig{Shoot: nil},
+				Monitoring: config.MonitoringConfig{Shoot: nil},
 			}
 			Expect(IsMonitoringEnabled(gardenletConfig)).To(BeTrue())
 		})
 
 		It("should return true when Monitoring.Shoot.Enabled is nil", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Monitoring: &config.MonitoringConfig{Shoot: &config.ShootMonitoringConfig{Enabled: nil}},
+				Monitoring: config.MonitoringConfig{Shoot: &config.ShootMonitoringConfig{Enabled: nil}},
 			}
 			Expect(IsMonitoringEnabled(gardenletConfig)).To(BeTrue())
 		})
@@ -146,7 +146,7 @@ var _ = Describe("helper", func() {
 
 		It("should return false when the logging is not enabled", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					Enabled: ptr.To(false),
 				},
 			}
@@ -156,7 +156,7 @@ var _ = Describe("helper", func() {
 
 		It("should return true when the logging is enabled", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					Enabled: ptr.To(true),
 				},
 			}
@@ -178,7 +178,7 @@ var _ = Describe("helper", func() {
 
 		It("should return false when the vali is not enabled", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					Vali: &config.Vali{
 						Enabled: ptr.To(false),
 					},
@@ -190,7 +190,7 @@ var _ = Describe("helper", func() {
 
 		It("should return true when the vali is enabled", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					Vali: &config.Vali{
 						Enabled: ptr.To(true),
 					},
@@ -214,7 +214,7 @@ var _ = Describe("helper", func() {
 
 		It("should return false when Logging configuration is empty", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{},
+				Logging: config.Logging{},
 			}
 
 			Expect(IsEventLoggingEnabled(gardenletConfig)).To(BeFalse())
@@ -222,7 +222,7 @@ var _ = Describe("helper", func() {
 
 		It("should return false when ShootEventLogging is nil", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					Enabled: ptr.To(true),
 				},
 			}
@@ -232,7 +232,7 @@ var _ = Describe("helper", func() {
 
 		It("should return false when ShootEventLogging is empty", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					Enabled:          ptr.To(true),
 					ShootNodeLogging: &config.ShootNodeLogging{},
 				},
@@ -243,7 +243,7 @@ var _ = Describe("helper", func() {
 
 		It("should return false when the event logging is not enabled", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					ShootEventLogging: &config.ShootEventLogging{
 						Enabled: ptr.To(false),
 					},
@@ -255,7 +255,7 @@ var _ = Describe("helper", func() {
 
 		It("should return true when the event logging is enabled", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					ShootEventLogging: &config.ShootEventLogging{
 						Enabled: ptr.To(true),
 					},
@@ -279,7 +279,7 @@ var _ = Describe("helper", func() {
 
 		It("should return nil when Controller configuration is empty", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Controllers: &config.GardenletControllerConfiguration{},
+				Controllers: config.GardenletControllerConfiguration{},
 			}
 
 			Expect(GetManagedResourceProgressingThreshold(gardenletConfig)).To(BeNil())
@@ -287,7 +287,7 @@ var _ = Describe("helper", func() {
 
 		It("should return nil when Shoot Care configuration is empty", func() {
 			gardenletConfig := &config.GardenletConfiguration{
-				Controllers: &config.GardenletControllerConfiguration{
+				Controllers: config.GardenletControllerConfiguration{
 					ShootCare: &config.ShootCareControllerConfiguration{},
 				},
 			}
@@ -298,7 +298,7 @@ var _ = Describe("helper", func() {
 		It("should return non nil value when ManagedResourceProgressingThreshold value is set", func() {
 			threshold := &metav1.Duration{Duration: time.Minute}
 			gardenletConfig := &config.GardenletConfiguration{
-				Controllers: &config.GardenletControllerConfiguration{
+				Controllers: config.GardenletControllerConfiguration{
 					ShootCare: &config.ShootCareControllerConfiguration{
 						ManagedResourceProgressingThreshold: threshold,
 					},

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -26,11 +26,11 @@ type GardenletConfiguration struct {
 	SeedClientConnection *SeedClientConnection
 	// ShootClientConnection specifies the client connection settings for the proxy server
 	// to use when communicating with the shoot apiserver.
-	ShootClientConnection *ShootClientConnection
+	ShootClientConnection ShootClientConnection
 	// Controllers defines the configuration of the controllers.
-	Controllers *GardenletControllerConfiguration
+	Controllers GardenletControllerConfiguration
 	// Resources defines the total capacity for seed resources and the amount reserved for use by Gardener.
-	Resources *ResourcesConfiguration
+	Resources ResourcesConfiguration
 	// LeaderElection defines the configuration of leader election client.
 	LeaderElection *componentbaseconfig.LeaderElectionConfiguration
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
@@ -50,17 +50,17 @@ type GardenletConfiguration struct {
 	SeedConfig *SeedConfig
 	// Logging contains an optional configurations for the logging stack deployed
 	// by the Gardenlet in the seed clusters.
-	Logging *Logging
+	Logging Logging
 	// SNI contains an optional configuration for the SNI settings used
 	// by the Gardenlet in the seed clusters.
-	SNI *SNI
+	SNI SNI
 	// ETCDConfig contains an optional configuration for the
 	// backup compaction feature of ETCD backup-restore functionality.
-	ETCDConfig *ETCDConfig
+	ETCDConfig ETCDConfig
 	// ExposureClassHandlers is a list of optional of exposure class handlers.
 	ExposureClassHandlers []ExposureClassHandler
 	// MonitoringConfig is optional and adds additional settings for the monitoring stack.
-	Monitoring *MonitoringConfig
+	Monitoring MonitoringConfig
 	// NodeToleration contains optional settings for default tolerations.
 	NodeToleration *NodeToleration
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -24,14 +24,6 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 		obj.SeedClientConnection = &SeedClientConnection{}
 	}
 
-	if obj.ShootClientConnection == nil {
-		obj.ShootClientConnection = &ShootClientConnection{}
-	}
-
-	if obj.Controllers == nil {
-		obj.Controllers = &GardenletControllerConfiguration{}
-	}
-
 	if obj.LeaderElection == nil {
 		obj.LeaderElection = &componentbaseconfigv1alpha1.LeaderElectionConfiguration{}
 	}
@@ -42,24 +34,6 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 
 	if obj.LogFormat == "" {
 		obj.LogFormat = LogFormatJSON
-	}
-
-	if obj.Logging == nil {
-		obj.Logging = &Logging{}
-	}
-
-	// TODO: consider enabling profiling by default (like in k8s components)
-
-	if obj.SNI == nil {
-		obj.SNI = &SNI{}
-	}
-
-	if obj.Monitoring == nil {
-		obj.Monitoring = &MonitoringConfig{}
-	}
-
-	if obj.ETCDConfig == nil {
-		obj.ETCDConfig = &ETCDConfig{}
 	}
 
 	SetDefaults_ExposureClassHandler(obj.ExposureClassHandlers)

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the shoot client connection", func() {
-			obj.ShootClientConnection = &ShootClientConnection{
+			obj.ShootClientConnection = ShootClientConnection{
 				ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 					QPS:   60.0,
 					Burst: 90,
@@ -182,7 +182,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the backup bucket controller configuration", func() {
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				BackupBucket: &BackupBucketControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -202,7 +202,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the backup entry controller configuration", func() {
 			deletionGracePeriodShootPurposes := []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				BackupEntry: &BackupEntryControllerConfiguration{
 					ConcurrentSyncs:                  ptr.To(10),
 					DeletionGracePeriodHours:         ptr.To(1),
@@ -225,7 +225,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the bastion controller configuration", func() {
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				Bastion: &BastionControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -242,7 +242,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the controller installation controller configuration", func() {
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				ControllerInstallation: &ControllerInstallationControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -262,7 +262,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the controller installation care controller configuration", func() {
 			v := metav1.Duration{Duration: 2 * time.Minute}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				ControllerInstallationCare: &ControllerInstallationCareControllerConfiguration{
 					ConcurrentSyncs: ptr.To(10),
 					SyncPeriod:      &v,
@@ -283,7 +283,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the controller installation required controller configuration", func() {
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				ControllerInstallationRequired: &ControllerInstallationRequiredControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -301,7 +301,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the managed seed controller configuration", func() {
 			v := metav1.Duration{Duration: 2 * time.Minute}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				Gardenlet: &GardenletObjectControllerConfiguration{
 					SyncPeriod: &v,
 				},
@@ -323,7 +323,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the seed controller configuration", func() {
 			syncPeriod := metav1.Duration{Duration: 2 * time.Minute}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				Seed: &SeedControllerConfiguration{
 					SyncPeriod:               &syncPeriod,
 					LeaseResyncSeconds:       ptr.To[int32](1),
@@ -347,7 +347,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the seed care controller configuration", func() {
 			syncPeriod := metav1.Duration{Duration: 2 * time.Minute}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				SeedCare: &SeedCareControllerConfiguration{SyncPeriod: &syncPeriod},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -370,7 +370,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the shoot controller configuration", func() {
 			v := metav1.Duration{Duration: 2 * time.Hour}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				Shoot: &ShootControllerConfiguration{
 					ConcurrentSyncs:            ptr.To(10),
 					SyncPeriod:                 &v,
@@ -403,7 +403,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the shoot care controller configuration", func() {
 			syncPeriod := metav1.Duration{Duration: 2 * time.Minute}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				ShootCare: &ShootCareControllerConfiguration{
 					SyncPeriod:                 &syncPeriod,
 					ConcurrentSyncs:            ptr.To(10),
@@ -427,7 +427,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the stale extension health checks", func() {
 			threshold := metav1.Duration{Duration: 2 * time.Minute}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				ShootCare: &ShootCareControllerConfiguration{
 					StaleExtensionHealthChecks: &StaleExtensionHealthChecks{Threshold: &threshold},
 				},
@@ -449,7 +449,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the shoot state controller configuration", func() {
 			syncPeriod := metav1.Duration{Duration: 2 * time.Hour}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				ShootState: &ShootStateControllerConfiguration{
 					SyncPeriod:      &syncPeriod,
 					ConcurrentSyncs: ptr.To(10),
@@ -471,7 +471,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the network policy controller configuration", func() {
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				NetworkPolicy: &NetworkPolicyControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -493,7 +493,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the managed seed controller configuration", func() {
 			v := metav1.Duration{Duration: 2 * time.Minute}
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				ManagedSeed: &ManagedSeedControllerConfiguration{
 					ConcurrentSyncs:  ptr.To(10),
 					SyncPeriod:       &v,
@@ -520,7 +520,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the token requestor controller configuration", func() {
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				TokenRequestorServiceAccount: &TokenRequestorServiceAccountControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -537,7 +537,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the token requestor controller configuration", func() {
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				TokenRequestorWorkloadIdentity: &TokenRequestorWorkloadIdentityControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -554,7 +554,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the VPA eviction requirements controller configuration", func() {
-			obj.Controllers = &GardenletControllerConfiguration{
+			obj.Controllers = GardenletControllerConfiguration{
 				VPAEvictionRequirements: &VPAEvictionRequirementsControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -639,7 +639,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the logging configuration", func() {
 			gardenValiStorage := resource.MustParse("10Gi")
-			expectedLogging := &Logging{
+			expectedLogging := Logging{
 				Enabled: ptr.To(true),
 				Vali: &Vali{
 					Enabled: ptr.To(false),
@@ -658,7 +658,7 @@ var _ = Describe("Defaults", func() {
 				},
 			}
 
-			obj.Logging = expectedLogging.DeepCopy()
+			obj.Logging = expectedLogging
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Logging).To(Equal(expectedLogging))
@@ -686,7 +686,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the SNI ingressgateway", func() {
-			obj.SNI = &SNI{
+			obj.SNI = SNI{
 				Ingress: &SNIIngress{
 					Namespace:   ptr.To("namespace"),
 					ServiceName: ptr.To("svc"),
@@ -720,7 +720,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the ETCD controller", func() {
-			obj.ETCDConfig = &ETCDConfig{
+			obj.ETCDConfig = ETCDConfig{
 				ETCDController: &ETCDController{Workers: ptr.To[int64](5)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -737,7 +737,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the ETCD custodian controller", func() {
-			obj.ETCDConfig = &ETCDConfig{
+			obj.ETCDConfig = ETCDConfig{
 				CustodianController: &CustodianController{Workers: ptr.To[int64](5)},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -758,7 +758,7 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for the ETCD backup compaction controller", func() {
 			v := metav1.Duration{Duration: 30 * time.Second}
-			obj.ETCDConfig = &ETCDConfig{
+			obj.ETCDConfig = ETCDConfig{
 				BackupCompactionController: &BackupCompactionController{
 					Workers:                   ptr.To[int64](4),
 					EnableBackupCompaction:    ptr.To(true),
@@ -852,7 +852,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for the shoot monitoring configuration", func() {
-			obj.Monitoring = &MonitoringConfig{
+			obj.Monitoring = MonitoringConfig{
 				&ShootMonitoringConfig{
 					Enabled: ptr.To(false),
 				}}

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -30,14 +30,11 @@ type GardenletConfiguration struct {
 	SeedClientConnection *SeedClientConnection `json:"seedClientConnection,omitempty"`
 	// ShootClientConnection specifies the client connection settings for the proxy server
 	// to use when communicating with the shoot apiserver.
-	// +optional
-	ShootClientConnection *ShootClientConnection `json:"shootClientConnection,omitempty"`
+	ShootClientConnection ShootClientConnection `json:"shootClientConnection"`
 	// Controllers defines the configuration of the controllers.
-	// +optional
-	Controllers *GardenletControllerConfiguration `json:"controllers,omitempty"`
+	Controllers GardenletControllerConfiguration `json:"controllers"`
 	// Resources defines the total capacity for seed resources and the amount reserved for use by Gardener.
-	// +optional
-	Resources *ResourcesConfiguration `json:"resources,omitempty"`
+	Resources ResourcesConfiguration `json:"resources"`
 	// LeaderElection defines the configuration of leader election client.
 	// +optional
 	LeaderElection *componentbaseconfigv1alpha1.LeaderElectionConfiguration `json:"leaderElection,omitempty"`
@@ -61,22 +58,18 @@ type GardenletConfiguration struct {
 	SeedConfig *SeedConfig `json:"seedConfig,omitempty"`
 	// Logging contains an optional configurations for the logging stack deployed
 	// by the Gardenlet in the seed clusters.
-	// +optional
-	Logging *Logging `json:"logging,omitempty"`
+	Logging Logging `json:"logging"`
 	// SNI contains an optional configuration for the SNI settings used
 	// by the Gardenlet in the seed clusters.
-	// +optional
-	SNI *SNI `json:"sni,omitempty"`
+	SNI SNI `json:"sni"`
 	// ETCDConfig contains an optional configuration for the
 	// backup compaction feature in etcdbr
-	// +optional
-	ETCDConfig *ETCDConfig `json:"etcdConfig,omitempty"`
+	ETCDConfig ETCDConfig `json:"etcdConfig"`
 	// ExposureClassHandlers is a list of optional of exposure class handlers.
 	// +optional
 	ExposureClassHandlers []ExposureClassHandler `json:"exposureClassHandlers,omitempty"`
 	// MonitoringConfig is optional and adds additional settings for the monitoring stack.
-	// +optional
-	Monitoring *MonitoringConfig `json:"monitoring,omitempty"`
+	Monitoring MonitoringConfig `json:"monitoring"`
 	// NodeToleration contains optional settings for default tolerations.
 	// +optional
 	NodeToleration *NodeToleration `json:"nodeToleration,omitempty"`

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -883,17 +883,15 @@ func autoConvert_v1alpha1_GardenletConfiguration_To_config_GardenletConfiguratio
 	} else {
 		out.SeedClientConnection = nil
 	}
-	if in.ShootClientConnection != nil {
-		in, out := &in.ShootClientConnection, &out.ShootClientConnection
-		*out = new(config.ShootClientConnection)
-		if err := Convert_v1alpha1_ShootClientConnection_To_config_ShootClientConnection(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ShootClientConnection = nil
+	if err := Convert_v1alpha1_ShootClientConnection_To_config_ShootClientConnection(&in.ShootClientConnection, &out.ShootClientConnection, s); err != nil {
+		return err
 	}
-	out.Controllers = (*config.GardenletControllerConfiguration)(unsafe.Pointer(in.Controllers))
-	out.Resources = (*config.ResourcesConfiguration)(unsafe.Pointer(in.Resources))
+	if err := Convert_v1alpha1_GardenletControllerConfiguration_To_config_GardenletControllerConfiguration(&in.Controllers, &out.Controllers, s); err != nil {
+		return err
+	}
+	if err := Convert_v1alpha1_ResourcesConfiguration_To_config_ResourcesConfiguration(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
 	if in.LeaderElection != nil {
 		in, out := &in.LeaderElection, &out.LeaderElection
 		*out = new(componentbaseconfig.LeaderElectionConfiguration)
@@ -927,11 +925,19 @@ func autoConvert_v1alpha1_GardenletConfiguration_To_config_GardenletConfiguratio
 	} else {
 		out.SeedConfig = nil
 	}
-	out.Logging = (*config.Logging)(unsafe.Pointer(in.Logging))
-	out.SNI = (*config.SNI)(unsafe.Pointer(in.SNI))
-	out.ETCDConfig = (*config.ETCDConfig)(unsafe.Pointer(in.ETCDConfig))
+	if err := Convert_v1alpha1_Logging_To_config_Logging(&in.Logging, &out.Logging, s); err != nil {
+		return err
+	}
+	if err := Convert_v1alpha1_SNI_To_config_SNI(&in.SNI, &out.SNI, s); err != nil {
+		return err
+	}
+	if err := Convert_v1alpha1_ETCDConfig_To_config_ETCDConfig(&in.ETCDConfig, &out.ETCDConfig, s); err != nil {
+		return err
+	}
 	out.ExposureClassHandlers = *(*[]config.ExposureClassHandler)(unsafe.Pointer(&in.ExposureClassHandlers))
-	out.Monitoring = (*config.MonitoringConfig)(unsafe.Pointer(in.Monitoring))
+	if err := Convert_v1alpha1_MonitoringConfig_To_config_MonitoringConfig(&in.Monitoring, &out.Monitoring, s); err != nil {
+		return err
+	}
 	out.NodeToleration = (*config.NodeToleration)(unsafe.Pointer(in.NodeToleration))
 	return nil
 }
@@ -960,17 +966,15 @@ func autoConvert_config_GardenletConfiguration_To_v1alpha1_GardenletConfiguratio
 	} else {
 		out.SeedClientConnection = nil
 	}
-	if in.ShootClientConnection != nil {
-		in, out := &in.ShootClientConnection, &out.ShootClientConnection
-		*out = new(ShootClientConnection)
-		if err := Convert_config_ShootClientConnection_To_v1alpha1_ShootClientConnection(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.ShootClientConnection = nil
+	if err := Convert_config_ShootClientConnection_To_v1alpha1_ShootClientConnection(&in.ShootClientConnection, &out.ShootClientConnection, s); err != nil {
+		return err
 	}
-	out.Controllers = (*GardenletControllerConfiguration)(unsafe.Pointer(in.Controllers))
-	out.Resources = (*ResourcesConfiguration)(unsafe.Pointer(in.Resources))
+	if err := Convert_config_GardenletControllerConfiguration_To_v1alpha1_GardenletControllerConfiguration(&in.Controllers, &out.Controllers, s); err != nil {
+		return err
+	}
+	if err := Convert_config_ResourcesConfiguration_To_v1alpha1_ResourcesConfiguration(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
 	if in.LeaderElection != nil {
 		in, out := &in.LeaderElection, &out.LeaderElection
 		*out = new(configv1alpha1.LeaderElectionConfiguration)
@@ -1004,11 +1008,19 @@ func autoConvert_config_GardenletConfiguration_To_v1alpha1_GardenletConfiguratio
 	} else {
 		out.SeedConfig = nil
 	}
-	out.Logging = (*Logging)(unsafe.Pointer(in.Logging))
-	out.SNI = (*SNI)(unsafe.Pointer(in.SNI))
-	out.ETCDConfig = (*ETCDConfig)(unsafe.Pointer(in.ETCDConfig))
+	if err := Convert_config_Logging_To_v1alpha1_Logging(&in.Logging, &out.Logging, s); err != nil {
+		return err
+	}
+	if err := Convert_config_SNI_To_v1alpha1_SNI(&in.SNI, &out.SNI, s); err != nil {
+		return err
+	}
+	if err := Convert_config_ETCDConfig_To_v1alpha1_ETCDConfig(&in.ETCDConfig, &out.ETCDConfig, s); err != nil {
+		return err
+	}
 	out.ExposureClassHandlers = *(*[]ExposureClassHandler)(unsafe.Pointer(&in.ExposureClassHandlers))
-	out.Monitoring = (*MonitoringConfig)(unsafe.Pointer(in.Monitoring))
+	if err := Convert_config_MonitoringConfig_To_v1alpha1_MonitoringConfig(&in.Monitoring, &out.Monitoring, s); err != nil {
+		return err
+	}
 	out.NodeToleration = (*NodeToleration)(unsafe.Pointer(in.NodeToleration))
 	return nil
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -431,21 +431,9 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 		*out = new(SeedClientConnection)
 		**out = **in
 	}
-	if in.ShootClientConnection != nil {
-		in, out := &in.ShootClientConnection, &out.ShootClientConnection
-		*out = new(ShootClientConnection)
-		**out = **in
-	}
-	if in.Controllers != nil {
-		in, out := &in.Controllers, &out.Controllers
-		*out = new(GardenletControllerConfiguration)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		*out = new(ResourcesConfiguration)
-		(*in).DeepCopyInto(*out)
-	}
+	out.ShootClientConnection = in.ShootClientConnection
+	in.Controllers.DeepCopyInto(&out.Controllers)
+	in.Resources.DeepCopyInto(&out.Resources)
 	if in.LeaderElection != nil {
 		in, out := &in.LeaderElection, &out.LeaderElection
 		*out = new(configv1alpha1.LeaderElectionConfiguration)
@@ -469,21 +457,9 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 		*out = new(SeedConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Logging != nil {
-		in, out := &in.Logging, &out.Logging
-		*out = new(Logging)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.SNI != nil {
-		in, out := &in.SNI, &out.SNI
-		*out = new(SNI)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.ETCDConfig != nil {
-		in, out := &in.ETCDConfig, &out.ETCDConfig
-		*out = new(ETCDConfig)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Logging.DeepCopyInto(&out.Logging)
+	in.SNI.DeepCopyInto(&out.SNI)
+	in.ETCDConfig.DeepCopyInto(&out.ETCDConfig)
 	if in.ExposureClassHandlers != nil {
 		in, out := &in.ExposureClassHandlers, &out.ExposureClassHandlers
 		*out = make([]ExposureClassHandler, len(*in))
@@ -491,11 +467,7 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Monitoring != nil {
-		in, out := &in.Monitoring, &out.Monitoring
-		*out = new(MonitoringConfig)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Monitoring.DeepCopyInto(&out.Monitoring)
 	if in.NodeToleration != nil {
 		in, out := &in.NodeToleration, &out.NodeToleration
 		*out = new(NodeToleration)

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
@@ -33,90 +33,80 @@ func SetObjectDefaults_GardenletConfiguration(in *GardenletConfiguration) {
 	if in.SeedClientConnection != nil {
 		SetDefaults_ClientConnectionConfiguration(&in.SeedClientConnection.ClientConnectionConfiguration)
 	}
-	if in.ShootClientConnection != nil {
-		SetDefaults_ClientConnectionConfiguration(&in.ShootClientConnection.ClientConnectionConfiguration)
+	SetDefaults_ClientConnectionConfiguration(&in.ShootClientConnection.ClientConnectionConfiguration)
+	SetDefaults_GardenletControllerConfiguration(&in.Controllers)
+	if in.Controllers.BackupBucket != nil {
+		SetDefaults_BackupBucketControllerConfiguration(in.Controllers.BackupBucket)
 	}
-	if in.Controllers != nil {
-		SetDefaults_GardenletControllerConfiguration(in.Controllers)
-		if in.Controllers.BackupBucket != nil {
-			SetDefaults_BackupBucketControllerConfiguration(in.Controllers.BackupBucket)
+	if in.Controllers.BackupEntry != nil {
+		SetDefaults_BackupEntryControllerConfiguration(in.Controllers.BackupEntry)
+	}
+	if in.Controllers.Bastion != nil {
+		SetDefaults_BastionControllerConfiguration(in.Controllers.Bastion)
+	}
+	if in.Controllers.ControllerInstallation != nil {
+		SetDefaults_ControllerInstallationControllerConfiguration(in.Controllers.ControllerInstallation)
+	}
+	if in.Controllers.ControllerInstallationCare != nil {
+		SetDefaults_ControllerInstallationCareControllerConfiguration(in.Controllers.ControllerInstallationCare)
+	}
+	if in.Controllers.ControllerInstallationRequired != nil {
+		SetDefaults_ControllerInstallationRequiredControllerConfiguration(in.Controllers.ControllerInstallationRequired)
+	}
+	if in.Controllers.Gardenlet != nil {
+		SetDefaults_GardenletObjectControllerConfiguration(in.Controllers.Gardenlet)
+	}
+	if in.Controllers.Seed != nil {
+		SetDefaults_SeedControllerConfiguration(in.Controllers.Seed)
+	}
+	if in.Controllers.SeedCare != nil {
+		SetDefaults_SeedCareControllerConfiguration(in.Controllers.SeedCare)
+	}
+	if in.Controllers.Shoot != nil {
+		SetDefaults_ShootControllerConfiguration(in.Controllers.Shoot)
+	}
+	if in.Controllers.ShootCare != nil {
+		SetDefaults_ShootCareControllerConfiguration(in.Controllers.ShootCare)
+		if in.Controllers.ShootCare.StaleExtensionHealthChecks != nil {
+			SetDefaults_StaleExtensionHealthChecks(in.Controllers.ShootCare.StaleExtensionHealthChecks)
 		}
-		if in.Controllers.BackupEntry != nil {
-			SetDefaults_BackupEntryControllerConfiguration(in.Controllers.BackupEntry)
-		}
-		if in.Controllers.Bastion != nil {
-			SetDefaults_BastionControllerConfiguration(in.Controllers.Bastion)
-		}
-		if in.Controllers.ControllerInstallation != nil {
-			SetDefaults_ControllerInstallationControllerConfiguration(in.Controllers.ControllerInstallation)
-		}
-		if in.Controllers.ControllerInstallationCare != nil {
-			SetDefaults_ControllerInstallationCareControllerConfiguration(in.Controllers.ControllerInstallationCare)
-		}
-		if in.Controllers.ControllerInstallationRequired != nil {
-			SetDefaults_ControllerInstallationRequiredControllerConfiguration(in.Controllers.ControllerInstallationRequired)
-		}
-		if in.Controllers.Gardenlet != nil {
-			SetDefaults_GardenletObjectControllerConfiguration(in.Controllers.Gardenlet)
-		}
-		if in.Controllers.Seed != nil {
-			SetDefaults_SeedControllerConfiguration(in.Controllers.Seed)
-		}
-		if in.Controllers.SeedCare != nil {
-			SetDefaults_SeedCareControllerConfiguration(in.Controllers.SeedCare)
-		}
-		if in.Controllers.Shoot != nil {
-			SetDefaults_ShootControllerConfiguration(in.Controllers.Shoot)
-		}
-		if in.Controllers.ShootCare != nil {
-			SetDefaults_ShootCareControllerConfiguration(in.Controllers.ShootCare)
-			if in.Controllers.ShootCare.StaleExtensionHealthChecks != nil {
-				SetDefaults_StaleExtensionHealthChecks(in.Controllers.ShootCare.StaleExtensionHealthChecks)
-			}
-		}
-		if in.Controllers.ShootState != nil {
-			SetDefaults_ShootStateControllerConfiguration(in.Controllers.ShootState)
-		}
-		if in.Controllers.NetworkPolicy != nil {
-			SetDefaults_NetworkPolicyControllerConfiguration(in.Controllers.NetworkPolicy)
-		}
-		if in.Controllers.ManagedSeed != nil {
-			SetDefaults_ManagedSeedControllerConfiguration(in.Controllers.ManagedSeed)
-		}
-		if in.Controllers.TokenRequestorServiceAccount != nil {
-			SetDefaults_TokenRequestorServiceAccountControllerConfiguration(in.Controllers.TokenRequestorServiceAccount)
-		}
-		if in.Controllers.TokenRequestorWorkloadIdentity != nil {
-			SetDefaults_TokenRequestorWorkloadIdentityControllerConfiguration(in.Controllers.TokenRequestorWorkloadIdentity)
-		}
-		if in.Controllers.VPAEvictionRequirements != nil {
-			SetDefaults_VPAEvictionRequirementsControllerConfiguration(in.Controllers.VPAEvictionRequirements)
-		}
+	}
+	if in.Controllers.ShootState != nil {
+		SetDefaults_ShootStateControllerConfiguration(in.Controllers.ShootState)
+	}
+	if in.Controllers.NetworkPolicy != nil {
+		SetDefaults_NetworkPolicyControllerConfiguration(in.Controllers.NetworkPolicy)
+	}
+	if in.Controllers.ManagedSeed != nil {
+		SetDefaults_ManagedSeedControllerConfiguration(in.Controllers.ManagedSeed)
+	}
+	if in.Controllers.TokenRequestorServiceAccount != nil {
+		SetDefaults_TokenRequestorServiceAccountControllerConfiguration(in.Controllers.TokenRequestorServiceAccount)
+	}
+	if in.Controllers.TokenRequestorWorkloadIdentity != nil {
+		SetDefaults_TokenRequestorWorkloadIdentityControllerConfiguration(in.Controllers.TokenRequestorWorkloadIdentity)
+	}
+	if in.Controllers.VPAEvictionRequirements != nil {
+		SetDefaults_VPAEvictionRequirementsControllerConfiguration(in.Controllers.VPAEvictionRequirements)
 	}
 	if in.LeaderElection != nil {
 		SetDefaults_LeaderElectionConfiguration(in.LeaderElection)
 	}
 	SetDefaults_ServerConfiguration(&in.Server)
-	if in.Logging != nil {
-		SetDefaults_Logging(in.Logging)
+	SetDefaults_Logging(&in.Logging)
+	SetDefaults_SNI(&in.SNI)
+	if in.SNI.Ingress != nil {
+		SetDefaults_SNIIngress(in.SNI.Ingress)
 	}
-	if in.SNI != nil {
-		SetDefaults_SNI(in.SNI)
-		if in.SNI.Ingress != nil {
-			SetDefaults_SNIIngress(in.SNI.Ingress)
-		}
+	SetDefaults_ETCDConfig(&in.ETCDConfig)
+	if in.ETCDConfig.ETCDController != nil {
+		SetDefaults_ETCDController(in.ETCDConfig.ETCDController)
 	}
-	if in.ETCDConfig != nil {
-		SetDefaults_ETCDConfig(in.ETCDConfig)
-		if in.ETCDConfig.ETCDController != nil {
-			SetDefaults_ETCDController(in.ETCDConfig.ETCDController)
-		}
-		if in.ETCDConfig.CustodianController != nil {
-			SetDefaults_CustodianController(in.ETCDConfig.CustodianController)
-		}
-		if in.ETCDConfig.BackupCompactionController != nil {
-			SetDefaults_BackupCompactionController(in.ETCDConfig.BackupCompactionController)
-		}
+	if in.ETCDConfig.CustodianController != nil {
+		SetDefaults_CustodianController(in.ETCDConfig.CustodianController)
+	}
+	if in.ETCDConfig.BackupCompactionController != nil {
+		SetDefaults_BackupCompactionController(in.ETCDConfig.BackupCompactionController)
 	}
 	for i := range in.ExposureClassHandlers {
 		a := &in.ExposureClassHandlers[i]
@@ -127,10 +117,8 @@ func SetObjectDefaults_GardenletConfiguration(in *GardenletConfiguration) {
 			}
 		}
 	}
-	if in.Monitoring != nil {
-		SetDefaults_MonitoringConfig(in.Monitoring)
-		if in.Monitoring.Shoot != nil {
-			SetDefaults_ShootMonitoringConfig(in.Monitoring.Shoot)
-		}
+	SetDefaults_MonitoringConfig(&in.Monitoring)
+	if in.Monitoring.Shoot != nil {
+		SetDefaults_ShootMonitoringConfig(in.Monitoring.Shoot)
 	}
 }

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -46,25 +46,23 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 		}
 	}
 
-	if cfg.Controllers != nil {
-		if cfg.Controllers.BackupEntry != nil {
-			allErrs = append(allErrs, validateBackupEntryControllerConfiguration(cfg.Controllers.BackupEntry, fldPath.Child("controllers", "backupEntry"))...)
-		}
-		if cfg.Controllers.Bastion != nil {
-			allErrs = append(allErrs, validateBastionControllerConfiguration(cfg.Controllers.Bastion, fldPath.Child("controllers", "bastion"))...)
-		}
-		if cfg.Controllers.Shoot != nil {
-			allErrs = append(allErrs, validateShootControllerConfiguration(cfg.Controllers.Shoot, fldPath.Child("controllers", "shoot"))...)
-		}
-		if cfg.Controllers.ShootCare != nil {
-			allErrs = append(allErrs, validateShootCareControllerConfiguration(cfg.Controllers.ShootCare, fldPath.Child("controllers", "shootCare"))...)
-		}
-		if cfg.Controllers.ManagedSeed != nil {
-			allErrs = append(allErrs, validateManagedSeedControllerConfiguration(cfg.Controllers.ManagedSeed, fldPath.Child("controllers", "managedSeed"))...)
-		}
-		if cfg.Controllers.NetworkPolicy != nil {
-			allErrs = append(allErrs, validateNetworkPolicyControllerConfiguration(cfg.Controllers.NetworkPolicy, fldPath.Child("controllers", "networkPolicy"))...)
-		}
+	if cfg.Controllers.BackupEntry != nil {
+		allErrs = append(allErrs, validateBackupEntryControllerConfiguration(cfg.Controllers.BackupEntry, fldPath.Child("controllers", "backupEntry"))...)
+	}
+	if cfg.Controllers.Bastion != nil {
+		allErrs = append(allErrs, validateBastionControllerConfiguration(cfg.Controllers.Bastion, fldPath.Child("controllers", "bastion"))...)
+	}
+	if cfg.Controllers.Shoot != nil {
+		allErrs = append(allErrs, validateShootControllerConfiguration(cfg.Controllers.Shoot, fldPath.Child("controllers", "shoot"))...)
+	}
+	if cfg.Controllers.ShootCare != nil {
+		allErrs = append(allErrs, validateShootCareControllerConfiguration(cfg.Controllers.ShootCare, fldPath.Child("controllers", "shootCare"))...)
+	}
+	if cfg.Controllers.ManagedSeed != nil {
+		allErrs = append(allErrs, validateManagedSeedControllerConfiguration(cfg.Controllers.ManagedSeed, fldPath.Child("controllers", "managedSeed"))...)
+	}
+	if cfg.Controllers.NetworkPolicy != nil {
+		allErrs = append(allErrs, validateNetworkPolicyControllerConfiguration(cfg.Controllers.NetworkPolicy, fldPath.Child("controllers", "networkPolicy"))...)
 	}
 
 	if cfg.LogLevel != "" {
@@ -88,21 +86,19 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 	}
 
 	resourcesPath := fldPath.Child("resources")
-	if cfg.Resources != nil {
-		for resourceName, quantity := range cfg.Resources.Capacity {
-			if reservedQuantity, ok := cfg.Resources.Reserved[resourceName]; ok && reservedQuantity.Value() > quantity.Value() {
-				allErrs = append(allErrs, field.Invalid(resourcesPath.Child("reserved", string(resourceName)), cfg.Resources.Reserved[resourceName], "reserved must be lower or equal to capacity"))
-			}
+	for resourceName, quantity := range cfg.Resources.Capacity {
+		if reservedQuantity, ok := cfg.Resources.Reserved[resourceName]; ok && reservedQuantity.Value() > quantity.Value() {
+			allErrs = append(allErrs, field.Invalid(resourcesPath.Child("reserved", string(resourceName)), cfg.Resources.Reserved[resourceName], "reserved must be lower or equal to capacity"))
 		}
-		for resourceName := range cfg.Resources.Reserved {
-			if _, ok := cfg.Resources.Capacity[resourceName]; !ok {
-				allErrs = append(allErrs, field.Invalid(resourcesPath.Child("reserved", string(resourceName)), cfg.Resources.Reserved[resourceName], "reserved without capacity"))
-			}
+	}
+	for resourceName := range cfg.Resources.Reserved {
+		if _, ok := cfg.Resources.Capacity[resourceName]; !ok {
+			allErrs = append(allErrs, field.Invalid(resourcesPath.Child("reserved", string(resourceName)), cfg.Resources.Reserved[resourceName], "reserved without capacity"))
 		}
 	}
 
 	sniPath := fldPath.Child("sni", "ingress")
-	if cfg.SNI != nil && cfg.SNI.Ingress != nil && cfg.SNI.Ingress.ServiceExternalIP != nil {
+	if cfg.SNI.Ingress != nil && cfg.SNI.Ingress.ServiceExternalIP != nil {
 		if ip := net.ParseIP(*cfg.SNI.Ingress.ServiceExternalIP); ip == nil {
 			allErrs = append(allErrs, field.Invalid(sniPath.Child("serviceExternalIP"), cfg.SNI.Ingress.ServiceExternalIP, "external service ip is invalid"))
 		}

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -31,7 +31,7 @@ var _ = Describe("GardenletConfiguration", func() {
 
 	BeforeEach(func() {
 		cfg = &config.GardenletConfiguration{
-			Controllers: &config.GardenletControllerConfiguration{
+			Controllers: config.GardenletControllerConfiguration{
 				BackupEntry: &config.BackupEntryControllerConfiguration{
 					DeletionGracePeriodHours:         &deletionGracePeriodHours,
 					DeletionGracePeriodShootPurposes: []gardencore.ShootPurpose{gardencore.ShootPurposeDevelopment},
@@ -95,7 +95,7 @@ var _ = Describe("GardenletConfiguration", func() {
 					},
 				},
 			},
-			Resources: &config.ResourcesConfiguration{
+			Resources: config.ResourcesConfiguration{
 				Capacity: corev1.ResourceList{
 					"foo": resource.MustParse("42"),
 					"bar": resource.MustParse("13"),
@@ -442,7 +442,7 @@ var _ = Describe("GardenletConfiguration", func() {
 
 		Context("resources", func() {
 			It("should forbid reserved greater than capacity", func() {
-				cfg.Resources = &config.ResourcesConfiguration{
+				cfg.Resources = config.ResourcesConfiguration{
 					Capacity: corev1.ResourceList{
 						"foo": resource.MustParse("42"),
 					},
@@ -460,7 +460,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 
 			It("should forbid reserved without capacity", func() {
-				cfg.Resources = &config.ResourcesConfiguration{
+				cfg.Resources = config.ResourcesConfiguration{
 					Reserved: corev1.ResourceList{
 						"foo": resource.MustParse("42"),
 					},
@@ -477,7 +477,7 @@ var _ = Describe("GardenletConfiguration", func() {
 
 		Context("sni", func() {
 			BeforeEach(func() {
-				cfg.SNI = &config.SNI{Ingress: &config.SNIIngress{}}
+				cfg.SNI = config.SNI{Ingress: &config.SNIIngress{}}
 			})
 
 			It("should pass as sni config contains a valid external service ip", func() {

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -431,21 +431,9 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 		*out = new(SeedClientConnection)
 		**out = **in
 	}
-	if in.ShootClientConnection != nil {
-		in, out := &in.ShootClientConnection, &out.ShootClientConnection
-		*out = new(ShootClientConnection)
-		**out = **in
-	}
-	if in.Controllers != nil {
-		in, out := &in.Controllers, &out.Controllers
-		*out = new(GardenletControllerConfiguration)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		*out = new(ResourcesConfiguration)
-		(*in).DeepCopyInto(*out)
-	}
+	out.ShootClientConnection = in.ShootClientConnection
+	in.Controllers.DeepCopyInto(&out.Controllers)
+	in.Resources.DeepCopyInto(&out.Resources)
 	if in.LeaderElection != nil {
 		in, out := &in.LeaderElection, &out.LeaderElection
 		*out = new(componentbaseconfig.LeaderElectionConfiguration)
@@ -469,21 +457,9 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 		*out = new(SeedConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Logging != nil {
-		in, out := &in.Logging, &out.Logging
-		*out = new(Logging)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.SNI != nil {
-		in, out := &in.SNI, &out.SNI
-		*out = new(SNI)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.ETCDConfig != nil {
-		in, out := &in.ETCDConfig, &out.ETCDConfig
-		*out = new(ETCDConfig)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Logging.DeepCopyInto(&out.Logging)
+	in.SNI.DeepCopyInto(&out.SNI)
+	in.ETCDConfig.DeepCopyInto(&out.ETCDConfig)
 	if in.ExposureClassHandlers != nil {
 		in, out := &in.ExposureClassHandlers, &out.ExposureClassHandlers
 		*out = make([]ExposureClassHandler, len(*in))
@@ -491,11 +467,7 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Monitoring != nil {
-		in, out := &in.Monitoring, &out.Monitoring
-		*out = new(MonitoringConfig)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Monitoring.DeepCopyInto(&out.Monitoring)
 	if in.NodeToleration != nil {
 		in, out := &in.NodeToleration, &out.NodeToleration
 		*out = new(NodeToleration)

--- a/pkg/gardenlet/controller/managedseed/add_test.go
+++ b/pkg/gardenlet/controller/managedseed/add_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Add", func() {
 
 		BeforeEach(func() {
 			cfg = config.GardenletConfiguration{
-				Controllers: &config.GardenletControllerConfiguration{
+				Controllers: config.GardenletControllerConfiguration{
 					ManagedSeed: &config.ManagedSeedControllerConfiguration{
 						SyncJitterPeriod: &metav1.Duration{Duration: 50 * time.Millisecond},
 					},

--- a/pkg/gardenlet/controller/managedseed/reconciler_test.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Reconciler", func() {
 		gardenClient.EXPECT().Status().Return(gardenStatusWriter).AnyTimes()
 
 		cfg = config.GardenletConfiguration{
-			Controllers: &config.GardenletControllerConfiguration{
+			Controllers: config.GardenletControllerConfiguration{
 				ManagedSeed: &config.ManagedSeedControllerConfiguration{
 					SyncPeriod:     &metav1.Duration{Duration: syncPeriod},
 					WaitSyncPeriod: &metav1.Duration{Duration: waitSyncPeriod},

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -478,7 +478,7 @@ func (r *Reconciler) newSystem(seed *gardencorev1beta1.Seed) (component.DeployWa
 
 func (r *Reconciler) newVali() (component.Deployer, error) {
 	var storage *resource.Quantity
-	if r.Config.Logging != nil && r.Config.Logging.Vali != nil && r.Config.Logging.Vali.Garden != nil {
+	if r.Config.Logging.Vali != nil && r.Config.Logging.Vali.Garden != nil {
 		storage = r.Config.Logging.Vali.Garden.Storage
 	}
 
@@ -723,7 +723,7 @@ func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface) (comp
 		r.GardenNamespace,
 		r.SeedVersion,
 		r.ComponentImageVectors,
-		r.Config.ETCDConfig,
+		&r.Config.ETCDConfig,
 		secretsManager,
 		v1beta1constants.SecretNameCASeed,
 		v1beta1constants.PriorityClassNameSeedSystem800,

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -165,7 +165,7 @@ func (r *Reconciler) updateStatusOperationStart(ctx context.Context, seed *garde
 
 	// Initialize capacity and allocatable
 	var capacity, allocatable corev1.ResourceList
-	if r.Config.Resources != nil && len(r.Config.Resources.Capacity) > 0 {
+	if len(r.Config.Resources.Capacity) > 0 {
 		capacity = make(corev1.ResourceList, len(r.Config.Resources.Capacity))
 		allocatable = make(corev1.ResourceList, len(r.Config.Resources.Capacity))
 

--- a/pkg/gardenlet/controller/shoot/care/add_test.go
+++ b/pkg/gardenlet/controller/shoot/care/add_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Add", func() {
 		reconciler = &Reconciler{
 			SeedName: "shoot",
 			Config: config.GardenletConfiguration{
-				Controllers: &config.GardenletControllerConfiguration{
+				Controllers: config.GardenletControllerConfiguration{
 					ShootCare: &config.ShootCareControllerConfiguration{
 						SyncPeriod: &metav1.Duration{Duration: time.Minute},
 					},

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Shoot Care Control", func() {
 			req = reconcile.Request{NamespacedName: client.ObjectKey{Namespace: shootNamespace, Name: shootName}}
 
 			gardenletConf = gardenletconfig.GardenletConfiguration{
-				Controllers: &gardenletconfig.GardenletControllerConfiguration{
+				Controllers: gardenletconfig.GardenletControllerConfiguration{
 					ShootCare: &gardenletconfig.ShootCareControllerConfiguration{
 						SyncPeriod: &metav1.Duration{Duration: careSyncPeriod},
 					},

--- a/pkg/gardenlet/controller/shoot/shoot/add_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot/add_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Add", func() {
 
 		cl = testclock.NewFakeClock(time.Now())
 		cfg = gardenletconfig.GardenletConfiguration{
-			Controllers: &gardenletconfig.GardenletControllerConfiguration{
+			Controllers: gardenletconfig.GardenletControllerConfiguration{
 				Shoot: &gardenletconfig.ShootControllerConfiguration{
 					SyncPeriod: &metav1.Duration{Duration: time.Hour},
 				},

--- a/pkg/gardenlet/operation/botanist/blackboxexporter_test.go
+++ b/pkg/gardenlet/operation/botanist/blackboxexporter_test.go
@@ -121,7 +121,7 @@ var _ = Describe("BlackboxExporter", func() {
 		Context("shoot monitoring is disabled in GardenletConfiguration", func() {
 			BeforeEach(func() {
 				botanist.Config = &config.GardenletConfiguration{
-					Monitoring: &config.MonitoringConfig{
+					Monitoring: config.MonitoringConfig{
 						Shoot: &config.ShootMonitoringConfig{
 							Enabled: ptr.To(false),
 						},

--- a/pkg/gardenlet/operation/botanist/dns_test.go
+++ b/pkg/gardenlet/operation/botanist/dns_test.go
@@ -52,7 +52,7 @@ var _ = Describe("dns", func() {
 		b = &Botanist{
 			Operation: &operation.Operation{
 				Config: &config.GardenletConfiguration{
-					Controllers: &config.GardenletControllerConfiguration{
+					Controllers: config.GardenletControllerConfiguration{
 						Shoot: &config.ShootControllerConfiguration{
 							DNSEntryTTLSeconds: &dnsEntryTTL,
 						},

--- a/pkg/gardenlet/operation/botanist/dnsrecord_test.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord_test.go
@@ -100,7 +100,7 @@ var _ = Describe("dnsrecord", func() {
 		b = &Botanist{
 			Operation: &operation.Operation{
 				Config: &config.GardenletConfiguration{
-					Controllers: &config.GardenletControllerConfiguration{
+					Controllers: config.GardenletControllerConfiguration{
 						Shoot: &config.ShootControllerConfiguration{
 							DNSEntryTTLSeconds: ptr.To(ttl),
 						},

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -100,7 +100,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 			backupLeaderElection         *config.ETCDBackupLeaderElection
 			deltaSnapshotRetentionPeriod *metav1.Duration
 		)
-		if b.Config != nil && b.Config.ETCDConfig != nil {
+		if b.Config != nil {
 			backupLeaderElection = b.Config.ETCDConfig.BackupLeaderElection
 			deltaSnapshotRetentionPeriod = b.Config.ETCDConfig.DeltaSnapshotRetentionPeriod
 		}

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Etcd", func() {
 					Provider: backupProvider,
 				}
 				botanist.Config = &gardenletconfig.GardenletConfiguration{
-					ETCDConfig: &gardenletconfig.ETCDConfig{
+					ETCDConfig: gardenletconfig.ETCDConfig{
 						BackupLeaderElection: backupLeaderElectionConfig,
 					},
 				}

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
@@ -98,7 +98,7 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			})
 
 			botanist.Config = &config.GardenletConfiguration{
-				SNI: &config.SNI{
+				SNI: config.SNI{
 					Ingress: &config.SNIIngress{
 						Namespace: ptr.To("istio-ingress"),
 						Labels:    map[string]string{"istio": "ingressgateway"},

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -53,7 +53,7 @@ func (b *Botanist) DestroySeedLogging(ctx context.Context) error {
 func (b *Botanist) isShootNodeLoggingEnabled() bool {
 	if b.Shoot != nil && !b.Shoot.IsWorkerless && b.Shoot.IsShootControlPlaneLoggingEnabled(b.Config) &&
 		gardenlethelper.IsValiEnabled(b.Config) && b.Config != nil &&
-		b.Config.Logging != nil && b.Config.Logging.ShootNodeLogging != nil {
+		b.Config.Logging.ShootNodeLogging != nil {
 		for _, purpose := range b.Config.Logging.ShootNodeLogging.ShootPurposes {
 			if gardencore.ShootPurpose(b.Shoot.Purpose) == purpose {
 				return true

--- a/pkg/gardenlet/operation/botanist/logging_test.go
+++ b/pkg/gardenlet/operation/botanist/logging_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Logging", func() {
 				SecretsManager: fakeSecretManager,
 				SeedClientSet:  k8sSeedClient,
 				Config: &config.GardenletConfiguration{
-					Logging: &config.Logging{
+					Logging: config.Logging{
 						Enabled: ptr.To(true),
 						Vali: &config.Vali{
 							Enabled: ptr.To(true),

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -79,7 +79,7 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		"ignoreAlerts":  strconv.FormatBool(b.Shoot.IgnoreAlerts),
 	}
 
-	if b.Config.Monitoring != nil && b.Config.Monitoring.Shoot != nil {
+	if b.Config.Monitoring.Shoot != nil {
 		externalLabels = utils.MergeStringMaps(externalLabels, b.Config.Monitoring.Shoot.ExternalLabels)
 	}
 
@@ -132,7 +132,7 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		}
 	}
 
-	if b.Config.Monitoring != nil && b.Config.Monitoring.Shoot != nil && b.Config.Monitoring.Shoot.RemoteWrite != nil {
+	if b.Config.Monitoring.Shoot != nil && b.Config.Monitoring.Shoot.RemoteWrite != nil {
 		values.RemoteWrite = &prometheus.RemoteWriteValues{
 			URL:                          b.Config.Monitoring.Shoot.RemoteWrite.URL,
 			KeptMetrics:                  b.Config.Monitoring.Shoot.RemoteWrite.Keep,

--- a/pkg/gardenlet/operation/botanist/nginxingress_test.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress_test.go
@@ -122,7 +122,7 @@ var _ = Describe("NginxIngress", func() {
 		b = &Botanist{
 			Operation: &operation.Operation{
 				Config: &config.GardenletConfiguration{
-					Controllers: &config.GardenletControllerConfiguration{
+					Controllers: config.GardenletControllerConfiguration{
 						Shoot: &config.ShootControllerConfiguration{
 							DNSEntryTTLSeconds: ptr.To(ttl),
 						},

--- a/pkg/gardenlet/operation/botanist/nodeexporter_test.go
+++ b/pkg/gardenlet/operation/botanist/nodeexporter_test.go
@@ -32,7 +32,7 @@ var _ = Describe("NodeExporter", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		botanist = &Botanist{Operation: &operation.Operation{
 			Config: &config.GardenletConfiguration{
-				Monitoring: &config.MonitoringConfig{
+				Monitoring: config.MonitoringConfig{
 					Shoot: &config.ShootMonitoringConfig{
 						Enabled: ptr.To(true),
 					},

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -146,7 +146,7 @@ var _ = Describe("operatingsystemconfig", func() {
 			It("should deploy successfully shoot logging components with non testing purpose", func() {
 				botanist.Shoot.Purpose = "development"
 				botanist.Config = &config.GardenletConfiguration{
-					Logging: &config.Logging{
+					Logging: config.Logging{
 						Enabled: ptr.To(true),
 						ShootNodeLogging: &config.ShootNodeLogging{
 							ShootPurposes: []gardencore.ShootPurpose{"evaluation", "development"},

--- a/pkg/gardenlet/operation/botanist/vpnseedserver_test.go
+++ b/pkg/gardenlet/operation/botanist/vpnseedserver_test.go
@@ -66,7 +66,7 @@ var _ = Describe("VPNSeedServer", func() {
 				KubernetesVersion: semver.MustParse("1.26.3"),
 			}
 			botanist.Config = &config.GardenletConfiguration{
-				SNI: &config.SNI{
+				SNI: config.SNI{
 					Ingress: &config.SNIIngress{
 						Namespace: ptr.To("test-ns"),
 						Labels: map[string]string{
@@ -135,7 +135,7 @@ var _ = Describe("VPNSeedServer", func() {
 				},
 			}
 			botanist.Config = &config.GardenletConfiguration{
-				SNI: &config.SNI{
+				SNI: config.SNI{
 					Ingress: &config.SNIIngress{
 						Namespace: ptr.To("test-ns"),
 						Labels: map[string]string{

--- a/pkg/gardenlet/operation/istio_config.go
+++ b/pkg/gardenlet/operation/istio_config.go
@@ -78,7 +78,7 @@ func (o *Operation) sniConfig() *gardenletconfig.SNI {
 	if exposureClassHandler := o.exposureClassHandler(); exposureClassHandler != nil {
 		return exposureClassHandler.SNI
 	}
-	return o.Config.SNI
+	return &o.Config.SNI
 }
 
 func (o *Operation) addZonePinningIfRequired(namespace string) string {

--- a/pkg/gardenlet/operation/istio_config_test.go
+++ b/pkg/gardenlet/operation/istio_config_test.go
@@ -34,7 +34,7 @@ var _ = Describe("istioconfig", func() {
 			exposureClassLabels        = map[string]string{"exposure": "label"}
 			exposureClassAnnotations   = map[string]string{"exposure": "annotation"}
 			gardenletConfig            = &config.GardenletConfiguration{
-				SNI: &config.SNI{Ingress: &config.SNIIngress{
+				SNI: config.SNI{Ingress: &config.SNIIngress{
 					ServiceName: &defaultServiceName,
 					Namespace:   &defaultNamespaceName,
 					Labels:      defaultLabels,

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -245,7 +245,7 @@ var _ = BeforeSuite(func() {
 		HelmRegistry:  fakeRegistry,
 		SeedClientSet: testClientSet,
 		Config: config.GardenletConfiguration{
-			Controllers: &config.GardenletControllerConfiguration{
+			Controllers: config.GardenletControllerConfiguration{
 				ControllerInstallation: &config.ControllerInstallationControllerConfiguration{
 					ConcurrentSyncs: ptr.To(5),
 				},

--- a/test/integration/gardenlet/gardenlet/gardenlet_suite_test.go
+++ b/test/integration/gardenlet/gardenlet/gardenlet_suite_test.go
@@ -205,7 +205,7 @@ var _ = BeforeSuite(func() {
 
 	By("Register controller")
 	cfg := config.GardenletConfiguration{
-		Controllers: &config.GardenletControllerConfiguration{
+		Controllers: config.GardenletControllerConfiguration{
 			Gardenlet: &config.GardenletObjectControllerConfiguration{
 				// This controller is pretty heavy-weight, so use a higher duration.
 				SyncPeriod: &metav1.Duration{Duration: time.Minute},

--- a/test/integration/gardenlet/managedseed/managedseed_suite_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_suite_test.go
@@ -202,7 +202,7 @@ var _ = BeforeSuite(func() {
 	shootClientMap = fakeclientmap.NewClientMapBuilder().WithClientSetForKey(keys.ForShoot(&gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: gardenNamespaceGarden.Name}}), testClientSet).Build()
 
 	cfg := config.GardenletConfiguration{
-		Controllers: &config.GardenletControllerConfiguration{
+		Controllers: config.GardenletControllerConfiguration{
 			ManagedSeed: &config.ManagedSeedControllerConfiguration{
 				WaitSyncPeriod:   &metav1.Duration{Duration: 5 * time.Millisecond},
 				ConcurrentSyncs:  ptr.To(5),

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -128,24 +128,24 @@ var _ = Describe("Seed controller tests", func() {
 		Expect((&seedcontroller.Reconciler{
 			SeedClientSet: testClientSet,
 			Config: config.GardenletConfiguration{
-				Controllers: &config.GardenletControllerConfiguration{
+				Controllers: config.GardenletControllerConfiguration{
 					Seed: &config.SeedControllerConfiguration{
 						// This controller is pretty heavy-weight, so use a higher duration.
 						SyncPeriod: &metav1.Duration{Duration: time.Minute},
 					},
 				},
-				SNI: &config.SNI{
+				SNI: config.SNI{
 					Ingress: &config.SNIIngress{
 						Namespace: ptr.To(testNamespace.Name + "-istio"),
 					},
 				},
-				Logging: &config.Logging{
+				Logging: config.Logging{
 					Enabled: ptr.To(true),
 					Vali: &config.Vali{
 						Enabled: ptr.To(true),
 					},
 				},
-				ETCDConfig: &config.ETCDConfig{
+				ETCDConfig: config.ETCDConfig{
 					BackupCompactionController: &config.BackupCompactionController{
 						EnableBackupCompaction: ptr.To(false),
 						EventsThreshold:        ptr.To[int64](1),

--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -257,7 +257,7 @@ var _ = BeforeSuite(func() {
 		SeedClientSet:  testClientSet,
 		ShootClientMap: shootClientMap,
 		Config: config.GardenletConfiguration{
-			Controllers: &config.GardenletControllerConfiguration{
+			Controllers: config.GardenletControllerConfiguration{
 				ShootCare: &config.ShootCareControllerConfiguration{
 					SyncPeriod: &metav1.Duration{Duration: 500 * time.Millisecond},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

Removed some of the unnecessary pointers in the logic for the GardenletConfig resource since it gets "defaulted" to an empty struct just a bit after creation.

**Which issue(s) this PR fixes**:
Fixes #10378 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
