### PR TITLE
Change the helm chart label structure to helm best practices

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1-core-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1-core-gardener-cloud.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-operations-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-operations-gardener-cloud.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-security-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-security-gardener-cloud.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-seedmanagement-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-seedmanagement-gardener-cloud.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-settings-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-settings-gardener-cloud.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1beta1-core-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1beta1-core-gardener-cloud.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-apiserver.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-apiserver.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gardener.cloud:system:apiserver
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-controller-manager.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-controller-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gardener.cloud:system:controller-manager
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-scheduler.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-scheduler.yaml
@@ -13,7 +13,7 @@ metadata:
   name: gardener.cloud:system:scheduler
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-admission-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-apiserver.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-apiserver.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gardener.cloud:system:apiserver
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-controller-manager.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-controller-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gardener.cloud:system:controller-manager
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-scheduler.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-scheduler.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gardener.cloud:system:scheduler
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -230,7 +230,7 @@ metadata:
   name: gardener.cloud:system:read-global-resources
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
@@ -260,7 +260,7 @@ metadata:
   name: gardener.cloud:system:read-global-resources
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:
@@ -280,7 +280,7 @@ metadata:
   name: gardener.cloud:system:user-auth
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
@@ -303,7 +303,7 @@ metadata:
   name: gardener.cloud:system:user-auth
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:
@@ -324,7 +324,7 @@ metadata:
   namespace: kube-system
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
@@ -346,7 +346,7 @@ metadata:
   namespace: kube-system
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:
@@ -368,7 +368,7 @@ metadata:
   name: gardener.cloud:system:project-creation
   labels:
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
@@ -390,7 +390,7 @@ metadata:
   labels:
     gardener.cloud/role: project-member
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 aggregationRule:
@@ -405,7 +405,7 @@ metadata:
   labels:
     rbac.gardener.cloud/aggregate-to-project-member: "true"
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
@@ -541,7 +541,7 @@ metadata:
   labels:
     gardener.cloud/role: project-serviceaccountmanager
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 aggregationRule:
@@ -556,7 +556,7 @@ metadata:
   labels:
     rbac.gardener.cloud/aggregate-to-project-serviceaccountmanager: "true"
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
@@ -591,7 +591,7 @@ metadata:
   labels:
     gardener.cloud/role: project-viewer
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 aggregationRule:
@@ -606,7 +606,7 @@ metadata:
   labels:
     rbac.gardener.cloud/aggregate-to-project-viewer: "true"
     app: gardener
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/controlplane/charts/application/templates/rolebinding-apiserver-auth-reader.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rolebinding-apiserver-auth-reader.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/controlplane/charts/application/templates/service-apiserver.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/service-apiserver.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -27,7 +27,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   name: gardener-apiserver

--- a/charts/gardener/controlplane/charts/application/templates/serviceaccount-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/serviceaccount-admission-controller.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/serviceaccount-apiserver.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/serviceaccount-apiserver.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/serviceaccount-controller-manager.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/serviceaccount-controller-manager.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: controller-manager
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/serviceaccount-scheduler.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/serviceaccount-scheduler.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/configmap-componentconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -28,7 +28,7 @@ spec:
       labels:
         app: gardener
         role: admission-controller
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
         {{- if .Values.global.admission.podLabels }}

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/poddisruptionbudget.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/poddisruptionbudget.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       app: gardener
       role: admission-controller
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
 {{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/secret-cert.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/secret-cert.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/secret-kubeconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/secret-kubeconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/service.yaml
@@ -15,7 +15,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     {{- if .Values.global.admission.service.topologyAwareRouting.enabled }}

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/serviceaccount.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.admission.user.name }}
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: gardener
     role: admission-controller
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/configmap-admission-config.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/configmap-admission-config.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 data:

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/configmap-audit-policy.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/configmap-audit-policy.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -47,7 +47,7 @@ spec:
       labels:
         app: gardener
         role: apiserver
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
         {{- if .Values.global.apiserver.etcd.useSidecar }}
@@ -519,7 +519,7 @@ metadata:
   namespace: garden
   labels:
     sidecar: etcd
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/poddisruptionbudget.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/poddisruptionbudget.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       app: gardener
       role: apiserver
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
 {{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-admission-kubeconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-admission-kubeconfig.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 type: Opaque

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-audit-webhook-config.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-audit-webhook-config.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-cert.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-cert.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-kubeconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-kubeconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-workload-identity.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-workload-identity.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
@@ -15,7 +15,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     {{- if .Values.global.apiserver.service.topologyAwareRouting.enabled }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/serviceaccount.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.apiserver.user.name }}
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/vpa.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/vpa.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: controller-manager
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: controller-manager
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -27,7 +27,7 @@ spec:
       labels:
         app: gardener
         role: controller-manager
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
         {{- if .Values.global.controller.podLabels }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/poddisruptionbudget.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/poddisruptionbudget.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: controller-manager
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       app: gardener
       role: controller-manager
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
 {{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/secret-kubeconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/secret-kubeconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: controller-manager
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: controller-manager
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/serviceaccount.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: controller-manager
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.controller.user.name }}
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: gardener
     role: controller-manager
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/configmap-componentconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -27,7 +27,7 @@ spec:
       labels:
         app: gardener
         role: scheduler
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
         {{- if .Values.global.scheduler.podLabels }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/poddisruptionbudget.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/poddisruptionbudget.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       app: gardener
       role: scheduler
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
 {{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/secret-kubeconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/secret-kubeconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/serviceaccount.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.scheduler.user.name }}
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: gardener
     role: scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/charts/gardener/gardenlet/templates/clusterrole-apiserver-sni.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-apiserver-sni.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/gardenlet/templates/clusterrole-istio.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-istio.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/gardenlet/templates/clusterrolebinding-apiserver-sni.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrolebinding-apiserver-sni.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/gardenlet/templates/clusterrolebinding-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrolebinding-gardenlet.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/gardenlet/templates/clusterrolebinding-istio.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrolebinding-istio.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/gardenlet/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/templates/configmap-componentconfig.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/gardenlet/templates/configmap-imagevector-overwrite-components.yaml
+++ b/charts/gardener/gardenlet/templates/configmap-imagevector-overwrite-components.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/gardenlet/templates/configmap-imagevector-overwrite.yaml
+++ b/charts/gardener/gardenlet/templates/configmap-imagevector-overwrite.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/gardenlet/templates/configmap-selfupgrade-config.yaml
+++ b/charts/gardener/gardenlet/templates/configmap-selfupgrade-config.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 immutable: true

--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -21,7 +21,7 @@ role: gardenlet
 
 {{- define "gardenlet.deployment.labels" -}}
 {{- include "gardenlet.deployment.matchLabels" . }}
-chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 release: "{{ .Release.Name }}"
 heritage: "{{ .Release.Service }}"
 {{- end -}}

--- a/charts/gardener/gardenlet/templates/networkpolicy.yaml
+++ b/charts/gardener/gardenlet/templates/networkpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/gardenlet/templates/poddisruptionbudget.yaml
+++ b/charts/gardener/gardenlet/templates/poddisruptionbudget.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       app: gardener
       role: gardenlet
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
 {{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}

--- a/charts/gardener/gardenlet/templates/role-garden-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/role-garden-gardenlet.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/gardenlet/templates/rolebinding-garden-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/rolebinding-garden-gardenlet.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/gardenlet/templates/secret-kubeconfig-garden-bootstrap.yaml
+++ b/charts/gardener/gardenlet/templates/secret-kubeconfig-garden-bootstrap.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/gardener/gardenlet/templates/secret-kubeconfig-garden.yaml
+++ b/charts/gardener/gardenlet/templates/secret-kubeconfig-garden.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/gardenlet/templates/secret-kubeconfig-seed.yaml
+++ b/charts/gardener/gardenlet/templates/secret-kubeconfig-seed.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/gardenlet/templates/service.yaml
+++ b/charts/gardener/gardenlet/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/gardener/gardenlet/templates/serviceaccount.yaml
+++ b/charts/gardener/gardenlet/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: gardenlet
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.invalidateServiceAccountToken }}

--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/operator/templates/clusterrolebinding.yaml
+++ b/charts/gardener/operator/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/operator/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/operator/templates/configmap-componentconfig.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/operator/templates/configmap-imagevector-charts-overwrite.yaml
+++ b/charts/gardener/operator/templates/configmap-imagevector-charts-overwrite.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/operator/templates/configmap-imagevector-overwrite-components.yaml
+++ b/charts/gardener/operator/templates/configmap-imagevector-overwrite-components.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/operator/templates/configmap-imagevector-overwrite.yaml
+++ b/charts/gardener/operator/templates/configmap-imagevector-overwrite.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/operator/templates/deployment.yaml
+++ b/charts/gardener/operator/templates/deployment.yaml
@@ -21,7 +21,7 @@ role: operator
 
 {{- define "operator.deployment.labels" -}}
 {{- include "operator.deployment.matchLabels" . }}
-chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 release: "{{ .Release.Name }}"
 heritage: "{{ .Release.Service }}"
 {{- end -}}

--- a/charts/gardener/operator/templates/networkpolicy.yaml
+++ b/charts/gardener/operator/templates/networkpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/operator/templates/poddisruptionbudget.yaml
+++ b/charts/gardener/operator/templates/poddisruptionbudget.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/gardener/operator/templates/role.yaml
+++ b/charts/gardener/operator/templates/role.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/charts/gardener/operator/templates/rolebinding.yaml
+++ b/charts/gardener/operator/templates/rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:

--- a/charts/gardener/operator/templates/secret-kubeconfig.yaml
+++ b/charts/gardener/operator/templates/secret-kubeconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     resources.gardener.cloud/garbage-collectable-reference: "true"

--- a/charts/gardener/operator/templates/service.yaml
+++ b/charts/gardener/operator/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/gardener/operator/templates/serviceaccount.yaml
+++ b/charts/gardener/operator/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener
     role: operator
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.invalidateServiceAccountToken }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
  /area delivery
  /kind bug

**What this PR does / why we need it**:

This merge request changes the following line in all helm charts to helm best practices: https://helm.sh/docs/chart_best_practices/labels/#standard-labels
```
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
```

**Which issue(s) this PR fixes**:
Currently installing gardener-operator as a helm chart via fluxcd fails with the following error:
```
Helm install failed for release garden/gardener-operator-v1.109.0 with
      chart operator@1.109.0+0c82d346be13: 10 errors occurred:\n\t* NetworkPolicy.networking.k8s.io
      \"allow-everything-for-gardener-operator\" is invalid: metadata.labels: Invalid
      value: \"operator-1.109.0+0c82d346be13\": a valid label must be an empty string
      or consist of alphanumeric characters, '-', '_' or '.', and must start and end
      with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345',
      regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')\n\t*
```

**Special notes for your reviewer**:

Tested the fix and it looks fine for me:
![grafik](https://github.com/user-attachments/assets/db226e65-5a53-4397-bf50-40e57a204a43)


**Release note**:
Change the helm chart label structure to helm best practices
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
