### PR TITLE
Remove `ShootManagedIssuer` feature gate

### DIFF
--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -443,7 +443,6 @@ spec:
         concurrentSyncs: 0
     featureGates:
       DefaultSeccompProfile: true
-      ShootManagedIssuer: true
     etcdConfig:
       featureGates:
         UseEtcdWrapper: true

--- a/docs/deployment/deploy_gardenlet_via_operator.md
+++ b/docs/deployment/deploy_gardenlet_via_operator.md
@@ -40,8 +40,6 @@ spec:
         respectSyncPeriodOverwrite: true
       shootState:
         concurrentSyncs: 0
-    featureGates:
-      ShootManagedIssuer: true
     etcdConfig:
       featureGates:
         UseEtcdWrapper: true

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -24,7 +24,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootForceDeletion        | `false` | `Alpha` | `1.81`  | `1.90`  |
 | ShootForceDeletion        | `true`  | `Beta`  | `1.91`  |         |
 | UseNamespacedCloudProfile | `false` | `Alpha` | `1.92`  |         |
-| ShootManagedIssuer        | `false` | `Alpha` | `1.93`  |         |
 | ShootCredentialsBinding   | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding   | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash         | `false` | `Alpha` | `1.98`  |         |
@@ -176,6 +175,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | HVPAForShootedSeed                           |         | `Removed`    | `1.109` |         |
 | IPv6SingleStack                              | `false` | `Alpha`      | `1.63`  |         |
 | IPv6SingleStack                              |         | `Removed`    | `1.107` |         |
+| ShootManagedIssuer                           | `false` | `Alpha`      | `1.93`  | `1.110` |
+| ShootManagedIssuer                           |         | `Removed`    | `1.111` |         |
 
 ## Using a Feature
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -75,12 +75,12 @@ When the `gardenlet` starts, it scans the `garden` namespace of the garden clust
 * **Global monitoring secrets** (optional) - contains basic authentication credentials for the Prometheus aggregating metrics for all clusters.
   * These secrets are synced to each seed cluster and used to gain access to the aggregate monitoring components.
 
-* **Shoot Service Account Issuer secret** (optional) - contains the configuration needed to centrally configure gardenlets in order to implement [GEP-24](../proposals/24-shoot-oidc-issuer.md). Please see [the example configuration](../../example/10-secret-shoot-service-account-issuer.yaml) for more details. In addition to that, the [`ShootManagedIssuer`](../deployment/feature_gates.md#list-of-feature-gates) gardenlet feature gate should be enabled in order for configurations to take effect.
+* **Shoot Service Account Issuer secret** (optional) - contains the configuration needed to centrally configure gardenlets in order to implement [GEP-24](../proposals/24-shoot-oidc-issuer.md). Please see [the example configuration](../../example/10-secret-shoot-service-account-issuer.yaml) for more details.
   * This secret contains the hostname which will be used to configure the shoot's managed issuer, therefore the value of the hostname should not be changed once configured.
     > [!CAUTION]
     > [Gardener Operator](../concepts/operator.md) manages this field automatically if Gardener Discovery Server is enabled and does not provide a way to change the default value of it as of now.
     > It calculates it based on the first ingress domain for the runtime Garden cluster. The domain is prefixed with "discovery." using the formula `discovery.{garden.spec.runtimeCluster.ingress.domains[0]}`.
-    > If you are not yet using Gardener Operator but plan to enable the `ShootManagedIssuer` feature gate, it is **EXTREMELY** important to follow the same convention as Gardener Operator,
+    > If you are not yet using Gardener Operator it is **EXTREMELY** important to follow the same convention as Gardener Operator,
     > so that during migration to Gardener Operator the `hostname` can stay the same and avoid disruptions for shoots that already have a managed service account issuer.
 
 Apart from this "static" configuration there are several custom resources extending the Kubernetes API and used by Gardener.

--- a/docs/usage/security/shoot_serviceaccounts.md
+++ b/docs/usage/security/shoot_serviceaccounts.md
@@ -70,7 +70,6 @@ This ability removes the need for changing the `.spec.kubernetes.kubeAPIServer.s
 Prerequisites:
 - The Garden Cluster should have the Gardener Discovery Server deployed and configured.
   The easiest way to handle this is by using the [gardener-operator](../../concepts/operator.md#gardener-discovery-server).
-- The [`ShootManagedIssuer`](../../deployment/feature_gates.md#list-of-feature-gates) feature gate should be enabled.
 
 ### Enablement
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -116,7 +116,6 @@ debugging:
   enableContentionProfiling: false
 featureGates:
   DefaultSeccompProfile: true
-  ShootManagedIssuer: false
 # seedConfig:
 #   metadata:
 #     name: my-seed

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -37,7 +37,6 @@ config:
       concurrentSyncs: 0 # we don't need the shootstate controller locally, and enabling it would even distort the results of CPM e2e tests
   featureGates:
     DefaultSeccompProfile: true
-    ShootManagedIssuer: true
     NewWorkerPoolHash: true
     NewVPN: true
     NodeAgentAuthorizer: true

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -145,7 +145,6 @@ func ValidateShoot(shoot *core.Shoot) field.ErrorList {
 	allErrs = append(allErrs, validateShootOperation(shoot.Annotations[v1beta1constants.GardenerOperation], shoot.Annotations[v1beta1constants.GardenerMaintenanceOperation], shoot, field.NewPath("metadata", "annotations"))...)
 	allErrs = append(allErrs, ValidateShootSpec(shoot.ObjectMeta, &shoot.Spec, field.NewPath("spec"), false)...)
 	allErrs = append(allErrs, ValidateShootHAConfig(shoot)...)
-	allErrs = append(allErrs, validateShootManagedIssuer(shoot)...)
 
 	return allErrs
 }
@@ -176,10 +175,6 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	}
 	if newShoot.Spec.Hibernation != nil {
 		hibernationEnabled = ptr.Deref(newShoot.Spec.Hibernation.Enabled, false)
-	}
-
-	if helper.HasManagedIssuer(oldShoot) && !helper.HasManagedIssuer(newShoot) {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("metadata", "annotations").Key(v1beta1constants.AnnotationAuthenticationIssuer), "once enabled managed shoot issuer cannot be disabled"))
 	}
 
 	allErrs = append(allErrs, ValidateEncryptionConfigUpdate(newEncryptionConfig, oldEncryptionConfig, sets.New(newShoot.Status.EncryptedResources...), etcdEncryptionKeyRotation, hibernationEnabled, field.NewPath("spec", "kubernetes", "kubeAPIServer", "encryptionConfig"))...)
@@ -2687,17 +2682,4 @@ func getResourcesForEncryption(apiServerConfig *core.KubeAPIServerConfig) []stri
 	}
 
 	return sets.List(resources)
-}
-
-func validateShootManagedIssuer(shoot *core.Shoot) field.ErrorList {
-	var allErrors field.ErrorList
-	if helper.HasManagedIssuer(shoot) {
-		if kubeAPIServerConfig := shoot.Spec.Kubernetes.KubeAPIServer; kubeAPIServerConfig != nil &&
-			kubeAPIServerConfig.ServiceAccountConfig != nil &&
-			kubeAPIServerConfig.ServiceAccountConfig.Issuer != nil {
-			allErrors = append(allErrors, field.Forbidden(field.NewPath("metadata", "annotations").Key(v1beta1constants.AnnotationAuthenticationIssuer), "managed shoot issuer cannot be enabled when .kubernetes.kubeAPIServer.serviceAccountConfig.issuer is set"))
-		}
-	}
-
-	return allErrors
 }

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
@@ -102,7 +102,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	secrets, err := gardenerutils.ReadGardenSecrets(ctx, log, r.Client, gardenerutils.ComputeGardenNamespace(seed.Name), false, false)
+	secrets, err := gardenerutils.ReadGardenSecrets(ctx, log, r.Client, gardenerutils.ComputeGardenNamespace(seed.Name), false)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -35,12 +35,6 @@ const (
 	// alpha: v1.92.0
 	UseNamespacedCloudProfile featuregate.Feature = "UseNamespacedCloudProfile"
 
-	// ShootManagedIssuer enables the shoot managed issuer functionality described in GEP 24.
-	// If enabled it will force gardenlet to fail if shoot service account hostname is not configured.
-	// owner: @dimityrmirchev
-	// alpha: v1.93.0
-	ShootManagedIssuer featuregate.Feature = "ShootManagedIssuer"
-
 	// ShootCredentialsBinding enables the usage of the CredentialsBindingName API in shoot spec.
 	// owner: @vpnachev @dimityrmirchev
 	// alpha: v1.98.0
@@ -93,7 +87,6 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 // AllFeatureGates is the list of all feature gates.
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:     {Default: false, PreRelease: featuregate.Alpha},
-	ShootManagedIssuer:        {Default: false, PreRelease: featuregate.Alpha},
 	ShootForceDeletion:        {Default: true, PreRelease: featuregate.Beta},
 	UseNamespacedCloudProfile: {Default: false, PreRelease: featuregate.Alpha},
 	ShootCredentialsBinding:   {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -33,7 +33,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/networking/istio"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	"github.com/gardener/gardener/pkg/utils"
@@ -163,7 +162,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 		return err
 	}
 
-	secrets, err := gardenerutils.ReadGardenSecrets(ctx, log, r.GardenClient, gardenerutils.ComputeGardenNamespace(seed.GetInfo().Name), true, features.DefaultFeatureGate.Enabled(features.ShootManagedIssuer))
+	secrets, err := gardenerutils.ReadGardenSecrets(ctx, log, r.GardenClient, gardenerutils.ComputeGardenNamespace(seed.GetInfo().Name), true)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
@@ -99,7 +98,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// Only read Garden secrets once because we don't rely on up-to-date secrets for health checks.
 	if r.gardenSecrets == nil {
-		secrets, err := gardenerutils.ReadGardenSecrets(careCtx, log, r.GardenClient, gardenerutils.ComputeGardenNamespace(*shoot.Spec.SeedName), true, features.DefaultFeatureGate.Enabled(features.ShootManagedIssuer))
+		secrets, err := gardenerutils.ReadGardenSecrets(careCtx, log, r.GardenClient, gardenerutils.ComputeGardenNamespace(*shoot.Spec.SeedName), true)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("error reading Garden secrets: %w", err)
 		}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot/helper"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
@@ -333,7 +332,7 @@ func (r *Reconciler) initializeOperation(
 	*operation.Operation,
 	error,
 ) {
-	gardenSecrets, err := gardenerutils.ReadGardenSecrets(ctx, log, r.GardenClient, gardenerutils.ComputeGardenNamespace(seed.Name), true, features.DefaultFeatureGate.Enabled(features.ShootManagedIssuer))
+	gardenSecrets, err := gardenerutils.ReadGardenSecrets(ctx, log, r.GardenClient, gardenerutils.ComputeGardenNamespace(seed.Name), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -452,14 +452,8 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Name: "Sync public service account signing keys to Garden cluster",
 			Fn:   botanist.SyncPublicServiceAccountKeys,
 			SkipIf: o.Shoot.HibernationEnabled ||
-				!features.DefaultFeatureGate.Enabled(features.ShootManagedIssuer) ||
 				!v1beta1helper.HasManagedIssuer(botanist.Shoot.GetInfo()),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
-		})
-		_ = g.Add(flow.Task{
-			Name:   "Delete public service account signing keys from Garden cluster",
-			Fn:     botanist.DeletePublicServiceAccountKeys,
-			SkipIf: features.DefaultFeatureGate.Enabled(features.ShootManagedIssuer),
 		})
 		rewriteResourcesAddLabel = g.Add(flow.Task{
 			Name: "Labeling resources after modification of encryption config or to encrypt them with new ETCD encryption key",

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -20,7 +20,6 @@ func RegisterFeatureGates() {
 func GetFeatures() []featuregate.Feature {
 	return []featuregate.Feature{
 		features.DefaultSeccompProfile,
-		features.ShootManagedIssuer,
 		features.NewWorkerPoolHash,
 		features.NewVPN,
 		features.NodeAgentAuthorizer,

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -273,7 +273,7 @@ func (b *Botanist) computeKubeAPIServerServiceAccountConfig(externalHostname str
 		config = b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.DeepCopy()
 	}
 
-	shouldManageIssuer := v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo()) && features.DefaultFeatureGate.Enabled(features.ShootManagedIssuer)
+	shouldManageIssuer := v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo())
 	canManageIssuer := b.Shoot.ServiceAccountIssuerHostname != nil
 	if shouldManageIssuer && !canManageIssuer {
 		return kubeapiserver.ServiceAccountConfig{}, errors.New("shoot requires managed issuer, but gardener does not have shoot service account hostname configured")

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -185,9 +185,9 @@ func ReadGardenSecrets(
 		if secret.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShootServiceAccountIssuer {
 			shootIssuer := secret
 			if hostname, ok := secret.Data["hostname"]; !ok {
-				return nil, fmt.Errorf("cannot use Shoot Service Account Issuer secret '%s' as it does not contain key 'hostname'", secret.Name)
+				return nil, fmt.Errorf("cannot use Shoot Service Account Issuer secret %q as it does not contain key 'hostname'", secret.Name)
 			} else if strings.TrimSpace(string(hostname)) == "" {
-				return nil, fmt.Errorf("cannot use Shoot Service Account Issuer secret '%s' as it does contain an empty 'hostname' key", secret.Name)
+				return nil, fmt.Errorf("cannot use Shoot Service Account Issuer secret %q as it does contain an empty 'hostname' key", secret.Name)
 			}
 			secretsMap[v1beta1constants.GardenRoleShootServiceAccountIssuer] = &shootIssuer
 			logInfo = append(logInfo, fmt.Sprintf("Shoot Service Account Issuer secret %q", secret.Name))

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -104,7 +104,6 @@ func ReadGardenSecrets(
 	c client.Reader,
 	namespace string,
 	enforceInternalDomainSecret bool,
-	enforceShootServiceAccountIssuerSecret bool,
 ) (
 	map[string]*corev1.Secret,
 	error,
@@ -216,11 +215,6 @@ func ReadGardenSecrets(
 
 	if numberOfGlobalMonitoringSecrets > 1 {
 		return nil, fmt.Errorf("can only accept at most one global monitoring secret, but found %d", numberOfGlobalMonitoringSecrets)
-	}
-
-	// Ensure that configuration exists if the ShootManagedIssuer feature gate is enabled.
-	if enforceShootServiceAccountIssuerSecret && numberOfShootServiceAccountIssuerSecrets == 0 {
-		return nil, fmt.Errorf("feature gate ShootManagedIssuer is enabled, but shoot service account issuer secret is missing")
 	}
 
 	// The managed shoot service account issuer is configured centrally per Garden cluster.

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -2058,7 +2058,7 @@ func (c *validationContext) validateManagedServiceAccountIssuer(
 		v1beta1constants.GardenRole: v1beta1constants.GardenRoleShootServiceAccountIssuer,
 	}))
 	if err != nil {
-		return apierrors.NewInternalError(fmt.Errorf("could not retrieve managed service account issuer config secret: %+v", err.Error()))
+		return apierrors.NewInternalError(fmt.Errorf("could not retrieve managed service account issuer config secret: %w", err))
 	}
 
 	// Skip the validation if no managed service account issuer secrets are found and shoot does not contain managed service account issuer configs.
@@ -2074,20 +2074,6 @@ func (c *validationContext) validateManagedServiceAccountIssuer(
 			return apierrors.NewInternalError(errors.New("old shoot object has managed service account issuer enabled, but Gardener configuration is missing"))
 		}
 		return nil
-	}
-
-	// The managed service account issuer is configured centrally per Garden cluster.
-	// The presence of more than one secret is an ambiguous behaviour and should be disallowed.
-	if len(managedIssuerConfigSecrets) > 1 {
-		return apierrors.NewInternalError(fmt.Errorf("can only accept at most one managed service account issuer secret, but found %d", len(managedIssuerConfigSecrets)))
-	}
-
-	// Fail the validation if secret is present, but not configured correctly.
-	configSecret := managedIssuerConfigSecrets[0]
-	if hostname, ok := configSecret.Data["hostname"]; !ok {
-		return apierrors.NewInternalError(fmt.Errorf("cannot configure managed service account issuer: secret '%s' does not contain key 'hostname'", configSecret.Name))
-	} else if strings.TrimSpace(string(hostname)) == "" {
-		return apierrors.NewInternalError(fmt.Errorf("cannot configure managed service account issuer: secret '%s' does contain an empty 'hostname' key", configSecret.Name))
 	}
 
 	// Preserve the managed service account issuer enablement during updates.

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -5771,5 +5771,119 @@ var _ = Describe("validator", func() {
 				Entry("should not reject if the shoot has lastOperation=Restore:Succeeded ", core.LastOperationTypeRestore, core.LastOperationStateSucceeded, BeNil()),
 				Entry("should not reject the delete operation", core.LastOperationTypeReconcile, core.LastOperationStateSucceeded, BeNil()))
 		})
+
+		Context("checks for managed service account issuer", func() {
+			var (
+				oldShoot     *core.Shoot
+				issuerSecret *corev1.Secret
+			)
+
+			BeforeEach(func() {
+				issuerSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sa-issuer",
+						Namespace: "garden",
+						Labels: map[string]string{
+							"gardener.cloud/role": "shoot-service-account-issuer",
+						},
+					},
+					Data: map[string][]byte{
+						"hostname": []byte("foo.bar"),
+					},
+				}
+
+				shoot.Annotations = map[string]string{
+					"authentication.gardener.cloud/issuer": "managed",
+				}
+				oldShoot = shoot.DeepCopy()
+				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seedBase)).To(Succeed())
+				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+			})
+
+			It("should reject creating a shoot if managed service account issuer is not configured", func() {
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+
+				Expect(err).To(BeForbiddenError())
+				Expect(err.Error()).To(ContainSubstring("cannot enable managed service account issuer as it is not supported in this Gardener installation"))
+			})
+
+			It("should reject updating a shoot if managed service account issuer is not configured but old shoot has been annotated", func() {
+				shoot.Annotations = nil
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+
+				Expect(err).To(BeInternalServerError())
+				Expect(err.Error()).To(ContainSubstring("old shoot object has managed service account issuer enabled, but Gardener configuration is missing"))
+			})
+
+			It("should reject creating a shoot if there are multiple configuration secrets", func() {
+				issuerSecret2 := issuerSecret.DeepCopy()
+				issuerSecret2.Name = "sa-issuer-2"
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(issuerSecret)).To(Succeed())
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(issuerSecret2)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+
+				Expect(err).To(BeInternalServerError())
+				Expect(err.Error()).To(ContainSubstring("can only accept at most one managed service account issuer secret, but found 2"))
+			})
+
+			It("should reject creating a shoot if the config secret does not contain 'hostname' key", func() {
+				issuerSecret.Data = nil
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(issuerSecret)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+
+				Expect(err).To(BeInternalServerError())
+				Expect(err.Error()).To(ContainSubstring("cannot configure managed service account issuer: secret 'sa-issuer' does not contain key 'hostname'"))
+			})
+
+			It("should reject creating a shoot if the config secret does not contain 'hostname' key", func() {
+				issuerSecret.Data = map[string][]byte{
+					"hostname": []byte("  "),
+				}
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(issuerSecret)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+
+				Expect(err).To(BeInternalServerError())
+				Expect(err.Error()).To(ContainSubstring("cannot configure managed service account issuer: secret 'sa-issuer' does contain an empty 'hostname' key"))
+			})
+
+			It("should reject disabling managed service account issuer", func() {
+				shoot.Annotations = nil
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(issuerSecret)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+
+				Expect(err).To(BeForbiddenError())
+				Expect(err.Error()).To(ContainSubstring("once enabled managed service account issuer cannot be disabled"))
+			})
+
+			It("should reject shoots with conflicting configuration managed service account issuer", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
+					ServiceAccountConfig: &core.ServiceAccountConfig{
+						Issuer: ptr.To("foo"),
+					},
+				}
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(issuerSecret)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+
+				Expect(err).To(BeForbiddenError())
+				Expect(err.Error()).To(ContainSubstring("managed service account issuer cannot be enabled when .kubernetes.kubeAPIServer.serviceAccountConfig.issuer is set"))
+			})
+
+			It("should allow enabling managed service account issuer", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(issuerSecret)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+			})
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Please see the linked issue.

**Which issue(s) this PR fixes**:
Fixes #11024 

**Special notes for your reviewer**:
cc @rfranzke @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `ShootManagedIssuer` feature gate was removed. Enablement of the feature is now dependent on the existence of a secret in the `garden` namespace labeled with `gardener.cloud/role: shoot-service-account-issuer`.
```
