### PR TITLE
Fix `make check` when running a shoot in dev setup

### DIFF
--- a/hack/check-plutono-dashboards.sh
+++ b/hack/check-plutono-dashboards.sh
@@ -12,7 +12,7 @@ set -o pipefail
 echo "> Checking Plutono dashboards"
 
 function check_dashboards {
-  find . -path '*/dashboards/*' -name '*.json' -type f \
+  find . -path './dev/local-backupbuckets' -prune -o -path '*/dashboards/*' -name '*.json' -type f -print \
   | while IFS= read -r file; do
 
       jq -c -r '{title: (.title // error("title is not set")),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

When creating a dev cluster using `gardener-up` and running a shoot on this cluster, the `dev/local-backupbuckets` folder contains some folder only readably by root (at least on Linux). This causes the plutono dashboard check to fail when running `make check`:

```
> Checking Plutono dashboards
find: ‘./dev/local-backupbuckets/1f1e993d-9175-42b6-8c9a-f32521d8ae46/shoot--local--local--7ad2cc89-6865-4d34-95ec-fc98bf85ec43’: Permission denied
make: *** [Makefile:169: check] Error 1
```

Avoid this error by excluding the problematic folder.