### PR TITLE
Graduate `ShootForceDeletion` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -67,7 +67,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | RotateSSHKeypairOnMaintenance (deprecated)   | `false` | `Beta`       | `1.48`  | `1.50`  |
 | RotateSSHKeypairOnMaintenance (deprecated)   |         | `Removed`    | `1.51`  |         |
 | ShootForceDeletion                           | `false` | `Alpha`      | `1.81`  | `1.90`  |
-| ShootForceDeletion                           | `true`  | `Beta`       | `1.91`  | `1.111` |
+| ShootForceDeletion                           | `true`  | `Beta`       | `1.91`  | `1.110` |
 | ShootForceDeletion                           | `true`  | `GA`         | `1.111` |         |
 | ShootMaxTokenExpirationOverwrite             | `false` | `Alpha`      | `1.43`  | `1.44`  |
 | ShootMaxTokenExpirationOverwrite             | `true`  | `Beta`       | `1.45`  | `1.47`  |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -67,8 +67,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | RotateSSHKeypairOnMaintenance (deprecated)   | `false` | `Beta`       | `1.48`  | `1.50`  |
 | RotateSSHKeypairOnMaintenance (deprecated)   |         | `Removed`    | `1.51`  |         |
 | ShootForceDeletion                           | `false` | `Alpha`      | `1.81`  | `1.90`  |
-| ShootForceDeletion                           | `true`  | `Beta`       | `1.91`  | `1.112` |
-| ShootForceDeletion                           | `true`  | `GA`         | `1.112` |         |
+| ShootForceDeletion                           | `true`  | `Beta`       | `1.91`  | `1.111` |
+| ShootForceDeletion                           | `true`  | `GA`         | `1.111` |         |
 | ShootMaxTokenExpirationOverwrite             | `false` | `Alpha`      | `1.43`  | `1.44`  |
 | ShootMaxTokenExpirationOverwrite             | `true`  | `Beta`       | `1.45`  | `1.47`  |
 | ShootMaxTokenExpirationOverwrite             | `true`  | `GA`         | `1.48`  | `1.50`  |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -19,10 +19,8 @@ The following tables are a summary of the feature gates that you can set on diff
 ## Feature Gates for Alpha or Beta Features
 
 | Feature                   | Default | Stage   | Since   | Until   |
-|---------------------------|---------|---------|---------|---------|
+| ------------------------- | ------- | ------- | ------- | ------- |
 | DefaultSeccompProfile     | `false` | `Alpha` | `1.54`  |         |
-| ShootForceDeletion        | `false` | `Alpha` | `1.81`  | `1.90`  |
-| ShootForceDeletion        | `true`  | `Beta`  | `1.91`  |         |
 | UseNamespacedCloudProfile | `false` | `Alpha` | `1.92`  |         |
 | ShootCredentialsBinding   | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding   | `true`  | `Beta`  | `1.107` |         |
@@ -33,7 +31,7 @@ The following tables are a summary of the feature gates that you can set on diff
 ## Feature Gates for Graduated or Deprecated Features
 
 | Feature                                      | Default | Stage        | Since   | Until   |
-|----------------------------------------------|---------|--------------|---------|---------|
+| -------------------------------------------- | ------- | ------------ | ------- | ------- |
 | NodeLocalDNS                                 | `false` | `Alpha`      | `1.7`   | `1.25`  |
 | NodeLocalDNS                                 |         | `Removed`    | `1.26`  |         |
 | KonnectivityTunnel                           | `false` | `Alpha`      | `1.6`   | `1.26`  |
@@ -68,6 +66,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | RotateSSHKeypairOnMaintenance                | `true`  | `Beta`       | `1.45`  | `1.47`  |
 | RotateSSHKeypairOnMaintenance (deprecated)   | `false` | `Beta`       | `1.48`  | `1.50`  |
 | RotateSSHKeypairOnMaintenance (deprecated)   |         | `Removed`    | `1.51`  |         |
+| ShootForceDeletion                           | `false` | `Alpha`      | `1.81`  | `1.90`  |
+| ShootForceDeletion                           | `true`  | `Beta`       | `1.91`  | `1.112` |
+| ShootForceDeletion                           | `true`  | `GA`         | `1.112` |         |
 | ShootMaxTokenExpirationOverwrite             | `false` | `Alpha`      | `1.43`  | `1.44`  |
 | ShootMaxTokenExpirationOverwrite             | `true`  | `Beta`       | `1.45`  | `1.47`  |
 | ShootMaxTokenExpirationOverwrite             | `true`  | `GA`         | `1.48`  | `1.50`  |

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
@@ -181,12 +180,7 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	allErrs = append(allErrs, ValidateShoot(newShoot)...)
 	allErrs = append(allErrs, ValidateShootHAConfigUpdate(newShoot, oldShoot)...)
 	allErrs = append(allErrs, validateHibernationUpdate(newShoot, oldShoot)...)
-
-	if features.DefaultFeatureGate.Enabled(features.ShootForceDeletion) {
-		allErrs = append(allErrs, ValidateForceDeletion(newShoot, oldShoot)...)
-	} else if helper.ShootNeedsForceDeletion(newShoot) && !helper.ShootNeedsForceDeletion(oldShoot) {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("metadata", "annotations").Key(v1beta1constants.AnnotationConfirmationForceDeletion), "force-deletion annotation cannot be added when the ShootForceDeletion feature gate is not enabled"))
-	}
+	allErrs = append(allErrs, ValidateForceDeletion(newShoot, oldShoot)...)
 
 	return allErrs
 }
@@ -2613,6 +2607,7 @@ func ValidateForceDeletion(newShoot, oldShoot *core.Shoot) field.ErrorList {
 			allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("force-deletion annotation cannot be set when Shoot status does not contain one of these error codes: %v", sets.List(errorCodesAllowingForceDeletion))))
 		}
 	}
+
 	return allErrs
 }
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -27,7 +27,7 @@ const (
 	// owner: @acumino @ary1992 @shafeeqes
 	// alpha: v1.81.0
 	// beta: v1.91.0
-	// GA: v1.112.0
+	// GA: v1.111.0
 	ShootForceDeletion featuregate.Feature = "ShootForceDeletion"
 
 	// UseNamespacedCloudProfile enables the usage of the NamespacedCloudProfile API object

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -27,6 +27,7 @@ const (
 	// owner: @acumino @ary1992 @shafeeqes
 	// alpha: v1.81.0
 	// beta: v1.91.0
+	// GA: v1.112.0
 	ShootForceDeletion featuregate.Feature = "ShootForceDeletion"
 
 	// UseNamespacedCloudProfile enables the usage of the NamespacedCloudProfile API object
@@ -87,7 +88,7 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 // AllFeatureGates is the list of all feature gates.
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:     {Default: false, PreRelease: featuregate.Alpha},
-	ShootForceDeletion:        {Default: true, PreRelease: featuregate.Beta},
+	ShootForceDeletion:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	UseNamespacedCloudProfile: {Default: false, PreRelease: featuregate.Alpha},
 	ShootCredentialsBinding:   {Default: true, PreRelease: featuregate.Beta},
 	NewWorkerPoolHash:         {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Features", func() {
 		It("should return the spec for the given feature gate", func() {
 			Expect(GetFeatures("DefaultSeccompProfile", "ShootForceDeletion", "Foo")).To(Equal(map[featuregate.Feature]featuregate.FeatureSpec{
 				DefaultSeccompProfile: {Default: false, PreRelease: featuregate.Alpha},
-				ShootForceDeletion:    {Default: true, PreRelease: featuregate.GA},
+				ShootForceDeletion:    {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 			}))
 		})
 	})

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Features", func() {
 		It("should return the spec for the given feature gate", func() {
 			Expect(GetFeatures("DefaultSeccompProfile", "ShootForceDeletion", "Foo")).To(Equal(map[featuregate.Feature]featuregate.FeatureSpec{
 				DefaultSeccompProfile: {Default: false, PreRelease: featuregate.Alpha},
-				ShootForceDeletion:    {Default: true, PreRelease: featuregate.Beta},
+				ShootForceDeletion:    {Default: true, PreRelease: featuregate.GA},
 			}))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Graduate `ShootForceDeletion` feature gate to GA.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3110

**Special notes for your reviewer**:
/cc @acumino  @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `ShootForceDeletion` feature gate has been graduated to GA and is locked to `true`. 
```