### PR TITLE
Support switching cloud profile referenced in `Shoot` from `NamespacedCloudProfile` to parent `CloudProfile`.

### DIFF
--- a/docs/usage/project/namespaced-cloud-profiles.md
+++ b/docs/usage/project/namespaced-cloud-profiles.md
@@ -13,8 +13,8 @@ Project viewers have the permission to see `NamespacedCloudProfile`s associated 
 Project administrators can generally create, edit, or delete `NamespacedCloudProfile`s but with some exceptions (see the [restrictions](#field-modification-restrictions) outlined below).
 
 When creating or updating a `Shoot`, the cloud profile reference can be set to point to a `NamespacedCloudProfile`, allowing for more granular and project-specific configurations.
-The modification of a `Shoot`'s cloud profile reference is restricted to switching from a `CloudProfile` to a descendant `NamespacedCloudProfile`.
-Changing the reference from one `NamespacedCloudProfile` to another `NamespacedCloudProfile` or even to another `CloudProfile` is not allowed.
+The modification of a `Shoot`'s cloud profile reference is restricted to switching within the same profile hierarchy, i.e. from a `CloudProfile` to a descendant `NamespacedCloudProfile`, from a `NamespacedCloudProfile` to its parent `CloudProfile` and between `NamespacedCloudProfile`s having the same `CloudProfile` parent.
+Changing the reference from one `CloudProfile` or descendant `NamespacedCloudProfile` to another `CloudProfile` or descendant `NamespacedCloudProfile` is not allowed.
 
 The usage of `NamespacedCloudProfile`s is currently subject to an alpha feature gate and is not enabled by default.
 It requires the enabled provider extensions to support the feature as well.

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -928,10 +928,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.cloudProfile.name"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.region"),
 				})),
@@ -6123,7 +6119,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should not allow using no cloudProfile reference", func() {
-				errList := ValidateCloudProfileReference(nil, nil, nil, nil, fldPath)
+				errList := ValidateCloudProfileReference(nil, nil, fldPath)
 
 				Expect(errList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -6139,7 +6135,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Name: "",
 				}
 
-				errList := ValidateCloudProfileReference(cloudProfileReference, nil, nil, nil, fldPath)
+				errList := ValidateCloudProfileReference(cloudProfileReference, nil, fldPath)
 
 				Expect(errList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -6155,7 +6151,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Name: "my-profile",
 				}
 
-				errList := ValidateCloudProfileReference(cloudProfileReference, nil, nil, nil, fldPath)
+				errList := ValidateCloudProfileReference(cloudProfileReference, nil, fldPath)
 
 				Expect(errList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -6172,7 +6168,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Name: "my-profile",
 				}
 
-				errList := ValidateCloudProfileReference(cloudProfileReference, nil, nil, nil, fldPath)
+				errList := ValidateCloudProfileReference(cloudProfileReference, nil, fldPath)
 
 				Expect(errList).To(BeEmpty())
 			})
@@ -6183,81 +6179,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Name: "my-profile",
 				}
 
-				errList := ValidateCloudProfileReference(cloudProfileReference, nil, nil, nil, fldPath)
+				errList := ValidateCloudProfileReference(cloudProfileReference, nil, fldPath)
 
 				Expect(errList).To(BeEmpty())
-			})
-
-			It("should allow switching from a CloudProfile to a NamespacedCloudProfile", func() {
-				oldCloudProfileReference := &core.CloudProfileReference{
-					Kind: "CloudProfile",
-					Name: "my-profile",
-				}
-				cloudProfileReference := &core.CloudProfileReference{
-					Kind: "NamespacedCloudProfile",
-					Name: "my-profile-namespaced",
-				}
-
-				errList := ValidateCloudProfileReference(cloudProfileReference, oldCloudProfileReference, nil, nil, fldPath)
-
-				Expect(errList).To(BeEmpty())
-			})
-
-			It("should not allow switching from a NamespacedCloudProfile to a CloudProfile", func() {
-				oldCloudProfileReference := &core.CloudProfileReference{
-					Kind: "NamespacedCloudProfile",
-					Name: "my-profile",
-				}
-				cloudProfileReference := &core.CloudProfileReference{
-					Kind: "CloudProfile",
-					Name: "my-profile",
-				}
-
-				errList := ValidateCloudProfileReference(cloudProfileReference, oldCloudProfileReference, nil, nil, fldPath)
-
-				Expect(errList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeForbidden),
-						"Field":  Equal("cloudProfile.kind"),
-						"Detail": Equal("a namespacedcloudprofile must not be changed back to a cloudprofile"),
-					}))))
-			})
-
-			It("should not allow switching the name of the CloudProfile coming from a cloudProfileName", func() {
-				oldCloudProfileName := ptr.To("my-profile")
-				cloudProfileReference := &core.CloudProfileReference{
-					Kind: "CloudProfile",
-					Name: "my-profile-new",
-				}
-
-				errList := ValidateCloudProfileReference(cloudProfileReference, nil, nil, oldCloudProfileName, fldPath)
-
-				Expect(errList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeForbidden),
-						"Field":  Equal("cloudProfile.name"),
-						"Detail": Equal("changing the cloudProfile name is not allowed, except for switching from a CloudProfile to a directly descendant NamespacedCloudProfile"),
-					}))))
-			})
-
-			It("should not allow switching the name of the CloudProfile coming from a cloudProfile", func() {
-				oldCloudProfileReference := &core.CloudProfileReference{
-					Kind: "CloudProfile",
-					Name: "my-profile",
-				}
-				cloudProfileReference := &core.CloudProfileReference{
-					Kind: "CloudProfile",
-					Name: "my-profile-new",
-				}
-
-				errList := ValidateCloudProfileReference(cloudProfileReference, oldCloudProfileReference, nil, nil, fldPath)
-
-				Expect(errList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeForbidden),
-						"Field":  Equal("cloudProfile.name"),
-						"Detail": Equal("changing the cloudProfile name is not allowed, except for switching from a CloudProfile to a directly descendant NamespacedCloudProfile"),
-					}))))
 			})
 		})
 	})

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -34,6 +34,7 @@ import (
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -865,9 +866,53 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 }
 
 func (r *ReferenceManager) ensureShootReferences(ctx context.Context, attributes admission.Attributes, oldShoot, shoot *core.Shoot) error {
-	if utils.BuildCloudProfileReference(shoot) != utils.BuildCloudProfileReference(oldShoot) {
-		if _, err := utils.GetCloudProfileSpec(r.cloudProfileLister, r.namespacedCloudProfileLister, shoot); err != nil {
+	newCloudProfileReference := utils.BuildCloudProfileReference(shoot)
+	oldCloudProfileReference := utils.BuildCloudProfileReference(oldShoot)
+	if !apiequality.Semantic.DeepEqual(newCloudProfileReference, oldCloudProfileReference) {
+		newCloudProfileSpec, err := utils.GetCloudProfileSpec(r.cloudProfileLister, r.namespacedCloudProfileLister, shoot)
+		if err != nil {
 			return fmt.Errorf("could not find cloudProfileSpec from the shoot cloudProfile reference: %s", err.Error())
+		}
+		if oldCloudProfileReference != nil &&
+			(oldCloudProfileReference.Kind != newCloudProfileReference.Kind || oldCloudProfileReference.Name != newCloudProfileReference.Name) {
+			newCloudProfileSpecCore := &core.CloudProfileSpec{}
+			if err := api.Scheme.Convert(newCloudProfileSpec, newCloudProfileSpecCore, nil); err != nil {
+				return err
+			}
+			oldCloudProfileSpec, err := utils.GetCloudProfileSpec(r.cloudProfileLister, r.namespacedCloudProfileLister, oldShoot)
+			if err != nil {
+				return fmt.Errorf("could not find cloudProfileSpec from the shoot cloudProfile reference: %s", err.Error())
+			}
+			oldCloudProfileSpecCore := &core.CloudProfileSpec{}
+			if err := api.Scheme.Convert(oldCloudProfileSpec, oldCloudProfileSpecCore, nil); err != nil {
+				return err
+			}
+
+			// Check that the target cloud profile still supports the currently used machine types, machine images and volume types.
+			// No need to check for Kubernetes versions, as the NamespacedCloudProfile could have only extended a version so with the next maintenance the Shoot will be updated to a supported version.
+			_, removedMachineImageVersions, _, _ := helper.GetMachineImageDiff(oldCloudProfileSpecCore.MachineImages, newCloudProfileSpecCore.MachineImages)
+			machineTypes := gardenerutils.CreateMapFromSlice(newCloudProfileSpec.MachineTypes, func(mt gardencorev1beta1.MachineType) string { return mt.Name })
+			volumeTypes := gardenerutils.CreateMapFromSlice(newCloudProfileSpec.VolumeTypes, func(vt gardencorev1beta1.VolumeType) string { return vt.Name })
+
+			for _, w := range shoot.Spec.Provider.Workers {
+				if len(removedMachineImageVersions) > 0 && w.Machine.Image != nil {
+					if removedVersions, exists := removedMachineImageVersions[w.Machine.Image.Name]; exists {
+						if removedVersions.Has(w.Machine.Image.Version) {
+							return fmt.Errorf("newly referenced cloud profile does not contain the machine image version \"%s@%s\" currently in use by worker \"%s\"", w.Machine.Image.Name, w.Machine.Image.Version, w.Name)
+						}
+					}
+				}
+
+				if _, exists := machineTypes[w.Machine.Type]; !exists {
+					return fmt.Errorf("newly referenced cloud profile does not contain the machine type %q currently in use by worker %q", w.Machine.Type, w.Name)
+				}
+
+				if w.Volume != nil && w.Volume.Type != nil {
+					if _, exists := volumeTypes[*w.Volume.Type]; !exists {
+						return fmt.Errorf("newly referenced cloud profile does not contain the volume type %q currently in use by worker %q", *w.Volume.Type, w.Name)
+					}
+				}
+			}
 		}
 	}
 

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -1012,25 +1012,6 @@ var _ = Describe("resourcereferencemanager", func() {
 			})
 
 			Context("change the cloud profile reference", func() {
-				var (
-					namespacedCloudProfile gardencorev1beta1.NamespacedCloudProfile
-				)
-
-				BeforeEach(func() {
-					namespacedCloudProfile = gardencorev1beta1.NamespacedCloudProfile{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "namespaced-profile-1",
-							Namespace: namespace,
-						},
-						Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
-							Parent: gardencorev1beta1.CloudProfileReference{
-								Name: cloudProfileName,
-								Kind: "CloudProfile",
-							},
-						},
-					}
-				})
-
 				It("should reject because the referenced cloud profile does not exist (create)", func() {
 					attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
@@ -1080,113 +1061,6 @@ var _ = Describe("resourcereferencemanager", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(HaveOccurred())
-				})
-
-				It("should reject because the cloud profile changed to does not contain the Shoot's current machine type", func() {
-					Expect(gardenCoreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-					Expect(gardenCoreInformerFactory.Core().V1beta1().NamespacedCloudProfiles().Informer().GetStore().Add(&namespacedCloudProfile)).To(Succeed())
-
-					coreShoot.Spec.Provider.Workers = []core.Worker{
-						{
-							Name: "testing",
-							Machine: core.Machine{
-								Type: "a-special-machine-type",
-							},
-						},
-					}
-					oldShoot := coreShoot.DeepCopy()
-					oldShoot.Spec.CloudProfile = &core.CloudProfileReference{
-						Kind: "NamespacedCloudProfile",
-						Name: "namespaced-profile-1",
-					}
-
-					attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
-
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
-						"ErrStatus": MatchFields(IgnoreExtras, Fields{
-							"Code":    Equal(int32(http.StatusForbidden)),
-							"Message": ContainSubstring("newly referenced cloud profile does not contain the machine type \"a-special-machine-type\" currently in use by worker \"testing\""),
-						}),
-					})))
-				})
-
-				It("should reject because the cloud profile changed to does not contain the Shoot's current volume type", func() {
-					cloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{{Name: "a-special-machine-type"}}
-
-					Expect(gardenCoreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-					Expect(gardenCoreInformerFactory.Core().V1beta1().NamespacedCloudProfiles().Informer().GetStore().Add(&namespacedCloudProfile)).To(Succeed())
-
-					coreShoot.Spec.Provider.Workers = []core.Worker{
-						{
-							Name:    "testing",
-							Machine: core.Machine{Type: "a-special-machine-type"},
-							Volume: &core.Volume{
-								Type: ptr.To("a-special-volume-type"),
-							},
-						},
-					}
-					oldShoot := coreShoot.DeepCopy()
-					oldShoot.Spec.CloudProfile = &core.CloudProfileReference{
-						Kind: "NamespacedCloudProfile",
-						Name: "namespaced-profile-1",
-					}
-
-					attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
-
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
-						"ErrStatus": MatchFields(IgnoreExtras, Fields{
-							"Code":    Equal(int32(http.StatusForbidden)),
-							"Message": ContainSubstring("newly referenced cloud profile does not contain the volume type \"a-special-volume-type\" currently in use by worker \"testing\""),
-						}),
-					})))
-				})
-
-				It("should reject because the cloud profile changed to does not contain the Shoot's current machine image version", func() {
-					cloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{{Name: "a-special-machine-type"}}
-
-					namespacedCloudProfile.Status.CloudProfileSpec.MachineImages = []gardencorev1beta1.MachineImage{
-						{
-							Name: "gardenlinux",
-							Versions: []gardencorev1beta1.MachineImageVersion{
-								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1592.1.0-dev"}},
-							},
-						},
-					}
-					Expect(gardenCoreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-					Expect(gardenCoreInformerFactory.Core().V1beta1().NamespacedCloudProfiles().Informer().GetStore().Add(&namespacedCloudProfile)).To(Succeed())
-
-					coreShoot.Spec.Provider.Workers = []core.Worker{
-						{
-							Name: "testing",
-							Machine: core.Machine{
-								Type: "a-special-machine-type",
-								Image: &core.ShootMachineImage{
-									Name:    "gardenlinux",
-									Version: "1592.1.0-dev",
-								},
-							},
-						},
-					}
-					oldShoot := coreShoot.DeepCopy()
-					oldShoot.Spec.CloudProfile = &core.CloudProfileReference{
-						Kind: "NamespacedCloudProfile",
-						Name: "namespaced-profile-1",
-					}
-
-					attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
-
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
-						"ErrStatus": MatchFields(IgnoreExtras, Fields{
-							"Code":    Equal(int32(http.StatusForbidden)),
-							"Message": ContainSubstring("newly referenced cloud profile does not contain the machine image version \"gardenlinux@1592.1.0-dev\" currently in use by worker \"testing\""),
-						}),
-					})))
 				})
 			})
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -259,7 +259,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, _ adm
 		return fmt.Errorf("new shoot can only specify either cloudProfileName or cloudProfile reference")
 	}
 
-	err = admissionutils.ValidateCloudProfileChanges(v.namespacedCloudProfileLister, shoot, oldShoot)
+	err = admissionutils.ValidateCloudProfileChanges(v.cloudProfileLister, v.namespacedCloudProfileLister, shoot, oldShoot)
 	if err != nil {
 		return err
 	}

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -957,7 +957,7 @@ var _ = Describe("validator", func() {
 					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 					err := admissionHandler.Admit(ctx, attrs, nil)
 
-					Expect(err).To(MatchError(ContainSubstring("cannot change from \"profile\" (root: \"profile\") to \"another-namespacedprofile\" (root: \"another-root-profile\")")))
+					Expect(err).To(MatchError(ContainSubstring("cannot change from \"profile\" to \"another-namespacedprofile\" (root: \"another-root-profile\")")))
 				})
 
 				It("should fail validation on a change from a CloudProfileName to a NamespacedCloudProfile with forbidden parent", func() {
@@ -979,7 +979,7 @@ var _ = Describe("validator", func() {
 					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 					err := admissionHandler.Admit(ctx, attrs, nil)
 
-					Expect(err).To(MatchError(ContainSubstring("cannot change from \"profile\" (root: \"profile\") to \"another-namespacedprofile\" (root: \"another-root-profile\")")))
+					Expect(err).To(MatchError(ContainSubstring("cannot change from \"profile\" to \"another-namespacedprofile\" (root: \"another-root-profile\")")))
 				})
 
 				It("should pass validation on a change from a NamespacedCloudProfile to a CloudProfile", func() {
@@ -1037,6 +1037,105 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(ctx, attrs, nil)
 
 					Expect(err).To(MatchError(ContainSubstring("cannot change from \"namespacedprofile\" (root: \"profile\") to \"namespacedprofile-unrelated\" (root: \"unrelated-profile\")")))
+				})
+
+				It("should reject because the cloud profile changed to does not contain the Shoot's current machine type", func() {
+					shoot.Spec.CloudProfile = &core.CloudProfileReference{
+						Kind: "CloudProfile",
+						Name: "profile",
+					}
+					shoot.Spec.Provider.Workers = []core.Worker{
+						{
+							Name: "testing",
+							Machine: core.Machine{
+								Type: "a-special-machine-type",
+							},
+						},
+					}
+					oldShoot := shoot.DeepCopy()
+					oldShoot.Spec.CloudProfile = &core.CloudProfileReference{
+						Kind: "NamespacedCloudProfile",
+						Name: "namespacedprofile",
+					}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(MatchError(ContainSubstring("newly referenced cloud profile does not contain the machine type \"a-special-machine-type\" currently in use by worker \"testing\"")))
+				})
+
+				It("should reject because the cloud profile changed to does not contain the Shoot's current volume type", func() {
+					cloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{{Name: "a-special-machine-type"}}
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Update(&cloudProfile)).To(Succeed())
+
+					shoot.Spec.CloudProfile = &core.CloudProfileReference{
+						Kind: "CloudProfile",
+						Name: "profile",
+					}
+					shoot.Spec.Provider.Workers = []core.Worker{
+						{
+							Name:    "testing",
+							Machine: core.Machine{Type: "a-special-machine-type"},
+							Volume: &core.Volume{
+								Type: ptr.To("a-special-volume-type"),
+							},
+						},
+					}
+					oldShoot := shoot.DeepCopy()
+					oldShoot.Spec.CloudProfile = &core.CloudProfileReference{
+						Kind: "NamespacedCloudProfile",
+						Name: "namespacedprofile",
+					}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(MatchError(ContainSubstring("newly referenced cloud profile does not contain the volume type \"a-special-volume-type\" currently in use by worker \"testing\"")))
+				})
+
+				It("should reject because the cloud profile changed to does not contain the Shoot's current machine image version", func() {
+					cloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{{Name: "a-special-machine-type"}}
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Update(&cloudProfile)).To(Succeed())
+
+					namespacedCloudProfile.Status.CloudProfileSpec.MachineImages = []gardencorev1beta1.MachineImage{
+						{
+							Name: "gardenlinux",
+							Versions: []gardencorev1beta1.MachineImageVersion{
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1592.1.0-dev"}},
+							},
+						},
+					}
+					Expect(coreInformerFactory.Core().V1beta1().NamespacedCloudProfiles().Informer().GetStore().Update(&namespacedCloudProfile)).To(Succeed())
+
+					shoot.Spec.CloudProfile = &core.CloudProfileReference{
+						Kind: "CloudProfile",
+						Name: "profile",
+					}
+					shoot.Spec.Provider.Workers = []core.Worker{
+						{
+							Name: "testing",
+							Machine: core.Machine{
+								Type: "a-special-machine-type",
+								Image: &core.ShootMachineImage{
+									Name:    "gardenlinux",
+									Version: "1592.1.0-dev",
+								},
+							},
+						},
+					}
+					oldShoot := shoot.DeepCopy()
+					oldShoot.Spec.CloudProfile = &core.CloudProfileReference{
+						Kind: "NamespacedCloudProfile",
+						Name: "namespacedprofile",
+					}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(MatchError(ContainSubstring("newly referenced cloud profile does not contain the machine image version \"gardenlinux@1592.1.0-dev\" currently in use by worker \"testing\"")))
 				})
 			})
 

--- a/plugin/pkg/utils/cloudprofile_test.go
+++ b/plugin/pkg/utils/cloudprofile_test.go
@@ -131,7 +131,7 @@ var _ = Describe("CloudProfile", func() {
 				Name: cloudProfileName,
 			}
 
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -142,7 +142,7 @@ var _ = Describe("CloudProfile", func() {
 			}
 			newShoot := shoot.DeepCopy()
 
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -154,7 +154,7 @@ var _ = Describe("CloudProfile", func() {
 			}
 			newShoot.Spec.CloudProfileName = &cloudProfileName
 
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -167,7 +167,7 @@ var _ = Describe("CloudProfile", func() {
 			}
 			newShoot := shoot.DeepCopy()
 
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -183,7 +183,7 @@ var _ = Describe("CloudProfile", func() {
 				Kind: "NamespacedCloudProfile",
 				Name: namespacedCloudProfileName,
 			}
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -202,7 +202,7 @@ var _ = Describe("CloudProfile", func() {
 				Kind: "NamespacedCloudProfile",
 				Name: namespacedCloudProfileName,
 			}
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -221,7 +221,7 @@ var _ = Describe("CloudProfile", func() {
 				Kind: "CloudProfile",
 				Name: cloudProfileName,
 			}
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -244,7 +244,7 @@ var _ = Describe("CloudProfile", func() {
 				Kind: "NamespacedCloudProfile",
 				Name: namespacedCloudProfileName + "-2",
 			}
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -266,7 +266,7 @@ var _ = Describe("CloudProfile", func() {
 				Kind: "NamespacedCloudProfile",
 				Name: unrelatedNamespacedCloudProfile.Name,
 			}
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -285,7 +285,7 @@ var _ = Describe("CloudProfile", func() {
 				Kind: "CloudProfile",
 				Name: unrelatedCloudProfile.Name,
 			}
-			err := admissionutils.ValidateCloudProfileChanges(namespacedCloudProfileLister, newShoot, shoot)
+			err := admissionutils.ValidateCloudProfileChanges(cloudProfileLister, namespacedCloudProfileLister, newShoot, shoot)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Allow for switching between related `NamespacedCloudProfile`s as well as back and forth between the related `CloudProfile` and `NamespacedCloudProfile`s.
As noted [here](https://github.com/gardener/gardener/pull/10629#discussion_r1802903487).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9504

**Special notes for your reviewer**:
/cc @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Allow changing `shoot.spec.cloudProfile` between `CloudProfile` and its descendant `NamespacedCloudProfile`s.
```
