### PR TITLE
🧹 No Longer Generate Empty `Secret` For `reconcile` `OperatingSystemConfig`s

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4020,7 +4020,7 @@ CloudConfig
 <em>(Optional)</em>
 <p>CloudConfig is a structure for containing the generated output for the given operating system
 config spec. It contains a reference to a secret as the result may contain confidential data.
-After Gardener v1.112, this will be only set of OperatingSystemConfigs with purpose &lsquo;provision&rsquo;.</p>
+After Gardener v1.112, this will be only set for OperatingSystemConfigs with purpose &lsquo;provision&rsquo;.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4019,7 +4019,8 @@ CloudConfig
 <td>
 <em>(Optional)</em>
 <p>CloudConfig is a structure for containing the generated output for the given operating system
-config spec. It contains a reference to a secret as the result may contain confidential data.</p>
+config spec. It contains a reference to a secret as the result may contain confidential data.
+After Gardener v1.112, this will be only set of OperatingSystemConfigs with purpose &lsquo;provision&rsquo;.</p>
 </td>
 </tr>
 </tbody>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -336,7 +336,7 @@ spec:
                 description: |-
                   CloudConfig is a structure for containing the generated output for the given operating system
                   config spec. It contains a reference to a secret as the result may contain confidential data.
-                  After Gardener v1.112, this will be only set of OperatingSystemConfigs with purpose 'provision'.
+                  After Gardener v1.112, this will be only set for OperatingSystemConfigs with purpose 'provision'.
                 properties:
                   secretRef:
                     description: SecretRef is a reference to a secret that contains

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -336,6 +336,7 @@ spec:
                 description: |-
                   CloudConfig is a structure for containing the generated output for the given operating system
                   config spec. It contains a reference to a secret as the result may contain confidential data.
+                  After Gardener v1.112, this will be only set of OperatingSystemConfigs with purpose 'provision'.
                 properties:
                   secretRef:
                     description: SecretRef is a reference to a secret that contains

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -120,9 +120,6 @@ func (r *reconciler) reconcile(
 		return reconcilerutils.ReconcileErr(err)
 	}
 
-	// For backwards-compatibility, we have to always create a secret since gardenlet expects to find it - even if the
-	// user data is nil/empty (which should always be the case when purpose=reconcile).
-	// https://github.com/gardener/gardener/blob/328e10d975c7b6caa5db139badcc42ac8f772d31/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go#L257-L259
 	secret, err := r.reconcileOSCResultSecret(ctx, osc, userData)
 	if err != nil {
 		_ = r.statusUpdater.Error(ctx, log, osc, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Could not apply secret for generated cloud config")
@@ -168,9 +165,6 @@ func (r *reconciler) restore(
 		return reconcilerutils.ReconcileErr(err)
 	}
 
-	// For backwards-compatibility, we have to always create a secret since gardenlet expects to find it - even if the
-	// user data is nil/empty (which should always be the case when purpose=reconcile).
-	// https://github.com/gardener/gardener/blob/328e10d975c7b6caa5db139badcc42ac8f772d31/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go#L257-L259
 	secret, err := r.reconcileOSCResultSecret(ctx, osc, userData)
 	if err != nil {
 		_ = r.statusUpdater.Error(ctx, log, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not apply secret for generated cloud config")
@@ -279,6 +273,14 @@ func (r *reconciler) migrate(
 }
 
 func (r *reconciler) reconcileOSCResultSecret(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, userData []byte) (*corev1.Secret, error) {
+	// For backwards-compatibility, we have to always create a secret since gardenlet expects to find it - even if the
+	// user data is nil/empty (which should always be the case when purpose=reconcile).
+	// https://github.com/gardener/gardener/blob/328e10d975c7b6caa5db139badcc42ac8f772d31/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go#L257-L259
+	// TODO(rfranzke): Activate the `if`-block after Gardener v1.112 has been released.
+	// if userData == nil {
+	// 	return nil, nil
+	// }
+
 	secret := &corev1.Secret{ObjectMeta: SecretObjectMetaForConfig(osc)}
 	if _, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, r.client, secret, func() error {
 		if secret.Data == nil {

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -200,7 +200,7 @@ type OperatingSystemConfigStatus struct {
 	ExtensionFiles []File `json:"extensionFiles,omitempty" patchStrategy:"merge" patchMergeKey:"path"`
 	// CloudConfig is a structure for containing the generated output for the given operating system
 	// config spec. It contains a reference to a secret as the result may contain confidential data.
-	// After Gardener v1.112, this will be only set of OperatingSystemConfigs with purpose 'provision'.
+	// After Gardener v1.112, this will be only set for OperatingSystemConfigs with purpose 'provision'.
 	// +optional
 	CloudConfig *CloudConfig `json:"cloudConfig,omitempty"`
 }

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -200,6 +200,7 @@ type OperatingSystemConfigStatus struct {
 	ExtensionFiles []File `json:"extensionFiles,omitempty" patchStrategy:"merge" patchMergeKey:"path"`
 	// CloudConfig is a structure for containing the generated output for the given operating system
 	// config spec. It contains a reference to a secret as the result may contain confidential data.
+	// After Gardener v1.112, this will be only set of OperatingSystemConfigs with purpose 'provision'.
 	// +optional
 	CloudConfig *CloudConfig `json:"cloudConfig,omitempty"`
 }

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -338,6 +338,7 @@ spec:
                 description: |-
                   CloudConfig is a structure for containing the generated output for the given operating system
                   config spec. It contains a reference to a secret as the result may contain confidential data.
+                  After Gardener v1.112, this will be only set of OperatingSystemConfigs with purpose 'provision'.
                 properties:
                   secretRef:
                     description: SecretRef is a reference to a secret that contains

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -338,7 +338,7 @@ spec:
                 description: |-
                   CloudConfig is a structure for containing the generated output for the given operating system
                   config spec. It contains a reference to a secret as the result may contain confidential data.
-                  After Gardener v1.112, this will be only set of OperatingSystemConfigs with purpose 'provision'.
+                  After Gardener v1.112, this will be only set for OperatingSystemConfigs with purpose 'provision'.
                 properties:
                   secretRef:
                     description: SecretRef is a reference to a secret that contains

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -974,7 +974,6 @@ var _ = Describe("OperatingSystemConfig", func() {
 						},
 						Original: Data{
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker1Name + "-77ac3",
-							SecretName:                  ptr.To("cc-" + expected[1].Name),
 							Object:                      worker1OSCOriginal,
 						},
 					},
@@ -986,7 +985,6 @@ var _ = Describe("OperatingSystemConfig", func() {
 						},
 						Original: Data{
 							GardenerNodeAgentSecretName: "gardener-node-agent-" + worker2Name + "-d9e53",
-							SecretName:                  ptr.To("cc-" + expected[3].Name),
 							Object:                      worker2OSCOriginal,
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
See https://github.com/gardener-community/hackathon/blob/main/2024-12_Schelklingen/README.md#-no-longer-generate-empty-secret-for-reconcile-operatingsystemconfigs for motivation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
