### PR TITLE
Use role `garden-cert` for wildcard TLS certificate used for Garden runtime

### DIFF
--- a/docs/operations/trusted-tls-for-garden-runtime.md
+++ b/docs/operations/trusted-tls-for-garden-runtime.md
@@ -31,7 +31,7 @@ data:
 kind: Secret
 metadata:
   labels:
-    gardener.cloud/role: controlplane-cert
+    gardener.cloud/role: garden-cert
   name: garden-ingress-certificate
   namespace: garden
 type: Opaque

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -276,8 +276,11 @@ const (
 	// GardenRoleAlerting is the value of GardenRole key indicating type 'alerting'.
 	GardenRoleAlerting = "alerting"
 	// GardenRoleControlPlaneWildcardCert is the value of the GardenRole key indicating type 'controlplane-cert'.
-	// It refers to a wildcard tls certificate which can be used for services exposed under the corresponding domain.
+	// It refers to a wildcard TLS certificate which can be used for seed services exposed under the corresponding domain.
 	GardenRoleControlPlaneWildcardCert = "controlplane-cert"
+	// GardenRoleGardenWildcardCert is the value of the GardenRole key indicating type 'garden-cert'.
+	// It refers to a wildcard TLS certificate which can be used for Garden runtime services exposed under the corresponding domain.
+	GardenRoleGardenWildcardCert = "garden-cert"
 	// GardenRoleExposureClassHandler is the value of the GardenRole key indicating type 'exposureclass-handler'.
 	GardenRoleExposureClassHandler = "exposureclass-handler"
 	// GardenRoleShootServiceAccountIssuer is the value of the GardenRole key indicating type 'shoot-service-account-issuer'.

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -116,7 +116,7 @@ type Values struct {
 	VPAEnabled bool
 	// VPNHighAvailabilityEnabled specifies whether the cluster is configured with HA VPN.
 	VPNHighAvailabilityEnabled bool
-	// WildcardCertName is name of wildcard tls certificate which is issued for the seed's ingress domain.
+	// WildcardCertName is name of wildcard TLS certificate which is issued for the seed's ingress domain.
 	WildcardCertName *string
 }
 

--- a/pkg/gardenlet/operation/types.go
+++ b/pkg/gardenlet/operation/types.go
@@ -59,6 +59,6 @@ type Operation struct {
 	APIServerClusterIP    string
 	SeedNamespaceObject   *corev1.Namespace
 
-	// ControlPlaneWildcardCert is a wildcard tls certificate which is issued for the seed's ingress domain.
+	// ControlPlaneWildcardCert is a wildcard TLS certificate which is issued for the seed's ingress domain.
 	ControlPlaneWildcardCert *corev1.Secret
 }

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -111,7 +111,7 @@ func (r *Reconciler) reconcile(
 		}
 	}
 
-	wildcardCert, err := gardenerutils.GetWildcardCertificate(ctx, r.RuntimeClientSet.Client())
+	wildcardCert, err := gardenerutils.GetGardenWildcardCertificate(ctx, r.RuntimeClientSet.Client())
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/utils/gardener/seed.go
+++ b/pkg/utils/gardener/seed.go
@@ -106,7 +106,8 @@ func GetGardenWildcardCertificate(ctx context.Context, c client.Client) (*corev1
 		return nil, error
 	}
 	if secret == nil {
-		// try to lookup secret with old role name
+		// TODO(MartinWeindel): Remove this fallback after the next release (v1.111.0)
+		// try to look up secret with old role name
 		secret, error = getWildcardCertificate(ctx, c, v1beta1constants.GardenRoleControlPlaneWildcardCert)
 	}
 	return secret, error

--- a/pkg/utils/gardener/seed_test.go
+++ b/pkg/utils/gardener/seed_test.go
@@ -74,9 +74,10 @@ var _ = Describe("utils", func() {
 
 	Describe("#GetWildcardCertificate", func() {
 		var (
-			ctx        = context.TODO()
-			fakeClient client.Client
-			secret     *corev1.Secret
+			ctx          = context.TODO()
+			fakeClient   client.Client
+			secret       *corev1.Secret
+			gardenSecret *corev1.Secret
 		)
 
 		BeforeEach(func() {
@@ -89,6 +90,13 @@ var _ = Describe("utils", func() {
 					Labels:       map[string]string{"gardener.cloud/role": "controlplane-cert"},
 				},
 			}
+			gardenSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "secret-",
+					Namespace:    "garden",
+					Labels:       map[string]string{"gardener.cloud/role": "garden-cert"},
+				},
+			}
 		})
 
 		It("should return an error because there are more than one wildcard certificates", func() {
@@ -98,7 +106,7 @@ var _ = Describe("utils", func() {
 
 			result, err := GetWildcardCertificate(ctx, fakeClient)
 			Expect(result).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring("misconfigured cluster: not possible to provide more than one secret with annotation")))
+			Expect(err).To(MatchError(ContainSubstring("misconfigured cluster: not possible to provide more than one secret with label")))
 		})
 
 		It("should return the wildcard certificate secret", func() {
@@ -112,6 +120,37 @@ var _ = Describe("utils", func() {
 		It("should return nil because there is no wildcard certificate secret", func() {
 			result, err := GetWildcardCertificate(ctx, fakeClient)
 			Expect(result).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return the Garden wildcard certificate secret with old role name", func() {
+			Expect(fakeClient.Create(ctx, gardenSecret)).To(Succeed())
+
+			result, err := GetGardenWildcardCertificate(ctx, fakeClient)
+			Expect(result).To(Equal(gardenSecret))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error because there are more than one Garden wildcard certificates", func() {
+			secret2 := gardenSecret.DeepCopy()
+			Expect(fakeClient.Create(ctx, gardenSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, secret2)).To(Succeed())
+
+			result, err := GetGardenWildcardCertificate(ctx, fakeClient)
+			Expect(result).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("misconfigured cluster: not possible to provide more than one secret with label")))
+		})
+
+		It("should return the correct wildcard certificate secrets if secrets for seed and garden are existing", func() {
+			Expect(fakeClient.Create(ctx, gardenSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+			result, err := GetWildcardCertificate(ctx, fakeClient)
+			Expect(result).To(Equal(secret))
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err = GetGardenWildcardCertificate(ctx, fakeClient)
+			Expect(result).To(Equal(gardenSecret))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The wildcard TLS certificate for the Garden runtime cluster is looked up with `gardener.cloud/role=garden-cert`. Only if no such secret is found, a lookup with the former role `gardener.cloud/role=controlplane-cert` is tried.
Background of this change is that there will be two wildcard TLS certificates with the same role if the runtime cluster is also used as seed. In this case, the secret for the runtime and the seed cannot be distinguished currently.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The wildcard TLS certificate for the runtime cluster must now be labelled with `gardener.cloud/role=garden-cert` instead of `gardener.cloud/role=controlplane-cert` to avoid duplicate role assignments for runtime and seed certificate secrets if Gardener runtime and seed run on the same cluster.
The old role name is deprecated for the runtime cluster. It will not be accepted anymore with the next Gardener release.
```
