### PR TITLE
Set env variables for dual-stack in kube-apiserver.

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -2700,6 +2700,21 @@ kind: AuthorizationConfiguration
 			})
 
 			haVPNClientContainerFor := func(index int, disableNewVPN bool) corev1.Container {
+
+				var serviceCIDRs, podCIDRs, nodeCIDRs []string
+
+				for _, v := range values.ServiceNetworkCIDRs {
+					serviceCIDRs = append(serviceCIDRs, v.String())
+				}
+
+				for _, v := range values.VPN.PodNetworkCIDRs {
+					podCIDRs = append(podCIDRs, v.String())
+				}
+
+				for _, v := range values.VPN.NodeNetworkCIDRs {
+					nodeCIDRs = append(nodeCIDRs, v.String())
+				}
+
 				container := corev1.Container{
 					Name:            fmt.Sprintf("vpn-client-%d", index),
 					Image:           "vpn-client-image:really-latest",
@@ -2720,6 +2735,18 @@ kind: AuthorizationConfiguration
 						{
 							Name:  "NODE_NETWORK",
 							Value: values.VPN.NodeNetworkCIDRs[0].String(),
+						},
+						{
+							Name:  "SERVICE_NETWORKS",
+							Value: strings.Join(serviceCIDRs, ","),
+						},
+						{
+							Name:  "POD_NETWORKS",
+							Value: strings.Join(podCIDRs, ","),
+						},
+						{
+							Name:  "NODE_NETWORKS",
+							Value: strings.Join(nodeCIDRs, ","),
 						},
 						{
 							Name:  "VPN_SERVER_INDEX",
@@ -2868,6 +2895,17 @@ kind: AuthorizationConfiguration
 					Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(labelKey, "allowed"))
 					Expect(deployment.Spec.Template.Spec.Containers[i+1]).To(DeepEqual(haVPNClientContainerFor(i, disableNewVPN)))
 				}
+
+				var serviceCIDRs, podCIDRs, nodeCIDRs []string
+				for _, v := range values.ServiceNetworkCIDRs {
+					serviceCIDRs = append(serviceCIDRs, v.String())
+				}
+				for _, v := range values.VPN.PodNetworkCIDRs {
+					podCIDRs = append(podCIDRs, v.String())
+				}
+				for _, v := range values.VPN.NodeNetworkCIDRs {
+					nodeCIDRs = append(nodeCIDRs, v.String())
+				}
 				pathControllerContainer := corev1.Container{
 					Name:            "vpn-path-controller",
 					Image:           "vpn-client-image:really-latest",
@@ -2885,6 +2923,18 @@ kind: AuthorizationConfiguration
 						{
 							Name:  "NODE_NETWORK",
 							Value: values.VPN.NodeNetworkCIDRs[0].String(),
+						},
+						{
+							Name:  "SERVICE_NETWORKS",
+							Value: strings.Join(serviceCIDRs, ","),
+						},
+						{
+							Name:  "POD_NETWORKS",
+							Value: strings.Join(podCIDRs, ","),
+						},
+						{
+							Name:  "NODE_NETWORKS",
+							Value: strings.Join(nodeCIDRs, ","),
 						},
 						{
 							Name:  "IS_HA",

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -774,9 +774,21 @@ func (k *kubeAPIServer) vpnSeedClientInitContainer() *corev1.Container {
 }
 
 func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
-	nodes := ""
+	var serviceCIDRs, podCIDRs, nodeCIDRs []string
+	nodeCIDR := ""
 	if len(k.values.VPN.NodeNetworkCIDRs) > 0 {
-		nodes = k.values.VPN.NodeNetworkCIDRs[0].String()
+		nodeCIDR = k.values.VPN.NodeNetworkCIDRs[0].String()
+		for _, v := range k.values.VPN.NodeNetworkCIDRs {
+			nodeCIDRs = append(nodeCIDRs, v.String())
+		}
+	}
+
+	for _, v := range k.values.ServiceNetworkCIDRs {
+		serviceCIDRs = append(serviceCIDRs, v.String())
+	}
+
+	for _, v := range k.values.VPN.PodNetworkCIDRs {
+		podCIDRs = append(podCIDRs, v.String())
 	}
 
 	container := &corev1.Container{
@@ -798,7 +810,19 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 			},
 			{
 				Name:  "NODE_NETWORK",
-				Value: nodes,
+				Value: nodeCIDR,
+			},
+			{
+				Name:  "SERVICE_NETWORKS",
+				Value: strings.Join(serviceCIDRs, ","),
+			},
+			{
+				Name:  "POD_NETWORKS",
+				Value: strings.Join(podCIDRs, ","),
+			},
+			{
+				Name:  "NODE_NETWORKS",
+				Value: strings.Join(nodeCIDRs, ","),
 			},
 			{
 				Name:  "VPN_SERVER_INDEX",
@@ -875,9 +899,21 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 }
 
 func (k *kubeAPIServer) vpnSeedPathControllerContainer() *corev1.Container {
-	nodes := ""
+	var serviceCIDRs, podCIDRs, nodeCIDRs []string
+	nodeCIDR := ""
 	if len(k.values.VPN.NodeNetworkCIDRs) > 0 {
-		nodes = k.values.VPN.NodeNetworkCIDRs[0].String()
+		nodeCIDR = k.values.VPN.NodeNetworkCIDRs[0].String()
+		for _, v := range k.values.VPN.NodeNetworkCIDRs {
+			nodeCIDRs = append(nodeCIDRs, v.String())
+		}
+	}
+
+	for _, v := range k.values.ServiceNetworkCIDRs {
+		serviceCIDRs = append(serviceCIDRs, v.String())
+	}
+
+	for _, v := range k.values.VPN.PodNetworkCIDRs {
+		podCIDRs = append(podCIDRs, v.String())
 	}
 
 	container := &corev1.Container{
@@ -896,7 +932,19 @@ func (k *kubeAPIServer) vpnSeedPathControllerContainer() *corev1.Container {
 			},
 			{
 				Name:  "NODE_NETWORK",
-				Value: nodes,
+				Value: nodeCIDR,
+			},
+			{
+				Name:  "SERVICE_NETWORKS",
+				Value: strings.Join(serviceCIDRs, ","),
+			},
+			{
+				Name:  "POD_NETWORKS",
+				Value: strings.Join(podCIDRs, ","),
+			},
+			{
+				Name:  "NODE_NETWORKS",
+				Value: strings.Join(nodeCIDRs, ","),
 			},
 			{
 				Name:  "IS_HA",


### PR DESCRIPTION
This is needed for VPN containers to create both IPv4 and IPv6 routes to services, pods and nodes in the shoot.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set env variables for dual-stack in kube-apiserver.
```
