### PR TITLE
fix: Ignore wrong assertion warnings from ginkgo-linter where appropriate

### DIFF
--- a/pkg/gardenadm/cmd/token/token_test.go
+++ b/pkg/gardenadm/cmd/token/token_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Token", func() {
 
 	Describe("#RunE", func() {
 		It("should not have a Run function", func() {
+			// ginkgo-linter:ignore-err-assert-warning
 			Expect(cmd.RunE).To(BeNil())
 		})
 	})

--- a/pkg/utils/istio/destinationrule_test.go
+++ b/pkg/utils/istio/destinationrule_test.go
@@ -19,6 +19,7 @@ var _ = Describe("DestinationRule", func() {
 
 		function := DestinationRuleWithLocalityPreference(destinationRule, labels, destinationHost)
 
+		// ginkgo-linter:ignore-err-assert-warning
 		Expect(function).NotTo(BeNil())
 
 		err := function()
@@ -37,6 +38,7 @@ var _ = Describe("DestinationRule", func() {
 
 		function := DestinationRuleWithLocalityPreferenceAndTLS(destinationRule, labels, destinationHost, tlsMode)
 
+		// ginkgo-linter:ignore-err-assert-warning
 		Expect(function).NotTo(BeNil())
 
 		err := function()

--- a/pkg/utils/istio/gateway_test.go
+++ b/pkg/utils/istio/gateway_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Gateway", func() {
 
 		function := GatewayWithTLSPassthrough(gateway, labels, istioLabels, hosts, port)
 
+		// ginkgo-linter:ignore-err-assert-warning
 		Expect(function).NotTo(BeNil())
 
 		err := function()
@@ -39,6 +40,7 @@ var _ = Describe("Gateway", func() {
 
 		function := GatewayWithTLSTermination(gateway, labels, istioLabels, hosts, port, tlsSecret)
 
+		// ginkgo-linter:ignore-err-assert-warning
 		Expect(function).NotTo(BeNil())
 
 		err := function()

--- a/pkg/utils/istio/virtualservice_test.go
+++ b/pkg/utils/istio/virtualservice_test.go
@@ -18,6 +18,7 @@ var _ = Describe("VirtualService", func() {
 
 		function := VirtualServiceWithSNIMatch(virtualService, labels, hosts, gatewayName, port, destinationHost)
 
+		// ginkgo-linter:ignore-err-assert-warning
 		Expect(function).NotTo(BeNil())
 
 		err := function()


### PR DESCRIPTION
I've not been added to the team @gardener-maintainers yet, hence I can't push to branches on the repository itself.
Contributing my fix via a PR instead :) 