### PR TITLE
Deflake `operator/gardenlet` integration test

### DIFF
--- a/test/integration/operator/gardenlet/gardenlet_test.go
+++ b/test/integration/operator/gardenlet/gardenlet_test.go
@@ -179,6 +179,8 @@ var _ = Describe("Gardenlet controller test", func() {
 
 	When("Seed object gets created", func() {
 		It("should deploy gardenlet and no longer touch it when Seed object got created", func() {
+			verifyGardenletDeployment(false)
+
 			By("Create Seed") // gardenlet would do this typically, but it doesn't run in this setup
 			seed.Name = gardenlet.Name
 			Expect(testClient.Create(ctx, seed)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
Deflakes `operator/gardenlet` integration test ([example run](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10760/pull-gardener-integration/1851977106720821248)). The `gardenlet` resource must be checked before, otherwise the `seed` is created too quickly and Gardenlet controller drops the event due to the [OperatorResponsiblePredicate](https://github.com/gardener/gardener/blob/d1d774749d22de6b85f1e02b39d969fa9227e079/pkg/operator/controller/gardenlet/add.go#L85).

```
> stress -ignore "unable to grab random port" -p 16 ./gardenlet.test
5s: 24 runs so far, 0 failures
10s: 48 runs so far, 0 failures
15s: 74 runs so far, 0 failures
20s: 98 runs so far, 0 failures
25s: 123 runs so far, 0 failures
30s: 147 runs so far, 0 failures
35s: 173 runs so far, 0 failures
40s: 198 runs so far, 0 failures
45s: 224 runs so far, 0 failures
50s: 249 runs so far, 0 failures
55s: 253 runs so far, 0 failures
```

**Special notes for your reviewer**:
/cc @LucaBernstein @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
