### PR TITLE
Fix static path in `check-charts.sh`

### DIFF
--- a/hack/check-charts.sh
+++ b/hack/check-charts.sh
@@ -17,7 +17,7 @@ if [[ -d "$1" ]]; then
     exit 1
   fi
   echo "Checking whether all charts can be rendered"
-  for chart_dir in $(find charts -type d -exec test -f '{}'/Chart.yaml \; -print -prune | sort); do
+  for chart_dir in $(find "$1" -type d -exec test -f '{}'/Chart.yaml \; -print -prune | sort); do
     [ -f "$chart_dir/values-test.yaml" ] && values_files="-f $chart_dir/values-test.yaml" || unset values_files
     helm template $values_files "$chart_dir" > /dev/null 2> >(sed '/found symbolic link in path/d' >&2)
   done


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fixes the `check-charts.sh` script to use the passed parameter when detecting Charts to check. I suspect this has 0 impact, I checked many public gardener extensions, and they all pass `./charts` as the argument. But we have a private extension where some charts are in different folders, which would not be covered.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
I believe this requires no 
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
