### PR TITLE
Use external version of `k8s.io/component-base/config.ClientConnectionConfiguration`

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -104,6 +104,8 @@ linters-settings:
         alias: utilfeature
       - pkg: k8s.io/component-base/config
         alias: componentbaseconfig
+      - pkg: k8s.io/component-base/config/([\w\d]+)
+        alias: componentbaseconfig$1
       - pkg: k8s.io/component-base/logs/api/v1
         alias: logsv1
       - pkg: sigs.k8s.io/controller-runtime/pkg/client/fake

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	baseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -610,7 +610,7 @@ func ComputeExpectedGardenletConfiguration(
 			APIVersion: "gardenlet.config.gardener.cloud/v1alpha1",
 		},
 		GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
-			ClientConnectionConfiguration: baseconfigv1alpha1.ClientConnectionConfiguration{
+			ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   100,
 				Burst: 130,
 			},
@@ -620,13 +620,13 @@ func ComputeExpectedGardenletConfiguration(
 			},
 		},
 		SeedClientConnection: &gardenletconfigv1alpha1.SeedClientConnection{
-			ClientConnectionConfiguration: baseconfigv1alpha1.ClientConnectionConfiguration{
+			ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   100,
 				Burst: 130,
 			},
 		},
 		ShootClientConnection: &gardenletconfigv1alpha1.ShootClientConnection{
-			ClientConnectionConfiguration: baseconfigv1alpha1.ClientConnectionConfiguration{
+			ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   25,
 				Burst: 50,
 			},
@@ -763,7 +763,7 @@ func ComputeExpectedGardenletConfiguration(
 				ConcurrentSyncs: &five,
 			},
 		},
-		LeaderElection: &baseconfigv1alpha1.LeaderElectionConfiguration{
+		LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 			LeaderElect:       ptr.To(true),
 			LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
 			RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
@@ -794,7 +794,7 @@ func ComputeExpectedGardenletConfiguration(
 				Port: 2729,
 			},
 		},
-		Debugging: &baseconfigv1alpha1.DebuggingConfiguration{
+		Debugging: &componentbaseconfigv1alpha1.DebuggingConfiguration{
 			EnableProfiling:           ptr.To(false),
 			EnableContentionProfiling: ptr.To(false),
 		},

--- a/cmd/gardener-admission-controller/app/app.go
+++ b/cmd/gardener-admission-controller/app/app.go
@@ -64,7 +64,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.AdmissionControllerCo
 		cfg.GardenClientConnection.Kubeconfig = kubeconfig
 	}
 
-	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.GardenClientConnection, nil, kubernetes.AuthTokenFile)
+	restConfig, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&cfg.GardenClientConnection, nil, kubernetes.AuthTokenFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -79,7 +79,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.ControllerManagerConf
 		cfg.GardenClientConnection.Kubeconfig = kubeconfig
 	}
 
-	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.GardenClientConnection, nil, kubernetes.AuthTokenFile)
+	restConfig, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&cfg.GardenClientConnection, nil, kubernetes.AuthTokenFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/gardener-extension-admission-local/app/app.go
+++ b/cmd/gardener-extension-admission-local/app/app.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,7 +86,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("error completing options: %w", err)
 			}
 
-			util.ApplyClientConnectionConfigurationToRESTConfig(&componentbaseconfig.ClientConnectionConfiguration{
+			util.ApplyClientConnectionConfigurationToRESTConfig(&componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   100.0,
 				Burst: 130,
 			}, restOpts.Completed().Config)

--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -218,7 +218,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 func getRESTConfig(ctx context.Context, log logr.Logger, fs afero.Afero, cfg *config.NodeAgentConfiguration) (*rest.Config, error) {
 	if len(cfg.ClientConnection.Kubeconfig) > 0 {
 		log.Info("Creating REST config from client configuration")
-		restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.ClientConnection, nil, kubernetes.AuthTokenFile)
+		restConfig, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&cfg.ClientConnection, nil, kubernetes.AuthTokenFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed getting REST config from client connection configuration: %w", err)
 		}

--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -80,7 +80,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.OperatorConfiguration
 		cfg.RuntimeClientConnection.Kubeconfig = kubeconfig
 	}
 
-	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.RuntimeClientConnection, nil, kubernetes.AuthTokenFile)
+	restConfig, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&cfg.RuntimeClientConnection, nil, kubernetes.AuthTokenFile)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.OperatorConfiguration
 	gardenClientMap, err := clientmapbuilder.
 		NewGardenClientMapBuilder().
 		WithRuntimeClient(mgr.GetClient()).
-		WithClientConnectionConfig(&cfg.VirtualClientConnection).
+		WithInternalClientConnectionConfig(&cfg.VirtualClientConnection).
 		WithGardenNamespace(v1beta1constants.GardenNamespace).
 		Build(mgr.GetLogger())
 	if err != nil {

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -78,7 +78,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.ResourceManagerConfig
 		cfg.SourceClientConnection.Kubeconfig = kubeconfig
 	}
 
-	sourceRESTConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.SourceClientConnection.ClientConnectionConfiguration, nil, kubernetes.AuthTokenFile)
+	sourceRESTConfig, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&cfg.SourceClientConnection.ClientConnectionConfiguration, nil, kubernetes.AuthTokenFile)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.ResourceManagerConfig
 		}
 
 		var err error
-		targetRESTConfig, err = kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.TargetClientConnection.ClientConnectionConfiguration, nil, kubernetes.AuthTokenFile)
+		targetRESTConfig, err = kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&cfg.TargetClientConnection.ClientConnectionConfiguration, nil, kubernetes.AuthTokenFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/gardener-scheduler/app/app.go
+++ b/cmd/gardener-scheduler/app/app.go
@@ -73,7 +73,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.SchedulerConfiguratio
 		cfg.ClientConnection.Kubeconfig = kubeconfig
 	}
 
-	restCfg, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.ClientConnection, nil, kubernetes.AuthTokenFile)
+	restCfg, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&cfg.ClientConnection, nil, kubernetes.AuthTokenFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -107,7 +107,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 	}
 
 	log.Info("Getting rest config for seed")
-	seedRESTConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.SeedClientConnection.ClientConnectionConfiguration, nil)
+	seedRESTConfig, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&cfg.SeedClientConnection.ClientConnectionConfiguration, nil)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func (g *garden) Start(ctx context.Context) error {
 	log := g.mgr.GetLogger()
 
 	log.Info("Getting rest config for garden")
-	gardenRESTConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&g.config.GardenClientConnection.ClientConnectionConfiguration, g.kubeconfigBootstrapResult.Kubeconfig)
+	gardenRESTConfig, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&g.config.GardenClientConnection.ClientConnectionConfiguration, g.kubeconfigBootstrapResult.Kubeconfig)
 	if err != nil {
 		return err
 	}
@@ -368,7 +368,7 @@ func (g *garden) Start(ctx context.Context) error {
 		NewShootClientMapBuilder().
 		WithGardenClient(gardenCluster.GetClient()).
 		WithSeedClient(g.mgr.GetClient()).
-		WithClientConnectionConfig(&g.config.ShootClientConnection.ClientConnectionConfiguration).
+		WithInternalClientConnectionConfig(&g.config.ShootClientConnection.ClientConnectionConfiguration).
 		Build(log)
 	if err != nil {
 		return fmt.Errorf("failed to build shoot ClientMap: %w", err)

--- a/extensions/pkg/util/clientset.go
+++ b/extensions/pkg/util/clientset.go
@@ -7,7 +7,7 @@ package util
 import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
@@ -29,7 +29,7 @@ var ApplyClientConnectionConfigurationToRESTConfig = kubernetes.ApplyClientConne
 
 // createRESTConfig creates a Config object for a rest client. If a clientConnection configuration object is passed
 // as well then the specified fields will be taken over as well.
-func createRESTConfig(clientConfig clientcmd.ClientConfig, clientConnection *componentbaseconfig.ClientConnectionConfiguration) (*rest.Config, error) {
+func createRESTConfig(clientConfig clientcmd.ClientConfig, clientConnection *componentbaseconfigv1alpha1.ClientConnectionConfiguration) (*rest.Config, error) {
 	config, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -128,9 +129,31 @@ func NewClientFromSecretObject(secret *corev1.Secret, fns ...ConfigFunc) (Interf
 	return nil, errors.New("the secret does not contain a field with name 'kubeconfig'")
 }
 
-// RESTConfigFromClientConnectionConfiguration creates a *rest.Config from a componentbaseconfig.ClientConnectionConfiguration and the configured kubeconfig.
+// RESTConfigFromInternalClientConnectionConfiguration creates a *rest.Config from a componentbaseconfig.ClientConnectionConfiguration and the configured kubeconfig.
 // Allowed fields are not considered unsupported if used in the kubeconfig.
-func RESTConfigFromClientConnectionConfiguration(cfg *componentbaseconfig.ClientConnectionConfiguration, kubeconfig []byte, allowedFields ...string) (*rest.Config, error) {
+// Deprecated: use RESTConfigFromClientConnectionConfiguration instead.
+// TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
+func RESTConfigFromInternalClientConnectionConfiguration(cfg *componentbaseconfig.ClientConnectionConfiguration, kubeconfig []byte, allowedFields ...string) (*rest.Config, error) {
+	return RESTConfigFromClientConnectionConfiguration(ConvertClientConnectionConfigurationToExternal(cfg), kubeconfig, allowedFields...)
+}
+
+// ConvertClientConnectionConfigurationToExternal converts a componentbaseconfig.ClientConnectionConfiguration to componentbaseconfigv1alpha1.ClientConnectionConfiguration.
+// This function is added for supporting the transition to the external version while dropping the internal version of config APIs.
+// Deprecated: use the external version of ClientConnectionConfiguration directly instead.
+// TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
+func ConvertClientConnectionConfigurationToExternal(cfg *componentbaseconfig.ClientConnectionConfiguration) *componentbaseconfigv1alpha1.ClientConnectionConfiguration {
+	return &componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+		Kubeconfig:         cfg.Kubeconfig,
+		AcceptContentTypes: cfg.AcceptContentTypes,
+		ContentType:        cfg.ContentType,
+		QPS:                cfg.QPS,
+		Burst:              cfg.Burst,
+	}
+}
+
+// RESTConfigFromClientConnectionConfiguration creates a *rest.Config from a componentbaseconfigv1alpha1.ClientConnectionConfiguration and the configured kubeconfig.
+// Allowed fields are not considered unsupported if used in the kubeconfig.
+func RESTConfigFromClientConnectionConfiguration(cfg *componentbaseconfigv1alpha1.ClientConnectionConfiguration, kubeconfig []byte, allowedFields ...string) (*rest.Config, error) {
 	var (
 		restConfig *rest.Config
 		err        error
@@ -407,7 +430,7 @@ func (d *FallbackClient) List(ctx context.Context, list client.ObjectList, opts 
 
 // ApplyClientConnectionConfigurationToRESTConfig applies the given client connection configurations to the given
 // REST config.
-func ApplyClientConnectionConfigurationToRESTConfig(clientConnection *componentbaseconfig.ClientConnectionConfiguration, rest *rest.Config) {
+func ApplyClientConnectionConfigurationToRESTConfig(clientConnection *componentbaseconfigv1alpha1.ClientConnectionConfiguration, rest *rest.Config) {
 	if clientConnection == nil {
 		return
 	}

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -130,7 +130,7 @@ func NewClientFromSecretObject(secret *corev1.Secret, fns ...ConfigFunc) (Interf
 }
 
 // RESTConfigFromInternalClientConnectionConfiguration creates a *rest.Config from a componentbaseconfig.ClientConnectionConfiguration and the configured kubeconfig.
-// Allowed fields are not considered unsupported if used in the kubeconfig.
+// It takes an optional list of additionally allowed kubeconfig fields.
 // Deprecated: use RESTConfigFromClientConnectionConfiguration instead.
 // TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
 func RESTConfigFromInternalClientConnectionConfiguration(cfg *componentbaseconfig.ClientConnectionConfiguration, kubeconfig []byte, allowedFields ...string) (*rest.Config, error) {
@@ -152,7 +152,7 @@ func ConvertClientConnectionConfigurationToExternal(cfg *componentbaseconfig.Cli
 }
 
 // RESTConfigFromClientConnectionConfiguration creates a *rest.Config from a componentbaseconfigv1alpha1.ClientConnectionConfiguration and the configured kubeconfig.
-// Allowed fields are not considered unsupported if used in the kubeconfig.
+// It takes an optional list of additionally allowed kubeconfig fields.
 func RESTConfigFromClientConnectionConfiguration(cfg *componentbaseconfigv1alpha1.ClientConnectionConfiguration, kubeconfig []byte, allowedFields ...string) (*rest.Config, error) {
 	var (
 		restConfig *rest.Config
@@ -191,7 +191,7 @@ func RESTConfigFromClientConnectionConfiguration(cfg *componentbaseconfigv1alpha
 }
 
 // RESTConfigFromKubeconfigFile returns a rest.Config from the bytes of a kubeconfig file.
-// Allowed fields are not considered unsupported if used in the kubeconfig.
+// It takes an optional list of additionally allowed kubeconfig fields.
 func RESTConfigFromKubeconfigFile(kubeconfigFile string, allowedFields ...string) (*rest.Config, error) {
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigFile},
@@ -206,7 +206,7 @@ func RESTConfigFromKubeconfigFile(kubeconfigFile string, allowedFields ...string
 }
 
 // RESTConfigFromKubeconfig returns a rest.Config from the bytes of a kubeconfig.
-// Allowed fields are not considered unsupported if used in the kubeconfig.
+// It takes an optional list of additionally allowed kubeconfig fields.
 func RESTConfigFromKubeconfig(kubeconfig []byte, allowedFields ...string) (*rest.Config, error) {
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
 	if err != nil {

--- a/pkg/client/kubernetes/clientmap/builder/garden_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/garden_builder.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/go-logr/logr"
 	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 )
 
@@ -18,7 +20,7 @@ import (
 // request and store clients for virtual gardens.
 type GardenClientMapBuilder struct {
 	runtimeClient          client.Client
-	clientConnectionConfig *componentbaseconfig.ClientConnectionConfiguration
+	clientConnectionConfig *componentbaseconfigv1alpha1.ClientConnectionConfiguration
 	gardenNamespace        string
 }
 
@@ -33,8 +35,15 @@ func (b *GardenClientMapBuilder) WithRuntimeClient(client client.Client) *Garden
 	return b
 }
 
+// WithInternalClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.
+// Deprecated: use WithClientConnectionConfig instead
+// TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
+func (b *GardenClientMapBuilder) WithInternalClientConnectionConfig(cfg *componentbaseconfig.ClientConnectionConfiguration) *GardenClientMapBuilder {
+	return b.WithClientConnectionConfig(kubernetes.ConvertClientConnectionConfigurationToExternal(cfg))
+}
+
 // WithClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.
-func (b *GardenClientMapBuilder) WithClientConnectionConfig(cfg *componentbaseconfig.ClientConnectionConfiguration) *GardenClientMapBuilder {
+func (b *GardenClientMapBuilder) WithClientConnectionConfig(cfg *componentbaseconfigv1alpha1.ClientConnectionConfiguration) *GardenClientMapBuilder {
 	b.clientConnectionConfig = cfg
 	return b
 }

--- a/pkg/client/kubernetes/clientmap/builder/garden_builder_test.go
+++ b/pkg/client/kubernetes/clientmap/builder/garden_builder_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -16,12 +16,12 @@ import (
 var _ = Describe("GardenClientMapBuilder", func() {
 	var (
 		fakeRuntimeClient      client.Client
-		clientConnectionConfig *componentbaseconfig.ClientConnectionConfiguration
+		clientConnectionConfig *componentbaseconfigv1alpha1.ClientConnectionConfiguration
 	)
 
 	BeforeEach(func() {
 		fakeRuntimeClient = fakeclient.NewClientBuilder().Build()
-		clientConnectionConfig = &componentbaseconfig.ClientConnectionConfiguration{}
+		clientConnectionConfig = &componentbaseconfigv1alpha1.ClientConnectionConfiguration{}
 	})
 
 	Describe("#WithRuntimeClient", func() {

--- a/pkg/client/kubernetes/clientmap/builder/shoot_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/shoot_builder.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/go-logr/logr"
 	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 )
 
@@ -19,7 +21,7 @@ import (
 type ShootClientMapBuilder struct {
 	gardenClient           client.Client
 	seedClient             client.Client
-	clientConnectionConfig *componentbaseconfig.ClientConnectionConfiguration
+	clientConnectionConfig *componentbaseconfigv1alpha1.ClientConnectionConfiguration
 }
 
 // NewShootClientMapBuilder constructs a new ShootClientMapBuilder.
@@ -39,8 +41,15 @@ func (b *ShootClientMapBuilder) WithSeedClient(client client.Client) *ShootClien
 	return b
 }
 
+// WithInternalClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.
+// Deprecated: use WithClientConnectionConfig instead
+// TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
+func (b *ShootClientMapBuilder) WithInternalClientConnectionConfig(cfg *componentbaseconfig.ClientConnectionConfiguration) *ShootClientMapBuilder {
+	return b.WithClientConnectionConfig(kubernetes.ConvertClientConnectionConfigurationToExternal(cfg))
+}
+
 // WithClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.
-func (b *ShootClientMapBuilder) WithClientConnectionConfig(cfg *componentbaseconfig.ClientConnectionConfiguration) *ShootClientMapBuilder {
+func (b *ShootClientMapBuilder) WithClientConnectionConfig(cfg *componentbaseconfigv1alpha1.ClientConnectionConfiguration) *ShootClientMapBuilder {
 	b.clientConnectionConfig = cfg
 	return b
 }

--- a/pkg/client/kubernetes/clientmap/builder/shoot_builder_test.go
+++ b/pkg/client/kubernetes/clientmap/builder/shoot_builder_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -17,13 +17,13 @@ var _ = Describe("ShootClientMapBuilder", func() {
 	var (
 		fakeGardenClient       client.Client
 		fakeSeedClient         client.Client
-		clientConnectionConfig *componentbaseconfig.ClientConnectionConfiguration
+		clientConnectionConfig *componentbaseconfigv1alpha1.ClientConnectionConfiguration
 	)
 
 	BeforeEach(func() {
 		fakeGardenClient = fakeclient.NewClientBuilder().Build()
 		fakeSeedClient = fakeclient.NewClientBuilder().Build()
-		clientConnectionConfig = &componentbaseconfig.ClientConnectionConfiguration{}
+		clientConnectionConfig = &componentbaseconfigv1alpha1.ClientConnectionConfiguration{}
 	})
 
 	Describe("#WithGardenClient", func() {

--- a/pkg/client/kubernetes/clientmap/garden_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/garden_clientmap.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,7 +40,7 @@ type GardenClientSetFactory struct {
 	// RuntimeClient is the runtime cluster client.
 	RuntimeClient client.Client
 	// ClientConnectionConfiguration is the configuration that will be used by created ClientSets.
-	ClientConnectionConfig componentbaseconfig.ClientConnectionConfiguration
+	ClientConnectionConfig componentbaseconfigv1alpha1.ClientConnectionConfiguration
 	// GardenNamespace is the namespace the virtual gardens run in. Defaults to `garden` if not set.
 	GardenNamespace string
 

--- a/pkg/client/kubernetes/clientmap/garden_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/garden_clientmap_test.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
@@ -38,7 +38,7 @@ var _ = Describe("GardenClientMap", func() {
 		cm                     ClientMap
 		key                    ClientSetKey
 		factory                *GardenClientSetFactory
-		clientConnectionConfig componentbaseconfig.ClientConnectionConfiguration
+		clientConnectionConfig componentbaseconfigv1alpha1.ClientConnectionConfiguration
 		clientOptions          client.Options
 
 		garden *operatorv1alpha1.Garden
@@ -63,7 +63,7 @@ var _ = Describe("GardenClientMap", func() {
 
 		key = keys.ForGarden(garden)
 
-		clientConnectionConfig = componentbaseconfig.ClientConnectionConfiguration{
+		clientConnectionConfig = componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 			Kubeconfig:         "/var/run/secrets/kubeconfig",
 			AcceptContentTypes: "application/vnd.kubernetes.protobuf;application/json",
 			ContentType:        "application/vnd.kubernetes.protobuf",

--- a/pkg/client/kubernetes/clientmap/shoot_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/shoot_clientmap.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -44,7 +44,7 @@ type ShootClientSetFactory struct {
 	// SeedClient is the seed cluster client.
 	SeedClient client.Client
 	// ClientConnectionConfiguration is the configuration that will be used by created ClientSets.
-	ClientConnectionConfig componentbaseconfig.ClientConnectionConfiguration
+	ClientConnectionConfig componentbaseconfigv1alpha1.ClientConnectionConfiguration
 
 	// log is a logger for logging entries related to creating Shoot ClientSets.
 	log logr.Logger

--- a/pkg/client/kubernetes/clientmap/shoot_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/shoot_clientmap_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -43,7 +43,7 @@ var _ = Describe("ShootClientMap", func() {
 		cm                     ClientMap
 		key                    ClientSetKey
 		factory                *ShootClientSetFactory
-		clientConnectionConfig componentbaseconfig.ClientConnectionConfiguration
+		clientConnectionConfig componentbaseconfigv1alpha1.ClientConnectionConfiguration
 		clientOptions          client.Options
 
 		shoot *gardencorev1beta1.Shoot
@@ -84,7 +84,7 @@ var _ = Describe("ShootClientMap", func() {
 
 		key = keys.ForShoot(shoot)
 
-		clientConnectionConfig = componentbaseconfig.ClientConnectionConfiguration{
+		clientConnectionConfig = componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 			Kubeconfig:         "/var/run/secrets/kubeconfig",
 			AcceptContentTypes: "application/vnd.kubernetes.protobuf;application/json",
 			ContentType:        "application/vnd.kubernetes.protobuf",

--- a/pkg/client/kubernetes/options.go
+++ b/pkg/client/kubernetes/options.go
@@ -10,7 +10,7 @@ import (
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -76,7 +76,7 @@ func WithRuntimeCache(runtimeCache cache.Cache) ConfigFunc {
 // WithClientConnectionOptions returns a ConfigFunc that transfers settings from
 // the passed ClientConnectionConfiguration.
 // The kubeconfig location in ClientConnectionConfiguration is disregarded, though!
-func WithClientConnectionOptions(cfg componentbaseconfig.ClientConnectionConfiguration) ConfigFunc {
+func WithClientConnectionOptions(cfg componentbaseconfigv1alpha1.ClientConnectionConfiguration) ConfigFunc {
 	return func(config *Config) error {
 		if config.restConfig == nil {
 			return errors.New("REST config must be set before setting connection options")

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -216,7 +216,7 @@ func GetCurrentCertificate(log logr.Logger, gardenKubeconfig []byte, gardenClien
 	}
 
 	// get a rest config from either the `gardenClientConnection.KubeconfigSecret` or from the fallback kubeconfig specified in `gardenClientConnection.Kubeconfig`
-	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&gardenClientConnection.ClientConnectionConfiguration, gardenKubeconfig)
+	restConfig, err := kubernetes.RESTConfigFromInternalClientConnectionConfiguration(&gardenClientConnection.ClientConnectionConfiguration, gardenKubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/virtual/cluster/reconciler.go
+++ b/pkg/operator/controller/virtual/cluster/reconciler.go
@@ -48,7 +48,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request Request) (reconcile.
 
 	if r.virtualCluster == nil {
 		log.Info("Instantiating cluster.Cluster object for virtual cluster")
-		kubernetesclient.ApplyClientConnectionConfigurationToRESTConfig(&r.VirtualClientConnection, restConfig)
+		kubernetesclient.ApplyClientConnectionConfigurationToRESTConfig(kubernetesclient.ConvertClientConnectionConfigurationToExternal(&r.VirtualClientConnection), restConfig)
 
 		virtualCluster, err := cluster.New(restConfig, func(opts *cluster.Options) {
 			opts.Scheme = operatorclient.VirtualScheme

--- a/test/e2e/gardenadm/common/client.go
+++ b/test/e2e/gardenadm/common/client.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	. "github.com/onsi/gomega"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
@@ -21,7 +21,7 @@ var RuntimeClient kubernetes.Interface
 
 // SetupRuntimeClient initializes the runtime client.
 func SetupRuntimeClient() {
-	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&componentbaseconfig.ClientConnectionConfiguration{Kubeconfig: os.Getenv("KUBECONFIG")}, nil, kubernetes.AuthTokenFile)
+	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&componentbaseconfigv1alpha1.ClientConnectionConfiguration{Kubeconfig: os.Getenv("KUBECONFIG")}, nil, kubernetes.AuthTokenFile)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	RuntimeClient, err = kubernetes.NewWithConfig(kubernetes.WithRESTConfig(restConfig), kubernetes.WithDisabledCachedClient())

--- a/test/e2e/operator/garden/common.go
+++ b/test/e2e/operator/garden/common.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,7 +39,7 @@ var (
 var _ = BeforeSuite(func() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 
-	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&componentbaseconfig.ClientConnectionConfiguration{Kubeconfig: os.Getenv("KUBECONFIG")}, nil, kubernetes.AuthTokenFile)
+	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&componentbaseconfigv1alpha1.ClientConnectionConfiguration{Kubeconfig: os.Getenv("KUBECONFIG")}, nil, kubernetes.AuthTokenFile)
 	Expect(err).NotTo(HaveOccurred())
 
 	runtimeClient, err = client.New(restConfig, client.Options{Scheme: operatorclient.RuntimeScheme})

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -75,7 +75,7 @@ func (f *GardenerFramework) BeforeEach() {
 	validateGardenerConfig(f.Config)
 	gardenClient, err := kubernetes.NewClientFromFile("", f.Config.GardenerKubeconfig,
 		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
-		kubernetes.WithClientConnectionOptions(componentbaseconfig.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
+		kubernetes.WithClientConnectionOptions(componentbaseconfigv1alpha1.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
 		kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
 		kubernetes.WithDisabledCachedClient(),
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

This is a prefactoring for https://github.com/gardener/gardener/issues/11043:

This PR starts using the external version of `k8s.io/component-base/config.ClientConnectionConfiguration` in client-related functions while maintaining another variant with the internal version (deprecated).
This will help with a smooth removal of the internal version of component config APIs with individual PRs per component.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11043

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
Client-related functions have been adapted to use the external version of `k8s.io/component-base/config.ClientConnectionConfiguration`. If you need a helper function for transitioning to the external version, use `pkg/client/kubernetes.ConvertClientConnectionConfigurationToExternal`.
```
