### PR TITLE
Deflake `NamespacedCloudProfile` integration test

### DIFF
--- a/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
+++ b/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
@@ -118,6 +118,11 @@ var _ = Describe("NamespacedCloudProfile controller tests", func() {
 					Name: "some-image",
 					Versions: []gardencorev1beta1.MachineImageVersion{
 						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "7.8.9"},
+							CRI:              []gardencorev1beta1.CRI{{Name: "containerd"}},
+							Architectures:    []string{"amd64"},
+						},
+						{
 							ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.5.6", ExpirationDate: &expirationDateFuture},
 							CRI: []gardencorev1beta1.CRI{
 								{
@@ -128,11 +133,6 @@ var _ = Describe("NamespacedCloudProfile controller tests", func() {
 							Architectures: []string{
 								"amd64",
 							},
-						},
-						{
-							ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "7.8.9"},
-							CRI:              []gardencorev1beta1.CRI{{Name: "containerd"}},
-							Architectures:    []string{"amd64"},
 						},
 					},
 					UpdateStrategy: &updateStrategy,
@@ -531,6 +531,11 @@ func withSortedArrays(nscpfl gardencorev1beta1.CloudProfileSpec) gardencorev1bet
 	sort.Slice(nscpfl.MachineImages, func(i, j int) bool {
 		return strings.Compare(nscpfl.MachineImages[i].Name, nscpfl.MachineImages[j].Name) >= 0
 	})
+	for mi := range nscpfl.MachineImages {
+		sort.Slice(nscpfl.MachineImages[mi].Versions, func(j, k int) bool {
+			return strings.Compare(nscpfl.MachineImages[mi].Versions[j].Version, nscpfl.MachineImages[mi].Versions[k].Version) >= 0
+		})
+	}
 	sort.Slice(nscpfl.Kubernetes.Versions, func(i, j int) bool {
 		return strings.Compare(nscpfl.Kubernetes.Versions[i].Version, nscpfl.Kubernetes.Versions[j].Version) >= 0
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Fix flake of `NamespacedCloudProfile` integration test by sorting machine image versions.
Example: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10761/pull-gardener-integration/1853709223859326976

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy @tobschli 
```
Compiling namespacedcloudprofile...
    compiled namespacedcloudprofile.test
5s: 0 runs so far, 0 failures, 5 active
10s: 5 runs so far, 0 failures, 5 active
15s: 5 runs so far, 0 failures, 5 active
20s: 10 runs so far, 0 failures, 5 active
25s: 10 runs so far, 0 failures, 5 active
30s: 15 runs so far, 0 failures, 5 active
35s: 20 runs so far, 0 failures, 5 active
40s: 20 runs so far, 0 failures, 5 active
45s: 25 runs so far, 0 failures, 5 active
50s: 25 runs so far, 0 failures, 5 active
55s: 30 runs so far, 0 failures, 5 active
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
