### PR TITLE
[renovate] Group machine-controller-manager & etcd-druid updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,7 +111,8 @@
       matchPackageNames: [
         '/.+/api/.+/',
         '/.+/apis/.+/',
-        '/.*gardener\/machine-controller-manager$/'
+        '/.*gardener\/machine-controller-manager$/',
+        '/.*gardener\/etcd-druid$/',
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -202,6 +202,17 @@
         '/.+gardener-discovery-server$/'
       ],
     },
+        {
+      // Group machine-controller-manager updates in one PR.
+      groupName: 'machine-controller-manager',
+      matchDatasources: [
+        'github-releases',
+        'go',
+      ],
+      matchPackageNames: [
+        '/.*gardener\/machine-controller-manager$/'
+      ],
+    },
     {
       // Ask for manual approval to create PRs for minor and major updates of dependencies which most likely
       // require manual adaptations of the code.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,6 +111,7 @@
       matchPackageNames: [
         '/.+/api/.+/',
         '/.+/apis/.+/',
+        '/.*gardener\/machine-controller-manager$/'
       ],
     },
     {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR groups updates of `machine-controller-manager` in one single PR. Example
- https://github.com/gardener/gardener/pull/10905
- https://github.com/gardener/gardener/pull/10906

Additionally, it runs `make generate` when MCM is updated, because it might contain API changes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
