### PR TITLE
Consider architectures when validating machine images

### DIFF
--- a/extensions/pkg/util/cloudprofile.go
+++ b/extensions/pkg/util/cloudprofile.go
@@ -14,9 +14,9 @@ import (
 type ImagesContext[A any, B any] struct {
 	Images map[string]A
 
-	createVersionsMap func(A) map[string]B
-	// imageVersions will be calculated lazily on first access of each key.
-	imageVersions map[string]map[string]B
+	createArchitecturesMap func(A) map[string]map[string]B
+	// imageVersionArchitectures will be calculated lazily on first access of each key.
+	imageVersionsArchitectures map[string]map[string]map[string]B
 }
 
 // GetImage returns the image with the given name.
@@ -25,26 +25,37 @@ func (vc *ImagesContext[A, B]) GetImage(imageName string) (A, bool) {
 	return o, exists
 }
 
-// GetImageVersion returns the image version with the given name and version.
-func (vc *ImagesContext[A, B]) GetImageVersion(imageName string, version string) (B, bool) {
-	o, exists := vc.getImageVersions(imageName)[version]
+// GetImageVersionAnyArchitecture returns if an image with the given name, version an at least one architecture exists.
+func (vc *ImagesContext[A, B]) GetImageVersionAnyArchitecture(imageName string, version string) (B, bool) {
+	imageArchitectures := vc.getImageArchitectures(imageName, version)
+	for k := range imageArchitectures {
+		return imageArchitectures[k], true
+	}
+	var empty B
+	return empty, false
+}
+
+// GetImageVersion returns the image with the given name, version and architecture.
+func (vc *ImagesContext[A, B]) GetImageVersion(imageName string, version string, architecture string) (B, bool) {
+	o, exists := vc.getImageArchitectures(imageName, version)[architecture]
 	return o, exists
 }
 
-func (vc *ImagesContext[A, B]) getImageVersions(imageName string) map[string]B {
-	if versions, exists := vc.imageVersions[imageName]; exists {
-		return versions
+func (vc *ImagesContext[A, B]) getImageArchitectures(imageName string, version string) map[string]B {
+	if architectures, exists := vc.imageVersionsArchitectures[imageName][version]; exists {
+		return architectures
 	}
-	vc.imageVersions[imageName] = vc.createVersionsMap(vc.Images[imageName])
-	return vc.imageVersions[imageName]
+	vc.imageVersionsArchitectures[imageName] = vc.createArchitecturesMap(vc.Images[imageName])
+	return vc.imageVersionsArchitectures[imageName][version]
 }
 
 // NewImagesContext creates a new generic ImagesContext.
-func NewImagesContext[A any, B any](images map[string]A, createVersionsMap func(A) map[string]B) *ImagesContext[A, B] {
+func NewImagesContext[A any, B any](images map[string]A,
+	createArchitecturesMap func(A) map[string]map[string]B) *ImagesContext[A, B] {
 	return &ImagesContext[A, B]{
-		Images:            images,
-		createVersionsMap: createVersionsMap,
-		imageVersions:     make(map[string]map[string]B),
+		Images:                     images,
+		createArchitecturesMap:     createArchitecturesMap,
+		imageVersionsArchitectures: make(map[string]map[string]map[string]B),
 	}
 }
 
@@ -52,8 +63,18 @@ func NewImagesContext[A any, B any](images map[string]A, createVersionsMap func(
 func NewCoreImagesContext(profileImages []core.MachineImage) *ImagesContext[core.MachineImage, core.MachineImageVersion] {
 	return NewImagesContext(
 		utils.CreateMapFromSlice(profileImages, func(mi core.MachineImage) string { return mi.Name }),
-		func(mi core.MachineImage) map[string]core.MachineImageVersion {
-			return utils.CreateMapFromSlice(mi.Versions, func(v core.MachineImageVersion) string { return v.Version })
+		func(mi core.MachineImage) map[string]map[string]core.MachineImageVersion {
+			mapped := make(map[string]map[string]core.MachineImageVersion)
+			for _, value := range mi.Versions {
+				mapped[value.Version] = make(map[string]core.MachineImageVersion)
+				for _, arch := range value.Architectures {
+					mapped[value.Version][arch] = value
+				}
+				if len(value.Architectures) == 0 {
+					mapped[value.Version][""] = value
+				}
+			}
+			return mapped
 		},
 	)
 }
@@ -62,8 +83,18 @@ func NewCoreImagesContext(profileImages []core.MachineImage) *ImagesContext[core
 func NewV1beta1ImagesContext(parentImages []gardencorev1beta1.MachineImage) *ImagesContext[gardencorev1beta1.MachineImage, gardencorev1beta1.MachineImageVersion] {
 	return NewImagesContext(
 		utils.CreateMapFromSlice(parentImages, func(mi gardencorev1beta1.MachineImage) string { return mi.Name }),
-		func(mi gardencorev1beta1.MachineImage) map[string]gardencorev1beta1.MachineImageVersion {
-			return utils.CreateMapFromSlice(mi.Versions, func(v gardencorev1beta1.MachineImageVersion) string { return v.Version })
+		func(mi gardencorev1beta1.MachineImage) map[string]map[string]gardencorev1beta1.MachineImageVersion {
+			mapped := make(map[string]map[string]gardencorev1beta1.MachineImageVersion)
+			for _, value := range mi.Versions {
+				mapped[value.Version] = make(map[string]gardencorev1beta1.MachineImageVersion)
+				for _, arch := range value.Architectures {
+					mapped[value.Version][arch] = value
+				}
+				if len(value.Architectures) == 0 {
+					mapped[value.Version][""] = value
+				}
+			}
+			return mapped
 		},
 	)
 }

--- a/extensions/pkg/util/cloudprofile_test.go
+++ b/extensions/pkg/util/cloudprofile_test.go
@@ -11,96 +11,145 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/util"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 var _ = Describe("ImagesContext", func() {
 	Describe("#NewCoreImagesContext", func() {
+		var (
+			imageVersion1 = core.MachineImageVersion{
+				Architectures:    []string{v1beta1constants.ArchitectureAMD64},
+				ExpirableVersion: core.ExpirableVersion{Version: "1.0.0"},
+			}
+			imageVersion2 = core.MachineImageVersion{
+				Architectures:    []string{v1beta1constants.ArchitectureAMD64},
+				ExpirableVersion: core.ExpirableVersion{Version: "2.0.0"},
+			}
+			imageVersion3 = core.MachineImageVersion{
+				Architectures: []string{
+					v1beta1constants.ArchitectureAMD64,
+					v1beta1constants.ArchitectureARM64,
+				},
+				ExpirableVersion: core.ExpirableVersion{Version: "3.0.0"},
+			}
+		)
+
 		It("should successfully construct an ImagesContext from core.MachineImage slice", func() {
 			imagesContext := util.NewCoreImagesContext([]core.MachineImage{
-				{Name: "image-1", Versions: []core.MachineImageVersion{
-					{ExpirableVersion: core.ExpirableVersion{Version: "1.0.0"}},
-					{ExpirableVersion: core.ExpirableVersion{Version: "2.0.0"}},
-				}},
-				{Name: "image-2", Versions: []core.MachineImageVersion{
-					{ExpirableVersion: core.ExpirableVersion{Version: "3.0.0"}},
-				}},
+				{Name: "image-1", Versions: []core.MachineImageVersion{imageVersion1, imageVersion2}},
+				{Name: "image-2", Versions: []core.MachineImageVersion{imageVersion3}},
 			})
 
 			i, exists := imagesContext.GetImage("image-1")
 			Expect(exists).To(BeTrue())
 			Expect(i.Name).To(Equal("image-1"))
-			Expect(i.Versions).To(ConsistOf(
-				core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.0.0"}},
-				core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "2.0.0"}},
-			))
+			Expect(i.Versions).To(ConsistOf(imageVersion1, imageVersion2))
 
 			i, exists = imagesContext.GetImage("image-2")
 			Expect(exists).To(BeTrue())
 			Expect(i.Name).To(Equal("image-2"))
-			Expect(i.Versions).To(ConsistOf(
-				core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "3.0.0"}},
-			))
+			Expect(i.Versions).To(ConsistOf(imageVersion3))
 
 			i, exists = imagesContext.GetImage("image-99")
 			Expect(exists).To(BeFalse())
 			Expect(i.Name).To(Equal(""))
 			Expect(i.Versions).To(BeEmpty())
 
-			v, exists := imagesContext.GetImageVersion("image-1", "1.0.0")
-			Expect(exists).To(BeTrue())
-			Expect(v).To(Equal(core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.0.0"}}))
-
-			v, exists = imagesContext.GetImageVersion("image-1", "99.0.0")
+			v, exists := imagesContext.GetImageVersionAnyArchitecture("image-99", "1.0.0")
 			Expect(exists).To(BeFalse())
 			Expect(v).To(Equal(core.MachineImageVersion{}))
 
-			v, exists = imagesContext.GetImageVersion("image-99", "99.0.0")
+			v, exists = imagesContext.GetImageVersionAnyArchitecture("image-1", "99.0.0")
+			Expect(exists).To(BeFalse())
+			Expect(v).To(Equal(core.MachineImageVersion{}))
+
+			v, exists = imagesContext.GetImageVersionAnyArchitecture("image-2", "3.0.0")
+			Expect(exists).To(BeTrue())
+			Expect(v).To(Equal(imageVersion3))
+
+			v, exists = imagesContext.GetImageVersion("image-1", "1.0.0", v1beta1constants.ArchitectureAMD64)
+			Expect(exists).To(BeTrue())
+			Expect(v).To(Equal(imageVersion1))
+
+			v, exists = imagesContext.GetImageVersion("image-1", "1.0.0", v1beta1constants.ArchitectureARM64)
+			Expect(exists).To(BeFalse())
+			Expect(v).To(Equal(core.MachineImageVersion{}))
+
+			v, exists = imagesContext.GetImageVersion("image-1", "99.0.0", v1beta1constants.ArchitectureAMD64)
+			Expect(exists).To(BeFalse())
+			Expect(v).To(Equal(core.MachineImageVersion{}))
+
+			v, exists = imagesContext.GetImageVersion("image-99", "99.0.0", v1beta1constants.ArchitectureAMD64)
 			Expect(exists).To(BeFalse())
 			Expect(v).To(Equal(core.MachineImageVersion{}))
 		})
 	})
 
 	Describe("#NewV1beta1ImagesContext", func() {
+		var (
+			imageVersion1 = v1beta1.MachineImageVersion{
+				Architectures:    []string{v1beta1constants.ArchitectureAMD64},
+				ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0.0"},
+			}
+			imageVersion2 = v1beta1.MachineImageVersion{
+				Architectures:    []string{v1beta1constants.ArchitectureAMD64},
+				ExpirableVersion: v1beta1.ExpirableVersion{Version: "2.0.0"},
+			}
+			imageVersion3 = v1beta1.MachineImageVersion{
+				Architectures: []string{
+					v1beta1constants.ArchitectureAMD64,
+					v1beta1constants.ArchitectureARM64,
+				},
+				ExpirableVersion: v1beta1.ExpirableVersion{Version: "3.0.0"},
+			}
+		)
+
 		It("should successfully construct an ImagesContext from v1beta1.MachineImage slice", func() {
 			imagesContext := util.NewV1beta1ImagesContext([]v1beta1.MachineImage{
-				{Name: "image-1", Versions: []v1beta1.MachineImageVersion{
-					{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0.0"}},
-					{ExpirableVersion: v1beta1.ExpirableVersion{Version: "2.0.0"}},
-				}},
-				{Name: "image-2", Versions: []v1beta1.MachineImageVersion{
-					{ExpirableVersion: v1beta1.ExpirableVersion{Version: "3.0.0"}},
-				}},
+				{Name: "image-1", Versions: []v1beta1.MachineImageVersion{imageVersion1, imageVersion2}},
+				{Name: "image-2", Versions: []v1beta1.MachineImageVersion{imageVersion3}},
 			})
 
 			i, exists := imagesContext.GetImage("image-1")
 			Expect(exists).To(BeTrue())
 			Expect(i.Name).To(Equal("image-1"))
-			Expect(i.Versions).To(ConsistOf(
-				v1beta1.MachineImageVersion{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0.0"}},
-				v1beta1.MachineImageVersion{ExpirableVersion: v1beta1.ExpirableVersion{Version: "2.0.0"}},
-			))
+			Expect(i.Versions).To(ConsistOf(imageVersion1, imageVersion2))
 
 			i, exists = imagesContext.GetImage("image-2")
 			Expect(exists).To(BeTrue())
 			Expect(i.Name).To(Equal("image-2"))
-			Expect(i.Versions).To(ConsistOf(
-				v1beta1.MachineImageVersion{ExpirableVersion: v1beta1.ExpirableVersion{Version: "3.0.0"}},
-			))
+			Expect(i.Versions).To(ConsistOf(imageVersion3))
 
 			i, exists = imagesContext.GetImage("image-99")
 			Expect(exists).To(BeFalse())
 			Expect(i.Name).To(Equal(""))
 			Expect(i.Versions).To(BeEmpty())
 
-			v, exists := imagesContext.GetImageVersion("image-1", "1.0.0")
-			Expect(exists).To(BeTrue())
-			Expect(v).To(Equal(v1beta1.MachineImageVersion{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0.0"}}))
-
-			v, exists = imagesContext.GetImageVersion("image-1", "99.0.0")
+			v, exists := imagesContext.GetImageVersionAnyArchitecture("image-99", "1.0.0")
 			Expect(exists).To(BeFalse())
 			Expect(v).To(Equal(v1beta1.MachineImageVersion{}))
 
-			v, exists = imagesContext.GetImageVersion("image-99", "99.0.0")
+			v, exists = imagesContext.GetImageVersionAnyArchitecture("image-1", "99.0.0")
+			Expect(exists).To(BeFalse())
+			Expect(v).To(Equal(v1beta1.MachineImageVersion{}))
+
+			v, exists = imagesContext.GetImageVersionAnyArchitecture("image-2", "3.0.0")
+			Expect(exists).To(BeTrue())
+			Expect(v).To(Equal(imageVersion3))
+
+			v, exists = imagesContext.GetImageVersion("image-1", "1.0.0", v1beta1constants.ArchitectureAMD64)
+			Expect(exists).To(BeTrue())
+			Expect(v).To(Equal(imageVersion1))
+
+			v, exists = imagesContext.GetImageVersion("image-1", "1.0.0", v1beta1constants.ArchitectureARM64)
+			Expect(exists).To(BeFalse())
+			Expect(v).To(Equal(v1beta1.MachineImageVersion{}))
+
+			v, exists = imagesContext.GetImageVersion("image-1", "99.0.0", v1beta1constants.ArchitectureAMD64)
+			Expect(exists).To(BeFalse())
+			Expect(v).To(Equal(v1beta1.MachineImageVersion{}))
+
+			v, exists = imagesContext.GetImageVersion("image-99", "99.0.0", v1beta1constants.ArchitectureAMD64)
 			Expect(exists).To(BeFalse())
 			Expect(v).To(Equal(v1beta1.MachineImageVersion{}))
 		})

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -237,7 +237,7 @@ func (c *validationContext) validateMachineImageOverrides(attr admission.Attribu
 			}
 
 			for imageVersionIndex, imageVersion := range image.Versions {
-				if _, isExistingVersion := parentImages.GetImageVersion(image.Name, imageVersion.Version); isExistingVersion {
+				if _, isExistingVersion := parentImages.GetImageVersionAnyArchitecture(image.Name, imageVersion.Version); isExistingVersion {
 					// An image with the specified version is already present in the parent CloudProfile.
 					// Ensure that only the expiration date is overridden.
 					// For new versions added to an existing image, the validation will be done on the simulated merge result.
@@ -254,7 +254,7 @@ func (c *validationContext) validateMachineImageOverrides(attr admission.Attribu
 							exists   bool
 						)
 						if currentVersionsMerged != nil {
-							override, exists = currentVersionsMerged.GetImageVersion(image.Name, imageVersion.Version)
+							override, exists = currentVersionsMerged.GetImageVersionAnyArchitecture(image.Name, imageVersion.Version)
 						}
 						if !exists || !override.ExpirationDate.Equal(imageVersion.ExpirationDate) {
 							allErrs = append(allErrs, field.Invalid(imageVersionIndexPath.Child("expirationDate"), imageVersion.ExpirationDate, fmt.Sprintf("expiration date for version %q is in the past", imageVersion.Version)))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Because of increasing popularity of arm64 VMs and their corresponding images, we should consider architectures when validating images (using the ImageContext in this case).
Otherwise we validate that an image version exist but it supports the wrong architecture.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
