### PR TITLE
Check for pod's condition.Reason for pod completeness condition

### DIFF
--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -329,7 +329,7 @@ var _ = Describe("Deployment", func() {
 
 		It("should consider the deployment as updated even though there are still completed pods", func() {
 			p1 := pod.DeepCopy()
-			p1.Status.Conditions = []corev1.PodCondition{{Type: "Ready", Status: "PodCompleted"}}
+			p1.Status.Conditions = []corev1.PodCondition{{Type: "Ready", Status: "False", Reason: "PodCompleted"}}
 			Expect(fakeClient.Create(ctx, p1)).To(Succeed())
 
 			p2 := pod.DeepCopy()

--- a/pkg/utils/kubernetes/health/pod.go
+++ b/pkg/utils/kubernetes/health/pod.go
@@ -72,6 +72,6 @@ func IsPodStale(reason string) bool {
 // IsPodCompleted returns true when the pod ready condition indicates completeness.
 func IsPodCompleted(conditions []corev1.PodCondition) bool {
 	return slices.ContainsFunc(conditions, func(condition corev1.PodCondition) bool {
-		return condition.Type == corev1.PodReady && condition.Status == "PodCompleted"
+		return condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse && condition.Reason == "PodCompleted"
 	})
 }

--- a/pkg/utils/kubernetes/health/pod_test.go
+++ b/pkg/utils/kubernetes/health/pod_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Pod", func() {
 
 		Entry("No conditions", nil, BeFalse()),
 		Entry("No ready condition", []corev1.PodCondition{{}}, BeFalse()),
-		Entry("Not completed", []corev1.PodCondition{{Type: "Ready"}}, BeFalse()),
-		Entry("Completed", []corev1.PodCondition{{Type: "Ready", Status: "PodCompleted"}}, BeTrue()),
+		Entry("Not completed", []corev1.PodCondition{{Type: "Ready", Status: "False", Reason: "Failed"}}, BeFalse()),
+		Entry("Completed", []corev1.PodCondition{{Type: "Ready", Status: "False", Reason: "PodCompleted"}}, BeTrue()),
 	)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Pod completeness condition should check for pod's `condition.Reason` to be equal to "PodCompleted" and `condition.Reason` to be "False".

Check https://github.com/kubernetes/kubernetes/blob/763e810fb58e03c32a26ed504668261795bf91bf/pkg/kubelet/status/generate.go#L274-L287

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes the bug where ManagedResource were still in progressing phase because of `Completed` pods
```
