### PR TITLE
Error returned by determine-seed function should include an indicator of the error reason

### DIFF
--- a/pkg/scheduler/controller/shoot/error.go
+++ b/pkg/scheduler/controller/shoot/error.go
@@ -1,0 +1,70 @@
+package shoot
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+const ( //defines possible reasons why a shoot could not be determined
+	Unknown                       ErrorReason = "ukn"
+	NoMatchingSeed                ErrorReason = "nom"
+	NoUsableSeed                  ErrorReason = "nou"
+	LabelSelectorConversionFailed ErrorReason = "lsc"
+	NoMatchingLabels              ErrorReason = "nml"
+	NoMatchingProvider            ErrorReason = "nmp"
+	NoHASeedInZone                ErrorReason = "nsz"
+	NoSeedWithAccessRestriction   ErrorReason = "nar"
+	NoSeedForPurposeAndStrategy   ErrorReason = "nst"
+	NoSeedForProfileAndStrategy   ErrorReason = "npr"
+)
+
+var errorReasons = []ErrorReason{ //contains all possible ErrorReasons
+	Unknown,
+	NoMatchingSeed,
+	NoUsableSeed,
+	LabelSelectorConversionFailed,
+	NoMatchingLabels,
+	NoMatchingProvider,
+	NoHASeedInZone,
+	NoSeedWithAccessRestriction,
+	NoSeedForPurposeAndStrategy,
+	NoSeedForProfileAndStrategy,
+}
+
+const errorReasonPrefix = "dse"
+
+type ErrorReason string
+
+func (er ErrorReason) suffix() string {
+	return fmt.Sprintf("[%s-%s]", errorReasonPrefix, string(er))
+}
+
+type DetermineSeedError struct {
+	reason  ErrorReason
+	message string
+}
+
+func (e *DetermineSeedError) Error() string {
+	return e.message
+}
+
+func newDetermineSeedError(reason ErrorReason, msg string, args ...any) *DetermineSeedError {
+	errMsg := fmt.Sprintf("%s %s", msg, reason.suffix())
+	return &DetermineSeedError{
+		reason:  reason,
+		message: fmt.Sprintf(errMsg, args...),
+	}
+}
+
+func DetermineSeedErrorFromString(msg string) (*DetermineSeedError, error) {
+	for _, errReason := range errorReasons {
+		if strings.HasSuffix(msg, errReason.suffix()) {
+			return &DetermineSeedError{
+				reason:  errReason,
+				message: msg,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("error message could not be mapped to %s", reflect.TypeOf(DetermineSeedError{}).Name())
+}

--- a/pkg/scheduler/controller/shoot/error.go
+++ b/pkg/scheduler/controller/shoot/error.go
@@ -7,22 +7,38 @@ import (
 )
 
 const ( //defines possible reasons why a shoot could not be determined
-	Unknown                       ErrorReason = "ukn"
-	NoMatchingSeed                ErrorReason = "nom"
-	NoUsableSeed                  ErrorReason = "nou"
+
+	// Unknown indicates an unknown or non-specific reason for the occurred error.
+	Unknown ErrorReason = "ukn"
+
+	// NoMatchingSeed is used when no seed cluster was valid for scheduling the shoot.
+	NoMatchingSeed ErrorReason = "nom"
+
+	// LabelSelectorConversionFailed representation a failed conversion of label selectors.
 	LabelSelectorConversionFailed ErrorReason = "lsc"
-	NoMatchingLabels              ErrorReason = "nml"
-	NoMatchingProvider            ErrorReason = "nmp"
-	NoHASeedInZone                ErrorReason = "nsz"
-	NoSeedWithAccessRestriction   ErrorReason = "nar"
-	NoSeedForPurposeAndStrategy   ErrorReason = "nst"
-	NoSeedForProfileAndStrategy   ErrorReason = "npr"
+
+	// NoMatchingLabels is used when no seed was matching the labels defined by seed selector.
+	NoMatchingLabels ErrorReason = "nml"
+
+	// NoMatchingProvider indicates no seed had a matching provider.
+	NoMatchingProvider ErrorReason = "nmp"
+
+	// NoHASeedInZone is used when none of the seeds has at least 3 zones for hosting a shoot control plane with failure tolerance type 'zone'.
+	NoHASeedInZone ErrorReason = "nsz"
+
+	// NoSeedWithAccessRestriction indicates that no seed supports the access restrictions configured in the shoot specification.
+	NoSeedWithAccessRestriction ErrorReason = "nar"
+
+	// NoSeedForPurposeAndStrategy shows that no seed could be determined for the provided purpose and strategy.
+	NoSeedForPurposeAndStrategy ErrorReason = "nst"
+
+	// NoSeedForProfileAndStrategy is used when no seed could be determined for the provided cloud profile and strategy.
+	NoSeedForProfileAndStrategy ErrorReason = "npr"
 )
 
 var errorReasons = []ErrorReason{ //contains all possible ErrorReasons
 	Unknown,
 	NoMatchingSeed,
-	NoUsableSeed,
 	LabelSelectorConversionFailed,
 	NoMatchingLabels,
 	NoMatchingProvider,
@@ -34,12 +50,14 @@ var errorReasons = []ErrorReason{ //contains all possible ErrorReasons
 
 const errorReasonPrefix = "dse"
 
+// ErrorReason represents a failure case which can occur during the seed determination.
 type ErrorReason string
 
 func (er ErrorReason) suffix() string {
 	return fmt.Sprintf("[%s-%s]", errorReasonPrefix, string(er))
 }
 
+// DetermineSeedError indicates a failure case happening during the seed determination.
 type DetermineSeedError struct {
 	reason  ErrorReason
 	message string
@@ -57,6 +75,8 @@ func newDetermineSeedError(reason ErrorReason, msg string, args ...any) *Determi
 	}
 }
 
+// DetermineSeedErrorFromString converts an error message to a DetermineSeedError.
+// If the error message is not related to a DetermineSeedError, an error will be returned.
 func DetermineSeedErrorFromString(msg string) (*DetermineSeedError, error) {
 	for _, errReason := range errorReasons {
 		if strings.HasSuffix(msg, errReason.suffix()) {

--- a/pkg/scheduler/controller/shoot/error_test.go
+++ b/pkg/scheduler/controller/shoot/error_test.go
@@ -18,8 +18,8 @@ var _ = Describe("DetermineSeedError", func() {
 	It("Should convert string to DetermineSeedError", func() {
 		errMsg := fmt.Sprintf("the 1st error message %s", Unknown.suffix())
 		dsErr, err := DetermineSeedErrorFromString(errMsg)
-		Expect(err).To(BeNil())
-		Expect(dsErr).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dsErr).NotTo(BeNil())
 		Expect(dsErr).To(BeAssignableToTypeOf(&DetermineSeedError{}))
 		Expect(dsErr.reason).To(Equal(Unknown))
 	})

--- a/pkg/scheduler/controller/shoot/error_test.go
+++ b/pkg/scheduler/controller/shoot/error_test.go
@@ -1,0 +1,32 @@
+package shoot
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DetermineSeedError", func() {
+	It("should return an DetermineSeedError", func() {
+		dsErr := newDetermineSeedError(Unknown, "the %dst error message", 1)
+		Expect(dsErr).To(HaveOccurred())
+		Expect(dsErr).To(BeAssignableToTypeOf(&DetermineSeedError{}))
+		Expect(dsErr.message).To(Equal(fmt.Sprintf("the 1st error message %s", Unknown.suffix())))
+	})
+
+	It("Should convert string to DetermineSeedError", func() {
+		errMsg := fmt.Sprintf("the 1st error message %s", Unknown.suffix())
+		dsErr, err := DetermineSeedErrorFromString(errMsg)
+		Expect(err).To(BeNil())
+		Expect(dsErr).To(HaveOccurred())
+		Expect(dsErr).To(BeAssignableToTypeOf(&DetermineSeedError{}))
+		Expect(dsErr.reason).To(Equal(Unknown))
+	})
+
+	It("Should fail if string does not match with DetermineSeedError", func() {
+		dsErr, err := DetermineSeedErrorFromString("any kind of string")
+		Expect(dsErr).To(BeNil())
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind api-change

**What this PR does / why we need it**:

In Kyma we are adding a feature which enables our customers to enforce that Seed and Shoot have to be located in the same region (https://github.com/kyma-project/kyma/issues/18182).

If no seed exists in the Shoot region, the Shoot creation stays in `PENDING` state. We have to detect such cases and reply an error to our customers, asking him to adjust its configuration (either choose a different region or accept that shoot and seed run in different regions).

Currently, we use the replied error message to identify if no Seed exists in the Shoot region: https://github.com/kyma-project/infrastructure-manager/pull/532/files#diff-ab40ca3c155326cb4d7974eee9347c67351717c8aec2c52df14b6c753fb45d51R102

This is a unstable solution as each adjustment of the error message will break the code!

To detect **reliably** such case, the returned error message from Gardener should include an clear indicator which points out the reason why the shoot could not be scheduled.

This PR is a **proposal** for adding an suffix to the returned error messages. It includes also the logic to map the provided message back to the reason why  the shoot couldn't be scheduled.

Example how the new error-messages of the `determineSeed` logic are looking:

`none out of the 999 seeds has a matching provider for xyz [dse-nmp]` => `[dse-nmp]` is a unique suffix indicating the reason why the error occured.


**Which issue(s) this PR fixes**:
Related to https://github.com/kyma-project/infrastructure-manager/issues/241

**Special notes for your reviewer**:

This is a proposal which appends an indicator to the replied error message of the `determineSeed` function. The appended suffix is unique for each possible scheduling issue (e.g. no seed in region, no seed is matching the provided labels etc. etc.).

We are open for any alternative approach Goal should be to establish a reliable approach to map the replied error message to the corresponding scheduling issues. This is required to react accordingly on misconfigured Shoot-Specs and to provide our customers proper error messages.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
