### PR TITLE
chore: Extend Renovate group:kubernetes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -222,9 +222,9 @@
     },
     {
       // Copied and extended from: https://github.com/renovatebot/renovate/blob/3b8735d68cd02546244026ea028aae6044d598e9/lib/config/presets/internal/group.ts#L301-L339
-      groupName: 'kubernetes packages',
-      groupSlug: 'kubernetes-go',
-      description: 'Group Kubernetes packages together.',
+      groupName: 'kubernetes updates',
+      groupSlug: 'kubernetes-updates',
+      description: 'Group Kubernetes updates together.',
       matchDatasources: [
         'go',
         // the entries below extend the original group:kubernetes preset

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,9 @@
   extends: [
     'config:recommended',
   ],
+  ignorePresets: [
+    'group:kubernetes', // handled by our own package rule instead
+  ],
   labels: [
     'kind/enhancement',
   ],
@@ -206,7 +209,7 @@
         '/.+gardener-discovery-server$/'
       ],
     },
-        {
+    {
       // Group machine-controller-manager updates in one PR.
       groupName: 'machine-controller-manager',
       matchDatasources: [
@@ -215,6 +218,49 @@
       ],
       matchPackageNames: [
         '/.*gardener\/machine-controller-manager$/'
+      ],
+    },
+    {
+      // Copied and extended from: https://github.com/renovatebot/renovate/blob/3b8735d68cd02546244026ea028aae6044d598e9/lib/config/presets/internal/group.ts#L301-L339
+      groupName: 'kubernetes packages',
+      groupSlug: 'kubernetes-go',
+      description: 'Group Kubernetes packages together.',
+      matchDatasources: [
+        'go',
+        // the entries below extend the original group:kubernetes preset
+        'github-releases',
+      ],
+      matchPackageNames: [
+        'k8s.io/api**',
+        'k8s.io/apiextensions-apiserver**',
+        'k8s.io/apimachinery**',
+        'k8s.io/apiserver**',
+        'k8s.io/cli-runtime**',
+        'k8s.io/client-go**',
+        'k8s.io/cloud-provider**',
+        'k8s.io/cluster-bootstrap**',
+        'k8s.io/code-generator**',
+        'k8s.io/component-base**',
+        'k8s.io/controller-manager**',
+        'k8s.io/cri-api**',
+        // 'k8s.io/csi-api', has not go.mod set up and does not follow the versioning of other repos
+        'k8s.io/csi-translation-lib**',
+        'k8s.io/kube-aggregator**',
+        'k8s.io/kube-controller-manager**',
+        'k8s.io/kube-proxy**',
+        'k8s.io/kube-scheduler**',
+        'k8s.io/kubectl**',
+        'k8s.io/kubelet**',
+        'k8s.io/legacy-cloud-providers**',
+        'k8s.io/metrics**',
+        'k8s.io/mount-utils**',
+        'k8s.io/pod-security-admission**',
+        'k8s.io/sample-apiserver**',
+        'k8s.io/sample-cli-plugin**',
+        'k8s.io/sample-controller**',
+        // the entries below extend the original group:kubernetes preset
+        'kubernetes/kubernetes',
+        'k8s.io/component-helpers',
       ],
     },
     {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR adapts the configuration for [Renovate](https://docs.renovatebot.com/) to group more dependencies related to Kubernetes updates than included by the default `group:kubernetes` preset.

* Since we extend `config:recommended` the preset `group:kubernetes` is included and needs to be ignored through `ignorePresets` if we want to use our own rules.
* The data sources are extended to include `github-releases` to group PRs such as this one: https://github.com/gardener/gardener/pull/11017
* The matched package names are extended to include `kubernetes/kubernetes` (for grouping https://github.com/gardener/gardener/pull/11017) and `k8s.io/component-helpers (for grouping https://github.com/gardener/gardener/pull/11019).

In short, this PR aims to group the following Renovate PRs:
* https://github.com/gardener/gardener/pull/11017
* https://github.com/gardener/gardener/pull/11018
* https://github.com/gardener/gardener/pull/11019

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
