### PR TITLE
[node-agent] Delete systemd unit files and drop-ins only if the unit has been created by node-agent

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -50,13 +50,13 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 	}
 	if r.FS == nil {
 		var err error
-		r.FS, err = filespkg.NewNodeAgentFileSystem(afero.Afero{Fs: afero.NewOsFs()})
+		r.FS, err = filespkg.NewNodeAgentAfero(afero.NewOsFs())
 		if err != nil {
 			return fmt.Errorf("failed to create node agent file system: %w", err)
 		}
 	}
 	if r.Extractor == nil {
-		r.Extractor = registry.NewExtractor(r.afero())
+		r.Extractor = registry.NewExtractor(r.FS.Afero)
 	}
 
 	return builder.

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -50,7 +50,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 		r.FS = afero.Afero{Fs: afero.NewOsFs()}
 	}
 	if r.Extractor == nil {
-		r.Extractor = registry.NewExtractor()
+		r.Extractor = registry.NewExtractor(r.FS)
 	}
 
 	return builder.

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -13,9 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -25,17 +23,11 @@ import (
 	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 )
 
-var (
-	codec   runtime.Codec
-	decoder runtime.Decoder
-)
+var decoder runtime.Decoder
 
 func init() {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
-	ser := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
-	versions := schema.GroupVersions([]schema.GroupVersion{nodeagentv1alpha1.SchemeGroupVersion, extensionsv1alpha1.SchemeGroupVersion})
-	codec = serializer.NewCodecFactory(scheme).CodecForVersions(ser, ser, versions, versions)
 	decoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
 }
 
@@ -48,14 +40,6 @@ func extractOSCFromSecret(secret *corev1.Secret) (*extensionsv1alpha1.OperatingS
 	osc := &extensionsv1alpha1.OperatingSystemConfig{}
 	if err := runtime.DecodeInto(decoder, oscRaw, osc); err != nil {
 		return nil, nil, "", fmt.Errorf("unable to decode OSC from secret data key %s: %w", nodeagentv1alpha1.DataKeyOperatingSystemConfig, err)
-	}
-
-	// Ingest the containerd drop-in into the OSC to prevent side effects when containerd.service is changed by extensions too.
-	ingestContainerdEnvironmentDropIn(osc)
-
-	oscRaw, err := runtime.Encode(codec, osc)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("unable to encode OSC after ingesting containerd drop-in: %w", err)
 	}
 
 	return osc, oscRaw, secret.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig], nil

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
@@ -22,36 +22,60 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/go-logr/logr"
 	"github.com/pelletier/go-toml"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	filespkg "github.com/gardener/gardener/pkg/nodeagent/files"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/structuredmap"
 )
 
+var codec runtime.Codec
+
+func init() {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
+	ser := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, scheme, scheme, jsonserializer.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
+	versions := schema.GroupVersions([]schema.GroupVersion{nodeagentv1alpha1.SchemeGroupVersion, extensionsv1alpha1.SchemeGroupVersion})
+	codec = serializer.NewCodecFactory(scheme).CodecForVersions(ser, ser, versions, versions)
+}
+
 // ReconcileContainerdConfig sets required values of the given containerd configuration.
-func (r *Reconciler) ReconcileContainerdConfig(ctx context.Context, log logr.Logger, criConfig *extensionsv1alpha1.CRIConfig) error {
-	if !extensionsv1alpha1helper.HasContainerdConfiguration(criConfig) {
-		return nil
+func (r *Reconciler) ReconcileContainerdConfig(ctx context.Context, log logr.Logger, osc *extensionsv1alpha1.OperatingSystemConfig, oscRaw []byte) ([]byte, error) {
+	if !extensionsv1alpha1helper.HasContainerdConfiguration(osc.Spec.CRIConfig) {
+		return oscRaw, nil
 	}
 
 	if err := r.ensureContainerdConfigDirectories(); err != nil {
-		return fmt.Errorf("failed to ensure containerd config directories: %w", err)
+		return nil, fmt.Errorf("failed to ensure containerd config directories: %w", err)
 	}
 
 	if err := r.ensureContainerdDefaultConfig(ctx); err != nil {
-		return fmt.Errorf("failed to ensure containerd default config: %w", err)
+		return nil, fmt.Errorf("failed to ensure containerd default config: %w", err)
 	}
 
-	if err := r.ensureContainerdConfiguration(log, criConfig); err != nil {
-		return fmt.Errorf("failed to ensure containerd config: %w", err)
+	if err := r.ensureContainerdConfiguration(log, osc.Spec.CRIConfig); err != nil {
+		return nil, fmt.Errorf("failed to ensure containerd config: %w", err)
 	}
 
-	return nil
+	// Ingest the containerd drop-in into the OSC to prevent side effects when containerd.service is changed by extensions too.
+	ingestContainerdEnvironmentDropIn(osc)
+
+	oscRawContainerd, err := runtime.Encode(codec, osc)
+	if err != nil {
+		return nil, fmt.Errorf("unable to encode OSC after ingesting containerd drop-in: %w", err)
+	}
+
+	return oscRawContainerd, nil
 }
 
 // ReconcileContainerdRegistries configures desired registries for containerd and cleans up abandoned ones.

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -170,7 +170,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	)
 
 	log.Info("Persisting current operating system config as 'last-applied' file to the disk", "path", lastAppliedOperatingSystemConfigFilePath)
-	if err := r.FS.WriteFile(lastAppliedOperatingSystemConfigFilePath, oscRaw, 0644); err != nil {
+	if err := r.FS.WriteFile(lastAppliedOperatingSystemConfigFilePath, oscRaw, 0600); err != nil {
 		return reconcile.Result{}, fmt.Errorf("unable to write current OSC to file path %q: %w", lastAppliedOperatingSystemConfigFilePath, err)
 	}
 

--- a/pkg/nodeagent/files/filesystem.go
+++ b/pkg/nodeagent/files/filesystem.go
@@ -1,0 +1,356 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package files
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/afero"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+)
+
+const (
+	// OperationCreated represents the file system operation of creating an object.
+	OperationCreated FileSystemOperation = "created"
+	// OperationModified represents the file system operation of modifying an object.
+	OperationModified FileSystemOperation = "modified"
+	// OperationDeleted represents the file system operation of deleting an object.
+	OperationDeleted FileSystemOperation = "deleted"
+
+	nodeAgentFileSystemPath = nodeagentv1alpha1.BaseDir + "/node-agent-filesystem.yaml"
+)
+
+// NodeAgentFileSystem is a file system that keeps track of the file operations performed on the files.
+type NodeAgentFileSystem interface {
+	afero.Fs
+	// GetFileSystemOperation returns the file operation performed by this file system.
+	GetFileSystemOperation(path string) FileSystemOperation
+	// RemoveCreated removes the file from the file system if it was created by this file system.
+	RemoveCreated(name string) error
+	// RemoveAllCreated removes all files created by this file system in the given directory.
+	RemoveAllCreated(path string) error
+}
+
+// FileSystemOperation represents the file operation performed by NodeAgentFileSystem.
+type FileSystemOperation string
+
+// NewNodeAgentFileSystem creates a new NodeAgentFileSystem.
+func NewNodeAgentFileSystem(fs afero.Afero) (NodeAgentFileSystem, error) {
+	fsOperationsRaw, err := fs.ReadFile(nodeAgentFileSystemPath)
+	if errors.Is(err, afero.ErrFileNotFound) {
+		return &nodeAgentFileSystem{
+			fs: fs,
+			nodeAgentFsOperations: nodeAgentFsOperations{
+				FileSystemOperations: map[string]FileSystemOperation{},
+			},
+		}, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("unable to read %q file: %w", nodeAgentFileSystemPath, err)
+	}
+
+	fsOperations := nodeAgentFsOperations{}
+	err = yaml.Unmarshal(fsOperationsRaw, &fsOperations)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal %q file: %w", nodeAgentFileSystemPath, err)
+	}
+
+	return &nodeAgentFileSystem{
+		fs:                    fs,
+		nodeAgentFsOperations: fsOperations,
+	}, nil
+}
+
+type nodeAgentFsOperations struct {
+	FileSystemOperations map[string]FileSystemOperation `json:"fileSystemOperations"`
+}
+
+type nodeAgentFileSystem struct {
+	fs                    afero.Afero
+	mutex                 sync.Mutex
+	nodeAgentFsOperations nodeAgentFsOperations
+}
+
+// GetFileSystemOperation returns the file operation performed by this file system.
+func (n *nodeAgentFileSystem) GetFileSystemOperation(path string) FileSystemOperation {
+	return n.nodeAgentFsOperations.FileSystemOperations[path]
+}
+
+// RemoveCreated removes the file from the file system if it was created by this file system.
+func (n *nodeAgentFileSystem) RemoveCreated(name string) error {
+	if operation := n.nodeAgentFsOperations.FileSystemOperations[name]; operation != OperationCreated {
+		return nil
+	}
+
+	return n.Remove(name)
+}
+
+// RemoveAllCreated removes all files created by this file system in the given directory.
+func (n *nodeAgentFileSystem) RemoveAllCreated(path string) error {
+	isDir, err := afero.IsDir(n.fs, path)
+	if err != nil {
+		return fmt.Errorf("unable to check if %q is a directory: %w", path, err)
+	}
+
+	if !isDir {
+		if err := n.Remove(path); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
+			return fmt.Errorf("unable to remove file %q: %w", path, err)
+		}
+
+		return nil
+	}
+
+	files, err := afero.ReadDir(n.fs, path)
+	if err != nil {
+		return fmt.Errorf("unable to read directory %q: %w", path, err)
+	}
+
+	for _, file := range files {
+		if err := n.Remove(filepath.Join(path, file.Name())); err != nil {
+			return fmt.Errorf("unable to remove file %q: %w", filepath.Join(path, file.Name()), err)
+		}
+	}
+
+	if empty, err := afero.IsEmpty(n.fs, path); err != nil {
+		return fmt.Errorf("unable to check if directory %q is empty: %w", path, err)
+	} else if empty {
+		return n.RemoveAll(path)
+	}
+
+	return nil
+}
+
+// Create creates a file in the filesystem, returning the file and an
+// error, if any happens.
+func (n *nodeAgentFileSystem) Create(name string) (afero.File, error) {
+	operation, err := n.beforeWrite(name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to prepare file %q for writing: %w", name, err)
+	}
+	file, err := n.fs.Create(name)
+	if err != nil {
+		return file, err
+	}
+
+	if err := n.saveState(name, operation); err != nil {
+		return nil, fmt.Errorf("unable to save state %q: %w", name, err)
+	}
+
+	return file, nil
+}
+
+// Mkdir creates a directory in the filesystem, return an error if any
+// happens.
+func (n *nodeAgentFileSystem) Mkdir(name string, perm os.FileMode) error {
+	operation, err := n.beforeWrite(name)
+	if err != nil {
+		return fmt.Errorf("unable to prepare directory %q for writing: %w", name, err)
+	}
+
+	if err := n.fs.Mkdir(name, perm); err != nil {
+		return err
+	}
+
+	if err := n.saveState(name, operation); err != nil {
+		return fmt.Errorf("unable to save state for directory %q: %w", name, err)
+	}
+
+	return nil
+}
+
+// MkdirAll creates a directory path and all parents that does not exist
+// yet.
+func (n *nodeAgentFileSystem) MkdirAll(path string, perm os.FileMode) error {
+	operation, err := n.beforeWrite(path)
+	if err != nil {
+		return fmt.Errorf("unable to prepare directory %q for writing: %w", path, err)
+	}
+
+	if err := n.fs.MkdirAll(path, perm); err != nil {
+		return err
+	}
+
+	if err := n.saveState(path, operation); err != nil {
+		return fmt.Errorf("unable to save state for path %q: %w", path, err)
+	}
+
+	return nil
+}
+
+// Open opens a file, returning it or an error, if any happens.
+func (n *nodeAgentFileSystem) Open(name string) (afero.File, error) {
+	return n.fs.Open(name)
+}
+
+// OpenFile opens a file using the given flags and the given mode.
+func (n *nodeAgentFileSystem) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if flag == os.O_RDONLY {
+		return n.fs.OpenFile(name, flag, perm)
+	}
+
+	operation, err := n.beforeWrite(name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to prepare file %q for writing: %w", name, err)
+	}
+
+	file, err := n.fs.OpenFile(name, flag, perm)
+	if err != nil {
+		return file, err
+	}
+
+	if err := n.saveState(name, operation); err != nil {
+		return nil, fmt.Errorf("unable to save state for file %q: %w", name, err)
+	}
+
+	return file, nil
+}
+
+// Remove removes a file identified by name, returning an error, if any
+// happens.
+func (n *nodeAgentFileSystem) Remove(name string) error {
+	if err := n.fs.Remove(name); err != nil {
+		return err
+	}
+
+	if err := n.deleteState(name); err != nil {
+		return fmt.Errorf("unable to save state for removing file %q: %w", name, err)
+	}
+
+	return nil
+}
+
+// RemoveAll removes a directory path and any children it contains. It
+// does not fail if the path does not exist (return nil).
+func (n *nodeAgentFileSystem) RemoveAll(path string) error {
+	if err := n.fs.RemoveAll(path); err != nil {
+		return err
+	}
+
+	for nodeAgentFile := range n.nodeAgentFsOperations.FileSystemOperations {
+		if !strings.HasPrefix(nodeAgentFile, path) {
+			continue
+		}
+		if err := n.deleteState(nodeAgentFile); err != nil {
+			return fmt.Errorf("unable to save state for removing path %q: %w", nodeAgentFile, err)
+		}
+	}
+
+	return nil
+}
+
+// Rename renames a file.
+func (n *nodeAgentFileSystem) Rename(oldname, newname string) error {
+	operation, err := n.beforeWrite(newname)
+	if err != nil {
+		return fmt.Errorf("unable to prepare file %q for writing: %w", newname, err)
+	}
+
+	if err := n.fs.Rename(oldname, newname); err != nil {
+		return err
+	}
+
+	if err := n.saveState(newname, operation); err != nil {
+		return fmt.Errorf("unable to save state for renaming file %q: %w", newname, err)
+	}
+
+	if err := n.deleteState(oldname); err != nil {
+		return fmt.Errorf("unable to save state for renaming old file %q: %w", oldname, err)
+	}
+
+	return nil
+}
+
+// Stat returns a FileInfo describing the named file, or an error, if any
+// happens.
+func (n *nodeAgentFileSystem) Stat(name string) (os.FileInfo, error) {
+	return n.fs.Stat(name)
+}
+
+// Name returns the name of this FileSystem
+func (n *nodeAgentFileSystem) Name() string {
+	return "NodeAgentFileSystem"
+}
+
+// Chmod changes the mode of the named file to mode.
+func (n *nodeAgentFileSystem) Chmod(name string, mode os.FileMode) error {
+	return n.fs.Chmod(name, mode)
+}
+
+// Chown changes the uid and gid of the named file.
+func (n *nodeAgentFileSystem) Chown(name string, uid, gid int) error {
+	return n.fs.Chown(name, uid, gid)
+}
+
+// Chtimes changes the access and modification times of the named file
+func (n *nodeAgentFileSystem) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return n.fs.Chtimes(name, atime, mtime)
+}
+
+func (n *nodeAgentFileSystem) beforeWrite(path string) (*FileSystemOperation, error) {
+	if operation, ok := n.nodeAgentFsOperations.FileSystemOperations[path]; operation == OperationDeleted {
+		return ptr.To(OperationDeleted), nil
+	} else if ok {
+		return nil, nil
+	}
+
+	exists, err := n.fs.Exists(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check if file %q exists: %w", path, err)
+	}
+
+	operation := OperationCreated
+	if exists {
+		operation = OperationModified
+	}
+
+	return &operation, nil
+}
+
+func (n *nodeAgentFileSystem) deleteState(path string) error {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	if operation := n.nodeAgentFsOperations.FileSystemOperations[path]; operation == OperationCreated {
+		delete(n.nodeAgentFsOperations.FileSystemOperations, path)
+	} else {
+		n.nodeAgentFsOperations.FileSystemOperations[path] = OperationDeleted
+	}
+
+	return n.marshallStateAndSave()
+}
+
+func (n *nodeAgentFileSystem) saveState(path string, operation *FileSystemOperation) error {
+	if operation == nil {
+		return nil
+	}
+
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	n.nodeAgentFsOperations.FileSystemOperations[path] = *operation
+
+	return n.marshallStateAndSave()
+}
+
+func (n *nodeAgentFileSystem) marshallStateAndSave() error {
+	nodeAgentFilesRaw, err := yaml.Marshal(n.nodeAgentFsOperations)
+	if err != nil {
+		return fmt.Errorf("unable to marshal file %q: %w", nodeAgentFileSystemPath, err)
+	}
+
+	if err = n.fs.WriteFile(nodeAgentFileSystemPath, nodeAgentFilesRaw, 0600); err != nil {
+		return fmt.Errorf("unable to write file %q: %w", nodeAgentFileSystemPath, err)
+	}
+
+	return nil
+}

--- a/pkg/nodeagent/files/filesystem_test.go
+++ b/pkg/nodeagent/files/filesystem_test.go
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package files_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	. "github.com/gardener/gardener/pkg/nodeagent/files"
+)
+
+var _ = Describe("Filesystem", func() {
+	var (
+		fakeFS            afero.Afero
+		fakeNodeAgentFS   *NodeAgentAfero
+		testFilePath      string
+		testDirectoryPath string
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		fakeFS = afero.Afero{Fs: afero.NewMemMapFs()}
+		fakeNodeAgentFS, err = NewNodeAgentAfero(fakeFS)
+		Expect(err).ToNot(HaveOccurred())
+
+		testDirectoryPath = "/foo-directory"
+		testFilePath = testDirectoryPath + "/bar-file"
+
+		Expect(fakeFS.Mkdir(testDirectoryPath, 0700)).To(Succeed())
+	})
+
+	Describe("#GetFileSystemOperation", func() {
+		It("should return `create` if the file was created by node agent fs", func() {
+			_, err := fakeNodeAgentFS.Create(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testFilePath)).To(Equal(OperationCreated))
+		})
+
+		It("should return `create` if a new file was written by node agent fs", func() {
+			Expect(fakeNodeAgentFS.WriteFile(testFilePath, []byte("foobar"), 0600)).To(Succeed())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testFilePath)).To(Equal(OperationCreated))
+		})
+
+		It("should return `create` if the directory was created by node agent fs", func() {
+			newDirectoryPath := testDirectoryPath + "/new-directory"
+			Expect(fakeNodeAgentFS.Mkdir(newDirectoryPath, 0700)).To(Succeed())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(newDirectoryPath)).To(Equal(OperationCreated))
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testDirectoryPath)).To(Equal(OperationNone))
+		})
+
+		It("should return `create` if multiple directories were created by node agent fs. Existing parent directories should not be touched", func() {
+			newDirectoryPath := testDirectoryPath + "/new-directory"
+			newSubDirectoryPath := newDirectoryPath + "/sub-directory"
+			Expect(fakeNodeAgentFS.MkdirAll(newSubDirectoryPath, 0700)).To(Succeed())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(newSubDirectoryPath)).To(Equal(OperationCreated))
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(newDirectoryPath)).To(Equal(OperationCreated))
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testDirectoryPath)).To(Equal(OperationNone))
+		})
+
+		It("should return `modified` if the file was modified by node agent fs", func() {
+			_, err := fakeFS.Create(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeNodeAgentFS.WriteFile(testFilePath, []byte("foobar"), 0600)).To(Succeed())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testFilePath)).To(Equal(OperationModified))
+		})
+
+		It("should return `deleted` if the file was deleted by node agent fs", func() {
+			_, err := fakeFS.Create(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeNodeAgentFS.Remove(testFilePath)).To(Succeed())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testFilePath)).To(Equal(OperationDeleted))
+		})
+
+		It("should return nothing if the file was not touched by node agent fs", func() {
+			_, err := fakeFS.Create(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testFilePath)).To(Equal(OperationNone))
+		})
+
+		It("should return `deleted` if the directory was deleted by node agent fs", func() {
+			Expect(fakeNodeAgentFS.RemoveAll(testDirectoryPath)).To(Succeed())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testDirectoryPath)).To(Equal(OperationDeleted))
+		})
+	})
+
+	Describe("#RemoveCreated", func() {
+		It("should remove the file if it was created by node agent fs", func() {
+			_, err := fakeNodeAgentFS.Create(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeNodeAgentFS.RemoveCreated(testFilePath)).To(Succeed())
+			exists, err := fakeFS.Exists(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should not remove the file if it was not created by node agent fs", func() {
+			_, err := fakeFS.Create(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeNodeAgentFS.RemoveCreated(testFilePath)).To(Succeed())
+			exists, err := fakeFS.Exists(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+		})
+
+		It("should not remove the file if it was not created but modified by node agent fs", func() {
+			_, err := fakeFS.Create(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeNodeAgentFS.WriteFile(testFilePath, []byte("foobar"), 0600)).To(Succeed())
+			Expect(fakeNodeAgentFS.RemoveCreated(testFilePath)).To(Succeed())
+			exists, err := fakeFS.Exists(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+		})
+	})
+
+	Describe("#RemoveAllCreated", func() {
+		It("should remove all files and directories created by node agent fs", func() {
+			newDirectoryPath := testDirectoryPath + "/new-directory"
+			newSubDirectoryPath := newDirectoryPath + "/sub-directory"
+			newFilePath := newSubDirectoryPath + "/new-file"
+			Expect(fakeNodeAgentFS.MkdirAll(newSubDirectoryPath, 0700)).To(Succeed())
+			Expect(fakeNodeAgentFS.WriteFile(newFilePath, []byte("foobar"), 0600)).To(Succeed())
+
+			Expect(fakeNodeAgentFS.RemoveAllCreated(newDirectoryPath)).To(Succeed())
+
+			exists, err := fakeFS.Exists(newFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(newFilePath)).To(Equal(OperationNone))
+
+			exists, err = fakeFS.Exists(newSubDirectoryPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(newSubDirectoryPath)).To(Equal(OperationNone))
+
+			exists, err = fakeFS.Exists(newDirectoryPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(newDirectoryPath)).To(Equal(OperationNone))
+
+			exists, err = fakeFS.Exists(testDirectoryPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testDirectoryPath)).To(Equal(OperationNone))
+		})
+
+		It("should not remove files and directories not created by node agent fs", func() {
+			_, err := fakeNodeAgentFS.Create(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			nonNodeAgentFilePath := testDirectoryPath + "/non-node-agent-file"
+			_, err = fakeFS.Create(nonNodeAgentFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			nonNodeAgentDirectoryPath := testDirectoryPath + "/non-node-agent-directory"
+			Expect(fakeFS.Mkdir(nonNodeAgentDirectoryPath, 0700)).To(Succeed())
+
+			Expect(fakeNodeAgentFS.RemoveAllCreated(testDirectoryPath)).To(Succeed())
+
+			exists, err := fakeFS.Exists(testFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testFilePath)).To(Equal(OperationNone))
+
+			exists, err = fakeFS.Exists(nonNodeAgentFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(nonNodeAgentFilePath)).To(Equal(OperationNone))
+
+			exists, err = fakeFS.Exists(nonNodeAgentDirectoryPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(nonNodeAgentDirectoryPath)).To(Equal(OperationNone))
+
+			exists, err = fakeFS.Exists(testDirectoryPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(fakeNodeAgentFS.GetFileSystemOperation(testDirectoryPath)).To(Equal(OperationNone))
+		})
+	})
+})

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -72,7 +72,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		fakeDBus = fakedbus.New()
 		fakeFS = afero.Afero{Fs: afero.NewMemMapFs()}
-		fakeFsNodeAgent, err := nodeagentfiles.NewNodeAgentFileSystem(fakeFS)
+		fakeFsNodeAgent, err := nodeagentfiles.NewNodeAgentAfero(fakeFS)
 		Expect(err).NotTo(HaveOccurred())
 
 		imageMountDirectory, err = fakeFS.TempDir("", "fake-node-agent-")

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
 	fakedbus "github.com/gardener/gardener/pkg/nodeagent/dbus/fake"
+	nodeagentfiles "github.com/gardener/gardener/pkg/nodeagent/files"
 	fakeregistry "github.com/gardener/gardener/pkg/nodeagent/registry/fake"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -71,6 +72,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		fakeDBus = fakedbus.New()
 		fakeFS = afero.Afero{Fs: afero.NewMemMapFs()}
+		fakeFsNodeAgent, err := nodeagentfiles.NewNodeAgentFileSystem(fakeFS)
+		Expect(err).NotTo(HaveOccurred())
 
 		imageMountDirectory, err = fakeFS.TempDir("", "fake-node-agent-")
 		Expect(err).NotTo(HaveOccurred())
@@ -145,10 +148,10 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 				KubernetesVersion: kubernetesVersion,
 			},
 			DBus:          fakeDBus,
-			FS:            fakeFS,
+			FS:            fakeFsNodeAgent,
 			HostName:      hostName,
 			NodeName:      node.Name,
-			Extractor:     fakeregistry.NewExtractor(fakeFS, imageMountDirectory),
+			Extractor:     fakeregistry.NewExtractor(afero.Afero{Fs: fakeFsNodeAgent}, imageMountDirectory),
 			CancelContext: cancelFunc.cancel,
 		}).AddToManager(ctx, mgr)).To(Succeed())
 

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -439,7 +439,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/containerd/conf.d")
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d")
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", containerdConfigFileContent, 0644)
-		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.hub.docker.com\"\n\n[host.\"https://10.10.10.100:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n[host.\"https://10.10.10.200:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n", 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
 
@@ -455,6 +455,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit7.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit8.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit9.Name}},
+			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit1.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionStop, UnitNames: []string{unit2.Name}},
@@ -575,7 +576,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/containerd/conf.d")
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d")
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", containerdConfigFileContent, 0644)
-		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.hub.docker.com\"\n\n[host.\"https://10.10.10.100:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n[host.\"https://10.10.10.200:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n", 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness|
/kind bug

**What this PR does / why we need it**:
Currently `gardener-node-agent` always deletes a systemd unit file and the drop-in folder when the unit was deleted from OperatingSystemConfig.
While this correct for units which have been created by `gardener-node-agent`, it incorrectly deletes `*.service` file and the drop-in folder for units created by other parties (like default OS units). This can be the case if we use the unit to add additional drop-ins or in order to change the start command.

With this PR, unit file and drop-in folder are deleted only if `Unit.Content` of the old unit is not nil. 
Otherwise, it keeps the unit file and deletes the drop-in files only.

**Which issue(s) this PR fixes**:
Fixes #10809 

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
`gardener-node-agent` deletes unit files and drop-ins only if it created them previously.
```
