### PR TITLE
[GEP-26] WorkloadIdentity now implements GetProviderType

### DIFF
--- a/pkg/apis/security/types_workloadidentity.go
+++ b/pkg/apis/security/types_workloadidentity.go
@@ -27,6 +27,13 @@ type WorkloadIdentity struct {
 	Status WorkloadIdentityStatus
 }
 
+var _ Object = (*WorkloadIdentity)(nil)
+
+// GetProviderType gets the type of the target system.
+func (wi *WorkloadIdentity) GetProviderType() string {
+	return wi.Spec.TargetSystem.Type
+}
+
 // WorkloadIdentitySpec configures the JSON Web Token issued by the Gardener API server.
 type WorkloadIdentitySpec struct {
 	// Audiences specify the list of recipients that the JWT is intended for.

--- a/pkg/apis/security/v1alpha1/types_workloadidentity.go
+++ b/pkg/apis/security/v1alpha1/types_workloadidentity.go
@@ -7,6 +7,8 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	gardensecurity "github.com/gardener/gardener/pkg/apis/security"
 )
 
 // +genclient
@@ -27,6 +29,13 @@ type WorkloadIdentity struct {
 	Spec WorkloadIdentitySpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 	// Status contain the latest observed status of the WorkloadIdentity.
 	Status WorkloadIdentityStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+}
+
+var _ gardensecurity.Object = (*WorkloadIdentity)(nil)
+
+// GetProviderType gets the type of the target system.
+func (wi *WorkloadIdentity) GetProviderType() string {
+	return wi.Spec.TargetSystem.Type
 }
 
 // WorkloadIdentitySpec configures the JSON Web Token issued by the Gardener API server.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security ipcei
/kind enhancement
/ipcei workload-identity

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Type `WorkloadIdentity` now implements `GetProviderType()` and can be matched by the `extensions/pkg/predicate.GardenSecurityProviderType` predicate.
```
