### PR TITLE
Fix BackupBucket reconciliation error by replacing `StrategicMergePatch` with `MergePatch`

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -493,7 +493,7 @@ func deployBackupBucketInGarden(ctx context.Context, k8sGardenClient client.Clie
 
 	ownerRef := metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))
 
-	_, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, k8sGardenClient, backupBucket, func() error {
+	_, err := controllerutils.CreateOrGetAndMergePatch(ctx, k8sGardenClient, backupBucket, func() error {
 		metav1.SetMetaDataAnnotation(&backupBucket.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 		backupBucket.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 		backupBucket.Spec = gardencorev1beta1.BackupBucketSpec{


### PR DESCRIPTION
**How to categorize this PR?**

/area backup
/kind bug

**What this PR does / why we need it:**

This PR fixes an error encountered during the reconciliation when deploying `BackupBucket` resources in the garden cluster with `ProviderConfig`.

The error encountered was:

```
unable to find api field in struct RawExtension for the json field
```

- This happens because `StrategicMergePatch` requires schema information to process fields, but `runtime.RawExtension` lacks schema due to its nature of holding arbitrary JSON data. 
- By switching to `MergePatch`, which treats `runtime.RawExtension` fields as opaque, avoid this error and ensure that `BackupBucket` resources are reconciled correctly when `ProviderConfig` is used.

**Which issue(s) this PR fixes:**

**Special notes for your reviewer:**

Found the bug while testing #10866 for PR https://github.com/gardener/gardener-extension-provider-gcp/pull/906
**Release note:**

```bugfix operator
Fixed an error in `BackupBucket` reconciliation by replacing `StrategicMergePatch` with `MergePatch` to properly handle `runtime.RawExtension` fields.
```