### PR TITLE
Add field `.spec.virtualCluster.etcd.main.backup.managed` for Garden resource

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -372,6 +372,11 @@ spec:
                                 x-kubernetes-validations:
                                 - message: BucketName is immutable
                                   rule: self == oldSelf
+                              managed:
+                                description: Managed is a flag to enable/disable the
+                                  generation of a BackupBucket resource managed by
+                                  a provider extension on the runtime cluster.
+                                type: boolean
                               provider:
                                 description: Provider is a provider name. This field
                                   is immutable.

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -283,6 +283,18 @@ Kubernetes core/v1.LocalObjectReference
 backups should be stored. It should have enough privileges to manipulate the objects as well as buckets.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>managed</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Managed is a flag to enable/disable the generation of a BackupBucket resource managed by a provider extension on the runtime cluster.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="operator.gardener.cloud/v1alpha1.ControlPlane">ControlPlane

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -372,6 +372,11 @@ spec:
                                 x-kubernetes-validations:
                                 - message: BucketName is immutable
                                   rule: self == oldSelf
+                              managed:
+                                description: Managed is a flag to enable/disable the
+                                  generation of a BackupBucket resource managed by
+                                  a provider extension on the runtime cluster.
+                                type: boolean
                               provider:
                                 description: Provider is a provider name. This field
                                   is immutable.

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -75,6 +75,7 @@ spec:
           secretRef:
             name: virtual-garden-etcd-main-backup-local
         # bucketName: gardener-operator # if not provided, gardener-operator generates a name
+        # managed: true
         storage:
           capacity: 25Gi
         # className: default

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -288,6 +288,9 @@ type Backup struct {
 	// SecretRef is a reference to a Secret object containing the cloud provider credentials for the object store where
 	// backups should be stored. It should have enough privileges to manipulate the objects as well as buckets.
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
+	// Managed is a flag to enable/disable the generation of a BackupBucket resource managed by a provider extension on the runtime cluster.
+	// +optional
+	Managed *bool `json:"managed,omitempty"`
 }
 
 // Maintenance contains information about the time window for maintenance operations.

--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -122,6 +122,9 @@ func validateVirtualClusterUpdate(oldGarden, newGarden *operatorv1alpha1.Garden)
 		if newVirtualCluster.ETCD.Main.Backup == nil {
 			allErrs = append(allErrs, field.Forbidden(fldBackup, "backup must not be deactivated if it was set before"))
 		}
+		if ptr.Deref(oldVirtualCluster.ETCD.Main.Backup.Managed, false) && !ptr.Deref(newVirtualCluster.ETCD.Main.Backup.Managed, false) {
+			allErrs = append(allErrs, field.Forbidden(fldBackup.Child("managed"), "managed must not be deactivated if it was set before"))
+		}
 	}
 
 	if oldVirtualCluster.ControlPlane != nil && oldVirtualCluster.ControlPlane.HighAvailability != nil &&

--- a/pkg/apis/operator/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation_test.go
@@ -2218,6 +2218,31 @@ var _ = Describe("Validation Tests", func() {
 						"Field": Equal("spec.virtualCluster.etcd.main.backup"),
 					}))))
 				})
+
+				It("should not be possible to disable the managed flag if it was set initially", func() {
+					oldGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
+						Main: &operatorv1alpha1.ETCDMain{
+							Backup: &operatorv1alpha1.Backup{
+								Provider:   "foo-provider",
+								BucketName: ptr.To("foo-bucket"),
+								Managed:    ptr.To(true),
+							},
+						},
+					}
+					newGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
+						Main: &operatorv1alpha1.ETCDMain{
+							Backup: &operatorv1alpha1.Backup{
+								Provider:   "foo-provider",
+								BucketName: ptr.To("foo-bucket"),
+							},
+						},
+					}
+
+					Expect(ValidateGardenUpdate(oldGarden, newGarden)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("spec.virtualCluster.etcd.main.backup.managed"),
+					}))))
+				})
 			})
 
 			Context("control plane", func() {

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -137,6 +137,11 @@ func (in *Backup) DeepCopyInto(out *Backup) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.SecretRef = in.SecretRef
+	if in.Managed != nil {
+		in, out := &in.Managed, &out.Managed
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -275,7 +275,10 @@ func (r *Reconciler) reconcile(
 					nil,
 				)
 			},
-			SkipIf:       garden.Spec.VirtualCluster.ETCD == nil || garden.Spec.VirtualCluster.ETCD.Main == nil || garden.Spec.VirtualCluster.ETCD.Main.Backup == nil,
+			SkipIf: garden.Spec.VirtualCluster.ETCD == nil ||
+				garden.Spec.VirtualCluster.ETCD.Main == nil ||
+				garden.Spec.VirtualCluster.ETCD.Main.Backup == nil ||
+				!ptr.Deref(garden.Spec.VirtualCluster.ETCD.Main.Backup.Managed, false),
 			Dependencies: flow.NewTaskIDs(deployExtensionCRD),
 		})
 		deployEtcds = g.Add(flow.Task{

--- a/test/e2e/operator/garden/common.go
+++ b/test/e2e/operator/garden/common.go
@@ -115,6 +115,7 @@ func defaultGarden(backupSecret *corev1.Secret, specifyBackupBucket bool) *opera
 							SecretRef: corev1.LocalObjectReference{
 								Name: backupSecret.Name,
 							},
+							Managed: ptr.To(true),
 						},
 					},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The newly introduced generation of the `BackupBucket` resource for the virtual garden by the gardener-operator is now controlled by the new boolean field `.spec.virtualCluster.etcd.main.backup.managed` for the `Garden` resource kind.
This is needed at least temporarily until the provider extensions are ready to be deployed on the runtime cluster.
The section `.spec.virtualCluster.etcd.main.backup` is typically already specified for configuring ETCD druid.
With the current logic, the garden reconciliation waits endless for the reconciliation of the `BackupBucket` in this case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add field `.spec.virtualCluster.etcd.main.backup.managed` for Garden resource to enable gardener managed `BackupBucket` by provider extension on runtime cluster optionally.
```
