### PR TITLE
dual stack support for vpn component

### DIFF
--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -134,6 +134,18 @@ var _ = Describe("VpnSeedServer", func() {
 									Value: nodes,
 								},
 								{
+									Name:  "SERVICE_NETWORKS",
+									Value: values.Network.ServiceCIDRs[0].String(),
+								},
+								{
+									Name:  "POD_NETWORKS",
+									Value: values.Network.PodCIDRs[0].String(),
+								},
+								{
+									Name:  "NODE_NETWORKS",
+									Value: nodes,
+								},
+								{
 									Name: "LOCAL_NODE_IP",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{
@@ -356,11 +368,6 @@ var _ = Describe("VpnSeedServer", func() {
 					exporterContainer.Env = nil
 				}
 				template.Spec.Containers = append(template.Spec.Containers, exporterContainer)
-				template.Spec.Containers[0].Ports = append(template.Spec.Containers[0].Ports, corev1.ContainerPort{
-					Name:          "metrics",
-					ContainerPort: 15000,
-					Protocol:      corev1.ProtocolTCP,
-				})
 				template.Spec.Volumes = append(template.Spec.Volumes, corev1.Volume{
 					Name: "openvpn-status",
 					VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Add dual stack support to vpn2 and remove container port collision on port 15000.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add dual stack support for VPN.
```
