### PR TITLE
Trigger shoot care reconcile on `ManagedResource` status change

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -538,6 +538,7 @@ func addAllFieldIndexes(ctx context.Context, i client.FieldIndexer) error {
 		// core API group
 		indexer.AddShootSeedName,
 		indexer.AddShootStatusSeedName,
+		indexer.AddShootStatusTechnicalID,
 		indexer.AddBackupBucketSeedName,
 		indexer.AddBackupEntrySeedName,
 		indexer.AddBackupEntryBucketName,

--- a/pkg/api/indexer/gardener_core.go
+++ b/pkg/api/indexer/gardener_core.go
@@ -114,6 +114,20 @@ func AddShootStatusSeedName(ctx context.Context, indexer client.FieldIndexer) er
 	return nil
 }
 
+// AddShootStatusTechnicalID adds an index for core.ShootStatusTechnicalID to the given indexer.
+func AddShootStatusTechnicalID(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &gardencorev1beta1.Shoot{}, core.ShootStatusTechnicalID, func(obj client.Object) []string {
+		shoot, ok := obj.(*gardencorev1beta1.Shoot)
+		if !ok {
+			return []string{""}
+		}
+		return []string{shoot.Status.TechnicalID}
+	}); err != nil {
+		return fmt.Errorf("failed to add indexer for %s to Shoot Informer: %w", core.ShootStatusTechnicalID, err)
+	}
+	return nil
+}
+
 // AddBackupBucketSeedName adds an index for core.BackupBucketSeedName to the given indexer.
 func AddBackupBucketSeedName(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &gardencorev1beta1.BackupBucket{}, core.BackupBucketSeedName, BackupBucketSeedNameIndexerFunc); err != nil {

--- a/pkg/apis/core/field_constants.go
+++ b/pkg/apis/core/field_constants.go
@@ -48,7 +48,10 @@ const (
 	// the Seed cluster of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot
 	// referred in the status.
 	ShootStatusSeedName = "status.seedName"
-
+	// ShootStatusTechnicalId is the field selector path for finding
+	// the technicalID of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot
+	// referred in the status.
+	ShootStatusTechnicalID = "status.technicalID"
 	// NamespacedCloudProfileParentRefName is the field selector path for finding
 	// the parent CloudProfile of a core.gardener.cloud/v1beta1 NamespacedCloudProfile.
 	NamespacedCloudProfileParentRefName = "spec.parent.name"

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -90,7 +90,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 		SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace", core.ShootSeedName, core.ShootCloudProfileName, core.ShootCloudProfileRefName, core.ShootCloudProfileRefKind, core.ShootStatusSeedName:
+			case "metadata.name", "metadata.namespace", core.ShootSeedName, core.ShootCloudProfileName, core.ShootCloudProfileRefName, core.ShootCloudProfileRefKind, core.ShootStatusSeedName, core.ShootStatusTechnicalID:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -290,9 +290,10 @@ func ToSelectableFields(shoot *core.Shoot) fields.Set {
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	shootSpecificFieldsSet := make(fields.Set, 7)
+	shootSpecificFieldsSet := make(fields.Set, 8)
 	shootSpecificFieldsSet[core.ShootSeedName] = getSeedName(shoot)
 	shootSpecificFieldsSet[core.ShootStatusSeedName] = getStatusSeedName(shoot)
+	shootSpecificFieldsSet[core.ShootStatusTechnicalID] = shoot.Status.TechnicalID
 	if shoot.Spec.CloudProfileName != nil {
 		shootSpecificFieldsSet[core.ShootCloudProfileName] = *shoot.Spec.CloudProfileName
 	}

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -1012,7 +1012,7 @@ var _ = Describe("ToSelectableFields", func() {
 	It("should return correct fields", func() {
 		result := ToSelectableFields(createNewShootObject("foo"))
 
-		Expect(result).To(HaveLen(7))
+		Expect(result).To(HaveLen(8))
 		Expect(result.Has(core.ShootSeedName)).To(BeTrue())
 		Expect(result.Get(core.ShootSeedName)).To(Equal("foo"))
 		Expect(result.Has(core.ShootCloudProfileName)).To(BeTrue())
@@ -1023,6 +1023,8 @@ var _ = Describe("ToSelectableFields", func() {
 		Expect(result.Get(core.ShootCloudProfileRefKind)).To(Equal("CloudProfile"))
 		Expect(result.Has(core.ShootStatusSeedName)).To(BeTrue())
 		Expect(result.Get(core.ShootStatusSeedName)).To(Equal("foo"))
+		Expect(result.Has(core.ShootStatusTechnicalID)).To(BeTrue())
+		Expect(result.Get(core.ShootStatusTechnicalID)).To(Equal("shoot--test-namespace--test"))
 	})
 })
 
@@ -1078,7 +1080,8 @@ func createNewShootObject(seedName string) *core.Shoot {
 			},
 		},
 		Status: core.ShootStatus{
-			SeedName: &seedName,
+			SeedName:    &seedName,
+			TechnicalID: "shoot--test-namespace--test",
 		},
 	}
 }

--- a/pkg/gardenlet/controller/shoot/add.go
+++ b/pkg/gardenlet/controller/shoot/add.go
@@ -65,7 +65,7 @@ func AddToManager(
 		Identity:              identity,
 		GardenClusterIdentity: gardenClusterIdentity,
 		SeedName:              cfg.SeedConfig.Name,
-	}).AddToManager(ctx, mgr, gardenCluster); err != nil {
+	}).AddToManager(mgr, gardenCluster); err != nil {
 		return fmt.Errorf("failed adding care reconciler: %w", err)
 	}
 

--- a/pkg/gardenlet/controller/shoot/add.go
+++ b/pkg/gardenlet/controller/shoot/add.go
@@ -65,7 +65,7 @@ func AddToManager(
 		Identity:              identity,
 		GardenClusterIdentity: gardenClusterIdentity,
 		SeedName:              cfg.SeedConfig.Name,
-	}).AddToManager(mgr, gardenCluster); err != nil {
+	}).AddToManager(ctx, mgr, gardenCluster); err != nil {
 		return fmt.Errorf("failed adding care reconciler: %w", err)
 	}
 

--- a/pkg/gardenlet/controller/shoot/care/add.go
+++ b/pkg/gardenlet/controller/shoot/care/add.go
@@ -139,7 +139,9 @@ func seedGotAssigned(oldShoot, newShoot *gardencorev1beta1.Shoot) bool {
 func (r *Reconciler) MapManagedResource(_ context.Context, mr client.Object) []Request {
 	return []Request{{
 		NamespacedName: types.NamespacedName{
-			Name:      mr.GetName(),
+			// avoid duplicate triggers by letting all managed resources of a shoot use the same
+			// reconcile key
+			Name:      "unused",
 			Namespace: mr.GetNamespace(),
 		},
 		IsManagedResource: true,

--- a/pkg/gardenlet/controller/shoot/care/add_test.go
+++ b/pkg/gardenlet/controller/shoot/care/add_test.go
@@ -14,10 +14,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
@@ -49,15 +49,15 @@ var _ = Describe("Add", func() {
 	Describe("#EventHandler", func() {
 		var (
 			ctx   = context.TODO()
-			hdlr  handler.EventHandler
-			queue *mockworkqueue.MockTypedRateLimitingInterface[reconcile.Request]
-			req   reconcile.Request
+			hdlr  handler.TypedEventHandler[client.Object, Request]
+			queue *mockworkqueue.MockTypedRateLimitingInterface[Request]
+			req   Request
 		)
 
 		BeforeEach(func() {
 			hdlr = reconciler.EventHandler()
-			queue = mockworkqueue.NewMockTypedRateLimitingInterface[reconcile.Request](gomock.NewController(GinkgoT()))
-			req = reconcile.Request{NamespacedName: types.NamespacedName{Name: shoot.Name, Namespace: shoot.Namespace}}
+			queue = mockworkqueue.NewMockTypedRateLimitingInterface[Request](gomock.NewController(GinkgoT()))
+			req = Request{NamespacedName: types.NamespacedName{Name: shoot.Name, Namespace: shoot.Namespace}}
 		})
 
 		It("should enqueue the object for Create events according to the calculated duration", func() {

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -73,8 +73,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req Request) (reconcile.Resu
 		return r.reconcileShoot(ctx, log, req.NamespacedName)
 	}
 
-	var shoots gardencorev1beta1.ShootList
-	if err := r.GardenClient.List(context.Background(), &shoots, client.MatchingFields{
+	shoots := &gardencorev1beta1.ShootList{}
+	if err := r.GardenClient.List(context.Background(), shoots, client.MatchingFields{
 		core.ShootStatusTechnicalID: req.Namespace,
 	}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error looking up shoot by technical id: %w", err)
@@ -83,13 +83,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req Request) (reconcile.Resu
 	if len(shoots.Items) == 0 {
 		log.V(1).Info("No shoot found for managed resource, stop reconciling")
 		return reconcile.Result{}, nil
-	} else if len(shoots.Items) == 1 {
+	} else {
 		return r.reconcileShoot(ctx, log, types.NamespacedName{
 			Name:      shoots.Items[0].Name,
 			Namespace: shoots.Items[0].Namespace,
 		})
-	} else {
-		return reconcile.Result{}, fmt.Errorf("technicalID %v is not unique", req.Namespace)
 	}
 }
 

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -96,7 +96,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// if shoot is no longer managed by this gardenlet (e.g., due to migration to another seed) then don't requeue.
 	if ptr.Deref(shoot.Status.SeedName, "") != r.SeedName {
 		if shoot.Status.TechnicalID != "" {
-			// cleanup mapping
+			// forget mapping as this gardenlet is no longer responsible for the shoot
 			r.namespaceToShootName.Delete(shoot.Status.TechnicalID)
 		}
 		return reconcile.Result{}, nil

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -81,13 +81,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req Request) (reconcile.Resu
 	}
 
 	if len(shoots.Items) == 0 {
-		log.V(1).Info("No shoot found for managed resource, stop reconciling")
+		log.V(1).Info("No shoot found for managed resource, ignoring it")
 		return reconcile.Result{}, nil
 	} else {
-		return r.reconcileShoot(ctx, log, types.NamespacedName{
+		result, err := r.reconcileShoot(ctx, log, types.NamespacedName{
 			Name:      shoots.Items[0].Name,
 			Namespace: shoots.Items[0].Namespace,
 		})
+		if err != nil {
+			return result, err
+		}
+		// Reconciles triggered due to a changed managed resource are one time checks.
+		// Periodic checks are already performed based on the existing shoot objects.
+		return reconcile.Result{}, nil
 	}
 }
 

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -91,6 +91,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req Request) (reconcile.Resu
 	if err != nil {
 		return result, err
 	}
+	// Do not requeue the shoot to avoid reconcile amplifications.
 	// Reconciles triggered due to a changed managed resource are one time checks.
 	// Periodic checks are already performed based on the existing shoot objects.
 	return reconcile.Result{}, nil

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -570,7 +570,8 @@ var _ = Describe("Shoot Care Control", func() {
 							NamespacedName:    client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: "ignored-by-reconcile"},
 							IsManagedResource: true,
 						}
-						Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
+						// reconciles for a managed resource must not be requeued
+						Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{}))
 						expectHealthyShoot()
 					})
 				})

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Shoot Care Control", func() {
 	var (
 		ctx           context.Context
 		gardenClient  client.Client
-		reconciler    reconcile.Reconciler
+		reconciler    reconcile.TypedReconciler[Request]
 		gardenletConf gardenletconfigv1alpha1.GardenletConfiguration
 		fakeClock     *testclock.FakeClock
 
@@ -92,7 +92,7 @@ var _ = Describe("Shoot Care Control", func() {
 			careSyncPeriod time.Duration
 
 			gardenSecrets []corev1.Secret
-			req           reconcile.Request
+			req           Request
 		)
 
 		BeforeEach(func() {
@@ -107,7 +107,7 @@ var _ = Describe("Shoot Care Control", func() {
 				},
 			}}
 
-			req = reconcile.Request{NamespacedName: client.ObjectKey{Namespace: shootNamespace, Name: shootName}}
+			req = Request{NamespacedName: client.ObjectKey{Namespace: shootNamespace, Name: shootName}}
 
 			gardenletConf = gardenletconfigv1alpha1.GardenletConfiguration{
 				Controllers: &gardenletconfigv1alpha1.GardenletControllerConfiguration{

--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -239,6 +239,7 @@ var _ = BeforeSuite(func() {
 	By("Setup field indexes")
 	Expect(indexer.AddManagedSeedShootName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 	Expect(indexer.AddControllerInstallationSeedRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+	Expect(indexer.AddShootStatusTechnicalID(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
 	By("Create test clientset")
 	testClientSet, err = kubernetes.NewWithConfig(

--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -273,7 +273,7 @@ var _ = BeforeSuite(func() {
 		},
 		Clock:    fakeClock,
 		SeedName: seedName,
-	}).AddToManager(ctx, mgr, mgr)).To(Succeed())
+	}).AddToManager(mgr, mgr)).To(Succeed())
 
 	By("Start manager")
 	mgrContext, mgrCancel := context.WithCancel(ctx)

--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -68,6 +68,7 @@ var (
 	testClientSet  kubernetes.Interface
 	shootClientMap clientmap.ClientMap
 	mgrClient      client.Client
+	syncPeriod     *metav1.Duration
 
 	project       *gardencorev1beta1.Project
 	seed          *gardencorev1beta1.Seed
@@ -252,13 +253,14 @@ var _ = BeforeSuite(func() {
 	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
 
 	By("Register controller")
+	syncPeriod = &metav1.Duration{Duration: 500 * time.Millisecond}
 	Expect((&care.Reconciler{
 		SeedClientSet:  testClientSet,
 		ShootClientMap: shootClientMap,
 		Config: gardenletconfigv1alpha1.GardenletConfiguration{
 			Controllers: &gardenletconfigv1alpha1.GardenletControllerConfiguration{
 				ShootCare: &gardenletconfigv1alpha1.ShootCareControllerConfiguration{
-					SyncPeriod: &metav1.Duration{Duration: 500 * time.Millisecond},
+					SyncPeriod: syncPeriod,
 				},
 			},
 			SeedConfig: &gardenletconfigv1alpha1.SeedConfig{

--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -271,7 +271,7 @@ var _ = BeforeSuite(func() {
 		},
 		Clock:    fakeClock,
 		SeedName: seedName,
-	}).AddToManager(mgr, mgr)).To(Succeed())
+	}).AddToManager(ctx, mgr, mgr)).To(Succeed())
 
 	By("Start manager")
 	mgrContext, mgrCancel := context.WithCancel(ctx)

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -521,8 +521,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 						g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 						return shoot.Status.Conditions
 					}).Should(
-						// here SystemComponentsHealthy condition is not healthy because for SystemComponentsHealthy to be healthy a tunnel connection is required
-						// which can't be faked, if it would have been failing because of MangedResource is not healthy then the reason will not be `NoTunnelDeployed`.
+						// check that the failed managed resource is reflected in the shoot state
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithMessageSubstrings("Resources failed to get applied")),
 					)
 				})

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -523,7 +523,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 					Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 						g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 						return shoot.Status.Conditions
-					}).WithTimeout(1 * time.Second).Should(And(
+					}).WithTimeout(5 * time.Second).Should(And(
 						// here SystemComponentsHealthy condition is not healthy because for SystemComponentsHealthy to be healthy a tunnel connection is required
 						// which can't be faked, if it would have been failing because of MangedResource is not healthy then the reason will not be `NoTunnelDeployed`.
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithMessageSubstrings("Resources failed to get applied")),

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -516,7 +516,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 						g.Expect(testClient.Status().Patch(ctx, managedResource1, patch)).To(Succeed())
 					}).Should(Succeed())
 
-					// Use short timeout here to ensure a test failure if triggering by ManagedResource change doesn't work
+					// Eventually uses a default timeout that is shorter than the sync period. Thus this check will time out if triggering by ManagedResource change doesn't work.
 					Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 						g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 						return shoot.Status.Conditions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

The shoot care controller currently runs in a fixed cycle, which by default is one minute. This leads to some delay between all ManagedResources getting healthy and the shoot status reflecting this. The PR adds a watch on ManagedResources. To map back to the corresponding shoot, the controller also collects a mapping from namespace to shoot object key when first processing a shoot. Entries are removed from the mapping once the controller is no longer responsible for a shoot.

**Which issue(s) this PR fixes**:

This is part of the hackathon https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The shoot health state is immediately refreshed once ManagedResources change their state.
```
