### PR TITLE
Make dropping versions from `NamespacedCloudProfile` idempotent

### DIFF
--- a/pkg/apiserver/registry/core/namespacedcloudprofile/strategy_test.go
+++ b/pkg/apiserver/registry/core/namespacedcloudprofile/strategy_test.go
@@ -19,6 +19,8 @@ import (
 
 var _ = Describe("NamespacedCloudProfile Strategy", func() {
 	var (
+		ctx context.Context
+
 		namespacedCloudProfile *core.NamespacedCloudProfile
 
 		validExpirationDate1   *metav1.Time
@@ -31,6 +33,8 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 	)
 
 	BeforeEach(func() {
+		ctx = context.Background()
+
 		namespacedCloudProfile = &core.NamespacedCloudProfile{}
 
 		validExpirationDate1 = &metav1.Time{Time: time.Now().Add(144 * time.Hour)}
@@ -110,7 +114,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 		}
 	})
 
-	Describe("PrepareForCreate", func() {
+	Describe("#PrepareForCreate", func() {
 		DescribeTable("should drop expired versions from the NamespacedCloudProfile",
 			func(useKubernetesSettings, useMachineImages bool) {
 				namespacedCloudProfile = &core.NamespacedCloudProfile{}
@@ -190,14 +194,14 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 
 		Describe("generation increment", func() {
 			It("should set generation to 1 initially", func() {
-				namespacedcloudprofileregistry.Strategy.PrepareForCreate(context.Background(), namespacedCloudProfile)
+				namespacedcloudprofileregistry.Strategy.PrepareForCreate(ctx, namespacedCloudProfile)
 
 				Expect(namespacedCloudProfile.Generation).To(Equal(int64(1)))
 			})
 		})
 	})
 
-	Describe("PrepareForUpdate", func() {
+	Describe("#PrepareForUpdate", func() {
 		var (
 			oldNamespacedCloudProfile *core.NamespacedCloudProfile
 		)
@@ -209,7 +213,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 		It("should drop expired Kubernetes versions not already present in the NamespacedCloudProfile", func() {
 			namespacedCloudProfile.Spec.Kubernetes = kubernetesSettings
 
-			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, namespacedCloudProfile, oldNamespacedCloudProfile)
 
 			Expect(namespacedCloudProfile.Spec.Kubernetes.Versions).To(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{
@@ -226,7 +230,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 			oldNamespacedCloudProfile.Spec.Kubernetes = kubernetesSettings
 			namespacedCloudProfile.Spec.Kubernetes = kubernetesSettings
 
-			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, namespacedCloudProfile, oldNamespacedCloudProfile)
 
 			Expect(namespacedCloudProfile.Spec.Kubernetes.Versions).To(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{
@@ -246,7 +250,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 		It("should drop expired MachineImage versions not already present in the NamespacedCloudProfile", func() {
 			namespacedCloudProfile.Spec.MachineImages = machineImages
 
-			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, namespacedCloudProfile, oldNamespacedCloudProfile)
 
 			Expect(namespacedCloudProfile.Spec.MachineImages).To(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{
@@ -279,7 +283,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 			oldNamespacedCloudProfile.Spec.MachineImages = machineImages
 			namespacedCloudProfile.Spec.MachineImages = machineImages
 
-			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, namespacedCloudProfile, oldNamespacedCloudProfile)
 
 			Expect(namespacedCloudProfile.Spec.MachineImages).To(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{
@@ -318,7 +322,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 
 		Describe("generation increment", func() {
 			It("should not increment generation if spec has not changed", func() {
-				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, namespacedCloudProfile, oldNamespacedCloudProfile)
 
 				Expect(namespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation))
 			})
@@ -329,7 +333,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 					Name: "def",
 				}
 
-				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, namespacedCloudProfile, oldNamespacedCloudProfile)
 
 				Expect(namespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation + 1))
 			})
@@ -337,7 +341,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 			It("should increment generation if deletion timestamp is set", func() {
 				namespacedCloudProfile.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 
-				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, namespacedCloudProfile, oldNamespacedCloudProfile)
 
 				Expect(namespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation + 1))
 			})
@@ -352,7 +356,7 @@ var _ = Describe("NamespacedCloudProfile Strategy", func() {
 				},
 			}
 
-			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, namespacedCloudProfile, oldNamespacedCloudProfile)
 
 			Expect(namespacedCloudProfile.Status).To(Equal(oldNamespacedCloudProfile.Status))
 		})

--- a/pkg/apiserver/registry/core/namespacedcloudprofile/strategy_test.go
+++ b/pkg/apiserver/registry/core/namespacedcloudprofile/strategy_test.go
@@ -17,14 +17,26 @@ import (
 	namespacedcloudprofileregistry "github.com/gardener/gardener/pkg/apiserver/registry/core/namespacedcloudprofile"
 )
 
-var _ = Describe("PrepareForCreate", func() {
+var _ = Describe("NamespacedCloudProfile Strategy", func() {
 	var (
-		validExpirationDate1   = &metav1.Time{Time: time.Now().Add(144 * time.Hour)}
-		validExpirationDate2   = &metav1.Time{Time: time.Now().Add(24 * time.Hour)}
+		namespacedCloudProfile *core.NamespacedCloudProfile
+
+		validExpirationDate1   *metav1.Time
+		validExpirationDate2   *metav1.Time
+		expiredExpirationDate1 *metav1.Time
+		expiredExpirationDate2 *metav1.Time
+
+		kubernetesSettings *core.KubernetesSettings
+		machineImages      []core.MachineImage
+	)
+
+	BeforeEach(func() {
+		namespacedCloudProfile = &core.NamespacedCloudProfile{}
+
+		validExpirationDate1 = &metav1.Time{Time: time.Now().Add(144 * time.Hour)}
+		validExpirationDate2 = &metav1.Time{Time: time.Now().Add(24 * time.Hour)}
 		expiredExpirationDate1 = &metav1.Time{Time: time.Now().Add(-time.Hour)}
 		expiredExpirationDate2 = &metav1.Time{Time: time.Now().Add(-24 * time.Hour)}
-
-		namespacedCloudProfile *core.NamespacedCloudProfile
 
 		kubernetesSettings = &core.KubernetesSettings{
 			Versions: []core.ExpirableVersion{
@@ -96,130 +108,239 @@ var _ = Describe("PrepareForCreate", func() {
 				},
 			},
 		}
-	)
+	})
 
-	DescribeTable("should drop expired versions from the NamespacedCloudProfile",
-		func(useKubernetesSettings, useMachineImages bool) {
-			namespacedCloudProfile = &core.NamespacedCloudProfile{}
+	Describe("PrepareForCreate", func() {
+		DescribeTable("should drop expired versions from the NamespacedCloudProfile",
+			func(useKubernetesSettings, useMachineImages bool) {
+				namespacedCloudProfile = &core.NamespacedCloudProfile{}
 
-			if useKubernetesSettings {
-				namespacedCloudProfile.Spec.Kubernetes = kubernetesSettings
-			}
-			if useMachineImages {
-				namespacedCloudProfile.Spec.MachineImages = machineImages
+				if useKubernetesSettings {
+					namespacedCloudProfile.Spec.Kubernetes = kubernetesSettings
+				}
+				if useMachineImages {
+					namespacedCloudProfile.Spec.MachineImages = machineImages
+				}
+
+				namespacedcloudprofileregistry.Strategy.PrepareForCreate(context.TODO(), namespacedCloudProfile)
+
+				if useKubernetesSettings {
+					Expect(namespacedCloudProfile.Spec.Kubernetes.Versions).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("1.27.3"),
+						}), MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("1.26.4"),
+						}), MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("1.25.6"),
+						}),
+					))
+				}
+				if useMachineImages {
+					Expect(namespacedCloudProfile.Spec.MachineImages).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("machineImage1"),
+							"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
+								"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+									"Version": Equal("2.1.0"),
+								})},
+							), MatchFields(IgnoreExtras, Fields{
+								"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+									"Version": Equal("2.0.3"),
+								})},
+							)),
+						}), MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("machineImage2"),
+							"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
+								"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+									"Version": Equal("4.3.0"),
+								})},
+							), MatchFields(IgnoreExtras, Fields{
+								"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+									"Version": Equal("4.2.3"),
+								})},
+							)),
+						}),
+					))
+				}
+			},
+
+			Entry("only machineImage set", false, true),
+			Entry("only kubernetes set", true, false),
+			Entry("both kubernetes and machineImages set", true, true),
+		)
+
+		It("should drop empty machine image entries from NamespacedCloudProfile after dropping expired versions", func() {
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{Name: "machineImage1", Versions: []core.MachineImageVersion{
+					{ExpirableVersion: core.ExpirableVersion{Version: "1.0.0", ExpirationDate: expiredExpirationDate1}},
+				}},
+				{Name: "machineImage2", Versions: []core.MachineImageVersion{
+					{ExpirableVersion: core.ExpirableVersion{Version: "1.2.0"}},
+				}},
 			}
 
 			namespacedcloudprofileregistry.Strategy.PrepareForCreate(context.TODO(), namespacedCloudProfile)
 
-			if useKubernetesSettings {
-				Expect(namespacedCloudProfile.Spec.Kubernetes.Versions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Version": Equal("1.27.3"),
-					}), MatchFields(IgnoreExtras, Fields{
-						"Version": Equal("1.26.4"),
-					}), MatchFields(IgnoreExtras, Fields{
-						"Version": Equal("1.25.6"),
-					}),
-				))
-			}
-			if useMachineImages {
-				Expect(namespacedCloudProfile.Spec.MachineImages).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Name": Equal("machineImage1"),
-						"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
-							"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
-								"Version": Equal("2.1.0"),
-							})},
-						), MatchFields(IgnoreExtras, Fields{
-							"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
-								"Version": Equal("2.0.3"),
-							})},
-						)),
-					}), MatchFields(IgnoreExtras, Fields{
-						"Name": Equal("machineImage2"),
-						"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
-							"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
-								"Version": Equal("4.3.0"),
-							})},
-						), MatchFields(IgnoreExtras, Fields{
-							"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
-								"Version": Equal("4.2.3"),
-							})},
-						)),
-					}),
-				))
-			}
-		},
+			Expect(namespacedCloudProfile.Spec.MachineImages).To(Equal([]core.MachineImage{
+				{Name: "machineImage2", Versions: []core.MachineImageVersion{
+					{ExpirableVersion: core.ExpirableVersion{Version: "1.2.0"}},
+				}},
+			}))
+		})
 
-		Entry("only machineImage set", false, true),
-		Entry("only kubernetes set", true, false),
-		Entry("both kubernetes and machineImages set", true, true),
-	)
+		Describe("generation increment", func() {
+			It("should set generation to 1 initially", func() {
+				namespacedcloudprofileregistry.Strategy.PrepareForCreate(context.Background(), namespacedCloudProfile)
 
-	It("should drop empty machine image entries from NamespacedCloudProfile after dropping expired versions", func() {
-		namespacedCloudProfile = &core.NamespacedCloudProfile{}
-		namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
-			{Name: "machineImage1", Versions: []core.MachineImageVersion{
-				{ExpirableVersion: core.ExpirableVersion{Version: "1.0.0", ExpirationDate: expiredExpirationDate1}},
-			}},
-			{Name: "machineImage2", Versions: []core.MachineImageVersion{
-				{ExpirableVersion: core.ExpirableVersion{Version: "1.2.0"}},
-			}},
-		}
-
-		namespacedcloudprofileregistry.Strategy.PrepareForCreate(context.TODO(), namespacedCloudProfile)
-
-		Expect(namespacedCloudProfile.Spec.MachineImages).To(Equal([]core.MachineImage{
-			{Name: "machineImage2", Versions: []core.MachineImageVersion{
-				{ExpirableVersion: core.ExpirableVersion{Version: "1.2.0"}},
-			}},
-		}))
+				Expect(namespacedCloudProfile.Generation).To(Equal(int64(1)))
+			})
+		})
 	})
 
-	Describe("generation increment", func() {
+	Describe("PrepareForUpdate", func() {
 		var (
-			ctx context.Context
-
 			oldNamespacedCloudProfile *core.NamespacedCloudProfile
-			newNamespacedCloudProfile *core.NamespacedCloudProfile
 		)
 
 		BeforeEach(func() {
-			ctx = context.TODO()
-
 			oldNamespacedCloudProfile = &core.NamespacedCloudProfile{}
-			newNamespacedCloudProfile = &core.NamespacedCloudProfile{}
 		})
 
-		It("should set generation to 1 initially", func() {
-			namespacedcloudprofileregistry.Strategy.PrepareForCreate(ctx, newNamespacedCloudProfile)
+		It("should drop expired Kubernetes versions not already present in the NamespacedCloudProfile", func() {
+			namespacedCloudProfile.Spec.Kubernetes = kubernetesSettings
 
-			Expect(newNamespacedCloudProfile.Generation).To(Equal(int64(1)))
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+
+			Expect(namespacedCloudProfile.Spec.Kubernetes.Versions).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Version": Equal("1.27.3"),
+				}), MatchFields(IgnoreExtras, Fields{
+					"Version": Equal("1.26.4"),
+				}), MatchFields(IgnoreExtras, Fields{
+					"Version": Equal("1.25.6"),
+				}),
+			))
 		})
 
-		It("should not increment generation if spec has not changed", func() {
-			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, newNamespacedCloudProfile, oldNamespacedCloudProfile)
+		It("should not drop expired Kubernetes versions already present in the NamespacedCloudProfile", func() {
+			oldNamespacedCloudProfile.Spec.Kubernetes = kubernetesSettings
+			namespacedCloudProfile.Spec.Kubernetes = kubernetesSettings
 
-			Expect(newNamespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation))
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+
+			Expect(namespacedCloudProfile.Spec.Kubernetes.Versions).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Version": Equal("1.27.3"),
+				}), MatchFields(IgnoreExtras, Fields{
+					"Version": Equal("1.26.4"),
+				}), MatchFields(IgnoreExtras, Fields{
+					"Version": Equal("1.25.6"),
+				}), MatchFields(IgnoreExtras, Fields{
+					"Version": Equal("1.24.8"),
+				}), MatchFields(IgnoreExtras, Fields{
+					"Version": Equal("1.24.6"),
+				}),
+			))
 		})
 
-		It("should increment generation if spec has changed", func() {
-			newNamespacedCloudProfile.Spec.Parent = core.CloudProfileReference{
-				Kind: "abc",
-				Name: "def",
-			}
+		It("should drop expired MachineImage versions not already present in the NamespacedCloudProfile", func() {
+			namespacedCloudProfile.Spec.MachineImages = machineImages
 
-			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, newNamespacedCloudProfile, oldNamespacedCloudProfile)
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
 
-			Expect(newNamespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation + 1))
+			Expect(namespacedCloudProfile.Spec.MachineImages).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("machineImage1"),
+					"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("2.1.0"),
+						})},
+					), MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("2.0.3"),
+						})},
+					)),
+				}), MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("machineImage2"),
+					"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("4.3.0"),
+						})},
+					), MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("4.2.3"),
+						})},
+					)),
+				}),
+			))
 		})
 
-		It("should increment generation if deletion timestamp is set", func() {
-			newNamespacedCloudProfile.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		It("should not drop expired MachineImage versions already present in the NamespacedCloudProfile", func() {
+			oldNamespacedCloudProfile.Spec.MachineImages = machineImages
+			namespacedCloudProfile.Spec.MachineImages = machineImages
 
-			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(ctx, newNamespacedCloudProfile, oldNamespacedCloudProfile)
+			namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
 
-			Expect(newNamespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation + 1))
+			Expect(namespacedCloudProfile.Spec.MachineImages).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("machineImage1"),
+					"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("2.1.0"),
+						})},
+					), MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("2.0.3"),
+						})},
+					), MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("1.9.7"),
+						})},
+					)),
+				}), MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("machineImage2"),
+					"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("4.3.0"),
+						})},
+					), MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("4.2.3"),
+						})},
+					), MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{
+							"Version": Equal("4.1.8"),
+						})},
+					)),
+				}),
+			))
+		})
+
+		Describe("generation increment", func() {
+			It("should not increment generation if spec has not changed", func() {
+				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+
+				Expect(namespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation))
+			})
+
+			It("should increment generation if spec has changed", func() {
+				namespacedCloudProfile.Spec.Parent = core.CloudProfileReference{
+					Kind: "abc",
+					Name: "def",
+				}
+
+				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+
+				Expect(namespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation + 1))
+			})
+
+			It("should increment generation if deletion timestamp is set", func() {
+				namespacedCloudProfile.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+				namespacedcloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), namespacedCloudProfile, oldNamespacedCloudProfile)
+
+				Expect(namespacedCloudProfile.Generation).To(Equal(oldNamespacedCloudProfile.Generation + 1))
+			})
 		})
 
 		It("should prevent manual updates of the status field", func() {

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -112,14 +112,16 @@ func (v *ValidateNamespacedCloudProfile) Validate(_ context.Context, a admission
 		return apierrors.NewInternalError(errors.New("could not convert object to NamespacedCloudProfile"))
 	}
 
-	// Exit early if the spec hasn't changed
-	if a.GetOperation() == admission.Update {
-		old, ok := a.GetOldObject().(*gardencore.NamespacedCloudProfile)
+	if a.GetOperation() == admission.Update || a.GetOperation() == admission.Delete {
+		var ok bool
+		oldNamespacedCloudProfile, ok = a.GetOldObject().(*gardencore.NamespacedCloudProfile)
 		if !ok {
 			return apierrors.NewInternalError(errors.New("could not convert old resource into NamespacedCloudProfile object"))
 		}
-		oldNamespacedCloudProfile = old
+	}
 
+	// Exit early if the spec hasn't changed
+	if a.GetOperation() == admission.Update {
 		// do not ignore metadata updates to detect and prevent removal of the gardener finalizer or unwanted changes to annotations
 		if reflect.DeepEqual(namespacedCloudProfile.Spec, oldNamespacedCloudProfile.Spec) && reflect.DeepEqual(namespacedCloudProfile.ObjectMeta, oldNamespacedCloudProfile.ObjectMeta) {
 			return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Formerly, if a `NamespacedCloudProfile` has been created with an expired Kubernetes (or MachineImage) version, the versions have been dropped. If immediately afterwards the same spec was re-applied with kubectl, it failed for the reason that the expirationDate is in the past, though it silently dropped the version previously.
This PR drops expired versions always, as long as they don't exist in a probably already existing `NamespacedCloudProfile`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Expired versions from the `NamespacedCloudProfile` are always dropped, except for already applied versions.
```
