### PR TITLE
Update testing.md with RawExtension findings and add doc string why GardenletConfiguration fields are pointers

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -371,6 +371,7 @@ stress -ignore "unable to grab random port" -p 16 ./bastion.test
     - This avoids conflicts between test cases and cascading failures which distract from the actual root failures
   - Don't tolerate already existing resources (~dirty test environment), code smell: ignoring already exist errors
 - Don't use a cached client in test code (e.g., the one from a controller-runtime manager), always construct a dedicated test client (uncached): [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/managedresource/resource_suite_test.go#L96-L97)
+- Don't use the Object field when you want to have a client-like behaviour and communicate through a network. You should encode and use the Raw field with runtime.RawExtension since Object doesn't have a protobuf tag, but RawExtension does, which allows it to be serialized. 
 - Use [asynchronous assertions](https://onsi.github.io/gomega/#making-asynchronous-assertions): `Eventually` and `Consistently`.
   - Never `Expect` anything to happen synchronously (immediately).
   - Don't use retry or wait until functions -> use `Eventually`, `Consistently` instead: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/controllermanager/shootmaintenance/utils_test.go#L36-L48)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -371,7 +371,7 @@ stress -ignore "unable to grab random port" -p 16 ./bastion.test
     - This avoids conflicts between test cases and cascading failures which distract from the actual root failures
   - Don't tolerate already existing resources (~dirty test environment), code smell: ignoring already exist errors
 - Don't use a cached client in test code (e.g., the one from a controller-runtime manager), always construct a dedicated test client (uncached): [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/managedresource/resource_suite_test.go#L96-L97)
-- Don't use the `Object` field when you want to have a client-like behaviour and communicate through a network. You should encode and use the `Raw` field of `runtime.RawExtension` since `Object` doesn't have a protobuf tag, and `Raw` does, which allows it to be serialized. 
+- When creating/updating an object with `runtime.RawExtension` field against a real cluster (not fake or mocked client), pass the field definition in the `Raw` field of the `runtime.RawExtension`. The `Object` field of `runtime.RawExtension` doesn't have a protobuf tag, and the `Raw` field does, which allows it to be serialized.
 - Use [asynchronous assertions](https://onsi.github.io/gomega/#making-asynchronous-assertions): `Eventually` and `Consistently`.
   - Never `Expect` anything to happen synchronously (immediately).
   - Don't use retry or wait until functions -> use `Eventually`, `Consistently` instead: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/controllermanager/shootmaintenance/utils_test.go#L36-L48)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -371,7 +371,7 @@ stress -ignore "unable to grab random port" -p 16 ./bastion.test
     - This avoids conflicts between test cases and cascading failures which distract from the actual root failures
   - Don't tolerate already existing resources (~dirty test environment), code smell: ignoring already exist errors
 - Don't use a cached client in test code (e.g., the one from a controller-runtime manager), always construct a dedicated test client (uncached): [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/managedresource/resource_suite_test.go#L96-L97)
-- Don't use the Object field when you want to have a client-like behaviour and communicate through a network. You should encode and use the Raw field with runtime.RawExtension since Object doesn't have a protobuf tag, but RawExtension does, which allows it to be serialized. 
+- Don't use the `Object` field when you want to have a client-like behaviour and communicate through a network. You should encode and use the `Raw` field of `runtime.RawExtension` since `Object` doesn't have a protobuf tag, and `Raw` does, which allows it to be serialized. 
 - Use [asynchronous assertions](https://onsi.github.io/gomega/#making-asynchronous-assertions): `Eventually` and `Consistently`.
   - Never `Expect` anything to happen synchronously (immediately).
   - Don't use retry or wait until functions -> use `Eventually`, `Consistently` instead: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/controllermanager/shootmaintenance/utils_test.go#L36-L48)

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -16,7 +16,10 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GardenletConfiguration defines the configuration for the Gardenlet.
-// Note: Most fields need to be pointers for merging with the parent gardenlet configuration
+//
+// Note: Most fields need to be optional (pointers) to allow ManagedSeed's gardenlet configuration
+// to be merged with the parent gardenlet configuration.
+// For more information, see the ManagedSeed's '.spec.gardenlet.mergeWithParent' field.
 type GardenletConfiguration struct {
 	metav1.TypeMeta
 	// GardenClientConnection specifies the kubeconfig file and the client connection settings

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -16,6 +16,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GardenletConfiguration defines the configuration for the Gardenlet.
+// Note: Most fields that are pointers are used as optionals in logic for merging with parent
 type GardenletConfiguration struct {
 	metav1.TypeMeta
 	// GardenClientConnection specifies the kubeconfig file and the client connection settings

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -16,7 +16,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GardenletConfiguration defines the configuration for the Gardenlet.
-// Note: Most fields that are pointers are used as optionals in logic for merging with parent
+// Note: Most fields need to be pointers for merging with the parent gardenlet configuration
 type GardenletConfiguration struct {
 	metav1.TypeMeta
 	// GardenClientConnection specifies the kubeconfig file and the client connection settings

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -18,6 +18,10 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GardenletConfiguration defines the configuration for the Gardenlet.
+//
+// Note: Most fields need to be optional (pointers) to allow ManagedSeed's gardenlet configuration
+// to be merged with the parent gardenlet configuration.
+// For more information, see the ManagedSeed's '.spec.gardenlet.mergeWithParent' field.
 type GardenletConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 	// GardenClientConnection specifies the kubeconfig file and the client connection settings


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
To make the use of Object and Raw clearer and explicitly give a reason for the optional fields in ManagedSeed.

**Which issue(s) this PR fixes**:
Fixes #10378

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
