### PR TITLE
Fix `NamespacedCloudProfile` validation for {`MachineImages`,`MachineTypes`} added to parent `CloudProfile` later

### DIFF
--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -141,11 +141,29 @@ func mergeExpirationDates(base, override gardencorev1beta1.ExpirableVersion) gar
 }
 
 func mergeMachineImages(base, override gardencorev1beta1.MachineImage) gardencorev1beta1.MachineImage {
-	base.Versions = mergeDeep(base.Versions, override.Versions, machineImageVersionKeyFunc, mergeMachineImageVersions, true)
-	return base
+	if override.UpdateStrategy == nil {
+		// The NamespacedCloudProfile only extends parent CloudProfile machine image versions by the expiration date.
+		base.Versions = mergeDeep(base.Versions, override.Versions, machineImageVersionKeyFunc, mergeMachineImageVersions, true)
+		return base
+	}
+
+	// A formerly new machine image in the NamespacedCloudProfile has been added to the parent CloudProfile by now.
+	// If NamespacedCloudProfile and parent CloudProfile UpdateStrategies conflict, only use NamespacedCloudProfile machine images.
+	if override.UpdateStrategy == base.UpdateStrategy {
+		// Add additional CloudProfile machine image versions to the NamespacedCloudProfile versions without overriding explicitly set expiration dates.
+		override.Versions = mergeDeep(override.Versions, base.Versions, machineImageVersionKeyFunc, nil, true)
+	}
+	return override
 }
 
 func mergeMachineImageVersions(base, override gardencorev1beta1.MachineImageVersion) gardencorev1beta1.MachineImageVersion {
+	if len(override.Architectures) > 0 ||
+		len(override.CRI) > 0 ||
+		len(ptr.Deref(override.KubeletVersionConstraint, "")) > 0 ||
+		len(ptr.Deref(override.Classification, "")) > 0 {
+		// If the NamespacedCloudProfile machine image version has been there before, do not merge it with the parent CloudProfile machine image version.
+		return override
+	}
 	base.ExpirableVersion = mergeExpirationDates(base.ExpirableVersion, override.ExpirableVersion)
 	return base
 }

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -120,7 +120,7 @@ func MergeCloudProfiles(namespacedCloudProfile *gardencorev1beta1.NamespacedClou
 	}
 	namespacedCloudProfile.Status.CloudProfileSpec.MachineImages = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.MachineImages, namespacedCloudProfile.Spec.MachineImages, machineImageKeyFunc, mergeMachineImages, true)
 	namespacedCloudProfile.Status.CloudProfileSpec.MachineTypes = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.MachineTypes, namespacedCloudProfile.Spec.MachineTypes, machineTypeKeyFunc, nil, true)
-	namespacedCloudProfile.Status.CloudProfileSpec.VolumeTypes = append(namespacedCloudProfile.Status.CloudProfileSpec.VolumeTypes, namespacedCloudProfile.Spec.VolumeTypes...)
+	namespacedCloudProfile.Status.CloudProfileSpec.VolumeTypes = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.VolumeTypes, namespacedCloudProfile.Spec.VolumeTypes, volumeTypeKeyFunc, nil, true)
 	if namespacedCloudProfile.Spec.CABundle != nil {
 		mergedCABundles := fmt.Sprintf("%s%s", ptr.Deref(namespacedCloudProfile.Status.CloudProfileSpec.CABundle, ""), ptr.Deref(namespacedCloudProfile.Spec.CABundle, ""))
 		namespacedCloudProfile.Status.CloudProfileSpec.CABundle = &mergedCABundles
@@ -132,6 +132,7 @@ var (
 	machineImageKeyFunc        = func(i gardencorev1beta1.MachineImage) string { return i.Name }
 	machineImageVersionKeyFunc = func(v gardencorev1beta1.MachineImageVersion) string { return v.Version }
 	machineTypeKeyFunc         = func(t gardencorev1beta1.MachineType) string { return t.Name }
+	volumeTypeKeyFunc          = func(t gardencorev1beta1.VolumeType) string { return t.Name }
 )
 
 func mergeExpirationDates(base, override gardencorev1beta1.ExpirableVersion) gardencorev1beta1.ExpirableVersion {

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -223,8 +223,10 @@ func (c *validationContext) validateKubernetesVersionOverrides(attr admission.At
 func (c *validationContext) validateMachineImageOverrides(attr admission.Attributes) error {
 	now := ptr.To(metav1.Now())
 	parentImages := util.NewV1beta1ImagesContext(c.parentCloudProfile.Spec.MachineImages)
+	var currentVersionsSpec *util.ImagesContext[gardencore.MachineImage, gardencore.MachineImageVersion]
 	var currentVersionsMerged *util.ImagesContext[gardencore.MachineImage, gardencore.MachineImageVersion]
 	if attr.GetOperation() == admission.Update {
+		currentVersionsSpec = util.NewCoreImagesContext(c.oldNamespacedCloudProfile.Spec.MachineImages)
 		currentVersionsMerged = util.NewCoreImagesContext(c.oldNamespacedCloudProfile.Status.CloudProfileSpec.MachineImages)
 	}
 
@@ -234,7 +236,19 @@ func (c *validationContext) validateMachineImageOverrides(attr admission.Attribu
 		_, isExistingImage := parentImages.GetImage(image.Name)
 
 		if isExistingImage {
-			if len(ptr.Deref(image.UpdateStrategy, "")) > 0 {
+			// If in the meantime an image specified only in the NamespacedCloudProfile has been
+			// added to the parent CloudProfile, then ignore already existing fields otherwise invalid for a new override.
+			var imageAlreadyExistsInNamespacedCloudProfile bool
+			if currentVersionsSpec != nil {
+				var currentImage gardencore.MachineImage
+				currentImage, imageAlreadyExistsInNamespacedCloudProfile = currentVersionsSpec.GetImage(image.Name)
+
+				if imageAlreadyExistsInNamespacedCloudProfile && ptr.Deref(image.UpdateStrategy, "") != ptr.Deref(currentImage.UpdateStrategy, "") {
+					allErrs = append(allErrs, field.Forbidden(imageIndexPath.Child("updateStrategy"), fmt.Sprintf("cannot update the machine image update strategy of %q, as this version has been added to the parent CloudProfile by now", image.Name)))
+				}
+			}
+
+			if len(ptr.Deref(image.UpdateStrategy, "")) > 0 && !imageAlreadyExistsInNamespacedCloudProfile {
 				allErrs = append(allErrs, field.Forbidden(imageIndexPath.Child("updateStrategy"), "must not provide an updateStrategy to an extended machine image in NamespacedCloudProfile"))
 			}
 
@@ -245,11 +259,26 @@ func (c *validationContext) validateMachineImageOverrides(attr admission.Attribu
 					// For new versions added to an existing image, the validation will be done on the simulated merge result.
 					imageVersionIndexPath := imageIndexPath.Child("versions").Index(imageVersionIndex)
 
-					allErrs = append(allErrs, validateNamespacedCloudProfileExtendedMachineImages(imageVersion, imageVersionIndexPath)...)
+					// If in the meantime an image version specified only in the NamespacedCloudProfile has been
+					// added to the parent CloudProfile, then ignore already existing fields otherwise invalid for a new override.
+					var imageVersionAlreadyInNamespacedCloudProfile bool
+					if imageAlreadyExistsInNamespacedCloudProfile {
+						var oldMachineImageVersion gardencore.MachineImageVersion
+						oldMachineImageVersion, imageVersionAlreadyInNamespacedCloudProfile = currentVersionsSpec.GetImageVersion(image.Name, imageVersion.Version)
 
-					if imageVersion.ExpirationDate == nil {
-						allErrs = append(allErrs, field.Invalid(imageVersionIndexPath.Child("expirationDate"), imageVersion.ExpirationDate, fmt.Sprintf("expiration date for version %q must be set", imageVersion.Version)))
+						if imageVersionAlreadyInNamespacedCloudProfile && !reflect.DeepEqual(oldMachineImageVersion, imageVersion) {
+							allErrs = append(allErrs, field.Forbidden(imageVersionIndexPath, fmt.Sprintf("cannot update the machine image version spec of \"%s@%s\", as this version has been added to the parent CloudProfile by now", image.Name, imageVersion.Version)))
+						}
 					}
+
+					if !imageVersionAlreadyInNamespacedCloudProfile {
+						allErrs = append(allErrs, validateNamespacedCloudProfileExtendedMachineImages(imageVersion, imageVersionIndexPath)...)
+
+						if imageVersion.ExpirationDate == nil {
+							allErrs = append(allErrs, field.Invalid(imageVersionIndexPath.Child("expirationDate"), imageVersion.ExpirationDate, fmt.Sprintf("expiration date for version %q must be set", imageVersion.Version)))
+						}
+					}
+
 					if attr.GetOperation() == admission.Update && imageVersion.ExpirationDate.Before(now) {
 						var (
 							override gardencore.MachineImageVersion

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -433,7 +433,7 @@ var _ = Describe("Admission", func() {
 
 				namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{
 					{Name: "test-image", Versions: []gardencore.MachineImageVersion{
-						{ExpirableVersion: gardencore.ExpirableVersion{Version: "1.1.0"}, CRI: []gardencore.CRI{{Name: "containerd"}}},
+						{ExpirableVersion: gardencore.ExpirableVersion{Version: "1.1.0"}, CRI: []gardencore.CRI{{Name: "containerd"}}, Architectures: []string{"amd64", "arm64"}},
 					}},
 				}
 				oldNamespacedCloudProfile := namespacedCloudProfile.DeepCopy()
@@ -559,7 +559,6 @@ var _ = Describe("Admission", func() {
 										ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 											Version: "1.0.0",
 										},
-										CRI: []gardencorev1beta1.CRI{{Name: "containerd"}},
 									},
 								},
 							},

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -421,6 +421,59 @@ var _ = Describe("Admission", func() {
 
 				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
+
+			It("should allow a NamespacedCloudProfile to specify a MachineImage, if it has been added to the parent CloudProfile only afterwards", func() {
+				parentCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{Name: "test-image", Versions: []gardencorev1beta1.MachineImageVersion{
+						{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.1.0"}, CRI: []gardencorev1beta1.CRI{{Name: "containerd"}}},
+					}},
+				}
+				gardencorev1beta1.SetObjectDefaults_CloudProfile(parentCloudProfile)
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{
+					{Name: "test-image", Versions: []gardencore.MachineImageVersion{
+						{ExpirableVersion: gardencore.ExpirableVersion{Version: "1.1.0"}, CRI: []gardencore.CRI{{Name: "containerd"}}},
+					}},
+				}
+				oldNamespacedCloudProfile := namespacedCloudProfile.DeepCopy()
+				namespacedCloudProfile.Generation++ // Increase generation to trigger full validation check.
+
+				attrs := admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+			})
+
+			It("should not allow any changes to a MachineImage in a NamespacedCloudProfile, if it has been added to the parent CloudProfile in the meantime", func() {
+				parentCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{Name: "test-image", Versions: []gardencorev1beta1.MachineImageVersion{
+						{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.1.0"}, CRI: []gardencorev1beta1.CRI{{Name: "containerd"}}},
+					}},
+				}
+				gardencorev1beta1.SetObjectDefaults_CloudProfile(parentCloudProfile)
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{
+					{Name: "test-image", Versions: []gardencore.MachineImageVersion{
+						{ExpirableVersion: gardencore.ExpirableVersion{Version: "1.1.0"}, CRI: []gardencore.CRI{{Name: "containerd"}}},
+					}},
+				}
+				oldNamespacedCloudProfile := namespacedCloudProfile.DeepCopy()
+				namespacedCloudProfile.Spec.MachineImages[0].UpdateStrategy = ptr.To(gardencore.UpdateStrategyMajor)
+				namespacedCloudProfile.Spec.MachineImages[0].Versions[0].Architectures = []string{"amd64", "arm64"}
+
+				attrs := admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.machineImages[0].updateStrategy"),
+					"Detail": ContainSubstring("cannot update the machine image update strategy of \"test-image\", as this version has been added to the parent CloudProfile by now"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.machineImages[0].versions[0]"),
+					"Detail": ContainSubstring("cannot update the machine image version spec of \"test-image@1.1.0\", as this version has been added to the parent CloudProfile by now"),
+				}))))
+			})
 		})
 
 		Context("simulated NamespacedCloudProfile status", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR enables the deletion of `NamespacedCloudProfile`s, as well as other updates, if featured entries (machine images, machine types) are later added to the parent `CloudProfile`.

**Which issue(s) this PR fixes**:
While testing the issue occurred, that a `NamespacedCloudProfile` could not be deleted anymore if it featured a machine image before, which was later added to the parent `CloudProfile`.

**Special notes for your reviewer**:
/cc @timuthy @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Custom machine images and machine types in `NamespacedCloudProfile` are not interfered by later added conflicting entries in the parent `CloudProfile`.
```
