### PR TITLE
Allow dual-stack shoots creation.

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -938,7 +938,10 @@ func validateNetworking(networking *core.Networking, workerless bool, fldPath *f
 		cidr := cidrvalidation.NewCIDR(*networking.Nodes, path)
 
 		allErrs = append(allErrs, cidr.ValidateParse()...)
-		allErrs = append(allErrs, cidr.ValidateIPFamily(string(primaryIPFamily))...)
+		// For dualstack, primaryIPFamily might not match configured CIDRs
+		if len(networking.IPFamilies) < 2 {
+			allErrs = append(allErrs, cidr.ValidateIPFamily(string(primaryIPFamily))...)
+		}
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(path, cidr.GetCIDR())...)
 	}
 
@@ -947,7 +950,10 @@ func validateNetworking(networking *core.Networking, workerless bool, fldPath *f
 		cidr := cidrvalidation.NewCIDR(*networking.Pods, path)
 
 		allErrs = append(allErrs, cidr.ValidateParse()...)
-		allErrs = append(allErrs, cidr.ValidateIPFamily(string(primaryIPFamily))...)
+		// For dualstack, primaryIPFamily might not match configured CIDRs
+		if len(networking.IPFamilies) < 2 {
+			allErrs = append(allErrs, cidr.ValidateIPFamily(string(primaryIPFamily))...)
+		}
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(path, cidr.GetCIDR())...)
 	}
 
@@ -956,7 +962,10 @@ func validateNetworking(networking *core.Networking, workerless bool, fldPath *f
 		cidr := cidrvalidation.NewCIDR(*networking.Services, path)
 
 		allErrs = append(allErrs, cidr.ValidateParse()...)
-		allErrs = append(allErrs, cidr.ValidateIPFamily(string(primaryIPFamily))...)
+		// For dualstack, primaryIPFamily might not match configured CIDRs
+		if len(networking.IPFamilies) < 2 {
+			allErrs = append(allErrs, cidr.ValidateIPFamily(string(primaryIPFamily))...)
+		}
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(path, cidr.GetCIDR())...)
 	}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3734,6 +3734,20 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 		})
 
+		Context("dual-stack", func() {
+			BeforeEach(func() {
+				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6, core.IPFamilyIPv4}
+			})
+
+			It("should allow IPv4 networking configuration", func() {
+				shoot.Spec.Networking.Nodes = ptr.To("10.250.0.0/16")
+				shoot.Spec.Networking.Services = ptr.To("100.64.0.0/13")
+				shoot.Spec.Networking.Pods = ptr.To("100.96.0.0/11")
+				errorList := ValidateShoot(shoot)
+				Expect(errorList).To(BeEmpty())
+			})
+		})
+
 		Context("maintenance section", func() {
 			It("should forbid invalid formats for the time window begin and end values", func() {
 				shoot.Spec.Maintenance.TimeWindow.Begin = "invalidformat"

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -171,6 +171,20 @@ var _ = Describe("Network validation tests", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 		})
+
+		Context("dual-stack", func() {
+			BeforeEach(func() {
+				network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6, extensionsv1alpha1.IPFamilyIPv4}
+			})
+
+			It("should allow valid network resources", func() {
+				network.Spec.PodCIDR = "10.20.30.40/26"
+				network.Spec.ServiceCIDR = "10.30.40.50/26"
+
+				errorList := ValidateNetwork(network)
+				Expect(errorList).To(BeEmpty())
+			})
+		})
 	})
 
 	Describe("#ValidateNetworkUpdate", func() {

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -280,17 +280,10 @@ var _ = Describe("Network validation tests", func() {
 			))
 		})
 
-		It("should deny dual-stack IP families", func() {
+		It("should allow dual-stack IP families", func() {
 			ipFamilies := []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6}
 			errorList := ValidateIPFamilies(ipFamilies, fldPath)
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal(fldPath.String()),
-					"BadValue": Equal(ipFamilies),
-					"Detail":   Equal("dual-stack networking is not supported"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
 		It("should allow IPv4 single-stack", func() {

--- a/pkg/component/extensions/network/network.go
+++ b/pkg/component/extensions/network/network.go
@@ -172,6 +172,13 @@ func (n *network) WaitCleanup(ctx context.Context) error {
 	)
 }
 
+func getCIDRforSpec(ipFamilies []extensionsv1alpha1.IPFamily, PodCIDRs []net.IPNet) string {
+	if len(ipFamilies) == 2 && ipFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 {
+		return PodCIDRs[1].String()
+	}
+	return PodCIDRs[0].String()
+}
+
 func (n *network) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, n.client, n.network, func() error {
 		metav1.SetMetaDataAnnotation(&n.network.ObjectMeta, v1beta1constants.GardenerOperation, operation)
@@ -183,8 +190,8 @@ func (n *network) deploy(ctx context.Context, operation string) (extensionsv1alp
 				ProviderConfig: n.values.ProviderConfig,
 			},
 			IPFamilies:  n.values.IPFamilies,
-			PodCIDR:     n.values.PodCIDRs[0].String(),
-			ServiceCIDR: n.values.ServiceCIDRs[0].String(),
+			PodCIDR:     getCIDRforSpec(n.values.IPFamilies, n.values.PodCIDRs),
+			ServiceCIDR: getCIDRforSpec(n.values.IPFamilies, n.values.ServiceCIDRs),
 		}
 
 		return nil

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -1019,7 +1019,8 @@ func commandForKubernetesVersion(
 
 	if !isWorkerless {
 		if nodeCIDRMaskSize != nil {
-			command = append(command, fmt.Sprintf("--node-cidr-mask-size=%d", *nodeCIDRMaskSize))
+			command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv4=%d", *nodeCIDRMaskSize))
+			command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv6=%d", 64))
 		}
 
 		command = append(command,

--- a/pkg/gardenlet/operation/botanist/infrastructure.go
+++ b/pkg/gardenlet/operation/botanist/infrastructure.go
@@ -64,7 +64,7 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 
 	networkingStatus := &gardencorev1beta1.NetworkingStatus{}
 	if nodesCIDRs := b.Shoot.Components.Extensions.Infrastructure.NodesCIDRs(); len(nodesCIDRs) > 0 {
-		// Only update node CIDR in IPv6 single stack clusters.
+		// Only update node CIDR if it's not already set.
 		if b.Shoot.GetInfo().Spec.Networking.Nodes == nil {
 			if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
 				shoot.Spec.Networking.Nodes = &nodesCIDRs[0]

--- a/pkg/gardenlet/operation/botanist/infrastructure.go
+++ b/pkg/gardenlet/operation/botanist/infrastructure.go
@@ -63,13 +63,15 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 	}
 
 	networkingStatus := &gardencorev1beta1.NetworkingStatus{}
-
 	if nodesCIDRs := b.Shoot.Components.Extensions.Infrastructure.NodesCIDRs(); len(nodesCIDRs) > 0 {
-		if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
-			shoot.Spec.Networking.Nodes = &nodesCIDRs[0]
-			return nil
-		}); err != nil {
-			return err
+		// Only update node CIDR in IPv6 single stack clusters.
+		if b.Shoot.GetInfo().Spec.Networking.Nodes == nil {
+			if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+				shoot.Spec.Networking.Nodes = &nodesCIDRs[0]
+				return nil
+			}); err != nil {
+				return err
+			}
 		}
 
 		networkingStatus.Nodes = nodesCIDRs

--- a/pkg/gardenlet/operation/botanist/infrastructure_test.go
+++ b/pkg/gardenlet/operation/botanist/infrastructure_test.go
@@ -196,17 +196,19 @@ var _ = Describe("Infrastructure", func() {
 			infrastructure.EXPECT().PodsCIDRs()
 			infrastructure.EXPECT().ServicesCIDRs()
 			infrastructure.EXPECT().EgressCIDRs()
-			shoot.Spec.Networking.Nodes = ptr.To(nodesCIDRs[0])
 
 			updatedShoot := shoot.DeepCopy()
-			updatedShoot.Status.Networking = &gardencorev1beta1.NetworkingStatus{}
+			updatedShoot.Spec.Networking.Nodes = ptr.To(nodesCIDRs[0])
+			botanist.Shoot.SetInfo(updatedShoot)
+			updatedShoot2 := updatedShoot.DeepCopy()
+			updatedShoot2.Status.Networking = &gardencorev1beta1.NetworkingStatus{}
 			gardenClient.EXPECT().Status().Return(mockStatusWriter)
-			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType)
+			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot2, updatedShoot, types.StrategicMergePatchType)
 
 			seedClientSet.EXPECT().Client().Return(seedClient)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(Succeed())
-			Expect(botanist.Shoot.GetInfo()).To(Equal(updatedShoot))
+			Expect(botanist.Shoot.GetInfo()).To(Equal(updatedShoot2))
 		})
 
 		It("should return the error during wait", func() {

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -10,6 +10,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
 	kubeapiserverexposure "github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure"
@@ -67,15 +68,7 @@ func (b *Botanist) DeployKubeAPIServerSNI(ctx context.Context) error {
 }
 
 func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
-	isShootIPv6Only := true
-	for _, s := range b.Shoot.Networks.Services {
-		if s.IP.To4() != nil {
-			isShootIPv6Only = false
-			break
-		}
-	}
-
-	if isShootIPv6Only && net.ParseIP(clusterIP).To4() != nil {
+	if b.Shoot.GetInfo().Spec.Networking.IPFamilies[0] == v1beta1.IPFamilyIPv6 && net.ParseIP(clusterIP).To4() != nil {
 		// "64:ff9b:1::" is a well known prefix for address translation for use
 		// in local networks.
 		b.APIServerClusterIP = "64:ff9b:1::" + clusterIP

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -92,9 +92,10 @@ var _ = Describe("shoot", func() {
 			It("returns correct joined networks if shoot status is set", func() {
 				shoot.Status.Networking = &gardencorev1beta1.NetworkingStatus{
 					Pods:     []string{"11.0.0.0/24", "12.0.0.0/24", "10.0.0.0/24"},
-					Services: []string{"20.0.0.0/24", "21.0.0.0/24"},
+					Services: []string{"20.0.0.0/24", "2001:db8::/64"},
 					Nodes:    []string{"30.0.0.0/24", "2001:db8::/64"},
 				}
+				shoot.Spec.Networking.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6, gardencorev1beta1.IPFamilyIPv4}
 				result, err := ToNetworks(shoot, false)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -115,26 +116,26 @@ var _ = Describe("shoot", func() {
 					},
 					Services: []net.IPNet{
 						{
-							IP:   []byte{20, 0, 0, 0},
-							Mask: []byte{255, 255, 255, 0},
+							IP:   []byte{32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0},
 						},
 						{
-							IP:   []byte{21, 0, 0, 0},
+							IP:   []byte{20, 0, 0, 0},
 							Mask: []byte{255, 255, 255, 0},
 						},
 					},
 					Nodes: []net.IPNet{
 						{
-							IP:   []byte{30, 0, 0, 0},
-							Mask: []byte{255, 255, 255, 0},
-						},
-						{
 							IP:   []byte{32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 							Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0},
 						},
+						{
+							IP:   []byte{30, 0, 0, 0},
+							Mask: []byte{255, 255, 255, 0},
+						},
 					},
-					APIServer: []net.IP{[]byte{20, 0, 0, 1}, []byte{21, 0, 0, 1}},
-					CoreDNS:   []net.IP{[]byte{20, 0, 0, 10}, []byte{21, 0, 0, 10}},
+					APIServer: []net.IP{[]byte{32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, []byte{20, 0, 0, 1}},
+					CoreDNS:   []net.IP{[]byte{32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10}, []byte{20, 0, 0, 10}},
 				})))
 			})
 


### PR DESCRIPTION
The PR contains changes that allow the creation of dual-stack shoots.
* Adapt validation to allow dual-stack clusters.
* Provide correct command line for kube-controller-manager for dual-stack.
* Don't overwrite  node CIDR in Shoot spec.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow dual-stack shoots creation.
```
