### PR TITLE
Correctly update the value in list

### DIFF
--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -160,9 +160,9 @@ func appendToleration(tolerations []gardencorev1beta1.Toleration, key string, va
 	if tolerations == nil {
 		tolerations = make([]gardencorev1beta1.Toleration, 0)
 	} else {
-		for _, t := range tolerations {
+		for i, t := range tolerations {
 			if t.Key == key {
-				t.Value = value
+				tolerations[i].Value = value
 				return tolerations
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
The function was supposed to update the value in the tolerations list when the key matches but was instead updating the value in the local variable and not in the actual list.
The PR correctly assign the value in the original list for matching key.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
