### PR TITLE
Support VGO in environments where `$GOPATH` is not set and Go `bin` directories are not part of `$PATH`

### DIFF
--- a/hack/vgopath-setup.sh
+++ b/hack/vgopath-setup.sh
@@ -1,14 +1,15 @@
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-# Ensure that if GOPATH is set, the GOPATH/{bin,pkg} directory exists. This seems to be not always
+# Ensure that the GOPATH/{bin,pkg} directory exists. This seems to be not always
 # the case in certain environments like Prow. As we will create a symlink against the bin folder we
 # need to make sure that the bin directory is present in the GOPATH.
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/bin" ]; then mkdir -p "$GOPATH/bin"; fi
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
+if [ -n "$(go env GOPATH)" ] && [ ! -d "$(go env GOPATH)/bin" ]; then mkdir -p "$(go env GOPATH)/bin"; fi
+if [ -n "$(go env GOPATH)" ] && [ ! -d "$(go env GOPATH)/pkg" ]; then mkdir -p "$(go env GOPATH)/pkg"; fi
 
 VIRTUAL_GOPATH="$(mktemp -d)"
 trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
@@ -21,3 +22,4 @@ TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
 
 export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
 export GOPATH="$VIRTUAL_GOPATH"
+export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"

--- a/hack/vgopath-setup.sh
+++ b/hack/vgopath-setup.sh
@@ -8,8 +8,8 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Ensure that the GOPATH/{bin,pkg} directory exists. This seems to be not always
 # the case in certain environments like Prow. As we will create a symlink against the bin folder we
 # need to make sure that the bin directory is present in the GOPATH.
-if [ -n "$(go env GOPATH)" ] && [ ! -d "$(go env GOPATH)/bin" ]; then mkdir -p "$(go env GOPATH)/bin"; fi
-if [ -n "$(go env GOPATH)" ] && [ ! -d "$(go env GOPATH)/pkg" ]; then mkdir -p "$(go env GOPATH)/pkg"; fi
+if [ ! -d "$(go env GOPATH)/bin" ]; then mkdir -p "$(go env GOPATH)/bin"; fi
+if [ ! -d "$(go env GOPATH)/pkg" ]; then mkdir -p "$(go env GOPATH)/pkg"; fi
 
 VIRTUAL_GOPATH="$(mktemp -d)"
 trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
@@ -22,4 +22,4 @@ TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
 
 export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
 export GOPATH="$VIRTUAL_GOPATH"
-export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"
+export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
There is always a `GOPATH` when Go is installed even though `$GOPATH` environment variable might not be set. `go env GOPATH` always gets the correct path.
Additionally, the `$PATH` might not include `$GOROOT/bin` and `$GOPATH/bin`.  If they exist, it is no big deal to have them twice in the VGO environment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
