### PR TITLE
Use Subresource client for `serviceaccounts/token`

### DIFF
--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -15,7 +15,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
@@ -775,13 +774,7 @@ func createBootstrapKubeconfig(
 			serviceAccountNamespace = obj.GetNamespace()
 		)
 
-		// Create a kubeconfig containing a valid service account token as client credentials
-		kubernetesClientSet, err := kubernetesclientset.NewForConfig(gardenClientRestConfig)
-		if err != nil {
-			return "", fmt.Errorf("failed creating Kubernetes client: %w", err)
-		}
-
-		bootstrapKubeconfig, err = gardenletbootstraputil.ComputeGardenletKubeconfigWithServiceAccountToken(ctx, gardenClient, kubernetesClientSet.CoreV1(), gardenClientRestConfig, serviceAccountName, serviceAccountNamespace)
+		bootstrapKubeconfig, err = gardenletbootstraputil.ComputeGardenletKubeconfigWithServiceAccountToken(ctx, gardenClient, gardenClientRestConfig, serviceAccountName, serviceAccountNamespace)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controller/tokenrequestor/add.go
+++ b/pkg/controller/tokenrequestor/add.go
@@ -5,10 +5,7 @@
 package tokenrequestor
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
-	corev1clientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -30,14 +27,6 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, sourceCluster, targetClus
 	}
 	if r.TargetClient == nil {
 		r.TargetClient = targetCluster.GetClient()
-	}
-	if r.TargetCoreV1Client == nil {
-		var err error
-
-		r.TargetCoreV1Client, err = corev1clientset.NewForConfig(targetCluster.GetConfig())
-		if err != nil {
-			return fmt.Errorf("could not create coreV1Client: %w", err)
-		}
 	}
 
 	return builder.

--- a/pkg/controller/tokenrequestor/reconciler_test.go
+++ b/pkg/controller/tokenrequestor/reconciler_test.go
@@ -6,7 +6,6 @@ package tokenrequestor_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -15,17 +14,17 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	corev1fake "k8s.io/client-go/kubernetes/typed/core/v1/fake"
-	"k8s.io/client-go/testing"
 	"k8s.io/utils/clock"
 	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	. "github.com/gardener/gardener/pkg/controller/tokenrequestor"
@@ -41,7 +40,6 @@ var _ = Describe("Reconciler", func() {
 			fakeJitter func(time.Duration, float64) time.Duration
 
 			sourceClient, targetClient client.Client
-			coreV1Client               *corev1fake.FakeCoreV1
 
 			ctrl *Reconciler
 
@@ -55,31 +53,6 @@ var _ = Describe("Reconciler", func() {
 			expectedRenewDuration   time.Duration
 			token                   string
 			fakeNow                 time.Time
-
-			fakeCreateServiceAccountToken = func() {
-				coreV1Client.AddReactor("create", "serviceaccounts", func(action testing.Action) (bool, runtime.Object, error) {
-					if action.GetSubresource() != "token" {
-						return false, nil, errors.New("subresource should be 'token'")
-					}
-
-					cAction, ok := action.(testing.CreateAction)
-					if !ok {
-						return false, nil, fmt.Errorf("could not convert action (type %T) to type testing.CreateAction", cAction)
-					}
-
-					tokenRequest, ok := cAction.GetObject().(*authenticationv1.TokenRequest)
-					if !ok {
-						return false, nil, fmt.Errorf("could not convert object (type %T) to type *authenticationv1.TokenRequest", cAction.GetObject())
-					}
-
-					return true, &authenticationv1.TokenRequest{
-						Status: authenticationv1.TokenRequestStatus{
-							Token:               token,
-							ExpirationTimestamp: metav1.Time{Time: fakeNow.Add(time.Duration(*tokenRequest.Spec.ExpirationSeconds) * time.Second)},
-						},
-					}, nil
-				})
-			}
 		)
 
 		BeforeEach(func() {
@@ -87,24 +60,39 @@ var _ = Describe("Reconciler", func() {
 			fakeClock = testclock.NewFakeClock(fakeNow)
 			fakeJitter = func(d time.Duration, _ float64) time.Duration { return d }
 
+			// If no token-expiration-duration is set then the default of 12 hours is used
+			expectedRenewDuration = 12 * time.Hour * 80 / 100
+			token = "foo"
+
 			sourceClient = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
-			targetClient = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
-			coreV1Client = &corev1fake.FakeCoreV1{Fake: &testing.Fake{}}
+
+			targetClient = fakeclient.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+				SubResourceCreate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+					tokenRequest, isTokenRequest := subResource.(*authenticationv1.TokenRequest)
+					if !isTokenRequest {
+						return apierrors.NewBadRequest(fmt.Sprintf("got invalid type %T, expected TokenRequest", subResource))
+					}
+					if _, isServiceAccount := obj.(*corev1.ServiceAccount); !isServiceAccount {
+						return apierrors.NewNotFound(schema.GroupResource{}, "")
+					}
+
+					tokenRequest.Status.Token = token
+					tokenRequest.Status.ExpirationTimestamp = metav1.Time{Time: fakeClock.Now().Add(time.Duration(ptr.Deref(tokenRequest.Spec.ExpirationSeconds, 3600)) * time.Second)}
+
+					return c.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+				},
+			}).WithScheme(scheme.Scheme).Build()
 
 			ctrl = &Reconciler{
-				SourceClient:       sourceClient,
-				TargetClient:       targetClient,
-				TargetCoreV1Client: coreV1Client,
-				Clock:              fakeClock,
-				JitterFunc:         fakeJitter,
+				SourceClient: sourceClient,
+				TargetClient: targetClient,
+				Clock:        fakeClock,
+				JitterFunc:   fakeJitter,
 			}
 
 			secretName = "kube-scheduler"
 			serviceAccountName = "kube-scheduler-serviceaccount"
 			serviceAccountNamespace = "kube-system"
-			// If no token-expiration-duration is set then the default of 12 hours is used
-			expectedRenewDuration = 12 * time.Hour * 80 / 100
-			token = "foo"
 
 			secret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -132,7 +120,6 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should create a new service account, generate a new token and requeue", func() {
-			fakeCreateServiceAccountToken()
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(BeNotFoundError())
 
@@ -151,7 +138,6 @@ var _ = Describe("Reconciler", func() {
 		It("should create a new service account, generate a new token for the kubeconfig and requeue", func() {
 			secret.Data = map[string][]byte{"kubeconfig": newKubeconfigRaw("")}
 
-			fakeCreateServiceAccountToken()
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(BeNotFoundError())
 
@@ -173,7 +159,6 @@ var _ = Describe("Reconciler", func() {
 			secret.Annotations["token-requestor.resources.gardener.cloud/target-secret-name"] = targetSecretName
 			secret.Annotations["token-requestor.resources.gardener.cloud/target-secret-namespace"] = targetSecretNamespace
 
-			fakeCreateServiceAccountToken()
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(BeNotFoundError())
 
@@ -203,7 +188,6 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should create a new service account, generate a new token and requeue, and create the target secret in the next reconciliation", func() {
-			fakeCreateServiceAccountToken()
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(BeNotFoundError())
 
@@ -251,7 +235,6 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should create a new service account, generate a new token and requeue", func() {
-				fakeCreateServiceAccountToken()
 				Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(BeNotFoundError())
 
@@ -270,7 +253,6 @@ var _ = Describe("Reconciler", func() {
 			It("should create a new service account, generate a new token for the kubeconfig and requeue", func() {
 				secret.Data = map[string][]byte{"kubeconfig": newKubeconfigRaw("")}
 
-				fakeCreateServiceAccountToken()
 				Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(BeNotFoundError())
 
@@ -312,7 +294,6 @@ var _ = Describe("Reconciler", func() {
 		It("should fail when the provided kubeconfig cannot be decoded", func() {
 			secret.Data = map[string][]byte{"kubeconfig": []byte("some non-decodeable stuff")}
 
-			fakeCreateServiceAccountToken()
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(BeNotFoundError())
 
@@ -352,7 +333,6 @@ var _ = Describe("Reconciler", func() {
 			metav1.SetMetaDataAnnotation(&secret.ObjectMeta, "serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(-expiredSince).Format(time.RFC3339))
 
 			token = "new-token"
-			fakeCreateServiceAccountToken()
 
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 			Expect(targetClient.Create(ctx, serviceAccount)).To(Succeed())
@@ -369,7 +349,6 @@ var _ = Describe("Reconciler", func() {
 		It("should reconcile the service account settings", func() {
 			serviceAccount.AutomountServiceAccountToken = ptr.To(true)
 
-			fakeCreateServiceAccountToken()
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 			Expect(targetClient.Create(ctx, serviceAccount)).To(Succeed())
 
@@ -399,7 +378,6 @@ var _ = Describe("Reconciler", func() {
 			expirationDuration := 10 * time.Minute
 			expectedRenewDuration = 8 * time.Minute
 			metav1.SetMetaDataAnnotation(&secret.ObjectMeta, "serviceaccount.resources.gardener.cloud/token-expiration-duration", expirationDuration.String())
-			fakeCreateServiceAccountToken()
 
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 
@@ -415,7 +393,6 @@ var _ = Describe("Reconciler", func() {
 			expirationDuration := 100 * time.Hour
 			expectedRenewDuration = 24 * time.Hour * 80 / 100
 			metav1.SetMetaDataAnnotation(&secret.ObjectMeta, "serviceaccount.resources.gardener.cloud/token-expiration-duration", expirationDuration.String())
-			fakeCreateServiceAccountToken()
 
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 
@@ -454,7 +431,6 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should create a new service account in the fixed target namespace, generate a new token and requeue", func() {
-				fakeCreateServiceAccountToken()
 				Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(BeNotFoundError())
 

--- a/pkg/controller/tokenrequestor/reconciler_test.go
+++ b/pkg/controller/tokenrequestor/reconciler_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Reconciler", func() {
 			sourceClient = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 
 			targetClient = fakeclient.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
-				SubResourceCreate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+				SubResourceCreate: func(ctx context.Context, c client.Client, _ string, obj client.Object, subResource client.Object, _ ...client.SubResourceCreateOption) error {
 					tokenRequest, isTokenRequest := subResource.(*authenticationv1.TokenRequest)
 					if !isTokenRequest {
 						return apierrors.NewBadRequest(fmt.Sprintf("got invalid type %T, expected TokenRequest", subResource))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Use Subresource client for `serviceaccounts/token` in Token requestor controller. Earlier we were waiting for `fakeSubResourceClient` to support Create. But we can make use of `WithInterceptor` to suit our use case. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
