### PR TITLE
control plane blackbox-exporter: Remove unneeded NetworkPolicy label to kube-apiserver

### DIFF
--- a/pkg/gardenlet/operation/botanist/blackboxexporter.go
+++ b/pkg/gardenlet/operation/botanist/blackboxexporter.go
@@ -11,7 +11,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
-	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter"
 	clusterblackboxexporter "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/shoot/cluster"
 	controlplaneblackboxexporter "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/shoot/controlplane"
@@ -30,11 +29,12 @@ func (b *Botanist) DefaultBlackboxExporterControlPlane() (component.DeployWaiter
 			VPAEnabled:        true,
 			KubernetesVersion: b.Seed.KubernetesVersion,
 			PodLabels: map[string]string{
-				// needed to talk to shoot API server via istio-ingressgateway
 				v1beta1constants.LabelNetworkPolicyToDNS:            v1beta1constants.LabelNetworkPolicyAllowed,
 				v1beta1constants.LabelNetworkPolicyToPublicNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
+				// The control plane blackbox-exporter is using the internal cluster domain to probe the shoot API server.
+				// Traffic to the istio-ingressgateway needs to be allowed because on some infrastructures kube-proxy shortcuts the network path.
+				// It directly forwards the traffic to the target within the cluster (i.e., istio-ingressgateway) instead of first going out and then coming in again.
 				gardenerutils.NetworkPolicyLabel(v1beta1constants.LabelNetworkPolicyIstioIngressNamespaceAlias+"-istio-ingressgateway", 9443): v1beta1constants.LabelNetworkPolicyAllowed,
-				gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port):                   v1beta1constants.LabelNetworkPolicyAllowed,
 			},
 			PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane100,
 			Config:            controlplaneblackboxexporter.Config(),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind cleanup

**What this PR does / why we need it**:
The control plane blackbox-exporter is using the internal domain to probe the kube-apiserver: https://github.com/gardener/gardener/blob/c5c95b35a78a291bda3685a6fe942fdcaeb2abf4/pkg/gardenlet/operation/botanist/blackboxexporter.go#L41

Hence, it should not need a NetworkPolicy label for the kube-apiserver. As written in the comment, on some infrastructures kube-proxy shortcuts the network path by directly forwarding the traffic without the cluster instead of first going out and the coming in again.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
