### PR TITLE
Fix Prometheus rule `shoot-kube-proxy` (kube-proxy.rules)

### DIFF
--- a/pkg/component/kubernetes/proxy/proxy.go
+++ b/pkg/component/kubernetes/proxy/proxy.go
@@ -163,17 +163,17 @@ func (k *kubeProxy) Deploy(ctx context.Context) error {
 					},
 					{
 						Record: "kubeproxy_sync_proxy:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.99, sum(rate("kubeproxy_sync_proxy_rules_duration_seconds_bucket"[10m])) by (le))`),
+						Expr:   intstr.FromString(`histogram_quantile(0.99, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))`),
 						Labels: map[string]string{"quantile": "0.99"},
 					},
 					{
 						Record: "kubeproxy_sync_proxy:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.9, sum(rate("kubeproxy_sync_proxy_rules_duration_seconds_bucket"[10m])) by (le))`),
+						Expr:   intstr.FromString(`histogram_quantile(0.9, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))`),
 						Labels: map[string]string{"quantile": "0.9"},
 					},
 					{
 						Record: "kubeproxy_sync_proxy:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.5, sum(rate("kubeproxy_sync_proxy_rules_duration_seconds_bucket"[10m])) by (le))`),
+						Expr:   intstr.FromString(`histogram_quantile(0.5, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))`),
 						Labels: map[string]string{"quantile": "0.5"},
 					},
 				},

--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -215,17 +215,17 @@ var _ = Describe("KubeProxy", func() {
 						},
 						{
 							Record: "kubeproxy_sync_proxy:quantile",
-							Expr:   intstr.FromString(`histogram_quantile(0.99, sum(rate("kubeproxy_sync_proxy_rules_duration_seconds_bucket"[10m])) by (le))`),
+							Expr:   intstr.FromString(`histogram_quantile(0.99, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))`),
 							Labels: map[string]string{"quantile": "0.99"},
 						},
 						{
 							Record: "kubeproxy_sync_proxy:quantile",
-							Expr:   intstr.FromString(`histogram_quantile(0.9, sum(rate("kubeproxy_sync_proxy_rules_duration_seconds_bucket"[10m])) by (le))`),
+							Expr:   intstr.FromString(`histogram_quantile(0.9, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))`),
 							Labels: map[string]string{"quantile": "0.9"},
 						},
 						{
 							Record: "kubeproxy_sync_proxy:quantile",
-							Expr:   intstr.FromString(`histogram_quantile(0.5, sum(rate("kubeproxy_sync_proxy_rules_duration_seconds_bucket"[10m])) by (le))`),
+							Expr:   intstr.FromString(`histogram_quantile(0.5, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))`),
 							Labels: map[string]string{"quantile": "0.5"},
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
With quotation marks, we get the error `Error executing query: invalid parameter "query": 1:86: parse error: ranges only allowed for vector selectors` and the prometheus-controller keeps posting cluster events with the error message `PrometheusRule shoot-kube-proxy was rejected due to invalid configuration: Invalid rule`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix Prometheus rule `shoot-kube-proxy`.
```
