### PR TITLE
Add support for `node-local-dns` in dual-stack cluster.

### DIFF
--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -21,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -520,16 +520,47 @@ ip6.arpa:53 {
 	)
 }
 
+func selectIPAddress(addresses []string, preferIPv6 bool) string {
+	if len(addresses) == 1 {
+		return addresses[0]
+	}
+	var ipv4, ipv6 string
+	for _, addr := range addresses {
+		ip := net.ParseIP(addr)
+		if ip.To4() != nil {
+			ipv4 = addr
+		} else {
+			ipv6 = addr
+		}
+	}
+	if preferIPv6 {
+		return ipv6
+	}
+	return ipv4
+}
+
 func (n *nodeLocalDNS) bindIP() string {
 	if len(n.values.DNSServers) > 0 {
-		return n.getIPVSAddress() + " " + strings.Join(n.values.DNSServers, " ")
+		if n.values.IPFamilies[0] == gardencorev1beta1.IPFamilyIPv4 {
+			dnsAddress := selectIPAddress(n.values.DNSServers, false)
+			return n.getIPVSAddress() + " " + dnsAddress
+		} else {
+			dnsAddress := selectIPAddress(n.values.DNSServers, true)
+			return n.getIPVSAddress() + " " + dnsAddress
+		}
 	}
 	return n.getIPVSAddress()
 }
 
 func (n *nodeLocalDNS) containerArg() string {
 	if len(n.values.DNSServers) > 0 {
-		return n.getIPVSAddress() + "," + strings.Join(n.values.DNSServers, ",")
+		if n.values.IPFamilies[0] == gardencorev1beta1.IPFamilyIPv4 {
+			dnsAddress := selectIPAddress(n.values.DNSServers, false)
+			return n.getIPVSAddress() + "," + dnsAddress
+		} else {
+			dnsAddress := selectIPAddress(n.values.DNSServers, true)
+			return n.getIPVSAddress() + "," + dnsAddress
+		}
 	}
 	return n.getIPVSAddress()
 }
@@ -580,15 +611,12 @@ func (n *nodeLocalDNS) getHealthAddress() (healthAddress string) {
 }
 
 func (n *nodeLocalDNS) getAddress(useIPv6Brackets bool) string {
-	ipFamiliesSet := sets.New[gardencorev1beta1.IPFamily](n.values.IPFamilies...)
-	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) {
+	if n.values.IPFamilies[0] == gardencorev1beta1.IPFamilyIPv4 {
 		return nodelocaldnsconstants.IPVSAddress
-	}
-	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) && !ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) {
+	} else {
 		if useIPv6Brackets {
 			return fmt.Sprintf("[%s]", nodelocaldnsconstants.IPVSIPv6Address)
 		}
 		return nodelocaldnsconstants.IPVSIPv6Address
 	}
-	return ""
 }

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -541,26 +541,16 @@ func selectIPAddress(addresses []string, preferIPv6 bool) string {
 
 func (n *nodeLocalDNS) bindIP() string {
 	if len(n.values.DNSServers) > 0 {
-		if n.values.IPFamilies[0] == gardencorev1beta1.IPFamilyIPv4 {
-			dnsAddress := selectIPAddress(n.values.DNSServers, false)
-			return n.getIPVSAddress() + " " + dnsAddress
-		} else {
-			dnsAddress := selectIPAddress(n.values.DNSServers, true)
-			return n.getIPVSAddress() + " " + dnsAddress
-		}
+		dnsAddress := selectIPAddress(n.values.DNSServers, n.values.IPFamilies[0] != gardencorev1beta1.IPFamilyIPv4)
+		return n.getIPVSAddress() + " " + dnsAddress
 	}
 	return n.getIPVSAddress()
 }
 
 func (n *nodeLocalDNS) containerArg() string {
 	if len(n.values.DNSServers) > 0 {
-		if n.values.IPFamilies[0] == gardencorev1beta1.IPFamilyIPv4 {
-			dnsAddress := selectIPAddress(n.values.DNSServers, false)
-			return n.getIPVSAddress() + "," + dnsAddress
-		} else {
-			dnsAddress := selectIPAddress(n.values.DNSServers, true)
-			return n.getIPVSAddress() + "," + dnsAddress
-		}
+		dnsAddress := selectIPAddress(n.values.DNSServers, n.values.IPFamilies[0] != gardencorev1beta1.IPFamilyIPv4)
+		return n.getIPVSAddress() + "," + dnsAddress
 	}
 	return n.getIPVSAddress()
 }
@@ -613,10 +603,9 @@ func (n *nodeLocalDNS) getHealthAddress() (healthAddress string) {
 func (n *nodeLocalDNS) getAddress(useIPv6Brackets bool) string {
 	if n.values.IPFamilies[0] == gardencorev1beta1.IPFamilyIPv4 {
 		return nodelocaldnsconstants.IPVSAddress
-	} else {
-		if useIPv6Brackets {
-			return fmt.Sprintf("[%s]", nodelocaldnsconstants.IPVSIPv6Address)
-		}
-		return nodelocaldnsconstants.IPVSIPv6Address
 	}
+	if useIPv6Brackets {
+		return fmt.Sprintf("[%s]", nodelocaldnsconstants.IPVSIPv6Address)
+	}
+	return nodelocaldnsconstants.IPVSIPv6Address
 }


### PR DESCRIPTION
`node-local-dns` accepts only one ip-family as localip. With this PR, we only use addresses of the primary ipfamily.
Queries to address of the secondary ipfamily of the service would not be cached.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for `node-local-dns` in dual-stack cluster.
```
