### PR TITLE
Add check for using plain http on helm push only if registry is glgc

### DIFF
--- a/hack/push-helm.sh
+++ b/hack/push-helm.sh
@@ -33,7 +33,7 @@ yq -i ".name |= \"$name\"" "$chart_dir/Chart.yaml"
 helm package "$chart_dir" -d "$chart_dir" --version "$tag"
 
 if echo $registry | grep -q -F "garden.local.gardener.cloud:5001"; then
-    PUSH_HTTP="--plain-http"
+    push_http="--plain-http"
 fi 
 
-helm push $PUSH_HTTP "$chart_dir/$name-$tag.tgz" "oci://$registry"
+helm push $push_http "$chart_dir/$name-$tag.tgz" "oci://$registry"

--- a/hack/push-helm.sh
+++ b/hack/push-helm.sh
@@ -31,4 +31,9 @@ yq -i "$image_ref |= \"$IMG\"" "$chart_dir/values.yaml"
 yq -i ".name |= \"$name\"" "$chart_dir/Chart.yaml"
 
 helm package "$chart_dir" -d "$chart_dir" --version "$tag"
-helm push --plain-http "$chart_dir/$name-$tag.tgz" "oci://$registry"
+
+if echo $registry | grep -q -F "garden.local.gardener.cloud:5001"; then
+    PUSH_HTTP="--plain-http"
+fi 
+
+helm push $PUSH_HTTP "$chart_dir/$name-$tag.tgz" "oci://$registry"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression

**What this PR does / why we need it**:
Due to https://github.com/gardener/gardener/pull/10257, helm push is always called using plain http. This becomes an issue during the remote extensions setup since the registry is opened only on port 443. With this change, plain http is used only if the registry domain is garden.local.gardener.cloud:5001
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
