### PR TITLE
Remove `botanist.DefaultDomainSecret` and code related to it

### DIFF
--- a/pkg/gardenlet/operation/botanist/types.go
+++ b/pkg/gardenlet/operation/botanist/types.go
@@ -5,13 +5,10 @@
 package botanist
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 )
 
 // Botanist is a struct which has methods that perform cloud-independent operations for a Shoot cluster.
 type Botanist struct {
 	*operation.Operation
-	DefaultDomainSecret *corev1.Secret
 }

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation/garden"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -339,12 +338,6 @@ func (o *Operation) IsAPIServerRunning(ctx context.Context) (bool, error) {
 	return *deployment.Spec.Replicas > 0, nil
 }
 
-// GetSecretKeysOfRole returns a list of keys which are present in the Garden Secrets map and which
-// are prefixed with <kind>.
-func (o *Operation) GetSecretKeysOfRole(kind string) []string {
-	return utils.FilterEntriesByPrefix(kind, o.AllSecretKeys())
-}
-
 // ReportShootProgress will update the last operation object in the Shoot manifest `status` section
 // by the current progress of the Flow execution.
 func (o *Operation) ReportShootProgress(ctx context.Context, stats *flow.Stats) {
@@ -452,18 +445,6 @@ func (o *Operation) StoreSecret(key string, secret *corev1.Secret) {
 	}
 
 	o.secrets[key] = secret
-}
-
-// AllSecretKeys returns all stored secret keys from the operation. Calling this function is thread-safe.
-func (o *Operation) AllSecretKeys() []string {
-	o.secretsMutex.RLock()
-	defer o.secretsMutex.RUnlock()
-
-	var keys []string
-	for key := range o.secrets {
-		keys = append(keys, key)
-	}
-	return keys
 }
 
 // LoadSecret loads the secret under the given key from the operation. Calling this function is thread-safe.

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -157,17 +157,6 @@ func InterfaceMapToStringMap(in map[string]any) map[string]string {
 	return m
 }
 
-// FilterEntriesByPrefix returns a list of strings which begin with the given prefix.
-func FilterEntriesByPrefix(prefix string, entries []string) []string {
-	var result []string
-	for _, entry := range entries {
-		if strings.HasPrefix(entry, prefix) {
-			result = append(result, entry)
-		}
-	}
-	return result
-}
-
 // FilterEntriesByFilterFn returns a list of entries which passes the filter function.
 func FilterEntriesByFilterFn(entries []string, filterFn func(entry string) bool) []string {
 	var result []string

--- a/pkg/utils/miscellaneous_test.go
+++ b/pkg/utils/miscellaneous_test.go
@@ -5,7 +5,6 @@
 package utils_test
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
@@ -198,50 +197,6 @@ baz`, spaces)).To(Equal(`foo
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
-		})
-	})
-
-	Describe("#FilterEntriesByPrefix", func() {
-		var (
-			prefix  string
-			entries []string
-		)
-
-		BeforeEach(func() {
-			prefix = "role"
-			entries = []string{
-				"foo",
-				"bar",
-			}
-		})
-
-		It("should only return entries with prefix", func() {
-			expectedEntries := []string{
-				fmt.Sprintf("%s-%s", prefix, "foo"),
-				fmt.Sprintf("%s-%s", prefix, "bar"),
-			}
-
-			entries = append(entries, expectedEntries...)
-
-			result := FilterEntriesByPrefix(prefix, entries)
-			Expect(result).To(ContainElements(expectedEntries))
-		})
-
-		It("should return all entries", func() {
-			expectedEntries := []string{
-				fmt.Sprintf("%s-%s", prefix, "foo"),
-				fmt.Sprintf("%s-%s", prefix, "bar"),
-			}
-
-			entries = expectedEntries
-
-			result := FilterEntriesByPrefix(prefix, entries)
-			Expect(result).To(ContainElements(expectedEntries))
-		})
-
-		It("should return no entries", func() {
-			result := FilterEntriesByPrefix(prefix, entries)
-			Expect(result).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
This PR removes `botanist.DefaultDomainSecret` as after it's value of type `corev1.Secret` is set it's never used anywhere

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
