### PR TITLE
[node-agent] Delete systemd unit files and drop-ins only if the unit has been created by node-agent

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -31,18 +31,18 @@ func init() {
 	decoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
 }
 
-func extractOSCFromSecret(secret *corev1.Secret) (*extensionsv1alpha1.OperatingSystemConfig, []byte, string, error) {
+func extractOSCFromSecret(secret *corev1.Secret) (*extensionsv1alpha1.OperatingSystemConfig, string, error) {
 	oscRaw, ok := secret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig]
 	if !ok {
-		return nil, nil, "", fmt.Errorf("no %s key found in OSC secret", nodeagentv1alpha1.DataKeyOperatingSystemConfig)
+		return nil, "", fmt.Errorf("no %s key found in OSC secret", nodeagentv1alpha1.DataKeyOperatingSystemConfig)
 	}
 
 	osc := &extensionsv1alpha1.OperatingSystemConfig{}
 	if err := runtime.DecodeInto(decoder, oscRaw, osc); err != nil {
-		return nil, nil, "", fmt.Errorf("unable to decode OSC from secret data key %s: %w", nodeagentv1alpha1.DataKeyOperatingSystemConfig, err)
+		return nil, "", fmt.Errorf("unable to decode OSC from secret data key %s: %w", nodeagentv1alpha1.DataKeyOperatingSystemConfig, err)
 	}
 
-	return osc, oscRaw, secret.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig], nil
+	return osc, secret.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig], nil
 }
 
 type operatingSystemConfigChanges struct {

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
@@ -23,38 +23,59 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pelletier/go-toml"
 	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/structuredmap"
 )
 
+var codec runtime.Codec
+
+func init() {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
+	ser := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, scheme, scheme, jsonserializer.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
+	versions := schema.GroupVersions([]schema.GroupVersion{nodeagentv1alpha1.SchemeGroupVersion, extensionsv1alpha1.SchemeGroupVersion})
+	codec = serializer.NewCodecFactory(scheme).CodecForVersions(ser, ser, versions, versions)
+}
+
 // ReconcileContainerdConfig sets required values of the given containerd configuration.
-func (r *Reconciler) ReconcileContainerdConfig(ctx context.Context, log logr.Logger, criConfig *extensionsv1alpha1.CRIConfig) error {
-	if !extensionsv1alpha1helper.HasContainerdConfiguration(criConfig) {
-		return nil
+func (r *Reconciler) ReconcileContainerdConfig(ctx context.Context, log logr.Logger, osc *extensionsv1alpha1.OperatingSystemConfig, oscRaw []byte) ([]byte, error) {
+	if !extensionsv1alpha1helper.HasContainerdConfiguration(osc.Spec.CRIConfig) {
+		return oscRaw, nil
 	}
 
 	if err := r.ensureContainerdConfigDirectories(); err != nil {
-		return fmt.Errorf("failed to ensure containerd config directories: %w", err)
+		return nil, fmt.Errorf("failed to ensure containerd config directories: %w", err)
 	}
 
 	if err := r.ensureContainerdDefaultConfig(ctx); err != nil {
-		return fmt.Errorf("failed to ensure containerd default config: %w", err)
+		return nil, fmt.Errorf("failed to ensure containerd default config: %w", err)
 	}
 
-	if err := r.ensureContainerdEnvironment(); err != nil {
-		return fmt.Errorf("failed to ensure containerd environment: %w", err)
+	if err := r.ensureContainerdConfiguration(log, osc.Spec.CRIConfig); err != nil {
+		return nil, fmt.Errorf("failed to ensure containerd config: %w", err)
 	}
 
-	if err := r.ensureContainerdConfiguration(log, criConfig); err != nil {
-		return fmt.Errorf("failed to ensure containerd config: %w", err)
+	// Ingest the containerd drop-in into the OSC to prevent side effects when containerd.service is changed by extensions too.
+	ingestContainerdEnvironmentDropIn(osc)
+
+	oscRawContainerd, err := runtime.Encode(codec, osc)
+	if err != nil {
+		return nil, fmt.Errorf("unable to encode OSC after ingesting containerd drop-in: %w", err)
 	}
 
-	return nil
+	return oscRawContainerd, nil
 }
 
 // ReconcileContainerdRegistries configures desired registries for containerd and cleans up abandoned ones.
@@ -81,11 +102,36 @@ func (r *Reconciler) ReconcileContainerdRegistries(ctx context.Context, log logr
 	}
 }
 
+// ingestContainerdEnvironmentDropIn ingests a drop-in to set the environment for the 'containerd' service.
+func ingestContainerdEnvironmentDropIn(osc *extensionsv1alpha1.OperatingSystemConfig) {
+	if osc.Spec.CRIConfig == nil {
+		return
+	}
+
+	unitDropIn := extensionsv1alpha1.DropIn{
+		Name: "30-env_config.conf",
+		Content: `[Service]
+Environment="PATH=` + extensionsv1alpha1.ContainerDRuntimeContainersBinFolder + `:` + os.Getenv("PATH") + `"
+`,
+	}
+
+	for i, unit := range osc.Spec.Units {
+		if unit.Name == v1beta1constants.OperatingSystemConfigUnitNameContainerDService {
+			osc.Spec.Units[i].DropIns = append(osc.Spec.Units[i].DropIns, unitDropIn)
+			return
+		}
+	}
+
+	osc.Spec.Units = append(osc.Spec.Units, extensionsv1alpha1.Unit{
+		Name:    v1beta1constants.OperatingSystemConfigUnitNameContainerDService,
+		DropIns: []extensionsv1alpha1.DropIn{unitDropIn},
+	})
+}
+
 const (
 	baseDir   = "/etc/containerd"
 	certsDir  = baseDir + "/certs.d"
 	configDir = baseDir + "/conf.d"
-	dropinDir = "/etc/systemd/system/containerd.service.d"
 )
 
 func (r *Reconciler) ensureContainerdConfigDirectories() error {
@@ -94,7 +140,6 @@ func (r *Reconciler) ensureContainerdConfigDirectories() error {
 		baseDir,
 		configDir,
 		certsDir,
-		dropinDir,
 	} {
 		if err := r.FS.MkdirAll(dir, defaultDirPermissions); err != nil {
 			return fmt.Errorf("failure for directory %q: %w", dir, err)
@@ -128,32 +173,6 @@ func (r *Reconciler) ensureContainerdDefaultConfig(ctx context.Context) error {
 	}
 
 	return r.FS.WriteFile(configFile, output, 0644)
-}
-
-// ensureContainerdEnvironment sets the environment for the 'containerd' service.
-func (r *Reconciler) ensureContainerdEnvironment() error {
-	var (
-		unitDropin = `[Service]
-Environment="PATH=` + extensionsv1alpha1.ContainerDRuntimeContainersBinFolder + `:` + os.Getenv("PATH") + `"
-`
-	)
-
-	containerdEnvFilePath := path.Join(dropinDir, "30-env_config.conf")
-	exists, err := r.FS.Exists(containerdEnvFilePath)
-	if err != nil {
-		return err
-	}
-
-	if exists {
-		return nil
-	}
-
-	err = r.FS.WriteFile(containerdEnvFilePath, []byte(unitDropin), 0644)
-	if err != nil {
-		return fmt.Errorf("unable to write unit dropin: %w", err)
-	}
-
-	return nil
 }
 
 // ensureContainerdConfiguration sets the configuration for containerd.

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -170,7 +170,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	)
 
 	log.Info("Persisting current operating system config as 'last-applied' file to the disk", "path", lastAppliedOperatingSystemConfigFilePath)
-	if err := r.FS.WriteFile(lastAppliedOperatingSystemConfigFilePath, oscRaw, 0644); err != nil {
+	if err := r.FS.WriteFile(lastAppliedOperatingSystemConfigFilePath, oscRaw, 0600); err != nil {
 		return reconcile.Result{}, fmt.Errorf("unable to write current OSC to file path %q: %w", lastAppliedOperatingSystemConfigFilePath, err)
 	}
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -105,8 +105,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	log.Info("Applying containerd configuration")
-	err = r.ReconcileContainerdConfig(ctx, log, osc)
-	if err != nil {
+	if err := r.ReconcileContainerdConfig(ctx, log, osc); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed reconciling containerd configuration: %w", err)
 	}
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -90,6 +90,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed extracting OSC from secret: %w", err)
 	}
 
+	log.Info("Applying containerd configuration")
+	oscRaw, err = r.ReconcileContainerdConfig(ctx, log, osc, oscRaw)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed reconciling containerd configuration: %w", err)
+	}
+
 	oscChanges, err := computeOperatingSystemConfigChanges(r.FS, osc)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed calculating the OSC changes: %w", err)
@@ -98,11 +104,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if node != nil && node.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig] == oscChecksum {
 		log.Info("Configuration on this node is up to date, nothing to be done")
 		return reconcile.Result{}, nil
-	}
-
-	log.Info("Applying containerd configuration")
-	if err := r.ReconcileContainerdConfig(ctx, log, osc.Spec.CRIConfig); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed reconciling containerd configuration: %w", err)
 	}
 
 	log.Info("Applying new or changed inline files")

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -436,7 +436,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/containerd/conf.d")
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d")
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", containerdConfigFileContent, 0644)
-		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.hub.docker.com\"\n\n[host.\"https://10.10.10.100:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n[host.\"https://10.10.10.200:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n", 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
 
@@ -452,6 +452,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit7.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit8.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit9.Name}},
+			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit1.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionStop, UnitNames: []string{unit2.Name}},
@@ -572,7 +573,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/containerd/conf.d")
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d")
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", containerdConfigFileContent, 0644)
-		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.hub.docker.com\"\n\n[host.\"https://10.10.10.100:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n[host.\"https://10.10.10.200:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n", 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
 

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -50,11 +50,11 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		containerdConfigFileContent string
 
-		file1, file2, file3, file4, file5, file6, file7, file8                                           extensionsv1alpha1.File
-		gnaUnit, unit1, unit2, unit3, unit4, unit5, unit5DropInsOnly, unit6, unit7, unit8, unit9, unit10 extensionsv1alpha1.Unit
-		cgroupDriver                                                                                     extensionsv1alpha1.CgroupDriverName
-		registryConfig1, registryConfig2                                                                 extensionsv1alpha1.RegistryConfig
-		pluginConfig1, pluginConfig2, pluginConfig3                                                      extensionsv1alpha1.PluginConfig
+		file1, file2, file3, file4, file5, file6, file7, file8                                                                                 extensionsv1alpha1.File
+		gnaUnit, unit1, unit2, unit3, unit4, unit5, unit5DropInsOnly, unit6, unit7, unit8, unit9, unit10, existingUnitDropIn, containerdDropIn extensionsv1alpha1.Unit
+		cgroupDriver                                                                                                                           extensionsv1alpha1.CgroupDriverName
+		registryConfig1, registryConfig2                                                                                                       extensionsv1alpha1.RegistryConfig
+		pluginConfig1, pluginConfig2, pluginConfig3                                                                                            extensionsv1alpha1.PluginConfig
 
 		operatingSystemConfig *extensionsv1alpha1.OperatingSystemConfig
 		oscRaw                []byte
@@ -304,6 +304,20 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			Name:      "containerd-initializer.service",
 			FilePaths: []string{file8.Path},
 		}
+		existingUnitDropIn = extensionsv1alpha1.Unit{
+			Name: "existing-unit.service",
+			DropIns: []extensionsv1alpha1.DropIn{{
+				Name:    "drop",
+				Content: "#unit11drop",
+			}},
+		}
+		containerdDropIn = extensionsv1alpha1.Unit{
+			Name: "containerd.service",
+			DropIns: []extensionsv1alpha1.DropIn{{
+				Name:    "extensionsdrop.conf",
+				Content: "#containerdextensionsdrop",
+			}},
+		}
 
 		cgroupDriver = "systemd"
 
@@ -351,13 +365,20 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			},
 			Status: extensionsv1alpha1.OperatingSystemConfigStatus{
 				ExtensionFiles: []extensionsv1alpha1.File{file2, file4, file6, file7},
-				ExtensionUnits: []extensionsv1alpha1.Unit{unit3, unit4, unit8, unit9},
+				ExtensionUnits: []extensionsv1alpha1.Unit{unit3, unit4, unit8, unit9, existingUnitDropIn},
 			},
 		}
 
 	})
 
 	JustBeforeEach(func() {
+		if operatingSystemConfig.Spec.CRIConfig != nil {
+			operatingSystemConfig.Status.ExtensionUnits = append(operatingSystemConfig.Status.ExtensionUnits, containerdDropIn)
+		}
+
+		Expect(fakeFS.WriteFile("/etc/systemd/system/existing-unit.service", []byte("#existingunit"), 0600)).To(Succeed())
+		Expect(fakeFS.WriteFile("/etc/systemd/system/existing-unit.service.d/existing-dropin.conf", []byte("#existingdropin"), 0600)).To(Succeed())
+
 		var err error
 		oscRaw, err = runtime.Encode(codec, operatingSystemConfig)
 		Expect(err).NotTo(HaveOccurred())
@@ -437,8 +458,12 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d")
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", containerdConfigFileContent, 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0600)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/"+containerdDropIn.DropIns[0].Name, containerdDropIn.DropIns[0].Content, 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.hub.docker.com\"\n\n[host.\"https://10.10.10.100:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n[host.\"https://10.10.10.200:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n", 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service", "#existingunit", 0600)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service.d/existing-dropin.conf", "#existingdropin", 0600)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+existingUnitDropIn.Name+".d/"+existingUnitDropIn.DropIns[0].Name, "#unit11drop", 0600)
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
@@ -453,6 +478,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit8.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit9.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{"containerd.service"}},
+			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{"existing-unit.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit1.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionStop, UnitNames: []string{unit2.Name}},
@@ -464,6 +490,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit8.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit9.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"containerd.service"}},
+			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"existing-unit.service"}},
 		))
 
 		By("Assert that bootstrap files have been deleted")
@@ -508,6 +535,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		// the content of file6 (belonging to unit8) is changed, so unit8 is restarting
 		// the content of file7 (belonging to unit9) is changed, so unit9 is restarting
 		// file1, unit3, and gardener-node-agent unit are unchanged, so unit3 is not restarting and cancel func is not called
+		// remove existingUnitDropIn, so the drop-in file should be removed, but the existing unit should not be affected
+		// remove containerd drop-in extension unit, the other containerd drop-in should not be affected
 		unit2.Enable = ptr.To(true)
 		unit2.Command = ptr.To(extensionsv1alpha1.CommandStart)
 		unit2.DropIns = []extensionsv1alpha1.DropIn{{Name: "dropdropdrop", Content: "#unit2drop"}}
@@ -574,8 +603,12 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d")
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", containerdConfigFileContent, 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0600)
+		test.AssertNoFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/"+containerdDropIn.DropIns[0].Name)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.hub.docker.com\"\n\n[host.\"https://10.10.10.100:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n[host.\"https://10.10.10.200:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n", 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service", "#existingunit", 0600)
+		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service.d/existing-dropin.conf", "#existingdropin", 0600)
+		test.AssertNoFileOnDisk(fakeFS, "/etc/systemd/system/"+existingUnitDropIn.Name+".d/"+existingUnitDropIn.DropIns[0].Name)
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
@@ -586,6 +619,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit7.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit8.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit9.Name}},
+			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDisable, UnitNames: []string{unit4.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDisable, UnitNames: []string{unit1.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionStop, UnitNames: []string{unit1.Name}},
@@ -597,6 +631,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit7.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit8.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit9.Name}},
+			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"containerd.service"}},
+			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"existing-unit.service"}},
 		))
 
 		By("Assert that cancel func has not been called")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
Currently `gardener-node-agent` always deletes a systemd unit file and the drop-in folder when the unit was deleted from OperatingSystemConfig.
While this correct for units which have been created by `gardener-node-agent`, it incorrectly deletes `*.service` file and the drop-in folder for units created by other parties (like default OS units). This can be the case if we use the unit to add additional drop-ins or in order to change the start command.

With this PR, unit file is deleted only if `Unit.Content` of the old unit is not nil. Otherwise, it keeps the unit file and does not stop the unit.
Additionally, GNA deletes only the drop-in files listed in previously applied OSC. The drop-in folder is only deleted if it is empty. 

**Which issue(s) this PR fixes**:
Fixes #10809 

**Special notes for your reviewer**:
/cc @rfranzke 

The PR supersedes #10918 (see https://github.com/gardener/gardener/pull/10918#issuecomment-2532333523).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
`gardener-node-agent` deletes unit files and drop-ins only if it created them previously.
```
