### PR TITLE
Remove OwnerReference from EnvoyFilter for apiserver-proxy in `apiserverexposure` package

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -15,7 +15,6 @@ import (
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -54,7 +53,6 @@ type SNIValues struct {
 
 // APIServerProxy contains values for the APIServer proxy protocol configuration.
 type APIServerProxy struct {
-	NamespaceUID       types.UID
 	APIServerClusterIP string
 }
 
@@ -170,7 +168,6 @@ func (s *sni) Destroy(ctx context.Context) error {
 		ctx,
 		s.client,
 		s.emptyDestinationRule(),
-		s.emptyEnvoyFilter(),
 		s.emptyGateway(),
 		s.emptyVirtualService(),
 	)

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -17,7 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +40,6 @@ var _ = Describe("#SNI", func() {
 
 		defaultDepWaiter component.DeployWaiter
 		namespace        = "test-namespace"
-		namespaceUID     = types.UID("123456")
 		istioLabels      = map[string]string{"foo": "bar"}
 		istioNamespace   = "istio-foo"
 		hosts            = []string{"foo.bar"}
@@ -67,7 +65,6 @@ var _ = Describe("#SNI", func() {
 		c = fake.NewClientBuilder().WithScheme(s).Build()
 		apiServerProxyValues = &APIServerProxy{
 			APIServerClusterIP: "1.1.1.1",
-			NamespaceUID:       namespaceUID,
 		}
 
 		expectedDestinationRule = &istionetworkingv1beta1.DestinationRule{
@@ -111,14 +108,6 @@ var _ = Describe("#SNI", func() {
 		expectedEnvoyFilterObjectMeta = metav1.ObjectMeta{
 			Name:      namespace,
 			Namespace: istioNamespace,
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "v1",
-				Kind:               "Namespace",
-				Name:               namespace,
-				UID:                namespaceUID,
-				BlockOwnerDeletion: ptr.To(false),
-				Controller:         ptr.To(false),
-			}},
 		}
 		expectedGateway = &istionetworkingv1beta1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter.yaml
@@ -4,13 +4,6 @@ kind: EnvoyFilter
 metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
-  ownerReferences:
-  - apiVersion: v1
-    kind: Namespace
-    name: {{ .Name }}
-    uid: {{ .NamespaceUID | quote }}
-    controller: false
-    blockOwnerDeletion: false
 spec:
   workloadSelector:
     labels:

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -87,7 +87,6 @@ func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 				},
 				APIServerProxy: &kubeapiserverexposure.APIServerProxy{
 					APIServerClusterIP: b.APIServerClusterIP,
-					NamespaceUID:       b.SeedNamespaceObject.UID,
 				},
 				IstioIngressGateway: kubeapiserverexposure.IstioIngressGateway{
 					Namespace: b.IstioNamespace(),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking quality
/kind cleanup

**What this PR does / why we need it**:
EnvoyFilter for apiserver-proxy in `apiserverexposure` package is created via managed-resource ([ref](https://github.com/gardener/gardener/blob/5b0b1c38437fbaab2ead89cc9ba0af248a83a9c5/pkg/component/kubernetes/apiserverexposure/sni.go#L144-L146)).
Thus, it is not necessary to set an owner reference to the seed namespace since it is cleaned up by its managed-resource. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
