### PR TITLE
Remove `HVPA` from `etcd` component and only use `VPA` for autoscaling

### DIFF
--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -8,31 +8,9 @@ This document describes the used autoscaling mechanism for several components.
 
 ## Garden or Shoot Cluster etcd
 
-By default, if none of the autoscaling modes is requested the `etcd` is deployed with static resources, without autoscaling.
+The `etcd` is scaled by a native `VPA` resource.
 
-However, there are two supported autoscaling modes for the Garden or Shoot cluster etcd.
-
-- `HVPA`
-
-   In `HVPA` mode, the etcd is scaled by the [hvpa-controller](https://github.com/gardener/hvpa-controller). The gardenlet/gardener-operator is creating an `HVPA` resource for the etcd (`main` or `events`).
-   The `HVPA` enables a vertical scaling for etcd.
-
-   The `HVPA` mode is the used autoscaling mode when the `HVPA` feature gate is enabled and the `VPAForETCD` feature gate is disabled.
-
-> [!NOTE]
-> Starting with release `v1.106`, the `HVPA` feature gate is deprecated and locked to false.
-
-- `VPA`
-
-   In `VPA` mode, the etcd is scaled by a native `VPA` resource.
-
-   The `VPA` mode is the used autoscaling mode when the `VPAForETCD` feature gate is enabled (takes precedence over the `HVPA` feature gate).
-
-> [!NOTE]
-> Starting with release `v1.97`, the `VPAForETCD` feature gate is enabled by default.
-> Starting with release `v1.105`, the `VPAForETCD` feature gate is promoted to GA and locked to true.
-
-For both of the autoscaling modes downscaling is handled more pessimistically to prevent many subsequent etcd restarts. Thus, for `production` and `infrastructure` Shoot clusters (or all Garden clusters), downscaling is deactivated for the main etcd. For all other Shoot clusters, lower advertised requests/limits are only applied during the Shoot's maintenance time window.
+Downscaling is handled more pessimistically to prevent many subsequent etcd restarts. Thus, for `production` and `infrastructure` Shoot clusters (or all Garden clusters), downscaling is deactivated for the main etcd. For all other Shoot clusters, lower advertised requests/limits are only applied during the Shoot's maintenance time window.
 
 ## Shoot Kubernetes API Server
 

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -406,10 +405,6 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	// TODO(plkokanov): Remove the HVPA cleanup after gardener v1.109.0 has been released.
-	if err := kubernetesutils.DeleteObjects(ctx, e.client, e.emptyHVPA()); err != nil {
-		return err
-	}
 	if err := e.reconcileVerticalPodAutoscaler(ctx, vpa, minAllowed); err != nil {
 		return err
 	}
@@ -724,8 +719,6 @@ func (e *etcd) Destroy(ctx context.Context) error {
 	}
 
 	return kubernetesutils.DeleteObjects(ctx, e.client,
-		// TODO(plkokanov): Remove the HVPA cleanup after gardener v1.109.0 has been released.
-		e.emptyHVPA(),
 		e.emptyVerticalPodAutoscaler(),
 		e.emptyServiceMonitor(),
 		e.emptyScrapeConfig(),
@@ -746,10 +739,6 @@ func (e *etcd) prometheusLabel() string {
 		return garden.Label
 	}
 	return shoot.Label
-}
-
-func (e *etcd) emptyHVPA() *hvpav1alpha1.Hvpa {
-	return &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: e.etcd.Name, Namespace: e.namespace}}
 }
 
 func (e *etcd) emptyServiceMonitor() *monitoringv1.ServiceMonitor {

--- a/pkg/component/etcd/etcd/etcd_suite_test.go
+++ b/pkg/component/etcd/etcd/etcd_suite_test.go
@@ -10,13 +10,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 func TestEtcd(t *testing.T) {
-	gardenletfeatures.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Etcd Suite")
 }

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -23,13 +23,11 @@ import (
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
@@ -86,30 +84,25 @@ var _ = Describe("Etcd", func() {
 		secretNameServerPeer = "etcd-peer-server-" + testRole
 		secretNameClient     = "etcd-client"
 
-		hvpaEnabled           bool
 		maintenanceTimeWindow = gardencorev1beta1.MaintenanceTimeWindow{
 			Begin: "1234",
 			End:   "5678",
 		}
-		scaleDownUpdateMode         *string
-		updateModeMaintenanceWindow = hvpav1alpha1.UpdateModeMaintenanceWindow
-		vpaEnabled                  bool
-		highAvailabilityEnabled     bool
-		caRotationPhase             gardencorev1beta1.CredentialsRotationPhase
-		backupConfig                *BackupConfig
-		now                         = time.Time{}
-		quota                       = resource.MustParse("8Gi")
-		garbageCollectionPolicy     = druidv1alpha1.GarbageCollectionPolicy(druidv1alpha1.GarbageCollectionPolicyExponential)
-		garbageCollectionPeriod     = metav1.Duration{Duration: 12 * time.Hour}
-		compressionPolicy           = druidv1alpha1.GzipCompression
-		compressionSpec             = druidv1alpha1.CompressionSpec{
+		highAvailabilityEnabled bool
+		caRotationPhase         gardencorev1beta1.CredentialsRotationPhase
+		backupConfig            *BackupConfig
+		now                     = time.Time{}
+		quota                   = resource.MustParse("8Gi")
+		garbageCollectionPolicy = druidv1alpha1.GarbageCollectionPolicy(druidv1alpha1.GarbageCollectionPolicyExponential)
+		garbageCollectionPeriod = metav1.Duration{Duration: 12 * time.Hour}
+		compressionPolicy       = druidv1alpha1.GzipCompression
+		compressionSpec         = druidv1alpha1.CompressionSpec{
 			Enabled: ptr.To(true),
 			Policy:  &compressionPolicy,
 		}
 		backupLeaderElectionEtcdConnectionTimeout = &metav1.Duration{Duration: 10 * time.Second}
 		backupLeaderElectionReelectionPeriod      = &metav1.Duration{Duration: 11 * time.Second}
 
-		updateModeAuto      = hvpav1alpha1.UpdateModeAuto
 		vpaUpdateMode       = vpaautoscalingv1.UpdateModeAuto
 		containerPolicyOff  = vpaautoscalingv1.ContainerScalingModeOff
 		containerPolicyAuto = vpaautoscalingv1.ContainerScalingModeAuto
@@ -351,187 +344,57 @@ var _ = Describe("Etcd", func() {
 
 			return obj
 		}
-		hvpaFor = func(class Class, replicas int32, scaleDownUpdateMode string) *hvpav1alpha1.Hvpa {
-			obj := &hvpav1alpha1.Hvpa{
+
+		expectedVPAFor = func(class Class, evictionRequirement string) *vpaautoscalingv1.VerticalPodAutoscaler {
+			vpa := &vpaautoscalingv1.VerticalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      hvpaName,
+					Name:      vpaName,
 					Namespace: testNamespace,
-					Labels: map[string]string{
-						"gardener.cloud/role": "controlplane",
-						"role":                testRole,
-						"app":                 "etcd-statefulset",
-					},
+					Labels:    map[string]string{v1beta1constants.LabelRole: "etcd-vpa-main"},
 				},
-				Spec: hvpav1alpha1.HvpaSpec{
-					Replicas: ptr.To[int32](1),
-					MaintenanceTimeWindow: &hvpav1alpha1.MaintenanceTimeWindow{
-						Begin: maintenanceTimeWindow.Begin,
-						End:   maintenanceTimeWindow.End,
+				Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Name: etcdName, Kind: "StatefulSet",
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
-					Hpa: hvpav1alpha1.HpaSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"role": "etcd-hpa-" + testRole,
-							},
-						},
-						Deploy: false,
-						Template: hvpav1alpha1.HpaTemplate{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"role": "etcd-hpa-" + testRole,
-								},
-							},
-							Spec: hvpav1alpha1.HpaTemplateSpec{
-								MinReplicas: &replicas,
-								MaxReplicas: replicas,
-								Metrics: []autoscalingv2beta1.MetricSpec{
-									{
-										Type: autoscalingv2beta1.ResourceMetricSourceType,
-										Resource: &autoscalingv2beta1.ResourceMetricSource{
-											Name:                     corev1.ResourceCPU,
-											TargetAverageUtilization: ptr.To[int32](80),
-										},
-									},
-									{
-										Type: autoscalingv2beta1.ResourceMetricSourceType,
-										Resource: &autoscalingv2beta1.ResourceMetricSource{
-											Name:                     corev1.ResourceMemory,
-											TargetAverageUtilization: ptr.To[int32](80),
-										},
-									},
-								},
-							},
-						},
+					UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+						UpdateMode: &vpaUpdateMode,
 					},
-					Vpa: hvpav1alpha1.VpaSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"role": "etcd-vpa-" + testRole,
+					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+							{
+								ContainerName:    "etcd",
+								MinAllowed:       corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("60M")},
+								ControlledValues: &controlledValues,
+								Mode:             &containerPolicyAuto,
+							},
+							{
+								ContainerName:    "backup-restore",
+								Mode:             &containerPolicyOff,
+								ControlledValues: &controlledValues,
 							},
 						},
-						Deploy: true,
-						ScaleUp: hvpav1alpha1.ScaleType{
-							UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-								UpdateMode: &updateModeAuto,
-							},
-							StabilizationDuration: ptr.To("5m"),
-							MinChange: hvpav1alpha1.ScaleParams{
-								CPU: hvpav1alpha1.ChangeParams{
-									Value:      ptr.To("1"),
-									Percentage: ptr.To[int32](80),
-								},
-								Memory: hvpav1alpha1.ChangeParams{
-									Value:      ptr.To("2G"),
-									Percentage: ptr.To[int32](80),
-								},
-							},
-						},
-						ScaleDown: hvpav1alpha1.ScaleType{
-							UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-								UpdateMode: &scaleDownUpdateMode,
-							},
-							StabilizationDuration: ptr.To("15m"),
-							MinChange: hvpav1alpha1.ScaleParams{
-								CPU: hvpav1alpha1.ChangeParams{
-									Value:      ptr.To("1"),
-									Percentage: ptr.To[int32](80),
-								},
-								Memory: hvpav1alpha1.ChangeParams{
-									Value:      ptr.To("2G"),
-									Percentage: ptr.To[int32](80),
-								},
-							},
-						},
-						LimitsRequestsGapScaleParams: hvpav1alpha1.ScaleParams{
-							CPU: hvpav1alpha1.ChangeParams{
-								Value:      ptr.To("2"),
-								Percentage: ptr.To[int32](40),
-							},
-							Memory: hvpav1alpha1.ChangeParams{
-								Value:      ptr.To("5G"),
-								Percentage: ptr.To[int32](40),
-							},
-						},
-						Template: hvpav1alpha1.VpaTemplate{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"role": "etcd-vpa-" + testRole,
-								},
-							},
-							Spec: hvpav1alpha1.VpaTemplateSpec{
-								ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-									ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-										{
-											ContainerName: "etcd",
-											MinAllowed: corev1.ResourceList{
-												corev1.ResourceMemory: resource.MustParse("60M"),
-											},
-											ControlledValues: &controlledValues,
-										},
-										{
-											ContainerName:    "backup-restore",
-											Mode:             &containerPolicyOff,
-											ControlledValues: &controlledValues,
-										},
-									},
-								},
-							},
-						},
-					},
-					WeightBasedScalingIntervals: []hvpav1alpha1.WeightBasedScalingInterval{
-						{
-							VpaWeight:         hvpav1alpha1.VpaOnly,
-							StartReplicaCount: replicas,
-							LastReplicaCount:  replicas,
-						},
-					},
-					TargetRef: &autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: "apps/v1",
-						Kind:       "StatefulSet",
-						Name:       etcdName,
 					},
 				},
 			}
 
+			switch evictionRequirement {
+			case v1beta1constants.EvictionRequirementInMaintenanceWindowOnly:
+				metav1.SetMetaDataLabel(&vpa.ObjectMeta, v1beta1constants.LabelVPAEvictionRequirementsController, v1beta1constants.EvictionRequirementManagedByController)
+				metav1.SetMetaDataAnnotation(&vpa.ObjectMeta, v1beta1constants.AnnotationVPAEvictionRequirementDownscaleRestriction, v1beta1constants.EvictionRequirementInMaintenanceWindowOnly)
+				metav1.SetMetaDataAnnotation(&vpa.ObjectMeta, v1beta1constants.AnnotationShootMaintenanceWindow, maintenanceTimeWindow.Begin+","+maintenanceTimeWindow.End)
+			case v1beta1constants.EvictionRequirementNever:
+				metav1.SetMetaDataLabel(&vpa.ObjectMeta, v1beta1constants.LabelVPAEvictionRequirementsController, v1beta1constants.EvictionRequirementManagedByController)
+				metav1.SetMetaDataAnnotation(&vpa.ObjectMeta, v1beta1constants.AnnotationVPAEvictionRequirementDownscaleRestriction, v1beta1constants.EvictionRequirementNever)
+			}
+
 			if class == ClassImportant {
-				obj.Spec.Vpa.Template.Spec.ResourcePolicy.ContainerPolicies[0].MinAllowed = corev1.ResourceList{
+				vpa.Spec.ResourcePolicy.ContainerPolicies[0].MinAllowed = corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("300M"),
 				}
 			}
 
-			return obj
-		}
-
-		expectedVPA = &vpaautoscalingv1.VerticalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vpaName,
-				Namespace: testNamespace,
-				Labels:    map[string]string{v1beta1constants.LabelRole: "etcd-vpa-main"},
-			},
-			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
-				TargetRef: &autoscalingv1.CrossVersionObjectReference{
-					Name: etcdName, Kind: "StatefulSet",
-					APIVersion: appsv1.SchemeGroupVersion.String(),
-				},
-				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-					UpdateMode: &vpaUpdateMode,
-				},
-				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-						{
-							ContainerName:    "etcd",
-							MinAllowed:       corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("60M")},
-							ControlledValues: &controlledValues,
-							Mode:             &containerPolicyAuto,
-						},
-						{
-							ContainerName:    "backup-restore",
-							Mode:             &containerPolicyOff,
-							ControlledValues: &controlledValues,
-						},
-					},
-				},
-			},
+			return vpa
 		}
 
 		serviceMonitorJobNames = func(prometheusName string) (string, string) {
@@ -799,8 +662,6 @@ var _ = Describe("Etcd", func() {
 	)
 
 	BeforeEach(func() {
-		hvpaEnabled = true
-		vpaEnabled = false
 		caRotationPhase = ""
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 		sm = fakesecretsmanager.New(fakeClient, testNamespace)
@@ -824,10 +685,7 @@ var _ = Describe("Etcd", func() {
 			DefragmentationSchedule: &defragmentationSchedule,
 			CARotationPhase:         caRotationPhase,
 			PriorityClassName:       priorityClassName,
-			HVPAEnabled:             hvpaEnabled,
 			MaintenanceTimeWindow:   maintenanceTimeWindow,
-			ScaleDownUpdateMode:     scaleDownUpdateMode,
-			VPAEnabled:              vpaEnabled,
 			HighAvailabilityEnabled: highAvailabilityEnabled,
 			BackupConfig:            backupConfig,
 		})
@@ -844,37 +702,9 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
 		})
 
-		It("should fail because the statefulset object retrieval fails (using the default sts name)", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
-
-			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-		})
-
-		It("should fail because the statefulset object retrieval fails (using the sts name from etcd object)", func() {
-			statefulSetName := "sts-name"
-
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
-					(&druidv1alpha1.Etcd{
-						Status: druidv1alpha1.EtcdStatus{
-							Etcd: &druidv1alpha1.CrossVersionObjectReference{
-								Name: statefulSetName,
-							},
-						},
-					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
-					return nil
-				},
-			)
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: statefulSetName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
-
-			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-		})
-
 		It("should fail because the etcd cannot be created", func() {
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Return(fakeErr),
 			)
@@ -882,21 +712,7 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
 		})
 
-		It("should fail because the hvpa cannot be created", func() {
-			gomock.InOrder(
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Return(fakeErr),
-			)
-
-			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-		})
-
-		It("should fail because the hvpa cannot be deleted", func() {
+		It("should fail because the hvpa cannot be cleaned up", func() {
 			// update HVPA enablement to 'false', such that the component tries to remove the HVPA object
 			etcd = New(log, c, testNamespace, sm, Values{
 				Role:                    testRole,
@@ -907,14 +723,11 @@ var _ = Describe("Etcd", func() {
 				DefragmentationSchedule: &defragmentationSchedule,
 				CARotationPhase:         "",
 				PriorityClassName:       priorityClassName,
-				HVPAEnabled:             false,
 				MaintenanceTimeWindow:   maintenanceTimeWindow,
-				ScaleDownUpdateMode:     scaleDownUpdateMode,
 			})
 
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
 				c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Return(fakeErr),
@@ -930,7 +743,6 @@ var _ = Describe("Etcd", func() {
 
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(etcdObjFor(
@@ -948,10 +760,10 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
+				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -984,7 +796,6 @@ var _ = Describe("Etcd", func() {
 				DefragmentationSchedule: &defragmentationSchedule,
 				CARotationPhase:         "",
 				PriorityClassName:       priorityClassName,
-				HVPAEnabled:             true,
 				MaintenanceTimeWindow:   maintenanceTimeWindow,
 			})
 
@@ -1001,7 +812,6 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
 					// ignore status when comparing
@@ -1022,10 +832,10 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, updateModeMaintenanceWindow)))
+				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1057,7 +867,6 @@ var _ = Describe("Etcd", func() {
 				StorageClassName:        &storageClassName,
 				DefragmentationSchedule: &defragmentationSchedule,
 				CARotationPhase:         "",
-				HVPAEnabled:             true,
 				MaintenanceTimeWindow:   maintenanceTimeWindow,
 				PriorityClassName:       priorityClassName,
 			})
@@ -1080,7 +889,6 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
 					// ignore status when comparing
@@ -1101,10 +909,10 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, updateModeMaintenanceWindow)))
+				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1142,7 +950,6 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
 					// ignore status when comparing
@@ -1168,10 +975,10 @@ var _ = Describe("Etcd", func() {
 
 					Expect(obj).To(DeepEqual(expectedObj))
 				}),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
+				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1213,7 +1020,6 @@ var _ = Describe("Etcd", func() {
 					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 					return nil
 				}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
 					// ignore status when comparing
@@ -1234,10 +1040,10 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
+				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1252,68 +1058,13 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Deploy(ctx)).To(Succeed())
 		})
 
-		It("should successfully deploy (normal etcd) and keep the existing resource request settings (but not limits) to not interfer with HVPA controller", func() {
+		It("should successfully deploy (normal etcd) and not keep the existing resource request settings", func() {
 			oldTimeNow := TimeNow
 			defer func() { TimeNow = oldTimeNow }()
 			TimeNow = func() time.Time { return now }
 
-			var (
-				existingResourcesContainerEtcd = corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1"),
-						corev1.ResourceMemory: resource.MustParse("2G"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("3"),
-						corev1.ResourceMemory: resource.MustParse("4G"),
-					},
-				}
-				existingResourcesContainerBackupRestore = corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("5"),
-						corev1.ResourceMemory: resource.MustParse("6G"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("7"),
-						corev1.ResourceMemory: resource.MustParse("8G"),
-					},
-				}
-
-				expectedResourcesContainerEtcd = corev1.ResourceRequirements{
-					Requests: existingResourcesContainerEtcd.Requests,
-				}
-				expectedResourcesContainerBackupRestore = corev1.ResourceRequirements{
-					Requests: existingResourcesContainerBackupRestore.Requests,
-				}
-			)
-
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
-					(&appsv1.StatefulSet{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      etcdName,
-							Namespace: testNamespace,
-						},
-						Spec: appsv1.StatefulSetSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{
-											Name:      "etcd",
-											Resources: existingResourcesContainerEtcd,
-										},
-										{
-											Name:      "backup-restore",
-											Resources: existingResourcesContainerBackupRestore,
-										},
-									},
-								},
-							},
-						},
-					}).DeepCopyInto(obj.(*appsv1.StatefulSet))
-					return nil
-				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(etcdObjFor(
@@ -1322,8 +1073,8 @@ var _ = Describe("Etcd", func() {
 						nil,
 						"",
 						"",
-						&expectedResourcesContainerEtcd,
-						&expectedResourcesContainerBackupRestore,
+						nil,
+						nil,
 						secretNameCA,
 						secretNameClient,
 						secretNameServer,
@@ -1331,10 +1082,10 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-					Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
+				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1349,65 +1100,36 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Deploy(ctx)).To(Succeed())
 		})
 
-		Context("When VPAforETCD is enabled", func() {
-			BeforeEach(func() {
-				vpaEnabled = true
-			})
-			It("should successfully deploy (normal etcd) and not keep the existing resource request settings, because we're not using HVPA here", func() {
+		for _, shootPurpose := range []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation, gardencorev1beta1.ShootPurposeProduction} {
+			var purpose = shootPurpose
+			It(fmt.Sprintf("should successfully deploy (important etcd): purpose = %q", purpose), func() {
 				oldTimeNow := TimeNow
 				defer func() { TimeNow = oldTimeNow }()
 				TimeNow = func() time.Time { return now }
 
-				var (
-					existingResourcesContainerEtcd = corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("1"),
-							corev1.ResourceMemory: resource.MustParse("2G"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("3"),
-							corev1.ResourceMemory: resource.MustParse("4G"),
-						},
-					}
-					existingResourcesContainerBackupRestore = corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("5"),
-							corev1.ResourceMemory: resource.MustParse("6G"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("7"),
-							corev1.ResourceMemory: resource.MustParse("8G"),
-						},
-					}
-				)
+				class := ClassImportant
+
+				evictionRequirement := v1beta1constants.EvictionRequirementInMaintenanceWindowOnly
+
+				if purpose == gardencorev1beta1.ShootPurposeProduction {
+					evictionRequirement = v1beta1constants.EvictionRequirementNever
+				}
+
+				etcd = New(log, c, testNamespace, sm, Values{
+					Role:                    testRole,
+					Class:                   class,
+					Replicas:                replicas,
+					StorageCapacity:         storageCapacity,
+					StorageClassName:        &storageClassName,
+					DefragmentationSchedule: &defragmentationSchedule,
+					CARotationPhase:         "",
+					MaintenanceTimeWindow:   maintenanceTimeWindow,
+					PriorityClassName:       priorityClassName,
+					EvictionRequirement:     ptr.To(evictionRequirement),
+				})
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
-						(&appsv1.StatefulSet{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      etcdName,
-								Namespace: testNamespace,
-							},
-							Spec: appsv1.StatefulSetSpec{
-								Template: corev1.PodTemplateSpec{
-									Spec: corev1.PodSpec{
-										Containers: []corev1.Container{
-											{
-												Name:      "etcd",
-												Resources: existingResourcesContainerEtcd,
-											},
-											{
-												Name:      "backup-restore",
-												Resources: existingResourcesContainerBackupRestore,
-											},
-										},
-									},
-								},
-							},
-						}).DeepCopyInto(obj.(*appsv1.StatefulSet))
-						return nil
-					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
@@ -1428,74 +1150,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-						Expect(obj).To(DeepEqual(expectedVPA))
-					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
-					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(prometheusRule("shoot", class, 1, false)))
-					}),
-				)
-
-				Expect(etcd.Deploy(ctx)).To(Succeed())
-			})
-		})
-
-		for _, shootPurpose := range []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation, gardencorev1beta1.ShootPurposeProduction} {
-			var purpose = shootPurpose
-			It(fmt.Sprintf("should successfully deploy (important etcd): purpose = %q", purpose), func() {
-				oldTimeNow := TimeNow
-				defer func() { TimeNow = oldTimeNow }()
-				TimeNow = func() time.Time { return now }
-
-				class := ClassImportant
-
-				updateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
-				if purpose == gardencorev1beta1.ShootPurposeProduction {
-					updateMode = hvpav1alpha1.UpdateModeOff
-				}
-
-				etcd = New(log, c, testNamespace, sm, Values{
-					Role:                    testRole,
-					Class:                   class,
-					Replicas:                replicas,
-					StorageCapacity:         storageCapacity,
-					StorageClassName:        &storageClassName,
-					DefragmentationSchedule: &defragmentationSchedule,
-					CARotationPhase:         "",
-					HVPAEnabled:             true,
-					MaintenanceTimeWindow:   maintenanceTimeWindow,
-					PriorityClassName:       priorityClassName,
-					ScaleDownUpdateMode:     ptr.To(updateMode),
-				})
-
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(etcdObjFor(
-							class,
-							1,
-							nil,
-							"",
-							"",
-							nil,
-							nil,
-							secretNameCA,
-							secretNameClient,
-							secretNameServer,
-							nil,
-							nil,
-							false)))
-					}),
-					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateMode)))
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, evictionRequirement)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1532,7 +1187,6 @@ var _ = Describe("Etcd", func() {
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
@@ -1550,10 +1204,10 @@ var _ = Describe("Etcd", func() {
 							nil,
 							false)))
 					}),
-					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
+					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1595,7 +1249,6 @@ var _ = Describe("Etcd", func() {
 						}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 						return nil
 					}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						expobj := etcdObjFor(
@@ -1616,10 +1269,10 @@ var _ = Describe("Etcd", func() {
 
 						Expect(obj).To(DeepEqual(expobj))
 					}),
-					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateModeMaintenanceWindow)))
+					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1637,8 +1290,6 @@ var _ = Describe("Etcd", func() {
 
 		When("HA setup is configured", func() {
 			BeforeEach(func() {
-				hvpaEnabled = false
-				vpaEnabled = true
 				highAvailabilityEnabled = true
 				replicas = ptr.To[int32](3)
 				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd-peer", Namespace: testNamespace}})).To(Succeed())
@@ -1647,7 +1298,6 @@ var _ = Describe("Etcd", func() {
 			createExpectations := func(caSecretName, clientSecretName, serverSecretName, peerCASecretName, peerServerSecretName string) {
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 						func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 							if peerServerSecretName != "" {
@@ -1680,7 +1330,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-						Expect(obj).To(DeepEqual(expectedVPA))
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1812,8 +1462,6 @@ var _ = Describe("Etcd", func() {
 				secretNamesToTimes := map[string]time.Time{}
 				replicas = ptr.To[int32](0)
 				caRotationPhase = gardencorev1beta1.RotationCompleted
-				hvpaEnabled = false
-				vpaEnabled = true
 
 				var err error
 				sm, err = secretsmanager.New(
@@ -1862,7 +1510,6 @@ var _ = Describe("Etcd", func() {
 							}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 							return nil
 						}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 							func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 								etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
@@ -1881,7 +1528,7 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-							Expect(obj).To(DeepEqual(expectedVPA))
+							Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1917,7 +1564,6 @@ var _ = Describe("Etcd", func() {
 							}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 							return nil
 						}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 							func(_ context.Context, _ client.ObjectKey, _ *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 								return nil
@@ -1930,7 +1576,7 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-							Expect(obj).To(DeepEqual(expectedVPA))
+							Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1954,7 +1600,6 @@ var _ = Describe("Etcd", func() {
 				TimeNow = func() time.Time { return now }
 
 				class := ClassImportant
-				updateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
 
 				replicas = ptr.To[int32](1)
 
@@ -1968,14 +1613,12 @@ var _ = Describe("Etcd", func() {
 					CARotationPhase:             "",
 					RuntimeKubernetesVersion:    semver.MustParse("1.26.1"),
 					PriorityClassName:           priorityClassName,
-					HVPAEnabled:                 hvpaEnabled,
 					MaintenanceTimeWindow:       maintenanceTimeWindow,
 					TopologyAwareRoutingEnabled: true,
 				})
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
@@ -1993,10 +1636,10 @@ var _ = Describe("Etcd", func() {
 							nil,
 							true)))
 					}),
-					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: hvpaName}, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateMode)))
+					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -2019,7 +1662,6 @@ var _ = Describe("Etcd", func() {
 				TimeNow = func() time.Time { return now }
 
 				class := ClassImportant
-				updateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
 
 				replicas = ptr.To[int32](1)
 
@@ -2063,18 +1705,17 @@ var _ = Describe("Etcd", func() {
 				delete(etcdObj.Spec.Etcd.ClientService.Annotations, "networking.resources.gardener.cloud/namespace-selectors")
 				delete(etcdObj.Spec.Etcd.ClientService.Annotations, "networking.resources.gardener.cloud/pod-label-selector-namespace-alias")
 
-				hvpaObj := hvpaFor(class, 1, updateMode)
-				hvpaObj.Name = hvpaName
-
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObj))
 					}),
 					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: testNamespace}}),
-					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: vpaName, Namespace: testNamespace}}),
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
+					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "garden-virtual-garden-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(serviceMonitor("garden", "etcd-client")))
@@ -2269,7 +1910,6 @@ var _ = Describe("Etcd", func() {
 		var etcdObj *druidv1alpha1.Etcd
 
 		BeforeEach(func() {
-			hvpaEnabled = false
 			etcdObj = &druidv1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "etcd-" + testRole,
@@ -2371,59 +2011,6 @@ var _ = Describe("Etcd", func() {
 			)
 
 			Expect(etcd.Scale(ctx, 1)).Should(MatchError(`etcd object still has operation annotation set`))
-		})
-
-		Context("When HVPA is enabled", func() {
-			BeforeEach(func() {
-				hvpaEnabled = true
-				vpaEnabled = false
-			})
-
-			It("should update HVPA with the new replica count if it is enabled", func() {
-				etcdObj.Spec.Replicas = 1
-
-				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdObj), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
-						*etcd = *etcdObj
-						return nil
-					},
-				)
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any())
-
-				hvpaObj := hvpaFor(ClassImportant, 1, hvpav1alpha1.UpdateModeDefault)
-				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(hvpaObj), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, hvpa *hvpav1alpha1.Hvpa, _ ...client.GetOptions) error {
-						*hvpa = *hvpaObj
-						return nil
-					},
-				)
-
-				expectedHvpa := hvpaObj.DeepCopy()
-				expectedHvpa.Spec.Hpa.Template.Spec.MaxReplicas = 3
-				expectedHvpa.Spec.Hpa.Template.Spec.MinReplicas = ptr.To[int32](3)
-				test.EXPECTPatch(ctx, c, expectedHvpa, hvpaObj, types.MergePatchType)
-
-				Expect(etcd.Scale(ctx, 3)).To(Succeed())
-			})
-			Context("When VPAforETCD is enabled", func() {
-				BeforeEach(func() {
-					vpaEnabled = true
-				})
-
-				It("should not update HVPA with the new replica count, because we're not using HVPA here", func() {
-					etcdObj.Spec.Replicas = 1
-
-					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdObj), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
-						func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
-							*etcd = *etcdObj
-							return nil
-						},
-					)
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any())
-
-					Expect(etcd.Scale(ctx, 3)).To(Succeed())
-				})
-			})
 		})
 	})
 

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -111,7 +110,6 @@ var _ = Describe("Etcd", func() {
 		metricsExtensive    = druidv1alpha1.Extensive
 
 		etcdName = "etcd-" + testRole
-		hvpaName = "etcd-" + testRole
 		vpaName  = etcdName
 
 		etcdObjFor = func(
@@ -712,30 +710,6 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
 		})
 
-		It("should fail because the hvpa cannot be cleaned up", func() {
-			// update HVPA enablement to 'false', such that the component tries to remove the HVPA object
-			etcd = New(log, c, testNamespace, sm, Values{
-				Role:                    testRole,
-				Class:                   class,
-				Replicas:                replicas,
-				StorageCapacity:         storageCapacity,
-				StorageClassName:        &storageClassName,
-				DefragmentationSchedule: &defragmentationSchedule,
-				CARotationPhase:         "",
-				PriorityClassName:       priorityClassName,
-				MaintenanceTimeWindow:   maintenanceTimeWindow,
-			})
-
-			gomock.InOrder(
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
-				c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Return(fakeErr),
-			)
-
-			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-		})
-
 		It("should successfully deploy (normal etcd)", func() {
 			oldTimeNow := TimeNow
 			defer func() { TimeNow = oldTimeNow }()
@@ -760,7 +734,6 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -832,7 +805,6 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -909,7 +881,6 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -975,7 +946,6 @@ var _ = Describe("Etcd", func() {
 
 					Expect(obj).To(DeepEqual(expectedObj))
 				}),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1040,7 +1010,6 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1082,7 +1051,6 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false)))
 				}),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 					Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1147,7 +1115,6 @@ var _ = Describe("Etcd", func() {
 							nil,
 							false)))
 					}),
-					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 						Expect(obj).To(DeepEqual(expectedVPAFor(class, evictionRequirement)))
@@ -1204,7 +1171,6 @@ var _ = Describe("Etcd", func() {
 							nil,
 							false)))
 					}),
-					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1269,7 +1235,6 @@ var _ = Describe("Etcd", func() {
 
 						Expect(obj).To(DeepEqual(expobj))
 					}),
-					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1327,7 +1292,6 @@ var _ = Describe("Etcd", func() {
 							false,
 						)))
 					}),
-					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1525,7 +1489,6 @@ var _ = Describe("Etcd", func() {
 							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).NotTo(BeNil())
 							clientSecretName = obj.(*druidv1alpha1.Etcd).Spec.Etcd.ClientUrlTLS.ClientTLSSecretRef.Name
 						}),
-						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1573,7 +1536,6 @@ var _ = Describe("Etcd", func() {
 							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).NotTo(BeNil())
 							clientSecretName = obj.(*druidv1alpha1.Etcd).Spec.Etcd.ClientUrlTLS.ClientTLSSecretRef.Name
 						}),
-						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1636,7 +1598,6 @@ var _ = Describe("Etcd", func() {
 							nil,
 							true)))
 					}),
-					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1680,7 +1641,6 @@ var _ = Describe("Etcd", func() {
 				})
 
 				DeferCleanup(test.WithVar(&etcdName, "virtual-garden-"+etcdName))
-				DeferCleanup(test.WithVar(&hvpaName, "virtual-garden-"+hvpaName))
 				DeferCleanup(test.WithVar(&vpaName, "virtual-garden-"+vpaName))
 
 				etcdObj := etcdObjFor(
@@ -1711,7 +1671,6 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObj))
 					}),
-					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: testNamespace}}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
 						Expect(obj).To(DeepEqual(expectedVPAFor(class, "")))
@@ -1779,7 +1738,6 @@ var _ = Describe("Etcd", func() {
 
 			gomock.InOrder(
 				c.EXPECT().Patch(ctx, etcdRes, gomock.Any()),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-" + testRole, Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
@@ -1789,23 +1747,11 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Destroy(ctx)).To(Succeed())
 		})
 
-		It("should fail when the hvpa deletion fails", func() {
-			defer test.WithVar(&gardener.TimeNow, nowFunc)()
-
-			gomock.InOrder(
-				c.EXPECT().Patch(ctx, etcdRes, gomock.Any()),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}).Return(fakeErr),
-			)
-
-			Expect(etcd.Destroy(ctx)).To(MatchError(fakeErr))
-		})
-
 		It("should fail when VPA deletion fails", func() {
 			defer test.WithVar(&gardener.TimeNow, nowFunc)()
 
 			gomock.InOrder(
 				c.EXPECT().Patch(ctx, etcdRes, gomock.Any()),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}).Return(fakeErr),
 			)
 
@@ -1817,7 +1763,6 @@ var _ = Describe("Etcd", func() {
 
 			gomock.InOrder(
 				c.EXPECT().Patch(ctx, etcdRes, gomock.Any()),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-" + testRole, Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}).Return(fakeErr),
 			)
@@ -1830,7 +1775,6 @@ var _ = Describe("Etcd", func() {
 
 			gomock.InOrder(
 				c.EXPECT().Patch(ctx, etcdRes, gomock.Any()),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-" + testRole, Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}).Return(fakeErr),
@@ -1844,7 +1788,6 @@ var _ = Describe("Etcd", func() {
 
 			gomock.InOrder(
 				c.EXPECT().Patch(ctx, etcdRes, gomock.Any()),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-" + testRole, Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
@@ -1859,7 +1802,6 @@ var _ = Describe("Etcd", func() {
 
 			gomock.InOrder(
 				c.EXPECT().Patch(ctx, etcdRes, gomock.Any()),
-				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 				c.EXPECT().Delete(ctx, &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-" + testRole, Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),
 				c.EXPECT().Delete(ctx, &monitoringv1alpha1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{Name: "shoot-etcd-druid", Namespace: testNamespace, Labels: map[string]string{"prometheus": "shoot"}}}),

--- a/pkg/component/etcd/etcd/waiter_test.go
+++ b/pkg/component/etcd/etcd/waiter_test.go
@@ -87,12 +87,11 @@ var _ = Describe("#Wait", func() {
 			Role:            testRole,
 			Class:           ClassNormal,
 			StorageCapacity: "20Gi",
-			HVPAEnabled:     true,
 			MaintenanceTimeWindow: gardencorev1beta1.MaintenanceTimeWindow{
 				Begin: "1234",
 				End:   "5678",
 			},
-			ScaleDownUpdateMode: ptr.To(hvpav1alpha1.UpdateModeMaintenanceWindow),
+			EvictionRequirement: ptr.To(v1beta1constants.EvictionRequirementInMaintenanceWindowOnly),
 		})
 
 		expected = &druidv1alpha1.Etcd{

--- a/pkg/component/etcd/etcd/waiter_test.go
+++ b/pkg/component/etcd/etcd/waiter_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,6 +21,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -65,7 +65,7 @@ var _ = Describe("#Wait", func() {
 		Expect(corev1.AddToScheme(s)).To(Succeed())
 		Expect(appsv1.AddToScheme(s)).To(Succeed())
 		Expect(networkingv1.AddToScheme(s)).To(Succeed())
-		Expect(hvpav1alpha1.AddToScheme(s)).To(Succeed())
+		Expect(vpaautoscalingv1.AddToScheme(s)).To(Succeed())
 		Expect(druidv1alpha1.AddToScheme(s)).To(Succeed())
 		Expect(monitoringv1alpha1.AddToScheme(s)).To(Succeed())
 		Expect(monitoringv1.AddToScheme(s)).To(Succeed())

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Etcd", func() {
 			})
 		})
 
-		Context("no ManagedSeeds", func() {
+		Context("no ManagedSeed", func() {
 			BeforeEach(func() {
 				botanist.ManagedSeed = nil
 			})
@@ -144,7 +144,7 @@ var _ = Describe("Etcd", func() {
 			}
 		})
 
-		Context("no HVPAShootedSeed feature gate", func() {
+		Context("with ManagedSeed", func() {
 			BeforeEach(func() {
 				botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
This PR removes `HVPA` based autoscaling from the `etcd` component so that only VPA is used. It essentially removes no-longer used code as the `HVPA` feature gate was locked to `false` in gardener `v1.106.0` and the `VPAForETCD` feature gate was locked to `true` in gardener `v1.105.0`. A similar PR was opened for the `{gardener,kube}-apiserver` - #10796

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The HVPA autoscaling option (which is unconditionally disabled since v1.105.0) is removed from the `etcd` component. Before updating to this version of Gardener, make sure that you upgraded to v1.106.0 and all Seed and Garden resources reconciled with that version. This is required to ensure that the HVPA component and its CRD were properly cleaned up.
```
