### PR TITLE
[GEP-28] Add `build-gardenadm` script for Concourse CI

### DIFF
--- a/.ci/build-gardenadm
+++ b/.ci/build-gardenadm
@@ -6,17 +6,8 @@
 
 set -e
 
-if [[ -z "${MAIN_REPO_DIR}" ]]; then
-  export MAIN_REPO_DIR="$(readlink -f $(dirname ${0})/..)"
-else
-  export MAIN_REPO_DIR="$(readlink -f "${MAIN_REPO_DIR}")"
-fi
-
-if [[ -z "${BINARY_PATH}" ]]; then
-  export BINARY_PATH="$(readlink -f $(dirname ${0})/../bin)"
-else
-  export BINARY_PATH="$(readlink -f "${BINARY_PATH}")"
-fi
+export MAIN_REPO_DIR="$(readlink -f "${MAIN_REPO_DIR:-$(dirname ${0})/..}")"
+export BINARY_PATH="$(readlink -f "${BINARY_PATH:-$(dirname ${0})/../bin}")"
 
 pushd "${MAIN_REPO_DIR}" > /dev/null
 

--- a/.ci/build-gardenadm
+++ b/.ci/build-gardenadm
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+if [[ -z "${MAIN_REPO_DIR}" ]]; then
+  export MAIN_REPO_DIR="$(readlink -f $(dirname ${0})/..)"
+else
+  export MAIN_REPO_DIR="$(readlink -f "${MAIN_REPO_DIR}")"
+fi
+
+if [[ -z "${BINARY_PATH}" ]]; then
+  export BINARY_PATH="$(readlink -f $(dirname ${0})/../bin)"
+else
+  export BINARY_PATH="$(readlink -f "${BINARY_PATH}")"
+fi
+
+pushd "${MAIN_REPO_DIR}" > /dev/null
+
+echo "Fetching LD flags for build..."
+ld_flags="$(hack/get-build-ld-flags.sh)"
+
+for os in linux darwin windows; do
+  for arch in amd64 arm64; do
+    out_file="${BINARY_PATH}/gardenadm-${os}-${arch}"
+    if [[ "${os}" == "windows" ]]; then
+      out_file="${out_file}.exe"
+    fi
+
+    echo "Building gardenadm for ${os}-${arch} and writing output to ${out_file}..."
+    GOOS="${os}" GOARCH="${arch}" LD_FLAGS="${ld_flags}" BUILD_OUTPUT_FILE="${out_file}" BUILD_PACKAGES="./cmd/gardenadm" make build
+  done
+done
+
+popd > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,13 @@ start-envtest: $(SETUP_ENVTEST)
 install:
 	@EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) ./hack/install.sh ./...
 
+BUILD_OUTPUT_FILE ?= .
+BUILD_PACKAGES ?= ./...
+
+.PHONY: build
+build:
+	@EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) ./hack/build.sh -o $(BUILD_OUTPUT_FILE) $(BUILD_PACKAGES)
+
 .PHONY: docker-images
 docker-images:
 	@echo "Building docker images with version and tag $(EFFECTIVE_VERSION)"

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Build"
+
+GOOS="${GOOS:-$(go env GOOS)}"
+GOARCH="${GOARCH:-$(go env GOARCH)}"
+LD_FLAGS="${LD_FLAGS:-$($(dirname $0)/get-build-ld-flags.sh)}"
+
+CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" GO111MODULE=on \
+  go build -ldflags "$LD_FLAGS" \
+  $@

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -8,8 +8,10 @@ set -e
 
 echo "> Install"
 
+GOOS="${GOOS:-$(go env GOOS)}"
+GOARCH="${GOARCH:-$(go env GOARCH)}"
 LD_FLAGS="${LD_FLAGS:-$($(dirname $0)/get-build-ld-flags.sh)}"
 
-CGO_ENABLED=0 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) GO111MODULE=on \
+CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" GO111MODULE=on \
   go install -ldflags "$LD_FLAGS" \
   $@


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Add `build-gardenadm` script for Concourse CI. The idea is that the `head-update` and `release` jobs run this script in order to build the binaries and add them as assets to the respective (draft) releases.

Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ @ccwienk @8R0WNI3 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
