### PR TITLE
docs: Document host entry for Plutono in local operator setup

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -371,9 +371,10 @@ In this setup, the virtual garden cluster has its own load balancer, so you have
 ```shell
 cat <<EOF | sudo tee -a /etc/hosts
 
-# Manually created to access local Gardener virtual garden cluster.
-# TODO: Remove this again when the virtual garden cluster access is no longer required.
+# Begin of Gardener Operator local setup section
 172.18.255.3 api.virtual-garden.local.gardener.cloud
+172.18.255.3 plutono-garden.ingress.runtime-garden.local.gardener.cloud
+# End of Gardener Operator local setup section
 EOF
 ```
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -50,11 +50,11 @@ if [[ "$TYPE" == "operator" ]] || [[ "$TYPE" == "operator-seed" ]]; then
     printf "\n$local_address_operator plutono-garden.ingress.runtime-garden.local.gardener.cloud\n" >>/etc/hosts
   else
     if ! grep -q -x "$local_address_operator api.virtual-garden.local.gardener.cloud" /etc/hosts; then
-      printf "Hostname for the virtual garden cluster is missing in /etc/hosts. To access the virtual garden cluster and run e2e tests, you need to extend your /etc/hosts file.\nPlease refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster\n\n"
+      printf "Hostname for the virtual garden cluster is missing in /etc/hosts. To access the virtual garden cluster and run e2e tests, you need to extend your /etc/hosts file.\nPlease refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator\n\n"
       exit 1
     fi
     if ! grep -q -x "$local_address_operator plutono-garden.ingress.runtime-garden.local.gardener.cloud" /etc/hosts; then
-      printf "Hostname for the plutono is missing in /etc/hosts. To access the plutono and run e2e tests, you need to extend your /etc/hosts file.\nPlease refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster\n\n"
+      printf "Hostname for Plutono is missing in /etc/hosts. To access Plutono and run e2e tests, you need to extend your /etc/hosts file.\nPlease refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator\n\n"
       exit 1
     fi
   fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/area testing
/area dev-productivity
/kind enhancement
/kind test

**What this PR does / why we need it**:

Currently, when you run any local E2E Make target (`make test-e2e-local*`) it runs [`hack/test-e2e-local.sh`](https://github.com/gardener/gardener/blob/master/hack/test-e2e-local.sh).

If the `/etc/hosts` file is **missing** an entry for:
`172.18.255.3 plutono-garden.ingress.runtime-garden.local.gardener.cloud`
you'll receive an error like this:

```shell
make test-e2e-local-operator-seed
USE_PROVIDER_LOCAL_COREDNS_SERVER=true ./hack/test-e2e-local.sh operator-seed --procs=5 --label-filter="default && ManagedSeed" ./test/e2e/gardener/...
> E2E Tests
Hostname for the plutono is missing in /etc/hosts. To access the plutono and run e2e tests, you need to extend your /etc/hosts file.\nPlease refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster

make: *** [test-e2e-local-operator-seed] Error 1
```

Unfortunately, the specific section of the page that the message points to does **not** mention host entries for Plutono (nor the virtual garden which is also checked by the same script).
👉 https://github.com/gardener/gardener/blob/3265f4aca9712247c40bff51e3c842c93f0d3a05/hack/test-e2e-local.sh#L52-L59

Therefore, this PR does two things:
* it expands the section of the **Getting Started Locally** page that mentions the `/etc/hosts` entry for the virtual garden to also reference the entry for Plutono. ([ref](https://gardener.cloud/docs/gardener/deployment/getting_started_locally/#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator))
* it changes the error message of the `test-e2e-local.sh` script to point to the latter section that's specific to the local Gardener Operator setup instead.

The new, local output of `test-e2e-local.sh` in case of a missing Plutono `/etc/hosts` entry looks like this:

```shell
make test-e2e-local-operator-seed
USE_PROVIDER_LOCAL_COREDNS_SERVER=true ./hack/test-e2e-local.sh operator-seed --procs=5 --label-filter="default && ManagedSeed" ./test/e2e/gardener/...
> E2E Tests
Hostname for Plutono is missing in /etc/hosts. To access Plutono and run e2e tests, you need to extend your /etc/hosts file.
Please refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator

make: *** [test-e2e-local-operator-seed] Error 1
```

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 
I came across this issue when trying the changes of your PR locally: https://github.com/gardener/gardener/pull/10865

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
