### PR TITLE
Fix `CalculateMaxNodesForShoot` for `cluster-autoscaler` in dual-stack case.

### DIFF
--- a/pkg/gardenlet/operation/botanist/clusterautoscaler.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler.go
@@ -72,7 +72,7 @@ func (b *Botanist) CalculateMaxNodesForShoot(shoot *gardencorev1beta1.Shoot) (*i
 	if err != nil {
 		return nil, err
 	}
-	maxNodesForNodesNetwork, err := b.calculateMaxNodesForNodesNetwork(shoot)
+	maxNodesForNodesNetwork, err := b.calculateMaxNodesForNodesNetwork()
 	if err != nil {
 		return nil, err
 	}
@@ -97,13 +97,17 @@ func (b *Botanist) calculateMaxNodesForPodsNetwork(shoot *gardencorev1beta1.Shoo
 		// Calculate how many subnets with nodeCIDRMaskSize can be allocated out of the pod network (with podCIDRMaskSize).
 		// This indicates how many Nodes we can host at max from a networking perspective.
 		var maxNodeCount = &big.Int{}
-		exp := int64(*shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize) - int64(podCIDRMaskSize)
+		exp := 64 - int64(podCIDRMaskSize)
+		if podNetwork.IP.To4() != nil {
+			exp = int64(*shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize) - int64(podCIDRMaskSize)
+		}
 		// Bigger numbers than 2^62 do not fit into an int64 variable and big.Int{}.Int64() is undefined in such cases.
 		// The pod network is no limitation in this case anyway.
 		if exp > 62 {
-			return nil, nil
+			maxNodeCount = big.NewInt(math.MaxInt64)
+		} else {
+			maxNodeCount.Exp(big.NewInt(2), big.NewInt(exp), nil)
 		}
-		maxNodeCount.Exp(big.NewInt(2), big.NewInt(exp), nil)
 
 		if podNetwork.IP.To4() != nil {
 			resultPerIPFamily[gardencorev1beta1.IPFamilyIPv4] += maxNodeCount.Int64()
@@ -120,7 +124,7 @@ func (b *Botanist) calculateMaxNodesForPodsNetwork(shoot *gardencorev1beta1.Shoo
 	return &result, nil
 }
 
-func (b *Botanist) calculateMaxNodesForNodesNetwork(shoot *gardencorev1beta1.Shoot) (*int64, error) {
+func (b *Botanist) calculateMaxNodesForNodesNetwork() (*int64, error) {
 	if len(b.Shoot.Networks.Nodes) == 0 {
 		return nil, nil
 	}
@@ -131,9 +135,9 @@ func (b *Botanist) calculateMaxNodesForNodesNetwork(shoot *gardencorev1beta1.Sho
 		if nodeCIDRMaskSize == 0 {
 			return nil, fmt.Errorf("node CIDR is not in its canonical form")
 		}
-		ipCIDRMaskSize := int64(32)
-		if gardencorev1beta1.IsIPv6SingleStack(shoot.Spec.Networking.IPFamilies) {
-			ipCIDRMaskSize = 128
+		ipCIDRMaskSize := int64(128)
+		if nodeNetwork.IP.To4() != nil {
+			ipCIDRMaskSize = int64(32)
 		}
 		// Calculate how many "single IP" subnets fit into the node network
 		var maxNodeCount = &big.Int{}
@@ -141,9 +145,10 @@ func (b *Botanist) calculateMaxNodesForNodesNetwork(shoot *gardencorev1beta1.Sho
 		// Bigger numbers than 2^62 do not fit into an int64 variable and big.Int{}.Int64() is undefined in such cases.
 		// The node network is no limitation in this case anyway.
 		if exp > 62 {
-			return nil, nil
+			maxNodeCount = big.NewInt(math.MaxInt64)
+		} else {
+			maxNodeCount.Exp(big.NewInt(2), big.NewInt(exp), nil)
 		}
-		maxNodeCount.Exp(big.NewInt(2), big.NewInt(exp), nil)
 
 		if nodeNetwork.IP.To4() != nil {
 			// Subtract the broadcast addresses

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
@@ -356,5 +356,51 @@ var _ = Describe("ClusterAutoscaler", func() {
 			},
 			ptr.To[int64](8188),
 		),
+		Entry(
+			"Dual-stack - IPv4 nodes network is restriction (with mutliple networks)",
+			&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						KubeControllerManager: &gardencorev1beta1.KubeControllerManagerConfig{
+							NodeCIDRMaskSize: ptr.To[int32](24),
+						},
+					},
+					Networking: &gardencorev1beta1.Networking{
+						Pods:  ptr.To("100.64.0.0/11"),
+						Nodes: ptr.To("10.250.0.0/20"),
+					},
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					Networking: &gardencorev1beta1.NetworkingStatus{
+						Pods:  []string{"100.96.0.0/11", "2001:db8:1::/48"},
+						Nodes: []string{"10.251.0.0/20", "2001:db8:1::/48"},
+					},
+				},
+			},
+			ptr.To[int64](8188),
+		),
+		Entry(
+			"Dual-stack - IPv6 pods network is restriction (with mutliple networks)",
+			&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						KubeControllerManager: &gardencorev1beta1.KubeControllerManagerConfig{
+							NodeCIDRMaskSize: ptr.To[int32](24),
+						},
+					},
+					Networking: &gardencorev1beta1.Networking{
+						Pods:  ptr.To("100.64.0.0/11"),
+						Nodes: ptr.To("10.250.0.0/20"),
+					},
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					Networking: &gardencorev1beta1.NetworkingStatus{
+						Pods:  []string{"100.96.0.0/11", "2001:db8:1::/56"},
+						Nodes: []string{"10.251.0.0/20", "2001:db8:1::/48"},
+					},
+				},
+			},
+			ptr.To[int64](256),
+		),
 	)
 })

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
@@ -357,7 +357,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 			ptr.To[int64](8188),
 		),
 		Entry(
-			"Dual-stack - IPv4 nodes network is restriction (with mutliple networks)",
+			"Dual-stack - IPv4 nodes network is restriction",
 			&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Kubernetes: gardencorev1beta1.Kubernetes{
@@ -366,8 +366,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 						},
 					},
 					Networking: &gardencorev1beta1.Networking{
-						Pods:  ptr.To("100.64.0.0/11"),
-						Nodes: ptr.To("10.250.0.0/20"),
+						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6, gardencorev1beta1.IPFamilyIPv4},
 					},
 				},
 				Status: gardencorev1beta1.ShootStatus{
@@ -377,10 +376,10 @@ var _ = Describe("ClusterAutoscaler", func() {
 					},
 				},
 			},
-			ptr.To[int64](8188),
+			ptr.To[int64](4094),
 		),
 		Entry(
-			"Dual-stack - IPv6 pods network is restriction (with mutliple networks)",
+			"Dual-stack - IPv4 pods network is restriction",
 			&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Kubernetes: gardencorev1beta1.Kubernetes{
@@ -389,18 +388,17 @@ var _ = Describe("ClusterAutoscaler", func() {
 						},
 					},
 					Networking: &gardencorev1beta1.Networking{
-						Pods:  ptr.To("100.64.0.0/11"),
-						Nodes: ptr.To("10.250.0.0/20"),
+						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6, gardencorev1beta1.IPFamilyIPv4},
 					},
 				},
 				Status: gardencorev1beta1.ShootStatus{
 					Networking: &gardencorev1beta1.NetworkingStatus{
-						Pods:  []string{"100.96.0.0/11", "2001:db8:1::/56"},
-						Nodes: []string{"10.251.0.0/20", "2001:db8:1::/48"},
+						Pods:  []string{"100.64.0.0/12", "2001:db8:1::/56"},
+						Nodes: []string{"10.250.0.0/16", "2001:db8:1::/56"},
 					},
 				},
 			},
-			ptr.To[int64](256),
+			ptr.To[int64](4096),
 		),
 	)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixes the calculation of the maximum number of nodes for cluster autoscaling for dual-stack shoots.
```
