### PR TITLE
Allow some changes of IPFamilies

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -39,6 +39,27 @@ func IsIPv6SingleStack(ipFamilies []IPFamily) bool {
 	return len(ipFamilies) == 1 && ipFamilies[0] == IPFamilyIPv6
 }
 
+// IsDualStack determines whether the given list of IP families specifies dual-stack networking.
+func IsDualStack(ipFamilies []IPFamily) bool {
+	if len(ipFamilies) != 2 {
+		return false
+	}
+
+	hasIPv4 := false
+	hasIPv6 := false
+
+	for _, ipFamily := range ipFamilies {
+		switch ipFamily {
+		case IPFamilyIPv4:
+			hasIPv4 = true
+		case IPFamilyIPv6:
+			hasIPv6 = true
+		}
+	}
+
+	return hasIPv4 && hasIPv6
+}
+
 // AccessRestriction describes an access restriction for a Kubernetes cluster (e.g., EU access-only).
 type AccessRestriction struct {
 	// Name is the name of the restriction.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -688,6 +688,12 @@ func validateNetworkingUpdate(newNetworking, oldNetworking *core.Networking, fld
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Services, oldNetworking.Services, fldPath.Child("services"))...)
 	}
 
+	// From Dual-stack to Single stack is not allowed
+	if !core.IsDualStack(newNetworking.IPFamilies) && core.IsDualStack(oldNetworking.IPFamilies) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("ipFamilies"),
+			"transition from dual-stack to single-stack is not allowed"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -681,7 +681,6 @@ func validateNetworkingUpdate(newNetworking, oldNetworking *core.Networking, fld
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Type, oldNetworking.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.IPFamilies, oldNetworking.IPFamilies, fldPath.Child("ipFamilies"))...)
 	if oldNetworking.Pods != nil {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Pods, oldNetworking.Pods, fldPath.Child("pods"))...)
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3820,6 +3820,20 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
+			It("should fail changing single-stack shoot to dual-stack without annotation", func() {
+				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4}
+
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6, core.IPFamilyIPv4}
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+				Expect(errorList).To(ConsistOfFields(Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+					"Detail": ContainSubstring(`"gardener.cloud/operation"="maintain"`),
+				}))
+			})
+
 			It("should fail changing dual-stack shoot to single-stack", func() {
 				newShoot := prepareShootForUpdate(shoot)
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -739,7 +739,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		Context("SecretBindingName/CredentialsBinding validation", func() {
-
 			It("should forbid adding secretBindingName in case of workerless shoot", func() {
 				shoot.Spec.Provider.Workers = nil
 				shoot.Spec.SecretBindingName = ptr.To("foo")
@@ -1018,7 +1017,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		Context("Extensions validation", func() {
-
 			It("should forbid passing an extension w/o type information", func() {
 				extension := core.Extension{}
 				shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension)
@@ -2772,7 +2770,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field":  Equal("spec.kubernetes.kubeScheduler"),
 					"Detail": ContainSubstring("this field should not be set for workerless Shoot clusters"),
 				}))))
-
 			})
 
 			It("should succeed when using valid scheduling profile", func() {
@@ -3777,21 +3774,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"Detail": Equal("must be valid canonical CIDR"),
 					}))
 				})
-			})
-
-			It("should fail updating immutable fields", func() {
-				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4}
-
-				newShoot := prepareShootForUpdate(shoot)
-				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6}
-
-				errorList := ValidateShootUpdate(newShoot, shoot)
-
-				Expect(errorList).To(ConsistOfFields(Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.networking.ipFamilies"),
-					"Detail": ContainSubstring(`field is immutable`),
-				}))
 			})
 		})
 

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -5,7 +5,6 @@
 package validation
 
 import (
-	"slices"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -95,13 +94,6 @@ func ValidateNetworkSpecUpdate(new, old *extensionsv1alpha1.NetworkSpec, deletio
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.PodCIDR, old.PodCIDR, fldPath.Child("podCIDR"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.ServiceCIDR, old.ServiceCIDR, fldPath.Child("serviceCIDR"))...)
-
-	// allow upgrades from empty IPFamilies to the default of IPv4
-	// the if condition can be removed once the network extension of all shoots have been updated
-	// TODO: Remove in Gardener 1.87
-	if !(old.IPFamilies == nil && slices.Equal(new.IPFamilies, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})) {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.IPFamilies, old.IPFamilies, fldPath.Child("ipFamilies"))...)
-	}
 
 	return allErrs
 }

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -225,26 +225,6 @@ var _ = Describe("Network validation tests", func() {
 			}))))
 		})
 
-		It("should prevent updating the ipFamilies", func() {
-			newNetwork := prepareNetworkForUpdate(network)
-			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6}
-
-			errorList := ValidateNetworkUpdate(newNetwork, network)
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.ipFamilies"),
-				"Detail": ContainSubstring("immutable"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.podCIDR"),
-				"Detail": Equal("must be a valid IPv6 address"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.serviceCIDR"),
-				"Detail": Equal("must be a valid IPv6 address"),
-			}))))
-		})
-
 		It("should allow updating the provider config", func() {
 			newNetwork := prepareNetworkForUpdate(network)
 			newNetwork.Spec.ProviderConfig = nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR removes the immutability of the IPFamilies field and introduces validation for transitions between IP family configurations. It disallows transitions from single stack (e.g., IPv4 to IPv6) and dual-stack to single stack while allowing single stack to dual-stack upgrades. This ensures stricter control over unsupported changes while enabling flexibility where needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow IPFamilies some transitions from single stack to dualstack
```
