### PR TITLE
[GEP-23] Update the GEP - no longer implementable and describe what was the replacement

### DIFF
--- a/docs/proposals/23-autoscaling-kube-apiserver-via-independent-hpa-and-vpa.md
+++ b/docs/proposals/23-autoscaling-kube-apiserver-via-independent-hpa-and-vpa.md
@@ -2,7 +2,7 @@
 title: Autoscaling Shoot `kube-apiserver` via Independently Driven HPA and VPA
 gep-number: 23
 creation-date: 2023-01-31
-status: implementable
+status: replaced
 authors:
 - "@andrerun"
 - "@voelzmo"
@@ -12,6 +12,12 @@ reviewers:
 ---
 
 # GEP-23: Autoscaling Shoot kube-apiserver via Independently Driven HPA and VPA
+
+📌 **Replacement Notice**
+
+The GEP is replaced by an autoscaling solution for Kubernetes API server based on native HPA and VPA resources. Kubernetes API server is scaled simultaneously by HPA and VPA on the same metric (CPU and memory usage). For more details, see the [Autoscaling Specifics for Components documentation](../development/autoscaling-specifics-for-components.md). The implementation PR of the replacement feature is [gardener/gardener#9678](https://github.com/gardener/gardener/pull/9678).
+
+---
 
 ## Table of Contents
 - [GEP-23: Autoscaling Shoot kube-apiserver via Independently Driven HPA and VPA](#gep-23-autoscaling-shoot-kube-apiserver-via-independently-driven-hpa-and-vpa)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
Update GEP-23 to do not confusion for the readers. We replaced GEP-23 with https://github.com/gardener/gardener/pull/9678.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
