### PR TITLE
Cleanup `hvpa` controller and CRD

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -170,12 +170,12 @@ gardener:
     priorityClassName: gardener-garden-system-200
 ```
 
-As soon as a `Garden` object is created and `runtimeValues` are configured, the extension is deployed in the runtime cluster. 
+As soon as a `Garden` object is created and `runtimeValues` are configured, the extension is deployed in the runtime cluster.
 
 ##### Extension Registration
 
 When the virtual garden cluster is available, the `Extension` controller manages [`ControllerRegistration`/`ControllerDeployment` resources](../extensions/controllerregistration.md#registering-extension-controllers)
-to register extensions for shoots.  The fields of `.spec.deployment.extension` include their configuration options. 
+to register extensions for shoots.  The fields of `.spec.deployment.extension` include their configuration options.
 
 #### Configuration for Admission Deployment
 
@@ -237,7 +237,6 @@ Other system components are:
 - runtime garden system resources ([`PriorityClass`es](../development/priority-classes.md) for the workload resources)
 - virtual garden system resources (RBAC rules)
 - Vertical Pod Autoscaler (if enabled via `.spec.runtimeCluster.settings.verticalPodAutoscaler.enabled=true` in the `Garden`)
-- HVPA Controller (when `HVPA` feature gate is enabled)
 - ETCD Druid
 - Istio
 
@@ -674,7 +673,6 @@ As of today, this applies to:
 
 - `gardener-resource-manager`
 - `vpa-{admission-controller,recommender,updater}`
-- `hvpa-controller` (when `HVPA` feature gate is enabled)
 - `etcd-druid`
 - `istio` control-plane
 - `nginx-ingress-controller`

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -25,7 +25,7 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 | `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver`                                                                                                      |
 | `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`, Extension Admission Controllers                                                                                                         |
 | `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`                                                                                                       |
-| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`, `gardener-dashboard`, `terminal-controller-manager`, `gardener-discovery-server`, Extension Controllers    |
+| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `gardener-scheduler`, `gardener-controller-manager`, `gardener-dashboard`, `terminal-controller-manager`, `gardener-discovery-server`, Extension Controllers    |
 | `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `gardener-metrics-exporter`, `kube-state-metrics`, `plutono`, `vali`, `prometheus-operator`, `alertmanager-garden`, `prometheus-garden`, `blackbox-exporter`, `prometheus-longterm` |
 
 ## Seed Clusters

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -24,7 +24,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -279,8 +278,4 @@ func determineClusterIdentity(ctx context.Context, c client.Client) (string, err
 
 func vpaEnabled(settings *gardencorev1beta1.SeedSettings) bool {
 	return settings == nil || settings.VerticalPodAutoscaler == nil || settings.VerticalPodAutoscaler.Enabled
-}
-
-func hvpaEnabled() bool {
-	return features.DefaultFeatureGate.Enabled(features.HVPA)
 }

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operator/apis/config"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/operator/controller/gardenlet"
@@ -554,10 +553,6 @@ func vpaEnabled(settings *operatorv1alpha1.Settings) bool {
 		return ptr.Deref(settings.VerticalPodAutoscaler.Enabled, false)
 	}
 	return false
-}
-
-func hvpaEnabled() bool {
-	return features.DefaultFeatureGate.Enabled(features.HVPA)
 }
 
 func getValidVolumeSize(volume *operatorv1alpha1.Volume, size string) string {

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -369,12 +369,6 @@ func (r *Reconciler) delete(
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Destroying custom resource definition for HVPA",
-			Fn:           c.hvpaCRD.Destroy,
-			SkipIf:       !hvpaEnabled(),
-			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
-		})
-		_ = g.Add(flow.Task{
 			Name:         "Destroying ETCD-related custom resource definitions",
 			Fn:           c.etcdCRD.Destroy,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
With the `HVPA` feature gate locked to false in #10659, the `HVPA` controller and CRD are no-longer deployed. 
This  PR cleans up the code so that the removal of the controller and CRD is done always and the feature gate can be easily removed in a future PR.

I have opened "similar" PRs which remove code related to HVPA from `{gardener,kube}-apiserver` and `etcd` components, respectively: https://github.com/gardener/gardener/pull/10796 https://github.com/gardener/gardener/pull/10800

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Note that if this PR is not merged for the gardener `v1.109.0` release, we could directly remove the cleanup logic, instead of adding `TODOs`. Potentially, this will also allow us to cleanup gardenlet's rbac and other resources that mention HVPA.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
