### PR TITLE
Remove ResourceNames restriction from 'create' verb

### DIFF
--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -836,12 +836,19 @@ frontend:
 					"role": "dashboard",
 				},
 			},
-			Rules: []rbacv1.PolicyRule{{
-				APIGroups:     []string{"coordination.k8s.io"},
-				Resources:     []string{"leases"},
-				ResourceNames: []string{"gardener-dashboard-github-webhook"},
-				Verbs:         []string{"create", "get", "patch", "watch", "list"},
-			}},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups:     []string{"coordination.k8s.io"},
+					Resources:     []string{"leases"},
+					ResourceNames: []string{"gardener-dashboard-github-webhook"},
+					Verbs:         []string{"get", "patch", "watch", "list"},
+				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"create"},
+				},
+			},
 		}
 		roleBindingGitHub = &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/gardener/dashboard/rbac.go
+++ b/pkg/component/gardener/dashboard/rbac.go
@@ -125,12 +125,19 @@ func (g *gardenerDashboard) role() *rbacv1.Role {
 			Namespace: v1beta1constants.GardenNamespace,
 			Labels:    GetLabels(),
 		},
-		Rules: []rbacv1.PolicyRule{{
-			APIGroups:     []string{coordinationv1.GroupName},
-			Resources:     []string{"leases"},
-			ResourceNames: []string{"gardener-dashboard-github-webhook"},
-			Verbs:         []string{"create", "get", "patch", "watch", "list"},
-		}},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{coordinationv1.GroupName},
+				Resources:     []string{"leases"},
+				ResourceNames: []string{"gardener-dashboard-github-webhook"},
+				Verbs:         []string{"get", "patch", "watch", "list"},
+			},
+			{
+				APIGroups: []string{coordinationv1.GroupName},
+				Resources: []string{"leases"},
+				Verbs:     []string{"create"},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR corrects the RBAC rules for the dashboard component by allowing the 'create' verb on 'leases' without restricting by resource name, as per Kubernetes guidelines.

> You cannot restrict create or deletecollection requests by their resource name

https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue where the dashboard's service account lacked permission to create `leases` in the `garden` namespace when `spec.virtualCluster.gardener.gardenerDashboard.gitHub` was configured in the `Garden` resource.
```
