### PR TITLE
[operator] Trigger restart when `garden` is deleted

### DIFF
--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -61,7 +61,8 @@ func NewCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return run(cmd.Context(), log, opts.config)
+			ctx, cancel := context.WithCancel(cmd.Context())
+			return run(ctx, cancel, log, opts.config)
 		},
 	}
 
@@ -72,7 +73,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func run(ctx context.Context, log logr.Logger, cfg *config.OperatorConfiguration) error {
+func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *config.OperatorConfiguration) error {
 	log.Info("Feature Gates", "featureGates", features.DefaultFeatureGate)
 
 	log.Info("Getting rest config")
@@ -196,7 +197,7 @@ func run(ctx context.Context, log logr.Logger, cfg *config.OperatorConfiguration
 	}
 
 	log.Info("Adding controllers to manager")
-	if err := controller.AddToManager(ctx, mgr, cfg, gardenClientMap); err != nil {
+	if err := controller.AddToManager(ctx, cancel, mgr, cfg, gardenClientMap); err != nil {
 		return fmt.Errorf("failed adding controllers to manager: %w", err)
 	}
 

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -105,7 +105,7 @@ func (cr *Manager) ScheduleCertificateRotation(ctx context.Context, gardenletCan
 			return
 		}
 
-		cr.log.Info("Terminating Gardenlet after successful certificate rotation")
+		cr.log.Info("Terminating gardenlet after successful certificate rotation")
 		gardenletCancel()
 	}, time.Second, ctx.Done())
 	return nil

--- a/pkg/operator/controller/add.go
+++ b/pkg/operator/controller/add.go
@@ -33,7 +33,7 @@ import (
 )
 
 // AddToManager adds all controllers to the given manager.
-func AddToManager(ctx context.Context, mgr manager.Manager, cfg *config.OperatorConfiguration, gardenClientMap clientmap.ClientMap) error {
+func AddToManager(ctx context.Context, operatorCancel context.CancelFunc, mgr manager.Manager, cfg *config.OperatorConfiguration, gardenClientMap clientmap.ClientMap) error {
 	identity, err := gardenerutils.DetermineIdentity()
 	if err != nil {
 		return err
@@ -54,6 +54,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg *config.Operator
 	})
 
 	if err := (&controllerregistrar.Reconciler{
+		OperatorCancel: operatorCancel,
 		Controllers: append([]controllerregistrar.Controller{
 			{
 				Name: networkpolicy.ControllerName,

--- a/pkg/operator/controller/controllerregistrar/add.go
+++ b/pkg/operator/controller/controllerregistrar/add.go
@@ -25,7 +25,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(&operatorv1alpha1.Garden{}, builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create))).
+		For(&operatorv1alpha1.Garden{}, builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Delete))).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 		}).

--- a/pkg/operator/controller/controllerregistrar/reconciler.go
+++ b/pkg/operator/controller/controllerregistrar/reconciler.go
@@ -41,7 +41,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if apierrors.IsNotFound(err) {
 			// Shut down Gardener-Operator in case the garden was deleted.
 			// This is a pragmatic way to deregister all controllers that depend on the existence of a garden cluster.
-			log.Info("Terminating Gardener-Operator after garden deletion")
+			log.Info("Terminating gardener-operator after garden deletion")
 			r.OperatorCancel()
 			return reconcile.Result{}, nil
 		}

--- a/test/integration/operator/controllerregistrar/controllerregistrar_suite_test.go
+++ b/test/integration/operator/controllerregistrar/controllerregistrar_suite_test.go
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerregistrar_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+func TestControllerRegistrar(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration Operator ControllerRegistrar Suite")
+}
+
+const testID = "controller-registrar-controller-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *envtest.Environment
+	testClient client.Client
+	mgr        manager.Manager
+
+	testRunID     string
+	testNamespace *corev1.Namespace
+	gardenName    string
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("Start test environment")
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
+			},
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("Create test client")
+	testClient, err = client.New(restConfig, client.Options{Scheme: operatorclient.RuntimeScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Create test Namespaces")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "garden-",
+		},
+	}
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+	gardenName = testNamespace.Name
+	testRunID = testNamespace.Name
+
+	DeferCleanup(func() {
+		By("Delete test Namespaces")
+		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("Setup manager")
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	Expect(err).NotTo(HaveOccurred())
+	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
+	Expect(err).NotTo(HaveOccurred())
+
+	mgr, err = manager.New(restConfig, manager.Options{
+		Scheme:  operatorclient.RuntimeScheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			Mapper: mapper,
+			ByObject: map[client.Object]cache.ByObject{
+				&operatorv1alpha1.Garden{}: {
+					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+				},
+			},
+		},
+		Controller: controllerconfig.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Start manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("Stop manager")
+		mgrCancel()
+	})
+})

--- a/test/integration/operator/controllerregistrar/controllerregistrar_test.go
+++ b/test/integration/operator/controllerregistrar/controllerregistrar_test.go
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerregistrar_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/operator/controller/controllerregistrar"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("Controller Registrar controller tests", Ordered, func() {
+	var (
+		operatorCtx, operatorCancel = context.WithCancel(ctx)
+		garden                      *operatorv1alpha1.Garden
+
+		controller1      *testController
+		controller1Added bool
+
+		controller2      *testController
+		controller2Added bool
+	)
+
+	BeforeEach(OncePerOrdered, func() {
+		garden = &operatorv1alpha1.Garden{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   gardenName,
+				Labels: map[string]string{testID: testRunID},
+			},
+			Spec: operatorv1alpha1.GardenSpec{
+				RuntimeCluster: operatorv1alpha1.RuntimeCluster{
+					Networking: operatorv1alpha1.RuntimeNetworking{
+						Pods:     "10.1.0.0/16",
+						Services: "10.2.0.0/16",
+					},
+					Ingress: operatorv1alpha1.Ingress{
+						Domains: []operatorv1alpha1.DNSDomain{{Name: "ingress.runtime-garden.local.gardener.cloud"}},
+						Controller: gardencorev1beta1.IngressController{
+							Kind: "nginx",
+						},
+					},
+					Provider: operatorv1alpha1.Provider{
+						Zones: []string{"a", "b", "c"},
+					},
+					Settings: &operatorv1alpha1.Settings{
+						VerticalPodAutoscaler: &operatorv1alpha1.SettingVerticalPodAutoscaler{
+							Enabled: ptr.To(true),
+						},
+					},
+				},
+				VirtualCluster: operatorv1alpha1.VirtualCluster{
+					DNS: operatorv1alpha1.DNS{
+						Domains: []operatorv1alpha1.DNSDomain{{Name: "virtual-garden.local.gardener.cloud"}},
+					},
+					Gardener: operatorv1alpha1.Gardener{
+						ClusterIdentity: "test",
+					},
+					Kubernetes: operatorv1alpha1.Kubernetes{
+						Version: "1.26.3",
+					},
+					Maintenance: operatorv1alpha1.Maintenance{
+						TimeWindow: gardencorev1beta1.MaintenanceTimeWindow{
+							Begin: "220000+0100",
+							End:   "230000+0100",
+						},
+					},
+					Networking: operatorv1alpha1.Networking{
+						Services: "100.64.0.0/13",
+					},
+				},
+			},
+		}
+
+		DeferCleanup(func() {
+			Expect(testClient.Delete(ctx, garden)).To(Or(Succeed(), BeNotFoundError()))
+		})
+
+		controller1 = &testController{}
+		controller2 = &testController{}
+
+		Expect((&controllerregistrar.Reconciler{
+			OperatorCancel: operatorCancel,
+			Controllers: []controllerregistrar.Controller{
+				{
+					Name: testControllerName + "-1",
+					AddToManagerFunc: func(_ context.Context, manager manager.Manager, _ *operatorv1alpha1.Garden) (bool, error) {
+						controller1Added = true
+						return true, controller1.AddToManager(manager, testControllerName+"-1")
+					},
+				},
+				{
+					Name: testControllerName + "-2",
+					AddToManagerFunc: func(_ context.Context, manager manager.Manager, garden *operatorv1alpha1.Garden) (bool, error) {
+						if !metav1.HasAnnotation(garden.ObjectMeta, "test.gardener.cloud/continue") {
+							return false, nil
+						}
+
+						controller2Added = true
+						return true, controller2.AddToManager(manager, testControllerName+"-2")
+					},
+				},
+			},
+		}).AddToManager(mgr)).To(Succeed())
+	})
+
+	Describe("Test controller registration", Ordered, func() {
+		It("should have the controllers not being registered", func() {
+			Consistently(func() bool { return controller1.reconciled }).Should(BeFalse())
+			Consistently(func() bool { return controller2.reconciled }).Should(BeFalse())
+		})
+
+		It("should register the first controller once the garden is created", func() {
+			Expect(testClient.Create(ctx, garden)).To(Succeed())
+			log.Info("Created Garden for test", "garden", garden.Name)
+
+			Eventually(func() bool { return controller1Added }).Should(BeTrue())
+			Expect(controller2Added).To(BeFalse())
+
+			Expect(testClient.Update(ctx, garden)).To(Succeed())
+			Eventually(func() bool { return controller1.reconciled }).Should(BeTrue())
+			Expect(controller2.reconciled).To(BeFalse())
+		})
+
+		It("should register the second controller once the garden is prepared", func() {
+			metav1.SetMetaDataAnnotation(&garden.ObjectMeta, "test.gardener.cloud/continue", "true")
+			Expect(testClient.Update(ctx, garden)).To(Succeed())
+
+			Eventually(func() bool { return controller2Added }).Should(BeTrue())
+			Eventually(func() bool { return controller2.reconciled }).Should(BeTrue())
+		})
+
+		It("should cancel the operator when garden is deleted", func() {
+			Expect(testClient.Delete(ctx, garden)).To(Succeed())
+
+			Eventually(operatorCtx.Done()).Should(BeClosed())
+		})
+	})
+})
+
+const testControllerName = "test-controller"
+
+type testController struct {
+	reconciled bool
+}
+
+func (t *testController) AddToManager(manager manager.Manager, controllerName string) error {
+	return builder.
+		ControllerManagedBy(manager).
+		Named(controllerName).
+		For(&operatorv1alpha1.Garden{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		}).
+		Complete(t)
+}
+
+func (t *testController) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+	log.V(1).Info("Reconcile start")
+
+	t.reconciled = true
+	return reconcile.Result{}, nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the `Controller-Registrar` controller to cancel the `gardener-operator` context when the `garden` resource is gone. It is a pragmatic way to deregister all controllers that depend on the existence of a garden cluster.

**Which issue(s) this PR fixes**:
Part of #9635

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-operator` restarts itself when the `garden` resource is deleted. This is required to stop controllers gracefully that depend on the existence of a virtual garden cluster.
```
