### PR TITLE
Allow control-plane blackbox exporter to talk to kube-apiserver service

### DIFF
--- a/pkg/gardenlet/operation/botanist/blackboxexporter.go
+++ b/pkg/gardenlet/operation/botanist/blackboxexporter.go
@@ -11,6 +11,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter"
 	clusterblackboxexporter "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/shoot/cluster"
 	controlplaneblackboxexporter "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/shoot/controlplane"
@@ -35,6 +36,7 @@ func (b *Botanist) DefaultBlackboxExporterControlPlane() (component.DeployWaiter
 				// Traffic to the istio-ingressgateway needs to be allowed because on some infrastructures kube-proxy shortcuts the network path.
 				// It directly forwards the traffic to the target within the cluster (i.e., istio-ingressgateway) instead of first going out and then coming in again.
 				gardenerutils.NetworkPolicyLabel(v1beta1constants.LabelNetworkPolicyIstioIngressNamespaceAlias+"-istio-ingressgateway", 9443): v1beta1constants.LabelNetworkPolicyAllowed,
+				gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port):                   v1beta1constants.LabelNetworkPolicyAllowed,
 			},
 			PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane100,
 			Config:            controlplaneblackboxexporter.Config(),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
The blackbox exporter uses the `kube-apiserver` service to verify that the VPN works. It does this by requesting logs for a container running in the shoot cluster (vpn-shoot-0's init container). When the network policy label above was removed in 413a66c (#10775), blackbox-exporter requests to the API server time out. This, in turn, means that the `probe_success` metric for this job in Prometheus becomes 0, and the VPN dashboard to show that the VPN is down, when it is in fact reachable. The impact of removing this network policy (label) is also visible in the list of blackbox exporter probe results:
![Screenshot 2024-11-13 at 13 07 32](https://github.com/user-attachments/assets/8aa5072a-93be-4941-b967-cb43b04d4894)
Therefore, this PR reintroduces the network policy label.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @MartinWeindel
FYI @ialidzhikov @timebertt  

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
