### PR TITLE
extensions local setup: Update registry image to 3.0.0-rc.2

### DIFF
--- a/example/provider-extensions/registry-seed/deploy-registry.sh
+++ b/example/provider-extensions/registry-seed/deploy-registry.sh
@@ -107,9 +107,9 @@ stringData:
       ctr snapshot rm seed-registry-cache
     fi
     echo "Pulling registry-cache image"
-    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-beta.1
+    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.2
     echo "Starting registry-cache"
-    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-beta.1 seed-registry-cache
+    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.2 seed-registry-cache
   stop-seed-registry-cache.sh: |
     #!/usr/bin/env bash
     echo "stopping seed-registry-cache"

--- a/example/provider-extensions/registry-seed/registry/registry.yaml
+++ b/example/provider-extensions/registry-seed/registry/registry.yaml
@@ -24,7 +24,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-beta.1
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.2
         imagePullPolicy: IfNotPresent
         env:
         - name: REGISTRY_HTTP_TLS_CERTIFICATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR uses the registry images in the provider-exensions setup to use the latest [3.0.0-rc.2](https://github.com/distribution/distribution/releases/tag/v3.0.0-rc.2) release.

I didn't update the registry images in provider-local due to the same reason as mentioned in https://github.com/gardener/gardener/pull/10180#issuecomment-2257584134.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/289

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The images of the registry caches used in the extensions local setup are now updated to [distribution/distribution@3.0.0 rc.2](https://github.com/distribution/distribution/releases/tag/v3.0.0-rc.2).
```
