### PR TITLE
chore: Group Istio Renovate updates in one PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -128,24 +128,18 @@
       ],
     },
     {
-      // Group istio image updates in one PR.
-      groupName: 'istio images',
+      // Group Istio updates in one PR.
+      groupName: 'istio',
+      groupSlug: 'istio',
+      description: 'Group Istio updates in one PR.',
       matchDatasources: [
         'docker',
+        'go'
       ],
       matchPackageNames: [
         '/gcr\\.io/istio-release/.+/',
-      ],
-    },
-    {
-      // Group istio module updates in one PR.
-      groupName: 'istio modules',
-      matchDatasources: [
-        'go',
-      ],
-      matchPackageNames: [
         '/istio\\.io/api/',
-        '/istio\\.io/client-go/',
+        '/istio\\.io/client-go/'
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -139,7 +139,7 @@
       matchPackageNames: [
         '/gcr\\.io/istio-release/.+/',
         '/istio\\.io/api/',
-        '/istio\\.io/client-go/'
+        '/istio\\.io/client-go/',
       ],
     },
     {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR aims to group the following Renovate updates in one PR:
* https://github.com/gardener/gardener/pull/11071
* https://github.com/gardener/gardener/pull/11070

_Uncertainty:_
In the Istio image update PR (https://github.com/gardener/gardener/pull/11071) Renovate is updating the version:
`1.23.4-distroless`. However, as I understand it Renovate properly deals with the semver string and works primarily with the pure version `1.23.4` as can be derived from the PR's title:
> chore(deps): update istio images to v1.23.4 (patch)

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
