### PR TITLE
Increase timeout for `Garden` in `make operator-seed-up`

### DIFF
--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -33,7 +33,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NO_COLOR='\033[0m'
 
-echo "⏳ Checking last operation state and conditions for ${RESOURCE_TYPE}/${OBJECT_NAME}..."
+echo "⏳ Checking last operation state and conditions for ${RESOURCE_TYPE}/${OBJECT_NAME} with a timeout of ${TIMEOUT} seconds..."
 retries=0
 while [ "${retries}" -lt "${TIMEOUT}" ]; do
   LAST_OPERATION_SUCCEEDED=true

--- a/skaffold-operator-garden.yaml
+++ b/skaffold-operator-garden.yaml
@@ -14,7 +14,7 @@ deploy:
             command:
               - bash
               - -ec
-              - hack/usage/wait-for.sh garden local VirtualGardenAPIServerAvailable RuntimeComponentsHealthy VirtualComponentsHealthy
+              - TIMEOUT=900 hack/usage/wait-for.sh garden local VirtualGardenAPIServerAvailable RuntimeComponentsHealthy VirtualComponentsHealthy
         - host:
             command:
               - bash


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
The timeout for waiting until `Garden` is ready in `make operator-seed-up` is currently 600 seconds. This seems to be too low, as the e2e tests fail quite frequently, but the `Garden` was reconciled successfully when it was exported at the end of the test ([ref](https://github.com/gardener/gardener/issues/10868#issuecomment-2493538716)).
Thus, this PR increases the timeout to 900 seconds.

Additionally, it prints the timeout in `hack/usage/wait-for.sh`.

**Which issue(s) this PR fixes**:
Part of #10868

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
