### PR TITLE
Metrics for shoot operation times including dashboard 

### DIFF
--- a/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
+++ b/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
@@ -16,24 +16,10 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
-  "iteration": 1734701406787,
+  "id": 14,
+  "iteration": 1737034390340,
   "links": [],
   "panels": [
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 10,
-      "panels": [],
-      "title": "Shoot Durations",
-      "type": "row"
-    },
     {
       "datasource": "seed-prometheus",
       "description": "The average time it takes for shoot $operation_type operation.",
@@ -60,7 +46,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 0
       },
       "id": 4,
       "options": {
@@ -105,7 +91,7 @@
       },
       "dataFormat": "timeseries",
       "datasource": "seed-prometheus",
-      "description": "The histogram provides a visual representation of the distribution of create and delete shoot operations.",
+      "description": "The histogram provides a visual representation of the distribution of create and delete shoot operations. Currently displaying P($percentile).",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -114,7 +100,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 9
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -128,16 +114,16 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(rate(gardenlet_shoot_operation_duration_seconds_bucket{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile($percentile/100, sum(rate(gardenlet_shoot_operation_duration_seconds_bucket{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])) by (le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{le}}",
+          "legendFormat": "",
           "refId": "A"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Shoot $operation_type Duration Over Time",
+      "title": "Shoot $operation_type Duration Over Time P($percentile)",
       "tooltip": {
         "show": true,
         "showHistogram": true
@@ -294,11 +280,47 @@
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "99",
+          "value": "99"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "percentile",
+        "options": [
+          {
+            "selected": false,
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "selected": false,
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "selected": true,
+            "text": "99",
+            "value": "99"
+          }
+        ],
+        "query": "50,90,99",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-12h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},

--- a/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
+++ b/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
-  "iteration": 1733305994807,
+  "id": 1,
+  "iteration": 1734701406787,
   "links": [],
   "panels": [
     {
@@ -79,79 +79,17 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(gardenlet_shoot_operation_duration_seconds_sum{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])) / sum(rate(gardenlet_shoot_operation_duration_seconds_count{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval]))",
+          "expr": "rate(gardenlet_shoot_operation_duration_seconds_sum{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval]) / rate(gardenlet_shoot_operation_duration_seconds_count{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])",
           "hide": false,
-          "instant": false,
           "interval": "",
-          "legendFormat": "",
-          "refId": "A"
+          "legendFormat": "{{workerless}}",
+          "refId": "B"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
       "title": "Average Shoot $operation_type Time",
       "type": "gauge"
-    },
-    {
-      "datasource": "seed-prometheus",
-      "description": "This panel displays the distribution of $operation_type operations.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 10
-      },
-      "id": 8,
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "text": {}
-      },
-      "pluginVersion": "7.5.34",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sum(rate(gardenlet_shoot_operation_duration_seconds_bucket{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{le}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Shoot $operation_type Distribution",
-      "type": "bargauge"
     },
     {
       "cards": {
@@ -175,7 +113,7 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
+        "x": 0,
         "y": 10
       },
       "heatmap": {},
@@ -278,9 +216,14 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "true",
-          "value": "true"
+          "selected": true,
+          "tags": [],
+          "text": [
+            "true"
+          ],
+          "value": [
+            "true"
+          ]
         },
         "description": null,
         "error": null,
@@ -316,8 +259,12 @@
         "current": {
           "selected": true,
           "tags": [],
-          "text": "false",
-          "value": "false"
+          "text": [
+            "false"
+          ],
+          "value": [
+            "false"
+          ]
         },
         "description": null,
         "error": null,

--- a/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
+++ b/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 25,
-  "iteration": 1733259548940,
+  "id": 2,
+  "iteration": 1733305994807,
   "links": [],
   "panels": [
     {
@@ -89,7 +89,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Average Shoot $operation_type time",
+      "title": "Average Shoot $operation_type Time",
       "type": "gauge"
     },
     {
@@ -141,9 +141,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(gardenlet_shoot_operation_duration_seconds_bucket{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}) by (le)",
+          "expr": "sum(rate(gardenlet_shoot_operation_duration_seconds_bucket{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
-          "instant": true,
+          "hide": false,
+          "instant": false,
           "interval": "",
           "legendFormat": "{{le}}",
           "refId": "A"
@@ -235,7 +236,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Create",
           "value": "Create"
         },
@@ -250,12 +251,12 @@
         "name": "operation_type",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "Create",
             "value": "Create"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "Delete",
             "value": "Delete"
           }
@@ -350,12 +351,12 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Shoot Operation Duration",
   "uid": "Oa2rLH4Nz",
-  "version": 70
+  "version": 1
 }

--- a/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
+++ b/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
@@ -68,7 +68,7 @@
           "expr": "rate(gardenlet_shoot_operation_duration_seconds_sum{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval]) / rate(gardenlet_shoot_operation_duration_seconds_count{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{workerless}}",
+          "legendFormat": "",
           "refId": "B"
         }
       ],
@@ -202,13 +202,13 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "tags": [],
           "text": [
-            "true"
+            "false"
           ],
           "value": [
-            "true"
+            "false"
           ]
         },
         "description": null,
@@ -225,12 +225,12 @@
             "value": "$__all"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "true",
             "value": "true"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "false",
             "value": "false"
           }

--- a/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
+++ b/pkg/component/observability/plutono/dashboards/seed/shoot-operation-duration.json
@@ -1,0 +1,361 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 25,
+  "iteration": 1733259548940,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Shoot Durations",
+      "type": "row"
+    },
+    {
+      "datasource": "seed-prometheus",
+      "description": "The average time it takes for shoot $operation_type operation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false,
+        "text": {}
+      },
+      "pluginVersion": "7.5.34",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(gardenlet_shoot_operation_duration_seconds_sum{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])) / sum(rate(gardenlet_shoot_operation_duration_seconds_count{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average Shoot $operation_type time",
+      "type": "gauge"
+    },
+    {
+      "datasource": "seed-prometheus",
+      "description": "This panel displays the distribution of $operation_type operations.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "7.5.34",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(gardenlet_shoot_operation_duration_seconds_bucket{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}) by (le)",
+          "format": "heatmap",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Shoot $operation_type Distribution",
+      "type": "bargauge"
+    },
+    {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#73BF69",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGreens",
+        "exponent": 0.8,
+        "mode": "opacity"
+      },
+      "dataFormat": "timeseries",
+      "datasource": "seed-prometheus",
+      "description": "The histogram provides a visual representation of the distribution of create and delete shoot operations.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 2,
+      "legend": {
+        "show": false
+      },
+      "pluginVersion": "7.5.34",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum(rate(gardenlet_shoot_operation_duration_seconds_bucket{operation=~\"$operation_type\",workerless=~\"$workerless\",hibernated=~\"$hibernated\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Shoot $operation_type Duration Over Time",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "short",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "monitoring",
+    "shoot"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "Create",
+          "value": "Create"
+        },
+        "datasource": "seed-prometheus",
+        "definition": "label_values(gardenlet_shoot_operation_duration_seconds_sum{}, operation)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Operation",
+        "multi": false,
+        "name": "operation_type",
+        "options": [
+          {
+            "selected": false,
+            "text": "Create",
+            "value": "Create"
+          },
+          {
+            "selected": true,
+            "text": "Delete",
+            "value": "Delete"
+          }
+        ],
+        "query": {
+          "query": "label_values(gardenlet_shoot_operation_duration_seconds_sum{}, operation)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "true",
+          "value": "true"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Workerless",
+        "multi": true,
+        "name": "workerless",
+        "options": [
+          {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": true,
+            "text": "true",
+            "value": "true"
+          },
+          {
+            "selected": false,
+            "text": "false",
+            "value": "false"
+          }
+        ],
+        "query": "true,false",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": "false",
+          "value": "false"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Hibernated",
+        "multi": true,
+        "name": "hibernated",
+        "options": [
+          {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": true,
+            "text": "false",
+            "value": "false"
+          },
+          {
+            "selected": false,
+            "text": "true",
+            "value": "true"
+          }
+        ],
+        "query": "false,true",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Shoot Operation Duration",
+  "uid": "Oa2rLH4Nz",
+  "version": 70
+}

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -637,7 +637,7 @@ status:
 				})
 
 				It("should successfully deploy all resources", func() {
-					checkDeployedResources("plutono-dashboards", 20)
+					checkDeployedResources("plutono-dashboards", 21)
 				})
 
 				Context("w/ enabled vpa", func() {
@@ -646,7 +646,7 @@ status:
 					})
 
 					It("should successfully deploy all resources", func() {
-						checkDeployedResources("plutono-dashboards", 23)
+						checkDeployedResources("plutono-dashboards", 24)
 					})
 				})
 			})

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -1162,17 +1162,9 @@ func startRotationObservability(shoot *gardencorev1beta1.Shoot, now *metav1.Time
 
 func reportMetrics(shoot *gardencorev1beta1.Shoot, operationType gardencorev1beta1.LastOperationType, duration time.Duration) {
 	var (
-		workerless = "false"
-		hibernated = "false"
+		workerless = utils.IifString(v1beta1helper.IsWorkerless(shoot), "true", "false")
+		hibernated = utils.IifString(v1beta1helper.HibernationIsEnabled(shoot), "true", "false")
 	)
-
-	if v1beta1helper.IsWorkerless(shoot) {
-		workerless = "true"
-	}
-
-	if v1beta1helper.HibernationIsEnabled(shoot) {
-		hibernated = "true"
-	}
 
 	gardenletmetrics.ShootOperationDurationSeconds.
 		WithLabelValues(string(operationType), workerless, hibernated).

--- a/pkg/gardenlet/metrics/metrics.go
+++ b/pkg/gardenlet/metrics/metrics.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Namespace is the metric namespace for the gardenlet.
+const Namespace = "gardenlet"
+
+var (
+	// Factory is used for registering metrics in the controller-runtime metrics registry.
+	Factory = promauto.With(runtimemetrics.Registry)
+	// ShootOperationTimings defines the histogram shoot_operation_duration_seconds.
+	ShootOperationTimings = Factory.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "shoot_operation_duration_seconds",
+			Help:      "Duration of shoot operations.",
+			Buckets:   prometheus.LinearBuckets(180, 120, 10),
+		},
+		[]string{
+			"operation",
+			"workerless",
+			"hibernated",
+		},
+	)
+)

--- a/pkg/gardenlet/metrics/metrics.go
+++ b/pkg/gardenlet/metrics/metrics.go
@@ -14,13 +14,13 @@ const Namespace = "gardenlet"
 
 var (
 	// Factory is used for registering metrics in the controller-runtime metrics registry.
-	Factory = promauto.With(runtimemetrics.Registry)
-	// ShootOperationTimings defines the histogram shoot_operation_duration_seconds.
-	ShootOperationTimings = Factory.NewHistogramVec(
+	factory = promauto.With(runtimemetrics.Registry)
+	// ShootOperationDurationSeconds defines the histogram shoot_operation_duration_seconds.
+	ShootOperationDurationSeconds = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: Namespace,
 			Name:      "shoot_operation_duration_seconds",
-			Help:      "Duration of shoot operations.",
+			Help:      "Duration of shoot operations in seconds.",
 			Buckets:   prometheus.LinearBuckets(180, 120, 10),
 		},
 		[]string{

--- a/pkg/provider-local/webhook/prometheus/mutator.go
+++ b/pkg/provider-local/webhook/prometheus/mutator.go
@@ -57,7 +57,7 @@ func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
 				},
 				{
 					SourceLabels: []monitoringv1.LabelName{"__name__"},
-					Regex:        "(up|flow_.+)",
+					Regex:        "(up|flow_.+|shoot_.+)",
 					Action:       "keep",
 				},
 			},

--- a/pkg/provider-local/webhook/prometheus/mutator.go
+++ b/pkg/provider-local/webhook/prometheus/mutator.go
@@ -57,7 +57,7 @@ func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
 				},
 				{
 					SourceLabels: []monitoringv1.LabelName{"__name__"},
-					Regex:        "(up|flow_.+|shoot_.+)",
+					Regex:        "(up|flow_.+|gardenlet_.+)",
 					Action:       "keep",
 				},
 			},

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1222,6 +1222,7 @@ build:
             - pkg/gardenlet/controller/tokenrequestor/workloadidentity
             - pkg/gardenlet/controller/vpaevictionrequirements
             - pkg/gardenlet/features
+            - pkg/gardenlet/metrics
             - pkg/gardenlet/operation
             - pkg/gardenlet/operation/botanist
             - pkg/gardenlet/operation/botanist/matchers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Introduces the `shoot_operation_duration_seconds` metric exposed via `gardenlet` and adds a grafana dashboard. It is useful for providers to see how long the `shoot` operations `Create` and `Delete` take. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-community/hackathon/blob/main/2024-12_Schelklingen/README.md#-gardener-slis-shoot-cluster-creationdeletion-times

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Introduces `shoot_operation_duration_seconds` metric to record `Shoot` operation `Create` and `Delete`. 
```
