### PR TITLE
Ensure early-exits are executed even for `DELETE` requests for `Shoot`s

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1309,7 +1309,8 @@ func (c *validationContext) validateDNSDomainUniqueness(shootLister gardencorev1
 	}
 
 	for _, shoot := range shoots {
-		if shoot.Name == c.shoot.Name {
+		if shoot.Name == c.shoot.Name &&
+			shoot.Namespace == c.shoot.Namespace {
 			continue
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Earlier, the `oldShoot` in the `shoot/validator` admission plugin was never initialized on `DELETE` requests. Hence, early exists like https://github.com/gardener/gardener/blob/0b2f2a117b13f2c4e37bfd083e9a5b511e340071/plugin/pkg/shoot/validator/admission.go#L1639-L1641 were not executed and the real validation was performed (which is undesired).

With this PR, we set `shoot=oldShoot` for such `DELETE` requests, ensuring that the early exists are executed.

On the way, we found a glitch in the DNS domain uniqueness check (only considering shoot name, not both name+namespace) which we fixed as well.

**Special notes for your reviewer**:
/cc @voelzmo @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
On `Shoot` deletion, Gardener now properly skips certain validation checks that are only relevant for creations or updates of `Shoot` resources.
```
