### PR TITLE
Improve Shoot DNS Admission error message

### DIFF
--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -334,13 +334,13 @@ func checkDefaultDomainFormat(a admission.Attributes, shoot *core.Shoot, project
 			if len(shoot.GenerateName) > 0 && (len(shoot.Name) == 0 || strings.HasPrefix(shoot.Name, shoot.GenerateName)) {
 				// Case where shoot name is generated or to be generated
 				if !strings.HasSuffix(*shootDomain, fmt.Sprintf(".%s.%s", project.Name, domain)) {
-					fieldErr := field.Invalid(field.NewPath("spec", "dns"), shoot.Name, "shoot with 'metadata.generateName' uses a default domain but does not match expected scheme: <random-subdomain>.<project-name>.<default-domain>")
+					fieldErr := field.Invalid(field.NewPath("spec", "dns"), shoot.Name, fmt.Sprintf("shoot with 'metadata.generateName' uses a default domain but does not match expected scheme: <random-subdomain>.<project-name>.<default-domain> (expected '.%s.%s' to be a suffix of '%s')", project.Name, domain, *shootDomain))
 					return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, field.ErrorList{fieldErr})
 				}
 				return nil
 			}
 			if *shootDomain != fmt.Sprintf("%s.%s.%s", shoot.Name, project.Name, domain) {
-				fieldErr := field.Invalid(field.NewPath("spec", "dns"), shoot.Name, "shoot uses a default domain but does not match expected scheme: <shoot-name>.<project-name>.<default-domain>")
+				fieldErr := field.Invalid(field.NewPath("spec", "dns"), shoot.Name, fmt.Sprintf("shoot uses a default domain but does not match expected scheme: <shoot-name>.<project-name>.<default-domain> (expected '%s.%s.%s', but got '%s')", shoot.Name, project.Name, domain, *shootDomain))
 				return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, field.ErrorList{fieldErr})
 			}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

Improve Shoot DNS Admission error message.

Previously, the error message let the user put everything together to understand what was actually wrong. Now, we simply include the expected value and provide what we got in comparison so that it is more obvious for users what was wrong.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add additional context to shoot admission DNS errors so that it is more obvious what should be changed.
```
