### PR TITLE
Rename the controlplane exposure webhook to seed provider webhook.

### DIFF
--- a/docs/extensions/controlplane-webhooks.md
+++ b/docs/extensions/controlplane-webhooks.md
@@ -24,7 +24,7 @@ See [Contract Specification](#contract-specification) for more details on the co
 You can install 3 different kinds of controlplane webhooks:
 
 * `Shoot`, or `controlplane` webhooks apply changes needed by the Shoot cloud provider, for example the `--cloud-provider` command line flag of `kube-apiserver` and `kube-controller-manager`. Such webhooks should only operate on Shoot namespaces labeled with `shoot.gardener.cloud/provider=<provider>`.
-* `Seed`, or `controlplaneexposure` webhooks apply changes needed by the Seed cloud provider, for example annotations on the `kube-apiserver` service to ensure cloud-specific load balancers are correctly provisioned for a service of type `LoadBalancer`. Such webhooks should only operate on Shoot namespaces labeled with `seed.gardener.cloud/provider=<provider>`.
+* `Seed`, or `seedprovider` webhooks apply changes needed by the Seed cloud provider, for example adapting the storage class and capacity on `Etcd` objects. Such webhooks should only operate on Shoot namespaces labeled with `seed.gardener.cloud/provider=<provider>`.
 
 The labels `shoot.gardener.cloud/provider` and `seed.gardener.cloud/provider` are added by Gardener when it creates the Shoot namespace.
 
@@ -70,7 +70,7 @@ The `env` field of the `kube-apiserver` container **shall not** contain any prov
 
 The `volumes` field of the pod template of the `kube-apiserver` deployment, and respectively the `volumeMounts` field of the `kube-apiserver` container **shall not** contain any provider-specific `Secret` or `ConfigMap` resources. If such resources should be mounted as volumes, this should be done by webhooks.
 
-The `kube-apiserver` `Service` **may** be of type `LoadBalancer`, but **shall not** contain any provider-specific annotations that may be needed to actually provision a load balancer resource in the Seed provider's cloud. If any such annotations are needed, they should be added by webhooks (typically `controlplaneexposure` webhooks).
+The `kube-apiserver` `Service` **may** be of type `LoadBalancer`, but **shall not** contain any provider-specific annotations that may be needed to actually provision a load balancer resource in the Seed provider's cloud. If any such annotations are needed, they should be added by webhooks (typically `seedprovider` webhooks).
 
 The `kube-apiserver` `Service` **will** be of type `ClusterIP`. In this case, Gardener **will** label this `Service` with `core.gardener.cloud/apiserver-exposure: gardener-managed` label (deprecated, the label will no longer be added as of `v1.80`) and expects that no mutations happen.
 

--- a/docs/extensions/controlplane-webhooks.md
+++ b/docs/extensions/controlplane-webhooks.md
@@ -21,7 +21,7 @@ In order to support a new cloud provider, you should install "controlplane" muta
 
 See [Contract Specification](#contract-specification) for more details on the contract that Gardener and webhooks should adhere to regarding the content of the above resources.
 
-You can install 3 different kinds of controlplane webhooks:
+You can install 2 different kinds of controlplane webhooks:
 
 * `Shoot`, or `controlplane` webhooks apply changes needed by the Shoot cloud provider, for example the `--cloud-provider` command line flag of `kube-apiserver` and `kube-controller-manager`. Such webhooks should only operate on Shoot namespaces labeled with `shoot.gardener.cloud/provider=<provider>`.
 * `Seed`, or `seedprovider` webhooks apply changes needed by the Seed cloud provider, for example adapting the storage class and capacity on `Etcd` objects. Such webhooks should only operate on Shoot namespaces labeled with `seed.gardener.cloud/provider=<provider>`.
@@ -62,7 +62,7 @@ The `kube-apiserver` command line **may** contain a number of additional provide
 * `--advertise-address`
 * `--feature-gates`
 
-Gardener uses [SNI](../proposals/08-shoot-apiserver-via-sni.md) to expose the apiserver. In this case, Gardener **will** label the `kube-apiserver`'s `Deployment` with `core.gardener.cloud/apiserver-exposure: gardener-managed` label (deprecated, the label will no longer be added as of `v1.80`) and expects that the `--endpoint-reconciler-type` and `--advertise-address` flags are not modified.
+Gardener uses [SNI](../proposals/08-shoot-apiserver-via-sni.md) to expose the apiserver. In this case, Gardener expects that the `--endpoint-reconciler-type` and `--advertise-address` flags of the `kube-apiserver`'s `Deployment` are not modified.
 
 The `--enable-admission-plugins` flag **may** contain admission plugins that are not compatible with CSI plugins such as `PersistentVolumeLabel`. Webhooks should therefore ensure that such admission plugins are either explicitly enabled (if CSI plugins are not used) or disabled (otherwise).
 
@@ -70,9 +70,7 @@ The `env` field of the `kube-apiserver` container **shall not** contain any prov
 
 The `volumes` field of the pod template of the `kube-apiserver` deployment, and respectively the `volumeMounts` field of the `kube-apiserver` container **shall not** contain any provider-specific `Secret` or `ConfigMap` resources. If such resources should be mounted as volumes, this should be done by webhooks.
 
-The `kube-apiserver` `Service` **may** be of type `LoadBalancer`, but **shall not** contain any provider-specific annotations that may be needed to actually provision a load balancer resource in the Seed provider's cloud. If any such annotations are needed, they should be added by webhooks (typically `seedprovider` webhooks).
-
-The `kube-apiserver` `Service` **will** be of type `ClusterIP`. In this case, Gardener **will** label this `Service` with `core.gardener.cloud/apiserver-exposure: gardener-managed` label (deprecated, the label will no longer be added as of `v1.80`) and expects that no mutations happen.
+The `kube-apiserver` `Service` **will** be of type `ClusterIP`. In this case, Gardener expects that for this `Service` no mutations happen.
 
 ### kube-controller-manager
 

--- a/extensions/pkg/webhook/controlplane/controlplane.go
+++ b/extensions/pkg/webhook/controlplane/controlplane.go
@@ -20,8 +20,8 @@ import (
 const (
 	// WebhookName is the webhook name.
 	WebhookName = "controlplane"
-	// ExposureWebhookName is the exposure webhook name.
-	ExposureWebhookName = "controlplaneexposure"
+	// SeedProviderWebhookName is the seed provider webhook name.
+	SeedProviderWebhookName = "seedprovider"
 	// BackupWebhookName is the backup webhook name.
 	BackupWebhookName = "controlplanebackup"
 
@@ -83,7 +83,7 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 func getName(kind string) string {
 	switch kind {
 	case KindSeed:
-		return ExposureWebhookName
+		return SeedProviderWebhookName
 	case KindBackup:
 		return BackupWebhookName
 	default:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Rename the webhook to better reflect its usecase, to improve readability and understandibility.

**Which issue(s) this PR fixes**:
See #10017

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Rename the controlplane exposure webhook (`ExposureWebhookName`) to seed provider webhook (`SeedProviderWebhookName`).
```

```noteworthy developer
extension library: Provider extensions should rename control plane exposure webhook related packages to seed provider to reflect the naming change on their side (for example rename `pkg/webhook/controlplaneexposure` to `pkg/webhook/seedprovider`).
```
