### PR TITLE
Several `renovate` tuning measurements

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -78,14 +78,6 @@
       "matchPackagePatterns": ["gcr\\.io\/istio-release\/.+"],
     },
     {
-      // Group etcd-druid image updates in one PR.
-      "groupName": "etcd-druid images",
-      "matchPackagePatterns": [
-        "github.com/gardener/etcd-druid",
-        "gardener/etcd-druid"
-      ],
-    },
-    {
       // Group istio module updates in one PR.
       "groupName": "istio modules",
       "matchDatasources": ["go"],
@@ -95,10 +87,21 @@
       ],
     },
     {
+      // Group etcd-druid updates in one PR.
+      "groupName": "etcd-druid",
+      "matchDatasources": ["github-releases", "go"],
+      "matchPackagePatterns": [
+        "github\\.com\/gardener\/etcd-druid",
+        "gardener\/etcd-druid"
+      ],
+    },
+    {
       // Group prometheus-operator image updates in one PR.
       "groupName": "prometheus-operator images",
-      "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["quay\\.io\/prometheus-operator\/.+"],
+      "matchDatasources": ["docker", "go"],
+      "matchPackagePatterns": [
+        "quay\\.io\/prometheus-operator\/.+",
+        "github\\.com\/prometheus-operator\/prometheus-operator\/pkg\/apis\/.+"]
     },
     {
       // Ask for manual approval to create PRs for minor and major updates of dependencies which most likely

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,20 @@
   "separateMinorPatch": true,
   "packageRules": [
     {
+      // Run make generate when Go API packages have been changed because CRDs might have changed.
+      "matchDatasources": ["go"],
+      "matchPackagePatterns": [
+        ".+\/api\/.+",
+        ".+\/apis\/.+"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "make generate MODE=sequential"
+        ],
+        "executionMode": "branch"
+      }
+    },
+    {
       // Group golang updates in one PR.
       "groupName": "golang",
       "matchDatasources": ["docker"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -125,6 +125,8 @@
       "matchPackagePatterns": [
         "fluent\/.+",
         "gcr\\.io\/istio-release\/.+",
+        // valitail updates have a hard dependency on glibc version of the target nodes.
+        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/credativ\/valitail",
       ],
       "dependencyDashboardApproval": true
     },
@@ -180,15 +182,6 @@
       "excludePackagePatterns": [
         "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/alpine",
         "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/kubernetesui\/.+"
-      ],
-      "enabled": false
-    },
-    {
-      // Exclude valitail updates due to hard dependency on glibc version of the target nodes.
-      "matchDatasources": ["docker"],
-      "matchFileNames": ["imagevector/**"],
-      "matchPackagePatterns": [
-        "europe-docker\\.pkg\\.dev\/gardener-project\/releases\/3rd\/credativ\/valitail"
       ],
       "enabled": false
     },


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR includes several `renovate` tuning measurements:
- Group prometheus PRs + update etcd-druid grouping
- Change `valitail` updates from disabled to manual as we do it for all other update which require manual interaction
- Run `make generate` when Go API packages have been changed to (hopefully) generate CRDs.

I'm not sure whether the latter change works. I switched to `sequential` mode because the renovate container does not have `parallel`. The other stuff might be installed automatically.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
