### PR TITLE
Add Service TrafficDistribution to TopologyAwareRouting

### DIFF
--- a/pkg/component/autoscaling/vpa/admissioncontroller.go
+++ b/pkg/component/autoscaling/vpa/admissioncontroller.go
@@ -143,7 +143,7 @@ func (v *vpa) reconcileAdmissionControllerService(service *corev1.Service) {
 		metav1.SetMetaDataLabel(&service.ObjectMeta, label, value)
 	}
 	topologyAwareRoutingEnabled := v.values.AdmissionController.TopologyAwareRoutingEnabled && v.values.ClusterType == component.ClusterTypeShoot
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(service, topologyAwareRoutingEnabled, v.values.RuntimeKubernetesVersion)
+	gardenerutils.ReconcileTopologyAwareRouting(service, topologyAwareRoutingEnabled, v.values.RuntimeKubernetesVersion)
 
 	switch v.values.ClusterType {
 	case component.ClusterTypeSeed:

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -248,7 +248,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 	}
 
 	clientService := &corev1.Service{}
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(clientService, e.values.TopologyAwareRoutingEnabled, e.values.RuntimeKubernetesVersion)
+	gardenerutils.ReconcileTopologyAwareRouting(clientService, e.values.TopologyAwareRoutingEnabled, e.values.RuntimeKubernetesVersion)
 
 	ports := []networkingv1.NetworkPolicyPort{
 		{Port: ptr.To(intstr.FromInt32(etcdconstants.PortEtcdClient)), Protocol: ptr.To(corev1.ProtocolTCP)},

--- a/pkg/component/gardener/admissioncontroller/service.go
+++ b/pkg/component/gardener/admissioncontroller/service.go
@@ -54,7 +54,7 @@ func (a *gardenerAdmissionController) service() *corev1.Service {
 		Protocol: ptr.To(corev1.ProtocolTCP),
 	}))
 
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(svc, a.values.TopologyAwareRoutingEnabled, a.values.RuntimeVersion)
+	gardenerutils.ReconcileTopologyAwareRouting(svc, a.values.TopologyAwareRoutingEnabled, a.values.RuntimeVersion)
 
 	return svc
 }

--- a/pkg/component/gardener/apiserver/service.go
+++ b/pkg/component/gardener/apiserver/service.go
@@ -24,7 +24,7 @@ func (g *gardenerAPIServer) serviceRuntime() *corev1.Service {
 	service := g.service()
 	service.Namespace = g.namespace
 
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(service, g.values.TopologyAwareRoutingEnabled, g.values.RuntimeVersion)
+	gardenerutils.ReconcileTopologyAwareRouting(service, g.values.TopologyAwareRoutingEnabled, g.values.RuntimeVersion)
 	// allow gardener-apiserver being reached from kube-apiserver
 	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForWebhookTargets(service, networkingv1.NetworkPolicyPort{
 		Port:     ptr.To(intstr.FromInt32(port)),

--- a/pkg/component/gardener/dashboard/terminal/service.go
+++ b/pkg/component/gardener/dashboard/terminal/service.go
@@ -52,7 +52,7 @@ func (t *terminal) service() *corev1.Service {
 		Protocol: ptr.To(corev1.ProtocolTCP),
 	}))
 
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(svc, t.values.TopologyAwareRoutingEnabled, t.values.RuntimeVersion)
+	gardenerutils.ReconcileTopologyAwareRouting(svc, t.values.TopologyAwareRoutingEnabled, t.values.RuntimeVersion)
 
 	return svc
 }

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -739,7 +739,7 @@ func (r *resourceManager) ensureService(ctx context.Context) error {
 		}
 
 		topologyAwareRoutingEnabled := r.values.TopologyAwareRoutingEnabled && r.values.TargetDiffersFromSourceCluster
-		gardenerutils.ReconcileTopologyAwareRoutingMetadata(service, topologyAwareRoutingEnabled, r.values.RuntimeKubernetesVersion)
+		gardenerutils.ReconcileTopologyAwareRouting(service, topologyAwareRoutingEnabled, r.values.RuntimeKubernetesVersion)
 
 		service.Spec.Selector = r.appLabel()
 		service.Spec.Type = corev1.ServiceTypeClusterIP

--- a/pkg/component/kubernetes/apiserverexposure/service.go
+++ b/pkg/component/kubernetes/apiserverexposure/service.go
@@ -154,7 +154,7 @@ func (s *service) Deploy(ctx context.Context) error {
 		}
 
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyNamespaceSelectors(obj, namespaceSelectors...))
-		gardenerutils.ReconcileTopologyAwareRoutingMetadata(obj, s.values.topologyAwareRoutingEnabled, s.values.runtimeKubernetesVersion)
+		gardenerutils.ReconcileTopologyAwareRouting(obj, s.values.topologyAwareRoutingEnabled, s.values.runtimeKubernetesVersion)
 
 		obj.Labels = utils.MergeStringMaps(obj.Labels, getLabels())
 		obj.Spec.Type = corev1.ServiceTypeClusterIP

--- a/pkg/utils/gardener/topology_aware_routing.go
+++ b/pkg/utils/gardener/topology_aware_routing.go
@@ -44,3 +44,9 @@ func ReconcileTopologyAwareRouting(service *corev1.Service, topologyAwareRouting
 	metav1.SetMetaDataAnnotation(&service.ObjectMeta, corev1.DeprecatedAnnotationTopologyAwareHints, "auto")
 	metav1.SetMetaDataLabel(&service.ObjectMeta, resourcesv1alpha1.EndpointSliceHintsConsider, "true")
 }
+
+// ReconcileTopologyAwareRoutingMetadata adds (or removes) the required annotation, label and trafficDistribution setting to make a Service topology-aware.
+// Deprecated: please use ReconcileTopologyAwareRouting instead.
+func ReconcileTopologyAwareRoutingMetadata(service *corev1.Service, topologyAwareRoutingEnabled bool, k8sVersion *semver.Version) {
+	ReconcileTopologyAwareRouting(service, topologyAwareRoutingEnabled, k8sVersion)
+}

--- a/pkg/utils/gardener/topology_aware_routing.go
+++ b/pkg/utils/gardener/topology_aware_routing.go
@@ -8,24 +8,39 @@ import (
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/version"
 )
 
-// ReconcileTopologyAwareRoutingMetadata adds (or removes) the required annotation and label to make a Service topology-aware.
-func ReconcileTopologyAwareRoutingMetadata(service *corev1.Service, topologyAwareRoutingEnabled bool, k8sVersion *semver.Version) {
-	if topologyAwareRoutingEnabled {
-		if version.ConstraintK8sGreaterEqual127.Check(k8sVersion) {
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, corev1.AnnotationTopologyMode, "auto")
-			delete(service.Annotations, corev1.DeprecatedAnnotationTopologyAwareHints)
-		} else {
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, corev1.DeprecatedAnnotationTopologyAwareHints, "auto")
-		}
-		metav1.SetMetaDataLabel(&service.ObjectMeta, resourcesv1alpha1.EndpointSliceHintsConsider, "true")
-	} else {
-		delete(service.Annotations, corev1.AnnotationTopologyMode)
-		delete(service.Annotations, corev1.DeprecatedAnnotationTopologyAwareHints)
-		delete(service.Labels, resourcesv1alpha1.EndpointSliceHintsConsider)
+// ReconcileTopologyAwareRouting adds (or removes) the required annotation, label and trafficDistribution setting to make a Service topology-aware.
+func ReconcileTopologyAwareRouting(service *corev1.Service, topologyAwareRoutingEnabled bool, k8sVersion *semver.Version) {
+	// remove settings for topologyAwareRouting, as these settings are controlled via this function.
+	delete(service.Annotations, corev1.AnnotationTopologyMode)
+	delete(service.Annotations, corev1.DeprecatedAnnotationTopologyAwareHints)
+	delete(service.Labels, resourcesv1alpha1.EndpointSliceHintsConsider)
+	service.Spec.TrafficDistribution = nil
+
+	// return without topologyAwareRouting settings if disabled
+	if !topologyAwareRoutingEnabled {
+		return
 	}
+
+	// use trafficDistribution feature in kubernetes 1.31.x or above
+	if version.ConstraintK8sGreaterEqual131.Check(k8sVersion) {
+		service.Spec.TrafficDistribution = ptr.To(corev1.ServiceTrafficDistributionPreferClose)
+		return
+	}
+
+	// use topology-mode auto and GRM webhook in kubernetes 1.27.x or above
+	if version.ConstraintK8sGreaterEqual127.Check(k8sVersion) {
+		metav1.SetMetaDataAnnotation(&service.ObjectMeta, corev1.AnnotationTopologyMode, "auto")
+		metav1.SetMetaDataLabel(&service.ObjectMeta, resourcesv1alpha1.EndpointSliceHintsConsider, "true")
+		return
+	}
+
+	// use topology-aware-hints auto and GRM webhook in kubernetes 1.26.x or below
+	metav1.SetMetaDataAnnotation(&service.ObjectMeta, corev1.DeprecatedAnnotationTopologyAwareHints, "auto")
+	metav1.SetMetaDataLabel(&service.ObjectMeta, resourcesv1alpha1.EndpointSliceHintsConsider, "true")
 }

--- a/pkg/utils/gardener/topology_aware_routing_test.go
+++ b/pkg/utils/gardener/topology_aware_routing_test.go
@@ -10,20 +10,47 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 var _ = Describe("TopologyAwareRouting", func() {
-	Describe("#ReconcileTopologyAwareRoutingMetadata", func() {
+	Describe("#ReconcileTopologyAwareRouting", func() {
+		Context("when K8s version >= 1.31", func() {
+			It("should add the setting in service spec when topology-aware routing is enabled", func() {
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"service.kubernetes.io/topology-aware-hints": "auto",
+							"service.kubernetes.io/topology-mode":        "auto",
+						},
+						Labels: map[string]string{"endpoint-slice-hints.resources.gardener.cloud/consider": "true"},
+					},
+				}
+
+				ReconcileTopologyAwareRouting(service, true, semver.MustParse("1.31.1"))
+
+				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-aware-hints"))
+				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-mode"))
+				Expect(service.Labels).NotTo(HaveKey("endpoint-slice-hints.resources.gardener.cloud/consider"))
+
+				Expect(service.Spec.TrafficDistribution).NotTo(BeNil())
+				Expect(ptr.Deref(service.Spec.TrafficDistribution, "")).To(Equal(corev1.ServiceTrafficDistributionPreferClose))
+
+			})
+		})
+
 		Context("when K8s version < 1.27", func() {
 			It("should add the required annotation and label when topology-aware routing is enabled", func() {
 				service := &corev1.Service{}
 
-				ReconcileTopologyAwareRoutingMetadata(service, true, semver.MustParse("1.26.1"))
+				ReconcileTopologyAwareRouting(service, true, semver.MustParse("1.26.1"))
 
 				Expect(service.Annotations).To(HaveKeyWithValue("service.kubernetes.io/topology-aware-hints", "auto"))
 				Expect(service.Labels).To(HaveKeyWithValue("endpoint-slice-hints.resources.gardener.cloud/consider", "true"))
+				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-mode"))
+				Expect(service.Spec.TrafficDistribution).To(BeNil())
 			})
 		})
 
@@ -37,15 +64,16 @@ var _ = Describe("TopologyAwareRouting", func() {
 					},
 				}
 
-				ReconcileTopologyAwareRoutingMetadata(service, true, semver.MustParse("1.27.1"))
+				ReconcileTopologyAwareRouting(service, true, semver.MustParse("1.27.1"))
 
 				Expect(service.Annotations).To(HaveKeyWithValue("service.kubernetes.io/topology-mode", "auto"))
 				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-aware-hints"))
 				Expect(service.Labels).To(HaveKeyWithValue("endpoint-slice-hints.resources.gardener.cloud/consider", "true"))
+				Expect(service.Spec.TrafficDistribution).To(BeNil())
 			})
 		})
 
-		It("should remove the annotations and label when topology-aware routing is disabled", func() {
+		It("should remove the annotations, label and TrafficDistribution setting when topology-aware routing is disabled", func() {
 			service := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -54,13 +82,15 @@ var _ = Describe("TopologyAwareRouting", func() {
 					},
 					Labels: map[string]string{"endpoint-slice-hints.resources.gardener.cloud/consider": "true"},
 				},
+				Spec: corev1.ServiceSpec{TrafficDistribution: ptr.To(corev1.ServiceTrafficDistributionPreferClose)},
 			}
 
-			ReconcileTopologyAwareRoutingMetadata(service, false, semver.MustParse("1.25.1"))
+			ReconcileTopologyAwareRouting(service, false, semver.MustParse("1.25.1"))
 
 			Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-aware-hints"))
 			Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-mode"))
 			Expect(service.Labels).NotTo(HaveKey("endpoint-slice-hints.resources.gardener.cloud/consider"))
+			Expect(service.Spec.TrafficDistribution).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area high-availability
/kind enhancement

cc @ialidzhikov 

**What this PR does / why we need it**:
With kubernetes version `1.31.x` the [ServiceTrafficDistribution](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution) got beta and enabled by default. `ServiceTrafficDistribution` `PreferClose ` only uses zone information for routing th traffic without taking into account the allocatable CPUs see also [Comparison with `service.kubernetes.io/topology-mode: Auto`](https://kubernetes.io/docs/reference/networking/virtual-ips/#comparison-with-service-kubernetes-io-topology-mode-auto)

This PR use the `ServiceTrafficDistribution` instead of `TopologyAwareHints` with the GRM webhook, if `topologyAwareRouting` is enabled and kubernetes version is 1.31 or above.

The function was renamed from `ReconcileTopologyAwareRoutingMetadata` to `ReconcileTopologyAwareRouting` as this function now also changes settings in the spec.

**Which issue(s) this PR fixes**:
Part of #10421

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use `ServiceTrafficDistribution` for `TopologyAwareRouting` on kubernetes version 1.31. or above.
```

```breaking developer
Rename function in gardenerutils from `ReconcileTopologyAwareRoutingMetadata` to `ReconcileTopologyAwareRouting`.
```