### PR TITLE
Use consistent import aliases for config APIs

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -167,8 +167,12 @@ linters-settings:
         alias: $1$2$3
       - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config
         alias: ${1}config
-      - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config/([\w\d]+)
+      - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config/([a-z]+)
         alias: $1$2
+      - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config/(v\d[\w\d]*)
+        alias: ${1}config${2}
+      - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config/(v\d[\w\d]*)/([a-z]+)
+        alias: $1$3
       - pkg: github.com/gardener/gardener/pkg/(\w+)/features
         alias: ${1}features
       - pkg: github.com/gardener/gardener/pkg/\w+/controller/([\w\d]+)

--- a/charts/gardener/gardenlet/test/chart_test.go
+++ b/charts/gardener/gardenlet/test/chart_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/component"
 	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -82,7 +82,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 		Expect(appsv1.AddToScheme(s)).To(Succeed())
 		// for unmarshal of GardenletConfiguration
 		Expect(gardenletconfig.AddToScheme(s)).To(Succeed())
-		Expect(gardenletv1alpha1.AddToScheme(s)).To(Succeed())
+		Expect(gardenletconfigv1alpha1.AddToScheme(s)).To(Succeed())
 		// for priority class
 		Expect(schedulingv1.AddToScheme(s)).To(Succeed())
 		// for ClusterRole and ClusterRoleBinding
@@ -136,7 +136,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 			bootstrapKubeconfig *corev1.SecretReference,
 			bootstrapKubeconfigSecret *corev1.SecretReference,
 			bootstrapKubeconfigContent *string,
-			seedConfig *gardenletv1alpha1.SeedConfig,
+			seedConfig *gardenletconfigv1alpha1.SeedConfig,
 			deploymentConfiguration *seedmanagement.GardenletDeployment,
 			imageVectorOverwrite *string,
 			componentImageVectorOverwrites *string,
@@ -356,7 +356,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 			"gardenlet-configmap": "gardenlet-configmap-800a10ff",
 		}, false),
 		Entry("verify that the SeedConfig is set in the component config Config Map", nil, nil, nil, nil, nil,
-			&gardenletv1alpha1.SeedConfig{
+			&gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "sweet-seed",
@@ -367,7 +367,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				},
 			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-7ca44afd"}, false),
 		Entry("verify deployment with two replica and three zones", nil, nil, nil, nil, nil,
-			&gardenletv1alpha1.SeedConfig{
+			&gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "sweet-seed",
@@ -382,7 +382,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				ReplicaCount: ptr.To[int32](2),
 			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-387e51e0"}, false),
 		Entry("verify deployment with only one replica", nil, nil, nil, nil, nil,
-			&gardenletv1alpha1.SeedConfig{
+			&gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "sweet-seed",
@@ -397,7 +397,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				ReplicaCount: ptr.To[int32](1),
 			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-387e51e0"}, false),
 		Entry("verify deployment with only one zone", nil, nil, nil, nil, nil,
-			&gardenletv1alpha1.SeedConfig{
+			&gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "sweet-seed",

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -32,7 +32,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -589,9 +589,9 @@ func ComputeExpectedGardenletConfiguration(
 	hasGardenClientConnectionKubeconfig, hasSeedClientConnectionKubeconfig bool,
 	bootstrapKubeconfig *corev1.SecretReference,
 	kubeconfigSecret *corev1.SecretReference,
-	seedConfig *gardenletv1alpha1.SeedConfig,
+	seedConfig *gardenletconfigv1alpha1.SeedConfig,
 	featureGates map[string]bool,
-) gardenletv1alpha1.GardenletConfiguration {
+) gardenletconfigv1alpha1.GardenletConfiguration {
 	var (
 		zero   = 0
 		one    = 1
@@ -604,57 +604,57 @@ func ComputeExpectedGardenletConfiguration(
 		lockObjectNamespace = "garden"
 	)
 
-	config := gardenletv1alpha1.GardenletConfiguration{
+	config := gardenletconfigv1alpha1.GardenletConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "GardenletConfiguration",
 			APIVersion: "gardenlet.config.gardener.cloud/v1alpha1",
 		},
-		GardenClientConnection: &gardenletv1alpha1.GardenClientConnection{
+		GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
 			ClientConnectionConfiguration: baseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   100,
 				Burst: 130,
 			},
-			KubeconfigValidity: &gardenletv1alpha1.KubeconfigValidity{
+			KubeconfigValidity: &gardenletconfigv1alpha1.KubeconfigValidity{
 				AutoRotationJitterPercentageMin: ptr.To[int32](70),
 				AutoRotationJitterPercentageMax: ptr.To[int32](90),
 			},
 		},
-		SeedClientConnection: &gardenletv1alpha1.SeedClientConnection{
+		SeedClientConnection: &gardenletconfigv1alpha1.SeedClientConnection{
 			ClientConnectionConfiguration: baseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   100,
 				Burst: 130,
 			},
 		},
-		ShootClientConnection: &gardenletv1alpha1.ShootClientConnection{
+		ShootClientConnection: &gardenletconfigv1alpha1.ShootClientConnection{
 			ClientConnectionConfiguration: baseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   25,
 				Burst: 50,
 			},
 		},
-		Controllers: &gardenletv1alpha1.GardenletControllerConfiguration{
-			BackupBucket: &gardenletv1alpha1.BackupBucketControllerConfiguration{
+		Controllers: &gardenletconfigv1alpha1.GardenletControllerConfiguration{
+			BackupBucket: &gardenletconfigv1alpha1.BackupBucketControllerConfiguration{
 				ConcurrentSyncs: &twenty,
 			},
-			BackupEntry: &gardenletv1alpha1.BackupEntryControllerConfiguration{
+			BackupEntry: &gardenletconfigv1alpha1.BackupEntryControllerConfiguration{
 				ConcurrentSyncs:          &twenty,
 				DeletionGracePeriodHours: &zero,
 			},
-			Bastion: &gardenletv1alpha1.BastionControllerConfiguration{
+			Bastion: &gardenletconfigv1alpha1.BastionControllerConfiguration{
 				ConcurrentSyncs: &twenty,
 			},
-			Gardenlet: &gardenletv1alpha1.GardenletObjectControllerConfiguration{
+			Gardenlet: &gardenletconfigv1alpha1.GardenletObjectControllerConfiguration{
 				SyncPeriod: &metav1.Duration{
 					Duration: 1 * time.Hour,
 				},
 			},
-			Seed: &gardenletv1alpha1.SeedControllerConfiguration{
+			Seed: &gardenletconfigv1alpha1.SeedControllerConfiguration{
 				SyncPeriod: &metav1.Duration{
 					Duration: 1 * time.Hour,
 				},
 				LeaseResyncSeconds:       ptr.To[int32](2),
 				LeaseResyncMissThreshold: ptr.To[int32](10),
 			},
-			Shoot: &gardenletv1alpha1.ShootControllerConfiguration{
+			Shoot: &gardenletconfigv1alpha1.ShootControllerConfiguration{
 				ReconcileInMaintenanceOnly: ptr.To(false),
 				RespectSyncPeriodOverwrite: ptr.To(false),
 				ConcurrentSyncs:            &twenty,
@@ -666,7 +666,7 @@ func ComputeExpectedGardenletConfiguration(
 				},
 				DNSEntryTTLSeconds: ptr.To[int64](120),
 			},
-			ManagedSeed: &gardenletv1alpha1.ManagedSeedControllerConfiguration{
+			ManagedSeed: &gardenletconfigv1alpha1.ManagedSeedControllerConfiguration{
 				ConcurrentSyncs: &five,
 				JitterUpdates:   ptr.To(false),
 				SyncPeriod: &metav1.Duration{
@@ -679,17 +679,17 @@ func ComputeExpectedGardenletConfiguration(
 					Duration: 300000000000,
 				},
 			},
-			ShootCare: &gardenletv1alpha1.ShootCareControllerConfiguration{
+			ShootCare: &gardenletconfigv1alpha1.ShootCareControllerConfiguration{
 				ConcurrentSyncs: &five,
 				SyncPeriod: &metav1.Duration{
 					Duration: 30 * time.Second,
 				},
-				StaleExtensionHealthChecks: &gardenletv1alpha1.StaleExtensionHealthChecks{
+				StaleExtensionHealthChecks: &gardenletconfigv1alpha1.StaleExtensionHealthChecks{
 					Enabled:   true,
 					Threshold: &metav1.Duration{Duration: 300000000000},
 				},
 				ManagedResourceProgressingThreshold: &metav1.Duration{Duration: time.Hour},
-				ConditionThresholds: []gardenletv1alpha1.ConditionThreshold{
+				ConditionThresholds: []gardenletconfigv1alpha1.ConditionThreshold{
 					{
 						Type: string(gardencorev1beta1.ShootAPIServerAvailable),
 						Duration: metav1.Duration{
@@ -723,11 +723,11 @@ func ComputeExpectedGardenletConfiguration(
 				},
 				WebhookRemediatorEnabled: ptr.To(false),
 			},
-			SeedCare: &gardenletv1alpha1.SeedCareControllerConfiguration{
+			SeedCare: &gardenletconfigv1alpha1.SeedCareControllerConfiguration{
 				SyncPeriod: &metav1.Duration{
 					Duration: 30 * time.Second,
 				},
-				ConditionThresholds: []gardenletv1alpha1.ConditionThreshold{
+				ConditionThresholds: []gardenletconfigv1alpha1.ConditionThreshold{
 					{
 						Type: string(gardencorev1beta1.SeedSystemComponentsHealthy),
 						Duration: metav1.Duration{
@@ -736,30 +736,30 @@ func ComputeExpectedGardenletConfiguration(
 					},
 				},
 			},
-			ShootState: &gardenletv1alpha1.ShootStateControllerConfiguration{
+			ShootState: &gardenletconfigv1alpha1.ShootStateControllerConfiguration{
 				ConcurrentSyncs: &five,
 				SyncPeriod:      &metav1.Duration{Duration: 6 * time.Hour},
 			},
-			TokenRequestorServiceAccount: &gardenletv1alpha1.TokenRequestorServiceAccountControllerConfiguration{
+			TokenRequestorServiceAccount: &gardenletconfigv1alpha1.TokenRequestorServiceAccountControllerConfiguration{
 				ConcurrentSyncs: &five,
 			},
-			TokenRequestorWorkloadIdentity: &gardenletv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{
+			TokenRequestorWorkloadIdentity: &gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{
 				ConcurrentSyncs: &five,
 			},
-			VPAEvictionRequirements: &gardenletv1alpha1.VPAEvictionRequirementsControllerConfiguration{
+			VPAEvictionRequirements: &gardenletconfigv1alpha1.VPAEvictionRequirementsControllerConfiguration{
 				ConcurrentSyncs: &five,
 			},
-			ControllerInstallation: &gardenletv1alpha1.ControllerInstallationControllerConfiguration{
+			ControllerInstallation: &gardenletconfigv1alpha1.ControllerInstallationControllerConfiguration{
 				ConcurrentSyncs: &twenty,
 			},
-			ControllerInstallationCare: &gardenletv1alpha1.ControllerInstallationCareControllerConfiguration{
+			ControllerInstallationCare: &gardenletconfigv1alpha1.ControllerInstallationCareControllerConfiguration{
 				ConcurrentSyncs: &twenty,
 				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
 			},
-			ControllerInstallationRequired: &gardenletv1alpha1.ControllerInstallationRequiredControllerConfiguration{
+			ControllerInstallationRequired: &gardenletconfigv1alpha1.ControllerInstallationRequiredControllerConfiguration{
 				ConcurrentSyncs: &one,
 			},
-			NetworkPolicy: &gardenletv1alpha1.NetworkPolicyControllerConfiguration{
+			NetworkPolicy: &gardenletconfigv1alpha1.NetworkPolicyControllerConfiguration{
 				ConcurrentSyncs: &five,
 			},
 		},
@@ -774,23 +774,23 @@ func ComputeExpectedGardenletConfiguration(
 		},
 		LogLevel:  logLevelInfo,
 		LogFormat: logFormatJson,
-		Logging: &gardenletv1alpha1.Logging{
+		Logging: &gardenletconfigv1alpha1.Logging{
 			Enabled: ptr.To(false),
-			Vali: &gardenletv1alpha1.Vali{
+			Vali: &gardenletconfigv1alpha1.Vali{
 				Enabled: ptr.To(false),
-				Garden: &gardenletv1alpha1.GardenVali{
-					Storage: &gardenletv1alpha1.DefaultCentralValiStorage,
+				Garden: &gardenletconfigv1alpha1.GardenVali{
+					Storage: &gardenletconfigv1alpha1.DefaultCentralValiStorage,
 				},
 			},
-			ShootEventLogging: &gardenletv1alpha1.ShootEventLogging{
+			ShootEventLogging: &gardenletconfigv1alpha1.ShootEventLogging{
 				Enabled: ptr.To(false),
 			},
 		},
-		Server: gardenletv1alpha1.ServerConfiguration{
-			HealthProbes: &gardenletv1alpha1.Server{
+		Server: gardenletconfigv1alpha1.ServerConfiguration{
+			HealthProbes: &gardenletconfigv1alpha1.Server{
 				Port: 2728,
 			},
-			Metrics: &gardenletv1alpha1.Server{
+			Metrics: &gardenletconfigv1alpha1.Server{
 				Port: 2729,
 			},
 		},
@@ -799,36 +799,36 @@ func ComputeExpectedGardenletConfiguration(
 			EnableContentionProfiling: ptr.To(false),
 		},
 		FeatureGates: featureGates,
-		Resources: &gardenletv1alpha1.ResourcesConfiguration{
+		Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 			Capacity: corev1.ResourceList{
 				"shoots": resource.MustParse("250"),
 			},
 		},
-		SNI: &gardenletv1alpha1.SNI{Ingress: &gardenletv1alpha1.SNIIngress{
+		SNI: &gardenletconfigv1alpha1.SNI{Ingress: &gardenletconfigv1alpha1.SNIIngress{
 			ServiceName: ptr.To(v1beta1constants.DefaultSNIIngressServiceName),
 			Namespace:   ptr.To(v1beta1constants.DefaultSNIIngressNamespace),
 			Labels:      map[string]string{"app": "istio-ingressgateway", "istio": "ingressgateway"},
 		}},
-		Monitoring: &gardenletv1alpha1.MonitoringConfig{
-			Shoot: &gardenletv1alpha1.ShootMonitoringConfig{
+		Monitoring: &gardenletconfigv1alpha1.MonitoringConfig{
+			Shoot: &gardenletconfigv1alpha1.ShootMonitoringConfig{
 				Enabled: ptr.To(true),
 			},
 		},
-		ETCDConfig: &gardenletv1alpha1.ETCDConfig{
-			BackupCompactionController: &gardenletv1alpha1.BackupCompactionController{
+		ETCDConfig: &gardenletconfigv1alpha1.ETCDConfig{
+			BackupCompactionController: &gardenletconfigv1alpha1.BackupCompactionController{
 				EnableBackupCompaction:    ptr.To(false),
 				EventsThreshold:           ptr.To[int64](1000000),
 				MetricsScrapeWaitDuration: &metav1.Duration{Duration: 60 * time.Second},
 				Workers:                   ptr.To[int64](3),
 			},
-			CustodianController: &gardenletv1alpha1.CustodianController{
+			CustodianController: &gardenletconfigv1alpha1.CustodianController{
 				Workers: ptr.To[int64](10),
 			},
-			ETCDController: &gardenletv1alpha1.ETCDController{
+			ETCDController: &gardenletconfigv1alpha1.ETCDController{
 				Workers: ptr.To[int64](50),
 			},
 		},
-		NodeToleration: &gardenletv1alpha1.NodeToleration{
+		NodeToleration: &gardenletconfigv1alpha1.NodeToleration{
 			DefaultNotReadyTolerationSeconds:    ptr.To[int64](60),
 			DefaultUnreachableTolerationSeconds: ptr.To[int64](60),
 		},
@@ -859,7 +859,7 @@ func VerifyGardenletComponentConfigConfigMap(
 	ctx context.Context,
 	c client.Client,
 	universalDecoder runtime.Decoder,
-	expectedGardenletConfig gardenletv1alpha1.GardenletConfiguration,
+	expectedGardenletConfig gardenletconfigv1alpha1.GardenletConfiguration,
 	expectedLabels map[string]string,
 	uniqueName string,
 ) {
@@ -885,7 +885,7 @@ func VerifyGardenletComponentConfigConfigMap(
 	// unmarshal Gardenlet Configuration from deployed Config Map
 	componentConfigYaml := componentConfigCm.Data["config.yaml"]
 	Expect(componentConfigYaml).ToNot(BeEmpty())
-	gardenletConfig := &gardenletv1alpha1.GardenletConfiguration{}
+	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
 	_, _, err := universalDecoder.Decode([]byte(componentConfigYaml), nil, gardenletConfig)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(*gardenletConfig).To(DeepEqual(expectedGardenletConfig))
@@ -910,7 +910,7 @@ func ComputeExpectedGardenletDeploymentSpec(
 	expectedLabels map[string]string,
 	imageVectorOverwrite, componentImageVectorOverwrites *string,
 	uniqueName map[string]string,
-	seedConfig *gardenletv1alpha1.SeedConfig,
+	seedConfig *gardenletconfigv1alpha1.SeedConfig,
 ) (
 	appsv1.DeploymentSpec,
 	error,

--- a/cmd/gardener-admission-controller/app/options.go
+++ b/cmd/gardener-admission-controller/app/options.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/admissioncontroller/apis/config"
-	admissioncontrollerv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	admissioncontrollervalidation "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/validation"
 )
 
@@ -25,7 +25,7 @@ func init() {
 	configScheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(
 		config.AddToScheme,
-		admissioncontrollerv1alpha1.AddToScheme,
+		admissioncontrollerconfigv1alpha1.AddToScheme,
 	)
 	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
 	configDecoder = serializer.NewCodecFactory(configScheme).UniversalDecoder()

--- a/cmd/gardener-controller-manager/app/options.go
+++ b/cmd/gardener-controller-manager/app/options.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	controllermanagervalidation "github.com/gardener/gardener/pkg/controllermanager/apis/config/validation"
 	"github.com/gardener/gardener/pkg/features"
 )
@@ -27,7 +27,7 @@ func init() {
 	configScheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(
 		config.AddToScheme,
-		controllermanagerv1alpha1.AddToScheme,
+		controllermanagerconfigv1alpha1.AddToScheme,
 	)
 	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
 	configDecoder = serializer.NewCodecFactory(configScheme).UniversalDecoder()

--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -45,7 +45,7 @@ import (
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/nodeagent"
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/nodeagent/bootstrap"
 	"github.com/gardener/gardener/pkg/nodeagent/controller"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
@@ -183,9 +183,9 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 		return err
 	}
 
-	log.Info("Creating directory for temporary files", "path", nodeagentv1alpha1.TempDir)
-	if err := fs.MkdirAll(nodeagentv1alpha1.TempDir, os.ModeDir); err != nil {
-		return fmt.Errorf("unable to create directory for temporary files %q: %w", nodeagentv1alpha1.TempDir, err)
+	log.Info("Creating directory for temporary files", "path", nodeagentconfigv1alpha1.TempDir)
+	if err := fs.MkdirAll(nodeagentconfigv1alpha1.TempDir, os.ModeDir); err != nil {
+		return fmt.Errorf("unable to create directory for temporary files %q: %w", nodeagentconfigv1alpha1.TempDir, err)
 	}
 
 	var machineName string
@@ -229,9 +229,9 @@ func getRESTConfig(ctx context.Context, log logr.Logger, fs afero.Afero, cfg *co
 	if !features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) {
 		log.Info("Creating REST config for gardener-node-agent access token")
 
-		migrate, err := fs.Exists(nodeagentv1alpha1.KubeconfigFilePath)
+		migrate, err := fs.Exists(nodeagentconfigv1alpha1.KubeconfigFilePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed checking whether kubeconfig file %q exists: %w", nodeagentv1alpha1.KubeconfigFilePath, err)
+			return nil, fmt.Errorf("failed checking whether kubeconfig file %q exists: %w", nodeagentconfigv1alpha1.KubeconfigFilePath, err)
 		}
 
 		if migrate {
@@ -247,7 +247,7 @@ func getRESTConfig(ctx context.Context, log logr.Logger, fs afero.Afero, cfg *co
 			}
 
 			log.Info("Deleting obsolete node-authorizer kubeconfig")
-			if err := fs.Remove(nodeagentv1alpha1.KubeconfigFilePath); err != nil {
+			if err := fs.Remove(nodeagentconfigv1alpha1.KubeconfigFilePath); err != nil {
 				return nil, fmt.Errorf("failed removing kubeconfig file: %w", err)
 			}
 		}
@@ -256,9 +256,9 @@ func getRESTConfig(ctx context.Context, log logr.Logger, fs afero.Afero, cfg *co
 
 	log.Info("Creating REST config for node-agent-authorizer")
 	// TODO(oliver-goetz): Remove this migration code when NodeAgentAuthorizer feature gate is removed.
-	migrate, err := fs.Exists(nodeagentv1alpha1.TokenFilePath)
+	migrate, err := fs.Exists(nodeagentconfigv1alpha1.TokenFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed checking whether token file %q exists: %w", nodeagentv1alpha1.TokenFilePath, err)
+		return nil, fmt.Errorf("failed checking whether token file %q exists: %w", nodeagentconfigv1alpha1.TokenFilePath, err)
 	}
 	if migrate {
 		log.Info("Start migrating from access token to node-agent-authorizer kubeconfig")
@@ -290,7 +290,7 @@ func getRESTConfig(ctx context.Context, log logr.Logger, fs afero.Afero, cfg *co
 		}
 
 		log.Info("Deleting obsolete access token file")
-		if err := fs.Remove(nodeagentv1alpha1.TokenFilePath); err != nil {
+		if err := fs.Remove(nodeagentconfigv1alpha1.TokenFilePath); err != nil {
 			return nil, fmt.Errorf("failed removing access token file: %w", err)
 		}
 	}
@@ -299,8 +299,8 @@ func getRESTConfig(ctx context.Context, log logr.Logger, fs afero.Afero, cfg *co
 }
 
 func getRESTConfigNodeAgentAuthorizer(ctx context.Context, log logr.Logger, fs afero.Afero, cfg *config.NodeAgentConfiguration) (*rest.Config, error) {
-	if kubeconfigExists, err := fs.Exists(nodeagentv1alpha1.KubeconfigFilePath); err != nil {
-		return nil, fmt.Errorf("failed checking whether kubeconfig file %q exists: %w", nodeagentv1alpha1.KubeconfigFilePath, err)
+	if kubeconfigExists, err := fs.Exists(nodeagentconfigv1alpha1.KubeconfigFilePath); err != nil {
+		return nil, fmt.Errorf("failed checking whether kubeconfig file %q exists: %w", nodeagentconfigv1alpha1.KubeconfigFilePath, err)
 	} else if !kubeconfigExists {
 		restConfig := &rest.Config{
 			Burst: int(cfg.ClientConnection.Burst),
@@ -311,15 +311,15 @@ func getRESTConfigNodeAgentAuthorizer(ctx context.Context, log logr.Logger, fs a
 			},
 			Host:            cfg.APIServer.Server,
 			TLSClientConfig: rest.TLSClientConfig{CAData: cfg.APIServer.CABundle},
-			BearerTokenFile: nodeagentv1alpha1.BootstrapTokenFilePath,
+			BearerTokenFile: nodeagentconfigv1alpha1.BootstrapTokenFilePath,
 		}
 
-		if bootstrapTokenExists, err := fs.Exists(nodeagentv1alpha1.BootstrapTokenFilePath); err != nil {
-			return nil, fmt.Errorf("failed checking whether bootstrap token file %q exists: %w", nodeagentv1alpha1.BootstrapTokenFilePath, err)
+		if bootstrapTokenExists, err := fs.Exists(nodeagentconfigv1alpha1.BootstrapTokenFilePath); err != nil {
+			return nil, fmt.Errorf("failed checking whether bootstrap token file %q exists: %w", nodeagentconfigv1alpha1.BootstrapTokenFilePath, err)
 		} else if !bootstrapTokenExists {
-			return nil, fmt.Errorf("unable to construct REST config (neither kubeconfig file %q nor bootstrap token file %q exist)", nodeagentv1alpha1.TokenFilePath, nodeagentv1alpha1.BootstrapTokenFilePath)
+			return nil, fmt.Errorf("unable to construct REST config (neither kubeconfig file %q nor bootstrap token file %q exist)", nodeagentconfigv1alpha1.TokenFilePath, nodeagentconfigv1alpha1.BootstrapTokenFilePath)
 		}
-		log.Info("Kubeconfig file does not exist, but bootstrap token file does - using it to request certificate", "path", nodeagentv1alpha1.BootstrapTokenFilePath)
+		log.Info("Kubeconfig file does not exist, but bootstrap token file does - using it to request certificate", "path", nodeagentconfigv1alpha1.BootstrapTokenFilePath)
 
 		machineName, err := fetchMachineNameFromFile(fs)
 		if err != nil {
@@ -331,15 +331,15 @@ func getRESTConfigNodeAgentAuthorizer(ctx context.Context, log logr.Logger, fs a
 		}
 	}
 
-	kubeconfig, err := fs.ReadFile(nodeagentv1alpha1.KubeconfigFilePath)
+	kubeconfig, err := fs.ReadFile(nodeagentconfigv1alpha1.KubeconfigFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed reading kubeconfig file %q: %w", nodeagentv1alpha1.KubeconfigFilePath, err)
+		return nil, fmt.Errorf("failed reading kubeconfig file %q: %w", nodeagentconfigv1alpha1.KubeconfigFilePath, err)
 	}
 
 	log.Info("Kubeconfig file exists, using it")
 	restConfig, err := kubernetes.RESTConfigFromKubeconfig(kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating REST config from kubeconfig file %q: %w", nodeagentv1alpha1.KubeconfigFilePath, err)
+		return nil, fmt.Errorf("failed creating REST config from kubeconfig file %q: %w", nodeagentconfigv1alpha1.KubeconfigFilePath, err)
 	}
 
 	return restConfig, nil
@@ -356,7 +356,7 @@ func getRESTConfigAccessToken(log logr.Logger, cfg *config.NodeAgentConfiguratio
 		},
 		Host:            cfg.APIServer.Server,
 		TLSClientConfig: rest.TLSClientConfig{CAData: cfg.APIServer.CABundle},
-		BearerTokenFile: nodeagentv1alpha1.TokenFilePath,
+		BearerTokenFile: nodeagentconfigv1alpha1.TokenFilePath,
 	}
 
 	if _, err := os.Stat(restConfig.BearerTokenFile); err != nil && !os.IsNotExist(err) {
@@ -366,11 +366,11 @@ func getRESTConfigAccessToken(log logr.Logger, cfg *config.NodeAgentConfiguratio
 		return restConfig, nil
 	}
 
-	if _, err := os.Stat(nodeagentv1alpha1.BootstrapTokenFilePath); err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("failed checking whether bootstrap token file %q exists: %w", nodeagentv1alpha1.BootstrapTokenFilePath, err)
+	if _, err := os.Stat(nodeagentconfigv1alpha1.BootstrapTokenFilePath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed checking whether bootstrap token file %q exists: %w", nodeagentconfigv1alpha1.BootstrapTokenFilePath, err)
 	} else if err == nil {
-		log.Info("Token file does not exist, but bootstrap token file does - using it to fetch access token", "path", nodeagentv1alpha1.BootstrapTokenFilePath)
-		restConfig.BearerTokenFile = nodeagentv1alpha1.BootstrapTokenFilePath
+		log.Info("Token file does not exist, but bootstrap token file does - using it to fetch access token", "path", nodeagentconfigv1alpha1.BootstrapTokenFilePath)
+		restConfig.BearerTokenFile = nodeagentconfigv1alpha1.BootstrapTokenFilePath
 
 		if err := fetchAccessToken(context.Background(), log, restConfig); err != nil {
 			return nil, fmt.Errorf("failed fetching access token: %w", err)
@@ -379,7 +379,7 @@ func getRESTConfigAccessToken(log logr.Logger, cfg *config.NodeAgentConfiguratio
 		return restConfig, nil
 	}
 
-	return nil, fmt.Errorf("unable to construct REST config (neither token file %q nor bootstrap token file %q exist)", nodeagentv1alpha1.TokenFilePath, nodeagentv1alpha1.BootstrapTokenFilePath)
+	return nil, fmt.Errorf("unable to construct REST config (neither token file %q nor bootstrap token file %q exist)", nodeagentconfigv1alpha1.TokenFilePath, nodeagentconfigv1alpha1.BootstrapTokenFilePath)
 }
 
 // TODO(oliver-goetz): Remove this function when NodeAgentAuthorizer feature gate is removed.
@@ -389,7 +389,7 @@ func fetchAccessToken(ctx context.Context, log logr.Logger, restConfig *rest.Con
 		return fmt.Errorf("unable to create client with bootstrap token: %w", err)
 	}
 
-	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: nodeagentv1alpha1.AccessSecretName, Namespace: metav1.NamespaceSystem}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: nodeagentconfigv1alpha1.AccessSecretName, Namespace: metav1.NamespaceSystem}}
 	log.Info("Reading access token secret", "secret", client.ObjectKeyFromObject(secret))
 	if err := c.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
 		return fmt.Errorf("failed fetching access token from API server: %w", err)
@@ -400,23 +400,23 @@ func fetchAccessToken(ctx context.Context, log logr.Logger, restConfig *rest.Con
 		return fmt.Errorf("secret key %q does not exist or empty", resourcesv1alpha1.DataKeyToken)
 	}
 
-	log.Info("Writing downloaded access token to disk", "path", nodeagentv1alpha1.TokenFilePath)
-	if err := os.MkdirAll(filepath.Dir(nodeagentv1alpha1.TokenFilePath), fs.ModeDir); err != nil {
-		return fmt.Errorf("unable to create directory %q: %w", filepath.Dir(nodeagentv1alpha1.TokenFilePath), err)
+	log.Info("Writing downloaded access token to disk", "path", nodeagentconfigv1alpha1.TokenFilePath)
+	if err := os.MkdirAll(filepath.Dir(nodeagentconfigv1alpha1.TokenFilePath), fs.ModeDir); err != nil {
+		return fmt.Errorf("unable to create directory %q: %w", filepath.Dir(nodeagentconfigv1alpha1.TokenFilePath), err)
 	}
-	if err := os.WriteFile(nodeagentv1alpha1.TokenFilePath, token, 0600); err != nil {
-		return fmt.Errorf("unable to write access token to %s: %w", nodeagentv1alpha1.TokenFilePath, err)
+	if err := os.WriteFile(nodeagentconfigv1alpha1.TokenFilePath, token, 0600); err != nil {
+		return fmt.Errorf("unable to write access token to %s: %w", nodeagentconfigv1alpha1.TokenFilePath, err)
 	}
 
 	log.Info("Token written to disk")
-	restConfig.BearerTokenFile = nodeagentv1alpha1.TokenFilePath
+	restConfig.BearerTokenFile = nodeagentconfigv1alpha1.TokenFilePath
 	return nil
 }
 
 func fetchMachineNameFromFile(fs afero.Afero) (string, error) {
-	machineName, err := fs.ReadFile(nodeagentv1alpha1.MachineNameFilePath)
+	machineName, err := fs.ReadFile(nodeagentconfigv1alpha1.MachineNameFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed reading machine-name file %q: %w", nodeagentv1alpha1.MachineNameFilePath, err)
+		return "", fmt.Errorf("failed reading machine-name file %q: %w", nodeagentconfigv1alpha1.MachineNameFilePath, err)
 	}
 	return strings.Split(string(machineName), "\n")[0], nil
 }
@@ -438,7 +438,7 @@ func fetchAndStoreMachineNameFromNode(ctx context.Context, restConfig *rest.Conf
 		return "", fmt.Errorf("unable to get machine name. No %q label on node %q", machineutils.MachineLabelKey, node.Name)
 	}
 
-	if err := fs.WriteFile(nodeagentv1alpha1.MachineNameFilePath, []byte(machineName), 0600); err != nil {
+	if err := fs.WriteFile(nodeagentconfigv1alpha1.MachineNameFilePath, []byte(machineName), 0600); err != nil {
 		return "", fmt.Errorf("error writing machine name to file %q: %w", nodeName, err)
 	}
 

--- a/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig.go
+++ b/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -35,12 +35,12 @@ type KubeletBootstrapKubeconfig struct {
 func (k *KubeletBootstrapKubeconfig) Start(_ context.Context) error {
 	k.Log.Info("Checking whether kubelet bootstrap kubeconfig needs to be created")
 
-	bootstrapToken, err := k.FS.ReadFile(nodeagentv1alpha1.BootstrapTokenFilePath)
+	bootstrapToken, err := k.FS.ReadFile(nodeagentconfigv1alpha1.BootstrapTokenFilePath)
 	if err != nil {
 		if !errors.Is(err, afero.ErrFileNotFound) {
-			return fmt.Errorf("failed checking whether bootstrap token file %q already exists: %w", nodeagentv1alpha1.BootstrapTokenFilePath, err)
+			return fmt.Errorf("failed checking whether bootstrap token file %q already exists: %w", nodeagentconfigv1alpha1.BootstrapTokenFilePath, err)
 		}
-		k.Log.Info("Bootstrap token file does not exist, nothing to be done", "path", nodeagentv1alpha1.BootstrapTokenFilePath)
+		k.Log.Info("Bootstrap token file does not exist, nothing to be done", "path", nodeagentconfigv1alpha1.BootstrapTokenFilePath)
 		return nil
 	}
 

--- a/cmd/gardener-node-agent/app/options.go
+++ b/cmd/gardener-node-agent/app/options.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	nodeagentvalidation "github.com/gardener/gardener/pkg/nodeagent/apis/config/validation"
 )
 
@@ -26,7 +26,7 @@ func init() {
 	configScheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(
 		config.AddToScheme,
-		nodeagentv1alpha1.AddToScheme,
+		nodeagentconfigv1alpha1.AddToScheme,
 	)
 	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
 	configDecoder = serializer.NewCodecFactory(configScheme).UniversalDecoder()

--- a/cmd/gardener-operator/app/options.go
+++ b/cmd/gardener-operator/app/options.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operator/apis/config"
-	operatorv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
+	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 	operatorvalidation "github.com/gardener/gardener/pkg/operator/apis/config/validation"
 )
 
@@ -26,7 +26,7 @@ func init() {
 	configScheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(
 		config.AddToScheme,
-		operatorv1alpha1.AddToScheme,
+		operatorconfigv1alpha1.AddToScheme,
 	)
 	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
 	configDecoder = serializer.NewCodecFactory(configScheme).UniversalDecoder()

--- a/cmd/gardener-resource-manager/app/options.go
+++ b/cmd/gardener-resource-manager/app/options.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
-	resourcemanagerv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
+	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
 	resourcemanagervalidation "github.com/gardener/gardener/pkg/resourcemanager/apis/config/validation"
 )
 
@@ -25,7 +25,7 @@ func init() {
 	configScheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(
 		config.AddToScheme,
-		resourcemanagerv1alpha1.AddToScheme,
+		resourcemanagerconfigv1alpha1.AddToScheme,
 	)
 	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
 	configDecoder = serializer.NewCodecFactory(configScheme).UniversalDecoder()

--- a/cmd/gardener-scheduler/app/options.go
+++ b/cmd/gardener-scheduler/app/options.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
-	schedulerv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
+	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
 	schedulervalidation "github.com/gardener/gardener/pkg/scheduler/apis/config/validation"
 )
 
@@ -26,7 +26,7 @@ func init() {
 	configScheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(
 		config.AddToScheme,
-		schedulerv1alpha1.AddToScheme,
+		schedulerconfigv1alpha1.AddToScheme,
 	)
 	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
 	configDecoder = serializer.NewCodecFactory(configScheme).UniversalDecoder()

--- a/cmd/gardenlet/app/options.go
+++ b/cmd/gardenlet/app/options.go
@@ -18,7 +18,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenletvalidation "github.com/gardener/gardener/pkg/gardenlet/apis/config/validation"
 )
 
@@ -28,7 +28,7 @@ func init() {
 	configScheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(
 		config.AddToScheme,
-		gardenletv1alpha1.AddToScheme,
+		gardenletconfigv1alpha1.AddToScheme,
 		gardencore.AddToScheme,
 		gardencorev1beta1.AddToScheme,
 	)

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -39,7 +39,7 @@ import (
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	mockcache "github.com/gardener/gardener/third_party/mock/controller-runtime/cache"
@@ -1725,7 +1725,7 @@ var _ = Describe("handler", func() {
 						var (
 							managedSeed1Namespace    string
 							shoot1, shoot2           *gardencorev1beta1.Shoot
-							seedConfig1, seedConfig2 *gardenletv1alpha1.SeedConfig
+							seedConfig1, seedConfig2 *gardenletconfigv1alpha1.SeedConfig
 							managedSeeds             []seedmanagementv1alpha1.ManagedSeed
 						)
 
@@ -1745,10 +1745,10 @@ var _ = Describe("handler", func() {
 								},
 								Spec: gardencorev1beta1.ShootSpec{SeedName: &seedName},
 							}
-							seedConfig1 = &gardenletv1alpha1.SeedConfig{
+							seedConfig1 = &gardenletconfigv1alpha1.SeedConfig{
 								SeedTemplate: gardencorev1beta1.SeedTemplate{},
 							}
-							seedConfig2 = &gardenletv1alpha1.SeedConfig{
+							seedConfig2 = &gardenletconfigv1alpha1.SeedConfig{
 								SeedTemplate: gardencorev1beta1.SeedTemplate{},
 							}
 							managedSeeds = []seedmanagementv1alpha1.ManagedSeed{
@@ -1758,7 +1758,7 @@ var _ = Describe("handler", func() {
 										Shoot: &seedmanagementv1alpha1.Shoot{Name: shoot1.Name},
 										Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 											Config: runtime.RawExtension{
-												Object: &gardenletv1alpha1.GardenletConfiguration{
+												Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 													SeedConfig: seedConfig1,
 												},
 											},
@@ -1771,7 +1771,7 @@ var _ = Describe("handler", func() {
 										Shoot: &seedmanagementv1alpha1.Shoot{Name: shoot2.Name},
 										Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 											Config: runtime.RawExtension{
-												Object: &gardenletv1alpha1.GardenletConfiguration{
+												Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 													SeedConfig: seedConfig2,
 												},
 											},
@@ -1816,7 +1816,7 @@ var _ = Describe("handler", func() {
 						It("should return an error because extracting the seed template failed", func() {
 							managedSeeds[1].Spec.Gardenlet = seedmanagementv1alpha1.GardenletConfig{
 								Config: runtime.RawExtension{
-									Object: &gardenletv1alpha1.GardenletConfiguration{
+									Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 										SeedConfig: nil,
 									},
 								},

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
@@ -34,7 +34,7 @@ import (
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/logger"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -108,8 +108,8 @@ var _ = Describe("graph", func() {
 		credentialsBinding1   *securityv1alpha1.CredentialsBinding
 		credentialsBindingRef = corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Namespace: "foobar", Name: "bazfoo"}
 
-		seedConfig1 *gardenletv1alpha1.SeedConfig
-		seedConfig2 *gardenletv1alpha1.SeedConfig
+		seedConfig1 *gardenletconfigv1alpha1.SeedConfig
+		seedConfig2 *gardenletconfigv1alpha1.SeedConfig
 
 		managedSeed1                  *seedmanagementv1alpha1.ManagedSeed
 		managedSeedBootstrapMode      = seedmanagementv1alpha1.BootstrapToken
@@ -304,7 +304,7 @@ var _ = Describe("graph", func() {
 			CredentialsRef: credentialsBindingRef,
 		}
 
-		seedConfig1 = &gardenletv1alpha1.SeedConfig{
+		seedConfig1 = &gardenletconfigv1alpha1.SeedConfig{
 			SeedTemplate: gardencorev1beta1.SeedTemplate{
 				Spec: gardencorev1beta1.SeedSpec{
 					Backup: &gardencorev1beta1.SeedBackup{
@@ -314,7 +314,7 @@ var _ = Describe("graph", func() {
 			},
 		}
 
-		seedConfig2 = &gardenletv1alpha1.SeedConfig{
+		seedConfig2 = &gardenletconfigv1alpha1.SeedConfig{
 			SeedTemplate: gardencorev1beta1.SeedTemplate{
 				Spec: gardencorev1beta1.SeedSpec{
 					Backup: &gardencorev1beta1.SeedBackup{
@@ -331,7 +331,7 @@ var _ = Describe("graph", func() {
 				Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 					Bootstrap: &managedSeedBootstrapMode,
 					Config: runtime.RawExtension{
-						Object: &gardenletv1alpha1.GardenletConfiguration{
+						Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 							SeedConfig: seedConfig1,
 						},
 					},
@@ -343,7 +343,7 @@ var _ = Describe("graph", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: seed1.Name, Namespace: "gardenletnamespace"},
 			Spec: seedmanagementv1alpha1.GardenletSpec{
 				Config: runtime.RawExtension{
-					Object: &gardenletv1alpha1.GardenletConfiguration{
+					Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 						SeedConfig: seedConfig2,
 					},
 				},

--- a/pkg/apis/operator/v1alpha1/conversion/conversion.go
+++ b/pkg/apis/operator/v1alpha1/conversion/conversion.go
@@ -5,29 +5,29 @@
 package conversion
 
 import (
-	admissioncontrollerv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 )
 
 // ConvertToAdmissionControllerResourceAdmissionConfiguration converts the given 'ResourceAdmissionConfiguration' into
-// a 'admissioncontrollerv1alpha1.ResourceAdmissionConfiguration' object.
+// a 'admissioncontrollerconfigv1alpha1.ResourceAdmissionConfiguration' object.
 // Note: References from the given config are re-used, the function does not deep copy the data.
-func ConvertToAdmissionControllerResourceAdmissionConfiguration(config *operatorv1alpha1.ResourceAdmissionConfiguration) *admissioncontrollerv1alpha1.ResourceAdmissionConfiguration {
+func ConvertToAdmissionControllerResourceAdmissionConfiguration(config *operatorv1alpha1.ResourceAdmissionConfiguration) *admissioncontrollerconfigv1alpha1.ResourceAdmissionConfiguration {
 	if config == nil {
 		return nil
 	}
 
-	out := &admissioncontrollerv1alpha1.ResourceAdmissionConfiguration{
+	out := &admissioncontrollerconfigv1alpha1.ResourceAdmissionConfiguration{
 		UnrestrictedSubjects: config.UnrestrictedSubjects,
-		OperationMode:        (*admissioncontrollerv1alpha1.ResourceAdmissionWebhookMode)(config.OperationMode),
+		OperationMode:        (*admissioncontrollerconfigv1alpha1.ResourceAdmissionWebhookMode)(config.OperationMode),
 	}
 
 	for _, limit := range config.Limits {
 		if config.Limits == nil {
-			out.Limits = make([]admissioncontrollerv1alpha1.ResourceLimit, 0, len(config.Limits))
+			out.Limits = make([]admissioncontrollerconfigv1alpha1.ResourceLimit, 0, len(config.Limits))
 		}
 
-		out.Limits = append(out.Limits, admissioncontrollerv1alpha1.ResourceLimit{
+		out.Limits = append(out.Limits, admissioncontrollerconfigv1alpha1.ResourceLimit{
 			APIGroups:   limit.APIGroups,
 			APIVersions: limit.APIVersions,
 			Resources:   limit.Resources,

--- a/pkg/apis/operator/v1alpha1/conversion/conversion_test.go
+++ b/pkg/apis/operator/v1alpha1/conversion/conversion_test.go
@@ -13,7 +13,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	admissioncontrollerv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	. "github.com/gardener/gardener/pkg/apis/operator/v1alpha1/conversion"
 )
@@ -49,16 +49,16 @@ var _ = Describe("conversion", func() {
 			admissionControllerConfig := ConvertToAdmissionControllerResourceAdmissionConfiguration(operatorConfig)
 
 			Expect(reflect.ValueOf(operatorConfig.UnrestrictedSubjects).Pointer()).To(Equal(reflect.ValueOf(admissionControllerConfig.UnrestrictedSubjects).Pointer()))
-			Expect(admissionControllerConfig.OperationMode).To(PointTo(Equal(admissioncontrollerv1alpha1.ResourceAdmissionWebhookMode("block"))))
+			Expect(admissionControllerConfig.OperationMode).To(PointTo(Equal(admissioncontrollerconfigv1alpha1.ResourceAdmissionWebhookMode("block"))))
 			Expect(admissionControllerConfig.Limits).To(HaveLen(len(operatorConfig.Limits)))
 			Expect(admissionControllerConfig.Limits).To(ConsistOf(
-				admissioncontrollerv1alpha1.ResourceLimit{
+				admissioncontrollerconfigv1alpha1.ResourceLimit{
 					APIGroups:   operatorConfig.Limits[0].APIGroups,
 					APIVersions: operatorConfig.Limits[0].APIVersions,
 					Resources:   operatorConfig.Limits[0].Resources,
 					Size:        operatorConfig.Limits[0].Size,
 				},
-				admissioncontrollerv1alpha1.ResourceLimit{
+				admissioncontrollerconfigv1alpha1.ResourceLimit{
 					APIGroups:   operatorConfig.Limits[1].APIGroups,
 					APIVersions: operatorConfig.Limits[1].APIVersions,
 					Resources:   operatorConfig.Limits[1].Resources,

--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	admissioncontrollerconfig "github.com/gardener/gardener/pkg/admissioncontroller/apis/config"
-	admissioncontrollerv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	admissioncontrollervalidation "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/validation"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
@@ -45,7 +45,7 @@ var gardenCoreScheme *runtime.Scheme
 func init() {
 	gardenCoreScheme = runtime.NewScheme()
 	utilruntime.Must(gardencoreinstall.AddToScheme(gardenCoreScheme))
-	utilruntime.Must(admissioncontrollerv1alpha1.AddToScheme(gardenCoreScheme))
+	utilruntime.Must(admissioncontrollerconfigv1alpha1.AddToScheme(gardenCoreScheme))
 }
 
 // ValidateGarden contains functionality for performing extended validation of a Garden object which is not possible

--- a/pkg/apis/seedmanagement/encoding/encoding.go
+++ b/pkg/apis/seedmanagement/encoding/encoding.go
@@ -17,7 +17,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 var scheme *runtime.Scheme
@@ -28,22 +28,22 @@ func init() {
 	utilruntime.Must(gardencore.AddToScheme(scheme))
 	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme))
 	utilruntime.Must(config.AddToScheme(scheme))
-	utilruntime.Must(gardenletv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(gardenletconfigv1alpha1.AddToScheme(scheme))
 }
 
 // DecodeGardenletConfiguration decodes the given raw extension into an external GardenletConfiguration version.
-func DecodeGardenletConfiguration(rawConfig *runtime.RawExtension, withDefaults bool) (*gardenletv1alpha1.GardenletConfiguration, error) {
-	if cfg, ok := rawConfig.Object.(*gardenletv1alpha1.GardenletConfiguration); ok {
+func DecodeGardenletConfiguration(rawConfig *runtime.RawExtension, withDefaults bool) (*gardenletconfigv1alpha1.GardenletConfiguration, error) {
+	if cfg, ok := rawConfig.Object.(*gardenletconfigv1alpha1.GardenletConfiguration); ok {
 		return cfg, nil
 	}
 	return DecodeGardenletConfigurationFromBytes(rawConfig.Raw, withDefaults)
 }
 
 // DecodeGardenletConfigurationFromBytes decodes the given byte slice into an external GardenletConfiguration version.
-func DecodeGardenletConfigurationFromBytes(bytes []byte, withDefaults bool) (*gardenletv1alpha1.GardenletConfiguration, error) {
-	cfg := &gardenletv1alpha1.GardenletConfiguration{
+func DecodeGardenletConfigurationFromBytes(bytes []byte, withDefaults bool) (*gardenletconfigv1alpha1.GardenletConfiguration, error) {
+	cfg := &gardenletconfigv1alpha1.GardenletConfiguration{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+			APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 			Kind:       "GardenletConfiguration",
 		},
 	}
@@ -54,7 +54,7 @@ func DecodeGardenletConfigurationFromBytes(bytes []byte, withDefaults bool) (*ga
 }
 
 // EncodeGardenletConfiguration encodes the given external GardenletConfiguration version into a raw extension.
-func EncodeGardenletConfiguration(cfg *gardenletv1alpha1.GardenletConfiguration) (*runtime.RawExtension, error) {
+func EncodeGardenletConfiguration(cfg *gardenletconfigv1alpha1.GardenletConfiguration) (*runtime.RawExtension, error) {
 	raw, err := EncodeGardenletConfigurationToBytes(cfg)
 	if err != nil {
 		return nil, err
@@ -66,8 +66,8 @@ func EncodeGardenletConfiguration(cfg *gardenletv1alpha1.GardenletConfiguration)
 }
 
 // EncodeGardenletConfigurationToBytes encodes the given external GardenletConfiguration version into a byte slice.
-func EncodeGardenletConfigurationToBytes(cfg *gardenletv1alpha1.GardenletConfiguration) ([]byte, error) {
-	encoder, err := getEncoder(gardenletv1alpha1.SchemeGroupVersion, runtime.ContentTypeJSON)
+func EncodeGardenletConfigurationToBytes(cfg *gardenletconfigv1alpha1.GardenletConfiguration) ([]byte, error) {
+	encoder, err := getEncoder(gardenletconfigv1alpha1.SchemeGroupVersion, runtime.ContentTypeJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/seedmanagement/encoding/encoding_test.go
+++ b/pkg/apis/seedmanagement/encoding/encoding_test.go
@@ -14,14 +14,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 var _ = Describe("Encoding", func() {
 	var (
-		config = &gardenletv1alpha1.GardenletConfiguration{
+		config = &gardenletconfigv1alpha1.GardenletConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
 		}
@@ -37,7 +37,7 @@ var _ = Describe("Encoding", func() {
 
 		It("should decode the raw config to a GardenletConfiguration with defaults", func() {
 			configWithDefaults := config.DeepCopy()
-			gardenletv1alpha1.SetObjectDefaults_GardenletConfiguration(configWithDefaults)
+			gardenletconfigv1alpha1.SetObjectDefaults_GardenletConfiguration(configWithDefaults)
 
 			result, err := DecodeGardenletConfiguration(&runtime.RawExtension{Raw: encode(config)}, true)
 

--- a/pkg/apis/seedmanagement/helper/helper_test.go
+++ b/pkg/apis/seedmanagement/helper/helper_test.go
@@ -14,7 +14,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 var _ = Describe("Helper", func() {
@@ -41,12 +41,12 @@ var _ = Describe("Helper", func() {
 		Context("#ExtractSeedSpec", func() {
 			It("should extract the seed spec when gardenlet is defined", func() {
 				managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{},
@@ -84,9 +84,9 @@ var _ = Describe("Helper", func() {
 
 			It("should fail when seedConfig is not defined in gardenlet config", func() {
 				managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
 					},

--- a/pkg/apis/seedmanagement/v1alpha1/conversions.go
+++ b/pkg/apis/seedmanagement/v1alpha1/conversions.go
@@ -17,7 +17,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
@@ -55,7 +55,7 @@ func Convert_seedmanagement_GardenletConfig_To_v1alpha1_GardenletConfig(in *seed
 		return err
 	}
 	if out.Config.Raw == nil && out.Config.Object != nil {
-		cfg, ok := out.Config.Object.(*gardenletv1alpha1.GardenletConfiguration)
+		cfg, ok := out.Config.Object.(*gardenletconfigv1alpha1.GardenletConfiguration)
 		if !ok {
 			return errors.New("unknown gardenlet config object type")
 		}
@@ -87,7 +87,7 @@ func Convert_seedmanagement_GardenletSpec_To_v1alpha1_GardenletSpec(in *seedmana
 		return err
 	}
 	if out.Config.Raw == nil && out.Config.Object != nil {
-		cfg, ok := out.Config.Object.(*gardenletv1alpha1.GardenletConfiguration)
+		cfg, ok := out.Config.Object.(*gardenletconfigv1alpha1.GardenletConfiguration)
 		if !ok {
 			return errors.New("unknown gardenlet config object type")
 		}

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
@@ -15,7 +15,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 var _ = Describe("Defaults", func() {
@@ -36,28 +36,28 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.Deployment).NotTo(BeNil())
 			Expect(obj.Spec.Config).To(Equal(runtime.RawExtension{
-				Object: &gardenletv1alpha1.GardenletConfiguration{
+				Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					Resources: &gardenletv1alpha1.ResourcesConfiguration{
+					Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 						Capacity: corev1.ResourceList{
 							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 						},
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{},
+					SeedConfig: &gardenletconfigv1alpha1.SeedConfig{},
 				}}))
 		})
 
 		It("should default gardenlet configuration, and backup secret reference if backup is specified", func() {
 			obj.Spec.Config = runtime.RawExtension{
-				Raw: encode(&gardenletv1alpha1.GardenletConfiguration{
+				Raw: encode(&gardenletconfigv1alpha1.GardenletConfiguration{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
+					SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 						SeedTemplate: gardencorev1beta1.SeedTemplate{
 							Spec: gardencorev1beta1.SeedSpec{
 								Backup: &gardencorev1beta1.SeedBackup{},
@@ -71,17 +71,17 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.Config).To(Equal(
 				runtime.RawExtension{
-					Object: &gardenletv1alpha1.GardenletConfiguration{
+					Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{
@@ -100,17 +100,17 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite already set values for GardenletConfiguration", func() {
 			obj.Spec.Config = runtime.RawExtension{
-				Raw: encode(&gardenletv1alpha1.GardenletConfiguration{
+				Raw: encode(&gardenletconfigv1alpha1.GardenletConfiguration{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					Resources: &gardenletv1alpha1.ResourcesConfiguration{
+					Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 						Capacity: corev1.ResourceList{
 							gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 						},
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
+					SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 						SeedTemplate: gardencorev1beta1.SeedTemplate{
 							Spec: gardencorev1beta1.SeedSpec{
 								Backup: &gardencorev1beta1.SeedBackup{
@@ -134,17 +134,17 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.Config).To(Equal(
 				runtime.RawExtension{
-					Object: &gardenletv1alpha1.GardenletConfiguration{
+					Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -13,7 +13,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 // SetDefaults_ManagedSeed sets default values for ManagedSeed objects.
@@ -89,9 +89,9 @@ func setDefaultsGardenletConfig(config *runtime.RawExtension, name, namespace st
 	// If the gardenlet config was decoded without errors to nil,
 	// initialize it with an empty config
 	if gardenletConfig == nil {
-		gardenletConfig = &gardenletv1alpha1.GardenletConfiguration{
+		gardenletConfig = &gardenletconfigv1alpha1.GardenletConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
 		}
@@ -105,10 +105,10 @@ func setDefaultsGardenletConfig(config *runtime.RawExtension, name, namespace st
 	*config = runtime.RawExtension{Object: gardenletConfig}
 }
 
-func setDefaultsGardenletConfiguration(obj *gardenletv1alpha1.GardenletConfiguration, name, namespace string) {
+func setDefaultsGardenletConfiguration(obj *gardenletconfigv1alpha1.GardenletConfiguration, name, namespace string) {
 	// Initialize resources
 	if obj.Resources == nil {
-		obj.Resources = &gardenletv1alpha1.ResourcesConfiguration{}
+		obj.Resources = &gardenletconfigv1alpha1.ResourcesConfiguration{}
 	}
 
 	// Set resources defaults
@@ -116,14 +116,14 @@ func setDefaultsGardenletConfiguration(obj *gardenletv1alpha1.GardenletConfigura
 
 	// Initialize seed config
 	if obj.SeedConfig == nil {
-		obj.SeedConfig = &gardenletv1alpha1.SeedConfig{}
+		obj.SeedConfig = &gardenletconfigv1alpha1.SeedConfig{}
 	}
 
 	// Set seed spec defaults
 	setDefaultsSeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace)
 }
 
-func setDefaultsResources(obj *gardenletv1alpha1.ResourcesConfiguration) {
+func setDefaultsResources(obj *gardenletconfigv1alpha1.ResourcesConfiguration) {
 	if _, ok := obj.Capacity[gardencorev1beta1.ResourceShoots]; !ok {
 		if obj.Capacity == nil {
 			obj.Capacity = make(corev1.ResourceList)

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
@@ -18,7 +18,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 const (
@@ -46,17 +46,17 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.Gardenlet.Deployment).NotTo(BeNil())
 			Expect(obj.Spec.Gardenlet.Config).To(Equal(runtime.RawExtension{
-				Object: &gardenletv1alpha1.GardenletConfiguration{
+				Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					Resources: &gardenletv1alpha1.ResourcesConfiguration{
+					Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 						Capacity: corev1.ResourceList{
 							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 						},
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{},
+					SeedConfig: &gardenletconfigv1alpha1.SeedConfig{},
 				}}))
 			Expect(obj.Spec.Gardenlet.Bootstrap).To(PointTo(Equal(BootstrapToken)))
 			Expect(obj.Spec.Gardenlet.MergeWithParent).To(PointTo(Equal(true)))
@@ -65,12 +65,12 @@ var _ = Describe("Defaults", func() {
 		It("should default gardenlet configuration, and backup secret reference if backup is specified", func() {
 			obj.Spec.Gardenlet = GardenletConfig{
 				Config: runtime.RawExtension{
-					Raw: encode(&gardenletv1alpha1.GardenletConfiguration{
+					Raw: encode(&gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{},
@@ -85,17 +85,17 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.Gardenlet.Config).To(Equal(
 				runtime.RawExtension{
-					Object: &gardenletv1alpha1.GardenletConfiguration{
+					Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{
@@ -115,17 +115,17 @@ var _ = Describe("Defaults", func() {
 		It("should not overwrite already set values for GardenletConfiguration", func() {
 			obj.Spec.Gardenlet = GardenletConfig{
 				Config: runtime.RawExtension{
-					Raw: encode(&gardenletv1alpha1.GardenletConfiguration{
+					Raw: encode(&gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{
@@ -152,17 +152,17 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.Gardenlet.Config).To(Equal(
 				runtime.RawExtension{
-					Object: &gardenletv1alpha1.GardenletConfiguration{
+					Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 							Capacity: corev1.ResourceList{
 								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
 							},
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{

--- a/pkg/apis/seedmanagement/v1alpha1/helper/helper.go
+++ b/pkg/apis/seedmanagement/v1alpha1/helper/helper.go
@@ -12,7 +12,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 // GetBootstrap returns the value of the given Bootstrap, or None if nil.
@@ -25,7 +25,7 @@ func GetBootstrap(bootstrap *seedmanagementv1alpha1.Bootstrap) seedmanagementv1a
 
 // ExtractSeedTemplateAndGardenletConfig extracts SeedTemplate and GardenletConfig from the given `managedSeed`.
 // An error is returned if either SeedTemplate of GardenletConfig is not specified.
-func ExtractSeedTemplateAndGardenletConfig(name string, config *runtime.RawExtension) (*gardencorev1beta1.SeedTemplate, *gardenletv1alpha1.GardenletConfiguration, error) {
+func ExtractSeedTemplateAndGardenletConfig(name string, config *runtime.RawExtension) (*gardencorev1beta1.SeedTemplate, *gardenletconfigv1alpha1.GardenletConfiguration, error) {
 	var err error
 
 	if config == nil {
@@ -33,7 +33,7 @@ func ExtractSeedTemplateAndGardenletConfig(name string, config *runtime.RawExten
 	}
 
 	// Decode gardenlet configuration
-	var gardenletConfig *gardenletv1alpha1.GardenletConfiguration
+	var gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration
 	gardenletConfig, err = encoding.DecodeGardenletConfiguration(config, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not decode gardenlet configuration: %w", err)

--- a/pkg/apis/seedmanagement/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/helper/helper_test.go
@@ -16,7 +16,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 var _ = Describe("Helper", func() {
@@ -39,9 +39,9 @@ var _ = Describe("Helper", func() {
 					},
 				},
 			}
-			config = &gardenletv1alpha1.GardenletConfiguration{
+			config = &gardenletconfigv1alpha1.GardenletConfiguration{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+					APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 					Kind:       "GardenletConfiguration",
 				},
 				LogLevel: "1234",
@@ -78,7 +78,7 @@ var _ = Describe("Helper", func() {
 			})
 
 			It("should return the template from `.spec.gardenlet.seedConfig.seedTemplate", func() {
-				config.SeedConfig = &gardenletv1alpha1.SeedConfig{SeedTemplate: *template}
+				config.SeedConfig = &gardenletconfigv1alpha1.SeedConfig{SeedTemplate: *template}
 				managedSeed.Spec.Gardenlet.Config = runtime.RawExtension{Raw: encode(config)}
 
 				seedTemplate, gardenletConfig, err := ExtractSeedTemplateAndGardenletConfig(managedSeed.Name, &managedSeed.Spec.Gardenlet.Config)

--- a/pkg/apis/seedmanagement/validation/gardenlet_test.go
+++ b/pkg/apis/seedmanagement/validation/gardenlet_test.go
@@ -20,7 +20,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 var _ = Describe("Gardenlet Validation Tests", func() {
@@ -265,7 +265,7 @@ var _ = Describe("Gardenlet Validation Tests", func() {
 
 			It("should forbid garden client connection kubeconfig if bootstrap is specified", func() {
 				gardenlet.Spec.Config = gardenletConfiguration(seedx,
-					&gardenletv1alpha1.GardenClientConnection{
+					&gardenletconfigv1alpha1.GardenClientConnection{
 						ClientConnectionConfiguration: v1alpha1.ClientConnectionConfiguration{
 							Kubeconfig: "foo",
 						},

--- a/pkg/apis/seedmanagement/validation/managedseed_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseed_test.go
@@ -20,7 +20,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 const (
@@ -294,7 +294,7 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 
 			It("should forbid garden client connection kubeconfig if bootstrap is specified", func() {
 				managedSeed.Spec.Gardenlet.Config = gardenletConfiguration(seedx,
-					&gardenletv1alpha1.GardenClientConnection{
+					&gardenletconfigv1alpha1.GardenClientConnection{
 						ClientConnectionConfiguration: v1alpha1.ClientConnectionConfiguration{
 							Kubeconfig: "foo",
 						},
@@ -312,7 +312,7 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 
 			It("should forbid garden client connection bootstrap kubeconfig and kubeconfig secret if bootstrap is not specified", func() {
 				managedSeed.Spec.Gardenlet.Config = gardenletConfiguration(seedx,
-					&gardenletv1alpha1.GardenClientConnection{
+					&gardenletconfigv1alpha1.GardenClientConnection{
 						BootstrapKubeconfig: &corev1.SecretReference{
 							Name:      name,
 							Namespace: namespace,
@@ -509,13 +509,13 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 	})
 })
 
-func gardenletConfiguration(seed *gardencorev1beta1.Seed, gcc *gardenletv1alpha1.GardenClientConnection) *gardenletv1alpha1.GardenletConfiguration {
-	return &gardenletv1alpha1.GardenletConfiguration{
+func gardenletConfiguration(seed *gardencorev1beta1.Seed, gcc *gardenletconfigv1alpha1.GardenClientConnection) *gardenletconfigv1alpha1.GardenletConfiguration {
+	return &gardenletconfigv1alpha1.GardenletConfiguration{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+			APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 			Kind:       "GardenletConfiguration",
 		},
-		SeedConfig: &gardenletv1alpha1.SeedConfig{
+		SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 			SeedTemplate: gardencorev1beta1.SeedTemplate{
 				ObjectMeta: seed.ObjectMeta,
 				Spec:       seed.Spec,

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/bootstrap_config.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/bootstrap_config.go
@@ -10,11 +10,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 )
 
-func getBootstrapConfiguration(worker gardencorev1beta1.Worker) (*nodeagentv1alpha1.BootstrapConfiguration, error) {
-	bootstrapConfiguration := &nodeagentv1alpha1.BootstrapConfiguration{}
+func getBootstrapConfiguration(worker gardencorev1beta1.Worker) (*nodeagentconfigv1alpha1.BootstrapConfiguration, error) {
+	bootstrapConfiguration := &nodeagentconfigv1alpha1.BootstrapConfiguration{}
 
 	var err error
 	bootstrapConfiguration.KubeletDataVolumeSize, err = getKubeletDataVolumeSize(worker)

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -16,12 +16,12 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
 	"github.com/gardener/gardener/pkg/features"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
 // PathInitScript is the path to the init script.
-const PathInitScript = nodeagentv1alpha1.BaseDir + "/init.sh"
+const PathInitScript = nodeagentconfigv1alpha1.BaseDir + "/init.sh"
 
 // Config returns the init units and the files for the OperatingSystemConfig for bootstrapping the gardener-node-agent.
 // ### !CAUTION! ###
@@ -32,7 +32,7 @@ const PathInitScript = nodeagentv1alpha1.BaseDir + "/init.sh"
 func Config(
 	worker gardencorev1beta1.Worker,
 	nodeAgentImage string,
-	config *nodeagentv1alpha1.NodeAgentConfiguration,
+	config *nodeagentconfigv1alpha1.NodeAgentConfiguration,
 ) (
 	[]extensionsv1alpha1.Unit,
 	[]extensionsv1alpha1.File,
@@ -45,7 +45,7 @@ func Config(
 
 	var (
 		nodeInitUnits = []extensionsv1alpha1.Unit{{
-			Name:    nodeagentv1alpha1.InitUnitName,
+			Name:    nodeagentconfigv1alpha1.InitUnitName,
 			Command: ptr.To(extensionsv1alpha1.CommandStart),
 			Enable:  ptr.To(true),
 			Content: ptr.To(`[Unit]
@@ -66,7 +66,7 @@ WantedBy=multi-user.target`),
 
 		nodeInitFiles = []extensionsv1alpha1.File{
 			{
-				Path:        nodeagentv1alpha1.BootstrapTokenFilePath,
+				Path:        nodeagentconfigv1alpha1.BootstrapTokenFilePath,
 				Permissions: ptr.To[uint32](0640),
 				Content: extensionsv1alpha1.FileContent{
 					Inline: &extensionsv1alpha1.FileContentInline{
@@ -96,7 +96,7 @@ WantedBy=multi-user.target`),
 	if features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) {
 		nodeInitFiles = append(nodeInitFiles,
 			extensionsv1alpha1.File{
-				Path:        nodeagentv1alpha1.MachineNameFilePath,
+				Path:        nodeagentconfigv1alpha1.MachineNameFilePath,
 				Permissions: ptr.To[uint32](0640),
 				Content: extensionsv1alpha1.FileContent{
 					Inline: &extensionsv1alpha1.FileContentInline{
@@ -144,8 +144,8 @@ func generateInitScript(nodeAgentImage string) ([]byte, error) {
 	var initScript bytes.Buffer
 	if err := initScriptTpl.Execute(&initScript, map[string]any{
 		"image":           nodeAgentImage,
-		"binaryDirectory": nodeagentv1alpha1.BinaryDir,
-		"configFile":      nodeagentv1alpha1.ConfigFilePath,
+		"binaryDirectory": nodeagentconfigv1alpha1.BinaryDir,
+		"configFile":      nodeagentconfigv1alpha1.ConfigFilePath,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/nodeinit"
 	nodeagentcomponent "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
 	"github.com/gardener/gardener/pkg/features"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
@@ -30,7 +30,7 @@ var _ = Describe("Init", func() {
 			worker gardencorev1beta1.Worker
 			image  = "gna-repo:gna-tag"
 
-			config            *nodeagentv1alpha1.NodeAgentConfiguration
+			config            *nodeagentconfigv1alpha1.NodeAgentConfiguration
 			oscSecretName     = "osc-secret-name"
 			apiServerURL      = "https://localhost"
 			caBundle          = []byte("cluster-ca")
@@ -48,7 +48,7 @@ var _ = Describe("Init", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(units).To(ConsistOf(extensionsv1alpha1.Unit{
-					Name:    nodeagentv1alpha1.InitUnitName,
+					Name:    nodeagentconfigv1alpha1.InitUnitName,
 					Command: ptr.To(extensionsv1alpha1.CommandStart),
 					Enable:  ptr.To(true),
 					Content: ptr.To(`[Unit]

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/features"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -236,8 +236,8 @@ func (o *operatingSystemConfig) Restore(ctx context.Context, shootState *gardenc
 func (o *operatingSystemConfig) reconcile(ctx context.Context, reconcileFn func(deployer) error) error {
 	if !features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) {
 		if err := gardenerutils.
-			NewShootAccessSecret(nodeagentv1alpha1.AccessSecretName, o.values.Namespace).
-			WithTargetSecret(nodeagentv1alpha1.AccessSecretName, metav1.NamespaceSystem).
+			NewShootAccessSecret(nodeagentconfigv1alpha1.AccessSecretName, o.values.Namespace).
+			WithTargetSecret(nodeagentconfigv1alpha1.AccessSecretName, metav1.NamespaceSystem).
 			WithTokenExpirationDuration("720h").
 			Reconcile(ctx, o.client); err != nil {
 			return err

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer"
 	"github.com/gardener/gardener/pkg/extensions"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -92,7 +92,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 			valitailEnabled         = false
 
 			//nolint:unparam
-			initConfigFn = func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentv1alpha1.NodeAgentConfiguration) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
+			initConfigFn = func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentconfigv1alpha1.NodeAgentConfiguration) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 				return []extensionsv1alpha1.Unit{
 						{Name: worker.Name},
 						{
@@ -208,7 +208,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				initUnits, initFiles, _ := initConfigFn(
 					worker,
 					imagesCopy["gardener-node-agent"].String(),
-					&nodeagentv1alpha1.NodeAgentConfiguration{APIServer: nodeagentv1alpha1.APIServer{
+					&nodeagentconfigv1alpha1.NodeAgentConfiguration{APIServer: nodeagentconfigv1alpha1.APIServer{
 						Server:   apiServerURL,
 						CABundle: []byte(*caBundle),
 					}},
@@ -597,7 +597,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 			It("should exclude the bootstrap token file if purpose is not provision", func() {
 				bootstrapTokenFile := extensionsv1alpha1.File{Path: "/var/lib/gardener-node-agent/credentials/bootstrap-token"}
-				initConfigFnWithBootstrapToken := func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentv1alpha1.NodeAgentConfiguration) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
+				initConfigFnWithBootstrapToken := func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentconfigv1alpha1.NodeAgentConfiguration) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 					units, files, err := initConfigFn(worker, nodeAgentImage, config)
 					return units, append(files, bootstrapTokenFile), err
 				}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
 	"github.com/gardener/gardener/pkg/features"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -29,7 +29,7 @@ var _ = Describe("Component", func() {
 		kubernetesVersion          = semver.MustParse("1.2.3")
 		apiServerURL               = "https://localhost"
 		caBundle                   = []byte("ca-bundle")
-		additionalTokenSyncConfigs = []nodeagentv1alpha1.TokenSecretSyncConfig{{
+		additionalTokenSyncConfigs = []nodeagentconfigv1alpha1.TokenSecretSyncConfig{{
 			SecretName: "gardener-valitail",
 			Path:       "/var/lib/valitail/auth-token",
 		}}
@@ -110,18 +110,18 @@ WantedBy=multi-user.target`))
 
 	Describe("#ComponentConfig", func() {
 		It("should return the expected result", func() {
-			Expect(ComponentConfig(oscSecretName, kubernetesVersion, apiServerURL, caBundle, additionalTokenSyncConfigs)).To(Equal(&nodeagentv1alpha1.NodeAgentConfiguration{
-				APIServer: nodeagentv1alpha1.APIServer{
+			Expect(ComponentConfig(oscSecretName, kubernetesVersion, apiServerURL, caBundle, additionalTokenSyncConfigs)).To(Equal(&nodeagentconfigv1alpha1.NodeAgentConfiguration{
+				APIServer: nodeagentconfigv1alpha1.APIServer{
 					Server:   apiServerURL,
 					CABundle: caBundle,
 				},
-				Controllers: nodeagentv1alpha1.ControllerConfiguration{
-					OperatingSystemConfig: nodeagentv1alpha1.OperatingSystemConfigControllerConfig{
+				Controllers: nodeagentconfigv1alpha1.ControllerConfiguration{
+					OperatingSystemConfig: nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig{
 						SecretName:        oscSecretName,
 						KubernetesVersion: kubernetesVersion,
 					},
-					Token: nodeagentv1alpha1.TokenControllerConfig{
-						SyncConfigs: []nodeagentv1alpha1.TokenSecretSyncConfig{
+					Token: nodeagentconfigv1alpha1.TokenControllerConfig{
+						SyncConfigs: []nodeagentconfigv1alpha1.TokenSecretSyncConfig{
 							{
 								SecretName: "gardener-valitail",
 								Path:       "/var/lib/valitail/auth-token",
@@ -140,18 +140,18 @@ WantedBy=multi-user.target`))
 
 		It("should return the expected result when NodeAgentAuthorizer feature gate is enabled", func() {
 			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, true))
-			Expect(ComponentConfig(oscSecretName, kubernetesVersion, apiServerURL, caBundle, additionalTokenSyncConfigs)).To(Equal(&nodeagentv1alpha1.NodeAgentConfiguration{
-				APIServer: nodeagentv1alpha1.APIServer{
+			Expect(ComponentConfig(oscSecretName, kubernetesVersion, apiServerURL, caBundle, additionalTokenSyncConfigs)).To(Equal(&nodeagentconfigv1alpha1.NodeAgentConfiguration{
+				APIServer: nodeagentconfigv1alpha1.APIServer{
 					Server:   apiServerURL,
 					CABundle: caBundle,
 				},
-				Controllers: nodeagentv1alpha1.ControllerConfiguration{
-					OperatingSystemConfig: nodeagentv1alpha1.OperatingSystemConfigControllerConfig{
+				Controllers: nodeagentconfigv1alpha1.ControllerConfiguration{
+					OperatingSystemConfig: nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig{
 						SecretName:        oscSecretName,
 						KubernetesVersion: kubernetesVersion,
 					},
-					Token: nodeagentv1alpha1.TokenControllerConfig{
-						SyncConfigs: []nodeagentv1alpha1.TokenSecretSyncConfig{
+					Token: nodeagentconfigv1alpha1.TokenControllerConfig{
+						SyncConfigs: []nodeagentconfigv1alpha1.TokenSecretSyncConfig{
 							{
 								SecretName: "gardener-valitail",
 								Path:       "/var/lib/valitail/auth-token",

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	"github.com/gardener/gardener/pkg/features"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
@@ -55,7 +55,7 @@ func RBACResourcesData(secretNames []string) (map[string][]byte, error) {
 			},
 			Subjects: []rbacv1.Subject{{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      nodeagentv1alpha1.AccessSecretName,
+				Name:      nodeagentconfigv1alpha1.AccessSecretName,
 				Namespace: metav1.NamespaceSystem,
 			}},
 		}
@@ -70,7 +70,7 @@ func RBACResourcesData(secretNames []string) (map[string][]byte, error) {
 				{
 					APIGroups:     []string{""},
 					Resources:     []string{"secrets"},
-					ResourceNames: append([]string{nodeagentv1alpha1.AccessSecretName, valiconstants.ValitailTokenSecretName}, secretNames...),
+					ResourceNames: append([]string{nodeagentconfigv1alpha1.AccessSecretName, valiconstants.ValitailTokenSecretName}, secretNames...),
 					Verbs:         []string{"get", "list", "watch"},
 				},
 				{
@@ -99,7 +99,7 @@ func RBACResourcesData(secretNames []string) (map[string][]byte, error) {
 				},
 				{
 					Kind:      rbacv1.ServiceAccountKind,
-					Name:      nodeagentv1alpha1.AccessSecretName,
+					Name:      nodeagentconfigv1alpha1.AccessSecretName,
 					Namespace: metav1.NamespaceSystem,
 				},
 			},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
@@ -15,7 +15,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -75,13 +75,13 @@ func OperatingSystemConfigSecret(
 			Name:      secretName,
 			Namespace: metav1.NamespaceSystem,
 			Annotations: map[string]string{
-				nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig: utils.ComputeSHA256Hex(operatingSystemConfigRaw),
+				nodeagentconfigv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig: utils.ComputeSHA256Hex(operatingSystemConfigRaw),
 			},
 			Labels: map[string]string{
 				v1beta1constants.GardenRole:      v1beta1constants.GardenRoleOperatingSystemConfig,
 				v1beta1constants.LabelWorkerPool: workerPoolName,
 			},
 		},
-		Data: map[string][]byte{nodeagentv1alpha1.DataKeyOperatingSystemConfig: operatingSystemConfigRaw},
+		Data: map[string][]byte{nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig: operatingSystemConfigRaw},
 	}, nil
 }

--- a/pkg/component/gardener/admissioncontroller/admission_controller.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	admissioncontrollerv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
@@ -52,7 +52,7 @@ type Values struct {
 	// Image is the container image used for the gardener-admission-controller pods.
 	Image string
 	// ResourceAdmissionConfiguration is the configuration for gardener-admission-controller's resource-size validator.
-	ResourceAdmissionConfiguration *admissioncontrollerv1alpha1.ResourceAdmissionConfiguration
+	ResourceAdmissionConfiguration *admissioncontrollerconfigv1alpha1.ResourceAdmissionConfiguration
 	// RuntimeVersion is the Kubernetes version of the runtime cluster.
 	RuntimeVersion *semver.Version
 	// SeedRestrictionEnabled specifies whether the seed-restriction webhook is enabled.

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -33,7 +33,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
-	admissioncontrollerv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -92,13 +92,13 @@ var _ = Describe("GardenerAdmissionController", func() {
 
 	Describe("#Deploy", func() {
 		BeforeEach(func() {
-			blockMode := admissioncontrollerv1alpha1.ResourceAdmissionWebhookMode("block")
+			blockMode := admissioncontrollerconfigv1alpha1.ResourceAdmissionWebhookMode("block")
 
 			// These are typical configuration values set for the admission controller and serves as the base for the following tests.
 			testValues = Values{
 				RuntimeVersion: semver.MustParse("v1.27.0"),
-				ResourceAdmissionConfiguration: &admissioncontrollerv1alpha1.ResourceAdmissionConfiguration{
-					Limits: []admissioncontrollerv1alpha1.ResourceLimit{
+				ResourceAdmissionConfiguration: &admissioncontrollerconfigv1alpha1.ResourceAdmissionConfiguration{
+					Limits: []admissioncontrollerconfigv1alpha1.ResourceLimit{
 						{
 							APIGroups:   []string{""},
 							APIVersions: []string{"v1"},
@@ -501,7 +501,7 @@ func verifyExpectations(ctx context.Context, fakeClient client.Client, consistOf
 }
 
 func configMap(namespace string, testValues Values) *corev1.ConfigMap {
-	admissionConfig := &admissioncontrollerv1alpha1.AdmissionControllerConfiguration{
+	admissionConfig := &admissioncontrollerconfigv1alpha1.AdmissionControllerConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "admissioncontroller.config.gardener.cloud/v1alpha1",
 			Kind:       "AdmissionControllerConfiguration",
@@ -513,13 +513,13 @@ func configMap(namespace string, testValues Values) *corev1.ConfigMap {
 		},
 		LogLevel:  testValues.LogLevel,
 		LogFormat: logger.FormatJSON,
-		Server: admissioncontrollerv1alpha1.ServerConfiguration{
-			Webhooks: admissioncontrollerv1alpha1.HTTPSServer{
-				Server: admissioncontrollerv1alpha1.Server{Port: 2719},
-				TLS:    admissioncontrollerv1alpha1.TLSServer{ServerCertDir: "/etc/gardener-admission-controller/srv"},
+		Server: admissioncontrollerconfigv1alpha1.ServerConfiguration{
+			Webhooks: admissioncontrollerconfigv1alpha1.HTTPSServer{
+				Server: admissioncontrollerconfigv1alpha1.Server{Port: 2719},
+				TLS:    admissioncontrollerconfigv1alpha1.TLSServer{ServerCertDir: "/etc/gardener-admission-controller/srv"},
 			},
-			HealthProbes:                   &admissioncontrollerv1alpha1.Server{Port: 2722},
-			Metrics:                        &admissioncontrollerv1alpha1.Server{Port: 2723},
+			HealthProbes:                   &admissioncontrollerconfigv1alpha1.Server{Port: 2722},
+			Metrics:                        &admissioncontrollerconfigv1alpha1.Server{Port: 2723},
 			ResourceAdmissionConfiguration: testValues.ResourceAdmissionConfiguration,
 		},
 	}

--- a/pkg/component/gardener/admissioncontroller/configmap.go
+++ b/pkg/component/gardener/admissioncontroller/configmap.go
@@ -14,7 +14,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 
-	admissioncontrollerv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -26,7 +26,7 @@ var admissionServerCodec runtime.Codec
 
 func init() {
 	admissionServerScheme := runtime.NewScheme()
-	utilruntime.Must(admissioncontrollerv1alpha1.AddToScheme(admissionServerScheme))
+	utilruntime.Must(admissioncontrollerconfigv1alpha1.AddToScheme(admissionServerScheme))
 
 	var (
 		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, admissionServerScheme, admissionServerScheme, json.SerializerOptions{
@@ -35,7 +35,7 @@ func init() {
 			Strict: false,
 		})
 		versions = schema.GroupVersions([]schema.GroupVersion{
-			admissioncontrollerv1alpha1.SchemeGroupVersion,
+			admissioncontrollerconfigv1alpha1.SchemeGroupVersion,
 		})
 	)
 
@@ -43,7 +43,7 @@ func init() {
 }
 
 func (a *gardenerAdmissionController) admissionConfigConfigMap() (*corev1.ConfigMap, error) {
-	admissionConfig := &admissioncontrollerv1alpha1.AdmissionControllerConfiguration{
+	admissionConfig := &admissioncontrollerconfigv1alpha1.AdmissionControllerConfiguration{
 		GardenClientConnection: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 			QPS:        100,
 			Burst:      130,
@@ -51,13 +51,13 @@ func (a *gardenerAdmissionController) admissionConfigConfigMap() (*corev1.Config
 		},
 		LogLevel:  a.values.LogLevel,
 		LogFormat: logger.FormatJSON,
-		Server: admissioncontrollerv1alpha1.ServerConfiguration{
-			Webhooks: admissioncontrollerv1alpha1.HTTPSServer{
-				Server: admissioncontrollerv1alpha1.Server{Port: serverPort},
-				TLS:    admissioncontrollerv1alpha1.TLSServer{ServerCertDir: volumeMountPathServerCert},
+		Server: admissioncontrollerconfigv1alpha1.ServerConfiguration{
+			Webhooks: admissioncontrollerconfigv1alpha1.HTTPSServer{
+				Server: admissioncontrollerconfigv1alpha1.Server{Port: serverPort},
+				TLS:    admissioncontrollerconfigv1alpha1.TLSServer{ServerCertDir: volumeMountPathServerCert},
 			},
-			HealthProbes:                   &admissioncontrollerv1alpha1.Server{Port: probePort},
-			Metrics:                        &admissioncontrollerv1alpha1.Server{Port: metricsPort},
+			HealthProbes:                   &admissioncontrollerconfigv1alpha1.Server{Port: probePort},
+			Metrics:                        &admissioncontrollerconfigv1alpha1.Server{Port: metricsPort},
 			ResourceAdmissionConfiguration: a.values.ResourceAdmissionConfiguration,
 		},
 	}

--- a/pkg/component/gardener/admissioncontroller/webhooks.go
+++ b/pkg/component/gardener/admissioncontroller/webhooks.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	admissioncontrollerv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
@@ -345,7 +345,7 @@ func (a *gardenerAdmissionController) validatingWebhookConfiguration(caSecret *c
 	return validatingWebhook
 }
 
-func buildWebhookConfigRulesForResourceSize(config *admissioncontrollerv1alpha1.ResourceAdmissionConfiguration) []admissionregistrationv1.RuleWithOperations {
+func buildWebhookConfigRulesForResourceSize(config *admissioncontrollerconfigv1alpha1.ResourceAdmissionConfiguration) []admissionregistrationv1.RuleWithOperations {
 	if config == nil || len(config.Limits) == 0 {
 		return nil
 	}

--- a/pkg/component/gardener/controllermanager/configmaps.go
+++ b/pkg/component/gardener/controllermanager/configmaps.go
@@ -17,7 +17,7 @@ import (
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
 
-	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -32,7 +32,7 @@ var controllerManagerCodec runtime.Codec
 
 func init() {
 	controllerManagerScheme := runtime.NewScheme()
-	utilruntime.Must(controllermanagerv1alpha1.AddToScheme(controllerManagerScheme))
+	utilruntime.Must(controllermanagerconfigv1alpha1.AddToScheme(controllerManagerScheme))
 
 	var (
 		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, controllerManagerScheme, controllerManagerScheme, json.SerializerOptions{
@@ -41,7 +41,7 @@ func init() {
 			Strict: false,
 		})
 		versions = schema.GroupVersions([]schema.GroupVersion{
-			controllermanagerv1alpha1.SchemeGroupVersion,
+			controllermanagerconfigv1alpha1.SchemeGroupVersion,
 		})
 	)
 
@@ -49,63 +49,63 @@ func init() {
 }
 
 func (g *gardenerControllerManager) configMapControllerManagerConfig() (*corev1.ConfigMap, error) {
-	controllerManagerConfig := &controllermanagerv1alpha1.ControllerManagerConfiguration{
+	controllerManagerConfig := &controllermanagerconfigv1alpha1.ControllerManagerConfiguration{
 		GardenClientConnection: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 			QPS:        100,
 			Burst:      130,
 			Kubeconfig: gardenerutils.PathGenericKubeconfig,
 		},
-		Controllers: controllermanagerv1alpha1.ControllerManagerControllerConfiguration{
-			ControllerRegistration: &controllermanagerv1alpha1.ControllerRegistrationControllerConfiguration{
+		Controllers: controllermanagerconfigv1alpha1.ControllerManagerControllerConfiguration{
+			ControllerRegistration: &controllermanagerconfigv1alpha1.ControllerRegistrationControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
-			Project: &controllermanagerv1alpha1.ProjectControllerConfiguration{
+			Project: &controllermanagerconfigv1alpha1.ProjectControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 				Quotas:          g.values.Quotas,
 			},
-			SecretBinding: &controllermanagerv1alpha1.SecretBindingControllerConfiguration{
+			SecretBinding: &controllermanagerconfigv1alpha1.SecretBindingControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
-			CredentialsBinding: &controllermanagerv1alpha1.CredentialsBindingControllerConfiguration{
+			CredentialsBinding: &controllermanagerconfigv1alpha1.CredentialsBindingControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
-			Seed: &controllermanagerv1alpha1.SeedControllerConfiguration{
+			Seed: &controllermanagerconfigv1alpha1.SeedControllerConfiguration{
 				ConcurrentSyncs:    ptr.To(20),
 				ShootMonitorPeriod: &metav1.Duration{Duration: 300 * time.Second},
 			},
-			SeedExtensionsCheck: &controllermanagerv1alpha1.SeedExtensionsCheckControllerConfiguration{
-				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
+			SeedExtensionsCheck: &controllermanagerconfigv1alpha1.SeedExtensionsCheckControllerConfiguration{
+				ConditionThresholds: []controllermanagerconfigv1alpha1.ConditionThreshold{{
 					Duration: metav1.Duration{Duration: 1 * time.Minute},
 					Type:     "ExtensionsReady",
 				}},
 			},
-			SeedBackupBucketsCheck: &controllermanagerv1alpha1.SeedBackupBucketsCheckControllerConfiguration{
-				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
+			SeedBackupBucketsCheck: &controllermanagerconfigv1alpha1.SeedBackupBucketsCheckControllerConfiguration{
+				ConditionThresholds: []controllermanagerconfigv1alpha1.ConditionThreshold{{
 					Duration: metav1.Duration{Duration: 1 * time.Minute},
 					Type:     "BackupBucketsReady",
 				}},
 			},
-			Event: &controllermanagerv1alpha1.EventControllerConfiguration{
+			Event: &controllermanagerconfigv1alpha1.EventControllerConfiguration{
 				ConcurrentSyncs:   ptr.To(10),
 				TTLNonShootEvents: &metav1.Duration{Duration: 2 * time.Hour},
 			},
-			ShootMaintenance: controllermanagerv1alpha1.ShootMaintenanceControllerConfiguration{
+			ShootMaintenance: controllermanagerconfigv1alpha1.ShootMaintenanceControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
-			ShootReference: &controllermanagerv1alpha1.ShootReferenceControllerConfiguration{
+			ShootReference: &controllermanagerconfigv1alpha1.ShootReferenceControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
 		},
 		LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 			LeaderElect:       ptr.To(true),
-			ResourceName:      controllermanagerv1alpha1.ControllerManagerDefaultLockObjectName,
+			ResourceName:      controllermanagerconfigv1alpha1.ControllerManagerDefaultLockObjectName,
 			ResourceNamespace: metav1.NamespaceSystem,
 		},
 		LogLevel:  g.values.LogLevel,
 		LogFormat: logger.FormatJSON,
-		Server: controllermanagerv1alpha1.ServerConfiguration{
-			HealthProbes: &controllermanagerv1alpha1.Server{Port: probePort},
-			Metrics:      &controllermanagerv1alpha1.Server{Port: metricsPort},
+		Server: controllermanagerconfigv1alpha1.ServerConfiguration{
+			HealthProbes: &controllermanagerconfigv1alpha1.Server{Port: probePort},
+			Metrics:      &controllermanagerconfigv1alpha1.Server{Port: metricsPort},
 		},
 		FeatureGates: g.values.FeatureGates,
 	}

--- a/pkg/component/gardener/controllermanager/controller_manager.go
+++ b/pkg/component/gardener/controllermanager/controller_manager.go
@@ -15,7 +15,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
-	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -47,7 +47,7 @@ type Values struct {
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
 	LogLevel string
 	// Quotas is the default configuration matching projects are set up with if a quota is not already specified.
-	Quotas []controllermanagerv1alpha1.QuotaConfiguration
+	Quotas []controllermanagerconfigv1alpha1.QuotaConfiguration
 	// RuntimeVersion is the Kubernetes version of the runtime cluster.
 	RuntimeVersion *semver.Version
 	// FeatureGates is the set of feature gates.

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -34,7 +34,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/gardener/controllermanager"
-	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -705,7 +705,7 @@ var (
 )
 
 func configMap(namespace string, testValues Values) *corev1.ConfigMap {
-	controllerManagerConfig := &controllermanagerv1alpha1.ControllerManagerConfiguration{
+	controllerManagerConfig := &controllermanagerconfigv1alpha1.ControllerManagerConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "controllermanager.config.gardener.cloud/v1alpha1",
 			Kind:       "ControllerManagerConfiguration",
@@ -715,57 +715,57 @@ func configMap(namespace string, testValues Values) *corev1.ConfigMap {
 			Burst:      130,
 			Kubeconfig: gardenerutils.PathGenericKubeconfig,
 		},
-		Controllers: controllermanagerv1alpha1.ControllerManagerControllerConfiguration{
-			ControllerRegistration: &controllermanagerv1alpha1.ControllerRegistrationControllerConfiguration{
+		Controllers: controllermanagerconfigv1alpha1.ControllerManagerControllerConfiguration{
+			ControllerRegistration: &controllermanagerconfigv1alpha1.ControllerRegistrationControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
-			Project: &controllermanagerv1alpha1.ProjectControllerConfiguration{
+			Project: &controllermanagerconfigv1alpha1.ProjectControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 				Quotas:          testValues.Quotas,
 			},
-			SecretBinding: &controllermanagerv1alpha1.SecretBindingControllerConfiguration{
+			SecretBinding: &controllermanagerconfigv1alpha1.SecretBindingControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
-			CredentialsBinding: &controllermanagerv1alpha1.CredentialsBindingControllerConfiguration{
+			CredentialsBinding: &controllermanagerconfigv1alpha1.CredentialsBindingControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
-			Seed: &controllermanagerv1alpha1.SeedControllerConfiguration{
+			Seed: &controllermanagerconfigv1alpha1.SeedControllerConfiguration{
 				ConcurrentSyncs:    ptr.To(20),
 				ShootMonitorPeriod: &metav1.Duration{Duration: 300 * time.Second},
 			},
-			SeedExtensionsCheck: &controllermanagerv1alpha1.SeedExtensionsCheckControllerConfiguration{
-				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
+			SeedExtensionsCheck: &controllermanagerconfigv1alpha1.SeedExtensionsCheckControllerConfiguration{
+				ConditionThresholds: []controllermanagerconfigv1alpha1.ConditionThreshold{{
 					Duration: metav1.Duration{Duration: 1 * time.Minute},
 					Type:     "ExtensionsReady",
 				}},
 			},
-			SeedBackupBucketsCheck: &controllermanagerv1alpha1.SeedBackupBucketsCheckControllerConfiguration{
-				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
+			SeedBackupBucketsCheck: &controllermanagerconfigv1alpha1.SeedBackupBucketsCheckControllerConfiguration{
+				ConditionThresholds: []controllermanagerconfigv1alpha1.ConditionThreshold{{
 					Duration: metav1.Duration{Duration: 1 * time.Minute},
 					Type:     "BackupBucketsReady",
 				}},
 			},
-			Event: &controllermanagerv1alpha1.EventControllerConfiguration{
+			Event: &controllermanagerconfigv1alpha1.EventControllerConfiguration{
 				ConcurrentSyncs:   ptr.To(10),
 				TTLNonShootEvents: &metav1.Duration{Duration: 2 * time.Hour},
 			},
-			ShootMaintenance: controllermanagerv1alpha1.ShootMaintenanceControllerConfiguration{
+			ShootMaintenance: controllermanagerconfigv1alpha1.ShootMaintenanceControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
-			ShootReference: &controllermanagerv1alpha1.ShootReferenceControllerConfiguration{
+			ShootReference: &controllermanagerconfigv1alpha1.ShootReferenceControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 			},
 		},
 		LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 			LeaderElect:       ptr.To(true),
-			ResourceName:      controllermanagerv1alpha1.ControllerManagerDefaultLockObjectName,
+			ResourceName:      controllermanagerconfigv1alpha1.ControllerManagerDefaultLockObjectName,
 			ResourceNamespace: metav1.NamespaceSystem,
 		},
 		LogLevel:  testValues.LogLevel,
 		LogFormat: logger.FormatJSON,
-		Server: controllermanagerv1alpha1.ServerConfiguration{
-			HealthProbes: &controllermanagerv1alpha1.Server{Port: 2718},
-			Metrics:      &controllermanagerv1alpha1.Server{Port: 2719},
+		Server: controllermanagerconfigv1alpha1.ServerConfiguration{
+			HealthProbes: &controllermanagerconfigv1alpha1.Server{Port: 2718},
+			Metrics:      &controllermanagerconfigv1alpha1.Server{Port: 2719},
 		},
 		FeatureGates: testValues.FeatureGates,
 	}

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -53,7 +53,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	resourcemanagerv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
+	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/crddeletionprotection"
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/endpointslicehints"
@@ -92,7 +92,7 @@ var (
 
 func init() {
 	scheme = runtime.NewScheme()
-	utilruntime.Must(resourcemanagerv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(resourcemanagerconfigv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 
 	var (
@@ -102,7 +102,7 @@ func init() {
 			Strict: false,
 		})
 		versions = schema.GroupVersions([]schema.GroupVersion{
-			resourcemanagerv1alpha1.SchemeGroupVersion,
+			resourcemanagerconfigv1alpha1.SchemeGroupVersion,
 			apiextensionsv1.SchemeGroupVersion,
 		})
 	)
@@ -253,7 +253,7 @@ type Values struct {
 	NetworkPolicyAdditionalNamespaceSelectors []metav1.LabelSelector
 	// NetworkPolicyControllerIngressControllerSelector is the peer information of the ingress controller for the
 	// network policy controller.
-	NetworkPolicyControllerIngressControllerSelector *resourcemanagerv1alpha1.IngressControllerSelector
+	NetworkPolicyControllerIngressControllerSelector *resourcemanagerconfigv1alpha1.IngressControllerSelector
 	// Image is the container image.
 	Image string
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
@@ -507,66 +507,66 @@ func (r *resourceManager) emptyClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 }
 
 func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1.ConfigMap) error {
-	config := &resourcemanagerv1alpha1.ResourceManagerConfiguration{
+	config := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{
 		LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 			LeaderElect:       ptr.To(true),
 			ResourceName:      r.values.NamePrefix + v1beta1constants.DeploymentNameGardenerResourceManager,
 			ResourceNamespace: r.namespace,
 		},
-		Server: resourcemanagerv1alpha1.ServerConfiguration{
-			HealthProbes: &resourcemanagerv1alpha1.Server{
+		Server: resourcemanagerconfigv1alpha1.ServerConfiguration{
+			HealthProbes: &resourcemanagerconfigv1alpha1.Server{
 				Port: healthPort,
 			},
-			Metrics: &resourcemanagerv1alpha1.Server{
+			Metrics: &resourcemanagerconfigv1alpha1.Server{
 				Port: metricsPort,
 			},
-			Webhooks: resourcemanagerv1alpha1.HTTPSServer{
-				Server: resourcemanagerv1alpha1.Server{
+			Webhooks: resourcemanagerconfigv1alpha1.HTTPSServer{
+				Server: resourcemanagerconfigv1alpha1.Server{
 					Port: resourcemanagerconstants.ServerPort,
 				},
-				TLS: resourcemanagerv1alpha1.TLSServer{
+				TLS: resourcemanagerconfigv1alpha1.TLSServer{
 					ServerCertDir: volumeMountPathCerts,
 				},
 			},
 		},
 		LogLevel:  r.values.LogLevel,
 		LogFormat: r.values.LogFormat,
-		Controllers: resourcemanagerv1alpha1.ResourceManagerControllerConfiguration{
+		Controllers: resourcemanagerconfigv1alpha1.ResourceManagerControllerConfiguration{
 			ClusterID:     r.values.ClusterIdentity,
 			ResourceClass: r.values.ResourceClass,
-			GarbageCollector: resourcemanagerv1alpha1.GarbageCollectorControllerConfig{
+			GarbageCollector: resourcemanagerconfigv1alpha1.GarbageCollectorControllerConfig{
 				Enabled:    true,
 				SyncPeriod: &metav1.Duration{Duration: 12 * time.Hour},
 			},
-			Health: resourcemanagerv1alpha1.HealthControllerConfig{
+			Health: resourcemanagerconfigv1alpha1.HealthControllerConfig{
 				ConcurrentSyncs: r.values.MaxConcurrentHealthWorkers,
 				SyncPeriod:      r.values.HealthSyncPeriod,
 			},
-			ManagedResource: resourcemanagerv1alpha1.ManagedResourceControllerConfig{
+			ManagedResource: resourcemanagerconfigv1alpha1.ManagedResourceControllerConfig{
 				ConcurrentSyncs: r.values.ConcurrentSyncs,
 				SyncPeriod:      r.values.SyncPeriod,
 				AlwaysUpdate:    r.values.AlwaysUpdate,
 			},
 		},
-		Webhooks: resourcemanagerv1alpha1.ResourceManagerWebhookConfiguration{
-			EndpointSliceHints: resourcemanagerv1alpha1.EndpointSliceHintsWebhookConfig{
+		Webhooks: resourcemanagerconfigv1alpha1.ResourceManagerWebhookConfiguration{
+			EndpointSliceHints: resourcemanagerconfigv1alpha1.EndpointSliceHintsWebhookConfig{
 				Enabled: r.values.EndpointSliceHintsEnabled,
 			},
-			HighAvailabilityConfig: resourcemanagerv1alpha1.HighAvailabilityConfigWebhookConfig{
+			HighAvailabilityConfig: resourcemanagerconfigv1alpha1.HighAvailabilityConfigWebhookConfig{
 				Enabled:                             true,
 				DefaultNotReadyTolerationSeconds:    r.values.DefaultNotReadyToleration,
 				DefaultUnreachableTolerationSeconds: r.values.DefaultUnreachableToleration,
 			},
-			PodTopologySpreadConstraints: resourcemanagerv1alpha1.PodTopologySpreadConstraintsWebhookConfig{
+			PodTopologySpreadConstraints: resourcemanagerconfigv1alpha1.PodTopologySpreadConstraintsWebhookConfig{
 				Enabled: r.values.PodTopologySpreadConstraintsEnabled,
 			},
-			ProjectedTokenMount: resourcemanagerv1alpha1.ProjectedTokenMountWebhookConfig{
+			ProjectedTokenMount: resourcemanagerconfigv1alpha1.ProjectedTokenMountWebhookConfig{
 				Enabled: true,
 			},
-			NodeAgentAuthorizer: resourcemanagerv1alpha1.NodeAgentAuthorizerWebhookConfig{
+			NodeAgentAuthorizer: resourcemanagerconfigv1alpha1.NodeAgentAuthorizerWebhookConfig{
 				Enabled: r.values.NodeAgentAuthorizerEnabled,
 			},
-			SeccompProfile: resourcemanagerv1alpha1.SeccompProfileWebhookConfig{
+			SeccompProfile: resourcemanagerconfigv1alpha1.SeccompProfileWebhookConfig{
 				Enabled: r.values.DefaultSeccompProfileEnabled,
 			},
 		},
@@ -580,14 +580,14 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 	}
 
 	if r.values.TargetDiffersFromSourceCluster {
-		config.TargetClientConnection = &resourcemanagerv1alpha1.ClientConnection{
+		config.TargetClientConnection = &resourcemanagerconfigv1alpha1.ClientConnection{
 			ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				Kubeconfig: gardenerutils.PathGenericKubeconfig,
 			},
 			Namespaces: r.values.TargetNamespaces,
 		}
 	} else {
-		config.Controllers.NetworkPolicy = resourcemanagerv1alpha1.NetworkPolicyControllerConfig{
+		config.Controllers.NetworkPolicy = resourcemanagerconfigv1alpha1.NetworkPolicyControllerConfig{
 			Enabled:         true,
 			ConcurrentSyncs: r.values.MaxConcurrentNetworkPolicyWorkers,
 			NamespaceSelectors: append([]metav1.LabelSelector{
@@ -639,7 +639,7 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 	}
 
 	if r.values.TargetDiffersFromSourceCluster {
-		config.Webhooks.SystemComponentsConfig = resourcemanagerv1alpha1.SystemComponentsConfigWebhookConfig{
+		config.Webhooks.SystemComponentsConfig = resourcemanagerconfigv1alpha1.SystemComponentsConfigWebhookConfig{
 			Enabled: true,
 			NodeSelector: map[string]string{
 				v1beta1constants.LabelWorkerPoolSystemComponents: "true",
@@ -2070,7 +2070,7 @@ type Secrets struct {
 	shootAccess *gardenerutils.AccessSecret
 }
 
-func disableControllersAndWebhooksForWorkerlessShoot(config *resourcemanagerv1alpha1.ResourceManagerConfiguration) {
+func disableControllersAndWebhooksForWorkerlessShoot(config *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration) {
 	// disable unneeded controllers
 	config.Controllers.CSRApprover.Enabled = false
 	config.Controllers.NodeCriticalComponents.Enabled = false

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -43,7 +43,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
-	resourcemanagerv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
+	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -104,7 +104,7 @@ var _ = Describe("ResourceManager", func() {
 		matchPolicyEquivalent                = admissionregistrationv1.Equivalent
 		sideEffect                           = admissionregistrationv1.SideEffectClassNone
 		priorityClassName                    = v1beta1constants.PriorityClassNameSeedSystemCritical
-		ingressControllerSelector            = &resourcemanagerv1alpha1.IngressControllerSelector{
+		ingressControllerSelector            = &resourcemanagerconfigv1alpha1.IngressControllerSelector{
 			Namespace:   "foo",
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"bar": "baz"}},
 		}
@@ -359,85 +359,85 @@ var _ = Describe("ResourceManager", func() {
 				},
 			}
 
-			config := &resourcemanagerv1alpha1.ResourceManagerConfiguration{
+			config := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{
 				LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 					LeaderElect:       ptr.To(true),
 					ResourceName:      "gardener-resource-manager",
 					ResourceNamespace: deployNamespace,
 				},
-				Server: resourcemanagerv1alpha1.ServerConfiguration{
-					HealthProbes: &resourcemanagerv1alpha1.Server{
+				Server: resourcemanagerconfigv1alpha1.ServerConfiguration{
+					HealthProbes: &resourcemanagerconfigv1alpha1.Server{
 						Port: int(healthPort),
 					},
-					Metrics: &resourcemanagerv1alpha1.Server{
+					Metrics: &resourcemanagerconfigv1alpha1.Server{
 						Port: int(metricsPort),
 					},
-					Webhooks: resourcemanagerv1alpha1.HTTPSServer{
-						Server: resourcemanagerv1alpha1.Server{
+					Webhooks: resourcemanagerconfigv1alpha1.HTTPSServer{
+						Server: resourcemanagerconfigv1alpha1.Server{
 							Port: int(serverPort),
 						},
-						TLS: resourcemanagerv1alpha1.TLSServer{
+						TLS: resourcemanagerconfigv1alpha1.TLSServer{
 							ServerCertDir: secretMountPathServer,
 						},
 					},
 				},
 				LogLevel:  "info",
 				LogFormat: "json",
-				Controllers: resourcemanagerv1alpha1.ResourceManagerControllerConfiguration{
+				Controllers: resourcemanagerconfigv1alpha1.ResourceManagerControllerConfiguration{
 					ClusterID:     &clusterIdentity,
 					ResourceClass: &resourceClass,
-					GarbageCollector: resourcemanagerv1alpha1.GarbageCollectorControllerConfig{
+					GarbageCollector: resourcemanagerconfigv1alpha1.GarbageCollectorControllerConfig{
 						Enabled:    true,
 						SyncPeriod: &metav1.Duration{Duration: 12 * time.Hour},
 					},
-					Health: resourcemanagerv1alpha1.HealthControllerConfig{
+					Health: resourcemanagerconfigv1alpha1.HealthControllerConfig{
 						ConcurrentSyncs: &maxConcurrentHealthWorkers,
 						SyncPeriod:      &healthSyncPeriod,
 					},
-					CSRApprover: resourcemanagerv1alpha1.CSRApproverControllerConfig{
+					CSRApprover: resourcemanagerconfigv1alpha1.CSRApproverControllerConfig{
 						Enabled:         !isWorkerless,
 						ConcurrentSyncs: &maxConcurrentCSRApproverWorkers,
 					},
-					ManagedResource: resourcemanagerv1alpha1.ManagedResourceControllerConfig{
+					ManagedResource: resourcemanagerconfigv1alpha1.ManagedResourceControllerConfig{
 						ConcurrentSyncs: &concurrentSyncs,
 						SyncPeriod:      &syncPeriod,
 						AlwaysUpdate:    &alwaysUpdate,
 					},
-					TokenInvalidator: resourcemanagerv1alpha1.TokenInvalidatorControllerConfig{
+					TokenInvalidator: resourcemanagerconfigv1alpha1.TokenInvalidatorControllerConfig{
 						Enabled:         true,
 						ConcurrentSyncs: &maxConcurrentTokenInvalidatorWorkers,
 					},
-					TokenRequestor: resourcemanagerv1alpha1.TokenRequestorControllerConfig{
+					TokenRequestor: resourcemanagerconfigv1alpha1.TokenRequestorControllerConfig{
 						Enabled:         true,
 						ConcurrentSyncs: &maxConcurrentTokenRequestorWorkers,
 					},
-					NodeCriticalComponents: resourcemanagerv1alpha1.NodeCriticalComponentsControllerConfig{
+					NodeCriticalComponents: resourcemanagerconfigv1alpha1.NodeCriticalComponentsControllerConfig{
 						Enabled: false,
 					},
 				},
-				Webhooks: resourcemanagerv1alpha1.ResourceManagerWebhookConfiguration{
-					HighAvailabilityConfig: resourcemanagerv1alpha1.HighAvailabilityConfigWebhookConfig{
+				Webhooks: resourcemanagerconfigv1alpha1.ResourceManagerWebhookConfiguration{
+					HighAvailabilityConfig: resourcemanagerconfigv1alpha1.HighAvailabilityConfigWebhookConfig{
 						Enabled:                             !isWorkerless,
 						DefaultNotReadyTolerationSeconds:    defaultNotReadyTolerationSeconds,
 						DefaultUnreachableTolerationSeconds: defaultUnreachableTolerationSeconds,
 					},
-					KubernetesServiceHost: resourcemanagerv1alpha1.KubernetesServiceHostWebhookConfig{
+					KubernetesServiceHost: resourcemanagerconfigv1alpha1.KubernetesServiceHostWebhookConfig{
 						Enabled: !isWorkerless,
 						Host:    kubernetesServiceHost,
 					},
-					PodSchedulerName: resourcemanagerv1alpha1.PodSchedulerNameWebhookConfig{
+					PodSchedulerName: resourcemanagerconfigv1alpha1.PodSchedulerNameWebhookConfig{
 						Enabled: false,
 					},
-					PodTopologySpreadConstraints: resourcemanagerv1alpha1.PodTopologySpreadConstraintsWebhookConfig{
+					PodTopologySpreadConstraints: resourcemanagerconfigv1alpha1.PodTopologySpreadConstraintsWebhookConfig{
 						Enabled: !isWorkerless,
 					},
-					ProjectedTokenMount: resourcemanagerv1alpha1.ProjectedTokenMountWebhookConfig{
+					ProjectedTokenMount: resourcemanagerconfigv1alpha1.ProjectedTokenMountWebhookConfig{
 						Enabled: !isWorkerless,
 					},
-					SystemComponentsConfig: resourcemanagerv1alpha1.SystemComponentsConfigWebhookConfig{
+					SystemComponentsConfig: resourcemanagerconfigv1alpha1.SystemComponentsConfigWebhookConfig{
 						Enabled: false,
 					},
-					TokenInvalidator: resourcemanagerv1alpha1.TokenInvalidatorWebhookConfig{
+					TokenInvalidator: resourcemanagerconfigv1alpha1.TokenInvalidatorWebhookConfig{
 						Enabled: true,
 					},
 				},
@@ -449,7 +449,7 @@ var _ = Describe("ResourceManager", func() {
 			}
 
 			if targetKubeconfig != nil {
-				config.TargetClientConnection = &resourcemanagerv1alpha1.ClientConnection{
+				config.TargetClientConnection = &resourcemanagerconfigv1alpha1.ClientConnection{
 					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 						Kubeconfig: gardenerutils.PathGenericKubeconfig,
 					},
@@ -457,11 +457,11 @@ var _ = Describe("ResourceManager", func() {
 				}
 
 				config.Controllers.NodeCriticalComponents.Enabled = !isWorkerless
-				config.Webhooks.PodSchedulerName = resourcemanagerv1alpha1.PodSchedulerNameWebhookConfig{
+				config.Webhooks.PodSchedulerName = resourcemanagerconfigv1alpha1.PodSchedulerNameWebhookConfig{
 					Enabled:       !isWorkerless,
 					SchedulerName: ptr.To("bin-packing-scheduler"),
 				}
-				config.Webhooks.SystemComponentsConfig = resourcemanagerv1alpha1.SystemComponentsConfigWebhookConfig{
+				config.Webhooks.SystemComponentsConfig = resourcemanagerconfigv1alpha1.SystemComponentsConfigWebhookConfig{
 					Enabled: !isWorkerless,
 					NodeSelector: map[string]string{
 						"worker.gardener.cloud/system-components": "true",
@@ -476,7 +476,7 @@ var _ = Describe("ResourceManager", func() {
 					},
 				}
 			} else {
-				config.Controllers.NetworkPolicy = resourcemanagerv1alpha1.NetworkPolicyControllerConfig{
+				config.Controllers.NetworkPolicy = resourcemanagerconfigv1alpha1.NetworkPolicyControllerConfig{
 					Enabled:         true,
 					ConcurrentSyncs: &maxConcurrentNetworkPolicyWorkers,
 					NamespaceSelectors: []metav1.LabelSelector{
@@ -2649,7 +2649,7 @@ var (
 
 func init() {
 	scheme = runtime.NewScheme()
-	utilruntime.Must(resourcemanagerv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(resourcemanagerconfigv1alpha1.AddToScheme(scheme))
 
 	var (
 		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{
@@ -2658,7 +2658,7 @@ func init() {
 			Strict: false,
 		})
 		versions = schema.GroupVersions([]schema.GroupVersion{
-			resourcemanagerv1alpha1.SchemeGroupVersion,
+			resourcemanagerconfigv1alpha1.SchemeGroupVersion,
 		})
 	)
 

--- a/pkg/component/gardener/scheduler/configmaps.go
+++ b/pkg/component/gardener/scheduler/configmaps.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/logger"
-	schedulerv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
+	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -30,7 +30,7 @@ var schedulerCodec runtime.Codec
 
 func init() {
 	schedulerScheme := runtime.NewScheme()
-	utilruntime.Must(schedulerv1alpha1.AddToScheme(schedulerScheme))
+	utilruntime.Must(schedulerconfigv1alpha1.AddToScheme(schedulerScheme))
 
 	var (
 		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, schedulerScheme, schedulerScheme, json.SerializerOptions{
@@ -39,7 +39,7 @@ func init() {
 			Strict: false,
 		})
 		versions = schema.GroupVersions([]schema.GroupVersion{
-			schedulerv1alpha1.SchemeGroupVersion,
+			schedulerconfigv1alpha1.SchemeGroupVersion,
 		})
 	)
 
@@ -47,7 +47,7 @@ func init() {
 }
 
 func (g *gardenerScheduler) configMapSchedulerConfig() (*corev1.ConfigMap, error) {
-	schedulerConfig := &schedulerv1alpha1.SchedulerConfiguration{
+	schedulerConfig := &schedulerconfigv1alpha1.SchedulerConfiguration{
 		ClientConnection: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 			QPS:        100,
 			Burst:      130,
@@ -55,18 +55,18 @@ func (g *gardenerScheduler) configMapSchedulerConfig() (*corev1.ConfigMap, error
 		},
 		LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 			LeaderElect:       ptr.To(true),
-			ResourceName:      schedulerv1alpha1.SchedulerDefaultLockObjectName,
+			ResourceName:      schedulerconfigv1alpha1.SchedulerDefaultLockObjectName,
 			ResourceNamespace: metav1.NamespaceSystem,
 		},
 		LogLevel:  g.values.LogLevel,
 		LogFormat: logger.FormatJSON,
-		Server: schedulerv1alpha1.ServerConfiguration{
-			HealthProbes: &schedulerv1alpha1.Server{Port: probePort},
-			Metrics:      &schedulerv1alpha1.Server{Port: metricsPort},
+		Server: schedulerconfigv1alpha1.ServerConfiguration{
+			HealthProbes: &schedulerconfigv1alpha1.Server{Port: probePort},
+			Metrics:      &schedulerconfigv1alpha1.Server{Port: metricsPort},
 		},
-		Schedulers: schedulerv1alpha1.SchedulerControllerConfiguration{
-			Shoot: &schedulerv1alpha1.ShootSchedulerConfiguration{
-				Strategy: schedulerv1alpha1.MinimalDistance,
+		Schedulers: schedulerconfigv1alpha1.SchedulerControllerConfiguration{
+			Shoot: &schedulerconfigv1alpha1.ShootSchedulerConfiguration{
+				Strategy: schedulerconfigv1alpha1.MinimalDistance,
 			},
 		},
 		FeatureGates: g.values.FeatureGates,

--- a/pkg/component/gardener/scheduler/rbac.go
+++ b/pkg/component/gardener/scheduler/rbac.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	schedulerv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
+	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
 )
 
 const (
@@ -71,7 +71,7 @@ func (g *gardenerScheduler) clusterRole() *rbacv1.ClusterRole {
 					"leases",
 				},
 				ResourceNames: []string{
-					schedulerv1alpha1.SchedulerDefaultLockObjectName,
+					schedulerconfigv1alpha1.SchedulerDefaultLockObjectName,
 				},
 				Verbs: []string{"get", "watch", "update"},
 			},

--- a/pkg/component/gardener/scheduler/scheduler_test.go
+++ b/pkg/component/gardener/scheduler/scheduler_test.go
@@ -36,7 +36,7 @@ import (
 	. "github.com/gardener/gardener/pkg/component/gardener/scheduler"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
-	schedulerv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
+	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -737,7 +737,7 @@ var (
 )
 
 func configMap(namespace string, testValues Values) *corev1.ConfigMap {
-	schedulerConfig := &schedulerv1alpha1.SchedulerConfiguration{
+	schedulerConfig := &schedulerconfigv1alpha1.SchedulerConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "scheduler.config.gardener.cloud/v1alpha1",
 			Kind:       "SchedulerConfiguration",
@@ -754,16 +754,16 @@ func configMap(namespace string, testValues Values) *corev1.ConfigMap {
 		},
 		LogLevel:  testValues.LogLevel,
 		LogFormat: "json",
-		Server: schedulerv1alpha1.ServerConfiguration{
-			HealthProbes: &schedulerv1alpha1.Server{
+		Server: schedulerconfigv1alpha1.ServerConfiguration{
+			HealthProbes: &schedulerconfigv1alpha1.Server{
 				Port: 10251,
 			},
-			Metrics: &schedulerv1alpha1.Server{
+			Metrics: &schedulerconfigv1alpha1.Server{
 				Port: 19251,
 			},
 		},
-		Schedulers: schedulerv1alpha1.SchedulerControllerConfiguration{
-			Shoot: &schedulerv1alpha1.ShootSchedulerConfiguration{
+		Schedulers: schedulerconfigv1alpha1.SchedulerControllerConfiguration{
+			Shoot: &schedulerconfigv1alpha1.ShootSchedulerConfiguration{
 				Strategy: "MinimalDistance",
 			},
 		},

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/networking/nginxingress"
-	resourcemanagerv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
+	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
@@ -71,7 +71,7 @@ func NewRuntimeGardenerResourceManager(
 		EndpointSliceHintsEnabled:                 endpointSliceHintsEnabled,
 		MaxConcurrentNetworkPolicyWorkers:         ptr.To(20),
 		NetworkPolicyAdditionalNamespaceSelectors: additionalNetworkPolicyNamespaceSelectors,
-		NetworkPolicyControllerIngressControllerSelector: &resourcemanagerv1alpha1.IngressControllerSelector{
+		NetworkPolicyControllerIngressControllerSelector: &resourcemanagerconfigv1alpha1.IngressControllerSelector{
 			Namespace: v1beta1constants.GardenNamespace,
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
 				v1beta1constants.LabelApp:      nginxingress.LabelAppValue,

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -329,7 +329,7 @@ func (a *Actuator) deployGardenlet(
 	targetClient kubernetes.Interface,
 	gardenletDeployment *seedmanagementv1alpha1.GardenletDeployment,
 	seed *gardencorev1beta1.Seed,
-	componentConfig *gardenletv1alpha1.GardenletConfiguration,
+	componentConfig *gardenletconfigv1alpha1.GardenletConfiguration,
 	bootstrap seedmanagementv1alpha1.Bootstrap,
 	mergeWithParent bool,
 ) error {
@@ -373,7 +373,7 @@ func (a *Actuator) deleteGardenlet(
 	targetClient kubernetes.Interface,
 	gardenletDeployment *seedmanagementv1alpha1.GardenletDeployment,
 	seed *gardencorev1beta1.Seed,
-	componentConfig *gardenletv1alpha1.GardenletConfiguration,
+	componentConfig *gardenletconfigv1alpha1.GardenletConfiguration,
 	bootstrap seedmanagementv1alpha1.Bootstrap,
 	mergeWithParent bool,
 ) error {
@@ -524,7 +524,7 @@ func (a *Actuator) prepareGardenletChartValues(
 	targetClient client.Client,
 	gardenletDeployment *seedmanagementv1alpha1.GardenletDeployment,
 	seed *gardencorev1beta1.Seed,
-	componentConfig *gardenletv1alpha1.GardenletConfiguration,
+	componentConfig *gardenletconfigv1alpha1.GardenletConfiguration,
 	bootstrap seedmanagementv1alpha1.Bootstrap,
 	mergeWithParent bool,
 ) (
@@ -576,7 +576,7 @@ func PrepareGardenletChartValues(
 	vp ValuesHelper,
 	bootstrap seedmanagementv1alpha1.Bootstrap,
 	gardenletDeployment *seedmanagementv1alpha1.GardenletDeployment,
-	gardenletConfig *gardenletv1alpha1.GardenletConfiguration,
+	gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration,
 	gardenNamespaceTargetCluster string,
 ) (
 	map[string]any,
@@ -584,7 +584,7 @@ func PrepareGardenletChartValues(
 ) {
 	// Ensure garden client connection is set
 	if gardenletConfig.GardenClientConnection == nil {
-		gardenletConfig.GardenClientConnection = &gardenletv1alpha1.GardenClientConnection{}
+		gardenletConfig.GardenClientConnection = &gardenletconfigv1alpha1.GardenClientConnection{}
 	}
 
 	// Prepare garden client connection
@@ -616,7 +616,7 @@ func PrepareGardenletChartValues(
 
 	// Ensure seed config is set
 	if gardenletConfig.SeedConfig == nil {
-		gardenletConfig.SeedConfig = &gardenletv1alpha1.SeedConfig{}
+		gardenletConfig.SeedConfig = &gardenletconfigv1alpha1.SeedConfig{}
 	}
 
 	// Set the seed name
@@ -672,7 +672,7 @@ func prepareGardenClientConnectionWithBootstrap(
 	targetClusterClient client.Client,
 	recorder record.EventRecorder,
 	obj client.Object,
-	gcc *gardenletv1alpha1.GardenClientConnection,
+	gcc *gardenletconfigv1alpha1.GardenClientConnection,
 	seed *gardencorev1beta1.Seed,
 	bootstrap seedmanagementv1alpha1.Bootstrap,
 	gardenNamespaceTargetCluster string,
@@ -738,7 +738,7 @@ func isAlreadyBootstrapped(ctx context.Context, c client.Client, s *corev1.Secre
 	return secret != nil, nil
 }
 
-func removeBootstrapConfigFromGardenClientConnection(gcc *gardenletv1alpha1.GardenClientConnection) {
+func removeBootstrapConfigFromGardenClientConnection(gcc *gardenletconfigv1alpha1.GardenClientConnection) {
 	// Ensure kubeconfig secret and bootstrap kubeconfig secret are not set
 	gcc.KubeconfigSecret = nil
 	gcc.BootstrapKubeconfig = nil

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	mockgardenletdepoyer "github.com/gardener/gardener/pkg/controller/gardenletdeployer/mock"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -79,7 +79,7 @@ var _ = Describe("Interface", func() {
 		gardenletDeployment *appsv1.Deployment
 
 		mergedDeployment      *seedmanagementv1alpha1.GardenletDeployment
-		mergedGardenletConfig *gardenletv1alpha1.GardenletConfiguration
+		mergedGardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration
 		gardenletChartValues  map[string]any
 	)
 
@@ -203,12 +203,12 @@ var _ = Describe("Interface", func() {
 				},
 			},
 			Config: runtime.RawExtension{
-				Object: &gardenletv1alpha1.GardenletConfiguration{
+				Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
+					SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 						SeedTemplate: *seedTemplate,
 					},
 				},
@@ -391,8 +391,8 @@ var _ = Describe("Interface", func() {
 				PullPolicy: ptr.To(corev1.PullIfNotPresent),
 			}
 
-			mergedGardenletConfig = managedSeed.Spec.Gardenlet.Config.Object.(*gardenletv1alpha1.GardenletConfiguration).DeepCopy()
-			mergedGardenletConfig.GardenClientConnection = &gardenletv1alpha1.GardenClientConnection{
+			mergedGardenletConfig = managedSeed.Spec.Gardenlet.Config.Object.(*gardenletconfigv1alpha1.GardenletConfiguration).DeepCopy()
+			mergedGardenletConfig.GardenClientConnection = &gardenletconfigv1alpha1.GardenClientConnection{
 				ClientConnectionConfiguration: v1alpha1.ClientConnectionConfiguration{
 					Kubeconfig: "kubeconfig",
 				},
@@ -439,8 +439,8 @@ var _ = Describe("Interface", func() {
 		expectGetGardenletChartValues = func(withBootstrap bool) {
 			gardenletChartValues = map[string]any{"foo": "bar"}
 
-			vh.EXPECT().GetGardenletChartValues(mergedDeployment, gomock.AssignableToTypeOf(&gardenletv1alpha1.GardenletConfiguration{}), gomock.AssignableToTypeOf("")).DoAndReturn(
-				func(_ *seedmanagementv1alpha1.GardenletDeployment, gc *gardenletv1alpha1.GardenletConfiguration, _ string) (map[string]any, error) {
+			vh.EXPECT().GetGardenletChartValues(mergedDeployment, gomock.AssignableToTypeOf(&gardenletconfigv1alpha1.GardenletConfiguration{}), gomock.AssignableToTypeOf("")).DoAndReturn(
+				func(_ *seedmanagementv1alpha1.GardenletDeployment, gc *gardenletconfigv1alpha1.GardenletConfiguration, _ string) (map[string]any, error) {
 					if withBootstrap {
 						Expect(gc.GardenClientConnection.Kubeconfig).To(Equal(""))
 						Expect(gc.GardenClientConnection.KubeconfigSecret).To(Equal(&corev1.SecretReference{

--- a/pkg/controller/gardenletdeployer/valueshelper.go
+++ b/pkg/controller/gardenletdeployer/valueshelper.go
@@ -15,7 +15,7 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -27,9 +27,9 @@ type ValuesHelper interface {
 	// MergeGardenletDeployment merges the given GardenletDeployment with the values from the parent gardenlet.
 	MergeGardenletDeployment(*seedmanagementv1alpha1.GardenletDeployment) (*seedmanagementv1alpha1.GardenletDeployment, error)
 	// MergeGardenletConfiguration merges the given GardenletConfiguration with the parent GardenletConfiguration.
-	MergeGardenletConfiguration(config *gardenletv1alpha1.GardenletConfiguration) (*gardenletv1alpha1.GardenletConfiguration, error)
+	MergeGardenletConfiguration(config *gardenletconfigv1alpha1.GardenletConfiguration) (*gardenletconfigv1alpha1.GardenletConfiguration, error)
 	// GetGardenletChartValues computes the values to be used when applying the gardenlet chart.
-	GetGardenletChartValues(*seedmanagementv1alpha1.GardenletDeployment, *gardenletv1alpha1.GardenletConfiguration, string) (map[string]any, error)
+	GetGardenletChartValues(*seedmanagementv1alpha1.GardenletDeployment, *gardenletconfigv1alpha1.GardenletConfiguration, string) (map[string]any, error)
 }
 
 // valuesHelper is a concrete implementation of ValuesHelper
@@ -75,7 +75,7 @@ func (vp *valuesHelper) MergeGardenletDeployment(deployment *seedmanagementv1alp
 }
 
 // MergeGardenletConfiguration merges the given GardenletConfiguration with the parent GardenletConfiguration.
-func (vp *valuesHelper) MergeGardenletConfiguration(config *gardenletv1alpha1.GardenletConfiguration) (*gardenletv1alpha1.GardenletConfiguration, error) {
+func (vp *valuesHelper) MergeGardenletConfiguration(config *gardenletconfigv1alpha1.GardenletConfiguration) (*gardenletconfigv1alpha1.GardenletConfiguration, error) {
 	// Convert configuration object to values
 	configValues, err := utils.ToValuesMap(config)
 	if err != nil {
@@ -110,7 +110,7 @@ func (vp *valuesHelper) MergeGardenletConfiguration(config *gardenletv1alpha1.Ga
 	configValues = utils.MergeMaps(parentConfigValues, configValues)
 
 	// Convert config values back to an object
-	var configObj *gardenletv1alpha1.GardenletConfiguration
+	var configObj *gardenletconfigv1alpha1.GardenletConfiguration
 	if err := utils.FromValuesMap(configValues, &configObj); err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (vp *valuesHelper) MergeGardenletConfiguration(config *gardenletv1alpha1.Ga
 // GetGardenletChartValues computes the values to be used when applying the gardenlet chart.
 func (vp *valuesHelper) GetGardenletChartValues(
 	deployment *seedmanagementv1alpha1.GardenletDeployment,
-	config *gardenletv1alpha1.GardenletConfiguration,
+	config *gardenletconfigv1alpha1.GardenletConfiguration,
 	bootstrapKubeconfig string,
 ) (map[string]any, error) {
 	var err error
@@ -182,7 +182,7 @@ func (vp *valuesHelper) getGardenletDeploymentValues(deployment *seedmanagementv
 }
 
 // getGardenletConfigurationValues computes and returns the gardenlet configuration values from the given GardenletConfiguration.
-func (vp *valuesHelper) getGardenletConfigurationValues(config *gardenletv1alpha1.GardenletConfiguration, bootstrapKubeconfig string) (map[string]any, error) {
+func (vp *valuesHelper) getGardenletConfigurationValues(config *gardenletconfigv1alpha1.GardenletConfiguration, bootstrapKubeconfig string) (map[string]any, error) {
 	// Convert configuration object to values
 	configValues, err := utils.ToValuesMap(config)
 	if err != nil {

--- a/pkg/controller/gardenletdeployer/valueshelper_test.go
+++ b/pkg/controller/gardenletdeployer/valueshelper_test.go
@@ -17,7 +17,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -36,10 +36,10 @@ var _ = Describe("ValuesHelper", func() {
 		vh ValuesHelper
 
 		deployment      *seedmanagementv1alpha1.GardenletDeployment
-		gardenletConfig *gardenletv1alpha1.GardenletConfiguration
+		gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration
 
 		mergedDeployment      *seedmanagementv1alpha1.GardenletDeployment
-		mergedGardenletConfig func(bool) *gardenletv1alpha1.GardenletConfiguration
+		mergedGardenletConfig func(bool) *gardenletconfigv1alpha1.GardenletConfiguration
 
 		gardenletChartValues func(bool, string, int32, map[string]any) map[string]any
 	)
@@ -117,9 +117,9 @@ var _ = Describe("ValuesHelper", func() {
 				"foo": "bar",
 			},
 		}
-		gardenletConfig = &gardenletv1alpha1.GardenletConfiguration{
+		gardenletConfig = &gardenletconfigv1alpha1.GardenletConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
 			FeatureGates: map[string]bool{
@@ -139,7 +139,7 @@ var _ = Describe("ValuesHelper", func() {
 				"foo": "bar",
 			},
 		}
-		mergedGardenletConfig = func(withBootstrap bool) *gardenletv1alpha1.GardenletConfiguration {
+		mergedGardenletConfig = func(withBootstrap bool) *gardenletconfigv1alpha1.GardenletConfiguration {
 			var kubeconfigPath string
 			var bootstrapKubeconfig, kubeconfigSecret *corev1.SecretReference
 			if withBootstrap {
@@ -154,12 +154,12 @@ var _ = Describe("ValuesHelper", func() {
 			} else {
 				kubeconfigPath = gardenKubeconfigPath
 			}
-			return &gardenletv1alpha1.GardenletConfiguration{
+			return &gardenletconfigv1alpha1.GardenletConfiguration{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+					APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 					Kind:       "GardenletConfiguration",
 				},
-				GardenClientConnection: &gardenletv1alpha1.GardenClientConnection{
+				GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
 					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 						Kubeconfig:         kubeconfigPath,
 						AcceptContentTypes: "application/json",
@@ -170,7 +170,7 @@ var _ = Describe("ValuesHelper", func() {
 					BootstrapKubeconfig: bootstrapKubeconfig,
 					KubeconfigSecret:    kubeconfigSecret,
 				},
-				SeedClientConnection: &gardenletv1alpha1.SeedClientConnection{
+				SeedClientConnection: &gardenletconfigv1alpha1.SeedClientConnection{
 					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 						AcceptContentTypes: "application/json",
 						ContentType:        "application/json",
@@ -178,12 +178,12 @@ var _ = Describe("ValuesHelper", func() {
 						Burst:              130,
 					},
 				},
-				Server: gardenletv1alpha1.ServerConfiguration{
-					HealthProbes: &gardenletv1alpha1.Server{
+				Server: gardenletconfigv1alpha1.ServerConfiguration{
+					HealthProbes: &gardenletconfigv1alpha1.Server{
 						BindAddress: "0.0.0.0",
 						Port:        2728,
 					},
-					Metrics: &gardenletv1alpha1.Server{
+					Metrics: &gardenletconfigv1alpha1.Server{
 						BindAddress: "0.0.0.0",
 						Port:        2729,
 					},
@@ -192,7 +192,7 @@ var _ = Describe("ValuesHelper", func() {
 					string("FooFeature"): false,
 					string("BarFeature"): true,
 				},
-				Logging: &gardenletv1alpha1.Logging{
+				Logging: &gardenletconfigv1alpha1.Logging{
 					Enabled: ptr.To(true),
 				},
 			}

--- a/pkg/controllermanager/controller/managedseedset/replica_test.go
+++ b/pkg/controllermanager/controller/managedseedset/replica_test.go
@@ -20,7 +20,7 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	seedmanagementv1alpha1constants "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/constants"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
@@ -61,8 +61,8 @@ var _ = Describe("Replica", func() {
 					Spec: seedmanagementv1alpha1.ManagedSeedSpec{
 						Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 							Config: runtime.RawExtension{
-								Object: &gardenletv1alpha1.GardenletConfiguration{
-									SeedConfig: &gardenletv1alpha1.SeedConfig{
+								Object: &gardenletconfigv1alpha1.GardenletConfiguration{
+									SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 										SeedTemplate: gardencorev1beta1.SeedTemplate{
 											Spec: gardencorev1beta1.SeedSpec{
 												Ingress: &gardencorev1beta1.Ingress{
@@ -352,8 +352,8 @@ var _ = Describe("Replica", func() {
 							},
 							Gardenlet: seedmanagementv1alpha1.GardenletConfig{
 								Config: runtime.RawExtension{
-									Object: &gardenletv1alpha1.GardenletConfiguration{
-										SeedConfig: &gardenletv1alpha1.SeedConfig{
+									Object: &gardenletconfigv1alpha1.GardenletConfiguration{
+										SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 											SeedTemplate: gardencorev1beta1.SeedTemplate{
 												Spec: gardencorev1beta1.SeedSpec{
 													Ingress: &gardencorev1beta1.Ingress{

--- a/pkg/gardenlet/apis/config/helper/helpers.go
+++ b/pkg/gardenlet/apis/config/helper/helpers.go
@@ -14,7 +14,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 // SeedNameFromSeedConfig returns an empty string if the given seed config is nil, or the
@@ -44,7 +44,7 @@ func init() {
 	utilruntime.Must(gardencore.AddToScheme(scheme))
 	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme))
 	utilruntime.Must(config.AddToScheme(scheme))
-	utilruntime.Must(gardenletv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(gardenletconfigv1alpha1.AddToScheme(scheme))
 }
 
 // ConvertGardenletConfiguration converts the given object to an internal GardenletConfiguration version.
@@ -61,14 +61,14 @@ func ConvertGardenletConfiguration(obj runtime.Object) (*config.GardenletConfigu
 }
 
 // ConvertGardenletConfigurationExternal converts the given object to an external  GardenletConfiguration version.
-func ConvertGardenletConfigurationExternal(obj runtime.Object) (*gardenletv1alpha1.GardenletConfiguration, error) {
-	obj, err := scheme.ConvertToVersion(obj, gardenletv1alpha1.SchemeGroupVersion)
+func ConvertGardenletConfigurationExternal(obj runtime.Object) (*gardenletconfigv1alpha1.GardenletConfiguration, error) {
+	obj, err := scheme.ConvertToVersion(obj, gardenletconfigv1alpha1.SchemeGroupVersion)
 	if err != nil {
 		return nil, err
 	}
-	result, ok := obj.(*gardenletv1alpha1.GardenletConfiguration)
+	result, ok := obj.(*gardenletconfigv1alpha1.GardenletConfiguration)
 	if !ok {
-		return nil, errors.New("could not convert GardenletConfiguration to version " + gardenletv1alpha1.SchemeGroupVersion.String())
+		return nil, errors.New("could not convert GardenletConfiguration to version " + gardenletconfigv1alpha1.SchemeGroupVersion.String())
 	}
 	return result, nil
 }

--- a/pkg/gardenlet/apis/config/helper/helpers_test.go
+++ b/pkg/gardenlet/apis/config/helper/helpers_test.go
@@ -15,7 +15,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	. "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 var _ = Describe("helper", func() {
@@ -64,9 +64,9 @@ var _ = Describe("helper", func() {
 
 	Describe("#ConvertGardenletConfiguration", func() {
 		It("should convert the external GardenletConfiguration version to an internal one", func() {
-			result, err := ConvertGardenletConfiguration(&gardenletv1alpha1.GardenletConfiguration{
+			result, err := ConvertGardenletConfiguration(&gardenletconfigv1alpha1.GardenletConfiguration{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+					APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 					Kind:       "GardenletConfiguration",
 				},
 			})
@@ -81,9 +81,9 @@ var _ = Describe("helper", func() {
 			result, err := ConvertGardenletConfigurationExternal(&config.GardenletConfiguration{})
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(&gardenletv1alpha1.GardenletConfiguration{
+			Expect(result).To(Equal(&gardenletconfigv1alpha1.GardenletConfiguration{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+					APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 					Kind:       "GardenletConfiguration",
 				},
 			}))

--- a/pkg/gardenlet/controller/gardenlet/reconciler.go
+++ b/pkg/gardenlet/controller/gardenlet/reconciler.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/oci"
 )
 
@@ -110,7 +110,7 @@ func (r *Reconciler) deployGardenlet(
 	log logr.Logger,
 	gardenlet *seedmanagementv1alpha1.Gardenlet,
 	seed *gardencorev1beta1.Seed,
-	gardenletConfig *gardenletv1alpha1.GardenletConfiguration,
+	gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration,
 ) error {
 	values, err := r.prepareGardenletChartValues(ctx, log, gardenlet, seed, gardenletConfig)
 	if err != nil {
@@ -143,7 +143,7 @@ func (r *Reconciler) prepareGardenletChartValues(
 	log logr.Logger,
 	gardenlet *seedmanagementv1alpha1.Gardenlet,
 	seed *gardencorev1beta1.Seed,
-	gardenletConfig *gardenletv1alpha1.GardenletConfiguration,
+	gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration,
 ) (
 	map[string]interface{},
 	error,

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -34,7 +34,7 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
@@ -382,7 +382,7 @@ var _ = Describe("health check", func() {
 			Entry("outdated OSC secret checksum for a worker pool",
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
+					newNode(labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentconfigv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -402,7 +402,7 @@ var _ = Describe("health check", func() {
 			Entry("outdated OSC secret checksum for a worker pool when shoot has not been reconciled yet",
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
+					newNode(labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentconfigv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -1043,7 +1043,7 @@ func deleteGardenerNodeAgentShootAccess(ctx context.Context, o *operation.Operat
 	if err := kubernetesutils.DeleteObject(
 		ctx,
 		o.SeedClientSet.Client(),
-		gardenerutils.NewShootAccessSecret(nodeagentv1alpha1.AccessSecretName, o.Shoot.SeedNamespace).Secret,
+		gardenerutils.NewShootAccessSecret(nodeagentconfigv1alpha1.AccessSecretName, o.Shoot.SeedNamespace).Secret,
 	); err != nil {
 		return fmt.Errorf("failed to delete gardener-node-agent shoot access secret in seed namespace: %w", err)
 	}
@@ -1053,13 +1053,13 @@ func deleteGardenerNodeAgentShootAccess(ctx context.Context, o *operation.Operat
 		o.ShootClientSet.Client(),
 		&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      nodeagentv1alpha1.AccessSecretName,
+				Name:      nodeagentconfigv1alpha1.AccessSecretName,
 				Namespace: metav1.NamespaceSystem,
 			},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      nodeagentv1alpha1.AccessSecretName,
+				Name:      nodeagentconfigv1alpha1.AccessSecretName,
 				Namespace: metav1.NamespaceSystem,
 			},
 		},

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/worker"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -126,7 +126,7 @@ func OperatingSystemConfigUpdatedForAllWorkerPools(
 
 		var (
 			gardenerNodeAgentSecretName = secretMeta.Name
-			secretChecksum              = secretMeta.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig]
+			secretChecksum              = secretMeta.Annotations[nodeagentconfigv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig]
 		)
 
 		for _, node := range workerPoolToNodes[worker.Name] {
@@ -140,7 +140,7 @@ func OperatingSystemConfigUpdatedForAllWorkerPools(
 				continue
 			}
 
-			if nodeChecksum, ok := node.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig]; nodeChecksum != secretChecksum {
+			if nodeChecksum, ok := node.Annotations[nodeagentconfigv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig]; nodeChecksum != secretChecksum {
 				if !ok {
 					result = multierror.Append(result, fmt.Errorf("the last successfully applied operating system config on node %q hasn't been reported yet", node.Name))
 				} else {

--- a/pkg/nodeagent/bootstrap/bootstrap.go
+++ b/pkg/nodeagent/bootstrap/bootstrap.go
@@ -16,7 +16,7 @@ import (
 
 	nodeagentcomponent "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 )
 
@@ -33,9 +33,9 @@ func Bootstrap(
 ) error {
 	log.Info("Starting bootstrap procedure")
 
-	log.Info("Creating directory for temporary files", "path", nodeagentv1alpha1.TempDir)
-	if err := fs.MkdirAll(nodeagentv1alpha1.TempDir, os.ModeDir); err != nil {
-		return fmt.Errorf("unable to create directory for temporary files %q: %w", nodeagentv1alpha1.TempDir, err)
+	log.Info("Creating directory for temporary files", "path", nodeagentconfigv1alpha1.TempDir)
+	if err := fs.MkdirAll(nodeagentconfigv1alpha1.TempDir, os.ModeDir); err != nil {
+		return fmt.Errorf("unable to create directory for temporary files %q: %w", nodeagentconfigv1alpha1.TempDir, err)
 	}
 
 	if bootstrapConfig != nil && bootstrapConfig.KubeletDataVolumeSize != nil {
@@ -49,10 +49,10 @@ func Bootstrap(
 		}
 	}
 
-	unitFilePath := path.Join("/", "etc", "systemd", "system", nodeagentv1alpha1.UnitName)
+	unitFilePath := path.Join("/", "etc", "systemd", "system", nodeagentconfigv1alpha1.UnitName)
 	log.Info("Writing unit file for gardener-node-agent", "path", unitFilePath)
 	if err := fs.WriteFile(unitFilePath, []byte(nodeagentcomponent.UnitContent()), 0644); err != nil {
-		return fmt.Errorf("unable to write unit file %q to path %q: %w", nodeagentv1alpha1.UnitName, unitFilePath, err)
+		return fmt.Errorf("unable to write unit file %q to path %q: %w", nodeagentconfigv1alpha1.UnitName, unitFilePath, err)
 	}
 
 	log.Info("Reloading systemd daemon")
@@ -61,18 +61,18 @@ func Bootstrap(
 	}
 
 	log.Info("Enabling gardener-node-agent unit")
-	if err := dbus.Enable(ctx, nodeagentv1alpha1.UnitName); err != nil {
-		return fmt.Errorf("unable to enable unit %q: %w", nodeagentv1alpha1.UnitName, err)
+	if err := dbus.Enable(ctx, nodeagentconfigv1alpha1.UnitName); err != nil {
+		return fmt.Errorf("unable to enable unit %q: %w", nodeagentconfigv1alpha1.UnitName, err)
 	}
 
 	log.Info("Starting gardener-node-agent unit")
-	if err := dbus.Start(ctx, nil, nil, nodeagentv1alpha1.UnitName); err != nil {
-		return fmt.Errorf("unable to start unit %q: %w", nodeagentv1alpha1.UnitName, err)
+	if err := dbus.Start(ctx, nil, nil, nodeagentconfigv1alpha1.UnitName); err != nil {
+		return fmt.Errorf("unable to start unit %q: %w", nodeagentconfigv1alpha1.UnitName, err)
 	}
 
 	log.Info("Disabling gardener-node-init unit")
-	if err := dbus.Disable(ctx, nodeagentv1alpha1.InitUnitName); err != nil {
-		return fmt.Errorf("unable to disable system unit %q: %w", nodeagentv1alpha1.InitUnitName, err)
+	if err := dbus.Disable(ctx, nodeagentconfigv1alpha1.InitUnitName); err != nil {
+		return fmt.Errorf("unable to disable system unit %q: %w", nodeagentconfigv1alpha1.InitUnitName, err)
 	}
 
 	// After this line, the execution of the gardener-node-agent bootstrap command terminates. It is not possible to

--- a/pkg/nodeagent/bootstrap/kubelet_data_volume.go
+++ b/pkg/nodeagent/bootstrap/kubelet_data_volume.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/afero"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 )
 
 var (
@@ -42,7 +42,7 @@ func formatKubeletDataDevice(log logr.Logger, fs afero.Afero, kubeletDataVolumeS
 	}
 
 	log.Info("Creating temporary file")
-	tmpFile, err := fs.TempFile(nodeagentv1alpha1.TempDir, "format-kubelet-data-volume-")
+	tmpFile, err := fs.TempFile(nodeagentconfigv1alpha1.TempDir, "format-kubelet-data-volume-")
 	if err != nil {
 		return fmt.Errorf("unable to create temporary directory: %w", err)
 	}

--- a/pkg/nodeagent/certificate.go
+++ b/pkg/nodeagent/certificate.go
@@ -21,7 +21,7 @@ import (
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/certificatesigningrequest"
 )
@@ -68,5 +68,5 @@ func RequestAndStoreKubeconfig(ctx context.Context, log logr.Logger, fs afero.Af
 		return fmt.Errorf("unable to encode the gardener-node-agent kubeconfig: %w", err)
 	}
 
-	return fs.WriteFile(nodeagentv1alpha1.KubeconfigFilePath, kubeconfig, 0600)
+	return fs.WriteFile(nodeagentconfigv1alpha1.KubeconfigFilePath, kubeconfig, 0600)
 }

--- a/pkg/nodeagent/controller/node/reconciler.go
+++ b/pkg/nodeagent/controller/node/reconciler.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/gardener/pkg/controllerutils"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 )
 
@@ -61,7 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		// If the gardener-node-agent itself should be restarted, we have to first remove the annotation from the node.
 		// Otherwise, the annotation is never removed and it restarts itself indefinitely.
-		if serviceName == nodeagentv1alpha1.UnitName {
+		if serviceName == nodeagentconfigv1alpha1.UnitName {
 			restartGardenerNodeAgent = true
 			continue
 		}
@@ -77,7 +77,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if restartGardenerNodeAgent {
-		r.restartService(ctx, log, node, nodeagentv1alpha1.UnitName)
+		r.restartService(ctx, log, node, nodeagentconfigv1alpha1.UnitName)
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -27,7 +27,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 	"github.com/gardener/gardener/pkg/nodeagent/registry"
 )
@@ -82,7 +82,7 @@ func (r *Reconciler) SecretPredicate() predicate.Predicate {
 				return false
 			}
 
-			return !bytes.Equal(oldSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig], newSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig])
+			return !bytes.Equal(oldSecret.Data[nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig], newSecret.Data[nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig])
 		},
 		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
@@ -122,7 +122,7 @@ func (r *Reconciler) EnqueueWithJitterDelay(ctx context.Context, log logr.Logger
 				return
 			}
 
-			if !bytes.Equal(oldSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig], newSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig]) {
+			if !bytes.Equal(oldSecret.Data[nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig], newSecret.Data[nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig]) {
 				duration := delay.fetch(ctx, r.NodeName)
 				log.Info("Enqueued secret with operating system config with a jitter period", "duration", duration)
 				q.AddAfter(reconcileRequest(evt.ObjectNew), duration)

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -20,7 +20,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	componentscontainerd "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd"
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 )
 
 var decoder runtime.Decoder
@@ -32,17 +32,17 @@ func init() {
 }
 
 func extractOSCFromSecret(secret *corev1.Secret) (*extensionsv1alpha1.OperatingSystemConfig, string, error) {
-	oscRaw, ok := secret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig]
+	oscRaw, ok := secret.Data[nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig]
 	if !ok {
-		return nil, "", fmt.Errorf("no %s key found in OSC secret", nodeagentv1alpha1.DataKeyOperatingSystemConfig)
+		return nil, "", fmt.Errorf("no %s key found in OSC secret", nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig)
 	}
 
 	osc := &extensionsv1alpha1.OperatingSystemConfig{}
 	if err := runtime.DecodeInto(decoder, oscRaw, osc); err != nil {
-		return nil, "", fmt.Errorf("unable to decode OSC from secret data key %s: %w", nodeagentv1alpha1.DataKeyOperatingSystemConfig, err)
+		return nil, "", fmt.Errorf("unable to decode OSC from secret data key %s: %w", nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig, err)
 	}
 
-	return osc, secret.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig], nil
+	return osc, secret.Annotations[nodeagentconfigv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig], nil
 }
 
 type operatingSystemConfigChanges struct {

--- a/pkg/nodeagent/registry/containerd_extractor.go
+++ b/pkg/nodeagent/registry/containerd_extractor.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/afero"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/nodeagent/files"
 )
 
@@ -68,7 +68,7 @@ func (e *containerdExtractor) CopyFromImage(ctx context.Context, imageRef string
 
 	snapshotter := client.SnapshotService(containerd.DefaultSnapshotter)
 
-	imageMountDirectory, err := fs.TempDir(nodeagentv1alpha1.TempDir, "mount-image-")
+	imageMountDirectory, err := fs.TempDir(nodeagentconfigv1alpha1.TempDir, "mount-image-")
 	if err != nil {
 		return fmt.Errorf("error creating temp directory: %w", err)
 	}

--- a/pkg/operator/apis/config/v1alpha1/defaults.go
+++ b/pkg/operator/apis/config/v1alpha1/defaults.go
@@ -11,7 +11,7 @@ import (
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
 
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 )
 
@@ -83,13 +83,13 @@ func SetDefaults_GardenControllerConfig(obj *GardenControllerConfig) {
 		obj.SyncPeriod = &metav1.Duration{Duration: time.Hour}
 	}
 	if obj.ETCDConfig == nil {
-		obj.ETCDConfig = &gardenletv1alpha1.ETCDConfig{}
+		obj.ETCDConfig = &gardenletconfigv1alpha1.ETCDConfig{}
 	}
 
-	gardenletv1alpha1.SetDefaults_ETCDConfig(obj.ETCDConfig)
-	gardenletv1alpha1.SetDefaults_ETCDController(obj.ETCDConfig.ETCDController)
-	gardenletv1alpha1.SetDefaults_CustodianController(obj.ETCDConfig.CustodianController)
-	gardenletv1alpha1.SetDefaults_BackupCompactionController(obj.ETCDConfig.BackupCompactionController)
+	gardenletconfigv1alpha1.SetDefaults_ETCDConfig(obj.ETCDConfig)
+	gardenletconfigv1alpha1.SetDefaults_ETCDController(obj.ETCDConfig.ETCDController)
+	gardenletconfigv1alpha1.SetDefaults_CustodianController(obj.ETCDConfig.CustodianController)
+	gardenletconfigv1alpha1.SetDefaults_BackupCompactionController(obj.ETCDConfig.BackupCompactionController)
 }
 
 // SetDefaults_GardenCareControllerConfiguration sets defaults for the GardenCareControllerConfiguration object.

--- a/pkg/operator/apis/config/v1alpha1/types.go
+++ b/pkg/operator/apis/config/v1alpha1/types.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -93,7 +93,7 @@ type GardenControllerConfig struct {
 	// ETCDConfig contains an optional configuration for the
 	// backup compaction feature of ETCD backup-restore functionality.
 	// +optional
-	ETCDConfig *gardenletv1alpha1.ETCDConfig `json:"etcdConfig,omitempty"`
+	ETCDConfig *gardenletconfigv1alpha1.ETCDConfig `json:"etcdConfig,omitempty"`
 }
 
 // GardenletDeployerControllerConfig is the configuration for the gardenlet deployer controller.

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -73,7 +73,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
 	"github.com/gardener/gardener/pkg/component/observability/plutono"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
-	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
@@ -1013,7 +1013,7 @@ func (r *Reconciler) newGardenerControllerManager(garden *operatorv1alpha1.Garde
 		}
 
 		for _, defaultProjectQuota := range config.DefaultProjectQuotas {
-			values.Quotas = append(values.Quotas, controllermanagerv1alpha1.QuotaConfiguration{
+			values.Quotas = append(values.Quotas, controllermanagerconfigv1alpha1.QuotaConfiguration{
 				Config:          defaultProjectQuota.Config,
 				ProjectSelector: defaultProjectQuota.ProjectSelector,
 			})

--- a/pkg/resourcemanager/predicate/class_filter.go
+++ b/pkg/resourcemanager/predicate/class_filter.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	resourcemanagerv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
+	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
 )
 
 const (
@@ -38,11 +38,11 @@ var _ predicate.Predicate = &ClassFilter{}
 // NewClassFilter returns a new `ClassFilter` instance.
 func NewClassFilter(class string) *ClassFilter {
 	if class == "" {
-		class = resourcemanagerv1alpha1.DefaultResourceClass
+		class = resourcemanagerconfigv1alpha1.DefaultResourceClass
 	}
 
 	finalizer := FinalizerName + "-" + class
-	if class == resourcemanagerv1alpha1.DefaultResourceClass {
+	if class == resourcemanagerconfigv1alpha1.DefaultResourceClass {
 		finalizer = FinalizerName
 	}
 
@@ -66,7 +66,7 @@ func (f *ClassFilter) FinalizerName() string {
 func (f *ClassFilter) Responsible(o runtime.Object) bool {
 	r := o.(*resourcesv1alpha1.ManagedResource)
 	c := ptr.Deref(r.Spec.Class, "")
-	return c == f.resourceClass || (c == "" && f.resourceClass == resourcemanagerv1alpha1.DefaultResourceClass)
+	return c == f.resourceClass || (c == "" && f.resourceClass == resourcemanagerconfigv1alpha1.DefaultResourceClass)
 }
 
 // IsTransferringResponsibility checks if a Managed Resource has changed its class and should have its resources cleaned by the given controller instance.

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -15,19 +15,19 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/logger"
-	schedulerv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
+	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
 )
 
 var _ = Describe("Defaults", func() {
-	var obj *schedulerv1alpha1.SchedulerConfiguration
+	var obj *schedulerconfigv1alpha1.SchedulerConfiguration
 
 	BeforeEach(func() {
-		obj = &schedulerv1alpha1.SchedulerConfiguration{}
+		obj = &schedulerconfigv1alpha1.SchedulerConfiguration{}
 	})
 
 	Describe("SchedulerConfiguration defaulting", func() {
 		It("should default the scheduler configuration", func() {
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
 			Expect(obj.LogLevel).To(Equal(logger.InfoLevel))
 			Expect(obj.LogFormat).To(Equal(logger.FormatJSON))
@@ -35,12 +35,12 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not overwrite already set values for scheduler configuration", func() {
-			obj = &schedulerv1alpha1.SchedulerConfiguration{
-				LogLevel:  schedulerv1alpha1.LogLevelDebug,
-				LogFormat: schedulerv1alpha1.LogFormatText,
+			obj = &schedulerconfigv1alpha1.SchedulerConfiguration{
+				LogLevel:  schedulerconfigv1alpha1.LogLevelDebug,
+				LogFormat: schedulerconfigv1alpha1.LogFormatText,
 			}
 
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
 			Expect(obj.LogLevel).To(Equal(logger.DebugLevel))
 			Expect(obj.LogFormat).To(Equal(logger.FormatText))
@@ -50,41 +50,41 @@ var _ = Describe("Defaults", func() {
 
 	Describe("SchedulerControllerConfiguration defaulting", func() {
 		It("should default the scheduler controller configuration", func() {
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
-			Expect(obj.Schedulers).To(Equal(schedulerv1alpha1.SchedulerControllerConfiguration{
-				BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
+			Expect(obj.Schedulers).To(Equal(schedulerconfigv1alpha1.SchedulerControllerConfiguration{
+				BackupBucket: &schedulerconfigv1alpha1.BackupBucketSchedulerConfiguration{
 					ConcurrentSyncs: 2,
 				},
-				Shoot: &schedulerv1alpha1.ShootSchedulerConfiguration{
+				Shoot: &schedulerconfigv1alpha1.ShootSchedulerConfiguration{
 					ConcurrentSyncs: 5,
-					Strategy:        schedulerv1alpha1.Default,
+					Strategy:        schedulerconfigv1alpha1.Default,
 				},
 			}))
 		})
 
 		It("should not overwrite already set values for scheduler controller configuration", func() {
-			obj = &schedulerv1alpha1.SchedulerConfiguration{
-				Schedulers: schedulerv1alpha1.SchedulerControllerConfiguration{
-					BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
+			obj = &schedulerconfigv1alpha1.SchedulerConfiguration{
+				Schedulers: schedulerconfigv1alpha1.SchedulerControllerConfiguration{
+					BackupBucket: &schedulerconfigv1alpha1.BackupBucketSchedulerConfiguration{
 						ConcurrentSyncs: 3,
 					},
-					Shoot: &schedulerv1alpha1.ShootSchedulerConfiguration{
+					Shoot: &schedulerconfigv1alpha1.ShootSchedulerConfiguration{
 						ConcurrentSyncs: 6,
-						Strategy:        schedulerv1alpha1.MinimalDistance,
+						Strategy:        schedulerconfigv1alpha1.MinimalDistance,
 					},
 				},
 			}
 
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
-			Expect(obj.Schedulers).To(Equal(schedulerv1alpha1.SchedulerControllerConfiguration{
-				BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
+			Expect(obj.Schedulers).To(Equal(schedulerconfigv1alpha1.SchedulerControllerConfiguration{
+				BackupBucket: &schedulerconfigv1alpha1.BackupBucketSchedulerConfiguration{
 					ConcurrentSyncs: 3,
 				},
-				Shoot: &schedulerv1alpha1.ShootSchedulerConfiguration{
+				Shoot: &schedulerconfigv1alpha1.ShootSchedulerConfiguration{
 					ConcurrentSyncs: 6,
-					Strategy:        schedulerv1alpha1.MinimalDistance,
+					Strategy:        schedulerconfigv1alpha1.MinimalDistance,
 				},
 			}))
 		})
@@ -92,11 +92,11 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ServerConfiguration defaulting", func() {
 		It("should not overwrite already set values for ServerConfiguration", func() {
-			serverConfiguration := &schedulerv1alpha1.ServerConfiguration{
-				HealthProbes: &schedulerv1alpha1.Server{
+			serverConfiguration := &schedulerconfigv1alpha1.ServerConfiguration{
+				HealthProbes: &schedulerconfigv1alpha1.Server{
 					Port: 1234,
 				},
-				Metrics: &schedulerv1alpha1.Server{
+				Metrics: &schedulerconfigv1alpha1.Server{
 					Port: 1235,
 				},
 			}
@@ -104,30 +104,30 @@ var _ = Describe("Defaults", func() {
 
 			expectedServerConfiguration := serverConfiguration.DeepCopy()
 
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 			Expect(obj.Server).To(Equal(*expectedServerConfiguration))
 		})
 
 		It("should default values for ServerConfiguration", func() {
-			obj.Server = schedulerv1alpha1.ServerConfiguration{}
+			obj.Server = schedulerconfigv1alpha1.ServerConfiguration{}
 
-			expectedServerConfiguration := schedulerv1alpha1.ServerConfiguration{
-				HealthProbes: &schedulerv1alpha1.Server{
+			expectedServerConfiguration := schedulerconfigv1alpha1.ServerConfiguration{
+				HealthProbes: &schedulerconfigv1alpha1.Server{
 					Port: 10251,
 				},
-				Metrics: &schedulerv1alpha1.Server{
+				Metrics: &schedulerconfigv1alpha1.Server{
 					Port: 19251,
 				},
 			}
 
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 			Expect(obj.Server).To(Equal(expectedServerConfiguration))
 		})
 	})
 
 	Describe("ClientConnection defaulting", func() {
 		It("should not default ContentType and AcceptContentTypes", func() {
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
 			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the intelligent
@@ -137,7 +137,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should correctly default ClientConnection", func() {
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 			Expect(obj.ClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   50.0,
 				Burst: 100,
@@ -150,7 +150,7 @@ var _ = Describe("Defaults", func() {
 				Burst: 110,
 			}
 
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
 			Expect(obj.ClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   60.0,
@@ -161,7 +161,7 @@ var _ = Describe("Defaults", func() {
 
 	Describe("LeaderElection defaulting", func() {
 		It("should default leader election settings", func() {
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
 			Expect(obj.LeaderElection).NotTo(BeNil())
 			Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
@@ -184,7 +184,7 @@ var _ = Describe("Defaults", func() {
 				ResourceName:      "lock-object",
 			}
 			obj.LeaderElection = expectedLeaderElection.DeepCopy()
-			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerconfigv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
 			Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
 		})
@@ -193,10 +193,10 @@ var _ = Describe("Defaults", func() {
 
 var _ = Describe("Constants", func() {
 	It("should have the same values as the corresponding constants in the logger package", func() {
-		Expect(schedulerv1alpha1.LogLevelDebug).To(Equal(logger.DebugLevel))
-		Expect(schedulerv1alpha1.LogLevelInfo).To(Equal(logger.InfoLevel))
-		Expect(schedulerv1alpha1.LogLevelError).To(Equal(logger.ErrorLevel))
-		Expect(schedulerv1alpha1.LogFormatJSON).To(Equal(logger.FormatJSON))
-		Expect(schedulerv1alpha1.LogFormatText).To(Equal(logger.FormatText))
+		Expect(schedulerconfigv1alpha1.LogLevelDebug).To(Equal(logger.DebugLevel))
+		Expect(schedulerconfigv1alpha1.LogLevelInfo).To(Equal(logger.InfoLevel))
+		Expect(schedulerconfigv1alpha1.LogLevelError).To(Equal(logger.ErrorLevel))
+		Expect(schedulerconfigv1alpha1.LogFormatJSON).To(Equal(logger.FormatJSON))
+		Expect(schedulerconfigv1alpha1.LogFormatText).To(Equal(logger.FormatText))
 	})
 })

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -31,7 +31,7 @@ import (
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	securityinformers "github.com/gardener/gardener/pkg/client/security/informers/externalversions"
 	fakeseedmanagement "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/fake"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/gardener/gardener/plugin/pkg/managedseed/validator"
@@ -350,12 +350,12 @@ var _ = Describe("ManagedSeed", func() {
 
 			BeforeEach(func() {
 				managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{},
@@ -377,12 +377,12 @@ var _ = Describe("ManagedSeed", func() {
 
 				seedx.Spec.Ingress.Controller.Kind = v1beta1constants.IngressKindNginx
 				Expect(managedSeed.Spec.Gardenlet).To(Equal(seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								ObjectMeta: seedx.ObjectMeta,
 								Spec:       seedx.Spec,
@@ -405,12 +405,12 @@ var _ = Describe("ManagedSeed", func() {
 				}
 
 				managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: seedx.Spec,
 							},
@@ -426,12 +426,12 @@ var _ = Describe("ManagedSeed", func() {
 					SecretRef: corev1.SecretReference{Name: "bar", Namespace: "garden"},
 				}
 				Expect(managedSeed.Spec.Gardenlet).To(Equal(seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								ObjectMeta: seedx.ObjectMeta,
 								Spec:       seedx.Spec,
@@ -454,12 +454,12 @@ var _ = Describe("ManagedSeed", func() {
 				}
 				shoot.Spec.SecretBindingName = ptr.To(secretBinding.Name)
 				managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: seedx.Spec,
 							},
@@ -475,12 +475,12 @@ var _ = Describe("ManagedSeed", func() {
 					SecretRef: corev1.SecretReference{Name: "bar", Namespace: "garden"},
 				}
 				Expect(managedSeed.Spec.Gardenlet).To(Equal(seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								ObjectMeta: seedx.ObjectMeta,
 								Spec:       seedx.Spec,
@@ -503,12 +503,12 @@ var _ = Describe("ManagedSeed", func() {
 				shoot.Spec.CredentialsBindingName = ptr.To(credentialsBinding.Name)
 
 				managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: seedx.Spec,
 							},
@@ -524,12 +524,12 @@ var _ = Describe("ManagedSeed", func() {
 					SecretRef: corev1.SecretReference{Name: "bar", Namespace: "garden"},
 				}
 				Expect(managedSeed.Spec.Gardenlet).To(Equal(seedmanagement.GardenletConfig{
-					Config: &gardenletv1alpha1.GardenletConfiguration{
+					Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								ObjectMeta: seedx.ObjectMeta,
 								Spec:       seedx.Spec,
@@ -578,12 +578,12 @@ var _ = Describe("ManagedSeed", func() {
 					},
 				}
 
-				managedSeed.Spec.Gardenlet.Config = &gardenletv1alpha1.GardenletConfiguration{
+				managedSeed.Spec.Gardenlet.Config = &gardenletconfigv1alpha1.GardenletConfiguration{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "GardenletConfiguration",
 					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
+					SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 						SeedTemplate: gardencorev1beta1.SeedTemplate{
 							Spec: seedSpec,
 						},
@@ -665,12 +665,12 @@ var _ = Describe("ManagedSeed", func() {
 					}
 
 					managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-						Config: &gardenletv1alpha1.GardenletConfiguration{
+						Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 							TypeMeta: metav1.TypeMeta{
-								APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+								APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 								Kind:       "GardenletConfiguration",
 							},
-							SeedConfig: &gardenletv1alpha1.SeedConfig{
+							SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 								SeedTemplate: gardencorev1beta1.SeedTemplate{
 									Spec: seedx.Spec,
 								},
@@ -723,12 +723,12 @@ var _ = Describe("ManagedSeed", func() {
 					}
 
 					managedSeed.Spec.Gardenlet = seedmanagement.GardenletConfig{
-						Config: &gardenletv1alpha1.GardenletConfiguration{
+						Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 							TypeMeta: metav1.TypeMeta{
-								APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+								APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 								Kind:       "GardenletConfiguration",
 							},
-							SeedConfig: &gardenletv1alpha1.SeedConfig{
+							SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 								SeedTemplate: gardencorev1beta1.SeedTemplate{
 									Spec: seedx.Spec,
 								},
@@ -748,12 +748,12 @@ var _ = Describe("ManagedSeed", func() {
 				)
 
 				BeforeEach(func() {
-					gardenletConfig := &gardenletv1alpha1.GardenletConfiguration{
+					gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
 						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Ingress: seedx.Spec.Ingress,
@@ -771,7 +771,7 @@ var _ = Describe("ManagedSeed", func() {
 				})
 
 				It("should allow zone removal when there are no shoots running on seed", func() {
-					newGardenletConfig := newManagedSeed.Spec.Gardenlet.Config.(*gardenletv1alpha1.GardenletConfiguration)
+					newGardenletConfig := newManagedSeed.Spec.Gardenlet.Config.(*gardenletconfigv1alpha1.GardenletConfiguration)
 					shoot.Spec.Provider.Workers[0].Zones = []string{zone2}
 					newGardenletConfig.SeedConfig.Spec.Provider.Zones = shoot.Spec.Provider.Workers[0].Zones
 
@@ -782,7 +782,7 @@ var _ = Describe("ManagedSeed", func() {
 				})
 
 				It("should forbid zone removal when at least one shoot is scheduled to seed", func() {
-					newGardenletConfig := newManagedSeed.Spec.Gardenlet.Config.(*gardenletv1alpha1.GardenletConfiguration)
+					newGardenletConfig := newManagedSeed.Spec.Gardenlet.Config.(*gardenletconfigv1alpha1.GardenletConfiguration)
 					shoot.Spec.Provider.Workers[0].Zones = []string{zone2}
 					newGardenletConfig.SeedConfig.Spec.Provider.Zones = shoot.Spec.Provider.Workers[0].Zones
 
@@ -809,7 +809,7 @@ var _ = Describe("ManagedSeed", func() {
 					shoot.Spec.Provider.Workers[0].Zones = append(shoot.Spec.Provider.Workers[0].Zones, "zone-bar")
 
 					// add a different zone name to ManagedSeed config
-					gardenletConfig := newManagedSeed.Spec.Gardenlet.Config.(*gardenletv1alpha1.GardenletConfiguration)
+					gardenletConfig := newManagedSeed.Spec.Gardenlet.Config.(*gardenletconfigv1alpha1.GardenletConfiguration)
 					gardenletConfig.SeedConfig.Spec.Provider.Zones = append(gardenletConfig.SeedConfig.Spec.Provider.Zones, "zone-foo")
 
 					coreClient.AddReactor("get", "shoots", func(_ testing.Action) (bool, runtime.Object, error) {
@@ -835,11 +835,11 @@ var _ = Describe("ManagedSeed", func() {
 					shoot.Spec.Provider.Workers[0].Zones = append(shoot.Spec.Provider.Workers[0].Zones, "zone-3")
 
 					// create an artificial mismatch in zone names between the seed config and the shoot
-					gardenletConfig := managedSeed.Spec.Gardenlet.Config.(*gardenletv1alpha1.GardenletConfiguration)
+					gardenletConfig := managedSeed.Spec.Gardenlet.Config.(*gardenletconfigv1alpha1.GardenletConfiguration)
 					gardenletConfig.SeedConfig.Spec.Provider.Zones = []string{"zone-foo", "zone-bar"}
 
 					// zones should still be configured in new ManagedSeed, plus an additional non-existing one
-					newGardenletConfig := newManagedSeed.Spec.Gardenlet.Config.(*gardenletv1alpha1.GardenletConfiguration)
+					newGardenletConfig := newManagedSeed.Spec.Gardenlet.Config.(*gardenletconfigv1alpha1.GardenletConfiguration)
 					newGardenletConfig.SeedConfig.Spec.Provider.Zones = []string{"zone-foo", "zone-bar", "zone-foobar"}
 
 					coreClient.AddReactor("get", "shoots", func(_ testing.Action) (bool, runtime.Object, error) {

--- a/plugin/pkg/shoot/managedseed/admission_test.go
+++ b/plugin/pkg/shoot/managedseed/admission_test.go
@@ -22,7 +22,7 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	corefake "github.com/gardener/gardener/pkg/client/core/clientset/versioned/fake"
 	fakeseedmanagement "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/fake"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/gardener/gardener/plugin/pkg/shoot/managedseed"
 )
@@ -37,7 +37,7 @@ var _ = Describe("ManagedSeed", func() {
 		var (
 			shoot                *core.Shoot
 			managedSeed          *seedmanagementv1alpha1.ManagedSeed
-			gardenletConfig      *gardenletv1alpha1.GardenletConfiguration
+			gardenletConfig      *gardenletconfigv1alpha1.GardenletConfiguration
 			coreClient           *corefake.Clientset
 			seedManagementClient *fakeseedmanagement.Clientset
 			admissionHandler     *ManagedSeed
@@ -86,8 +86,8 @@ var _ = Describe("ManagedSeed", func() {
 				},
 			}
 
-			gardenletConfig = &gardenletv1alpha1.GardenletConfiguration{
-				SeedConfig: &gardenletv1alpha1.SeedConfig{
+			gardenletConfig = &gardenletconfigv1alpha1.GardenletConfiguration{
+				SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 					SeedTemplate: gardencorev1beta1.SeedTemplate{
 						Spec: gardencorev1beta1.SeedSpec{
 							Provider: gardencorev1beta1.SeedProvider{
@@ -194,7 +194,7 @@ var _ = Describe("ManagedSeed", func() {
 			It("should forbid Shoot update if the seedTemplate is not specified", func() {
 				managedSeed.Spec.Gardenlet = seedmanagementv1alpha1.GardenletConfig{
 					Config: runtime.RawExtension{
-						Object: &gardenletv1alpha1.GardenletConfiguration{},
+						Object: &gardenletconfigv1alpha1.GardenletConfiguration{},
 					},
 				}
 				seedManagementClient.AddReactor("list", "managedseeds", func(_ testing.Action) (bool, runtime.Object, error) {

--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	. "github.com/gardener/gardener/pkg/utils/test"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
@@ -173,7 +173,7 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 				// kube-controller-manager backdates the issued certificate, see https://github.com/kubernetes/kubernetes/blob/252935368ab67f38cb252df0a961a6dcb81d20eb/pkg/controller/certificates/signer/signer.go#L197.
 				// ~40% * 15m =~ 6m. The jittering in gardenlet adds this to the time at which the certificate became
 				// valid and then renews it.
-				return patchGardenletKubeconfigValiditySettingsAndTriggerRotation(ctx, f.GardenClient.Client(), managedSeed, &gardenletv1alpha1.KubeconfigValidity{
+				return patchGardenletKubeconfigValiditySettingsAndTriggerRotation(ctx, f.GardenClient.Client(), managedSeed, &gardenletconfigv1alpha1.KubeconfigValidity{
 					Validity:                        &metav1.Duration{Duration: 10 * time.Minute},
 					AutoRotationJitterPercentageMin: ptr.To[int32](40),
 					AutoRotationJitterPercentageMax: ptr.To[int32](41),
@@ -253,18 +253,18 @@ const (
 )
 
 func buildManagedSeed(shoot *gardencorev1beta1.Shoot) (*seedmanagementv1alpha1.ManagedSeed, error) {
-	gardenletConfig := &gardenletv1alpha1.GardenletConfiguration{
+	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+			APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 			Kind:       "GardenletConfiguration",
 		},
-		GardenClientConnection: &gardenletv1alpha1.GardenClientConnection{
+		GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
 			KubeconfigSecret: &corev1.SecretReference{
 				Name:      gardenletKubeconfigSecretName,
 				Namespace: gardenletKubeconfigSecretNamespace,
 			},
 		},
-		SeedConfig: &gardenletv1alpha1.SeedConfig{
+		SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 			SeedTemplate: gardencorev1beta1.SeedTemplate{
 				Spec: gardencorev1beta1.SeedSpec{
 					Settings: &gardencorev1beta1.SeedSettings{
@@ -344,7 +344,7 @@ func patchGardenletKubeconfigValiditySettingsAndTriggerRotation(
 	ctx context.Context,
 	gardenClient client.Client,
 	managedSeed *seedmanagementv1alpha1.ManagedSeed,
-	kubeconfigValidity *gardenletv1alpha1.KubeconfigValidity,
+	kubeconfigValidity *gardenletconfigv1alpha1.KubeconfigValidity,
 ) error {
 	if err := gardenClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed); err != nil {
 		return err
@@ -356,7 +356,7 @@ func patchGardenletKubeconfigValiditySettingsAndTriggerRotation(
 	}
 
 	if gardenletConfig.GardenClientConnection == nil {
-		gardenletConfig.GardenClientConnection = &gardenletv1alpha1.GardenClientConnection{}
+		gardenletConfig.GardenClientConnection = &gardenletconfigv1alpha1.GardenClientConnection{}
 	}
 	gardenletConfig.GardenClientConnection.KubeconfigValidity = kubeconfigValidity
 

--- a/test/integration/controllermanager/managedseedset/managedseedset_test.go
+++ b/test/integration/controllermanager/managedseedset/managedseedset_test.go
@@ -20,7 +20,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -28,7 +28,7 @@ var _ = Describe("ManagedSeedSet controller test", func() {
 	var (
 		shoot           *gardencorev1beta1.Shoot
 		seed            *gardencorev1beta1.Seed
-		gardenletConfig *gardenletv1alpha1.GardenletConfiguration
+		gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration
 		managedSeed     *seedmanagementv1alpha1.ManagedSeed
 		managedSeedSet  *seedmanagementv1alpha1.ManagedSeedSet
 		selector        labels.Selector
@@ -135,12 +135,12 @@ var _ = Describe("ManagedSeedSet controller test", func() {
 			},
 		}
 
-		gardenletConfig = &gardenletv1alpha1.GardenletConfiguration{
+		gardenletConfig = &gardenletconfigv1alpha1.GardenletConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			SeedConfig: &gardenletv1alpha1.SeedConfig{
+			SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: seed.ObjectMeta,
 					Spec:       seed.Spec,

--- a/test/integration/gardenlet/gardenlet/gardenlet_test.go
+++ b/test/integration/gardenlet/gardenlet/gardenlet_test.go
@@ -20,7 +20,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -28,18 +28,18 @@ var _ = Describe("Gardenlet controller test", func() {
 	var gardenlet *seedmanagementv1alpha1.Gardenlet
 
 	BeforeEach(func() {
-		gardenletConfig, err := encoding.EncodeGardenletConfiguration(&gardenletv1alpha1.GardenletConfiguration{
+		gardenletConfig, err := encoding.EncodeGardenletConfiguration(&gardenletconfigv1alpha1.GardenletConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			GardenClientConnection: &gardenletv1alpha1.GardenClientConnection{
+			GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
 				KubeconfigSecret: &corev1.SecretReference{
 					Name:      "gardenlet-kubeconfig",
 					Namespace: gardenNamespaceSeed.Name,
 				},
 			},
-			SeedConfig: &gardenletv1alpha1.SeedConfig{
+			SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{

--- a/test/integration/gardenlet/managedseed/managedseed_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_test.go
@@ -20,7 +20,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -93,18 +93,18 @@ var _ = Describe("ManagedSeed controller test", func() {
 			},
 		}
 
-		gardenletConfig, err := encoding.EncodeGardenletConfiguration(&gardenletv1alpha1.GardenletConfiguration{
+		gardenletConfig, err := encoding.EncodeGardenletConfiguration(&gardenletconfigv1alpha1.GardenletConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			GardenClientConnection: &gardenletv1alpha1.GardenClientConnection{
+			GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
 				KubeconfigSecret: &corev1.SecretReference{
 					Name:      "gardenlet-kubeconfig",
 					Namespace: gardenNamespaceGarden.Name,
 				},
 			},
-			SeedConfig: &gardenletv1alpha1.SeedConfig{
+			SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{

--- a/test/integration/operator/gardenlet/gardenlet_test.go
+++ b/test/integration/operator/gardenlet/gardenlet_test.go
@@ -20,7 +20,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -65,12 +65,12 @@ var _ = Describe("Gardenlet controller test", func() {
 				},
 			},
 		}
-		gardenletConfig, err := encoding.EncodeGardenletConfiguration(&gardenletv1alpha1.GardenletConfiguration{
+		gardenletConfig, err := encoding.EncodeGardenletConfiguration(&gardenletconfigv1alpha1.GardenletConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			SeedConfig: &gardenletv1alpha1.SeedConfig{
+			SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
 					ObjectMeta: seed.ObjectMeta,
 					Spec:       seed.Spec,

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
-	resourcemanagerv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
+	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
 	resourcemanagerclient "github.com/gardener/gardener/pkg/resourcemanager/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/managedresource"
 	resourcemanagerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
@@ -115,7 +115,7 @@ var _ = BeforeSuite(func() {
 
 	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now())
-	filter = resourcemanagerpredicate.NewClassFilter(resourcemanagerv1alpha1.DefaultResourceClass)
+	filter = resourcemanagerpredicate.NewClassFilter(resourcemanagerconfigv1alpha1.DefaultResourceClass)
 
 	Expect((&managedresource.Reconciler{
 		Config: config.ManagedResourceControllerConfig{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

This is a prefactoring for https://github.com/gardener/gardener/issues/11043:

When we start using the external version of the operator config API, we will have overlapping import aliases with the current configuration, which will get confusing:

- `github.com/gardener/gardener/pkg/apis/operator/v1alpha1` -> imported as `operatorv1alpha1`
- `github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1` -> also imported as `operatorv1alpha1`

Therefore, this PR updates the import aliases to be consistent across all components:

- `github.com/gardener/gardener/pkg/*/apis/config/v1alpha1` -> imported as `*configv1alpha1`
- `github.com/gardener/gardener/pkg/*/apis/config/validation` -> imported as `*validation` (unchanged)
- `github.com/gardener/gardener/pkg/*/apis/config/v1alpha1/validation` -> imported as `*validation` (not used yet)

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11043

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
