### PR TITLE
Upgrade gardener/dependency-watchdog to v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-rc.1
 	github.com/fluent/fluent-operator/v2 v2.9.0
 	github.com/gardener/cert-management v0.16.0
-	github.com/gardener/dependency-watchdog v1.2.3
+	github.com/gardener/dependency-watchdog v1.3.0
 	github.com/gardener/etcd-druid v0.24.1
 	github.com/gardener/hvpa-controller/api v0.17.0
 	github.com/gardener/machine-controller-manager v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gardener/cert-management v0.16.0 h1:OlE8nnPgqUii5jBknwASy5EtQlJ3Udy2f7VKIk35A4Q=
 github.com/gardener/cert-management v0.16.0/go.mod h1:09sH/cxbK3o4xdwCjM7HE9gGX2wq2lLhhVIqiMpmZy4=
-github.com/gardener/dependency-watchdog v1.2.3 h1:G1gihyMxHLKtkb+/iAme8v5KuN0XNt4Z2+9aNgs/Vcs=
-github.com/gardener/dependency-watchdog v1.2.3/go.mod h1:DzjPnXWcDHmboMudqNZ1VXHfHLkgHy4jxPdyab/37oQ=
+github.com/gardener/dependency-watchdog v1.3.0 h1:C5EO/4GKv1TosvqVepJfzGssu8dDR06q1y05b11ozqI=
+github.com/gardener/dependency-watchdog v1.3.0/go.mod h1:KNUla1c54x6AGh7SXK/OlM0LrghMXXZG0f+d7+XojaA=
 github.com/gardener/etcd-druid v0.24.1 h1:BfFQXOevuJ5oOvM3rkQSJ5XITMJzY/a2j54e7XcBIos=
 github.com/gardener/etcd-druid v0.24.1/go.mod h1:6C0eyfdlw6CowLm/l4ZiKwrvkc+5NHrnc/rY2wCUwys=
 github.com/gardener/hvpa-controller/api v0.17.0 h1:1mNeP+xsnjPH6GhewugU5srslXiTCJgYIFCMuRXwI7w=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -72,7 +72,7 @@ images:
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog
-  tag: "v1.2.3"
+  tag: "v1.3.0"
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot

--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
@@ -317,6 +317,11 @@ func (b *bootstrapper) getClusterRolePolicyRules() []rbacv1.PolicyRule {
 				Resources: []string{"deployments", "deployments/scale"},
 				Verbs:     []string{"get", "list", "watch", "update", "patch"},
 			},
+			{
+				APIGroups: []string{"machine.sapcloud.io"},
+				Resources: []string{"machines"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
 		}
 	}
 

--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap_test.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap_test.go
@@ -128,6 +128,14 @@ rules:`
   - watch
   - update
   - patch
+- apiGroups:
+  - machine.sapcloud.io
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
 `
 					}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Upgrades the DWD version to `1.3.0`. This PR also modifies the clusterRole for DWD to allow access to machine objects in the control plane of shoots. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener/dependency-watchdog` image has been updated to `v1.3.0`. [Release Notes](https://redirect.github.com/gardener/dependency-watchdog/releases/tag/v1.3.0)
```
