### PR TITLE
`gardener-node-agent`: Persist applied changes after each step

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -76,6 +76,10 @@ func computeOperatingSystemConfigChanges(log logr.Logger, fs afero.Afero, newOSC
 
 	log.Info("OSC changes checksum did not match, computing new changes")
 
+	// create copy so that we don't accidentally update the `newOSC` when items are removed from the
+	// `operatingSystemConfigChanges` when they are marked as completed.
+	newOSC = newOSC.DeepCopy()
+
 	// osc.files and osc.unit.files should be changed the same way by OSC controller.
 	// The reason for assigning files to units is the detection of changes which require the restart of a unit.
 	newOSCFiles := collectAllFiles(newOSC)

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -111,6 +111,8 @@ func computeOperatingSystemConfigChanges(log logr.Logger, fs afero.Afero, newOSC
 		if extensionsv1alpha1helper.HasContainerdConfiguration(newOSC.Spec.CRIConfig) {
 			changes.Containerd.Registries.Desired = newOSC.Spec.CRIConfig.Containerd.Registries
 		}
+		changes.lock.Lock()
+		defer changes.lock.Unlock()
 		return changes, changes.persist()
 	}
 
@@ -154,6 +156,8 @@ func computeOperatingSystemConfigChanges(log logr.Logger, fs afero.Afero, newOSC
 	}
 	changes.Containerd.Registries = computeContainerdRegistryDiffs(newRegistries, oldRegistries)
 
+	changes.lock.Lock()
+	defer changes.lock.Unlock()
 	return changes, changes.persist()
 }
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
@@ -445,7 +445,7 @@ func addRegistryToContainerdFunc(ctx context.Context, log logr.Logger, registryC
 	if err := tplContainerdHosts.Execute(f, values); err != nil {
 		return err
 	}
-	log.Info("Configured registryConfig", "upstream", registryConfig.Upstream)
+	log.Info("Configured registry config", "upstream", registryConfig.Upstream)
 	return nil
 }
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/osc_changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/osc_changes.go
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package operatingsystemconfig
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/spf13/afero"
+	"sigs.k8s.io/yaml"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+type operatingSystemConfigChanges struct {
+	lock sync.Mutex
+	fs   afero.Afero
+
+	OSCChecksum     string     `json:"oscChecksum"`
+	Units           units      `json:"units"`
+	Files           files      `json:"files"`
+	Containerd      containerd `json:"containerd"`
+	RestartRequired bool       `json:"restartSelf"`
+}
+
+type units struct {
+	Changed  []changedUnit             `json:"changed,omitempty"`
+	Commands []unitCommand             `json:"commands,omitempty"`
+	Deleted  []extensionsv1alpha1.Unit `json:"deleted,omitempty"`
+}
+
+type changedUnit struct {
+	extensionsv1alpha1.Unit `json:",inline"`
+
+	DropInsChanges dropIns `json:"dropInsChanges"`
+}
+
+type unitCommand struct {
+	Name    string                         `json:"name"`
+	Command extensionsv1alpha1.UnitCommand `json:"command"`
+}
+
+type dropIns struct {
+	Changed []extensionsv1alpha1.DropIn `json:"changed,omitempty"`
+	Deleted []extensionsv1alpha1.DropIn `json:"deleted,omitempty"`
+}
+
+type files struct {
+	Changed []extensionsv1alpha1.File `json:"changed,omitempty"`
+	Deleted []extensionsv1alpha1.File `json:"deleted,omitempty"`
+}
+
+type containerd struct {
+	// ConfigFileChange tracks if the config file of containerd will change, so that GNA can restart the unit.
+	ConfigFileChange bool `json:"configFileChange"`
+	// Registries tracks the changes of configured Registries.
+	Registries containerdRegistries `json:"registries"`
+}
+
+type containerdRegistries struct {
+	Desired []extensionsv1alpha1.RegistryConfig `json:"desired,omitempty"`
+	Deleted []extensionsv1alpha1.RegistryConfig `json:"deleted,omitempty"`
+}
+
+func (o *operatingSystemConfigChanges) persist() error {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	out, err := yaml.Marshal(o)
+	if err != nil {
+		return err
+	}
+	return o.fs.WriteFile(operatingSystemConfigChangesFilePath, out, 0644)
+}
+
+func (o *operatingSystemConfigChanges) setRestartRequired(restart bool) error {
+	o.RestartRequired = restart
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedUnitCommand(name string) error {
+	o.lock.Lock()
+
+	o.Units.Commands = slices.DeleteFunc(o.Units.Commands, func(c unitCommand) bool {
+		return c.Name == name
+	})
+
+	o.lock.Unlock()
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedUnitChanged(name string) error {
+	o.lock.Lock()
+
+	o.Units.Changed = slices.DeleteFunc(o.Units.Changed, func(c changedUnit) bool {
+		return c.Name == name
+	})
+	o.lock.Unlock()
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedUnitDeleted(name string) error {
+	o.lock.Lock()
+
+	o.Units.Deleted = slices.DeleteFunc(o.Units.Deleted, func(c extensionsv1alpha1.Unit) bool {
+		return c.Name == name
+	})
+
+	o.lock.Unlock()
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedUnitDropInChanged(unitName, dropInName string) error {
+	o.lock.Lock()
+
+	i := slices.IndexFunc(o.Units.Changed, func(u changedUnit) bool {
+		return u.Name == unitName
+	})
+	if i < 0 {
+		o.lock.Unlock()
+		return fmt.Errorf("expected to find unit with name %q", unitName)
+	}
+	o.Units.Changed[i].DropIns = slices.DeleteFunc(o.Units.Changed[i].DropIns, func(d extensionsv1alpha1.DropIn) bool {
+		return d.Name == dropInName
+	})
+
+	o.lock.Unlock()
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedUnitDropInDeleted(unitName, dropInName string) error {
+	o.lock.Lock()
+
+	i := slices.IndexFunc(o.Units.Changed, func(u changedUnit) bool {
+		return u.Name == unitName
+	})
+	if i < 0 {
+		o.lock.Unlock()
+		return fmt.Errorf("expected to find unit with name %q", unitName)
+	}
+	o.Units.Changed[i].DropIns = slices.DeleteFunc(o.Units.Changed[i].DropIns, func(d extensionsv1alpha1.DropIn) bool {
+		return d.Name == dropInName
+	})
+
+	o.lock.Unlock()
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedFileDeleted(path string) error {
+	o.lock.Lock()
+
+	o.Files.Deleted = slices.DeleteFunc(o.Files.Deleted, func(f extensionsv1alpha1.File) bool {
+		return f.Path == path
+	})
+
+	o.lock.Unlock()
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedFileChanged(path string) error {
+	o.lock.Lock()
+
+	o.Files.Changed = slices.DeleteFunc(o.Files.Changed, func(f extensionsv1alpha1.File) bool {
+		return f.Path == path
+	})
+
+	o.lock.Unlock()
+	return o.persist()
+}
+func (o *operatingSystemConfigChanges) completedContainerdConfigFileChange() error {
+	o.Containerd.ConfigFileChange = false
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedContainerdRegistriesDesired(upstream string) error {
+	o.lock.Lock()
+
+	o.Containerd.Registries.Desired = slices.DeleteFunc(o.Containerd.Registries.Desired, func(c extensionsv1alpha1.RegistryConfig) bool {
+		return c.Upstream == upstream
+	})
+
+	o.lock.Unlock()
+	return o.persist()
+}
+
+func (o *operatingSystemConfigChanges) completedContainerdRegistriesDeleted(upstream string) error {
+	o.lock.Lock()
+
+	o.Containerd.Registries.Deleted = slices.DeleteFunc(o.Containerd.Registries.Deleted, func(c extensionsv1alpha1.RegistryConfig) bool {
+		return c.Upstream == upstream
+	})
+
+	o.lock.Unlock()
+	return o.persist()
+}
+
+func loadOSCChanges(fs afero.Afero) (*operatingSystemConfigChanges, error) {
+	raw, err := fs.ReadFile(operatingSystemConfigChangesFilePath)
+	if err != nil {
+		return nil, err
+	}
+	changes := operatingSystemConfigChanges{}
+	if err := yaml.Unmarshal(raw, &changes); err != nil {
+		return nil, err
+	}
+	changes.fs = fs
+	return &changes, nil
+}

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -45,7 +46,10 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
-const lastAppliedOperatingSystemConfigFilePath = nodeagentconfigv1alpha1.BaseDir + "/last-applied-osc.yaml"
+const (
+	lastAppliedOperatingSystemConfigFilePath = nodeagentconfigv1alpha1.BaseDir + "/last-applied-osc.yaml"
+	operatingSystemConfigChangesFilePath     = nodeagentconfigv1alpha1.BaseDir + "/oscc.yaml"
+)
 
 var codec runtime.Codec
 
@@ -109,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed reconciling containerd configuration: %w", err)
 	}
 
-	oscChanges, err := computeOperatingSystemConfigChanges(r.FS, osc)
+	oscChanges, err := computeOperatingSystemConfigChanges(log, r.FS, osc, oscChecksum)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed calculating the OSC changes: %w", err)
 	}
@@ -120,28 +124,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	log.Info("Applying new or changed inline files")
-	if err := r.applyChangedInlineFiles(log, oscChanges.files.changed); err != nil {
+	if err := r.applyChangedInlineFiles(log, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed applying changed inline files: %w", err)
 	}
 
 	log.Info("Applying containerd registries")
-	waitForRegistries, err := r.ReconcileContainerdRegistries(ctx, log, oscChanges.containerd)
+	waitForRegistries, err := r.ReconcileContainerdRegistries(ctx, log, oscChanges)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed reconciling containerd registries: %w", err)
 	}
 
 	log.Info("Applying new or changed imageRef files")
-	if err := r.applyChangedImageRefFiles(ctx, log, oscChanges.files.changed); err != nil {
+	if err := r.applyChangedImageRefFiles(ctx, log, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed applying changed imageRef files: %w", err)
 	}
 
-	log.Info("Applying new or changed units")
-	if err := r.applyChangedUnits(ctx, log, oscChanges.units.changed); err != nil {
+	log.Info("Applying new or changed units", "changedUnits", len(oscChanges.Units.Changed))
+	if err := r.applyChangedUnits(ctx, log, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed applying changed units: %w", err)
 	}
 
-	log.Info("Removing no longer needed units")
-	if err := r.removeDeletedUnits(ctx, log, node, oscChanges.units.deleted); err != nil {
+	log.Info("Removing no longer needed units", "deletedUnits", len(oscChanges.Units.Deleted))
+	if err := r.removeDeletedUnits(ctx, log, node, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed removing deleted units: %w", err)
 	}
 
@@ -157,9 +161,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed starting containerd: %w", err)
 	}
 
-	log.Info("Executing unit commands (start/stop)")
-	mustRestartGardenerNodeAgent, err := r.executeUnitCommands(ctx, log, node, oscChanges)
-	if err != nil {
+	log.Info("Executing unit commands (start/stop)", "unitCommands", len(oscChanges.Units.Commands))
+	if err := r.executeUnitCommands(ctx, log, node, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed executing unit commands: %w", err)
 	}
 
@@ -172,16 +175,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	log.Info("Removing no longer needed files")
-	if err := r.removeDeletedFiles(log, oscChanges.files.deleted); err != nil {
+	if err := r.removeDeletedFiles(log, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed removing deleted files: %w", err)
 	}
 
-	log.Info("Successfully applied operating system config",
-		"changedFiles", len(oscChanges.files.changed),
-		"deletedFiles", len(oscChanges.files.deleted),
-		"changedUnits", len(oscChanges.units.changed),
-		"deletedUnits", len(oscChanges.units.deleted),
-	)
+	log.Info("Successfully applied operating system config")
 
 	log.Info("Persisting current operating system config as 'last-applied' file to the disk", "path", lastAppliedOperatingSystemConfigFilePath)
 	oscRaw, err := runtime.Encode(codec, osc)
@@ -193,8 +191,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("unable to write current OSC to file path %q: %w", lastAppliedOperatingSystemConfigFilePath, err)
 	}
 
-	if mustRestartGardenerNodeAgent {
+	if oscChanges.RestartRequired {
 		log.Info("Must restart myself (gardener-node-agent unit), canceling the context to initiate graceful shutdown")
+		if err := oscChanges.setRestartRequired(false); err != nil {
+			return reconcile.Result{}, err
+		}
 		r.CancelContext()
 		return reconcile.Result{}, nil
 	}
@@ -257,8 +258,8 @@ func getFilePermissions(file extensionsv1alpha1.File) os.FileMode {
 	return permissions
 }
 
-func (r *Reconciler) applyChangedImageRefFiles(ctx context.Context, log logr.Logger, files []extensionsv1alpha1.File) error {
-	for _, file := range files {
+func (r *Reconciler) applyChangedImageRefFiles(ctx context.Context, log logr.Logger, changes *operatingSystemConfigChanges) error {
+	for _, file := range slices.Clone(changes.Files.Changed) {
 		if file.Content.ImageRef == nil {
 			continue
 		}
@@ -268,12 +269,15 @@ func (r *Reconciler) applyChangedImageRefFiles(ctx context.Context, log logr.Log
 		}
 
 		log.Info("Successfully applied new or changed file from image", "path", file.Path, "image", file.Content.ImageRef.Image)
+		if err := changes.completedFileChanged(file.Path); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (r *Reconciler) applyChangedInlineFiles(log logr.Logger, files []extensionsv1alpha1.File) error {
+func (r *Reconciler) applyChangedInlineFiles(log logr.Logger, changes *operatingSystemConfigChanges) error {
 	tmpDir, err := r.FS.TempDir(nodeagentconfigv1alpha1.TempDir, "osc-reconciliation-file-")
 	if err != nil {
 		return fmt.Errorf("unable to create temporary directory: %w", err)
@@ -281,7 +285,7 @@ func (r *Reconciler) applyChangedInlineFiles(log logr.Logger, files []extensions
 
 	defer func() { utilruntime.HandleError(r.FS.RemoveAll(tmpDir)) }()
 
-	for _, file := range files {
+	for _, file := range slices.Clone(changes.Files.Changed) {
 		if file.Content.Inline == nil {
 			continue
 		}
@@ -305,25 +309,31 @@ func (r *Reconciler) applyChangedInlineFiles(log logr.Logger, files []extensions
 		}
 
 		log.Info("Successfully applied new or changed file", "path", file.Path)
+		if err := changes.completedFileChanged(file.Path); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (r *Reconciler) removeDeletedFiles(log logr.Logger, files []extensionsv1alpha1.File) error {
-	for _, file := range files {
+func (r *Reconciler) removeDeletedFiles(log logr.Logger, changes *operatingSystemConfigChanges) error {
+	for _, file := range slices.Clone(changes.Files.Deleted) {
 		if err := r.FS.Remove(file.Path); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
 			return fmt.Errorf("unable to delete no longer needed file %q: %w", file.Path, err)
 		}
 
 		log.Info("Successfully removed no longer needed file", "path", file.Path)
+		if err := changes.completedFileDeleted(file.Path); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (r *Reconciler) applyChangedUnits(ctx context.Context, log logr.Logger, units []changedUnit) error {
-	for _, unit := range units {
+func (r *Reconciler) applyChangedUnits(ctx context.Context, log logr.Logger, changes *operatingSystemConfigChanges) error {
+	for _, unit := range slices.Clone(changes.Units.Changed) {
 		unitFilePath := path.Join(etcSystemdSystem, unit.Name)
 
 		if unit.Content != nil {
@@ -357,7 +367,7 @@ func (r *Reconciler) applyChangedUnits(ctx context.Context, log logr.Logger, uni
 				return fmt.Errorf("unable to create drop-in directory %q for unit %q: %w", dropInDirectory, unit.Name, err)
 			}
 
-			for _, dropIn := range unit.dropIns.changed {
+			for _, dropIn := range slices.Clone(unit.DropInsChanges.Changed) {
 				dropInFilePath := path.Join(dropInDirectory, dropIn.Name)
 
 				oldDropInContent, err := r.FS.ReadFile(dropInFilePath)
@@ -377,14 +387,20 @@ func (r *Reconciler) applyChangedUnits(ctx context.Context, log logr.Logger, uni
 				if err := r.FS.Chmod(dropInFilePath, defaultFilePermissions); err != nil {
 					return fmt.Errorf("unable to ensure permissions for drop-in file %q for unit %q: %w", unitFilePath, unit.Name, err)
 				}
+				if err := changes.completedUnitDropInChanged(unit.Name, dropIn.Name); err != nil {
+					return err
+				}
 			}
 
-			for _, dropIn := range unit.dropIns.deleted {
+			for _, dropIn := range slices.Clone(unit.DropInsChanges.Deleted) {
 				dropInFilePath := path.Join(dropInDirectory, dropIn.Name)
 				if err := r.FS.Remove(dropInFilePath); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
 					return fmt.Errorf("unable to delete drop-in file %q for unit %q: %w", dropInFilePath, unit.Name, err)
 				}
 				log.Info("Successfully removed no longer needed drop-in file for unit", "path", dropInFilePath, "unitName", unit.Name)
+				if err := changes.completedUnitDropInDeleted(unit.Name, dropIn.Name); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -399,13 +415,17 @@ func (r *Reconciler) applyChangedUnits(ctx context.Context, log logr.Logger, uni
 			}
 			log.Info("Successfully disabled unit", "unitName", unit.Name)
 		}
+
+		if err := changes.completedUnitChanged(unit.Name); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (r *Reconciler) removeDeletedUnits(ctx context.Context, log logr.Logger, node client.Object, units []extensionsv1alpha1.Unit) error {
-	for _, unit := range units {
+func (r *Reconciler) removeDeletedUnits(ctx context.Context, log logr.Logger, node client.Object, changes *operatingSystemConfigChanges) error {
+	for _, unit := range slices.Clone(changes.Units.Deleted) {
 		// The unit has been created by gardener-node-agent if it has content.
 		// Otherwise, it might be a default OS unit which was enabled/disabled or where drop-ins were added.
 		unitCreatedByNodeAgent := unit.Content != nil
@@ -465,22 +485,24 @@ func (r *Reconciler) removeDeletedUnits(ctx context.Context, log logr.Logger, no
 		}
 
 		log.Info("Successfully removed no longer needed unit", "unitName", unit.Name)
+		if err := changes.completedUnitDeleted(unit.Name); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (r *Reconciler) executeUnitCommands(ctx context.Context, log logr.Logger, node client.Object, oscChanges *operatingSystemConfigChanges) (bool, error) {
+func (r *Reconciler) executeUnitCommands(ctx context.Context, log logr.Logger, node client.Object, oscChanges *operatingSystemConfigChanges) error {
 	var (
-		mustRestartGardenerNodeAgent bool
-		fns                          []flow.TaskFn
+		fns []flow.TaskFn
 
 		restart = func(ctx context.Context, unitName string) error {
 			if err := r.DBus.Restart(ctx, r.Recorder, node, unitName); err != nil {
 				return fmt.Errorf("unable to restart unit %q: %w", unitName, err)
 			}
 			log.Info("Successfully restarted unit", "unitName", unitName)
-			return nil
+			return oscChanges.completedUnitCommand(unitName)
 		}
 
 		stop = func(ctx context.Context, unitName string) error {
@@ -488,35 +510,46 @@ func (r *Reconciler) executeUnitCommands(ctx context.Context, log logr.Logger, n
 				return fmt.Errorf("unable to stop unit %q: %w", unitName, err)
 			}
 			log.Info("Successfully stopped unit", "unitName", unitName)
-			return nil
+			return oscChanges.completedUnitCommand(unitName)
 		}
 	)
 
 	var containerdChanged bool
-	for _, u := range oscChanges.units.changed {
-		unit := u
-
+	for _, unit := range slices.Clone(oscChanges.Units.Commands) {
 		switch unit.Name {
 		case nodeagentconfigv1alpha1.UnitName:
-			mustRestartGardenerNodeAgent = true
+			if err := oscChanges.setRestartRequired(true); err != nil {
+				return err
+			}
+			if err := oscChanges.completedUnitCommand(unit.Name); err != nil {
+				return err
+			}
 			continue
 		case v1beta1constants.OperatingSystemConfigUnitNameContainerDService:
 			containerdChanged = true
 		}
 
 		fns = append(fns, func(ctx context.Context) error {
-			if !ptr.Deref(unit.Enable, true) || (unit.Command != nil && *unit.Command == extensionsv1alpha1.CommandStop) {
+			switch unit.Command {
+			case extensionsv1alpha1.CommandStop:
 				return stop(ctx, unit.Name)
+			case extensionsv1alpha1.CommandRestart:
+				return restart(ctx, unit.Name)
+			case "":
+				return oscChanges.completedUnitCommand(unit.Name)
 			}
-			return restart(ctx, unit.Name)
+			return fmt.Errorf("unknown unit command %q", unit.Command)
 		})
 	}
 
-	if oscChanges.containerd.configFileChange && !containerdChanged {
+	if oscChanges.Containerd.ConfigFileChange && !containerdChanged {
 		fns = append(fns, func(ctx context.Context) error {
-			return restart(ctx, v1beta1constants.OperatingSystemConfigUnitNameContainerDService)
+			if err := restart(ctx, v1beta1constants.OperatingSystemConfigUnitNameContainerDService); err != nil {
+				return err
+			}
+			return oscChanges.completedContainerdConfigFileChange()
 		})
 	}
 
-	return mustRestartGardenerNodeAgent, flow.Parallel(fns...)(ctx)
+	return flow.Parallel(fns...)(ctx)
 }

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -48,7 +48,7 @@ import (
 
 const (
 	lastAppliedOperatingSystemConfigFilePath = nodeagentconfigv1alpha1.BaseDir + "/last-applied-osc.yaml"
-	operatingSystemConfigChangesFilePath     = nodeagentconfigv1alpha1.BaseDir + "/oscc.yaml"
+	operatingSystemConfigChangesFilePath     = nodeagentconfigv1alpha1.BaseDir + "/osc-changes.yaml"
 )
 
 var codec runtime.Codec


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Persists the `operationSystemConfigChanges` to disk and updates it after each step (for example after applying a file). If the OSC is changed, the changes are always re-computed.

So the possible scenarios are:
- GNA runs for the first time: no `oscc.yaml`, no `last-applied-osc.yaml`: Apply entire OSC
- GNA encounters an error: `oscc.yaml` exists on disk, the checksum still matches: resume with the changes in `oscc.yaml`
- GNA is stuck, because the OSC (Version 2) is broken, then the OSC is updated (Version 3): `oscc.yaml` exists, but its checksum does not match. Compute changes as before.

**Which issue(s) this PR fixes**:
This is part of the [Hackathon December 2024](https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen)

**Special notes for your reviewer**:

**Release note**:
```feature operator
`gardener-node-agent` now persists its applied changes after each step when reconciling the OSC. This should avoid unnecessary work and systemd unit restarts.
```
