### PR TITLE
Update logging stack components

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -474,7 +474,7 @@ images:
 - name: fluent-operator
   sourceRepository: github.com/fluent/fluent-operator
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-operator
-  tag: "v3.1.0"
+  tag: "v3.2.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -491,7 +491,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-operator
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
-  tag: "v3.1.5"
+  tag: "v3.1.8"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -510,7 +510,7 @@ images:
     name: fluent-bit-to-vali
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-  tag: "v0.61.0"
+  tag: "v0.62.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -545,7 +545,7 @@ images:
 - name: vali-curator
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-  tag: "v0.61.0"
+  tag: "v0.62.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -601,7 +601,7 @@ images:
     name: telegraf-iptables
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-  tag: "v0.61.0"
+  tag: "v0.62.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -621,7 +621,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-  tag: "v0.61.0"
+  tag: "v0.62.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -638,7 +638,7 @@ images:
 - name: tune2fs
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-  tag: "v0.61.0"
+  tag: "v0.62.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind enhancement

This PR brings following updates to the logging stack components:

- fluent-operator v3.2.0 - [release notes](https://github.com/fluent/fluent-operator/releases/tag/v3.2.0)
- fluent-bit v3.1.8 - [release notes](https://fluentbit.io/announcements/v3.1.8/)
- gardener/logging v0.62.0 - [release notes](https://github.com/gardener/logging/releases/tag/v0.62.0)

```other operator
Following components in gardener logging stack are updated: fluent-operator to v3.2.0, fluent-bit to v3.1.8, gardener/logging to v0.62.0
```
