### PR TITLE
docs: Introduce section headings for prepare and complete of credential rotation

### DIFF
--- a/docs/usage/shoot-operations/shoot_credentials_rotation.md
+++ b/docs/usage/shoot-operations/shoot_credentials_rotation.md
@@ -9,7 +9,7 @@ This page explains how the varieties of credentials can be rotated so that the c
 ### Cloud Provider Keys
 
 End-users must provide credentials such that Gardener and Kubernetes controllers can communicate with the respective cloud provider APIs in order to perform infrastructure operations.
-For example, Gardener uses them to setup and maintain the networks, security groups, subnets, etc., while the [cloud-controller-manager](https://kubernetes.io/docs/concepts/architecture/cloud-controller/) uses them to reconcile load balancers and routes, and the [CSI controller](https://kubernetes-csi.github.io/docs/) uses them to reconcile volumes and disks.
+For example, Gardener uses them to set up and maintain the networks, security groups, subnets, etc., while the [cloud-controller-manager](https://kubernetes.io/docs/concepts/architecture/cloud-controller/) uses them to reconcile load balancers and routes, and the [CSI controller](https://kubernetes-csi.github.io/docs/) uses them to reconcile volumes and disks.
 
 Depending on the cloud provider, the required [data keys of the `Secret` differ](../../../example/70-secret-provider.yaml).
 Please consult the documentation of the respective provider extension documentation to get to know the concrete data keys (e.g., [this document for AWS](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#provider-secret-data)).
@@ -102,8 +102,8 @@ This is the same certificate that is also contained in the `kubeconfig`'s `certi
 
 > `Shoot`s created with Gardener >= v1.45 have a dedicated client CA which verifies the legitimacy of client certificates. For older `Shoot`s, the client CA is equal to the cluster CA. With the first CA rotation, such clusters will get a dedicated client CA as well.
 
-All of the certificates are valid for 10 years.
-Since it requires adaptation for the consumers of the `Shoot`, there is no automatic rotation and **it is the responsibility of the end-user to regularly rotate the CA certificates.**
+All the certificates are valid for 10 years.
+Since it requires adaptation for the consumers of the `Shoot`, there is no automatic rotation, and **it is the responsibility of the end-user to regularly rotate the CA certificates.**
 
 The rotation happens in three stages (see also [GEP-18](../../proposals/18-shoot-CA-rotation.md) for the full details):
 
@@ -151,9 +151,9 @@ The Plutono instance is exposed via `Ingress` and accessible for end-users via b
 
 Those credentials are stored in a `Secret` with the name `<shoot-name>.monitoring` in the project namespace in the garden cluster and has multiple data keys:
 
-- `username`: the user name
+- `username`: the username
 - `password`: the password
-- `auth`: the user name with SHA-1 representation of the password
+- `auth`: the username with SHA-1 representation of the password
 
 **It is the responsibility of the end-user to regularly rotate those credentials.**
 In order to rotate the `password`, annotate the `Shoot` with `gardener.cloud/operation=rotate-observability-credentials`.
@@ -192,7 +192,7 @@ The old key is stored in a `Secret` with the name `<shoot-name>.ssh-keypair.old`
 This key is used to encrypt the data of `Secret` resources inside etcd (see [upstream Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)).
 
 The encryption key has no expiration date.
-There is no automatic rotation and **it is the responsibility of the end-user to regularly rotate the encryption key.**
+There is no automatic rotation, and **it is the responsibility of the end-user to regularly rotate the encryption key.**
 
 The rotation happens in three stages:
 
@@ -230,7 +230,7 @@ Those tokens are typically used by workload `Pod`s running inside the cluster in
 This also includes system components running in the `kube-system` namespace.
 
 The token signing key has no expiration date.
-Since it might require adaptation for the consumers of the `Shoot`, there is no automatic rotation and **it is the responsibility of the end-user to regularly rotate the signing key.**
+Since it might require adaptation for the consumers of the `Shoot`, there is no automatic rotation, and **it is the responsibility of the end-user to regularly rotate the signing key.**
 
 The rotation happens in three stages, similar to how the [CA certificates](#certificate-authorities) are rotated:
 

--- a/docs/usage/shoot-operations/shoot_credentials_rotation.md
+++ b/docs/usage/shoot-operations/shoot_credentials_rotation.md
@@ -38,6 +38,9 @@ Those include:
 
 While it is possible to rotate them one by one, there is also a convenient method to combine the rotation of all of those credentials.
 The rotation happens in two phases since it might be required to update some API clients (e.g., when CAs are rotated).
+
+### Prepare Rotation of All Credentials
+
 In order to start the rotation (first phase), you have to annotate the shoot with the `rotate-credentials-start` operation:
 
 ```bash
@@ -49,6 +52,8 @@ kubectl -n <shoot-namespace> annotate shoot <shoot-name> gardener.cloud/operatio
 
 Kindly consider the detailed descriptions below to learn how the rotation is performed and what your responsibilities are.
 Please note that all respective individual actions apply for this combined rotation as well (e.g., worker nodes are rolled out in the first phase).
+
+### Complete Rotation of All Credentials
 
 You can complete the rotation (second phase) by annotating the shoot with the `rotate-credentials-complete` operation:
 

--- a/docs/usage/shoot-operations/shoot_credentials_rotation.md
+++ b/docs/usage/shoot-operations/shoot_credentials_rotation.md
@@ -68,7 +68,7 @@ If the `.spec.kubernetes.enableStaticTokenKubeconfig` field is set to `true` (de
 This `Secret` is stored with the name `<shoot-name>.kubeconfig` in the project namespace in the garden cluster and has multiple data keys:
 
 - `kubeconfig`: the completed kubeconfig
-- `ca.crt`: the CA bundle for establishing trust to the API server (same as in the [Cluster CA bundle secret](#cluster-certificate-authority-bundle))
+- `ca.crt`: the CA bundle for establishing trust to the API server (same as in the [Cluster CA bundle secret](#certificate-authorities))
 
 > `Shoots` created with Gardener <= 0.28 used to have a `kubeconfig` based on a client certificate instead of a static token. With the first kubeconfig rotation, such clusters will get a static token as well.
 >


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:

This PR introduces two section headings about the respective phases of the Gardener-provided credential rotation.
As this change is part of fixing issue #10484 the heading for the preparation phase uses the same wording seen in the UI.

**Which issue(s) this PR fixes**:
Fixes #10484

**Special notes for your reviewer**:

The primary change is: [`4c0e5e4` (#10998)](https://github.com/gardener/gardener/pull/10998/commits/4c0e5e49dde41009e6c003de07e20d0265d749f1)

All other changes are spellchecker/IDE suggestions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
Improve shoot credential rotation documentation.
```
