### PR TITLE
Replace deprecated sets.String with generic set.Set

### DIFF
--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -1102,14 +1102,14 @@ func isShootRelatedToCloudProfile(shoot *gardencorev1beta1.Shoot, cloudProfile *
 }
 
 // getRemovedKubernetesVersions returns Kubernetes versions that have been removed from the NamespacedCloudProfile.
-func getRemovedKubernetesVersions(namespacedCloudProfile, oldNamespacedCloudProfile *core.NamespacedCloudProfile) sets.String {
-	var removedKubernetesVersions sets.String
+func getRemovedKubernetesVersions(namespacedCloudProfile, oldNamespacedCloudProfile *core.NamespacedCloudProfile) sets.Set[string] {
+	var removedKubernetesVersions sets.Set[string]
 	if oldNamespacedCloudProfile.Spec.Kubernetes != nil {
 		var newKubernetesVersions []core.ExpirableVersion
 		if namespacedCloudProfile.Spec.Kubernetes != nil {
 			newKubernetesVersions = namespacedCloudProfile.Spec.Kubernetes.Versions
 		}
-		removedKubernetesVersions = sets.StringKeySet(helper.GetRemovedVersions(oldNamespacedCloudProfile.Spec.Kubernetes.Versions, newKubernetesVersions))
+		removedKubernetesVersions = sets.KeySet(helper.GetRemovedVersions(oldNamespacedCloudProfile.Spec.Kubernetes.Versions, newKubernetesVersions))
 	}
 	return removedKubernetesVersions
 }
@@ -1143,7 +1143,7 @@ func getRemovedMachineImageVersions(namespacedCloudProfile, oldNamespacedCloudPr
 }
 
 // validateShootForRemovedKubernetesVersions checks that for a removed Kubernetes version override from a NamespacedCloudProfile that is used by a Shoot there is still a valid expiration date in the parent CloudProfile.
-func validateShootForRemovedKubernetesVersions(channel chan error, shoot *gardencorev1beta1.Shoot, removedKubernetesVersions sets.String, parentCloudProfileKubernetesVersions map[string]gardencorev1beta1.ExpirableVersion, namespacedCloudProfile *core.NamespacedCloudProfile) {
+func validateShootForRemovedKubernetesVersions(channel chan error, shoot *gardencorev1beta1.Shoot, removedKubernetesVersions sets.Set[string], parentCloudProfileKubernetesVersions map[string]gardencorev1beta1.ExpirableVersion, namespacedCloudProfile *core.NamespacedCloudProfile) {
 	shootKubernetesVersion := shoot.Spec.Kubernetes.Version
 	if removedKubernetesVersions.Has(shootKubernetesVersion) {
 		if parentCloudProfileKubernetesVersions[shootKubernetesVersion].ExpirationDate != nil && parentCloudProfileKubernetesVersions[shootKubernetesVersion].ExpirationDate.Before(&metav1.Time{Time: time.Now()}) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind technical-debt

**What this PR does / why we need it**:

sets.String is deprecated and was replaced by a generic sets.Set

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
