### PR TITLE
Fix TopologySpreadConstraints for `StatefulSet`s

### DIFF
--- a/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
+++ b/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
@@ -63,7 +63,7 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 			hpa         *autoscalingv2.HorizontalPodAutoscaler
 			hvpa        *hvpav1alpha1.Hvpa
 
-			labels = map[string]string{"foo": "bar"}
+			labels = map[string]string{"foo": "bar", "app": "foo"}
 			zones  = []string{"a", "b", "c"}
 		)
 
@@ -90,7 +90,7 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 			statefulSet = &appsv1.StatefulSet{
 				ObjectMeta: objectMeta,
 				Spec: appsv1.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: labels},
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
 					Replicas: ptr.To[int32](1),
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -555,8 +555,17 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 					})
 
 					Context("when replicas are >= 2", func() {
+						var labelSelector *metav1.LabelSelector
+
 						BeforeEach(func() {
 							setReplicas(ptr.To[int32](2))
+
+							switch o := getObj().(type) {
+							case *appsv1.Deployment:
+								labelSelector = &metav1.LabelSelector{MatchLabels: labels}
+							case *appsv1.StatefulSet:
+								labelSelector = o.Spec.Selector
+							}
 						})
 
 						Context("when failure-tolerance-type is empty", func() {
@@ -566,7 +575,7 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 										TopologyKey:       corev1.LabelHostname,
 										MaxSkew:           1,
 										WhenUnsatisfiable: corev1.ScheduleAnyway,
-										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+										LabelSelector:     labelSelector,
 									}))
 								})
 							})
@@ -583,14 +592,14 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 												TopologyKey:       corev1.LabelHostname,
 												MaxSkew:           1,
 												WhenUnsatisfiable: corev1.ScheduleAnyway,
-												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+												LabelSelector:     labelSelector,
 											},
 											corev1.TopologySpreadConstraint{
 												TopologyKey:       corev1.LabelTopologyZone,
 												MaxSkew:           1,
 												MinDomains:        ptr.To[int32](2),
 												WhenUnsatisfiable: corev1.DoNotSchedule,
-												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+												LabelSelector:     labelSelector,
 											},
 										))
 									})
@@ -604,19 +613,19 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 													TopologyKey:       "some-key",
 													MaxSkew:           12,
 													WhenUnsatisfiable: corev1.DoNotSchedule,
-													LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+													LabelSelector:     labelSelector,
 												},
 												{
 													TopologyKey:       corev1.LabelHostname,
 													MaxSkew:           34,
 													WhenUnsatisfiable: corev1.DoNotSchedule,
-													LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+													LabelSelector:     labelSelector,
 												},
 												{
 													TopologyKey:       corev1.LabelTopologyZone,
 													MaxSkew:           56,
 													WhenUnsatisfiable: corev1.ScheduleAnyway,
-													LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+													LabelSelector:     labelSelector,
 												},
 											}
 										})
@@ -628,20 +637,20 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 												TopologyKey:       "some-key",
 												MaxSkew:           12,
 												WhenUnsatisfiable: corev1.DoNotSchedule,
-												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+												LabelSelector:     labelSelector,
 											},
 											corev1.TopologySpreadConstraint{
 												TopologyKey:       corev1.LabelHostname,
 												MaxSkew:           1,
 												WhenUnsatisfiable: corev1.ScheduleAnyway,
-												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+												LabelSelector:     labelSelector,
 											},
 											corev1.TopologySpreadConstraint{
 												TopologyKey:       corev1.LabelTopologyZone,
 												MaxSkew:           1,
 												MinDomains:        ptr.To[int32](2),
 												WhenUnsatisfiable: corev1.DoNotSchedule,
-												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+												LabelSelector:     labelSelector,
 											},
 										))
 									})
@@ -661,7 +670,7 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 										MinDomains:        ptr.To[int32](2),
 										MaxSkew:           1,
 										WhenUnsatisfiable: corev1.DoNotSchedule,
-										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+										LabelSelector:     labelSelector,
 									}))
 								})
 							})
@@ -678,7 +687,7 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 											MinDomains:        ptr.To[int32](2),
 											MaxSkew:           1,
 											WhenUnsatisfiable: corev1.DoNotSchedule,
-											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+											LabelSelector:     labelSelector,
 										},
 									))
 								})
@@ -710,14 +719,14 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 											TopologyKey:       corev1.LabelHostname,
 											MaxSkew:           1,
 											WhenUnsatisfiable: corev1.ScheduleAnyway,
-											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+											LabelSelector:     labelSelector,
 										},
 										corev1.TopologySpreadConstraint{
 											TopologyKey:       corev1.LabelTopologyZone,
 											MaxSkew:           1,
 											MinDomains:        minDomains,
 											WhenUnsatisfiable: corev1.DoNotSchedule,
-											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+											LabelSelector:     labelSelector,
 										},
 									))
 								})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes Fix TopologySpreadConstraints for `StatefulSet`s.

Several occurrences were observed in the past, that led to `Pending` etcd pods after upgrading to HA because additional labels were assigned to the pods (e.g. `networking.resources.gardener.cloud/to-etcd-main-client-tcp-2380: allowed`).
If TSCs consider all (new) pod labels in the upgrade step, then there are still pods **during** the rolling update that haven't gotten the new labels yet (e.g. `etcd-main-0`) and thus are not selected/considered by the TSCs.

See https://github.com/gardener/etcd-druid/issues/899 for more information.

**Special notes for your reviewer**:
`Deployment`s are not affected and not adjusted in this PR to prevent rolling updates of nearly all components.

/cc @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The TopologySpreadConstraints calculation was improved for `StatefulSet`s to always use a stable label selector. This led to issues in the past when shoots were upgraded to HA.
```
