### PR TITLE
chore: Run `make generate` for grouped Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,7 +102,7 @@
       // Run make generate when Go API packages have been changed because CRDs might have changed.
       matchDatasources: [
         'go',
-        'github-releases',
+        'github-releases', // Required for the `etc-druid` and `machine-controller-manager` groups.
       ],
       postUpgradeTasks: {
         commands: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,6 +102,7 @@
       // Run make generate when Go API packages have been changed because CRDs might have changed.
       matchDatasources: [
         'go',
+        'github-releases',
       ],
       postUpgradeTasks: {
         commands: [


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Renovate stopped running `make generate` for `etc-druid` and `machine-controller-manager` updates since grouping them in single PRs: #10907

According to the following package rule, Renovate is configured to run `make generate` but since the groups include dependencies from `github-releases` the rule for `make generate` does not match anymore:
https://github.com/gardener/gardener/blob/c53ca48952a1e64d231365f8c3c175d0e8b01187/.github/renovate.json5#L101-L118

Example PRs where Renovate did not run `make generate`:
* https://github.com/gardener/gardener/pull/10956
* https://github.com/gardener/gardener/pull/10926

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
