### PR TITLE
Update restriction handler preventing tampering with system `Secret`s and `ConfigMap`s

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -346,4 +346,34 @@ webhooks:
     {{- end }}
     caBundle: {{ required ".Values.global.admission.config.server.webhooks.tls.caBundle is required" (b64enc .Values.global.admission.config.server.webhooks.tls.caBundle) }}
   sideEffects: None
+- name: update-restriction.gardener.cloud
+  admissionReviewVersions: ["v1", "v1beta1"]
+  timeoutSeconds: 10
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - secrets
+    - configmaps
+  failurePolicy: Fail
+  objectSelector:
+    matchLabels:
+      gardener.cloud/update-restriction: "true"
+  clientConfig:
+    {{- if .Values.global.deployment.virtualGarden.enabled }}
+    url: https://gardener-admission-controller.garden/webhooks/update-restriction
+    {{- else }}
+    service:
+      namespace: garden
+      name: gardener-admission-controller
+      path: /webhooks/update-restriction
+    {{- end }}
+    caBundle: {{ required ".Values.global.admission.config.server.webhooks.tls.caBundle is required" (b64enc .Values.global.admission.config.server.webhooks.tls.caBundle) }}
+  sideEffects: None
 {{- end }}

--- a/docs/concepts/admission-controller.md
+++ b/docs/concepts/admission-controller.md
@@ -93,6 +93,13 @@ It's recommended to start with `log`, check the logs for exceeding requests, adj
 
 Please refer to [Scoped API Access for Gardenlets](../deployment/gardenlet_api_access.md) for more information.
 
+### UpdateRestriction
+
+Gardener stores public data regarding shoot clusters, i.e. certificate authority bundles, OIDC discovery documents, etc.
+This information can be used by third parties so that they establish trust to specific authorities, making the integrity of the stored data extremely important in a way that any unwanted modifications can be considered a security risk.
+This handler protects `secrets` and `configmaps` against tampering.
+It denies `CREATE`, `UPDATE` and `DELETE` requests if the resource is labeled with `gardener.cloud/update-restriction=true` and the request is not made by a `gardenlet`.
+
 ## Authorization Webhook Handlers
 
 This section describes the authorization webhook handlers that are currently served.

--- a/pkg/admissioncontroller/webhook/add.go
+++ b/pkg/admissioncontroller/webhook/add.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/resourcesize"
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/seedrestriction"
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/shootkubeconfigsecretref"
+	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/updaterestriction"
 	seedauthorizer "github.com/gardener/gardener/pkg/admissioncontroller/webhook/auth/seed"
 )
 
@@ -90,6 +91,10 @@ func AddToManager(
 		Client: mgr.GetClient(),
 	}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding %s webhook handler: %w", shootkubeconfigsecretref.HandlerName, err)
+	}
+
+	if err := updaterestriction.AddToManager(mgr); err != nil {
+		return fmt.Errorf("failed adding %s webhook handler: %w", updaterestriction.HandlerName, err)
 	}
 
 	return nil

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/add.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/add.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/add.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/add.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package updaterestriction
+
+import (
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	// HandlerName is the name of this admission webhook handler.
+	HandlerName = "update_restriction"
+	// WebhookPath is the HTTP handler path for this admission webhook handler.
+	WebhookPath = "/webhooks/update-restriction"
+)
+
+// AddToManager adds Handler to the given manager.
+func AddToManager(mgr manager.Manager) error {
+	webhook := &admission.Webhook{
+		Handler:      &Handler{},
+		RecoverPanic: ptr.To(true),
+	}
+
+	mgr.GetWebhookServer().Register(WebhookPath, webhook)
+	return nil
+}

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/handler.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/handler.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package updaterestriction
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
+// Handler handles resources that should not be modified
+// from users other than the gardenlet.
+type Handler struct{}
+
+// Handle checks if the request is issued by a gardenlet
+// and rejects the request if that is not the case.
+func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Response {
+	if !slices.Contains(req.UserInfo.Groups, v1beta1constants.SeedsGroup) {
+		return admission.Denied(fmt.Sprintf("user %q is not allowed to modify system %s", req.UserInfo.Username, req.Resource.Resource))
+	}
+
+	return admission.Allowed("")
+}

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/handler_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/handler_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package updaterestriction_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/updaterestriction"
+)
+
+var _ = Describe("handler", func() {
+	var (
+		ctx     context.Context
+		handler *updaterestriction.Handler
+		req     admission.Request
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		handler = &updaterestriction.Handler{}
+		req.UserInfo = authenticationv1.UserInfo{
+			Username: "gardenlet",
+			Groups:   []string{"gardener.cloud:system:seeds"},
+		}
+		req.Resource = metav1.GroupVersionResource{
+			Resource: "configmaps",
+		}
+	})
+
+	Describe("#Handle", func() {
+		It("should allow the request as it is made by a gardenlet", func() {
+			resp := handler.Handle(ctx, req)
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.AdmissionResponse).To(Equal(admissionv1.AdmissionResponse{
+				Allowed: true,
+				Result: &metav1.Status{
+					Code:    int32(200),
+					Reason:  "",
+					Message: "",
+				},
+			}))
+		})
+
+		It("should deny the request as it is not made by a gardenlet", func() {
+			req.UserInfo = authenticationv1.UserInfo{
+				Username: "not-gardenlet",
+			}
+			resp := handler.Handle(ctx, req)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.AdmissionResponse).To(Equal(admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Code:    int32(403),
+					Reason:  "Forbidden",
+					Message: "user \"not-gardenlet\" is not allowed to modify system configmaps",
+				},
+			}))
+		})
+	})
+})

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/updaterestriction_suite_test.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/updaterestriction_suite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/updaterestriction_suite_test.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/updaterestriction_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package updaterestriction_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpdateRestriction(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AdmissionController Webhook Admission UpdateRestriction Suite")
+}

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -722,6 +722,10 @@ const (
 	// LabelWorkerPoolGardenerNodeAgentSecretName is the name of the secret used by the gardener node agent
 	LabelWorkerPoolGardenerNodeAgentSecretName = "worker.gardener.cloud/gardener-node-agent-secret-name"
 
+	// LabelUpdateRestriction is a constant for a label key that indicates
+	// that a resource must be only updated by the gardenlet.
+	LabelUpdateRestriction = "gardener.cloud/update-restriction"
+
 	// EventResourceReferenced indicates that the resource deletion is in waiting mode because the resource is still
 	// being referenced by at least one other resource (e.g. a SecretBinding is still referenced by a Shoot)
 	EventResourceReferenced = "ResourceReferenced"

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -1144,6 +1144,36 @@ func validatingWebhookConfiguration(namespace string, caBundle []byte, testValue
 				},
 				SideEffects: &sideEffectsNone,
 			},
+			{
+				Name:                    "update-restriction.gardener.cloud",
+				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				TimeoutSeconds:          ptr.To[int32](10),
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
+							admissionregistrationv1.Delete,
+						},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{corev1.GroupName},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"secrets", "configmaps"},
+						},
+					},
+				},
+				FailurePolicy: &failurePolicyFail,
+				ObjectSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"gardener.cloud/update-restriction": "true",
+					},
+				},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					URL:      ptr.To("https://gardener-admission-controller." + namespace + "/webhooks/update-restriction"),
+					CABundle: caBundle,
+				},
+				SideEffects: &sideEffectsNone,
+			},
 		},
 	}
 

--- a/pkg/component/gardener/admissioncontroller/webhooks.go
+++ b/pkg/component/gardener/admissioncontroller/webhooks.go
@@ -237,6 +237,36 @@ func (a *gardenerAdmissionController) validatingWebhookConfiguration(caSecret *c
 				},
 				SideEffects: &sideEffectsNone,
 			},
+			{
+				Name:                    "update-restriction.gardener.cloud",
+				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				TimeoutSeconds:          ptr.To[int32](10),
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
+							admissionregistrationv1.Delete,
+						},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{corev1.GroupName},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"secrets", "configmaps"},
+						},
+					},
+				},
+				FailurePolicy: &failurePolicyFail,
+				ObjectSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						v1beta1constants.LabelUpdateRestriction: "true",
+					},
+				},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					URL:      buildClientConfigURL("/webhooks/update-restriction", a.namespace),
+					CABundle: caBundle,
+				},
+				SideEffects: &sideEffectsNone,
+			},
 		},
 	}
 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -866,6 +866,7 @@ build:
             - pkg/admissioncontroller/webhook/admission/resourcesize
             - pkg/admissioncontroller/webhook/admission/seedrestriction
             - pkg/admissioncontroller/webhook/admission/shootkubeconfigsecretref
+            - pkg/admissioncontroller/webhook/admission/updaterestriction
             - pkg/admissioncontroller/webhook/auth/seed
             - pkg/admissioncontroller/webhook/auth/seed/graph
             - pkg/apis/core

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -461,6 +461,7 @@ build:
             - pkg/admissioncontroller/webhook/admission/resourcesize
             - pkg/admissioncontroller/webhook/admission/seedrestriction
             - pkg/admissioncontroller/webhook/admission/shootkubeconfigsecretref
+            - pkg/admissioncontroller/webhook/admission/updaterestriction
             - pkg/admissioncontroller/webhook/auth/seed
             - pkg/admissioncontroller/webhook/auth/seed/graph
             - pkg/apis/core


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Please see motivation in #11095.

**Which issue(s) this PR fixes**:
Fixes #11095

**Special notes for your reviewer**:
cc @timuthy @vpnachev @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The Gardener Admission Controller now implements a handler that can prevent tampering with system `Secret`s and `ConfigMap`s if they are labeled with `gardener.cloud/update-restriction=true`.
```
