### PR TITLE
[node-agent] Perform hosts probing on `RegistryConfig.Hosts` change

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
@@ -58,7 +58,7 @@ func (r *Reconciler) ReconcileContainerdConfig(ctx context.Context, log logr.Log
 	return nil
 }
 
-// ReconcileContainerdRegistries configures changed registries for containerd and cleans up abandoned ones.
+// ReconcileContainerdRegistries configures desired registries for containerd and cleans up abandoned ones.
 // Registries without readiness probes are added synchronously and related errors are returned immediately.
 // Registries with configured readiness probes are added asynchronously and must be waited for by invoking the returned function.
 func (r *Reconciler) ReconcileContainerdRegistries(ctx context.Context, log logr.Logger, changes *operatingSystemConfigChanges) (func() error, error) {
@@ -295,7 +295,7 @@ func (r *Reconciler) ensureContainerdRegistries(ctx context.Context, log logr.Lo
 		registriesWithReadiness    []extensionsv1alpha1.RegistryConfig
 	)
 
-	for _, registryConfig := range changes.Containerd.Registries.Changed {
+	for _, registryConfig := range changes.Containerd.Registries.Desired {
 		if ptr.Deref(registryConfig.ReadinessProbe, false) {
 			registriesWithReadiness = append(registriesWithReadiness, registryConfig)
 		} else {
@@ -310,7 +310,7 @@ func (r *Reconciler) ensureContainerdRegistries(ctx context.Context, log logr.Lo
 			errChan <- err
 			return errChan
 		}
-		if err := changes.completedContainerdRegistriesChanged(registryConfig.Upstream); err != nil {
+		if err := changes.completedContainerdRegistriesDesired(registryConfig.Upstream); err != nil {
 			errChan <- err
 			return errChan
 		}
@@ -322,7 +322,7 @@ func (r *Reconciler) ensureContainerdRegistries(ctx context.Context, log logr.Lo
 			if err := addRegistryToContainerdFunc(ctx, log, registryConfig, r.FS); err != nil {
 				return err
 			}
-			return changes.completedContainerdRegistriesChanged(registryConfig.Upstream)
+			return changes.completedContainerdRegistriesDesired(registryConfig.Upstream)
 		})
 	}
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/osc_changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/osc_changes.go
@@ -61,7 +61,7 @@ type containerd struct {
 }
 
 type containerdRegistries struct {
-	Changed []extensionsv1alpha1.RegistryConfig `json:"changed,omitempty"`
+	Desired []extensionsv1alpha1.RegistryConfig `json:"desired,omitempty"`
 	Deleted []extensionsv1alpha1.RegistryConfig `json:"deleted,omitempty"`
 }
 
@@ -178,11 +178,11 @@ func (o *operatingSystemConfigChanges) completedContainerdConfigFileChange() err
 	return o.persist()
 }
 
-func (o *operatingSystemConfigChanges) completedContainerdRegistriesChanged(upstream string) error {
+func (o *operatingSystemConfigChanges) completedContainerdRegistriesDesired(upstream string) error {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 
-	o.Containerd.Registries.Changed = slices.DeleteFunc(o.Containerd.Registries.Changed, func(c extensionsv1alpha1.RegistryConfig) bool {
+	o.Containerd.Registries.Desired = slices.DeleteFunc(o.Containerd.Registries.Desired, func(c extensionsv1alpha1.RegistryConfig) bool {
 		return c.Upstream == upstream
 	})
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/osc_changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/osc_changes.go
@@ -61,7 +61,7 @@ type containerd struct {
 }
 
 type containerdRegistries struct {
-	Desired []extensionsv1alpha1.RegistryConfig `json:"desired,omitempty"`
+	Changed []extensionsv1alpha1.RegistryConfig `json:"changed,omitempty"`
 	Deleted []extensionsv1alpha1.RegistryConfig `json:"deleted,omitempty"`
 }
 
@@ -178,11 +178,11 @@ func (o *operatingSystemConfigChanges) completedContainerdConfigFileChange() err
 	return o.persist()
 }
 
-func (o *operatingSystemConfigChanges) completedContainerdRegistriesDesired(upstream string) error {
+func (o *operatingSystemConfigChanges) completedContainerdRegistriesChanged(upstream string) error {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 
-	o.Containerd.Registries.Desired = slices.DeleteFunc(o.Containerd.Registries.Desired, func(c extensionsv1alpha1.RegistryConfig) bool {
+	o.Containerd.Registries.Changed = slices.DeleteFunc(o.Containerd.Registries.Changed, func(c extensionsv1alpha1.RegistryConfig) bool {
 		return c.Upstream == upstream
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
There are cases where `RegistryConfig.Hosts` is changed, e.g. `CACerts` is added or rotated, the mirror `URL` is updated, etc. Is such cases the hosts probing should be performed to ensure that new configuration is valid.

**Which issue(s) this PR fixes**:
Part of [gardener-extension-registry-cache/issues/290](https://github.com/gardener/gardener-extension-registry-cache/issues/290)

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-node-agent` now performs host probing when `RegistryConfig.Hosts` changes.
```
