### PR TITLE
resource-manager: Clean up HVPA usages and mutations

### DIFF
--- a/charts/gardener/resource-manager/charts/application/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/gardener/resource-manager/charts/application/templates/mutatingwebhookconfiguration.yaml
@@ -85,15 +85,6 @@ webhooks:
     - UPDATE
     resources:
     - horizontalpodautoscalers
-  - apiGroups:
-    - autoscaling.k8s.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - hvpas
     scope: '*'
   sideEffects: None
   timeoutSeconds: 10

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -984,7 +984,7 @@ The controller adds the `node-agent.gardener.cloud/reconciliation-delay` annotat
 This webhook is used to conveniently apply the configuration to make components deployed to seed or shoot clusters highly available.
 The details and scenarios are described in [High Availability Of Deployed Components](../development/high-availability-of-components.md).
 
-The webhook reacts on creation/update of `Deployment`s, `StatefulSet`s, `HorizontalPodAutoscaler`s and `HVPA`s in namespaces labeled with `high-availability-config.resources.gardener.cloud/consider=true`.
+The webhook reacts on creation/update of `Deployment`s, `StatefulSet`s and `HorizontalPodAutoscaler`s in namespaces labeled with `high-availability-config.resources.gardener.cloud/consider=true`.
 
 
 The webhook performs the following actions:
@@ -999,7 +999,7 @@ The webhook performs the following actions:
    - The replica count values can be overwritten by the `high-availability-config.resources.gardener.cloud/replicas` annotation.
    - It does NOT mutate the replicas when:
      - the replicas are already set to `0` (hibernation case), or
-     - when the resource is scaled horizontally by `HorizontalPodAutoscaler` or `Hvpa`, and the current replica count is higher than what was computed above.
+     - when the resource is scaled horizontally by `HorizontalPodAutoscaler`, and the current replica count is higher than what was computed above.
 
 2. When the `high-availability-config.resources.gardener.cloud/zones` annotation is NOT empty and either the `high-availability-config.resources.gardener.cloud/failure-tolerance-type` annotation is set or the `high-availability-config.resources.gardener.cloud/zone-pinning` annotation is set to `true`, then it adds a [node affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) to the pod template spec:
 

--- a/docs/development/high-availability-of-components.md
+++ b/docs/development/high-availability-of-components.md
@@ -223,7 +223,7 @@ spec:
     matchLabels: ...
 ```
 
-1. Add the label `high-availability-config.resources.gardener.cloud/type` to `deployment`s or `statefulset`s, as well as optionally involved `horizontalpodautoscaler`s or `HVPA`s where the following two values are possible:
+1. Add the label `high-availability-config.resources.gardener.cloud/type` to `deployment`s or `statefulset`s, as well as optionally involved `horizontalpodautoscaler`s where the following two values are possible:
 
 - `controller`
 - `server`

--- a/example/resource-manager/10-mutatingwebhookconfiguration.yaml
+++ b/example/resource-manager/10-mutatingwebhookconfiguration.yaml
@@ -150,15 +150,6 @@ webhooks:
     - UPDATE
     resources:
     - horizontalpodautoscalers
-  - apiGroups:
-    - autoscaling.k8s.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - hvpas
   namespaceSelector:
     matchLabels:
       high-availability-config.resources.gardener.cloud/consider: "true"

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -1879,17 +1878,6 @@ func GetHighAvailabilityConfigMutatingWebhook(namespaceSelector, objectSelector 
 					APIGroups:   []string{autoscalingv2.GroupName},
 					APIVersions: []string{autoscalingv2beta1.SchemeGroupVersion.Version, autoscalingv2.SchemeGroupVersion.Version},
 					Resources:   []string{"horizontalpodautoscalers"},
-				},
-				Operations: []admissionregistrationv1.OperationType{
-					admissionregistrationv1.Create,
-					admissionregistrationv1.Update,
-				},
-			},
-			{
-				Rule: admissionregistrationv1.Rule{
-					APIGroups:   []string{hvpav1alpha1.GroupName},
-					APIVersions: []string{hvpav1alpha1.SchemeGroupVersionHvpa.Version},
-					Resources:   []string{"hvpas"},
 				},
 				Operations: []admissionregistrationv1.OperationType{
 					admissionregistrationv1.Create,

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -967,14 +967,6 @@ var _ = Describe("ResourceManager", func() {
 							},
 							Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
 						},
-						{
-							Rule: admissionregistrationv1.Rule{
-								APIGroups:   []string{"autoscaling.k8s.io"},
-								APIVersions: []string{"v1alpha1"},
-								Resources:   []string{"hvpas"},
-							},
-							Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
-						},
 					},
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
@@ -1287,15 +1279,6 @@ webhooks:
     - UPDATE
     resources:
     - horizontalpodautoscalers
-  - apiGroups:
-    - autoscaling.k8s.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - hvpas
   sideEffects: None
   timeoutSeconds: 10
 - admissionReviewVersions:

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -233,7 +233,7 @@ var _ = Describe("ResourceManager", func() {
 						c.EXPECT().Get(ctx, client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *resourcesv1alpha1.ManagedResource, _ ...client.GetOption) error {
 							obj.Status.ObservedGeneration = obj.Generation
 							obj.Status.Conditions = []gardencorev1beta1.Condition{
-								{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionFalse, Message: `failed to compute all HPA and HVPA target ref object keys: failed to list all HPAs: Unauthorized`},
+								{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionFalse, Message: `failed to compute all HPA target ref object keys: failed to list all HPAs: Unauthorized`},
 								{Type: "ResourcesHealthy", Status: gardencorev1beta1.ConditionTrue},
 							}
 							return nil

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -396,7 +396,7 @@ var _ = Describe("ResourceManager", func() {
 						c.EXPECT().Get(ctx, client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *resourcesv1alpha1.ManagedResource, _ ...client.GetOption) error {
 							obj.Status.ObservedGeneration = obj.Generation
 							obj.Status.Conditions = []gardencorev1beta1.Condition{
-								{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionFalse, Message: `failed to compute all HPA and HVPA target ref object keys: failed to list all HPAs: Unauthorized`},
+								{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionFalse, Message: `failed to compute all HPA target ref object keys: failed to list all HPAs: Unauthorized`},
 								{Type: "ResourcesHealthy", Status: gardencorev1beta1.ConditionTrue},
 							}
 							return nil

--- a/pkg/resourcemanager/client/scheme.go
+++ b/pkg/resourcemanager/client/scheme.go
@@ -7,7 +7,6 @@ package client
 import (
 	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -44,7 +43,6 @@ func init() {
 		)
 		targetSchemeBuilder = runtime.NewSchemeBuilder(
 			kubernetesscheme.AddToScheme,
-			hvpav1alpha1.AddToScheme,
 			volumesnapshotv1.AddToScheme,
 			monitoringv1alpha1.AddToScheme,
 			monitoringv1beta1.AddToScheme,

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -137,7 +137,7 @@ func mergeDeployment(scheme *runtime.Scheme, oldObj, newObj runtime.Object, pres
 	}
 
 	// Do not overwrite a Deployment's '.spec.replicas' if the new Deployment's '.spec.replicas'
-	// field is unset or the Deployment is scaled by either an HPA or HVPA.
+	// field is unset or we are asked to preserve the replicas (e.g. the Deployment is scaled by HPA).
 	if newDeployment.Spec.Replicas == nil || preserveReplicas {
 		newDeployment.Spec.Replicas = oldDeployment.Spec.Replicas
 	}
@@ -160,7 +160,7 @@ func mergePodTemplate(oldPod, newPod *corev1.PodTemplateSpec, preserveResources 
 	}
 
 	if preserveResources {
-		// Do not overwrite a PodTemplate's resource requests / limits if it is scaled by an HVPA
+		// Do not overwrite a PodTemplate's resource requests / limits when we are asked to preserve the resources
 		for i, newContainer := range newPod.Spec.Containers {
 			for j, oldContainer := range oldPod.Spec.Containers {
 				if newContainer.Name == oldContainer.Name {
@@ -277,7 +277,7 @@ func mergeStatefulSet(scheme *runtime.Scheme, oldObj, newObj runtime.Object, pre
 	}
 
 	// Do not overwrite a StatefulSet's '.spec.replicas' if the new StatefulSet's `.spec.replicas'
-	// field is unset or the Deployment is scaled by either an HPA or HVPA.
+	// field is unset or we are asked to preserve the replicas (e.g. the StatefulSet is scaled by HPA).
 	if newStatefulSet.Spec.Replicas == nil || preserveReplicas {
 		newStatefulSet.Spec.Replicas = oldStatefulSet.Spec.Replicas
 	}

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -32,7 +32,7 @@ Any modifications are discarded and the resource is returned to the original sta
 // merge merges the values of the `desired` object into the `current` object while preserving `current`'s important
 // metadata (like resourceVersion and finalizers), status and selected spec fields of the respective kind (e.g.
 // .spec.selector of a Job).
-func merge(origin string, desired, current *unstructured.Unstructured, forceOverwriteLabels bool, existingLabels map[string]string, forceOverwriteAnnotations bool, existingAnnotations map[string]string, preserveReplicas, preserveResources bool) error {
+func merge(origin string, desired, current *unstructured.Unstructured, forceOverwriteLabels bool, existingLabels map[string]string, forceOverwriteAnnotations bool, existingAnnotations map[string]string, preserveReplicas bool) error {
 	// save copy of current object before merging
 	oldObject := current.DeepCopy()
 
@@ -100,6 +100,7 @@ func merge(origin string, desired, current *unstructured.Unstructured, forceOver
 	if annotations[resourcesv1alpha1.PreserveReplicas] == "true" {
 		preserveReplicas = true
 	}
+	preserveResources := false
 	if annotations[resourcesv1alpha1.PreserveResources] == "true" {
 		preserveResources = true
 	}

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -72,7 +72,7 @@ var _ = Describe("merger", func() {
 			expected := current.DeepCopy()
 			addAnnotations(origin, expected)
 
-			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["metadata"]).To(Equal(expected.Object["metadata"]))
 		})
 
@@ -83,7 +83,7 @@ var _ = Describe("merger", func() {
 
 			expected := desired.DeepCopy()
 
-			Expect(merge(origin, desired, current, true, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, true, existingLabels, false, nil, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -98,7 +98,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -112,7 +112,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -127,7 +127,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -139,7 +139,7 @@ var _ = Describe("merger", func() {
 			expected := desired.DeepCopy()
 			addAnnotations(origin, expected)
 
-			Expect(merge(origin, desired, current, false, nil, true, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, true, existingAnnotations, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -156,7 +156,7 @@ var _ = Describe("merger", func() {
 			})
 			addAnnotations(origin, expected)
 
-			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -171,7 +171,7 @@ var _ = Describe("merger", func() {
 			})
 			addAnnotations(origin, expected)
 
-			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -187,7 +187,7 @@ var _ = Describe("merger", func() {
 			})
 			addAnnotations(origin, expected)
 
-			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -201,7 +201,7 @@ var _ = Describe("merger", func() {
 
 			expected := current.DeepCopy()
 
-			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(Equal(expected.Object["status"]))
 		})
 
@@ -212,7 +212,7 @@ var _ = Describe("merger", func() {
 
 			current.Object["status"] = map[string]any{}
 
-			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(BeNil())
 		})
 
@@ -223,7 +223,7 @@ var _ = Describe("merger", func() {
 
 			delete(current.Object, "status")
 
-			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(BeNil())
 		})
 
@@ -234,12 +234,12 @@ var _ = Describe("merger", func() {
 			})
 
 			It("when forceOverrideAnnotation is false", func() {
-				Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, false, nil, false)).ToNot(HaveOccurred(), "merge succeeds")
 			})
 			It("when forceOverrideAnnotation is false and old annotations exist", func() {
 				desired.SetAnnotations(map[string]string{"goo": "boo"})
 				current.SetAnnotations(map[string]string{"foo": "bar"})
-				Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, false, nil, false)).ToNot(HaveOccurred(), "merge succeeds")
 
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("goo", "boo"))
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("foo", "bar"))
@@ -247,7 +247,7 @@ var _ = Describe("merger", func() {
 
 			It("when forceOverrideAnnotation is true", func() {
 				desired.SetAnnotations(map[string]string{"goo": "boo"})
-				Expect(merge(origin, desired, current, false, nil, true, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, true, nil, false)).ToNot(HaveOccurred(), "merge succeeds")
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("goo", "boo"))
 			})
 		})
@@ -391,7 +391,7 @@ var _ = Describe("merger", func() {
 			Expect(s.Convert(old, current, nil)).Should(Succeed())
 			Expect(s.Convert(newDeployment, desired, nil)).Should(Succeed())
 
-			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).To(Succeed(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false)).To(Succeed(), "merge should be successful")
 			Expect(s.Convert(current, expected, nil)).Should(Succeed())
 
 			Expect(expected.Spec.Replicas).To(Equal(newDeployment.Spec.Replicas))
@@ -404,7 +404,7 @@ var _ = Describe("merger", func() {
 			Expect(s.Convert(old, current, nil)).Should(Succeed())
 			Expect(s.Convert(newDeployment, desired, nil)).Should(Succeed())
 
-			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).To(Succeed(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false)).To(Succeed(), "merge should be successful")
 			Expect(s.Convert(current, expected, nil)).Should(Succeed())
 			Expect(expected.Spec.Replicas).To(Equal(old.Spec.Replicas))
 		})
@@ -424,7 +424,7 @@ var _ = Describe("merger", func() {
 			Expect(s.Convert(old, current, nil)).Should(Succeed())
 			Expect(s.Convert(newDeployment, desired, nil)).Should(Succeed())
 
-			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).To(Succeed(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false)).To(Succeed(), "merge should be successful")
 			Expect(s.Convert(current, expected, nil)).Should(Succeed())
 
 			Expect(newDeployment.Spec.Template.Spec.Containers[0].Resources.Requests["cpu"].Equal(expected.Spec.Template.Spec.Containers[0].Resources.Requests["cpu"])).To(BeTrue())
@@ -450,7 +450,7 @@ var _ = Describe("merger", func() {
 			Expect(s.Convert(old, current, nil)).Should(Succeed())
 			Expect(s.Convert(newDeployment, desired, nil)).Should(Succeed())
 
-			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).To(Succeed(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false)).To(Succeed(), "merge should be successful")
 			Expect(s.Convert(current, expected, nil)).Should(Succeed())
 			Expect(expected.Spec.Template.Spec.Containers[0].Resources).To(Equal(old.Spec.Template.Spec.Containers[0].Resources))
 		})

--- a/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_suite_test.go
+++ b/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_suite_test.go
@@ -7,7 +7,6 @@ package highavailabilityconfig_test
 import (
 	"context"
 	"net/http"
-	"path/filepath"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -63,9 +62,6 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		ControlPlane: envtest.ControlPlane{
 			APIServer: &envtest.APIServer{},
-		},
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			Paths: []string{filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-autoscaling.k8s.io_hvpas.yaml")},
 		},
 		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -66,7 +66,6 @@ var _ = BeforeSuite(func() {
 		CRDInstallOptions: envtest.CRDInstallOptions{
 			Paths: []string{
 				filepath.Join("..", "..", "..", "..", "example", "resource-manager", "10-crd-resources.gardener.cloud_managedresources.yaml"),
-				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-autoscaling.k8s.io_hvpas.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
This PR is the 5th PR related to the HVPA removal. The first 4 PRs were:
1. https://github.com/gardener/gardener/pull/10796
2. https://github.com/gardener/gardener/pull/10800
3. https://github.com/gardener/gardener/pull/10851
4. https://github.com/gardener/gardener/pull/10853

This PR cleans up HVPA usages and mutations in the resource-manager. Currently the resources has the following two HVPA logics:
- The managedresource controller does not overwrite replicas and resources if the controller (Deployment, StatufulSet, ...) is scaled by HVPA.
- The high-availability-config webhook mutates HVPA's min and max replicas depending on HA's failureToleranceType and component's type (`controller`/`server`)

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
- [x] I will keep in draft state until the above-mentioned previous PRs from the HVPA removal story are merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The resource-manager is no longer HVPA-aware. 
```
