### PR TITLE
Fix kubelet CSRs to allow IPv6 addresses to be used

### DIFF
--- a/pkg/resourcemanager/controller/csrapprover/reconciler.go
+++ b/pkg/resourcemanager/controller/csrapprover/reconciler.go
@@ -208,7 +208,7 @@ func (r *Reconciler) mustApproveKubeletServing(ctx context.Context, csr *certifi
 		case corev1.NodeInternalIP, corev1.NodeExternalIP:
 			comparableIP, err := netip.ParseAddr(address.Address)
 			if err != nil {
-				return fmt.Sprintf("IP address %q in node.Status.Addresses is invalid", address.Address), false, nil
+				return fmt.Sprintf("IP address %q in node.Status.Addresses is invalid: %v", address.Address, err), false, nil //nolint:nilerr
 			}
 			ipAddresses = append(ipAddresses, comparableIP)
 		}

--- a/test/integration/resourcemanager/csrapprover/csrapprover_test.go
+++ b/test/integration/resourcemanager/csrapprover/csrapprover_test.go
@@ -31,15 +31,17 @@ var _ = Describe("CertificateSigningRequest Approver Controller tests", func() {
 		privateKey         *rsa.PrivateKey
 		certificateSubject *pkix.Name
 
-		ip1      = "1.2.3.4"
-		ip2      = "5.6.7.8"
-		ip3      = "9.0.1.2"
-		ips      []net.IP
-		dnsName1 = "foo.bar"
-		dnsName2 = "bar.baz"
-		dnsName3 = "baz.foo"
-		dnsName4 = "baz.bar"
-		dnsNames []string
+		ip1       = "1.2.3.4"
+		ip2       = "5.6.7.8"
+		ip3       = "9.0.1.2"
+		ipv6      = "2080:1000:1000:8ff0:0:0:0:0"
+		ipv6short = "2080:1000:1000:8ff0::"
+		ips       []net.IP
+		dnsName1  = "foo.bar"
+		dnsName2  = "bar.baz"
+		dnsName3  = "baz.foo"
+		dnsName4  = "baz.bar"
+		dnsNames  []string
 
 		csr     *certificatesv1.CertificateSigningRequest
 		node    *corev1.Node
@@ -53,7 +55,7 @@ var _ = Describe("CertificateSigningRequest Approver Controller tests", func() {
 			Organization: []string{user.NodesGroup},
 		}
 
-		ips = []net.IP{net.ParseIP(ip1), net.ParseIP(ip2), net.ParseIP(ip3)}
+		ips = []net.IP{net.ParseIP(ip1), net.ParseIP(ip2), net.ParseIP(ip3), net.ParseIP(ipv6short)}
 		dnsNames = []string{dnsName1, dnsName2, dnsName3, dnsName4}
 
 		csr = &certificatesv1.CertificateSigningRequest{
@@ -148,6 +150,7 @@ var _ = Describe("CertificateSigningRequest Approver Controller tests", func() {
 					corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: ip1},
 					corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: ip2},
 					corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: ip3},
+					corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: ipv6},
 				)
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind enhancement

**What this PR does / why we need it**:
When IPv6 addresses are introduced, they are represent in `Node.Status.Addresses` as strings, and will be compared to the `net.IP#String()` from CSR which is the problem since different CCMs have different ideas how string representation of an IPv6 should look like, with tailing all zeroes or with short form `::`.

Since `net.IP` is just a `[]byte`, it doesn't satisfy generic `comparable` interface of the `sets.New()`. But `netip.Addr` does so this PR converts `net.IP` to `netip.Addr` or simply parses the string into `netip.Addr` to further use them in sets comparison.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix kubelet CSRs to allow IPv6 addresses to be used
```
