### PR TITLE
Make determineSeed public

### DIFF
--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -69,7 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	// If no Seed is referenced, we try to determine an adequate one.
-	seed, err := r.determineSeed(ctx, log, shoot)
+	seed, err := r.DetermineSeed(ctx, log, shoot)
 	if err != nil {
 		r.reportFailedScheduling(ctx, log, shoot, err)
 		return reconcile.Result{}, fmt.Errorf("failed to determine seed for shoot: %w", err)
@@ -114,8 +114,8 @@ func (r *Reconciler) reportEvent(shoot *gardencorev1beta1.Shoot, eventType strin
 	r.Recorder.Eventf(shoot, eventType, eventReason, messageFmt, args...)
 }
 
-// determineSeed returns an appropriate Seed cluster (or nil).
-func (r *Reconciler) determineSeed(
+// DetermineSeed returns an appropriate Seed cluster (or nil).
+func (r *Reconciler) DetermineSeed(
 	ctx context.Context,
 	log logr.Logger,
 	shoot *gardencorev1beta1.Shoot,

--- a/pkg/scheduler/controller/shoot/reconciler_test.go
+++ b/pkg/scheduler/controller/shoot/reconciler_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(seed.Name))
 		})
@@ -169,7 +169,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, &secondShoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(secondSeed.Name))
 		})
@@ -186,7 +186,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, &secondSeed)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(secondSeed.Name))
 		})
@@ -199,7 +199,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -217,7 +217,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(MatchError("none of the 1 seeds has at least 3 zones for hosting a shoot control plane with failure tolerance type 'zone'"))
 			Expect(bestSeed).To(BeNil())
 		})
@@ -237,7 +237,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(MatchError("none of the 1 seeds has at least 3 zones for hosting a shoot control plane with failure tolerance type 'zone'"))
 			Expect(bestSeed).To(BeNil())
 		})
@@ -253,7 +253,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, &multiZonalSeed)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(multiZonalSeed.Name))
 		})
@@ -267,7 +267,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, &multiZonalSeed)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(multiZonalSeed.Name))
 		})
@@ -296,7 +296,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed).NotTo(BeNil())
 		})
@@ -310,7 +310,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed).NotTo(BeNil())
 		})
@@ -324,7 +324,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed).NotTo(BeNil())
 		})
@@ -344,7 +344,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed).NotTo(BeNil())
 		})
@@ -355,7 +355,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -372,7 +372,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -390,7 +390,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -411,7 +411,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(seedName))
 		})
@@ -423,7 +423,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(seedName))
 			// verify that shoot is in another region than the seed
@@ -451,7 +451,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, &secondSeed)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, &thirdSeed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(secondSeed.Name))
 			// verify that shoot is in another region than the chosen seed
@@ -473,7 +473,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, &secondShoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(secondSeed.Name))
 		})
@@ -513,7 +513,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, oldSeedEnvironment1)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, newSeedEnvironment2)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, testShoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, testShoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(newSeedEnvironment2.Name))
 		})
@@ -563,7 +563,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, newSeedEnvironment2)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, newSeedEnvironment3)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, testShoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, testShoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(newSeedEnvironment3.Name))
 		})
@@ -594,7 +594,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, &secondShoot)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, &thirdShoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(secondSeed.Name))
 		})
@@ -615,7 +615,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(seedName))
 		})
@@ -631,7 +631,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(seedName))
 		})
@@ -650,7 +650,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, &secondShoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bestSeed.Name).To(Equal(secondSeed.Name))
 		})
@@ -667,7 +667,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -683,7 +683,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed2)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(MatchError("0/2 seed cluster candidate(s) are eligible for scheduling: {seed-1 => shoot does not tolerate the seed's taints, seed-2 => shoot does not tolerate the seed's taints}"))
 			Expect(bestSeed).To(BeNil())
 		})
@@ -700,7 +700,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, shoot)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, &secondShoot)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -712,7 +712,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -723,7 +723,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -739,7 +739,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -756,7 +756,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -766,7 +766,7 @@ var _ = Describe("Scheduler_Control", func() {
 
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -782,7 +782,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -793,7 +793,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})
@@ -808,7 +808,7 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
 			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
 
-			bestSeed, err := reconciler.determineSeed(ctx, log, shoot)
+			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
 			Expect(err).To(HaveOccurred())
 			Expect(bestSeed).To(BeNil())
 		})


### PR DESCRIPTION
**How to categorize this PR?**

/area open-source
/kind api-change

**What this PR does / why we need it**:

Change visibility of `determineSeed` function to public to be reusable by other applications.

**Which issue(s) this PR fixes**:

Support "fail fast" of feature https://github.com/kyma-project/infrastructure-manager/issues/241 (see AC4):

For same customers, it is a mandatory requirement to ensure that Shoot- and Seed-cluster run in the same region. We want to enable the Kyma Infrastructure Manager to detect whether a Seed exists in the region of a requests shoot. This allows us to fail fast and improve the UX in case a customer tries to create a shoot in a region which has no seed. 

**Special notes for your reviewer**:

This is the follow-up PR based on the feedback provided in https://github.com/gardener/gardener/pull/9843#issuecomment-2141968796.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
