### PR TITLE
Use watch to drop seedfinalizer once ControllerInstallations are deleted

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/add.go
@@ -33,7 +33,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg config.Controlle
 		return fmt.Errorf("failed adding extension ClusterRole reconciler: %w", err)
 	}
 
-	if err := (&seedfinalizer.Reconciler{}).AddToManager(ctx, mgr); err != nil {
+	if err := (&seedfinalizer.Reconciler{}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding Seed finalizer reconciler: %w", err)
 	}
 

--- a/pkg/controllermanager/controller/controllerregistration/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/add.go
@@ -33,7 +33,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg config.Controlle
 		return fmt.Errorf("failed adding extension ClusterRole reconciler: %w", err)
 	}
 
-	if err := (&seedfinalizer.Reconciler{}).AddToManager(mgr); err != nil {
+	if err := (&seedfinalizer.Reconciler{}).AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed adding Seed finalizer reconciler: %w", err)
 	}
 

--- a/pkg/controllermanager/controller/controllerregistration/seedfinalizer/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/seedfinalizer/add.go
@@ -11,20 +11,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
 // ControllerName is the name of this controller.
 const ControllerName = "controllerregistration-seed-finalizer"
 
 // AddToManager adds Reconciler to the given manager.
-func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) error {
+func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
@@ -39,7 +39,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 		Watches(
 			&gardencorev1beta1.ControllerInstallation{},
 			handler.EnqueueRequestsFromMapFunc(r.MapControllerInstallationToSeed),
-			builder.WithPredicates(r.ControllerUninstallationPredicate()),
+			builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Delete)),
 		).
 		Complete(r)
 }
@@ -52,14 +52,4 @@ func (r *Reconciler) MapControllerInstallationToSeed(_ context.Context, obj clie
 	}
 
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: controllerInstallation.Spec.SeedRef.Name}}}
-}
-
-// ControllerUninstallationPredicate returns true for all ControllerInstallation 'delete' events. For other events, false is returned.
-func (r *Reconciler) ControllerUninstallationPredicate() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc:  func(_ event.CreateEvent) bool { return false },
-		UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
-		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
-		GenericFunc: func(_ event.GenericEvent) bool { return false },
-	}
 }

--- a/pkg/controllermanager/controller/controllerregistration/seedfinalizer/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/seedfinalizer/add.go
@@ -5,29 +5,67 @@
 package seedfinalizer
 
 import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/controllerutils/mapper"
+	"github.com/go-logr/logr"
 )
 
 // ControllerName is the name of this controller.
 const ControllerName = "controllerregistration-seed-finalizer"
 
 // AddToManager adds Reconciler to the given manager.
-func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) error {
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
 
-	return builder.
+	c, err := builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&gardencorev1beta1.Seed{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5,
 		}).
-		Complete(r)
+		Build(r)
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(source.Kind[client.Object](mgr.GetCache(),
+		&gardencorev1beta1.ControllerInstallation{},
+		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), mapper.MapFunc(r.MapControllerInstallationToSeed), mapper.UpdateWithNew, c.GetLogger()),
+		r.ControllerUninstallationPredicate(),
+	))
+}
+
+// MapControllerInstallationToSeed returns a reconcile.Request object for the seed specified in the .spec.seedRef.name field.
+func (r *Reconciler) MapControllerInstallationToSeed(_ context.Context, _ logr.Logger, _ client.Reader, obj client.Object) []reconcile.Request {
+	controllerInstallation, ok := obj.(*gardencorev1beta1.ControllerInstallation)
+	if !ok {
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: controllerInstallation.Spec.SeedRef.Name}}}
+}
+
+// ControllerUninstallationPredicate returns true for all ControllerInstallation 'delete' events. For other events, false is returned.
+func (r *Reconciler) ControllerUninstallationPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(_ event.CreateEvent) bool { return false },
+		UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
 }

--- a/pkg/controllermanager/controller/controllerregistration/seedfinalizer/add_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seedfinalizer/add_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package seedfinalizer_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/seedfinalizer"
+)
+
+var _ = Describe("Add", func() {
+	Describe("#MapControllerInstallationToSeed", func() {
+		var (
+			ctx context.Context
+			r   *Reconciler
+
+			seedName               string
+			controllerInstallation *gardencorev1beta1.ControllerInstallation
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			r = &Reconciler{}
+
+			seedName = "seed-1"
+			controllerInstallation = &gardencorev1beta1.ControllerInstallation{
+				Spec: gardencorev1beta1.ControllerInstallationSpec{
+					SeedRef: corev1.ObjectReference{
+						Name: seedName,
+					},
+				},
+			}
+		})
+
+		It("should return a request with the seed name", func() {
+			Expect(r.MapControllerInstallationToSeed(ctx, controllerInstallation)).To(ConsistOf(reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}}))
+		})
+
+		It("should return nil when object is not a ControllerInstallation", func() {
+			Expect(r.MapControllerInstallationToSeed(ctx, nil)).To(BeNil())
+		})
+	})
+})

--- a/pkg/controllermanager/controller/controllerregistration/seedfinalizer/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seedfinalizer/reconciler.go
@@ -58,7 +58,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 
 		if len(controllerInstallationList.Items) > 0 {
-			return reconcile.Result{}, fmt.Errorf("cannot remove finalizer of Seed %q because still found ControllerInstallations: %s", seed.Name, controllerutils.GetControllerInstallationNames(controllerInstallationList.Items))
+			// cannot remove finalizer yet, requeue will happen via watch on controllerinstallations
+			return reconcile.Result{}, nil
 		}
 
 		log.Info("Removing finalizer")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

The seedfinalizer only watch the seed object and when deleting a seed it returned an error while ControllerInstallations still exist. This causes the controller to enter a retry backoff, which delays the finalizer removal once the ControllerInstallations have been deleted.

Replace the backoff with an explicit watch for deleted ControllerInstallations.

**Which issue(s) this PR fixes**:
This is part of the hackathon https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
