### PR TITLE
Fix make target `test-e2e-local-operator-seed` for local execution

### DIFF
--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -42,5 +42,6 @@
 - containerPort: 30053
   hostPort: 5353
   protocol: TCP
+  listenAddress: 172.18.255.1
 {{- end -}}
 {{- end -}}

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -64,6 +64,7 @@ if [[ "$TYPE" == "operator" ]] || [[ "$TYPE" == "operator-seed" ]]; then
     # hack/ci-e2e-kind-operator-seed.sh script).
     echo "> Deploying Garden and Soil"
     make operator-seed-up
+    export OPERATOR_SEED="true"
   fi
 # If we are not running the gardener-operator tests then we have to make the shoot domains accessible.
 else

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UseProviderLocalCoreDNSServer sets the golang DefaultResolver to the CoreDNS server deployed as part of the
-// provider-local extension. This is port forwarded to the host on 127.0.0.1:5353. The tests can use this in-cluster
+// provider-local extension. This is port forwarded to the host on 172.18.255.1:5353. The tests can use this in-cluster
 // CoreDNS server for name resolution and can therefore resolve the API endpoint of shoot clusters to the correct Istio
 // instance (non-HA shoots are not exposed via 172.18.255.1 but via 172.18.255.{10,11,12}).
 func UseProviderLocalCoreDNSServer() {
@@ -22,7 +22,7 @@ func UseProviderLocalCoreDNSServer() {
 			// tcp). The result for cluster api names differ depending on the source.
 			return (&net.Dialer{
 				Timeout: time.Duration(5) * time.Second,
-			}).DialContext(ctx, "tcp", "127.0.0.1:5353")
+			}).DialContext(ctx, "tcp", "172.18.255.1:5353")
 		},
 	}
 }

--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -34,12 +34,13 @@ import (
 	"github.com/gardener/gardener/test/utils/rotation"
 )
 
-const (
-	// SeedName is the name of the managed seed used in this e2e test
-	SeedName = "e2e-managedseed"
-	// SeedNameOperator is the name of the managed seed used in this e2e test with the gardener-operator
-	SeedNameOperator = "e2e-mngdseed-op"
-)
+// GetSeedName returns the name of the managed seed used in this e2e test
+func GetSeedName() string {
+	if os.Getenv("OPERATOR_SEED") == "true" {
+		return "e2e-mngdseed-op"
+	}
+	return "e2e-managedseed"
+}
 
 var parentCtx context.Context
 
@@ -51,11 +52,7 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 	f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{
 		GardenerConfig: e2e.DefaultGardenConfig("garden"),
 	})
-	seedName := SeedName
-	if os.Getenv("OPERATOR_SEED") == "true" {
-		seedName = SeedNameOperator
-	}
-	f.Shoot = e2e.DefaultShoot(seedName)
+	f.Shoot = e2e.DefaultShoot(GetSeedName())
 
 	It("Create Shoot, Create ManagedSeed, Delete ManagedSeed, Delete Shoot", func() {
 		By("Create Shoot")

--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -34,8 +34,12 @@ import (
 	"github.com/gardener/gardener/test/utils/rotation"
 )
 
-// SeedName is the name of the managed seed used in this e2e test
-const SeedName = "e2e-managedseed"
+const (
+	// SeedName is the name of the managed seed used in this e2e test
+	SeedName = "e2e-managedseed"
+	// SeedNameOperator is the name of the managed seed used in this e2e test with the gardener-operator
+	SeedNameOperator = "e2e-mngdseed-op"
+)
 
 var parentCtx context.Context
 
@@ -47,7 +51,11 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 	f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{
 		GardenerConfig: e2e.DefaultGardenConfig("garden"),
 	})
-	f.Shoot = e2e.DefaultShoot(SeedName)
+	seedName := SeedName
+	if os.Getenv("OPERATOR_SEED") == "true" {
+		seedName = SeedNameOperator
+	}
+	f.Shoot = e2e.DefaultShoot(seedName)
 
 	It("Create Shoot, Create ManagedSeed, Delete ManagedSeed, Delete Shoot", func() {
 		By("Create Shoot")

--- a/test/e2e/gardener/seed/renew_garden_access_secrets.go
+++ b/test/e2e/gardener/seed/renew_garden_access_secrets.go
@@ -41,7 +41,7 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			seedList := &gardencorev1beta1.SeedList{}
 			Expect(testClient.List(ctx, seedList)).To(Succeed())
 			for _, s := range seedList.Items {
-				if s.Name != managedseed.SeedName && s.Name != managedseed.SeedNameOperator {
+				if s.Name != managedseed.GetSeedName() {
 					seed = s.DeepCopy()
 					break
 				}

--- a/test/e2e/gardener/seed/renew_garden_access_secrets.go
+++ b/test/e2e/gardener/seed/renew_garden_access_secrets.go
@@ -41,7 +41,7 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			seedList := &gardencorev1beta1.SeedList{}
 			Expect(testClient.List(ctx, seedList)).To(Succeed())
 			for _, s := range seedList.Items {
-				if s.Name != managedseed.SeedName {
+				if s.Name != managedseed.SeedName && s.Name != managedseed.SeedNameOperator {
 					seed = s.DeepCopy()
 					break
 				}

--- a/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
+++ b/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
@@ -28,7 +28,7 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			seedList := &gardencorev1beta1.SeedList{}
 			Expect(testClient.List(ctx, seedList)).To(Succeed())
 			for _, s := range seedList.Items {
-				if s.Name != managedseed.SeedName {
+				if s.Name != managedseed.SeedName && s.Name != managedseed.SeedNameOperator {
 					seed = s.DeepCopy()
 					break
 				}

--- a/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
+++ b/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
@@ -28,7 +28,7 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			seedList := &gardencorev1beta1.SeedList{}
 			Expect(testClient.List(ctx, seedList)).To(Succeed())
 			for _, s := range seedList.Items {
-				if s.Name != managedseed.SeedName && s.Name != managedseed.SeedNameOperator {
+				if s.Name != managedseed.GetSeedName() {
 					seed = s.DeepCopy()
 					break
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Local execution of the makefile target `test-e2e-local-operator-seed` fails (at least on MacOS), because the DNS lookup enabled with `USE_PROVIDER_LOCAL_COREDNS_SERVER` does not work.
The fix contains two parts:
- ensure that the additional coredns server deployed by the provider-local is reachable at IP `172.18.255.1` to resolve forwarding issue with Docker Desktop on Mac
- rename the seed name to avoid precedence of entry in `/etc/hosts`, if the managedseed e2e test is run from the `test-e2e-local-operator-seed` 

**Which issue(s) this PR fixes**:
Fixes #10468

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
