### PR TITLE
[provider-local]  Move `europe-docker.pkg.dev` registry config from init OSC to reconcile OSC

### DIFF
--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -81,12 +81,6 @@ func (e *ensurer) EnsureAdditionalProvisionFiles(_ context.Context, _ extensions
 			UpstreamHost: "localhost:5001",
 			MirrorHost:   "http://garden.local.gardener.cloud:5001",
 		},
-		// europe-docker.pkg.dev upstream is required for loading the Hyperkube image.
-		// Further registries are supposed to be added via the `EnsureCRIConfig` function (reconcile OSC).
-		{
-			UpstreamHost: "europe-docker.pkg.dev",
-			MirrorHost:   "http://garden.local.gardener.cloud:5008",
-		},
 		// Enable containerd to reach registry at garden.local.gardener.cloud:5001 via HTTP.
 		{
 			UpstreamHost: "garden.local.gardener.cloud:5001",
@@ -133,6 +127,12 @@ func (e *ensurer) EnsureCRIConfig(_ context.Context, _ extensionscontextwebhook.
 			Upstream: "garden.local.gardener.cloud:5001",
 			Server:   ptr.To("http://garden.local.gardener.cloud:5001"),
 			Hosts:    []extensionsv1alpha1.RegistryHost{{URL: "http://garden.local.gardener.cloud:5001"}},
+		},
+		// europe-docker.pkg.dev upstream is required for loading the Hyperkube image.
+		{
+			Upstream: "europe-docker.pkg.dev",
+			Server:   ptr.To("https://europe-docker.pkg.dev"),
+			Hosts:    []extensionsv1alpha1.RegistryHost{{URL: "http://garden.local.gardener.cloud:5008"}},
 		},
 	} {
 		// Only add registry when it is not already set in the OSC.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
If the `europe-docker.pkg.dev` registry config  is set in reconcile OSC, e.g. in the registry cache [create_enabled_delete_shoot_system_components](https://github.com/gardener/gardener-extension-registry-cache/blob/52e59975132a7313151552a257c1fa807741168b/test/e2e/cache/create_enabled_delete_shoot_system_components.go#L27) e2e test, the readiness probe is not performed and the following error is observed in the `gardener-node-agent` logs:
```
Dec 10 10:01:32 machine-shoot--local--local-local-6cffc-sqbdt gardener-node-agent[344]: time="2024-12-10T10:01:32Z" level=info msg="trying next host" error="failed to do request: Head \"http://10.4.105.197:5000/v2/gardener-project/releases/hyperkube/manifests/v1.31.1?ns=europe-docker.pkg.dev\": dial tcp 10.4.105.197:5000: i/o timeout" host="10.4.105.197:5000"
```
This PR moves the `europe-docker.pkg.dev` registry config from being a file in the init OSC to a registry config in the reconcile OSC. This can be done safely, as with #10831  the `Applying new or changed imageRef files` step is executed after `Applying containerd registries`.  This way extensions can overwrite `europe-docker.pkg.dev` registry config and the readiness probe will be respected.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/290

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
