### PR TITLE
[release-v1.107] Automated cherry pick of #10902: Ensure early-exits are executed even for `DELETE` requests for `Shoot`s

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1309,7 +1309,8 @@ func (c *validationContext) validateDNSDomainUniqueness(shootLister gardencorev1
 	}
 
 	for _, shoot := range shoots {
-		if shoot.Name == c.shoot.Name {
+		if shoot.Name == c.shoot.Name &&
+			shoot.Namespace == c.shoot.Namespace {
 			continue
 		}
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -233,13 +233,15 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, _ adm
 	// On DELETE operations we want to verify that the Shoot is not in Restore or Migrate phase
 
 	// Exit early if shoot spec hasn't changed
-	if a.GetOperation() == admission.Update {
-		old, ok := a.GetOldObject().(*core.Shoot)
+	if a.GetOperation() == admission.Update || a.GetOperation() == admission.Delete {
+		var ok bool
+		oldShoot, ok = a.GetOldObject().(*core.Shoot)
 		if !ok {
 			return apierrors.NewInternalError(errors.New("could not convert old resource into Shoot object"))
 		}
-		oldShoot = old
+	}
 
+	if a.GetOperation() == admission.Update {
 		if a.GetSubresource() == "binding" && reflect.DeepEqual(oldShoot.Spec.SeedName, shoot.Spec.SeedName) {
 			return fmt.Errorf("update of binding rejected, shoot is already assigned to the same seed")
 		}
@@ -259,8 +261,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, _ adm
 		return fmt.Errorf("new shoot can only specify either cloudProfileName or cloudProfile reference")
 	}
 
-	err = admissionutils.ValidateCloudProfileChanges(v.namespacedCloudProfileLister, shoot, oldShoot)
-	if err != nil {
+	if err := admissionutils.ValidateCloudProfileChanges(v.namespacedCloudProfileLister, shoot, oldShoot); err != nil {
 		return err
 	}
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1632,9 +1632,29 @@ var _ = Describe("validator", func() {
 				shoot.Spec.AccessRestrictions = nil
 
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-				err := admissionHandler.Admit(ctx, attrs, nil)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+			})
 
-				Expect(err).NotTo(HaveOccurred())
+			It("should allow deletion even if shoot access restrictions are (no longer) supported in this region", func() {
+				seed.Spec.AccessRestrictions = []gardencorev1beta1.AccessRestriction{{Name: "foo"}}
+				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Update(&seed)).To(Succeed())
+
+				shoot.Spec.AccessRestrictions = []core.AccessRestrictionWithOptions{{AccessRestriction: core.AccessRestriction{Name: "foo"}}}
+
+				oldShoot = shoot.DeepCopy()
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.UpdateOptions{}, false, nil)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+			})
+
+			It("should allow deletion even if shoot access restrictions are (no longer) supported by the seed", func() {
+				cloudProfile.Spec.Regions[0].AccessRestrictions = []gardencorev1beta1.AccessRestriction{{Name: "foo"}}
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Update(&cloudProfile)).To(Succeed())
+
+				shoot.Spec.AccessRestrictions = []core.AccessRestrictionWithOptions{{AccessRestriction: core.AccessRestriction{Name: "foo"}}}
+
+				oldShoot = shoot.DeepCopy()
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.UpdateOptions{}, false, nil)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 			})
 		})
 


### PR DESCRIPTION
/kind bug
/area usability

Cherry pick of #10902 on release-v1.107.

#10902: Ensure early-exits are executed even for `DELETE` requests for `Shoot`s

**Release Notes:**
```bugfix user
On `Shoot` deletion, Gardener now properly skips certain validation checks that are only relevant for creations or updates of `Shoot` resources.
```