### PR TITLE
Revert "chore(deps): update dependency kyverno/kyverno to v1.13.0 (#10746)"

### DIFF
--- a/example/provider-extensions/kyverno/kustomization.yaml
+++ b/example/provider-extensions/kyverno/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/kyverno/kyverno/releases/download/v1.13.0/install.yaml
+- https://github.com/kyverno/kyverno/releases/download/v1.12.6/install.yaml
 - kyverno-poddisruptionbudget.yaml
 
 patches:


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression

**What this PR does / why we need it**:
This reverts commit 6739e466d5fa29da168fcf2b9e0fc0db1140ed53.

As described in the comments in https://github.com/gardener/gardener/pull/10746, https://github.com/gardener/gardener/pull/10746 breaks the provider-extensions setup. This PR reverts the breaking commit to make possible to run the provider-eextension setup again. 
Upgrading to kyverno@v0.13.0 obviously has to be done with required adaptations.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
