### PR TITLE
Add `--exclude-dirs` and `--report-dir` flags to `sast.sh`

### DIFF
--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+report_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 
 gosec_report="false"
 gosec_report_parse_flags=""
@@ -17,6 +17,9 @@ parse_flags() {
     case "$1" in
       --gosec-report)
         shift; gosec_report="$1"
+        ;;
+      --report-dir)
+        shift; report_dir="$1"
         ;;
       --exclude-dirs)
         shift; exclude_dirs="${exclude_dirs},${1}"
@@ -35,7 +38,7 @@ parse_flags "$@"
 echo "> Running gosec"
 gosec --version
 if [[ "$gosec_report" != "false" ]]; then
-  echo "Exporting report to $root_dir/gosec-report.sarif"
+  echo "Exporting report to $report_dir/gosec-report.sarif"
   gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
 fi
 

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -10,12 +10,16 @@ root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 
 gosec_report="false"
 gosec_report_parse_flags=""
+exclude_dirs="hack"
 
 parse_flags() {
   while test $# -gt 1; do
     case "$1" in
       --gosec-report)
         shift; gosec_report="$1"
+        ;;
+      --exclude-dirs)
+        shift; exclude_dirs="${exclude_dirs},${1}"
         ;;
       *)
         echo "Unknown argument: $1"
@@ -41,4 +45,4 @@ fi
 # Thus, generated code is excluded from gosec scan.
 # Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
 # is excluded too. It does not contain productive code anyway.
-gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...
+gosec -exclude-generated $(echo "$exclude_dirs" | awk -v RS=',' '{printf "-exclude-dir %s ", $1}') $gosec_report_parse_flags ./...

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-report_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+report_dir="$(git rev-parse --show-toplevel)"
 
 gosec_report="false"
 gosec_report_parse_flags=""
@@ -22,7 +22,7 @@ parse_flags() {
         shift; report_dir="$1"
         ;;
       --exclude-dirs)
-        shift; exclude_dirs="${exclude_dirs},${1}"
+        shift; exclude_dirs="$1"
         ;;
       *)
         echo "Unknown argument: $1"
@@ -38,8 +38,8 @@ parse_flags "$@"
 echo "> Running gosec"
 gosec --version
 if [[ "$gosec_report" != "false" ]]; then
-  echo "Exporting report to $report_dir/gosec-report.sarif"
-  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+  echo "Exporting report to ${report_dir}/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=${report_dir}/gosec-report.sarif -stdout"
 fi
 
 # Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR adds `--exclude-dirs` and `--report-dir` flags to `sast.sh`
Example usage:
```
./hack/sast.sh --exclude-dirs pkg,test,cmd,third_party --report-dir /foo
```

**Special notes for your reviewer**:
You can validate the PR by changing the `Makefile` to
```
.PHONY: sast
sast: $(GOSEC)
	@./hack/sast.sh --exclude-dirs pkg,test,cmd,third_party
```
running `make sast` and taking a look at the logs

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `hack/sast.sh` script accepts two new optional flags:
- `--exclude-dirs`: comma-separated list of dirs to exclude
- `--report-dir`: where to store the gosec report
```
