### PR TITLE
add constants api to importas linter

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -161,6 +161,8 @@ linters-settings:
         alias: gardencore${1}
       - pkg: github.com/gardener/gardener/pkg/apis/core/([\w\d]+)/helper
         alias: ${1}helper
+      - pkg: github.com/gardener/gardener/pkg/apis/core/([\w\d]+)/constants
+        alias: ${1}constants
       - pkg: github.com/gardener/gardener/pkg/apis/([^c]\w+)/([\w\d]+)
         alias: $1$2
       - pkg: github.com/gardener/gardener/pkg/apis/([^c]\w+)/([\w\d]+)/([\w\d]+)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:

During development I noticed the linter didn't recognize my wrongly named import for gardener api constants. I checked the config and saw that the `constants` package was missing from the `importas` linter config. This PR fixes that.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
