### PR TITLE
[GEP-26] Extension labels admission plugin now labels workload identities

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -71,7 +71,7 @@ This prevents misconfigurations that would otherwise allow users to create such 
 
 _(enabled by default)_
 
-This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `Seed`s, `SecretBinding`s, `CredentialsBinding`s, `WorkloadIdentity`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
+This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `NamespacedCloudProfile`s, `Seed`s, `SecretBinding`s, `CredentialsBinding`s, `WorkloadIdentity`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
 
 ## `ProjectValidator`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -71,7 +71,7 @@ This prevents misconfigurations that would otherwise allow users to create such 
 
 _(enabled by default)_
 
-This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `Seed`s, `SecretBinding`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
+This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `Seed`s, `SecretBinding`s, `CredentialsBinding`s, `WorkloadIdentity`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
 
 ## `ProjectValidator`
 

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -154,6 +154,16 @@ func (e *ExtensionLabels) Admit(_ context.Context, a admission.Attributes, _ adm
 		providerType := credentialsBinding.Provider.Type
 		metav1.SetMetaDataLabel(&credentialsBinding.ObjectMeta, v1beta1constants.LabelExtensionProviderTypePrefix+providerType, "true")
 
+	case security.Kind("WorkloadIdentity"):
+		workloadIdentity, ok := a.GetObject().(*security.WorkloadIdentity)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert resource into WorkloadIdentity object")
+		}
+
+		removeLabels(&workloadIdentity.ObjectMeta)
+		providerType := workloadIdentity.Spec.TargetSystem.Type
+		metav1.SetMetaDataLabel(&workloadIdentity.ObjectMeta, v1beta1constants.LabelExtensionProviderTypePrefix+providerType, "true")
+
 	case core.Kind("Shoot"):
 		shoot, ok := a.GetObject().(*core.Shoot)
 		if !ok {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security ipcei
/kind enhancement
/ipcei workload-identity

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Part https://github.com/gardener/gardener/issues/9586
Related to https://github.com/gardener/gardener/issues/10745

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
gardener-apiserver: The `ExtensionLabels` admission plugin now also sets labels to `WorkloadIdentity`s.
```
