### PR TITLE
Ensure unique VPN tlsauth secrets for different tlsauth keys

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+secret:
+  ignored_matches:
+    - match: vpn-seed-server-tlsauth-a1d0aa00-2a3206b8
+      name: it's a secret name only

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -100,7 +100,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretNameServiceAccountKey       = "service-account-key-c37a87f6"
 		secretNameServiceAccountKeyBundle = "service-account-key-bundle"
 		secretNameVPNSeedClient           = "vpn-seed-client"
-		secretNameVPNSeedServerTLSAuth    = "vpn-seed-server-tlsauth-a1d0aa00"
+		secretNameVPNSeedServerTLSAuth    = "vpn-seed-server-tlsauth-a1d0aa00-2a3206b8"
 
 		configMapNameAdmissionConfigs  = "kube-apiserver-admission-config-e38ff146"
 		secretNameAdmissionKubeconfigs = "kube-apiserver-admission-kubeconfigs-e3b0c442"
@@ -2851,7 +2851,7 @@ kind: AuthorizationConfiguration
 					Expect(deployment.Annotations).To(Equal(utils.MergeStringMaps(defaultAnnotations, map[string]string{
 						"reference.resources.gardener.cloud/secret-8ddd8e24":    secretNameCAVPN,
 						"reference.resources.gardener.cloud/secret-a41fe9a3":    secretNameVPNSeedClient,
-						"reference.resources.gardener.cloud/secret-facfe649":    secretNameVPNSeedServerTLSAuth,
+						"reference.resources.gardener.cloud/secret-065be996":    secretNameVPNSeedServerTLSAuth,
 						"reference.resources.gardener.cloud/configmap-a9a818ab": "kube-root-ca.crt",
 					})))
 				})
@@ -3040,7 +3040,7 @@ kind: AuthorizationConfiguration
 					Expect(deployment.Spec.Template.Annotations).To(Equal(utils.MergeStringMaps(defaultAnnotations, map[string]string{
 						"reference.resources.gardener.cloud/secret-8ddd8e24":    secretNameCAVPN,
 						"reference.resources.gardener.cloud/secret-a41fe9a3":    secretNameVPNSeedClient,
-						"reference.resources.gardener.cloud/secret-facfe649":    secretNameVPNSeedServerTLSAuth,
+						"reference.resources.gardener.cloud/secret-065be996":    secretNameVPNSeedServerTLSAuth,
 						"reference.resources.gardener.cloud/configmap-a9a818ab": "kube-root-ca.crt",
 					})))
 				})

--- a/pkg/component/kubernetes/apiserver/secrets.go
+++ b/pkg/component/kubernetes/apiserver/secrets.go
@@ -21,10 +21,10 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component/apiserver"
-	vpnseedserver "github.com/gardener/gardener/pkg/component/networking/vpn/seedserver"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	"github.com/gardener/gardener/pkg/utils/secrets/vpntlsauth"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
@@ -227,9 +227,7 @@ func (k *kubeAPIServer) reconcileSecretHAVPNSeedClientTLSAuth(ctx context.Contex
 		return nil, nil
 	}
 
-	return k.secretsManager.Generate(ctx, &secretsutils.VPNTLSAuthConfig{
-		Name: vpnseedserver.SecretNameTLSAuth,
-	}, secretsmanager.Rotate(secretsmanager.InPlace))
+	return vpntlsauth.GenerateSecret(ctx, k.secretsManager)
 }
 
 type tlsSNISecret struct {

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -48,13 +48,14 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	"github.com/gardener/gardener/pkg/utils/secrets/vpntlsauth"
 )
 
 const (
 	// GatewayPort is the port exposed by the istio ingress gateway
 	GatewayPort = 8132
 	// SecretNameTLSAuth is the name of seed server tlsauth Secret.
-	SecretNameTLSAuth = "vpn-seed-server-tlsauth" // #nosec G101 -- No credential.
+	SecretNameTLSAuth = vpntlsauth.SecretNameTLSAuth
 	deploymentName    = v1beta1constants.DeploymentNameVPNSeedServer
 	// ServiceName is the name of the vpn seed server service running internally on the control plane in seed.
 	ServiceName = deploymentName
@@ -199,9 +200,7 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	secretTLSAuth, err := v.secretsManager.Generate(ctx, &secretsutils.VPNTLSAuthConfig{
-		Name: SecretNameTLSAuth,
-	}, secretsmanager.Rotate(secretsmanager.InPlace))
+	secretTLSAuth, err := vpntlsauth.GenerateSecret(ctx, v.secretsManager)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -66,7 +66,7 @@ var _ = Describe("VpnSeedServer", func() {
 		controlledValues = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 		namespaceUID     = types.UID("123456")
 
-		secretNameTLSAuth = "vpn-seed-server-tlsauth-a1d0aa00"
+		secretNameTLSAuth = "vpn-seed-server-tlsauth-a1d0aa00-2a3206b8"
 
 		listenAddress   = "0.0.0.0"
 		listenAddressV6 = "::"

--- a/pkg/utils/secrets/vpntlsauth/vpn_tlsauth.go
+++ b/pkg/utils/secrets/vpntlsauth/vpn_tlsauth.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vpntlsauth
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+const (
+	// SecretNameTLSAuth is the name of seed server tlsauth Secret.
+	SecretNameTLSAuth = "vpn-seed-server-tlsauth" // #nosec G101 -- No credential.
+)
+
+// VPNTLSAuthConfigFromSecret is a configuration for a VPN TLS auth secret with the tlsauth key itself as part
+// of the configuration.
+type VPNTLSAuthConfigFromSecret struct {
+	Name string
+	Data map[string][]byte
+}
+
+var _ secretsutils.ConfigInterface = &VPNTLSAuthConfigFromSecret{}
+var _ secretsutils.DataInterface = &VPNTLSAuthConfigFromSecret{}
+
+// GetName returns the name of the secret.
+func (s *VPNTLSAuthConfigFromSecret) GetName() string {
+	return s.Name
+}
+
+// Generate implements ConfigInterface.
+func (s *VPNTLSAuthConfigFromSecret) Generate() (secretsutils.DataInterface, error) {
+	return s, nil
+}
+
+// SecretData computes the data map which can be used in a Kubernetes secret.
+func (s *VPNTLSAuthConfigFromSecret) SecretData() map[string][]byte {
+	return s.Data
+}
+
+// GenerateSecret generates a VPN TLS auth secret using the provided secrets manager.
+// It is used for two-staged generation of tlsauth secret to include the tlsauth key in the secret name hash.
+func GenerateSecret(ctx context.Context, secretsManager secretsmanager.Interface) (*corev1.Secret, error) {
+	// generate a secret with the tlsauth key
+	secretTLSAuthIntermediate, err := secretsManager.Generate(ctx, &secretsutils.VPNTLSAuthConfig{
+		Name: SecretNameTLSAuth,
+	}, secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, err
+	}
+
+	// use the secret to get a secret with same data but including the tlsauth key itself in name hash
+	secretTLSAuth, err := secretsManager.Generate(ctx, &VPNTLSAuthConfigFromSecret{
+		Name: secretTLSAuthIntermediate.Name,
+		Data: secretTLSAuthIntermediate.Data,
+	}, secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, err
+	}
+	return secretTLSAuth, nil
+}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -304,6 +304,7 @@ build:
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
+            - pkg/utils/secrets/vpntlsauth
             - pkg/utils/timewindow
             - pkg/utils/validation/admissionplugins
             - pkg/utils/validation/apigroups

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1280,6 +1280,7 @@ build:
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
+            - pkg/utils/secrets/vpntlsauth
             - pkg/utils/time
             - pkg/utils/timewindow
             - pkg/utils/validation/admissionplugins


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The secret containing the VPN `tlsauth` key has always the same name `vpn-seed-server-tlsauth-a1d0aa00`, currently.
The secretsmanager works as designed. The hash calculation uses the provided config only. Unfortunately, in this case it is only the secret name prefix itself, as the `tlsauth` key is a purely random value.
In edge cases, e.g. if the `vpn-seed-server-tlsauth-*` secret is deleted, the secret is recreated with the same name but a new key. This can lead to situations where pods of `vpn-seed-server` and `vpn-shoot` (and `kube-apiserver` in the HA case) have different `tlsauth` keys, as the deployments stay unchanged. They have only a reference to the secret name, which remains the same, although its data has changed. In such cases the vpn-seed-server reports errors on client connection like

```
Authenticate/Decrypt packet error: packet HMAC authentication failed
```

With this PR it is ensured, that the secret has as an unique name with respect to the key itself and the deployments are updated accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Introducing `.gitguardian.yaml` to avoid incident with false positive.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Ensure unique VPN tlsauth secret names for different tlsauth keys.
```
