### PR TITLE
Fix race condition in garbage collection

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -47,6 +47,7 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	managedresourcesutils "github.com/gardener/gardener/pkg/utils/managedresources"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -355,7 +356,12 @@ webhooks:
 
 				utilruntime.Must(kubernetesutils.MakeUnique(createdMRSecretForShootWebhooks))
 				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(createdMRSecretForShootWebhooks), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(errNotFound)
-				c.EXPECT().Create(ctx, createdMRSecretForShootWebhooks).Return(nil)
+				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).
+					Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+						managedresourcesutils.CheckAndRemoveGCSuppressionAnnotation(obj.(*corev1.Secret))
+						Expect(obj).To(DeepEqual(createdMRSecretForShootWebhooks))
+					}).
+					Return(nil)
 				c.EXPECT().Get(ctx, resourceKeyShootWebhooks, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errNotFound)
 				createdMRForShootWebhooks.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: createdMRSecretForShootWebhooks.Name}}
 				utilruntime.Must(references.InjectAnnotations(createdMRForShootWebhooks))
@@ -369,7 +375,12 @@ webhooks:
 
 			utilruntime.Must(kubernetesutils.MakeUnique(createdMRSecretForCPShootChart))
 			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(createdMRSecretForCPShootChart), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(errNotFound)
-			c.EXPECT().Create(ctx, createdMRSecretForCPShootChart).Return(nil)
+			c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+					managedresourcesutils.CheckAndRemoveGCSuppressionAnnotation(obj.(*corev1.Secret))
+					Expect(obj).To(DeepEqual(createdMRSecretForCPShootChart))
+				}).
+				Return(nil)
 			c.EXPECT().Get(ctx, resourceKeyCPShootChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errNotFound)
 			createdMRForCPShootChart.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: createdMRSecretForCPShootChart.Name}}
 			utilruntime.Must(references.InjectAnnotations(createdMRForCPShootChart))
@@ -378,7 +389,12 @@ webhooks:
 			if withShootCRDsChart {
 				utilruntime.Must(kubernetesutils.MakeUnique(createdMRSecretForCPShootCRDsChart))
 				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(createdMRSecretForCPShootCRDsChart), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(errNotFound)
-				c.EXPECT().Create(ctx, createdMRSecretForCPShootCRDsChart).Return(nil)
+				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).
+					Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+						managedresourcesutils.CheckAndRemoveGCSuppressionAnnotation(obj.(*corev1.Secret))
+						Expect(obj).To(DeepEqual(createdMRSecretForCPShootCRDsChart))
+					}).
+					Return(nil)
 				c.EXPECT().Get(ctx, resourceKeyCPShootCRDsChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errNotFound)
 				createdMRForCPShootCRDsChart.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: createdMRSecretForCPShootCRDsChart.Name}}
 				utilruntime.Must(references.InjectAnnotations(createdMRForCPShootCRDsChart))
@@ -387,7 +403,12 @@ webhooks:
 
 			utilruntime.Must(kubernetesutils.MakeUnique(createdMRSecretForStorageClassesChart))
 			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(createdMRSecretForStorageClassesChart), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(errNotFound)
-			c.EXPECT().Create(ctx, createdMRSecretForStorageClassesChart).Return(nil)
+			c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+					managedresourcesutils.CheckAndRemoveGCSuppressionAnnotation(obj.(*corev1.Secret))
+					Expect(obj).To(DeepEqual(createdMRSecretForStorageClassesChart))
+				}).
+				Return(nil)
 			c.EXPECT().Get(ctx, resourceKeyStorageClassesChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errNotFound)
 			createdMRForStorageClassesChart.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: createdMRSecretForStorageClassesChart.Name}}
 			utilruntime.Must(references.InjectAnnotations(createdMRForStorageClassesChart))

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	managedresourcesutils "github.com/gardener/gardener/pkg/utils/managedresources"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -1920,6 +1921,7 @@ subjects:
 							}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})),
 						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
+							managedresourcesutils.CheckAndRemoveGCSuppressionAnnotation(obj.(*corev1.Secret))
 							Expect(obj).To(DeepEqual(managedResourceSecret))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
@@ -2023,6 +2025,7 @@ subjects:
 							}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})),
 						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
+							managedresourcesutils.CheckAndRemoveGCSuppressionAnnotation(obj.(*corev1.Secret))
 							Expect(obj).To(DeepEqual(managedResourceSecret))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
@@ -2113,6 +2116,7 @@ subjects:
 						}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})),
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
+						managedresourcesutils.CheckAndRemoveGCSuppressionAnnotation(obj.(*corev1.Secret))
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
@@ -2230,6 +2234,7 @@ subjects:
 						}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})),
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) {
+						managedresourcesutils.CheckAndRemoveGCSuppressionAnnotation(obj.(*corev1.Secret))
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),

--- a/pkg/utils/managedresources/builder/secrets.go
+++ b/pkg/utils/managedresources/builder/secrets.go
@@ -87,6 +87,17 @@ func (s *Secret) WithAnnotations(annotations map[string]string) *Secret {
 	return s
 }
 
+// AddAnnotations adds the specified annotations to the secret's existing annotations.
+func (s *Secret) AddAnnotations(annotations map[string]string) *Secret {
+	if s.secret.Annotations == nil {
+		s.secret.Annotations = make(map[string]string, len(annotations))
+	}
+	for k, v := range annotations {
+		s.secret.Annotations[k] = v
+	}
+	return s
+}
+
 // WithKeyValues sets the data map.
 func (s *Secret) WithKeyValues(keyValues map[string][]byte) *Secret {
 	s.secret.Data = keyValues

--- a/pkg/utils/managedresources/managedresources_test.go
+++ b/pkg/utils/managedresources/managedresources_test.go
@@ -210,6 +210,7 @@ var _ = Describe("managedresources", func() {
 				Namespace: namespace,
 			}}
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			CheckAndRemoveGCSuppressionAnnotation(secret)
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            secretName,
@@ -252,6 +253,7 @@ var _ = Describe("managedresources", func() {
 				Namespace: namespace,
 			}}
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			CheckAndRemoveGCSuppressionAnnotation(secret)
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            secretName,
@@ -341,6 +343,7 @@ var _ = Describe("managedresources", func() {
 				Namespace: namespace,
 			}}
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			CheckAndRemoveGCSuppressionAnnotation(secret)
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            secretName,
@@ -374,6 +377,7 @@ var _ = Describe("managedresources", func() {
 				Namespace: namespace,
 			}}
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			CheckAndRemoveGCSuppressionAnnotation(secret)
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            secretName,
@@ -402,6 +406,7 @@ var _ = Describe("managedresources", func() {
 				Namespace: namespace,
 			}}
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			CheckAndRemoveGCSuppressionAnnotation(secret)
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            secretName,

--- a/pkg/utils/managedresources/test_util.go
+++ b/pkg/utils/managedresources/test_util.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package managedresources
+
+import (
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CheckAndRemoveGCSuppressionAnnotation asserts that the specified secret was recently annotated for garbage collection
+// suppression. It then removes the annotation and sets secret.Annotations to nil, the removed annotation was the last
+// one in the map.
+//
+// This function assumes that no more than one minute has elapsed since the GC suppression annotation was placed on the
+// object.
+//
+// Remarks: This function is used by unit tests. Note that the content of a GC suppression annotation is time-dependent.
+// By removing the dynamic annotation, this function enables the unit test to handle the rest of the secret with the
+// simple "expect known fixed content" pattern, even if it did not isolate calls to the clock.
+func CheckAndRemoveGCSuppressionAnnotation(secret *corev1.Secret) {
+	now := time.Now()
+	gcSuppressionAnnotationValue := secret.Annotations[AnnotationKeySuppressGarbageCollectionUntil]
+	Expect(gcSuppressionAnnotationValue).NotTo(BeEmpty())
+	suppessUntilTime, err := time.Parse(time.RFC3339, gcSuppressionAnnotationValue)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(now.Add(AnnotationValueSuppressGarbageCollectionUntilDelay + 1*time.Minute).After(suppessUntilTime)).To(BeTrue())
+	Expect(now.Add(AnnotationValueSuppressGarbageCollectionUntilDelay - 1*time.Second).Before(suppessUntilTime)).To(BeTrue())
+	delete(secret.Annotations, AnnotationKeySuppressGarbageCollectionUntil)
+	if len(secret.Annotations) == 0 {
+		secret.Annotations = nil
+	}
+}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -408,6 +408,7 @@ build:
             - pkg/resourcemanager/webhook/systemcomponentsconfig
             - pkg/resourcemanager/webhook/tokeninvalidator
             - pkg/utils
+            - pkg/utils/chart
             - pkg/utils/context
             - pkg/utils/errors
             - pkg/utils/flow
@@ -416,6 +417,8 @@ build:
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/client
             - pkg/utils/kubernetes/health
+            - pkg/utils/managedresources
+            - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/time

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1410,6 +1410,7 @@ build:
             - pkg/resourcemanager/webhook/systemcomponentsconfig
             - pkg/resourcemanager/webhook/tokeninvalidator
             - pkg/utils
+            - pkg/utils/chart
             - pkg/utils/context
             - pkg/utils/errors
             - pkg/utils/flow
@@ -1418,6 +1419,8 @@ build:
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/client
             - pkg/utils/kubernetes/health
+            - pkg/utils/managedresources
+            - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/time


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes [issue#10081 - Race between ManagedResource update logic and GRM garbage collector, GC deletes MR secrets which are in use](https://github.com/gardener/gardener/issues/10081).

A `ManagedResource` (MR) is an aggregate object: in addition to the MR object, it contains a number of `Secret` objects.  This change fixes the existing race between MR creation/update, and `Secret` garbage collection (GC). The solution: An optional lease mechanism is introduced to Secrets. The lease is acquired as atomic part of MR creation/update.  GC performs an atomic lease check upon deletion, and does not delete a Secret if it has an active lease. The lease is expressed as an annotation on the Secret, with the expiration time set as the annotation's value.

The lease is time-based, and relies on clock synchronisation between GCs and MR creators/editors. The current implementation uses a 10 minute lease, and  tolerates up to 8 minutes of differential clock skew between any GC and MR creator/editor. It assumes that MR creation/update will complete within 2 minutes, i.e. it does not check if it ran out of lease time in the middle of creation/update. That is theoretically imperfect, but given the generous allowance (2 minutes), and liveness probes' intolerance of long process pauses, it seems unjustified to complicate the code with an extra check-and-retry loop which will never loop in practice. 

The current implementation ensures atomicity without incurring any extra server calls. Instead of a lease-based implementation, a lock-based one is possible. It would be insensitive to clock skew, however it would add a substantial burden of extra server round trips.

Exceeding the clock skew limit does not result in immediate data corruption. If all GC's clocks are too far behind an MR creator/editor, that only results in a longer retention of unused secrets (delayed GC). If any GC's clock is too far ahead, the race protection provided by this fix is lost, and the application effectively reverts to the operation mode before the fix - there is a moderate risk of reversible data corruption while clocks are out of sync.

**Which issue(s) this PR fixes**:
Fixes #10081

**Special notes for your reviewer**:

**Release note**:
```bugfix developer
NONE
```
