### PR TITLE
Adapt `configure-admission.sh` for new extension releases with changed value names for Helm charts.

### DIFF
--- a/pkg/operator/controller/extension/extension/admission/admission.go
+++ b/pkg/operator/controller/extension/extension/admission/admission.go
@@ -103,6 +103,7 @@ func (d *deployment) createOrUpdateAdmissionRuntimeClusterResources(ctx context.
 				"priorityClassName": v1beta1constants.PriorityClassNameGardenSystem400,
 			},
 			"virtualCluster": map[string]any{
+				"enabled":   true,
 				"namespace": virtualNamespace(extension).GetName(),
 			},
 		},
@@ -186,6 +187,7 @@ func (d *deployment) createOrUpdateAdmissionVirtualClusterResources(ctx context.
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
 			"virtualCluster": map[string]any{
+				"enabled": true,
 				"serviceAccount": map[string]any{
 					"name":      accessSecret.ServiceAccountName,
 					"namespace": metav1.NamespaceSystem,

--- a/pkg/operator/controller/extension/extension/admission/admission_test.go
+++ b/pkg/operator/controller/extension/extension/admission/admission_test.go
@@ -140,6 +140,7 @@ var _ = Describe("Deployment", func() {
 				"foo": "bar",
 				"gardener": map[string]any{
 					"virtualCluster": map[string]any{
+						"enabled": true,
 						"serviceAccount": map[string]any{
 							"name":      "extension-admission-" + extensionName,
 							"namespace": "kube-system",
@@ -154,6 +155,7 @@ var _ = Describe("Deployment", func() {
 						"priorityClassName": "gardener-garden-system-400",
 					},
 					"virtualCluster": map[string]any{
+						"enabled":   true,
 						"namespace": "extension-" + extensionName,
 					},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
The newly introduced `extension` controller of the gardener-operator expects Helm charts for extension admission controllers to have values without the `global` section. The `configure-admission.sh` script has been extended to recognise if the latest extension release already has been migrated to be used this way and to provide suitable values.

Additionally the extension controller always sets the value `.gardener.virtualCluster.enabled=true` to allow deployments like here in the local `gardener-extensions` without virtual Garden cluster to override the default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt `configure-admission.sh` for new extension releases with changed value names for Helm charts.
```
