### PR TITLE
chore: Group gardener-discovery-server Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -173,6 +173,7 @@
       groupName: 'gardener-discovery-server',
       matchDatasources: [
         'docker',
+        'github-releases',
       ],
       matchPackageNames: [
         '/.+gardener-discovery-server$/'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -169,6 +169,16 @@
       ],
     },
     {
+      // Group gardener-discovery-server updates in one PR.
+      groupName: 'gardener-discovery-server',
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        '/.+gardener-discovery-server$/'
+      ],
+    },
+    {
       // Ask for manual approval to create PRs for minor and major updates of dependencies which most likely
       // require manual adaptations of the code.
       matchDatasources: [


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR configures Renovate to group dependency updates for the [gardener-discovery-server](https://github.com/gardener/gardener-discovery-server) into one PR.
The package rule applies when the data source is Docker and the package name ends in `gardener-discovery-server`.

The goal of this PR is to group PRs like these:
* #10850
* #10849

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
