### PR TITLE
Record timings for `Shoot` creation and deletion operations

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot/helper"
+	gardenletmetrics "github.com/gardener/gardener/pkg/gardenlet/metrics"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/garden"
@@ -137,6 +138,12 @@ func (r *Reconciler) reconcileShoot(ctx context.Context, log logr.Logger, shoot 
 	// determine when the next shoot reconciliation is supposed to happen
 	result = helper.CalculateControllerInfos(shoot, r.Clock, *r.Config.Controllers.Shoot).RequeueAfter
 	nextReconciliation := r.Clock.Now().UTC().Add(result.RequeueAfter)
+
+	if operationType == gardencorev1beta1.LastOperationTypeCreate {
+		gardenletmetrics.ShootOperationTimings.
+			WithLabelValues(string(operationType)).
+			Observe(r.Clock.Now().UTC().Sub(shoot.CreationTimestamp.Time).Seconds())
+	}
 
 	log.Info("Shoot operation finished successfully, scheduling next reconciliation for Shoot", "requeueAfter", result.RequeueAfter, "nextReconciliation", nextReconciliation)
 	return result, nil
@@ -474,6 +481,10 @@ func (r *Reconciler) removeFinalizerFromShoot(ctx context.Context, log logr.Logg
 			return fmt.Errorf("failed to remove finalizer: %w", err)
 		}
 	}
+
+	gardenletmetrics.ShootOperationTimings.
+		WithLabelValues(string(gardencorev1beta1.LastOperationTypeDelete)).
+		Observe(r.Clock.Now().UTC().Sub(shoot.DeletionTimestamp.Time).Seconds())
 
 	// Wait until the above modifications are reflected in the cache to prevent unwanted reconcile
 	// operations (sometimes the cache is not synced fast enough).

--- a/pkg/gardenlet/metrics/metrics.go
+++ b/pkg/gardenlet/metrics/metrics.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Namespace is the metric namespace for the gardenlet.
+const Namespace = "gardenlet"
+
+var (
+	// Factory is used for registering metrics in the controller-runtime metrics registry.
+	Factory = promauto.With(runtimemetrics.Registry)
+
+	// ShootOperationTimings defines the histogram shoot_operation_duration_seconds.
+	ShootOperationTimings = Factory.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "shoot_operation_duration_seconds",
+			Help:      "Duration of shoot operations.",
+			Buckets:   prometheus.LinearBuckets(180, 120, 10),
+		},
+		[]string{
+			"operation",
+		},
+	)
+)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1230,6 +1230,7 @@ build:
             - pkg/gardenlet/controller/tokenrequestor/workloadidentity
             - pkg/gardenlet/controller/vpaevictionrequirements
             - pkg/gardenlet/features
+            - pkg/gardenlet/metrics
             - pkg/gardenlet/operation
             - pkg/gardenlet/operation/botanist
             - pkg/gardenlet/operation/botanist/matchers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add prometheus Histogram metrics for `Shoot` `Create` and `Delete` operations and expose via `gardenlet` metrics.

Glimpse into possible monitoring dashboard for the metrics added::
<img width="1634" alt="image" src="https://github.com/user-attachments/assets/fbfb7a1f-0694-46a8-8ae7-abc3c9e70196">

**Which issue(s) this PR fixes**:
Result of 2024-12 Gardener Hackathon.

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add `gardenlet` metrics for `Shoot` creation and deletion timings. 
```
