### PR TITLE
Removing `SeedConfig`'s pointer in `GardenletConfiguration`

### DIFF
--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -860,7 +860,7 @@ func ComputeExpectedGardenletConfiguration(
 	config.GardenClientConnection.KubeconfigSecret = kubeconfigSecret
 
 	if seedConfig != nil {
-		config.SeedConfig = seedConfig
+		config.SeedConfig = *seedConfig
 	}
 
 	return config

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -179,7 +179,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 		BootstrapRunnables: []manager.Runnable{
 			&bootstrappers.SeedConfigChecker{
 				SeedClient: mgr.GetClient(),
-				SeedConfig: cfg.SeedConfig,
+				SeedConfig: &cfg.SeedConfig,
 			},
 			&bootstrappers.GardenKubeconfig{
 				SeedClient: mgr.GetClient(),

--- a/cmd/gardenlet/app/bootstrappers/garden_kubeconfig.go
+++ b/cmd/gardenlet/app/bootstrappers/garden_kubeconfig.go
@@ -133,7 +133,7 @@ func (g *GardenKubeconfig) getOrBootstrapKubeconfig(
 		return nil, "", "", fmt.Errorf("unable to bootstrap client from bootstrap kubeconfig: %w", err)
 	}
 
-	seedName := gardenletbootstraputil.GetSeedName(g.Config.SeedConfig)
+	seedName := gardenletbootstraputil.GetSeedName(&g.Config.SeedConfig)
 	log = log.WithValues("seedName", seedName)
 
 	log.Info("Using provided bootstrap kubeconfig to request signed certificate")

--- a/cmd/gardenlet/app/bootstrappers/garden_kubeconfig.go
+++ b/cmd/gardenlet/app/bootstrappers/garden_kubeconfig.go
@@ -133,7 +133,7 @@ func (g *GardenKubeconfig) getOrBootstrapKubeconfig(
 		return nil, "", "", fmt.Errorf("unable to bootstrap client from bootstrap kubeconfig: %w", err)
 	}
 
-	seedName := gardenletbootstraputil.GetSeedName(&g.Config.SeedConfig)
+	seedName := g.Config.SeedConfig.Name
 	log = log.WithValues("seedName", seedName)
 
 	log.Info("Using provided bootstrap kubeconfig to request signed certificate")

--- a/cmd/gardenlet/app/bootstrappers/garden_kubeconfig_test.go
+++ b/cmd/gardenlet/app/bootstrappers/garden_kubeconfig_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GardenKubeconfig", func() {
 					Validity: &metav1.Duration{Duration: kubeconfigValidity},
 				},
 			},
-			SeedConfig: &config.SeedConfig{
+			SeedConfig: config.SeedConfig{
 				SeedTemplate: core.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: seedName,

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -1759,7 +1759,7 @@ var _ = Describe("handler", func() {
 										Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 											Config: runtime.RawExtension{
 												Object: &gardenletv1alpha1.GardenletConfiguration{
-													SeedConfig: seedConfig1,
+													SeedConfig: *seedConfig1,
 												},
 											},
 										},
@@ -1772,7 +1772,7 @@ var _ = Describe("handler", func() {
 										Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 											Config: runtime.RawExtension{
 												Object: &gardenletv1alpha1.GardenletConfiguration{
-													SeedConfig: seedConfig2,
+													SeedConfig: *seedConfig2,
 												},
 											},
 										},
@@ -1808,39 +1808,6 @@ var _ = Describe("handler", func() {
 									Result: &metav1.Status{
 										Code:    int32(http.StatusInternalServerError),
 										Message: fakeErr.Error(),
-									},
-								},
-							}))
-						})
-
-						It("should return an error because extracting the seed template failed", func() {
-							managedSeeds[1].Spec.Gardenlet = seedmanagementv1alpha1.GardenletConfig{
-								Config: runtime.RawExtension{
-									Object: &gardenletv1alpha1.GardenletConfiguration{
-										SeedConfig: nil,
-									},
-								},
-							}
-
-							mockCache.EXPECT().List(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedList{})).DoAndReturn(func(_ context.Context, list *seedmanagementv1alpha1.ManagedSeedList, _ ...client.ListOption) error {
-								(&seedmanagementv1alpha1.ManagedSeedList{Items: managedSeeds}).DeepCopyInto(list)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, client.ObjectKey{Namespace: managedSeed1Namespace, Name: shoot1.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-								shoot1.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, client.ObjectKey{Namespace: managedSeed1Namespace, Name: shoot2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-								shoot2.DeepCopyInto(obj)
-								return nil
-							})
-
-							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
-								AdmissionResponse: admissionv1.AdmissionResponse{
-									Allowed: false,
-									Result: &metav1.Status{
-										Code:    int32(http.StatusInternalServerError),
-										Message: "no seed config found for managedseed ",
 									},
 								},
 							}))
@@ -1897,6 +1864,12 @@ var _ = Describe("handler", func() {
 								SecretRef: corev1.SecretReference{
 									Name:      secretName,
 									Namespace: secretNamespace,
+								},
+							}
+
+							managedSeeds[1].Spec.Gardenlet.Config = runtime.RawExtension{
+								Object: &gardenletv1alpha1.GardenletConfiguration{
+									SeedConfig: *seedConfig2,
 								},
 							}
 

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
@@ -332,7 +332,7 @@ var _ = Describe("graph", func() {
 					Bootstrap: &managedSeedBootstrapMode,
 					Config: runtime.RawExtension{
 						Object: &gardenletv1alpha1.GardenletConfiguration{
-							SeedConfig: seedConfig1,
+							SeedConfig: *seedConfig1,
 						},
 					},
 				},
@@ -344,7 +344,7 @@ var _ = Describe("graph", func() {
 			Spec: seedmanagementv1alpha1.GardenletSpec{
 				Config: runtime.RawExtension{
 					Object: &gardenletv1alpha1.GardenletConfiguration{
-						SeedConfig: seedConfig2,
+						SeedConfig: *seedConfig2,
 					},
 				},
 			},

--- a/pkg/apis/seedmanagement/helper/helper.go
+++ b/pkg/apis/seedmanagement/helper/helper.go
@@ -23,9 +23,6 @@ func ExtractSeedSpec(managedSeed *seedmanagement.ManagedSeed) (*gardencore.SeedS
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert gardenlet config for managedseed %s: %w", managedSeed.Name, err)
 	}
-	if gardenletConfig.SeedConfig == nil {
-		return nil, fmt.Errorf("no seed config found for managedseed %s", managedSeed.Name)
-	}
 
 	return &gardenletConfig.SeedConfig.Spec, nil
 }

--- a/pkg/apis/seedmanagement/helper/helper_test.go
+++ b/pkg/apis/seedmanagement/helper/helper_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Helper", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{},
@@ -77,20 +77,6 @@ var _ = Describe("Helper", func() {
 
 			It("should fail when gardenlet config is not defined", func() {
 				managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{}
-
-				_, err := ExtractSeedSpec(managedSeed)
-				Expect(err).To(HaveOccurred())
-			})
-
-			It("should fail when seedConfig is not defined in gardenlet config", func() {
-				managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
-							Kind:       "GardenletConfiguration",
-						},
-					},
-				}
 
 				_, err := ExtractSeedSpec(managedSeed)
 				Expect(err).To(HaveOccurred())

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Defaults", func() {
 							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 						},
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{},
 				}}))
 		})
 
@@ -57,7 +56,7 @@ var _ = Describe("Defaults", func() {
 						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
+					SeedConfig: gardenletv1alpha1.SeedConfig{
 						SeedTemplate: gardencorev1beta1.SeedTemplate{
 							Spec: gardencorev1beta1.SeedSpec{
 								Backup: &gardencorev1beta1.SeedBackup{},
@@ -81,7 +80,7 @@ var _ = Describe("Defaults", func() {
 								gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{
@@ -110,7 +109,7 @@ var _ = Describe("Defaults", func() {
 							gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 						},
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
+					SeedConfig: gardenletv1alpha1.SeedConfig{
 						SeedTemplate: gardencorev1beta1.SeedTemplate{
 							Spec: gardencorev1beta1.SeedSpec{
 								Backup: &gardencorev1beta1.SeedBackup{
@@ -144,7 +143,7 @@ var _ = Describe("Defaults", func() {
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -114,11 +114,6 @@ func setDefaultsGardenletConfiguration(obj *gardenletv1alpha1.GardenletConfigura
 	// Set resources defaults
 	setDefaultsResources(obj.Resources)
 
-	// Initialize seed config
-	if obj.SeedConfig == nil {
-		obj.SeedConfig = &gardenletv1alpha1.SeedConfig{}
-	}
-
 	// Set seed spec defaults
 	setDefaultsSeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace)
 }

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
@@ -56,7 +56,6 @@ var _ = Describe("Defaults", func() {
 							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 						},
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{},
 				}}))
 			Expect(obj.Spec.Gardenlet.Bootstrap).To(PointTo(Equal(BootstrapToken)))
 			Expect(obj.Spec.Gardenlet.MergeWithParent).To(PointTo(Equal(true)))
@@ -70,7 +69,7 @@ var _ = Describe("Defaults", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{},
@@ -95,7 +94,7 @@ var _ = Describe("Defaults", func() {
 								gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{
@@ -125,7 +124,7 @@ var _ = Describe("Defaults", func() {
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{
@@ -162,7 +161,7 @@ var _ = Describe("Defaults", func() {
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{

--- a/pkg/apis/seedmanagement/v1alpha1/helper/helper.go
+++ b/pkg/apis/seedmanagement/v1alpha1/helper/helper.go
@@ -39,9 +39,5 @@ func ExtractSeedTemplateAndGardenletConfig(name string, config *runtime.RawExten
 		return nil, nil, fmt.Errorf("could not decode gardenlet configuration: %w", err)
 	}
 
-	if gardenletConfig.SeedConfig == nil {
-		return nil, nil, fmt.Errorf("no seed config found for managedseed %s", name)
-	}
-
 	return &gardenletConfig.SeedConfig.SeedTemplate, gardenletConfig, nil
 }

--- a/pkg/apis/seedmanagement/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/helper/helper_test.go
@@ -68,32 +68,14 @@ var _ = Describe("Helper", func() {
 				Expect(err).To(MatchError("could not decode gardenlet configuration: couldn't get version/kind; json parse error: unexpected end of JSON input"))
 			})
 
-			It("should return an error because seedTemplate is not specified", func() {
-				managedSeed.Spec.Gardenlet.Config = runtime.RawExtension{Raw: encode(config)}
-
-				seedTemplate, gardenletConfig, err := ExtractSeedTemplateAndGardenletConfig(managedSeed.Name, &managedSeed.Spec.Gardenlet.Config)
-				Expect(seedTemplate).To(BeNil())
-				Expect(gardenletConfig).To(BeNil())
-				Expect(err).To(HaveOccurred())
-			})
-
 			It("should return the template from `.spec.gardenlet.seedConfig.seedTemplate", func() {
-				config.SeedConfig = &gardenletv1alpha1.SeedConfig{SeedTemplate: *template}
+				config.SeedConfig = gardenletv1alpha1.SeedConfig{SeedTemplate: *template}
 				managedSeed.Spec.Gardenlet.Config = runtime.RawExtension{Raw: encode(config)}
 
 				seedTemplate, gardenletConfig, err := ExtractSeedTemplateAndGardenletConfig(managedSeed.Name, &managedSeed.Spec.Gardenlet.Config)
 				Expect(seedTemplate).To(Equal(template))
 				Expect(gardenletConfig).To(Equal(config))
 				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-
-		Context("w/o gardenlet config", func() {
-			It("should return an error if seed template cannot be determined", func() {
-				seedTemplate, gardenletConfig, err := ExtractSeedTemplateAndGardenletConfig(managedSeed.Name, &managedSeed.Spec.Gardenlet.Config)
-				Expect(seedTemplate).To(BeNil())
-				Expect(gardenletConfig).To(BeNil())
-				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -257,7 +257,7 @@ func validateGardenletConfiguration(gardenletConfig *config.GardenletConfigurati
 	allErrs := field.ErrorList{}
 
 	// Ensure name is not specified since it will be set by the controller
-	if gardenletConfig.SeedConfig != nil && gardenletConfig.SeedConfig.Name != "" {
+	if gardenletConfig.SeedConfig.Name != "" {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("seedConfig", "metadata", "name"), "seed name is forbidden"))
 	}
 

--- a/pkg/apis/seedmanagement/validation/managedseed_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseed_test.go
@@ -515,7 +515,7 @@ func gardenletConfiguration(seed *gardencorev1beta1.Seed, gcc *gardenletv1alpha1
 			APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 			Kind:       "GardenletConfiguration",
 		},
-		SeedConfig: &gardenletv1alpha1.SeedConfig{
+		SeedConfig: gardenletv1alpha1.SeedConfig{
 			SeedTemplate: gardencorev1beta1.SeedTemplate{
 				ObjectMeta: seed.ObjectMeta,
 				Spec:       seed.Spec,

--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -175,11 +175,7 @@ func ValidateManagedSeedTemplateForManagedSeedSet(template *seedmanagement.Manag
 			allErrs = append(allErrs, field.Invalid(configPath, template.Spec.Gardenlet.Config, fmt.Sprintf("could not convert gardenlet config: %v", err)))
 			return allErrs
 		}
-		if gardenletConfig.SeedConfig == nil {
-			allErrs = append(allErrs, field.Required(configPath.Child("seedConfig"), "seedConfig is required"))
-		} else {
-			allErrs = append(allErrs, validateSeedTemplateLabels(&gardenletConfig.SeedConfig.SeedTemplate, selector, configPath.Child("seedConfig"))...)
-		}
+		allErrs = append(allErrs, validateSeedTemplateLabels(&gardenletConfig.SeedConfig.SeedTemplate, selector, configPath.Child("seedConfig"))...)
 	}
 
 	return allErrs

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -615,11 +615,6 @@ func PrepareGardenletChartValues(
 		}
 	}
 
-	// Ensure seed config is set
-	if gardenletConfig.SeedConfig == nil {
-		gardenletConfig.SeedConfig = &gardenletv1alpha1.SeedConfig{}
-	}
-
 	// Set the seed name
 	gardenletConfig.SeedConfig.SeedTemplate.Name = obj.GetName()
 

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Interface", func() {
 						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
+					SeedConfig: gardenletv1alpha1.SeedConfig{
 						SeedTemplate: *seedTemplate,
 					},
 				},

--- a/pkg/controller/gardenletdeployer/valueshelper_test.go
+++ b/pkg/controller/gardenletdeployer/valueshelper_test.go
@@ -96,7 +96,7 @@ var _ = Describe("ValuesHelper", func() {
 			Logging: &config.Logging{
 				Enabled: ptr.To(true),
 			},
-			SeedConfig: &config.SeedConfig{
+			SeedConfig: config.SeedConfig{
 				SeedTemplate: gardencore.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bar",
@@ -233,6 +233,19 @@ var _ = Describe("ValuesHelper", func() {
 						"contentType":        "application/json",
 						"qps":                float64(100),
 						"burst":              float64(130),
+					},
+					"seedConfig": map[string]any{
+						"metadata": map[string]any{
+							"creationTimestamp": nil,
+						},
+						"spec": map[string]any{
+							"dns": map[string]any{},
+							"networks": map[string]any{
+								"pods":     "",
+								"services": "",
+							},
+							"provider": map[string]any{"type": "", "region": ""},
+						},
 					},
 					"server": map[string]any{
 						"healthProbes": map[string]any{

--- a/pkg/controllermanager/controller/managedseedset/replica_test.go
+++ b/pkg/controllermanager/controller/managedseedset/replica_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Replica", func() {
 						Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 							Config: runtime.RawExtension{
 								Object: &gardenletv1alpha1.GardenletConfiguration{
-									SeedConfig: &gardenletv1alpha1.SeedConfig{
+									SeedConfig: gardenletv1alpha1.SeedConfig{
 										SeedTemplate: gardencorev1beta1.SeedTemplate{
 											Spec: gardencorev1beta1.SeedSpec{
 												Ingress: &gardencorev1beta1.Ingress{
@@ -353,7 +353,7 @@ var _ = Describe("Replica", func() {
 							Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 								Config: runtime.RawExtension{
 									Object: &gardenletv1alpha1.GardenletConfiguration{
-										SeedConfig: &gardenletv1alpha1.SeedConfig{
+										SeedConfig: gardenletv1alpha1.SeedConfig{
 											SeedTemplate: gardencorev1beta1.SeedTemplate{
 												Spec: gardencorev1beta1.SeedSpec{
 													Ingress: &gardencorev1beta1.Ingress{

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -47,7 +47,7 @@ type GardenletConfiguration struct {
 	// Default: nil
 	FeatureGates map[string]bool
 	// SeedConfig contains configuration for the seed cluster.
-	SeedConfig *SeedConfig
+	SeedConfig SeedConfig
 	// Logging contains an optional configurations for the logging stack deployed
 	// by the Gardenlet in the seed clusters.
 	Logging *Logging

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -57,8 +57,7 @@ type GardenletConfiguration struct {
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// SeedConfig contains configuration for the seed cluster.
-	// +optional
-	SeedConfig *SeedConfig `json:"seedConfig,omitempty"`
+	SeedConfig SeedConfig `json:"seedConfig"`
 	// Logging contains an optional configurations for the logging stack deployed
 	// by the Gardenlet in the seed clusters.
 	// +optional

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -918,14 +918,8 @@ func autoConvert_v1alpha1_GardenletConfiguration_To_config_GardenletConfiguratio
 		out.Debugging = nil
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
-	if in.SeedConfig != nil {
-		in, out := &in.SeedConfig, &out.SeedConfig
-		*out = new(config.SeedConfig)
-		if err := Convert_v1alpha1_SeedConfig_To_config_SeedConfig(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SeedConfig = nil
+	if err := Convert_v1alpha1_SeedConfig_To_config_SeedConfig(&in.SeedConfig, &out.SeedConfig, s); err != nil {
+		return err
 	}
 	out.Logging = (*config.Logging)(unsafe.Pointer(in.Logging))
 	out.SNI = (*config.SNI)(unsafe.Pointer(in.SNI))
@@ -995,14 +989,8 @@ func autoConvert_config_GardenletConfiguration_To_v1alpha1_GardenletConfiguratio
 		out.Debugging = nil
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
-	if in.SeedConfig != nil {
-		in, out := &in.SeedConfig, &out.SeedConfig
-		*out = new(SeedConfig)
-		if err := Convert_config_SeedConfig_To_v1alpha1_SeedConfig(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SeedConfig = nil
+	if err := Convert_config_SeedConfig_To_v1alpha1_SeedConfig(&in.SeedConfig, &out.SeedConfig, s); err != nil {
+		return err
 	}
 	out.Logging = (*Logging)(unsafe.Pointer(in.Logging))
 	out.SNI = (*SNI)(unsafe.Pointer(in.SNI))

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -464,11 +464,7 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 			(*out)[key] = val
 		}
 	}
-	if in.SeedConfig != nil {
-		in, out := &in.SeedConfig, &out.SeedConfig
-		*out = new(SeedConfig)
-		(*in).DeepCopyInto(*out)
-	}
+	in.SeedConfig.DeepCopyInto(&out.SeedConfig)
 	if in.Logging != nil {
 		in, out := &in.Logging, &out.Logging
 		*out = new(Logging)

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -79,13 +79,7 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 		}
 	}
 
-	if !inTemplate && cfg.SeedConfig == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedConfig"), cfg, "seed config must be set"))
-	}
-
-	if cfg.SeedConfig != nil {
-		allErrs = append(allErrs, gardencorevalidation.ValidateSeedTemplate(&cfg.SeedConfig.SeedTemplate, fldPath.Child("seedConfig"))...)
-	}
+	allErrs = append(allErrs, gardencorevalidation.ValidateSeedTemplate(&cfg.SeedConfig.SeedTemplate, fldPath.Child("seedConfig"))...)
 
 	resourcesPath := fldPath.Child("resources")
 	if cfg.Resources != nil {
@@ -137,9 +131,7 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 func ValidateGardenletConfigurationUpdate(newCfg, oldCfg *config.GardenletConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if newCfg.SeedConfig != nil && oldCfg.SeedConfig != nil {
-		allErrs = append(allErrs, gardencorevalidation.ValidateSeedTemplateUpdate(&newCfg.SeedConfig.SeedTemplate, &oldCfg.SeedConfig.SeedTemplate, fldPath.Child("seedConfig"))...)
-	}
+	allErrs = append(allErrs, gardencorevalidation.ValidateSeedTemplateUpdate(&newCfg.SeedConfig.SeedTemplate, &oldCfg.SeedConfig.SeedTemplate, fldPath.Child("seedConfig"))...)
 
 	return allErrs
 }

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				},
 			},
 			FeatureGates: map[string]bool{},
-			SeedConfig: &config.SeedConfig{
+			SeedConfig: config.SeedConfig{
 				SeedTemplate: gardencore.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
@@ -409,19 +409,6 @@ var _ = Describe("GardenletConfiguration", func() {
 						"Field": Equal("controllers.networkPolicy.additionalNamespaceSelectors[1].matchLabels"),
 					})),
 				))
-			})
-		})
-
-		Context("seed config", func() {
-			It("should require a seedConfig", func() {
-				cfg.SeedConfig = nil
-
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
-
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("seedConfig"),
-				}))))
 			})
 		})
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -464,11 +464,7 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 			(*out)[key] = val
 		}
 	}
-	if in.SeedConfig != nil {
-		in, out := &in.SeedConfig, &out.SeedConfig
-		*out = new(SeedConfig)
-		(*in).DeepCopyInto(*out)
-	}
+	in.SeedConfig.DeepCopyInto(&out.SeedConfig)
 	if in.Logging != nil {
 		in, out := &in.Logging, &out.Logging
 		*out = new(Logging)

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -58,14 +58,12 @@ func NewCertificateManager(log logr.Logger, gardenCluster cluster.Cluster, seedC
 		return nil, fmt.Errorf("failed creating garden clientset: %w", err)
 	}
 
-	seedName := gardenletbootstraputil.GetSeedName(&config.SeedConfig)
-
 	return &Manager{
-		log:                    log.WithName("certificate-manager").WithValues("seedName", seedName),
+		log:                    log.WithName("certificate-manager").WithValues("seedName", config.SeedConfig.Name),
 		gardenClientSet:        gardenClientSet,
 		seedClient:             seedClient,
 		gardenClientConnection: config.GardenClientConnection,
-		seedName:               seedName,
+		seedName:               config.SeedConfig.Name,
 	}, nil
 }
 

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -58,7 +58,7 @@ func NewCertificateManager(log logr.Logger, gardenCluster cluster.Cluster, seedC
 		return nil, fmt.Errorf("failed creating garden clientset: %w", err)
 	}
 
-	seedName := gardenletbootstraputil.GetSeedName(config.SeedConfig)
+	seedName := gardenletbootstraputil.GetSeedName(&config.SeedConfig)
 
 	return &Manager{
 		log:                    log.WithName("certificate-manager").WithValues("seedName", seedName),

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -39,14 +39,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
 
-// GetSeedName returns the seed name from the SeedConfig or the default Seed name
-func GetSeedName(seedConfig *config.SeedConfig) string {
-	if seedConfig != nil {
-		return seedConfig.Name
-	}
-	return ""
-}
-
 // GetKubeconfigFromSecret tries to retrieve the kubeconfig bytes using the given client
 // returns the kubeconfig or nil if it cannot be found
 func GetKubeconfigFromSecret(ctx context.Context, seedClient client.Client, key client.ObjectKey) ([]byte, error) {

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	. "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
@@ -455,18 +454,6 @@ var _ = Describe("Util", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rest.Host).To(Equal(restConfig.Host))
 			})
-		})
-	})
-
-	Describe("GetSeedName", func() {
-		It("should return the configured name", func() {
-			name := "test-name"
-			result := GetSeedName(&config.SeedConfig{
-				SeedTemplate: gardencore.SeedTemplate{
-					ObjectMeta: metav1.ObjectMeta{Name: name},
-				},
-			})
-			Expect(result).To(Equal("test-name"))
 		})
 	})
 

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -323,16 +323,14 @@ func (v *ManagedSeed) admitGardenlet(gardenlet *seedmanagement.GardenletConfig, 
 			return allErrs, apierrors.NewInternalError(fmt.Errorf("could not convert config: %v", err))
 		}
 
-		if gardenletConfig.SeedConfig != nil {
-			seedConfigPath := configPath.Child("seedConfig")
+		seedConfigPath := configPath.Child("seedConfig")
 
-			// Admit seed spec against shoot
-			errs, err := v.admitSeedSpec(&gardenletConfig.SeedConfig.Spec, shoot, seedConfigPath.Child("spec"))
-			if err != nil {
-				return allErrs, err
-			}
-			allErrs = append(allErrs, errs...)
+		// Admit seed spec against shoot
+		errs, err := v.admitSeedSpec(&gardenletConfig.SeedConfig.Spec, shoot, seedConfigPath.Child("spec"))
+		if err != nil {
+			return allErrs, err
 		}
+		allErrs = append(allErrs, errs...)
 
 		// Convert gardenlet config to an external version and set it back to gardenlet.Config
 		gardenlet.Config, err = gardenlethelper.ConvertGardenletConfigurationExternal(gardenletConfig)

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -355,7 +355,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{},
@@ -382,7 +382,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								ObjectMeta: seedx.ObjectMeta,
 								Spec:       seedx.Spec,
@@ -410,7 +410,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: seedx.Spec,
 							},
@@ -431,7 +431,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								ObjectMeta: seedx.ObjectMeta,
 								Spec:       seedx.Spec,
@@ -459,7 +459,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: seedx.Spec,
 							},
@@ -480,7 +480,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								ObjectMeta: seedx.ObjectMeta,
 								Spec:       seedx.Spec,
@@ -508,7 +508,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: seedx.Spec,
 							},
@@ -529,7 +529,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								ObjectMeta: seedx.ObjectMeta,
 								Spec:       seedx.Spec,
@@ -583,7 +583,7 @@ var _ = Describe("ManagedSeed", func() {
 						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
+					SeedConfig: gardenletv1alpha1.SeedConfig{
 						SeedTemplate: gardencorev1beta1.SeedTemplate{
 							Spec: seedSpec,
 						},
@@ -670,7 +670,7 @@ var _ = Describe("ManagedSeed", func() {
 								APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 								Kind:       "GardenletConfiguration",
 							},
-							SeedConfig: &gardenletv1alpha1.SeedConfig{
+							SeedConfig: gardenletv1alpha1.SeedConfig{
 								SeedTemplate: gardencorev1beta1.SeedTemplate{
 									Spec: seedx.Spec,
 								},
@@ -728,7 +728,7 @@ var _ = Describe("ManagedSeed", func() {
 								APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 								Kind:       "GardenletConfiguration",
 							},
-							SeedConfig: &gardenletv1alpha1.SeedConfig{
+							SeedConfig: gardenletv1alpha1.SeedConfig{
 								SeedTemplate: gardencorev1beta1.SeedTemplate{
 									Spec: seedx.Spec,
 								},
@@ -753,7 +753,7 @@ var _ = Describe("ManagedSeed", func() {
 							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Ingress: seedx.Spec.Ingress,

--- a/plugin/pkg/shoot/managedseed/admission_test.go
+++ b/plugin/pkg/shoot/managedseed/admission_test.go
@@ -87,7 +87,7 @@ var _ = Describe("ManagedSeed", func() {
 			}
 
 			gardenletConfig = &gardenletv1alpha1.GardenletConfiguration{
-				SeedConfig: &gardenletv1alpha1.SeedConfig{
+				SeedConfig: gardenletv1alpha1.SeedConfig{
 					SeedTemplate: gardencorev1beta1.SeedTemplate{
 						Spec: gardencorev1beta1.SeedSpec{
 							Provider: gardencorev1beta1.SeedProvider{
@@ -189,23 +189,6 @@ var _ = Describe("ManagedSeed", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(BeInvalidError())
 				Expect(err).To(MatchError(ContainSubstring("field is immutable for managed seeds")))
-			})
-
-			It("should forbid Shoot update if the seedTemplate is not specified", func() {
-				managedSeed.Spec.Gardenlet = seedmanagementv1alpha1.GardenletConfig{
-					Config: runtime.RawExtension{
-						Object: &gardenletv1alpha1.GardenletConfiguration{},
-					},
-				}
-				seedManagementClient.AddReactor("list", "managedseeds", func(_ testing.Action) (bool, runtime.Object, error) {
-					return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*managedSeed}}, nil
-				})
-				oldShoot := shoot.DeepCopy()
-				attrs := getShootAttributes(shoot, oldShoot, admission.Update, &metav1.UpdateOptions{})
-				err := admissionHandler.Validate(context.TODO(), attrs, nil)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeInternalServerError())
-				Expect(err).To(MatchError(ContainSubstring("cannot extract the seed template")))
 			})
 
 			It("should forbid Shoot update when zones have changed but still configured in ManagedSeed", func() {

--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -259,7 +259,7 @@ func buildManagedSeed(shoot *gardencorev1beta1.Shoot) (*seedmanagementv1alpha1.M
 				Namespace: gardenletKubeconfigSecretNamespace,
 			},
 		},
-		SeedConfig: &gardenletv1alpha1.SeedConfig{
+		SeedConfig: gardenletv1alpha1.SeedConfig{
 			SeedTemplate: gardencorev1beta1.SeedTemplate{
 				Spec: gardencorev1beta1.SeedSpec{
 					Settings: &gardencorev1beta1.SeedSettings{

--- a/test/integration/controllermanager/managedseedset/managedseedset_test.go
+++ b/test/integration/controllermanager/managedseedset/managedseedset_test.go
@@ -140,7 +140,7 @@ var _ = Describe("ManagedSeedSet controller test", func() {
 				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			SeedConfig: &gardenletv1alpha1.SeedConfig{
+			SeedConfig: gardenletv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: seed.ObjectMeta,
 					Spec:       seed.Spec,

--- a/test/integration/gardenlet/gardenlet/gardenlet_suite_test.go
+++ b/test/integration/gardenlet/gardenlet/gardenlet_suite_test.go
@@ -211,7 +211,7 @@ var _ = BeforeSuite(func() {
 				SyncPeriod: &metav1.Duration{Duration: time.Minute},
 			},
 		},
-		SeedConfig: &config.SeedConfig{
+		SeedConfig: config.SeedConfig{
 			SeedTemplate: gardencore.SeedTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: seed.Name,

--- a/test/integration/gardenlet/gardenlet/gardenlet_test.go
+++ b/test/integration/gardenlet/gardenlet/gardenlet_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Gardenlet controller test", func() {
 					Namespace: gardenNamespaceSeed.Name,
 				},
 			},
-			SeedConfig: &gardenletv1alpha1.SeedConfig{
+			SeedConfig: gardenletv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{

--- a/test/integration/gardenlet/managedseed/managedseed_suite_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_suite_test.go
@@ -211,7 +211,7 @@ var _ = BeforeSuite(func() {
 				SyncPeriod: &metav1.Duration{Duration: time.Minute},
 			},
 		},
-		SeedConfig: &config.SeedConfig{
+		SeedConfig: config.SeedConfig{
 			SeedTemplate: gardencore.SeedTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: seed.Name,

--- a/test/integration/gardenlet/managedseed/managedseed_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_test.go
@@ -104,7 +104,7 @@ var _ = Describe("ManagedSeed controller test", func() {
 					Namespace: gardenNamespaceGarden.Name,
 				},
 			},
-			SeedConfig: &gardenletv1alpha1.SeedConfig{
+			SeedConfig: gardenletv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Seed controller tests", func() {
 						Workers: ptr.To[int64](1),
 					},
 				},
-				SeedConfig: &config.SeedConfig{
+				SeedConfig: config.SeedConfig{
 					SeedTemplate: gardencore.SeedTemplate{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: seedName,

--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -262,7 +262,7 @@ var _ = BeforeSuite(func() {
 					SyncPeriod: &metav1.Duration{Duration: 500 * time.Millisecond},
 				},
 			},
-			SeedConfig: &config.SeedConfig{
+			SeedConfig: config.SeedConfig{
 				SeedTemplate: gardencore.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: seedName,

--- a/test/integration/operator/gardenlet/gardenlet_test.go
+++ b/test/integration/operator/gardenlet/gardenlet_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Gardenlet controller test", func() {
 				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			SeedConfig: &gardenletv1alpha1.SeedConfig{
+			SeedConfig: gardenletv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: seed.ObjectMeta,
 					Spec:       seed.Spec,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Removes unnecessary pointer for `SeedConfig` in `GardenletConfiguration` since otherwise we would always try to default it somehow if it was nil.

**Which issue(s) this PR fixes**:
Fixes #10389

**Special notes for your reviewer**:
None

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `GardenletConfiguration.seedConfig` field of the `gardenlet.config.gardener.cloud/v1alpha1` API is not a pointer anymore.
```
