### PR TITLE
Deflake `operator/garden/garden` integration test

### DIFF
--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -6,7 +6,6 @@ package crddeployer
 
 import (
 	"context"
-	"time"
 
 	"golang.org/x/exp/maps"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -17,13 +16,6 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	"github.com/gardener/gardener/pkg/utils/retry"
-)
-
-var (
-	// CRDWaitTimeout specifies the total time to wait for CRDs to become ready.
-	CRDWaitTimeout = 15 * time.Second
 )
 
 // crdDeployer is a DeployWaiter that can deploy CRDs and wait for them to be ready.
@@ -33,9 +25,9 @@ type crdDeployer struct {
 	crdNameToManifest map[string]string
 }
 
-// NewCRDDeployer returns a DeployWaiter that can deploy CRDs and wait for them to be ready.
-func NewCRDDeployer(client client.Client, applier kubernetes.Applier, manifests []string) (component.DeployWaiter, error) {
-	crdNameToManifest, err := MakeCRDNameMap(manifests)
+// New returns a new instance of DeployWaiter for CRDs.
+func New(client client.Client, applier kubernetes.Applier, manifests []string) (component.DeployWaiter, error) {
+	crdNameToManifest, err := generateNameToCRDMap(manifests)
 	if err != nil {
 		return nil, err
 	}
@@ -79,77 +71,23 @@ func (c *crdDeployer) Destroy(ctx context.Context) error {
 
 // Wait waits for the CRDs to be deployed.
 func (c *crdDeployer) Wait(ctx context.Context) error {
-	return WaitUntilCRDManifestsReady(ctx, c.client, maps.Keys(c.crdNameToManifest))
+	return kubernetesutils.WaitUntilCRDManifestsReady(ctx, c.client, maps.Keys(c.crdNameToManifest)...)
 }
 
 // WaitCleanup waits for destruction to finish and CRDs to be fully removed.
 func (c *crdDeployer) WaitCleanup(ctx context.Context) error {
-	return WaitUntilCRDManifestsDestroyed(ctx, c.client, maps.Keys(c.crdNameToManifest))
+	return kubernetesutils.WaitUntilCRDManifestsDestroyed(ctx, c.client, maps.Keys(c.crdNameToManifest)...)
 }
 
-// MakeCRDNameMap returns a map that has the name of the resource as key, and the corresponding manifest as value.
-func MakeCRDNameMap(manifests []string) (map[string]string, error) {
+// generateNameToCRDMap returns a map that has the name of the resource as key, and the corresponding manifest as value.
+func generateNameToCRDMap(manifests []string) (map[string]string, error) {
 	crdNameToManifest := make(map[string]string)
 	for _, manifest := range manifests {
-		name, err := GetObjectNameFromManifest(manifest)
+		object, err := kubernetes.NewManifestReader([]byte(manifest)).Read()
 		if err != nil {
 			return nil, err
 		}
-		crdNameToManifest[name] = manifest
+		crdNameToManifest[object.GetName()] = manifest
 	}
 	return crdNameToManifest, nil
-}
-
-// WaitUntilCRDManifestsReady takes names of CRDs and waits for them to get ready with a timeout of 15 seconds.
-func WaitUntilCRDManifestsReady(ctx context.Context, c client.Client, crdNames []string) error {
-	var fns []flow.TaskFn
-	for _, crdName := range crdNames {
-		fns = append(fns, func(ctx context.Context) error {
-			timeoutCtx, cancel := context.WithTimeout(ctx, CRDWaitTimeout)
-			defer cancel()
-
-			return retry.Until(timeoutCtx, 1*time.Second, func(ctx context.Context) (done bool, err error) {
-				crd := &apiextensionsv1.CustomResourceDefinition{}
-
-				if err := c.Get(ctx, client.ObjectKey{Name: crdName}, crd); err != nil {
-					return retry.SevereError(err)
-				}
-
-				if err := health.CheckCustomResourceDefinition(crd); err != nil {
-					return retry.MinorError(err)
-				}
-				return retry.Ok()
-			})
-		})
-	}
-	return flow.Parallel(fns...)(ctx)
-}
-
-// WaitUntilCRDManifestsDestroyed takes names of CRDs and waits for them to get destroted with a timeout of 15 seconds.
-func WaitUntilCRDManifestsDestroyed(ctx context.Context, c client.Client, crdNames []string) error {
-	var fns []flow.TaskFn
-
-	for _, resourceName := range crdNames {
-		crd := &apiextensionsv1.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: resourceName,
-			},
-		}
-
-		fns = append(fns, func(ctx context.Context) error {
-			timeoutCtx, cancel := context.WithTimeout(ctx, CRDWaitTimeout)
-			defer cancel()
-			return kubernetesutils.WaitUntilResourceDeleted(timeoutCtx, c, crd, 1*time.Second)
-		})
-	}
-	return flow.Parallel(fns...)(ctx)
-}
-
-// GetObjectNameFromManifest takes a manifest and returns its corresponding name.
-func GetObjectNameFromManifest(manifest string) (string, error) {
-	object, err := kubernetes.NewManifestReader([]byte(manifest)).Read()
-	if err != nil {
-		return "", err
-	}
-	return object.GetName(), nil
 }

--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package crddeployer
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/exp/maps"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/retry"
+)
+
+var (
+	// CRDWaitTimeout specifies the total time to wait for CRDs to become ready.
+	CRDWaitTimeout = 15 * time.Second
+)
+
+// crdDeployer is a DeployWaiter that can deploy CRDs and wait for them to be ready.
+type crdDeployer struct {
+	client            client.Client
+	applier           kubernetes.Applier
+	crdNameToManifest map[string]string
+}
+
+// NewCRDDeployer returns a DeployWaiter that can deploy CRDs and wait for them to be ready.
+func NewCRDDeployer(client client.Client, applier kubernetes.Applier, manifests []string) (component.DeployWaiter, error) {
+	crdNameToManifest, err := MakeCRDNameMap(manifests)
+	if err != nil {
+		return nil, err
+	}
+	return &crdDeployer{
+		client:            client,
+		applier:           applier,
+		crdNameToManifest: crdNameToManifest,
+	}, nil
+}
+
+// Deploy deploys the CRDs.
+func (c *crdDeployer) Deploy(ctx context.Context) error {
+	var fns []flow.TaskFn
+
+	for _, resource := range c.crdNameToManifest {
+		fns = append(fns, func(ctx context.Context) error {
+			return c.applier.ApplyManifest(ctx, kubernetes.NewManifestReader([]byte(resource)), kubernetes.DefaultMergeFuncs)
+		})
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+// Destroy destroys the CRDs.
+func (c *crdDeployer) Destroy(ctx context.Context) error {
+	var fns []flow.TaskFn
+
+	for resourceName, _ := range c.crdNameToManifest {
+		fns = append(fns, func(ctx context.Context) error {
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: resourceName,
+				},
+			}
+			return client.IgnoreNotFound(c.client.Delete(ctx, crd))
+		})
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+// Wait waits for the CRDs to be deployed.
+func (c *crdDeployer) Wait(ctx context.Context) error {
+	return WaitUntilCRDManifestsReady(ctx, c.client, maps.Keys(c.crdNameToManifest))
+}
+
+// WaitCleanup waits for destruction to finish and CRDs to be fully removed.
+func (c *crdDeployer) WaitCleanup(ctx context.Context) error {
+	return WaitUntilCRDManifestsDestroyed(ctx, c.client, maps.Keys(c.crdNameToManifest))
+}
+
+// MakeCRDNameMap returns a map that has the name of the resource as key, and the corresponding manifest as value.
+func MakeCRDNameMap(manifests []string) (map[string]string, error) {
+	crdNameToManifest := make(map[string]string)
+	for _, manifest := range manifests {
+		name, err := GetObjectNameFromManifest(manifest)
+		if err != nil {
+			return nil, err
+		}
+		crdNameToManifest[name] = manifest
+	}
+	return crdNameToManifest, nil
+}
+
+// WaitUntilCRDManifestsReady takes names of CRDs and waits for them to get ready with a timeout of 15 seconds.
+func WaitUntilCRDManifestsReady(ctx context.Context, c client.Client, crdNames []string) error {
+	var fns []flow.TaskFn
+	for _, crdName := range crdNames {
+		fns = append(fns, func(ctx context.Context) error {
+			timeoutCtx, cancel := context.WithTimeout(ctx, CRDWaitTimeout)
+			defer cancel()
+
+			return retry.Until(timeoutCtx, 1*time.Second, func(ctx context.Context) (done bool, err error) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+
+				if err := c.Get(ctx, client.ObjectKey{Name: crdName}, crd); err != nil {
+					return retry.SevereError(err)
+				}
+
+				if err := health.CheckCustomResourceDefinition(crd); err != nil {
+					return retry.MinorError(err)
+				}
+				return retry.Ok()
+			})
+		})
+	}
+	return flow.Parallel(fns...)(ctx)
+}
+
+// WaitUntilCRDManifestsDestroyed takes names of CRDs and waits for them to get destroted with a timeout of 15 seconds.
+func WaitUntilCRDManifestsDestroyed(ctx context.Context, c client.Client, crdNames []string) error {
+	var fns []flow.TaskFn
+
+	for _, resourceName := range crdNames {
+		crd := &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: resourceName,
+			},
+		}
+
+		fns = append(fns, func(ctx context.Context) error {
+			timeoutCtx, cancel := context.WithTimeout(ctx, CRDWaitTimeout)
+			defer cancel()
+			return kubernetesutils.WaitUntilResourceDeleted(timeoutCtx, c, crd, 1*time.Second)
+		})
+	}
+	return flow.Parallel(fns...)(ctx)
+}
+
+// GetObjectNameFromManifest takes a manifest and returns its corresponding name.
+func GetObjectNameFromManifest(manifest string) (string, error) {
+	object, err := kubernetes.NewManifestReader([]byte(manifest)).Read()
+	if err != nil {
+		return "", err
+	}
+	return object.GetName(), nil
+}

--- a/pkg/component/crddeployer/crd_suite_test.go
+++ b/pkg/component/crddeployer/crd_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestCRDDeployer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "CRDDeployer Suite")
+	RunSpecs(t, "Component CRDDeployer Suite")
 }

--- a/pkg/component/crddeployer/crd_suite_test.go
+++ b/pkg/component/crddeployer/crd_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package crddeployer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCRDDeployer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CRDDeployer Suite")
+}

--- a/pkg/component/crddeployer/crd_test.go
+++ b/pkg/component/crddeployer/crd_test.go
@@ -140,7 +140,7 @@ status:
 			Expect(crdDeployer.WaitCleanup(ctx)).To(Succeed())
 		})
 
-		It("should time out because CRD is not ready", func() {
+		It("should time out because CRD is still present", func() {
 			// lower waiting timeout so that the unit test itself does not time out.
 			DeferCleanup(test.WithVar(&kubernetesutils.WaitTimeout, 10*time.Millisecond))
 

--- a/pkg/component/crddeployer/crd_test.go
+++ b/pkg/component/crddeployer/crd_test.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package crddeployer_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/crddeployer"
+	"github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("CRD", func() {
+	var (
+		ctx        context.Context
+		applier    kubernetes.Applier
+		testClient client.Client
+
+		unreadyCRD = &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "myresources.mygroup.example.com",
+			},
+		}
+		readyCRD = &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "myresources.mygroup.example.com",
+			},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+					{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+					{Type: apiextensionsv1.NamesAccepted, Status: apiextensionsv1.ConditionTrue},
+				},
+			},
+		}
+
+		validManifest   string
+		invalidManifest string
+
+		crdDeployer component.DeployWaiter
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		validManifest = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    name: myresources.mygroup.example.com`
+		invalidManifest = `thisIsNotAValidManifest`
+
+		testClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{apiextensionsv1.SchemeGroupVersion})
+		mapper.Add(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"), meta.RESTScopeRoot)
+		applier = kubernetes.NewApplier(testClient, mapper)
+		var err error
+		crdDeployer, err = NewCRDDeployer(testClient, applier, []string{validManifest})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(crdDeployer).ToNot(BeNil())
+	})
+
+	Describe("#Deploy", func() {
+		It("should deploy a CRD", func() {
+			actualCRD := &apiextensionsv1.CustomResourceDefinition{}
+
+			Expect(crdDeployer.Deploy(ctx)).To(Succeed())
+
+			Expect(testClient.Get(ctx, client.ObjectKey{Name: readyCRD.Name}, actualCRD)).To(Succeed())
+			Expect(actualCRD.Name).To(Equal(readyCRD.Name))
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should destroy a CRD", func() {
+			actualCRD := &apiextensionsv1.CustomResourceDefinition{}
+
+			Expect(testClient.Create(ctx, readyCRD)).To(Succeed())
+
+			Expect(crdDeployer.Destroy(ctx)).To(Succeed())
+
+			Expect(testClient.Get(ctx, client.ObjectKey{Name: readyCRD.Name}, actualCRD)).To(matchers.BeNotFoundError())
+		})
+	})
+
+	Describe("#MakeCRDNameMap", func() {
+		It("should return a map representing the CRD name map", func() {
+			crdNameToManifest, err := MakeCRDNameMap([]string{validManifest})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(crdNameToManifest).To(HaveKeyWithValue("myresources.mygroup.example.com", validManifest))
+		})
+
+		It("should throw an error when a non valid CRD is provided", func() {
+			crdMap, err := MakeCRDNameMap([]string{invalidManifest})
+			Expect(crdMap).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("error unmarshaling JSON")))
+		})
+	})
+
+	Describe("#WaitUntilCRDManifestsReady", func() {
+		It("should return true because the CRD is ready", func() {
+			testClient := fakeclient.NewClientBuilder().
+				WithScheme(apiextensionsscheme.Scheme).
+				WithObjects(readyCRD).
+				Build()
+
+			Expect(WaitUntilCRDManifestsReady(ctx, testClient, []string{"myresources.mygroup.example.com"})).
+				To(Succeed())
+		})
+
+		It("should time out because CRD is not ready", func() {
+			// lower waiting timeout so that the unit test itself does not time out
+			CRDWaitTimeout = 10 * time.Millisecond
+			testClient := fakeclient.NewClientBuilder().
+				WithScheme(apiextensionsscheme.Scheme).
+				WithObjects(unreadyCRD).
+				Build()
+
+			Expect(WaitUntilCRDManifestsReady(ctx, testClient, []string{"myresources.mygroup.example.com"})).
+				To(MatchError(ContainSubstring("retry failed with context deadline exceeded, last error: condition \"NamesAccepted\" is missing")))
+
+		})
+	})
+
+	Describe("#WaitUntilManifestsDestroyed", func() {
+		It("should return because the CRD is gone", func() {
+			testClient := fakeclient.NewClientBuilder().
+				WithScheme(apiextensionsscheme.Scheme).
+				WithObjects(readyCRD).
+				Build()
+
+			Expect(testClient.Delete(ctx, readyCRD)).To(Succeed())
+
+			Expect(WaitUntilCRDManifestsDestroyed(ctx, testClient, []string{readyCRD.Name})).To(Succeed())
+		})
+
+		It("should time out because CRD is not ready", func() {
+			// lower waiting timeout so that the unit test itself does not time out
+			CRDWaitTimeout = 10 * time.Millisecond
+
+			Expect(testClient.Create(ctx, unreadyCRD)).To(Succeed())
+
+			Expect(WaitUntilCRDManifestsDestroyed(ctx, testClient, []string{readyCRD.Name})).
+				To(MatchError(ContainSubstring("context deadline exceeded")))
+		})
+	})
+
+	Describe("#GetObjectNameFromManifest", func() {
+		It("should return the correct object key from the manifest", func() {
+			objKey, err := GetObjectNameFromManifest(validManifest)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(objKey).To(Equal("myresources.mygroup.example.com"))
+		})
+
+		It("should throw an error if no valid manifest is passed", func() {
+			objKey, err := GetObjectNameFromManifest(invalidManifest)
+
+			Expect(objKey).To(Equal(""))
+			Expect(err).To(MatchError(ContainSubstring("cannot unmarshal")))
+		})
+	})
+})

--- a/pkg/component/observability/monitoring/prometheusoperator/crd.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/crd.go
@@ -51,5 +51,5 @@ func NewCRDs(client client.Client, applier kubernetes.Applier) (component.Deploy
 		crdServiceMonitors,
 		crdThanosRulers,
 	}
-	return crddeployer.NewCRDDeployer(client, applier, resources)
+	return crddeployer.New(client, applier, resources)
 }

--- a/pkg/component/observability/monitoring/prometheusoperator/crd_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/crd_test.go
@@ -23,24 +23,26 @@ import (
 
 var _ = Describe("CRD", func() {
 	var (
-		ctx      = context.TODO()
-		c        client.Client
-		deployer component.Deployer
+		ctx          = context.TODO()
+		c            client.Client
+		deployWaiter component.DeployWaiter
 	)
 
 	BeforeEach(func() {
+		var err error
 		c = fake.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 
 		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{apiextensionsv1.SchemeGroupVersion})
 		mapper.Add(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"), meta.RESTScopeRoot)
 		applier := kubernetes.NewApplier(c, mapper)
 
-		deployer = NewCRDs(applier)
+		deployWaiter, err = NewCRDs(c, applier)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Describe("#Deploy", func() {
 		It("should deploy the CRD", func() {
-			Expect(deployer.Deploy(ctx)).To(Succeed())
+			Expect(deployWaiter.Deploy(ctx)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "alertmanagerconfigs.monitoring.coreos.com"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "alertmanagers.monitoring.coreos.com"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "podmonitors.monitoring.coreos.com"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
@@ -56,7 +58,7 @@ var _ = Describe("CRD", func() {
 
 	Describe("#Destroy", func() {
 		It("should delete the CRD", func() {
-			Expect(deployer.Destroy(ctx)).To(Succeed())
+			Expect(deployWaiter.Destroy(ctx)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "alertmanagerconfigs.monitoring.coreos.com"}, &apiextensionsv1.CustomResourceDefinition{})).To(matchers.BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "alertmanagers.monitoring.coreos.com"}, &apiextensionsv1.CustomResourceDefinition{})).To(matchers.BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "podmonitors.monitoring.coreos.com"}, &apiextensionsv1.CustomResourceDefinition{})).To(matchers.BeNotFoundError())

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -80,7 +80,7 @@ type components struct {
 	vpaCRD        component.Deployer
 	hvpaCRD       component.Deployer
 	fluentCRD     component.Deployer
-	prometheusCRD component.Deployer
+	prometheusCRD component.DeployWaiter
 
 	clusterIdentity          component.DeployWaiter
 	gardenerResourceManager  component.DeployWaiter
@@ -140,7 +140,10 @@ func (r *Reconciler) instantiateComponents(
 		c.hvpaCRD = component.OpDestroy(c.hvpaCRD)
 	}
 	c.fluentCRD = fluentoperator.NewCRDs(r.SeedClientSet.Applier())
-	c.prometheusCRD = prometheusoperator.NewCRDs(r.SeedClientSet.Applier())
+	c.prometheusCRD, err = prometheusoperator.NewCRDs(r.SeedClientSet.Client(), r.SeedClientSet.Applier())
+	if err != nil {
+		return
+	}
 
 	// seed system components
 	c.clusterIdentity = r.newClusterIdentity(seed.GetInfo())

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -239,7 +239,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 		})
 		deployPrometheusCRD = g.Add(flow.Task{
 			Name:   "Deploying monitoring-related custom resource definitions",
-			Fn:     c.prometheusCRD.Deploy,
+			Fn:     component.OpWait(c.prometheusCRD).Deploy,
 			SkipIf: seedIsGarden,
 		})
 		syncPointCRDs = flow.NewTaskIDs(

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -93,8 +93,8 @@ type components struct {
 	hvpaCRD       component.Deployer
 	istioCRD      component.Deployer
 	fluentCRD     component.Deployer
-	prometheusCRD component.Deployer
 	extensionCRD  component.Deployer
+	prometheusCRD component.DeployWaiter
 
 	gardenerResourceManager component.DeployWaiter
 	runtimeSystem           component.DeployWaiter
@@ -169,7 +169,10 @@ func (r *Reconciler) instantiateComponents(
 	}
 	c.istioCRD = istio.NewCRD(r.RuntimeClientSet.ChartApplier())
 	c.fluentCRD = fluentoperator.NewCRDs(applier)
-	c.prometheusCRD = prometheusoperator.NewCRDs(applier)
+	c.prometheusCRD, err = prometheusoperator.NewCRDs(r.RuntimeClientSet.Client(), applier)
+	if err != nil {
+		return
+	}
 	c.certManagementCRD = certmanagement.NewCRDs(applier)
 	c.extensionCRD = extensioncrds.NewCRD(applier, true, false)
 

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -173,7 +173,7 @@ func (r *Reconciler) reconcile(
 		})
 		deployPrometheusCRD = g.Add(flow.Task{
 			Name: "Deploying custom resource definitions for prometheus-operator",
-			Fn:   c.prometheusCRD.Deploy,
+			Fn:   component.OpWait(c.prometheusCRD).Deploy,
 		})
 		deployExtensionCRD = g.Add(flow.Task{
 			Name: "Deploying custom resource definitions for extensions",

--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/retry"
+)
+
+var (
+	// WaitTimeout specifies the total time to wait for CRDs to become ready or to be deleted. Exposed for testing.
+	WaitTimeout = 15 * time.Second
+)
+
+// WaitUntilCRDManifestsReady takes names of CRDs and waits for them to get ready with a timeout of 15 seconds.
+func WaitUntilCRDManifestsReady(ctx context.Context, c client.Client, crdNames ...string) error {
+	var fns []flow.TaskFn
+	for _, crdName := range crdNames {
+		fns = append(fns, func(ctx context.Context) error {
+			timeoutCtx, cancel := context.WithTimeout(ctx, WaitTimeout)
+			defer cancel()
+
+			return retry.Until(timeoutCtx, 1*time.Second, func(ctx context.Context) (done bool, err error) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+
+				if err := c.Get(ctx, client.ObjectKey{Name: crdName}, crd); err != nil {
+					if client.IgnoreNotFound(err) == nil {
+						return retry.MinorError(err)
+					}
+					return retry.SevereError(err)
+				}
+
+				if err := health.CheckCustomResourceDefinition(crd); err != nil {
+					return retry.MinorError(err)
+				}
+				return retry.Ok()
+			})
+		})
+	}
+	return flow.Parallel(fns...)(ctx)
+}
+
+// WaitUntilCRDManifestsDestroyed takes CRD names and waits for them to be gone with a timeout of 15 seconds.
+func WaitUntilCRDManifestsDestroyed(ctx context.Context, c client.Client, crdNames ...string) error {
+	var fns []flow.TaskFn
+
+	for _, resourceName := range crdNames {
+		crd := &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: resourceName,
+			},
+		}
+
+		fns = append(fns, func(ctx context.Context) error {
+			timeoutCtx, cancel := context.WithTimeout(ctx, WaitTimeout)
+			defer cancel()
+			return WaitUntilResourceDeleted(timeoutCtx, c, crd, 1*time.Second)
+		})
+	}
+	return flow.Parallel(fns...)(ctx)
+}

--- a/pkg/utils/kubernetes/crd_test.go
+++ b/pkg/utils/kubernetes/crd_test.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("CRD", func() {
+	var (
+		ctx               context.Context
+		testClientBuilder *fakeclient.ClientBuilder
+		testClient        client.Client
+
+		unreadyCRD = &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "myresources.mygroup.example.com",
+			},
+		}
+		readyCRD = &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "myresources.mygroup.example.com",
+			},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+					{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+					{Type: apiextensionsv1.NamesAccepted, Status: apiextensionsv1.ConditionTrue},
+				},
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testClientBuilder = fakeclient.NewClientBuilder().WithScheme(apiextensionsscheme.Scheme)
+	})
+
+	JustBeforeEach(func() {
+		// lower waiting timeout so that the unit test itself does not time out.
+		DeferCleanup(test.WithVar(&WaitTimeout, 10*time.Millisecond))
+	})
+
+	Describe("#WaitUntilCRDManifestsReady", func() {
+		It("should return true because the CRD is ready", func() {
+			testClient = testClientBuilder.WithObjects(readyCRD).Build()
+
+			Expect(WaitUntilCRDManifestsReady(ctx, testClient, "myresources.mygroup.example.com")).
+				To(Succeed())
+		})
+
+		It("should time out because CRD is not ready", func() {
+			testClient = testClientBuilder.WithObjects(unreadyCRD).Build()
+
+			Expect(WaitUntilCRDManifestsReady(ctx, testClient, "myresources.mygroup.example.com")).
+				To(MatchError(ContainSubstring("retry failed with context deadline exceeded, last error: condition \"NamesAccepted\" is missing")))
+		})
+	})
+
+	Describe("#WaitUntilManifestsDestroyed", func() {
+		It("should return because the CRD is gone", func() {
+			testClient = testClientBuilder.WithObjects(readyCRD).Build()
+
+			Expect(testClient.Delete(ctx, readyCRD)).To(Succeed())
+
+			Expect(WaitUntilCRDManifestsDestroyed(ctx, testClient, readyCRD.Name)).To(Succeed())
+		})
+
+		It("should time out because CRD is not ready", func() {
+			testClient = testClientBuilder.WithObjects(unreadyCRD).Build()
+
+			Expect(WaitUntilCRDManifestsDestroyed(ctx, testClient, readyCRD.Name)).
+				To(MatchError(ContainSubstring("context deadline exceeded")))
+		})
+	})
+})

--- a/pkg/utils/kubernetes/crd_test.go
+++ b/pkg/utils/kubernetes/crd_test.go
@@ -45,13 +45,11 @@ var _ = Describe("CRD", func() {
 	)
 
 	BeforeEach(func() {
-		ctx = context.Background()
-		testClientBuilder = fakeclient.NewClientBuilder().WithScheme(apiextensionsscheme.Scheme)
-	})
-
-	JustBeforeEach(func() {
 		// lower waiting timeout so that the unit test itself does not time out.
 		DeferCleanup(test.WithVar(&WaitTimeout, 10*time.Millisecond))
+
+		ctx = context.Background()
+		testClientBuilder = fakeclient.NewClientBuilder().WithScheme(apiextensionsscheme.Scheme)
 	})
 
 	Describe("#WaitUntilCRDManifestsReady", func() {
@@ -67,6 +65,15 @@ var _ = Describe("CRD", func() {
 
 			Expect(WaitUntilCRDManifestsReady(ctx, testClient, "myresources.mygroup.example.com")).
 				To(MatchError(ContainSubstring("retry failed with context deadline exceeded, last error: condition \"NamesAccepted\" is missing")))
+		})
+
+		It("should time out because CRD is not present", func() {
+			// testClient without any objects.
+			testClient = testClientBuilder.Build()
+
+			Expect(WaitUntilCRDManifestsReady(ctx, testClient, "myresources.mygroup.example.com")).
+				To(MatchError(ContainSubstring("retry failed with context deadline exceeded, last error: customresourcedefinitions.apiextensions.k8s.io \"myresources.mygroup.example.com\" not found")))
+
 		})
 	})
 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -93,6 +93,7 @@ build:
             - pkg/component/certmanagement/assets/crd-cert.gardener.cloud_certificaterevocations.yaml
             - pkg/component/certmanagement/assets/crd-cert.gardener.cloud_certificates.yaml
             - pkg/component/certmanagement/assets/crd-cert.gardener.cloud_issuers.yaml
+            - pkg/component/crddeployer
             - pkg/component/etcd/etcd
             - pkg/component/etcd/etcd/constants
             - pkg/component/etcd/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1010,6 +1010,7 @@ build:
             - pkg/component/autoscaling/vpa/templates/crd-autoscaling.k8s.io_verticalpodautoscalercheckpoints.yaml
             - pkg/component/autoscaling/vpa/templates/crd-autoscaling.k8s.io_verticalpodautoscalers.yaml
             - pkg/component/clusteridentity
+            - pkg/component/crddeployer
             - pkg/component/etcd/copybackupstask
             - pkg/component/etcd/etcd
             - pkg/component/etcd/etcd/constants

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -621,8 +621,10 @@ var _ = Describe("Seed controller tests", func() {
 							istioCRDs                = istio.NewCRD(chartApplier)
 							vpaCRD                   = vpa.NewCRD(applier, nil)
 							fluentCRD                = fluentoperator.NewCRDs(applier)
-							monitoringCRD            = prometheusoperator.NewCRDs(applier)
 						)
+
+						monitoringCRD, err := prometheusoperator.NewCRDs(testClient, applier)
+						Expect(err).NotTo(HaveOccurred())
 
 						Expect(applier.ApplyManifest(ctx, managedResourceCRDReader, kubernetes.DefaultMergeFuncs)).To(Succeed())
 						Expect(testClient.Create(ctx, istioSystemNamespace)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:

This PR aims to fix the flaky test mentioned in #10576.

As described in the meanwhile closed #10639, this PR is the first part of the implementation of a generic `CRDDeployer` that should fix the flake by providing an appropriate `Wait()` method.

**Which issue(s) this PR fixes**:
Fixes #10576 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
