### PR TITLE
local-setup: Fix Shoot Node logging

### DIFF
--- a/charts/gardener/provider-local/templates/coredns/configmap.yaml
+++ b/charts/gardener/provider-local/templates/coredns/configmap.yaml
@@ -41,7 +41,7 @@ data:
         ready
         import custom/*.override
         rewrite stop {
-          name regex (.*)\.ingress\.local\.seed\.local\.gardener\.cloud nginx-ingress-controller.garden.svc.cluster.local answer auto
+          name regex (.*)\.ingress\.local\.seed\.local\.gardener\.cloud istio-ingressgateway.istio-ingress.svc.cluster.local answer auto
         }
         prometheus :9153
         forward . /etc/resolv.conf {

--- a/pkg/provider-local/controller/infrastructure/actuator.go
+++ b/pkg/provider-local/controller/infrastructure/actuator.go
@@ -51,13 +51,6 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, infrastructure 
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "machine"}},
 				},
 				{
-					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "garden"}},
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"app":       "nginx-ingress",
-						"component": "controller",
-					}},
-				},
-				{
 					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "registry"}},
 					PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "registry"}},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
After we introduced network policies to the garden Namespace, the machine Pod was no longer able to talk to the garden/nginx-ingress Pods due to missing ingress rule from nginx-ingress side for traffic from the machine Pod.
This PR fixes the issue by adapting the coredns config to resolve the Ingress domains to the `istio-ingressgateway` Service. After https://github.com/gardener/gardener/pull/9038 the traffic goes first to the istio-ingressgateway then gets routed to the nginx-ingress.

The 2nd commit removes unused network policy as the machine Pod no longer needs egress to the nginx-ingress.

Many thanks to @rfranzke and @ScheererJ on coming up with the fix.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/10916

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
