### PR TITLE
Do not remove legacy fields when `.spec.accessRestrictions` is removed

### DIFF
--- a/pkg/apiserver/registry/core/cloudprofile/strategy.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy.go
@@ -129,12 +129,6 @@ func syncLegacyAccessRestrictionLabelWithNewField(cloudProfile *core.CloudProfil
 }
 
 func syncLegacyAccessRestrictionLabelWithNewFieldOnUpdate(cloudProfile, oldCloudProfile *core.CloudProfile) {
-	hasAccessRestriction := func(accessRestrictions []core.AccessRestriction, name string) bool {
-		return slices.ContainsFunc(accessRestrictions, func(accessRestriction core.AccessRestriction) bool {
-			return accessRestriction.Name == name
-		})
-	}
-
 	removeAccessRestriction := func(accessRestrictions []core.AccessRestriction, name string) []core.AccessRestriction {
 		var updatedAccessRestrictions []core.AccessRestriction
 		for _, accessRestriction := range accessRestrictions {
@@ -156,11 +150,6 @@ func syncLegacyAccessRestrictionLabelWithNewFieldOnUpdate(cloudProfile, oldCloud
 		if oldRegion.Labels["seed.gardener.cloud/eu-access"] == "true" &&
 			cloudProfile.Spec.Regions[i].Labels["seed.gardener.cloud/eu-access"] != "true" {
 			cloudProfile.Spec.Regions[i].AccessRestrictions = removeAccessRestriction(cloudProfile.Spec.Regions[i].AccessRestrictions, "eu-access-only")
-		}
-
-		if hasAccessRestriction(oldRegion.AccessRestrictions, "eu-access-only") &&
-			!hasAccessRestriction(cloudProfile.Spec.Regions[i].AccessRestrictions, "eu-access-only") {
-			delete(cloudProfile.Spec.Regions[i].Labels, "seed.gardener.cloud/eu-access")
 		}
 	}
 }

--- a/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Strategy", func() {
 			Expect(newCloudProfile.Spec.Regions[0].Labels).To(BeEmpty())
 		})
 
-		It("should remove the label when the access restriction is dropped", func() {
+		It("should not remove the label when the access restriction is dropped", func() {
 			oldCloudProfile.Spec.Regions[0].Labels = map[string]string{"seed.gardener.cloud/eu-access": "true"}
 			oldCloudProfile.Spec.Regions[0].AccessRestrictions = []core.AccessRestriction{{Name: "eu-access-only"}}
 			newCloudProfile.Spec.Regions[0].Labels = map[string]string{"seed.gardener.cloud/eu-access": "true"}
@@ -179,7 +179,7 @@ var _ = Describe("Strategy", func() {
 			cloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), newCloudProfile, oldCloudProfile)
 
 			Expect(newCloudProfile.Spec.Regions[0].AccessRestrictions).To(BeEmpty())
-			Expect(newCloudProfile.Spec.Regions[0].Labels).To(BeEmpty())
+			Expect(newCloudProfile.Spec.Regions[0].Labels).To(Equal(map[string]string{"seed.gardener.cloud/eu-access": "true"}))
 		})
 	})
 

--- a/pkg/apiserver/registry/core/seed/strategy.go
+++ b/pkg/apiserver/registry/core/seed/strategy.go
@@ -182,12 +182,6 @@ func syncLegacyAccessRestrictionLabelWithNewField(seed *core.Seed) {
 }
 
 func syncLegacyAccessRestrictionLabelWithNewFieldOnUpdate(seed, oldSeed *core.Seed) {
-	hasAccessRestriction := func(accessRestrictions []core.AccessRestriction, name string) bool {
-		return slices.ContainsFunc(accessRestrictions, func(accessRestriction core.AccessRestriction) bool {
-			return accessRestriction.Name == name
-		})
-	}
-
 	removeAccessRestriction := func(accessRestrictions []core.AccessRestriction, name string) []core.AccessRestriction {
 		var updatedAccessRestrictions []core.AccessRestriction
 		for _, accessRestriction := range accessRestrictions {
@@ -201,10 +195,5 @@ func syncLegacyAccessRestrictionLabelWithNewFieldOnUpdate(seed, oldSeed *core.Se
 	if oldSeed.Labels["seed.gardener.cloud/eu-access"] == "true" &&
 		seed.Labels["seed.gardener.cloud/eu-access"] != "true" {
 		seed.Spec.AccessRestrictions = removeAccessRestriction(seed.Spec.AccessRestrictions, "eu-access-only")
-	}
-
-	if hasAccessRestriction(oldSeed.Spec.AccessRestrictions, "eu-access-only") &&
-		!hasAccessRestriction(seed.Spec.AccessRestrictions, "eu-access-only") {
-		delete(seed.Labels, "seed.gardener.cloud/eu-access")
 	}
 }

--- a/pkg/apiserver/registry/core/seed/strategy_test.go
+++ b/pkg/apiserver/registry/core/seed/strategy_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Strategy", func() {
 					Expect(newSeed.Labels).To(BeEmpty())
 				})
 
-				It("should remove the label when the access restriction is dropped", func() {
+				It("should not remove the label when the access restriction is dropped", func() {
 					oldSeed.Labels = map[string]string{"seed.gardener.cloud/eu-access": "true"}
 					oldSeed.Spec.AccessRestrictions = []core.AccessRestriction{{Name: "eu-access-only"}}
 					newSeed.Labels = map[string]string{"seed.gardener.cloud/eu-access": "true"}
@@ -137,7 +137,7 @@ var _ = Describe("Strategy", func() {
 					strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
 
 					Expect(newSeed.Spec.AccessRestrictions).To(BeEmpty())
-					Expect(newSeed.Labels).To(BeEmpty())
+					Expect(newSeed.Labels).To(Equal(map[string]string{"seed.gardener.cloud/eu-access": "true"}))
 				})
 			})
 		})

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -671,7 +671,7 @@ var _ = Describe("Strategy", func() {
 				Expect(newShoot.Spec.SeedSelector).To(BeNil())
 			})
 
-			It("should remove the seed selector when the access restriction is dropped", func() {
+			It("should not remove the seed selector when the access restriction is dropped", func() {
 				oldShoot.Spec.SeedSelector = &core.SeedSelector{LabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{"seed.gardener.cloud/eu-access": "true"}}}
 				oldShoot.Spec.AccessRestrictions = []core.AccessRestrictionWithOptions{{AccessRestriction: core.AccessRestriction{Name: "eu-access-only"}}}
 				newShoot.Spec.SeedSelector = &core.SeedSelector{LabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{"seed.gardener.cloud/eu-access": "true"}}}
@@ -679,10 +679,10 @@ var _ = Describe("Strategy", func() {
 				strategy.PrepareForUpdate(context.Background(), newShoot, oldShoot)
 
 				Expect(newShoot.Spec.AccessRestrictions).To(BeEmpty())
-				Expect(newShoot.Spec.SeedSelector).To(BeNil())
+				Expect(newShoot.Spec.SeedSelector).To(Equal(&core.SeedSelector{LabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{"seed.gardener.cloud/eu-access": "true"}}}))
 			})
 
-			It("should remove the option annotations when they are removed from the access restrictions", func() {
+			It("should not remove the option annotations when they are removed from the access restrictions", func() {
 				oldShoot.Spec.AccessRestrictions = []core.AccessRestrictionWithOptions{{
 					AccessRestriction: core.AccessRestriction{Name: "eu-access-only"},
 					Options: map[string]string{
@@ -699,7 +699,10 @@ var _ = Describe("Strategy", func() {
 
 				strategy.PrepareForUpdate(context.Background(), newShoot, oldShoot)
 
-				Expect(newShoot.Annotations).To(BeEmpty())
+				Expect(newShoot.Annotations).To(Equal(map[string]string{
+					"support.gardener.cloud/eu-access-for-cluster-addons": "true",
+					"support.gardener.cloud/eu-access-for-cluster-nodes":  "false",
+				}))
 			})
 
 			It("should remove the options from the access restrictions when the annotations are removed", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
- The `seed.gardener.cloud/eu-access=true` label (in `CloudProfile`s and `Seeds`) or seed selector (in `Shoot`s) is no longer removed when the `eu-access-only` restriction is removed from the `.spec.accessRestrictions[]` field.
- Similarly, the `support.gardener.cloud/eu-access-for-cluster-{addons,nodes}` annotations in `Shoot`s are no longer removed when they are removed from the `.spec.accessRestrictions[].options` field.
- See linked issue description for reasoning.

**Which issue(s) this PR fixes**:
Fixes #10882
Follow-up of https://github.com/gardener/gardener/pull/10654

**Special notes for your reviewer**:
/cc @petersutter @voelzmo @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `seed.gardener.cloud/eu-access=true` label (in `CloudProfile`s and `Seeds`) or seed selector (in `Shoot`s) is no longer removed when the `eu-access-only` restriction is removed from the `.spec.accessRestrictions[]` field. Similarly, the `support.gardener.cloud/eu-access-for-cluster-{addons,nodes}` annotations in `Shoot`s are no longer removed when they are removed from the `.spec.accessRestrictions[].options` field.
```
