### PR TITLE
Update custom CAs on existing nodes

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component.go
@@ -16,6 +16,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -85,6 +86,12 @@ func (containerd) Config(_ components.Context) ([]extensionsv1alpha1.Unit, []ext
 		},
 	}
 
+	// Unit without content to trigger restart of containerd.service when CAs change.
+	containerdUnit := extensionsv1alpha1.Unit{
+		Name:      UnitName,
+		FilePaths: []string{rootcertificates.PathLocalSSLRootCerts},
+	}
+
 	monitorUnit := extensionsv1alpha1.Unit{
 		Name:    UnitNameMonitor,
 		Command: ptr.To(extensionsv1alpha1.CommandStart),
@@ -101,5 +108,5 @@ ExecStart=` + pathHealthMonitor),
 		FilePaths: []string{monitorFile.Path},
 	}
 
-	return append(logRotateUnits, monitorUnit), append(logRotateFiles, monitorFile), nil
+	return append(logRotateUnits, containerdUnit, monitorUnit), append(logRotateFiles, monitorFile), nil
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -28,6 +28,11 @@ var _ = Describe("Component", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 
+			containerdUnit := extensionsv1alpha1.Unit{
+				Name:      "containerd.service",
+				FilePaths: []string{"/var/lib/ca-certificates-local/ROOTcerts.crt"},
+			}
+
 			monitorUnit := extensionsv1alpha1.Unit{
 				Name:    "containerd-monitor.service",
 				Command: ptr.To(extensionsv1alpha1.CommandStart),
@@ -91,7 +96,7 @@ WantedBy=multi-user.target`),
 				},
 			}
 
-			Expect(units).To(ConsistOf(monitorUnit, logrotateUnit, logrotateTimerUnit))
+			Expect(units).To(ConsistOf(containerdUnit, monitorUnit, logrotateUnit, logrotateTimerUnit))
 			Expect(files).To(ConsistOf(monitorFile, logrotateConfigFile))
 		})
 	})

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -20,6 +20,7 @@ import (
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates"
 	oscutils "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils"
 	"github.com/gardener/gardener/pkg/utils"
 )
@@ -112,7 +113,7 @@ EnvironmentFile=/etc/environment
 EnvironmentFile=-/var/lib/kubelet/extra_args
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/kubelet \
     ` + utils.Indent(strings.Join(cliFlags, " \\\n"), 4) + ` $KUBELET_EXTRA_ARGS`),
-		FilePaths: extensionsv1alpha1helper.FilePathsFrom(kubeletFiles),
+		FilePaths: append(extensionsv1alpha1helper.FilePathsFrom(kubeletFiles), rootcertificates.PathLocalSSLRootCerts),
 	}
 
 	return []extensionsv1alpha1.Unit{kubeletUnit}, kubeletFiles, nil

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -239,10 +239,8 @@ EnvironmentFile=/etc/environment
 EnvironmentFile=-/var/lib/kubelet/extra_args` + kubeletStartPre + `
 ExecStart=/opt/bin/kubelet \
     ` + utils.Indent(strings.Join(cliFlags, " \\\n"), 4) + ` $KUBELET_EXTRA_ARGS`),
-		FilePaths: []string{"/var/lib/kubelet/ca.crt", "/var/lib/kubelet/config/kubelet"},
+		FilePaths: []string{"/var/lib/kubelet/ca.crt", "/var/lib/kubelet/config/kubelet", "/opt/bin/kubelet", "/var/lib/ca-certificates-local/ROOTcerts.crt"},
 	}
-
-	unit.FilePaths = append(unit.FilePaths, "/opt/bin/kubelet")
 
 	return unit
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -13,14 +13,17 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
 const (
+	// PathLocalSSLRootCerts is the path to the Gardener CAs. It can be used as trigger for other components to reload the CAs.
+	PathLocalSSLRootCerts = pathLocalSSLCerts + "/ROOTcerts.crt"
+
 	pathLocalSSLCerts             = "/var/lib/ca-certificates-local"
 	pathUpdateLocalCaCertificates = "/var/lib/ssl/update-local-ca-certificates.sh"
 )
@@ -69,7 +72,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		updateLocalCaCertificatesScriptFile,
 		// This file contains Gardener CAs for Debian based OS
 		{
-			Path:        pathLocalSSLCerts + "/ROOTcerts.crt",
+			Path:        PathLocalSSLRootCerts,
 			Permissions: ptr.To[uint32](0644),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
@@ -100,10 +103,9 @@ Description=Update local certificate authorities
 DefaultDependencies=no
 Wants=systemd-tmpfiles-setup.service clean-ca-certificates.service
 After=systemd-tmpfiles-setup.service clean-ca-certificates.service
-Before=sysinit.target ` + kubelet.UnitName + `
+Before=sysinit.target ` + v1beta1constants.OperatingSystemConfigUnitNameKubeletService + `
 ConditionPathIsReadWrite=` + pathEtcSSLCerts + `
 ConditionPathIsReadWrite=` + pathLocalSSLCerts + `
-ConditionPathExists=!` + kubelet.PathKubeconfigReal + `
 [Service]
 Type=oneshot
 ExecStart=` + pathUpdateLocalCaCertificates + `

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -57,7 +57,6 @@ After=systemd-tmpfiles-setup.service clean-ca-certificates.service
 Before=sysinit.target kubelet.service
 ConditionPathIsReadWrite=/etc/ssl/certs
 ConditionPathIsReadWrite=/var/lib/ca-certificates-local
-ConditionPathExists=!/var/lib/kubelet/kubeconfig-real
 [Service]
 Type=oneshot
 ExecStart=/var/lib/ssl/update-local-ca-certificates.sh

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -112,6 +112,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/health-monitor.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
+            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/utils
             - pkg/component/garden/system/runtime
             - pkg/component/garden/system/virtual
@@ -1067,6 +1069,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
             - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
+            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
+            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/valitail-config.tpl.yaml
             - pkg/component/extensions/operatingsystemconfig/utils

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -710,6 +710,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
             - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
+            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
+            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/valitail-config.tpl.yaml
             - pkg/component/extensions/operatingsystemconfig/utils
@@ -1481,6 +1483,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
             - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
+            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
+            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/valitail-config.tpl.yaml
             - pkg/component/extensions/operatingsystemconfig/utils


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
At the moment custom CAs are applied when the node is created only. Existing nodes are not updated.
This PR changes this behavior and allows updating custom CAs on existing nodes. It is possible to restart containerd without restarting all containers ([ref](https://github.com/moby/moby/discussions/46449#discussioncomment-6966822)) which was not the case for docker. As Gardener does not support Docker anymore, this change is possible now.

When custom CAs change `containerd` and `kubelet` services are restarted on the node.
Other services affected by CA changes like `gardener-node-agent` ([ref](https://github.com/gardener/gardener/blob/4ac6d019dfa2ded385bf74f1d0e814e12ab09703/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go#L58-L61)) and `valitail` ([ref](https://github.com/gardener/gardener/blob/4ac6d019dfa2ded385bf74f1d0e814e12ab09703/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go#L73-L86)) already include the CA bundle in their configuration or as own file, so they are restarting already. 

**Which issue(s) this PR fixes**:
Fixes #10040 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Custom CAs are updated on existing nodes too.
```
