### PR TITLE
Prevent reconciling `BackupEntries` between migration and reconciliation

### DIFF
--- a/pkg/gardenlet/controller/backupentry/add.go
+++ b/pkg/gardenlet/controller/backupentry/add.go
@@ -64,7 +64,8 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, gard
 				&gardencorev1beta1.BackupEntry{},
 				&handler.EnqueueRequestForObject{},
 				&predicate.GenerationChangedPredicate{},
-				predicateutils.SeedNamePredicate(r.SeedName, gardenerutils.GetBackupEntrySeedNames)),
+				predicateutils.SeedNamePredicate(r.SeedName, gardenerutils.GetBackupEntrySeedNames),
+				predicate.NewPredicateFuncs(restoreAfterMigratePredicate())),
 		).
 		Build(r)
 	if err != nil {
@@ -102,7 +103,7 @@ func (r *Reconciler) MapBackupBucketToBackupEntry(ctx context.Context, log logr.
 		return nil
 	}
 
-	return mapper.ObjectListToRequests(backupEntryList)
+	return mapper.ObjectListToRequests(backupEntryList, restoreAfterMigratePredicate())
 }
 
 // MapExtensionBackupEntryToCoreBackupEntry is a mapper.MapFunc for mapping a extensions.gardener.cloud/v1alpha1.BackupEntry to the owning
@@ -137,4 +138,25 @@ func getBackupBucketLastOperation(obj client.Object) *gardencorev1beta1.LastOper
 	}
 
 	return backupBucket.Status.LastOperation
+}
+
+// restoreAfterMigratePredicate returns a predicate which returns false if the core.gardener.cloud/v1beta1.BackupEntry has been
+// successfully migrated and does not have the `gardener.cloud/operation: restore` annotation.
+// It returns true in all other cases.
+func restoreAfterMigratePredicate() func(obj client.Object) bool {
+	return func(obj client.Object) bool {
+		backupEntry, ok := obj.(*gardencorev1beta1.BackupEntry)
+		if !ok {
+			return false
+		}
+
+		isMigrateSucceeded := backupEntry.Status.LastOperation != nil && backupEntry.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded && backupEntry.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate
+		hasRestoreAnnotation := backupEntry.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore
+
+		if !isMigrateSucceeded || hasRestoreAnnotation {
+			return true
+		}
+
+		return false
+	}
 }


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue that was causing the `core.gardener.cloud/v1beta1.BackupEntry` to be reconciled on the destination Seed after being successfully migrated from the source Seed, but before being restored.

The issue was occurring because `core.gardener.cloud/v1beta1.BackupEntry`s were enqueued for reconciliation when the corresponding `core.gardener.cloud/BackupBuckets` was reconciled successfully. Since `gardenlet`s on all Seeds watch for operation changes of all `core.gardener.cloud/BackupBuckets` as part of the following watch: https://github.com/gardener/gardener/blob/5417a7bbb3adab9d192abd8e8e2ac4b7fe7c9a2d/pkg/gardenlet/controller/backupentry/add.go#L83-L88

This resulted in the corresponding `core.gardener.cloud/v1beta1.BackupEntry`s to get enqueued on all `gardenlet`s. The reconciliations then end early due to this check: https://github.com/gardener/gardener/blob/5417a7bbb3adab9d192abd8e8e2ac4b7fe7c9a2d/pkg/gardenlet/controller/backupentry/reconciler.go#L86-L89

However, if the  `core.gardener.cloud/v1beta1.BackupEntry` is already migrated, the check above would pass on the destination seed, and reconciliation would continue.

With this PR we prevent enqueueing `core.gardener.cloud/v1beta1.BackupEntry` if they were successfully migrated, but not yet annotated with `gardener.cloud/operation: restore`. Additionally, this prevents a reconciliation on the destination seed if the `gardenlet` there is restarted  after `core.gardener.cloud/v1beta1.BackupEntry` was successfully migrated.

**Which issue(s) this PR fixes**:
Fixes #10718 
Fixes #10527 

**Special notes for your reviewer**:
/cc @shafeeqes @adenitiu 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue that that could occur during control plane migration causing the `core.gardener.cloud/v1beta1.BackupEntry` to be reconciled after it was successfully migrated, but before it was restored.
```
