### PR TITLE
Pin valitail version to v2.2.15

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -580,7 +580,8 @@ images:
 - name: valitail
   sourceRepository: github.com/credativ/vali
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/valitail
-  tag: "v2.2.19"
+  # Do not update valitail version due to hard dependency on glibc version of the target nodes.
+  tag: "v2.2.15"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/10278 was overwritten in https://github.com/gardener/gardener/pull/10292. Hence, it caused the same problems described in https://github.com/gardener/gardener/pull/10278.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
valitail version is now pinned to v2.2.15 (depends on glibc 2.32).
```
