### PR TITLE
Use cached client in garbage collector of `gardener-resource-manager`

### DIFF
--- a/pkg/resourcemanager/controller/garbagecollector/add.go
+++ b/pkg/resourcemanager/controller/garbagecollector/add.go
@@ -21,11 +21,8 @@ const ControllerName = "garbage-collector"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Cluster) error {
-	if r.TargetReader == nil {
-		r.TargetReader = targetCluster.GetAPIReader()
-	}
-	if r.TargetWriter == nil {
-		r.TargetWriter = targetCluster.GetClient()
+	if r.TargetClient == nil {
+		r.TargetClient = targetCluster.GetClient()
 	}
 	if r.MinimumObjectLifetime == nil {
 		r.MinimumObjectLifetime = ptr.To(10 * time.Minute)

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler.go
@@ -30,8 +30,7 @@ import (
 
 // Reconciler performs garbage collection.
 type Reconciler struct {
-	TargetReader          client.Reader
-	TargetWriter          client.Writer
+	TargetClient          client.Client
 	Config                config.GarbageCollectorControllerConfig
 	Clock                 clock.Clock
 	MinimumObjectLifetime *time.Duration
@@ -61,7 +60,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request
 	} {
 		objList := &metav1.PartialObjectMetadataList{}
 		objList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind(resource.listKind))
-		if err := r.TargetReader.List(ctx, objList, labels); err != nil {
+		if err := r.TargetClient.List(ctx, objList, labels); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -91,7 +90,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request
 	for _, gvk := range groupVersionKinds {
 		objList := &metav1.PartialObjectMetadataList{}
 		objList.SetGroupVersionKind(gvk)
-		if err := r.TargetReader.List(ctx, objList); err != nil {
+		if err := r.TargetClient.List(ctx, objList); err != nil {
 			if !meta.IsNoMatchError(err) {
 				return reconcile.Result{}, err
 			}
@@ -140,7 +139,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request
 				"name", objId.name,
 			)
 
-			if err := r.TargetWriter.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+			if err := r.TargetClient.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
 				results <- err
 			}
 		})

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler_test.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler_test.go
@@ -42,8 +42,7 @@ var _ = Describe("Collector", func() {
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 		gc = &Reconciler{
-			TargetReader:          c,
-			TargetWriter:          c,
+			TargetClient:          c,
 			Config:                config.GarbageCollectorControllerConfig{SyncPeriod: &metav1.Duration{}},
 			Clock:                 fakeClock,
 			MinimumObjectLifetime: &minimumObjectLifetime,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/4817/commits/aa81d39d33911721169749534088ddd050177341#diff-bcf0b5c4499882c7b94e6b854049d9de5ffcd3ae026f4515586592b4a752def2 has switched from the cached client to the uncached client (API reader), but https://github.com/gardener/gardener/pull/4817 doesn't really explain why (there is only
https://github.com/gardener/gardener/pull/4817#discussion_r730995153, but no detailed explanation).

I think that it might have been to prevent flooding the caches with undesired objects. Back in the days, the controller-runtime manager cache restriction functionality was not that feature-rich compared to today.
Meanwhile, we can already restrict the caches at manager level, i.e., I think it's safe to switch back to the cached client.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10081#issuecomment-2493658561

**Special notes for your reviewer**:
/cc @ialidzhikov @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug operator
The garbage collector controllers part of `gardener-resource-manager` instances in shoot control plane namespaces no longer unintentionally delete orphaned `Secret` in namespaces other than `kube-system`, `kubernetes-dashboard` or `kube-node-lease`.
```
