### PR TITLE
Enable Gardener scheduler to schedule Shoot with initial NamespacedCloudProfile reference successfully

### DIFF
--- a/pkg/component/gardener/scheduler/rbac.go
+++ b/pkg/component/gardener/scheduler/rbac.go
@@ -39,6 +39,7 @@ func (g *gardenerScheduler) clusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{gardencorev1beta1.GroupName},
 				Resources: []string{
 					"cloudprofiles",
+					"namespacedcloudprofiles",
 					"seeds",
 				},
 				Verbs: []string{"get", "list", "watch"},

--- a/pkg/component/gardener/scheduler/scheduler_test.go
+++ b/pkg/component/gardener/scheduler/scheduler_test.go
@@ -243,6 +243,7 @@ var _ = Describe("GardenerScheduler", func() {
 					APIGroups: []string{gardencorev1beta1.GroupName},
 					Resources: []string{
 						"cloudprofiles",
+						"namespacedcloudprofiles",
 						"seeds",
 					},
 					Verbs: []string{"get", "list", "watch"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Else the Seed scheduling fails with `Failed to schedule Shoot: Timeout: failed waiting for *v1beta1.NamespacedCloudProfile Informer to sync`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix initial scheduling of `Shoot` with `NamespacedCloudProfile` reference.
```
