### PR TITLE
Fix `/etc/hosts` configuration in the remote local setup

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,7 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo yaml2json       && wget -N "https://github.com/bronze1man/yaml2json/releases/download/$(curl -sL https://api.github.com/repos/bronze1man/yaml2json/releases/latest | jq .tag_name -r)/yaml2json_linux_amd64" && cp yaml2json_linux_amd64 /usr/local/bin/yaml2json && chmod +x /usr/local/bin/yaml2json
           echo golang
                VERSION=$(curl -sL https://golang.org/VERSION?m=text | awk 'NR==1{print}')
                wget -N "https://go.dev/dl/$VERSION.linux-amd64.tar.gz"
@@ -78,6 +77,11 @@ spec:
           echo tmux-completion
                wget -N "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux"
                cp tmux /usr/share/bash-completion/completions/tmux
+          echo yaml2json
+               VERSION=$(curl -sL https://api.github.com/repos/bronze1man/yaml2json/releases/latest | jq '.tag_name // "v1.3.3"' -r)
+               wget -N "https://github.com/bronze1man/yaml2json/releases/download/$VERSION/yaml2json_linux_amd64"
+               cp yaml2json_linux_amd64 /usr/local/bin/yaml2json
+               chmod +x /usr/local/bin/yaml2json
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,8 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo gardenctl       && wget -N "https://github.com/gardener/gardenctl-v2/releases/download/$(curl -sL https://raw.githubusercontent.com/gardener/gardenctl-v2/master/LATEST)/gardenctl_v2_linux_amd64" && mv gardenctl_v2_linux_amd64 /usr/local/bin/gardenctl && chmod +x /usr/local/bin/gardenctl \
-                               && ln -s "$(which gardenctl)" /usr/local/bin/g
           echo kind            && wget -N "https://kind.sigs.k8s.io/dl/$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq .tag_name -r)/kind-linux-amd64" && cp kind-linux-amd64 /usr/local/bin/kind && chmod +x /usr/local/bin/kind
           echo kns             && wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/kns" && cp kns /usr/local/bin/kns && chmod +x /usr/local/bin/kns
           echo krew            && wget -N "https://github.com/kubernetes-sigs/krew/releases/download/$(curl -sL https://api.github.com/repos/kubernetes-sigs/krew/releases/latest | jq .tag_name -r)/krew-linux_amd64.tar.gz" && tar -xzf krew-linux_amd64.tar.gz ./krew-linux_amd64 && mv krew-linux_amd64 /usr/local/bin/krew && krew install krew
@@ -52,6 +50,12 @@ spec:
                cp gardenlogin_linux_amd64 /usr/local/bin/gardenlogin
                chmod +x /usr/local/bin/gardenlogin
                ln -s "$(which gardenlogin)" /usr/local/bin/kubectl-gardenlogin
+          echo gardenctl
+               VERSION=$(curl -sL https://raw.githubusercontent.com/gardener/gardenctl-v2/master/LATEST)
+               wget -N "https://github.com/gardener/gardenctl-v2/releases/download/$VERSION/gardenctl_v2_linux_amd64"
+               cp gardenctl_v2_linux_amd64 /usr/local/bin/gardenctl
+               chmod +x /usr/local/bin/gardenctl
+               ln -s "$(which gardenctl)" /usr/local/bin/g
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,11 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo golang          && VERSION=$(curl -sL https://golang.org/VERSION?m=text | awk 'NR==1{print}') \
-                               && wget -N "https://go.dev/dl/$VERSION.linux-amd64.tar.gz" \
-                               && tar -C /usr/local -xzf "$VERSION.linux-amd64.tar.gz" \
-                               && ln -s /usr/local/go/bin/go /usr/local/bin/go \
-                               && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
           echo gardenlogin     && wget -N "https://github.com/gardener/gardenlogin/releases/download/$(curl -sL https://raw.githubusercontent.com/gardener/gardenlogin/master/LATEST)/gardenlogin_linux_amd64" && mv gardenlogin_linux_amd64 /usr/local/bin/gardenlogin && chmod +x /usr/local/bin/gardenlogin \
                                && ln -s "$(which gardenlogin)" /usr/local/bin/kubectl-gardenlogin
           echo gardenctl       && wget -N "https://github.com/gardener/gardenctl-v2/releases/download/$(curl -sL https://raw.githubusercontent.com/gardener/gardenctl-v2/master/LATEST)/gardenctl_v2_linux_amd64" && mv gardenctl_v2_linux_amd64 /usr/local/bin/gardenctl && chmod +x /usr/local/bin/gardenctl \
@@ -47,6 +42,12 @@ spec:
                                && ln -s "$(which kubectl)" /usr/local/bin/k
           echo tmux-completion && wget -N "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" && cp tmux /usr/share/bash-completion/completions/tmux
           echo yaml2json       && wget -N "https://github.com/bronze1man/yaml2json/releases/download/$(curl -sL https://api.github.com/repos/bronze1man/yaml2json/releases/latest | jq .tag_name -r)/yaml2json_linux_amd64" && cp yaml2json_linux_amd64 /usr/local/bin/yaml2json && chmod +x /usr/local/bin/yaml2json
+          echo golang
+               VERSION=$(curl -sL https://golang.org/VERSION?m=text | awk 'NR==1{print}')
+               wget -N "https://go.dev/dl/$VERSION.linux-amd64.tar.gz"
+               tar -C /usr/local -xzf "$VERSION.linux-amd64.tar.gz"
+               ln -s /usr/local/go/bin/go /usr/local/bin/go
+               ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt  
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,7 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo tmux-completion && wget -N "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" && cp tmux /usr/share/bash-completion/completions/tmux
           echo yaml2json       && wget -N "https://github.com/bronze1man/yaml2json/releases/download/$(curl -sL https://api.github.com/repos/bronze1man/yaml2json/releases/latest | jq .tag_name -r)/yaml2json_linux_amd64" && cp yaml2json_linux_amd64 /usr/local/bin/yaml2json && chmod +x /usr/local/bin/yaml2json
           echo golang
                VERSION=$(curl -sL https://golang.org/VERSION?m=text | awk 'NR==1{print}')
@@ -76,6 +75,9 @@ spec:
                cp kubectl /usr/local/bin/kubectl
                chmod +x /usr/local/bin/kubectl
                ln -s "$(which kubectl)" /usr/local/bin/k
+          echo tmux-completion
+               wget -N "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux"
+               cp tmux /usr/share/bash-completion/completions/tmux
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,7 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo kind            && wget -N "https://kind.sigs.k8s.io/dl/$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq .tag_name -r)/kind-linux-amd64" && cp kind-linux-amd64 /usr/local/bin/kind && chmod +x /usr/local/bin/kind
           echo kns             && wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/kns" && cp kns /usr/local/bin/kns && chmod +x /usr/local/bin/kns
           echo krew            && wget -N "https://github.com/kubernetes-sigs/krew/releases/download/$(curl -sL https://api.github.com/repos/kubernetes-sigs/krew/releases/latest | jq .tag_name -r)/krew-linux_amd64.tar.gz" && tar -xzf krew-linux_amd64.tar.gz ./krew-linux_amd64 && mv krew-linux_amd64 /usr/local/bin/krew && krew install krew
           echo ktx             && wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/ktx" && cp ktx /usr/local/bin/ktx && chmod +x /usr/local/bin/ktx
@@ -56,6 +55,11 @@ spec:
                cp gardenctl_v2_linux_amd64 /usr/local/bin/gardenctl
                chmod +x /usr/local/bin/gardenctl
                ln -s "$(which gardenctl)" /usr/local/bin/g
+          echo kind
+               VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq '.tag_name // "v0.24.0"' -r)
+               wget -N "https://kind.sigs.k8s.io/dl/$VERSION/kind-linux-amd64"
+               cp kind-linux-amd64 /usr/local/bin/kind
+               chmod +x /usr/local/bin/kind
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,7 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo kns             && wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/kns" && cp kns /usr/local/bin/kns && chmod +x /usr/local/bin/kns
           echo krew            && wget -N "https://github.com/kubernetes-sigs/krew/releases/download/$(curl -sL https://api.github.com/repos/kubernetes-sigs/krew/releases/latest | jq .tag_name -r)/krew-linux_amd64.tar.gz" && tar -xzf krew-linux_amd64.tar.gz ./krew-linux_amd64 && mv krew-linux_amd64 /usr/local/bin/krew && krew install krew
           echo ktx             && wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/ktx" && cp ktx /usr/local/bin/ktx && chmod +x /usr/local/bin/ktx
           echo kube-ps1        && wget -N "https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh" && cp kube-ps1.sh ~/.kube-ps1.sh
@@ -60,6 +59,10 @@ spec:
                wget -N "https://kind.sigs.k8s.io/dl/$VERSION/kind-linux-amd64"
                cp kind-linux-amd64 /usr/local/bin/kind
                chmod +x /usr/local/bin/kind
+          echo kns
+               wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/kns"
+               cp kns /usr/local/bin/kns
+               chmod +x /usr/local/bin/kns
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,7 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo ktx             && wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/ktx" && cp ktx /usr/local/bin/ktx && chmod +x /usr/local/bin/ktx
           echo kube-ps1        && wget -N "https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh" && cp kube-ps1.sh ~/.kube-ps1.sh
           echo kubectl         && wget -N "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && cp kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl \
                                && ln -s "$(which kubectl)" /usr/local/bin/k
@@ -67,6 +66,10 @@ spec:
                wget -N "https://github.com/kubernetes-sigs/krew/releases/download/$VERSION/krew-linux_amd64.tar.gz"
                tar --no-same-owner -xzf krew-linux_amd64.tar.gz ./krew-linux_amd64
                mv krew-linux_amd64 /usr/local/bin/krew
+          echo ktx
+               wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/ktx"
+               cp ktx /usr/local/bin/ktx
+               chmod +x /usr/local/bin/ktx
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -61,6 +61,7 @@ spec:
                  api.e2e-{unpriv,mgr-hib,force-delete,fd-hib}.local.{internal,external}.local.gardener.cloud
             " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort      >> /etc/hosts
           echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
+          echo "127.0.0.1 garden.local.gardener.cloud"                >> /etc/hosts
 
           # Resolve e.g. gu-local--e2e-rotate{-wl}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:
           echo '

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -54,8 +54,12 @@ spec:
           echo stern           && go install github.com/stern/stern@latest
           echo neat            && krew install neat
           echo node-shell      && krew install node-shell
-          bash -c "echo {{p,g}-seed,{gu,p,v}-local--local}.ingress.local.seed.local.gardener.cloud api.{e2e-managedseed.garden,{local,e2e-{hib,hib-wl,unpriv,wake-up,wake-up-wl,migrate,migrate-wl,mgr-hib,rotate,rotate-wl,default,default-wl,force-delete,fd-hib,upd-node,upd-node-wl,upgrade,upgrade-wl,upg-hib,upg-hib-wl}}.local}.{internal,external}.local.gardener.cloud" \
-            | sed 's/ /\n/g' | sed 's/^/127.0.0.1 /' | sort >> /etc/hosts
+          bash -c "
+            echo {{p,g}-seed,{gu,p,v}-local--local}.ingress.local.seed.local.gardener.cloud \
+                 api.{e2e-managedseed.garden,local.local}.{internal,external}.local.gardener.cloud \
+                 api.e2e-{hib,upg-hib,wake-up,migrate,rotate,default,upd-node,upgrade}{,-wl}.local.{internal,external}.local.gardener.cloud \
+                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib}.local.{internal,external}.local.gardener.cloud
+            " | sed 's/ /\n/g' | sed 's/^/127.0.0.1 /' | sort         >> /etc/hosts
           echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
 
           # Resolve e.g. gu-local--e2e-rotate{-wl}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,7 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo kube-ps1        && wget -N "https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh" && cp kube-ps1.sh ~/.kube-ps1.sh
           echo kubectl         && wget -N "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && cp kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl \
                                && ln -s "$(which kubectl)" /usr/local/bin/k
           echo tmux-completion && wget -N "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" && cp tmux /usr/share/bash-completion/completions/tmux
@@ -70,6 +69,9 @@ spec:
                wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/ktx"
                cp ktx /usr/local/bin/ktx
                chmod +x /usr/local/bin/ktx
+          echo kube-ps1
+               wget -N "https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh"
+               cp kube-ps1.sh /usr/local/bin/kube-ps1.sh
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest
@@ -207,7 +209,7 @@ spec:
             source /usr/share/bash-completion/completions/gardenctl
             complete -o default -F __start_kubectl k
             complete -o default -F __start_gardenctl g
-            source ~/.kube-ps1.sh
+            source /usr/local/bin/kube-ps1.sh
             source /usr/share/git-core/git-prompt.sh
             export PS1='[\w $(printf "$(kube_ps1)")] $(__git_ps1 "(%s)") [$(date +%H:%M)]\$ '
             stty -ixon

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,8 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo kubectl         && wget -N "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && cp kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl \
-                               && ln -s "$(which kubectl)" /usr/local/bin/k
           echo tmux-completion && wget -N "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" && cp tmux /usr/share/bash-completion/completions/tmux
           echo yaml2json       && wget -N "https://github.com/bronze1man/yaml2json/releases/download/$(curl -sL https://api.github.com/repos/bronze1man/yaml2json/releases/latest | jq .tag_name -r)/yaml2json_linux_amd64" && cp yaml2json_linux_amd64 /usr/local/bin/yaml2json && chmod +x /usr/local/bin/yaml2json
           echo golang
@@ -72,6 +70,12 @@ spec:
           echo kube-ps1
                wget -N "https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh"
                cp kube-ps1.sh /usr/local/bin/kube-ps1.sh
+          echo kubectl
+               VERSION=$(curl -sL https://dl.k8s.io/release/stable.txt)
+               wget -N "https://dl.k8s.io/release/$VERSION/bin/linux/amd64/kubectl"
+               cp kubectl /usr/local/bin/kubectl
+               chmod +x /usr/local/bin/kubectl
+               ln -s "$(which kubectl)" /usr/local/bin/k
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,8 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo gardenlogin     && wget -N "https://github.com/gardener/gardenlogin/releases/download/$(curl -sL https://raw.githubusercontent.com/gardener/gardenlogin/master/LATEST)/gardenlogin_linux_amd64" && mv gardenlogin_linux_amd64 /usr/local/bin/gardenlogin && chmod +x /usr/local/bin/gardenlogin \
-                               && ln -s "$(which gardenlogin)" /usr/local/bin/kubectl-gardenlogin
           echo gardenctl       && wget -N "https://github.com/gardener/gardenctl-v2/releases/download/$(curl -sL https://raw.githubusercontent.com/gardener/gardenctl-v2/master/LATEST)/gardenctl_v2_linux_amd64" && mv gardenctl_v2_linux_amd64 /usr/local/bin/gardenctl && chmod +x /usr/local/bin/gardenctl \
                                && ln -s "$(which gardenctl)" /usr/local/bin/g
           echo kind            && wget -N "https://kind.sigs.k8s.io/dl/$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq .tag_name -r)/kind-linux-amd64" && cp kind-linux-amd64 /usr/local/bin/kind && chmod +x /usr/local/bin/kind
@@ -48,6 +46,12 @@ spec:
                tar -C /usr/local -xzf "$VERSION.linux-amd64.tar.gz"
                ln -s /usr/local/go/bin/go /usr/local/bin/go
                ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt  
+          echo gardenlogin
+               VERSION=$(curl -sL https://raw.githubusercontent.com/gardener/gardenlogin/master/LATEST)
+               wget -N "https://github.com/gardener/gardenlogin/releases/download/$VERSION/gardenlogin_linux_amd64"
+               cp gardenlogin_linux_amd64 /usr/local/bin/gardenlogin
+               chmod +x /usr/local/bin/gardenlogin
+               ln -s "$(which gardenlogin)" /usr/local/bin/kubectl-gardenlogin
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -29,7 +29,6 @@ spec:
                   util-linux vim wget yq
           mkdir -p ~/.cache/wget
           cd ~/.cache/wget
-          echo krew            && wget -N "https://github.com/kubernetes-sigs/krew/releases/download/$(curl -sL https://api.github.com/repos/kubernetes-sigs/krew/releases/latest | jq .tag_name -r)/krew-linux_amd64.tar.gz" && tar -xzf krew-linux_amd64.tar.gz ./krew-linux_amd64 && mv krew-linux_amd64 /usr/local/bin/krew && krew install krew
           echo ktx             && wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/ktx" && cp ktx /usr/local/bin/ktx && chmod +x /usr/local/bin/ktx
           echo kube-ps1        && wget -N "https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh" && cp kube-ps1.sh ~/.kube-ps1.sh
           echo kubectl         && wget -N "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && cp kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl \
@@ -63,6 +62,11 @@ spec:
                wget -N "https://raw.githubusercontent.com/blendle/kns/master/bin/kns"
                cp kns /usr/local/bin/kns
                chmod +x /usr/local/bin/kns
+          echo krew
+               VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/krew/releases/latest | jq '.tag_name // "v0.4.4"' -r)
+               wget -N "https://github.com/kubernetes-sigs/krew/releases/download/$VERSION/krew-linux_amd64.tar.gz"
+               tar --no-same-owner -xzf krew-linux_amd64.tar.gz ./krew-linux_amd64
+               mv krew-linux_amd64 /usr/local/bin/krew
           cd
           echo delve           && go install github.com/go-delve/delve/cmd/dlv@latest
           echo gron            && go install github.com/tomnomnom/gron@latest

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -59,7 +59,7 @@ spec:
                  api.{e2e-managedseed.garden,local.local}.{internal,external}.local.gardener.cloud \
                  api.e2e-{hib,upg-hib,wake-up,migrate,rotate,default,upd-node,upgrade}{,-wl}.local.{internal,external}.local.gardener.cloud \
                  api.e2e-{unpriv,mgr-hib,force-delete,fd-hib}.local.{internal,external}.local.gardener.cloud
-            " | sed 's/ /\n/g' | sed 's/^/127.0.0.1 /' | sort         >> /etc/hosts
+            " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort      >> /etc/hosts
           echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
 
           # Resolve e.g. gu-local--e2e-rotate{-wl}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR fixes the following two aspects from the remote local setup:

- Use `172.18.255.1` instead of `127.0.0.1` for the istio ingress (see [9b5d96c](https://github.com/gardener/gardener/commit/9b5d96c625d272338d174d4849bfd62ad7b85dfe)). Please note using `127.0.0.1` works in the remote local setup but `172.18.255.1` is more consistent with the official docs.
- Map `garden.local.gardener.cloud` to `127.0.0.1` (see [5e518bd](https://github.com/gardener/gardener/commit/5e518bdf5d005e9d9f75ec911cf7079500214e88)).

Additionally, the installation of binaries during startup now falls back to a default version in case of error.

**Special notes for your reviewer**:

/cc @istvanballok @rickardsjp @chrkl 

**Release note**:

```other developer
Fix `/etc/hosts` configuration in the remote local setup
```
