### PR TITLE
Fix index out of range error in access restriction handling

### DIFF
--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -394,6 +394,9 @@ func syncLegacyAccessRestrictionLabelWithNewFieldOnUpdate(shoot, oldShoot *core.
 
 	updateOptionInAccessRestrictions := func(accessRestrictions []core.AccessRestrictionWithOptions, key, value string) {
 		i := slices.IndexFunc(accessRestrictions, filterEUAccessOnlyRestriction)
+		if i == -1 {
+			return
+		}
 		if accessRestrictions[i].Options == nil {
 			accessRestrictions[i].Options = make(map[string]string)
 		}
@@ -401,7 +404,11 @@ func syncLegacyAccessRestrictionLabelWithNewFieldOnUpdate(shoot, oldShoot *core.
 	}
 
 	removeOptionFromAccessRestrictions := func(accessRestrictions []core.AccessRestrictionWithOptions, key string) {
-		delete(accessRestrictions[slices.IndexFunc(accessRestrictions, filterEUAccessOnlyRestriction)].Options, key)
+		i := slices.IndexFunc(accessRestrictions, filterEUAccessOnlyRestriction)
+		if i == -1 {
+			return
+		}
+		delete(accessRestrictions[i].Options, key)
 	}
 
 	hasOptionInAccessRestrictions := func(accessRestrictions []core.AccessRestrictionWithOptions, option string) bool {

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -787,6 +787,18 @@ var _ = Describe("Strategy", func() {
 					"support.gardener.cloud/eu-access-for-cluster-nodes":  "false",
 				}))
 			})
+
+			It("should gracefully handle a missing access restriction when attempting to remove an option from the annotations", func() {
+				oldShoot.Annotations = map[string]string{
+					"support.gardener.cloud/eu-access-for-cluster-addons": "true",
+				}
+				newShoot.Annotations = map[string]string{}
+
+				strategy.PrepareForUpdate(context.Background(), newShoot, oldShoot)
+
+				Expect(newShoot.Spec.AccessRestrictions).To(BeEmpty())
+				Expect(newShoot.Annotations).NotTo(HaveKey("support.gardener.cloud/eu-access-for-cluster-addons"))
+			})
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in the `removeOptionFromAccessRestrictions` and related functions where missing checks for `slices.IndexFunc` could cause `index out of range` runtime errors if the target element was not found.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a fix for currently unreleased code, introduced with https://github.com/gardener/gardener/pull/10654

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
