### PR TITLE
Introducing x509 certificate monitoring within the runtime cluster

### DIFF
--- a/imagevector/containers.go
+++ b/imagevector/containers.go
@@ -133,4 +133,6 @@ const (
 	ContainerImageNameVpnServer = "vpn-server"
 	// ContainerImageNameVpnShootClient is a constant for an image in the image vector with name 'vpn-shoot-client'.
 	ContainerImageNameVpnShootClient = "vpn-shoot-client"
+	// ContainerImageNameX509CertificateExporter is a constant for an image in the image vector with name 'x509-certificate-exporter'.
+	ContainerImageNameX509CertificateExporter = "x509-certificate-exporter"
 )

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -395,6 +395,10 @@ images:
     value:
     - type: 'githubTeam'
       teamname: 'gardener/monitoring-maintainers'
+- name: x509-certificate-exporter
+  sourceRepository: github.com/enix/x509-certificate-exporter
+  repository: docker.io/enix/x509-certificate-exporter
+  tag: 3.18.0
 
 # Shoot core addons
 - name: vpn-client

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -398,7 +398,7 @@ images:
 - name: x509-certificate-exporter
   sourceRepository: github.com/enix/x509-certificate-exporter
   repository: docker.io/enix/x509-certificate-exporter
-  tag: 3.18.0
+  tag: 3.18.1
 
 # Shoot core addons
 - name: vpn-client

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -178,16 +178,16 @@ type Settings struct {
 type HostCertificates struct {
 	// MountPath is the host path that will be mounted
 	MountPath string
-	// Certificate paths is a list of certificates withion the specified mount
+	// CertificatePaths is a list of certificates withion the specified mount
 	// All relative paths are configured base on the specified mount
 	// +optional
 	CertificatePaths []string `json:"certificatePaths,omitempty"`
-	// Similat to CertificatePaths but for dirs
+	// CertificateDirPaths are similat to CertificatePaths but for dirs
 	// +optional
 	CertificateDirPaths []string `json:"certificateDirPaths,omitempty"`
 }
 
-// WorkerGroupCertificates contains the definition of the worker group certificate paths.
+// WorkerGroup describes worker groups and configures paths to host certificates
 type WorkerGroup struct {
 	// Selector is a label selector that selects the worker nodes of this group.
 	// +optional

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -101,6 +101,9 @@ type RuntimeCluster struct {
 	// Volume contains settings for persistent volumes created in the runtime cluster.
 	// +optional
 	Volume *Volume `json:"volume,omitempty"`
+	// WorkerGroups contains the worker group representations
+	// +optional
+	WorkerGroups map[string]WorkerGroup `json:"workerGroups,omitempty"`
 }
 
 // Ingress configures the Ingress specific settings of the runtime cluster.
@@ -168,6 +171,29 @@ type Settings struct {
 	// See https://github.com/gardener/gardener/blob/master/docs/operations/topology_aware_routing.md.
 	// +optional
 	TopologyAwareRouting *SettingTopologyAwareRouting `json:"topologyAwareRouting,omitempty"`
+}
+
+// HostCertificates describes certificates that will be configured for monitoring
+// from the host nodes
+type HostCertificates struct {
+	// MountPath is the host path that will be mounted
+	MountPath string
+	// Certificate paths is a list of certificates withion the specified mount
+	// All relative paths are configured base on the specified mount
+	// +optional
+	CertificatePaths []string `json:"certificatePaths,omitempty"`
+	// Similat to CertificatePaths but for dirs
+	// +optional
+	CertificateDirPaths []string `json:"certificateDirPaths,omitempty"`
+}
+
+// WorkerGroupCertificates contains the definition of the worker group certificate paths.
+type WorkerGroup struct {
+	// Selector is a label selector that selects the worker nodes of this group.
+	// +optional
+	Selector *metav1.LabelSelector `json:"selector,omitempty"`
+	// HostCertificates contains the definition of the host certificates.
+	HostCertificates []HostCertificates `json:"hostCertificates,omitempty"`
 }
 
 // SettingLoadBalancerServices controls certain settings for services of type load balancer that are created in the

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -178,11 +178,11 @@ type Settings struct {
 type HostCertificates struct {
 	// MountPath is the host path that will be mounted
 	MountPath string
-	// CertificatePaths is a list of certificates withion the specified mount
-	// All relative paths are configured base on the specified mount
+	// CertificatePaths is a list of certificates within the specified mount
+	// All relative paths are configured based on the specified mount
 	// +optional
 	CertificatePaths []string `json:"certificatePaths,omitempty"`
-	// CertificateDirPaths are similat to CertificatePaths but for dirs
+	// CertificateDirPaths are similar to CertificatePaths but for dirs
 	// +optional
 	CertificateDirPaths []string `json:"certificateDirPaths,omitempty"`
 }

--- a/pkg/component/observability/monitoring/x509certificateexporter/args.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args.go
@@ -56,7 +56,7 @@ type HostCertificates struct {
 // will fail if mountPath is not an absolute dir
 // if any certificatePath is not an abs path, mountPath will be prepend
 // mountPath: host path that will be mounted from the node
-// filePaths: paths that will be configured in certificate exporter ds. Paths can be either file paths or dirs. If not absolute - mountPath is prepended.
+// filePaths: paths that will be configured in certificate exporter daemonset. Paths can be either file paths or dirs. If not absolute - mountPath is prepended.
 // dirPaths: similar as above, but will be configured as dirs
 func NewHostCertificates(
 	mountPath string, filePaths []string, dirPaths []string,
@@ -75,7 +75,7 @@ func NewHostCertificates(
 	)
 
 	if !filepath.IsAbs(mountPath) {
-		return nil, errors.New("Path " + mountPath + "is not absolute file path")
+		return nil, errors.New("Path " + mountPath + " is not absolute file path")
 	}
 	ensureAbsolutePaths(filePaths)
 	if len(dirPaths) == 0 {

--- a/pkg/component/observability/monitoring/x509certificateexporter/args.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args.go
@@ -214,5 +214,5 @@ func (in IncludeNamespaces) AsArgs() []string {
 type ConfigMapKeys []string
 
 func (c ConfigMapKeys) AsArgs() []string {
-	return listToArgs("--configmap-key=", c)
+	return listToArgs("--configmap-keys=", c)
 }

--- a/pkg/component/observability/monitoring/x509certificateexporter/args.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args.go
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package x509certificateexporter
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type X509CertificateArg interface {
+	AsArg() string
+}
+
+type X509CertificateArgSet interface {
+	AsArgs() []string
+}
+
+type CertificatePath string
+
+func (c CertificatePath) AsArg() string {
+	return "--watch-file=" + string(c)
+}
+
+type CertificateDirPath string
+
+func (c CertificateDirPath) AsArg() string {
+	return "--watch-dir=" + string(c)
+}
+
+// HostCertificates describes certificates that will be configured for monitoring
+// from the host nodes
+type HostCertificates struct {
+	// MountPath is the host path that will be mounted
+	MountPath string
+	// Certificate paths is a list of certificates withion the specified mount
+	// All relative paths are configured base on the specified mount
+	CertificatePaths []CertificatePath
+	// Similat to CertificatePaths but for dirs
+	CertificateDirPaths []CertificateDirPath
+}
+
+// Produces `*hostCertificates`,
+// will fail if mountPath is not an absolute dir
+// if any certificatePath is not an abs path, mountPath will be prepend
+// mountPath: host path that will be mounted from the node
+// filePaths: paths that will be configured in certificate exporter ds. Paths can be either file paths or dirs. If not absolute - mountPath is prepended.
+// dirPaths: similar as above, but will be configured as dirs
+func NewHostCertificates(
+	mountPath string, filePaths []string, dirPaths []string,
+) (*HostCertificates, error) {
+	var (
+		ensureAbsolutePaths = func(paths []string) {
+			for idx, path := range paths {
+				if !filepath.IsAbs(path) {
+					paths[idx] = filepath.Join(mountPath, path)
+				}
+			}
+			sort.Strings(paths)
+		}
+		certificateDirs  []CertificateDirPath
+		certificatePaths []CertificatePath
+	)
+
+	if !filepath.IsAbs(mountPath) {
+		return nil, errors.New("Path " + mountPath + "is not absolute file path")
+	}
+	ensureAbsolutePaths(filePaths)
+	if len(dirPaths) == 0 {
+		dirPaths = []string{mountPath}
+	}
+	ensureAbsolutePaths(dirPaths)
+
+	certificateDirs = make([]CertificateDirPath, len(dirPaths))
+	for i, path := range dirPaths {
+		certificateDirs[i] = CertificateDirPath(path)
+	}
+
+	certificatePaths = make([]CertificatePath, len(filePaths))
+	for i, path := range filePaths {
+		certificatePaths[i] = CertificatePath(path)
+	}
+
+	return &HostCertificates{
+		MountPath:           mountPath,
+		CertificatePaths:    certificatePaths,
+		CertificateDirPaths: certificateDirs,
+	}, nil
+}
+
+func (h HostCertificates) AsArgs() []string {
+	var (
+		offset = len(h.CertificatePaths)
+		args   = make([]string, offset+len(h.CertificateDirPaths))
+	)
+
+	for idx, arg := range h.CertificatePaths {
+		args[idx] = arg.AsArg()
+	}
+	for idx, arg := range h.CertificateDirPaths {
+		args[offset+idx] = arg.AsArg()
+	}
+	return args
+}
+
+// Secret types and the key name contained within that secret
+type SecretType struct {
+	// Type of the secrets that should be searched
+	Type string
+	// Key within the secret that should be checked
+	Key string
+}
+
+func (s SecretType) String() string {
+	return s.Type + ":" + s.Key
+}
+
+func (s SecretType) AsArg() string {
+	return fmt.Sprintf("--secret-type=%s", s)
+}
+
+type SecretTypeList []SecretType
+
+func (s SecretTypeList) AsArgs() []string {
+	var (
+		args = make([]string, len(s))
+	)
+	for idx, arg := range s {
+		args[idx] = arg.AsArg()
+	}
+	return args
+}
+
+func labelsToArgs(argPrefix string, data map[string]string) []string {
+	var (
+		args = []string{}
+	)
+	for k, v := range data {
+		arg := argPrefix + k
+		if v != "" {
+			arg += "=" + v
+		}
+		args = append(args, arg)
+	}
+	sort.Strings(args)
+	return args
+}
+
+type IncludeLabels labels.Set
+
+func (il IncludeLabels) AsArgs() []string {
+	return labelsToArgs("--include-label=", map[string]string(il))
+}
+
+type ExcludeLabels labels.Set
+
+func (el ExcludeLabels) AsArgs() []string {
+	return labelsToArgs("--exclude-label=", el)
+}
+
+type ExcludeNamespaces []string
+
+func (en ExcludeNamespaces) AsArgs() []string {
+	var (
+		args = make([]string, len(en))
+	)
+	for idx, arg := range en {
+		args[idx] = "--exclude-namespace=" + arg
+	}
+	return args
+}
+
+type IncludeNamespaces []string
+
+func (in IncludeNamespaces) AsArgs() []string {
+	var (
+		args = make([]string, len(in))
+	)
+	for idx, arg := range in {
+		args[idx] = "--include-namespace=" + arg
+	}
+	return args
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/args.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args.go
@@ -137,9 +137,7 @@ func (s SecretType) AsArg() string {
 type SecretTypeList []SecretType
 
 func (s SecretTypeList) AsArgs() []string {
-	var (
-		args = make([]string, len(s))
-	)
+	args := make([]string, len(s))
 	for idx, arg := range s {
 		args[idx] = arg.AsArg()
 	}
@@ -147,9 +145,7 @@ func (s SecretTypeList) AsArgs() []string {
 }
 
 func labelsToArgs(argPrefix string, data map[string]string) []string {
-	var (
-		args = []string{}
-	)
+	args := []string{}
 	for k, v := range data {
 		arg := argPrefix + k
 		if v != "" {
@@ -186,7 +182,7 @@ func listToArgs(argPrefix string, data []string) []string {
 type IncludeLabels labels.Set
 
 func (il IncludeLabels) AsArgs() []string {
-	return labelsToArgs("--include-label=", map[string]string(il))
+	return labelsToArgs("--include-label=", il)
 }
 
 // ExcludeLabels are labels used to filter certificates from the k8s API.

--- a/pkg/component/observability/monitoring/x509certificateexporter/args.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args.go
@@ -24,7 +24,7 @@ type X509CertificateArgSet interface {
 	AsArgs() []string
 }
 
-// Filepath to a certificate on the node
+// CertificatePath filepath to a certificate on the node
 type CertificatePath string
 
 // AsArg returns the certificate path as an argument
@@ -45,10 +45,10 @@ func (c CertificateDirPath) AsArg() string {
 type HostCertificates struct {
 	// MountPath is the host path that will be mounted
 	MountPath string
-	// Certificate paths is a list of certificates withion the specified mount
+	// CertificatePaths is a list of certificates withion the specified mount
 	// All relative paths are configured base on the specified mount
 	CertificatePaths []CertificatePath
-	// Similat to CertificatePaths but for dirs
+	// CertificateDirPaths similat to CertificatePaths but for dirs
 	CertificateDirPaths []CertificateDirPath
 }
 
@@ -116,7 +116,7 @@ func (h HostCertificates) AsArgs() []string {
 	return args
 }
 
-// SecretType groups Secret types and the key name contained within that secret
+// SecretType groups secret types and the key name contained within that secret
 // to provide an argument for the x509 certificate exporter
 type SecretType struct {
 	// Type of the secrets that should be searched

--- a/pkg/component/observability/monitoring/x509certificateexporter/args_test.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args_test.go
@@ -11,7 +11,7 @@ import (
 	x "github.com/gardener/gardener/pkg/component/observability/monitoring/x509certificateexporter"
 )
 
-var _ = Describe("x509 certificate exporter", func() {
+var _ = Describe("x509 certificate exporter - arg calculation", func() {
 	Describe("CertificatePath", func() {
 		It("Should calculate string correctly", func() {
 			Expect(x.CertificatePath("/path/to/cert").AsArg()).To(Equal("--watch-file=/path/to/cert"))

--- a/pkg/component/observability/monitoring/x509certificateexporter/args_test.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args_test.go
@@ -28,14 +28,14 @@ var _ = Describe("x509 certificate exporter - arg calculation", func() {
 				It("should return error", func() {
 					_, err := x.NewHostCertificates("relative/path", []string{}, []string{})
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("Path relative/pathis not absolute file path"))
+					Expect(err.Error()).To(Equal("Path relative/path is not absolute file path"))
 				})
 			})
 			Context("Windows style path", func() {
 				It("should return error", func() {
 					_, err := x.NewHostCertificates("C:\\windows\\path", []string{}, []string{})
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("Path C:\\windows\\pathis not absolute file path"))
+					Expect(err.Error()).To(Equal("Path C:\\windows\\path is not absolute file path"))
 				})
 			})
 			Context("Absolute paths for certificates", func() {

--- a/pkg/component/observability/monitoring/x509certificateexporter/args_test.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args_test.go
@@ -135,4 +135,12 @@ var _ = Describe("x509 certificate exporter - arg calculation", func() {
 			}))
 		})
 	})
+	Describe("ConfigMapKeys", func() {
+		It("should return arg string", func() {
+			Expect(x.ConfigMapKeys{"key1", "key2", "key2"}.AsArgs()).To(Equal([]string{
+				"--configmap-key=key1",
+				"--configmap-key=key2",
+			}))
+		})
+	})
 })

--- a/pkg/component/observability/monitoring/x509certificateexporter/args_test.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/args_test.go
@@ -138,8 +138,8 @@ var _ = Describe("x509 certificate exporter - arg calculation", func() {
 	Describe("ConfigMapKeys", func() {
 		It("should return arg string", func() {
 			Expect(x.ConfigMapKeys{"key1", "key2", "key2"}.AsArgs()).To(Equal([]string{
-				"--configmap-key=key1",
-				"--configmap-key=key2",
+				"--configmap-keys=key1",
+				"--configmap-keys=key2",
 			}))
 		})
 	})

--- a/pkg/component/observability/monitoring/x509certificateexporter/common.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/common.go
@@ -75,8 +75,7 @@ func (x *x509CertificateExporter) defaultPodSpec(sa *corev1.ServiceAccount) core
 					Capabilities: &corev1.Capabilities{
 						Drop: []corev1.Capability{"ALL"},
 					},
-					ReadOnlyRootFilesystem:   ptr.To(true),
-					AllowPrivilegeEscalation: ptr.To(true),
+					ReadOnlyRootFilesystem: ptr.To(true),
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{

--- a/pkg/component/observability/monitoring/x509certificateexporter/common.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/common.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0package x509certificateexporter
+
+package x509certificateexporter
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+func (x *x509CertificateExporter) service(resName string, selector labels.Set) *corev1.Service {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resName,
+			Namespace: x.namespace,
+			Labels:    selector,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: selector,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       portName,
+					Port:       port,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(port),
+				},
+			},
+			Type: corev1.ServiceType("ClusterIP"),
+		},
+	}
+
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt(port)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}))
+	return service
+}
+
+func (x *x509CertificateExporter) getGenericLabels(source string) map[string]string {
+	return map[string]string{
+		v1beta1constants.LabelRole: labelComponent,
+		certificateSourceLabelName: source,
+	}
+}
+
+func (x *x509CertificateExporter) defaultPodSpec(sa *corev1.ServiceAccount) corev1.PodSpec {
+	return corev1.PodSpec{
+		ServiceAccountName: sa.Name,
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsGroup: ptr.To(int64(1000)),
+			RunAsUser:  ptr.To(int64(1000)),
+		},
+		Containers: []corev1.Container{
+			{
+				Name:            containerName,
+				Image:           x.values.Image,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          portName,
+						ContainerPort: port,
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+					ReadOnlyRootFilesystem:   ptr.To(true),
+					AllowPrivilegeEscalation: ptr.To(true),
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+			},
+		},
+		PriorityClassName: x.values.PriorityClassName,
+		RestartPolicy:     corev1.RestartPolicyAlways,
+	}
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/incluster_certificate_collection.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/incluster_certificate_collection.go
@@ -32,24 +32,27 @@ func (x *x509CertificateExporter) deployment(
 
 	podLabels[v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer] = v1beta1constants.LabelNetworkPolicyAllowed
 	args = func() []string {
+		defaultArgs := []string{
+			"--expose-relative-metrics",
+			"--expose-per-cert-error-metrics",
+			"--watch-kube-secrets",
+			"--max-cache-duration=" + x.values.CacheDuration.Duration.String(),
+			fmt.Sprintf("--listen-address=:%d", port),
+		}
 		secretTypes := x.values.SecretTypes.AsArgs()
+		configMapKeys := x.values.ConfigMapKeys.AsArgs()
 		includedLabels := x.values.IncludeLabels.AsArgs()
 		excludedLabels := x.values.ExcludeLabels.AsArgs()
 		excludedNamespaces := x.values.ExcludeNamespaces.AsArgs()
 		includedNamespaces := x.values.IncludeNamespaces.AsArgs()
-		args := make([]string, 0, 5+len(secretTypes)+len(includedLabels)+len(excludedLabels)+len(excludedNamespaces)+len(includedNamespaces))
+		args := make([]string, 0, len(secretTypes)+len(configMapKeys)+len(includedLabels)+len(excludedLabels)+len(excludedNamespaces)+len(includedNamespaces)+len(defaultArgs))
 		args = append(args, secretTypes...)
+		args = append(args, configMapKeys...)
 		args = append(args, includedLabels...)
 		args = append(args, excludedLabels...)
 		args = append(args, excludedNamespaces...)
 		args = append(args, includedNamespaces...)
-		args = append(args,
-			"--expose-relative-metrics",
-			"--expose-per-cert-error-metrics",
-			"--watch-kube-secrets",
-			"--max-cache-duration="+x.values.CacheDuration.Duration.String(),
-			fmt.Sprintf("--listen-address=:%d", port),
-		)
+		args = append(args, defaultArgs...)
 		sort.Strings(args)
 		return args
 	}()

--- a/pkg/component/observability/monitoring/x509certificateexporter/incluster_certificate_collection.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/incluster_certificate_collection.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0package x509certificateexporter
+
+package x509certificateexporter
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
+func (x *x509CertificateExporter) deployment(
+	resName string, sa *corev1.ServiceAccount,
+) (*appsv1.Deployment, error) {
+	if len(x.values.SecretTypes) == 0 {
+		return nil, errors.New("no secret types provided")
+	}
+
+	var (
+		podLabels = x.getGenericLabels(inClusterCertificateLabelValue)
+		args      []string
+		podSpec   corev1.PodSpec
+	)
+
+	podLabels[v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer] = v1beta1constants.LabelNetworkPolicyAllowed
+	args = func() []string {
+		secretTypes := x.values.SecretTypes.AsArgs()
+		includedLabels := x.values.IncludeLabels.AsArgs()
+		excludedLabels := x.values.ExcludeLabels.AsArgs()
+		excludedNamespaces := x.values.ExcludeNamespaces.AsArgs()
+		includedNamespaces := x.values.IncludeNamespaces.AsArgs()
+		args := make([]string, 0, 5+len(secretTypes)+len(includedLabels)+len(excludedLabels)+len(excludedNamespaces)+len(includedNamespaces))
+		args = append(args, secretTypes...)
+		args = append(args, includedLabels...)
+		args = append(args, excludedLabels...)
+		args = append(args, excludedNamespaces...)
+		args = append(args, includedNamespaces...)
+		args = append(args,
+			"--expose-relative-metrics",
+			"--expose-per-cert-error-metrics",
+			"--watch-kube-secrets",
+			"--max-cache-duration="+x.values.CacheDuration.Duration.String(),
+			fmt.Sprintf("--listen-address=:%d", port),
+		)
+		sort.Strings(args)
+		return args
+	}()
+	podSpec = x.defaultPodSpec(sa)
+	podSpec.Containers[0].Args = args
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resName,
+			Namespace: x.namespace,
+			Labels:    x.getGenericLabels(inClusterCertificateLabelValue),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &x.values.Replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: podSpec,
+			},
+		},
+	}, nil
+}
+
+func (x *x509CertificateExporter) getInClusterCertificateMonitoringResources() ([]client.Object, error) {
+	var (
+		resName = inClusterManagedResourceName + x.values.NameSuffix
+		sa      = x.serviceAccount(resName)
+		cr      = x.inClusterClusterRole(clusterRoleName, x.values)
+		crb     = x.inClusterClusterRoleBinding(clusterRoleBindingName, sa, cr)
+		service = x.service(resName, x.getGenericLabels(inClusterCertificateLabelValue))
+		sm      = x.serviceMonitor(resName, x.getGenericLabels(inClusterCertificateLabelValue))
+		dep     *appsv1.Deployment
+	)
+	dep, err := x.deployment(resName, sa)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create deployment: %w", err)
+	}
+	return []client.Object{sa, cr, crb, service, sm, dep}, nil
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/node_certificate_collection.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/node_certificate_collection.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0package x509certificateexporter
+
+package x509certificateexporter
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sort"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (x *x509CertificateExporter) daemonSet(
+	resName string, sa *corev1.ServiceAccount,
+) (*appsv1.DaemonSet, error) {
+	if len(x.values.HostCertificates) == 0 {
+		return nil, errors.New("no host certificates provided")
+	}
+
+	var (
+		hostPathType = corev1.HostPathDirectory
+		labelz       = x.getGenericLabels(nodeCertificateLabelValue)
+		hostPaths    []string
+		args         []string
+		volumeMounts []corev1.VolumeMount
+		volumes      []corev1.Volume
+		podSpec      corev1.PodSpec
+	)
+
+	hostPaths, args = func() ([]string, []string) {
+		paths := []string{}
+		certArgs := []string{}
+		for _, hc := range x.values.HostCertificates {
+			paths = append(paths, hc.MountPath)
+			certArgs = append(certArgs, hc.AsArgs()...)
+		}
+		return paths, certArgs
+	}()
+
+	args = append(args, func() []string {
+		return []string{
+			"--expose-relative-metrics",
+			"--watch-kube-secrets",
+			"--expose-per-cert-error-metrics",
+			fmt.Sprintf("--listen-address=:%d", port),
+		}
+	}()...,
+	)
+	sort.Strings(args)
+	sort.Strings(hostPaths)
+
+	volumeMounts = make([]corev1.VolumeMount, len(hostPaths))
+	volumes = make([]corev1.Volume, len(hostPaths))
+
+	for idx, path := range hostPaths {
+		name := fmt.Sprintf("%x", sha256.Sum256([]byte(path)))
+		volumes[idx] = corev1.Volume{
+			Name: name,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: path,
+					Type: &hostPathType,
+				},
+			},
+		}
+		volumeMounts[idx] = corev1.VolumeMount{
+			Name:      name,
+			ReadOnly:  true,
+			MountPath: path,
+		}
+	}
+	podSpec = x.defaultPodSpec(sa)
+	podSpec.Containers[0].Args = args
+	podSpec.Volumes = volumes
+	podSpec.Containers[0].VolumeMounts = volumeMounts
+
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resName,
+			Namespace: x.namespace,
+			Labels:    labelz,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labelz,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labelz,
+				},
+				Spec: podSpec,
+			},
+		},
+	}, nil
+}
+
+func (x *x509CertificateExporter) getHostCertificateMonitoringResources() ([]client.Object, error) {
+	var (
+		resName = nodeManagedResourceName + x.values.NameSuffix
+		sa      = x.serviceAccount(resName)
+		service = x.service(resName, x.getGenericLabels(nodeCertificateLabelValue))
+		sm      = x.serviceMonitor(resName, x.getGenericLabels(nodeCertificateLabelValue))
+		ds      *appsv1.DaemonSet
+	)
+	ds, err := x.daemonSet(resName, sa)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DaemonSet: %w", err)
+	}
+
+	return []client.Object{sa, service, sm, ds}, nil
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/node_certificate_collection.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/node_certificate_collection.go
@@ -80,14 +80,11 @@ func (x *x509CertificateExporter) daemonSet(
 		return paths, certArgs
 	}()
 
-	args = append(args, func() []string {
-		return []string{
-			"--expose-relative-metrics",
-			"--watch-kube-secrets",
-			"--expose-per-cert-error-metrics",
-			fmt.Sprintf("--listen-address=:%d", port),
-		}
-	}()...,
+	args = append(args,
+		"--expose-relative-metrics",
+		"--watch-kube-secrets",
+		"--expose-per-cert-error-metrics",
+		fmt.Sprintf("--listen-address=:%d", port),
 	)
 	sort.Strings(args)
 	sort.Strings(hostPaths)

--- a/pkg/component/observability/monitoring/x509certificateexporter/node_certificate_collection.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/node_certificate_collection.go
@@ -10,11 +10,13 @@ import (
 	"fmt"
 	"sort"
 
-	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 )
 
 func (x *x509CertificateExporter) daemonSetList(resNamePrefix string, sa *corev1.ServiceAccount) ([]client.Object, error) {
@@ -114,6 +116,7 @@ func (x *x509CertificateExporter) daemonSet(
 	podSpec.Containers[0].Args = args
 	podSpec.Volumes = volumes
 	podSpec.Containers[0].VolumeMounts = volumeMounts
+	podSpec.Containers[0].SecurityContext.AllowPrivilegeEscalation = ptr.To(true)
 	if selector != nil {
 		podSpec.NodeSelector = selector.MatchLabels
 	}

--- a/pkg/component/observability/monitoring/x509certificateexporter/prometheusrules.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/prometheusrules.go
@@ -19,7 +19,7 @@ func (x *x509CertificateExporter) prometheusRule(labelz labels.Set, renewalDays,
 		certificateErrorsSeverity = "info"
 		renewalSeverity           = "warning"
 		expirationSeverity        = "critical"
-		expisresTodaySeverity     = "blocker"
+		expiresTodaySeverity     = "blocker"
 		severityKey               = "severity"
 	)
 
@@ -39,7 +39,7 @@ func (x *x509CertificateExporter) prometheusRule(labelz labels.Set, renewalDays,
 		certificateErrorLabels map[string]string = genAlertLabels(certificateErrorsSeverity)
 		renewalLabels          map[string]string = genAlertLabels(renewalSeverity)
 		expirationLabels       map[string]string = genAlertLabels(expirationSeverity)
-		expiresTodayLabels     map[string]string = genAlertLabels(expisresTodaySeverity)
+		expiresTodayLabels     map[string]string = genAlertLabels(expiresTodaySeverity)
 	)
 
 	labelz["prometheus"] = x.values.PrometheusInstance

--- a/pkg/component/observability/monitoring/x509certificateexporter/prometheusrules.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/prometheusrules.go
@@ -19,7 +19,7 @@ func (x *x509CertificateExporter) prometheusRule(labelz labels.Set, renewalDays,
 		certificateErrorsSeverity = "info"
 		renewalSeverity           = "warning"
 		expirationSeverity        = "critical"
-		expiresTodaySeverity     = "blocker"
+		expiresTodaySeverity      = "blocker"
 		severityKey               = "severity"
 	)
 
@@ -61,15 +61,14 @@ func (x *x509CertificateExporter) prometheusRule(labelz labels.Set, renewalDays,
 								"description": "Over the last 15 minutes, this x509-certificate-exporter instance has experienced errors reading certificate files or querying the Kubernetes API. This could be caused by a misconfiguration if triggered when the exporter starts.",
 								"summary":     "Increasing read errors for x509-certificate-exporter on {{$externalLabels.landscape}} landscape",
 							},
-							Expr:   intstr.FromString("delta(x509_read_errors[15m]) > 0"),
-							For:    &for15mins,
+							Expr:   intstr.FromString("increase(x509_read_errors[15m]) > 0"),
 							Labels: readErrorsLabels,
 						},
 						{
 							Alert: "CertificateError",
 							Annotations: map[string]string{
-								"description": `Certificate could not be decoded {{if $labels.secret_name }}in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}"{{else}}at location "{{ $labels.filepath }}"{{end}}`,
-								"summary":     "Certificate cannot be decoded on {{$externalLabels.landscape}} landscape",
+								"description": `Certificate could not be decoded {{ if $labels.secret_name -}} in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}" {{- else -}} at location "{{ $labels.filepath }}" {{- end }}`,
+								"summary":     "Certificate cannot be decoded on {{ $externalLabels.landscape }} landscape",
 							},
 							Expr:   intstr.FromString("x509_cert_error > 0"),
 							For:    &for15mins,
@@ -78,31 +77,28 @@ func (x *x509CertificateExporter) prometheusRule(labelz labels.Set, renewalDays,
 						{
 							Alert: "CertificateRenewal",
 							Annotations: map[string]string{
-								"description": `Certificate for "{{ $labels.subject_CN }}" should be renewed {{if $labels.secret_name }}in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}"{{else}}at location "{{ $labels.filepath }}"{{end}}`,
-								"summary":     "Certificate should be renewed on {{$externalLabels.landscape}} landscape",
+								"description": `Certificate for "{{ $labels.subject_CN }}" should be renewed {{ if $labels.secret_name -}} in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}" {{- else -}} at location "{{ $labels.filepath }}" {{- end }}`,
+								"summary":     "Certificate should be renewed on {{ $externalLabels.landscape }} landscape",
 							},
 							Expr:   certRenewalExpr,
-							For:    &for15mins,
 							Labels: renewalLabels,
 						},
 						{
 							Alert: "CertificateExpiration",
 							Annotations: map[string]string{
-								"description": `Certificate for "{{ $labels.subject_CN }}" is about to expire after {{ humanizeDuration $value }} {{if $labels.secret_name }}in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}"{{else}}at location "{{ $labels.filepath }}"{{end}}`,
-								"summary":     "Certificate is about to expire on {{$externalLabels.landscape}} landscape",
+								"description": `Certificate for "{{ $labels.subject_CN }}" is about to expire after {{ humanizeDuration $value }} {{ if $labels.secret_name -}} in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}" {{- else -}} at location "{{ $labels.filepath }}" {{- end }}`,
+								"summary":     "Certificate is about to expire on {{ $externalLabels.landscape }} landscape",
 							},
 							Expr:   certExpirationExpr,
-							For:    &for15mins,
 							Labels: expirationLabels,
 						},
 						{
 							Alert: "CertificateExpiresToday",
 							Annotations: map[string]string{
-								"description": `Certificate for "{{ $labels.subject_CN }}" is about to expire TODAY {{if $labels.secret_name }}in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}"{{else}}at location "{{ $labels.filepath }}"{{end}}`,
-								"summary":     "Certificate expires today on {{$externalLabels.landscape}} landscape",
+								"description": `Certificate for "{{ $labels.subject_CN }}" is about to expire TODAY {{- if $labels.secret_name -}} in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}" {{- else -}} at location "{{ $labels.filepath }}"{{- end }}`,
+								"summary":     "Certificate expires today on {{ $externalLabels.landscape }} landscape",
 							},
 							Expr:   certExpiresTodayExpr,
-							For:    &for15mins,
 							Labels: expiresTodayLabels,
 						},
 					},

--- a/pkg/component/observability/monitoring/x509certificateexporter/prometheusrules.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/prometheusrules.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0package x509certificateexporter
+
+package x509certificateexporter
+
+import (
+	"fmt"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func (x *x509CertificateExporter) prometheusRule(labelz labels.Set, renewalDays, expirationDays uint) *monitoringv1.PrometheusRule {
+	const (
+		readErrorsSeverity        = "info"
+		certificateErrorsSeverity = "info"
+		renewalSeverity           = "warning"
+		expirationSeverity        = "critical"
+		expisresTodaySeverity     = "blocker"
+		severityKey               = "severity"
+	)
+
+	var (
+		for15mins            = monitoringv1.Duration("15m")
+		certRenewalExpr      = intstr.FromString(fmt.Sprintf("(x509_cert_not_after - time()) < (%d * 86400)", renewalDays))
+		certExpirationExpr   = intstr.FromString(fmt.Sprintf("(x509_cert_not_after - time()) < (%d * 86400)", expirationDays))
+		certExpiresTodayExpr = intstr.FromString("(x509_cert_not_after - time()) < 86400")
+		genAlertLabels       = func(sev string) map[string]string {
+			return map[string]string{
+				"service":  "x509-certificate-exporter",
+				"topology": x.values.PrometheusInstance,
+				"severity": sev,
+			}
+		}
+		readErrorsLabels       map[string]string = genAlertLabels(readErrorsSeverity)
+		certificateErrorLabels map[string]string = genAlertLabels(certificateErrorsSeverity)
+		renewalLabels          map[string]string = genAlertLabels(renewalSeverity)
+		expirationLabels       map[string]string = genAlertLabels(expirationSeverity)
+		expiresTodayLabels     map[string]string = genAlertLabels(expisresTodaySeverity)
+	)
+
+	labelz["prometheus"] = x.values.PrometheusInstance
+
+	return &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labelz,
+			Name:      x.values.PrometheusInstance + promRuleName,
+			Namespace: x.namespace,
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "x509-certificate-exporter.rules",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "X509ExporterReadErrors",
+							Annotations: map[string]string{
+								"description": "Over the last 15 minutes, this x509-certificate-exporter instance has experienced errors reading certificate files or querying the Kubernetes API. This could be caused by a misconfiguration if triggered when the exporter starts.",
+								"summary":     "Increasing read errors for x509-certificate-exporter on {{$externalLabels.landscape}} landscape",
+							},
+							Expr:   intstr.FromString("delta(x509_read_errors[15m]) > 0"),
+							For:    &for15mins,
+							Labels: readErrorsLabels,
+						},
+						{
+							Alert: "CertificateError",
+							Annotations: map[string]string{
+								"description": `Certificate could not be decoded {{if $labels.secret_name }}in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}"{{else}}at location "{{ $labels.filepath }}"{{end}}`,
+								"summary":     "Certificate cannot be decoded on {{$externalLabels.landscape}} landscape",
+							},
+							Expr:   intstr.FromString("x509_cert_error > 0"),
+							For:    &for15mins,
+							Labels: certificateErrorLabels,
+						},
+						{
+							Alert: "CertificateRenewal",
+							Annotations: map[string]string{
+								"description": `Certificate for "{{ $labels.subject_CN }}" should be renewed {{if $labels.secret_name }}in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}"{{else}}at location "{{ $labels.filepath }}"{{end}}`,
+								"summary":     "Certificate should be renewed on {{$externalLabels.landscape}} landscape",
+							},
+							Expr:   certRenewalExpr,
+							For:    &for15mins,
+							Labels: renewalLabels,
+						},
+						{
+							Alert: "CertificateExpiration",
+							Annotations: map[string]string{
+								"description": `Certificate for "{{ $labels.subject_CN }}" is about to expire after {{ humanizeDuration $value }} {{if $labels.secret_name }}in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}"{{else}}at location "{{ $labels.filepath }}"{{end}}`,
+								"summary":     "Certificate is about to expire on {{$externalLabels.landscape}} landscape",
+							},
+							Expr:   certExpirationExpr,
+							For:    &for15mins,
+							Labels: expirationLabels,
+						},
+						{
+							Alert: "CertificateExpiresToday",
+							Annotations: map[string]string{
+								"description": `Certificate for "{{ $labels.subject_CN }}" is about to expire TODAY {{if $labels.secret_name }}in Kubernetes secret "{{ $labels.secret_namespace }}/{{ $labels.secret_name }}"{{else}}at location "{{ $labels.filepath }}"{{end}}`,
+								"summary":     "Certificate expires today on {{$externalLabels.landscape}} landscape",
+							},
+							Expr:   certExpiresTodayExpr,
+							For:    &for15mins,
+							Labels: expiresTodayLabels,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/rbac.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/rbac.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0package x509certificateexporter
+
+package x509certificateexporter
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (x *x509CertificateExporter) serviceAccount(resName string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resName,
+			Namespace: x.namespace,
+		},
+	}
+}
+
+func (x *x509CertificateExporter) inClusterClusterRole(resName string, vals Values) *rbacv1.ClusterRole {
+	var (
+		nsses = []string{}
+	)
+	if len(vals.IncludeNamespaces) > 0 {
+		nsses = vals.IncludeNamespaces
+	}
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets", "configmaps"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"namespaces"},
+				Verbs:         []string{"get", "list", "watch"},
+				ResourceNames: nsses,
+			},
+		},
+	}
+}
+
+func (x *x509CertificateExporter) inClusterClusterRoleBinding(
+	resName string, sa *corev1.ServiceAccount, cr *rbacv1.ClusterRole,
+) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     cr.Name,
+			APIGroup: rbacv1.GroupName,
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/servicemonitor.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/servicemonitor.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package x509certificateexporter
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+func (x *x509CertificateExporter) serviceMonitor(resName string, selector labels.Set) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: monitoringutils.ConfigObjectMeta(resName, x.namespace, garden.Label),
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: selector},
+			Endpoints: []monitoringv1.Endpoint{{
+				TargetPort: ptr.To(intstr.FromInt32(port)),
+				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+					"x509_cert_not_before",
+					"x509_cert_not_after",
+					"x509_cert_expired",
+					"x509_cert_expires_in_seconds",
+					"x509_cert_valid_since_seconds",
+					"x509_cert_error",
+					"x509_read_errors",
+				),
+			}},
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
@@ -51,28 +51,30 @@ type x509CertificateExporter struct {
 
 // Configurations for the x509 certificate exporter
 type Values struct {
-	// Secret types that should be watched by the exporter.
+	// SecretTypes that should be watched by the exporter.
 	SecretTypes SecretTypeList
-	// Cache lifespan, usually cache is
+	// ConfigMapKeys that should be watched by the exporter.
+	ConfigMapKeys ConfigMapKeys
+	// CacheDuration sets cache lifespan, usually cache is
 	// regenerated a bit more than half that value.
 	CacheDuration metav1.Duration
-	// Container image.
+	// Image sets container image.
 	Image string
 	// PriorityClassName is the name of the priority class.
 	PriorityClassName string
-	// Number of replicas.
+	// Replicas sets the number of replicas.
 	Replicas int32
 	// NameSuffix is attached to the deployment name and related resources.
 	NameSuffix string
-	// Namespaces from which secrets are monitored.
+	// IncludeNamespaces are namespaces from which secrets are monitored.
 	// If non-zero len excludes all else.
 	IncludeNamespaces IncludeNamespaces
-	// Namespaces from which secrets are not monitored.
+	// ExcludeNamespaces namespaces from which secrets are not monitored.
 	// If non-zero len includes all else.
 	ExcludeNamespaces ExcludeNamespaces
-	// Includes labels, similar to the namespaces vars.
+	// IncludeLabels includes labels, similar to the namespaces vars.
 	IncludeLabels IncludeLabels
-	// Enclude labels, similar to the namespaces vars.
+	// ExcludeLabels exludes labels, similar to the namespaces vars.
 	ExcludeLabels ExcludeLabels
 	// HostCertificates that should be monitored from hosts
 	HostCertificates []HostCertificates

--- a/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
@@ -76,8 +77,8 @@ type Values struct {
 	IncludeLabels IncludeLabels
 	// ExcludeLabels exludes labels, similar to the namespaces vars.
 	ExcludeLabels ExcludeLabels
-	// HostCertificates that should be monitored from hosts
-	HostCertificates []HostCertificates
+	// WorkerGroups that should be monitored from nodes
+	WorkerGroups map[string]operatorv1alpha1.WorkerGroup
 	// CertificateExpirationDays is the number of days before expiration that will trigger a critical alert
 	CertificateExpirationDays uint
 	// CertificateRenewalDays is the number of days bedfore expiration that will trigger a warning alert
@@ -129,7 +130,7 @@ func (x *x509CertificateExporter) Deploy(ctx context.Context) error {
 	}
 	res = append(res, x.prometheusRule(x.getGenericLabels("any"), x.values.CertificateRenewalDays, x.values.CertificateExpirationDays))
 
-	if len(x.values.HostCertificates) > 0 {
+	if x.values.WorkerGroups != nil {
 		if hostResources, err = x.getHostCertificateMonitoringResources(); err != nil {
 			return fmt.Errorf("failed to get host certificate monitoring resources: %w", err)
 		}

--- a/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package x509certificateexporter
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/gardener/gardener/pkg/component"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	containerName                = "x509-certificate-exporter"
+	inClusterManagedResourceName = "x509-certificate-exporter"
+	nodeManagedResourceName      = "x509-certificate-exporter-node"
+	port                         = 9793
+)
+
+func defaultDeploymentArgs() []string {
+	return []string{
+		"--expose-relative-metrics",
+		"--watch-kube-secrets",
+		"--expose-per-cert-error-metrics",
+		fmt.Sprintf("--listen_address=%d", port),
+	}
+}
+
+func defaultDaemonSetArgs() []string {
+	return []string{
+		"--expose-relative-metrics",
+		"--trim-path-components=3",
+		"--expose-per-cert-error-metrics",
+		fmt.Sprintf("--listen_address=%d", port),
+	}
+}
+
+type X509CertificateArg interface {
+	AsArg() string
+}
+
+type X509CertificateArgSet interface {
+	AsArgs() []string
+}
+
+type CertificatePath string
+
+func (c CertificatePath) AsArg() string {
+	return "--watch-file=" + string(c)
+}
+
+type CertificateDirPath string
+
+func (c CertificateDirPath) AsArg() string {
+	return "--watch-dir=" + string(c)
+}
+
+// HostCertificates describes certificates that will be configured for monitoring
+// from the host nodes
+type HostCertificates struct {
+	// MountPath is the host path that will be mounted
+	MountPath string
+	// Certificate paths is a list of certificates withion the specified mount
+	// All relative paths are configured base on the specified mount
+	CertificatePaths []CertificatePath
+	// Similat to CertificatePaths but for dirs
+	CertificateDirPaths []CertificateDirPath
+}
+
+// Produces `*hostCertificates`,
+// will fail if mountPath is not an absolute dir
+// if any certificatePath is not an abs path, mountPath will be prepend
+// mountPath: host path that will be mounted from the node
+// filePaths: paths that will be configured in certificate exporter ds. Paths can be either file paths or dirs. If not absolute - mountPath is prepended.
+// dirPaths: similar as above, but will be configured as dirs
+func NewHostCertificates(
+	mountPath string, filePaths []string, dirPaths []string,
+) (*HostCertificates, error) {
+	ensureAbsolutePaths := func(paths []string) {
+		for idx, path := range paths {
+			if !filepath.IsAbs(path) {
+				paths[idx] = filepath.Join(mountPath, path)
+			}
+		}
+		sort.Strings(paths)
+	}
+
+	if !filepath.IsAbs(mountPath) {
+		return nil, errors.New("Path " + mountPath + "is not absolute file path")
+	}
+	ensureAbsolutePaths(filePaths)
+	if len(dirPaths) == 0 {
+		dirPaths = []string{mountPath}
+	}
+	ensureAbsolutePaths(dirPaths)
+
+	certificateDirs := make([]CertificateDirPath, len(dirPaths))
+	for i, path := range dirPaths {
+		certificateDirs[i] = CertificateDirPath(path)
+	}
+
+	certificatePaths := make([]CertificatePath, len(filePaths))
+	for i, path := range filePaths {
+		certificatePaths[i] = CertificatePath(path)
+	}
+
+	return &HostCertificates{
+		MountPath:           mountPath,
+		CertificatePaths:    certificatePaths,
+		CertificateDirPaths: certificateDirs,
+	}, nil
+}
+
+func (h HostCertificates) AsArgs() []string {
+	offset := len(h.CertificatePaths)
+	args := make([]string, offset+len(h.CertificateDirPaths))
+	for idx, arg := range h.CertificatePaths {
+		args[idx] = arg.AsArg()
+	}
+	for idx, arg := range h.CertificateDirPaths {
+		args[offset+idx] = arg.AsArg()
+	}
+	return args
+}
+
+// Secret types and the key name contained within that secret
+type SecretType struct {
+	// Type of the secrets that should be searched
+	Type string
+	// Key within the secret that should be checked
+	Key string
+}
+
+func (s SecretType) String() string {
+	return s.Type + ":" + s.Key
+}
+
+func (s SecretType) AsArg() string {
+	return fmt.Sprintf("--secret-type=%s", s)
+}
+
+type SecretTypeList []SecretType
+
+func (s SecretTypeList) AsArgs() []string {
+	args := make([]string, len(s))
+	for idx, arg := range s {
+		args[idx] = arg.AsArg()
+	}
+	return args
+}
+
+func labelsToArgs(argPrefix string, data map[string]string) []string {
+	args := []string{}
+	for k, v := range data {
+		arg := argPrefix + k
+		if v != "" {
+			arg += "=" + v
+		}
+		args = append(args, arg)
+	}
+	sort.Strings(args)
+	return args
+}
+
+type IncludeLabels labels.Set
+
+func (il IncludeLabels) AsArgs() []string {
+	return labelsToArgs("--include-label=", map[string]string(il))
+}
+
+type ExcludeLabels labels.Set
+
+func (el ExcludeLabels) AsArgs() []string {
+	return labelsToArgs("--exclude-label=", el)
+}
+
+// Configurations for the x509 certificate exporter
+type Values struct {
+	// Secret types that should be watched by the exporter.
+	SecretTypes SecretTypeList
+	// Cache lifespan, usually cache is
+	// regenerated a bit more than half that value.
+	CacheDuration metav1.Duration
+	// Container image.
+	Image string
+	// PriorityClassName is the name of the priority class.
+	PriorityClassName string
+	// Number of replicas.
+	Replicas int32
+	// NameSuffix is attached to the deployment name and related resources.
+	NameSuffix string
+	// Namespaces from which secrets are monitored.
+	// If non-zero len excludes all else.
+	IncludeNamespaces []string
+	// Namespaces from which secrets are not monitored.
+	// If non-zero len includes all else.
+	ExcludeNamespaces []string
+	// Includes labels, similar to the namespaces vars.
+	IncludeLabels labels.Set
+	// Enclude labels, similar to the namespaces vars.
+	ExcludeLabels labels.Set
+	// ClusterType specifies the type of the cluster to which x509-certificate-exporter is being deployed.
+	ClusterType component.ClusterType
+	// Host HostCertificates that should be monitored from hosts
+	HostCertificates *HostCertificates
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
@@ -39,7 +39,7 @@ const (
 	SuffixRuntime                    = "-runtime"
 	SuffixShoot                      = "-shoot"
 	labelComponent                   = "x509-certificate-exporter"
-	defuaultCertificateRenewalDays   = 14
+	defaultCertificateRenewalDays   = 14
 	defaultCertificateExpirationDays = 7
 	defaultReplicas                  = 1
 	defaultCertCacheDuration         = 24 * time.Hour
@@ -70,10 +70,10 @@ type Values struct {
 	// NameSuffix is attached to the deployment name and related resources.
 	NameSuffix string
 	// IncludeNamespaces are namespaces from which secrets are monitored.
-	// If non-zero len excludes all else.
+	// If non-zero length excludes all else.
 	IncludeNamespaces IncludeNamespaces
 	// ExcludeNamespaces namespaces from which secrets are not monitored.
-	// If non-zero len includes all else.
+	// If non-zero length includes all else.
 	ExcludeNamespaces ExcludeNamespaces
 	// IncludeLabels includes labels, similar to the namespaces vars.
 	IncludeLabels IncludeLabels
@@ -83,9 +83,9 @@ type Values struct {
 	WorkerGroups map[string]operatorv1alpha1.WorkerGroup
 	// CertificateExpirationDays is the number of days before expiration that will trigger a critical alert
 	CertificateExpirationDays uint
-	// CertificateRenewalDays is the number of days bedfore expiration that will trigger a warning alert
+	// CertificateRenewalDays is the number of days before expiration that will trigger a warning alert
 	CertificateRenewalDays uint
-	// PrometheusInstance is the label for thje prometheus instance
+	// PrometheusInstance is the label for the prometheus instance
 	PrometheusInstance string
 }
 
@@ -96,7 +96,7 @@ func New(
 	values Values,
 ) component.DeployWaiter {
 	if values.CertificateRenewalDays == 0 {
-		values.CertificateRenewalDays = defuaultCertificateRenewalDays
+		values.CertificateRenewalDays = defaultCertificateRenewalDays
 	}
 	if values.CertificateExpirationDays == 0 {
 		values.CertificateExpirationDays = defaultCertificateExpirationDays

--- a/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter.go
@@ -120,7 +120,7 @@ func (x *x509CertificateExporter) Deploy(ctx context.Context) error {
 		return errors.New("x509CertificateExporter is currently supported only on the seed and runtime clusters")
 	}
 
-	if x.values.WorkerGroups != nil && len(x.values.SecretTypes) == 0 && len(x.values.ConfigMapKeys) == 0 {
+	if x.values.WorkerGroups == nil && len(x.values.SecretTypes) == 0 && len(x.values.ConfigMapKeys) == 0 {
 		return fmt.Errorf("no secret types, configmap keys and worker groups provided, nothing to monitor")
 	}
 	var (

--- a/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter_suite_test.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package x509certificateexporter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHpc(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hpc Suite")
+}

--- a/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter_test.go
+++ b/pkg/component/observability/monitoring/x509certificateexporter/x509certificateexporter_test.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package x509certificateexporter_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	x "github.com/gardener/gardener/pkg/component/observability/monitoring/x509certificateexporter"
+)
+
+var _ = Describe("x509 certificate exporter", func() {
+	Describe("CertificatePath", func() {
+		It("Should calculate string correctly", func() {
+			Expect(x.CertificatePath("/path/to/cert").AsArg()).To(Equal("--watch-file=/path/to/cert"))
+		})
+	})
+	Describe("CertificateDirPath", func() {
+		It("Should calculate string correctly", func() {
+			Expect(x.CertificateDirPath("/path/to/cert/dir").AsArg()).To(Equal("--watch-dir=/path/to/cert/dir"))
+		})
+	})
+	Describe("HostCertificates", func() {
+		Describe("New HostCertificates", func() {
+			Context("Relative mount path", func() {
+				It("should return error", func() {
+					_, err := x.NewHostCertificates("relative/path", []string{}, []string{})
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("Path relative/pathis not absolute file path"))
+				})
+			})
+			Context("Windows style path", func() {
+				It("should return error", func() {
+					_, err := x.NewHostCertificates("C:\\windows\\path", []string{}, []string{})
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("Path C:\\windows\\pathis not absolute file path"))
+				})
+			})
+			Context("Absolute paths for certificates", func() {
+				It("should return host certificates", func() {
+					hostCertificates, err := x.NewHostCertificates(
+						"/absolute/mount/path",
+						[]string{"/absolute/cert/path"},
+						[]string{"/absolute/cert/dir"},
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(hostCertificates.MountPath).To(Equal("/absolute/mount/path"))
+					Expect(hostCertificates.CertificatePaths).To(Equal([]x.CertificatePath{"/absolute/cert/path"}))
+					Expect(hostCertificates.CertificateDirPaths).To(Equal([]x.CertificateDirPath{"/absolute/cert/dir"}))
+				})
+			})
+			Context("Mixed absolute and relative paths for certificates, paths are sorted", func() {
+				It("should return host certificates", func() {
+					hostCertificates, err := x.NewHostCertificates(
+						"/absolute/mount/path",
+						[]string{"/full/cert/path", "relative/cert/path"},
+						[]string{"/full/cert/dir", "relative/cert/dir"},
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(hostCertificates.MountPath).To(Equal("/absolute/mount/path"))
+					Expect(hostCertificates.CertificatePaths).To(Equal([]x.CertificatePath{
+						"/absolute/mount/path/relative/cert/path",
+						"/full/cert/path",
+					}))
+					Expect(hostCertificates.CertificateDirPaths).To(Equal([]x.CertificateDirPath{
+						"/absolute/mount/path/relative/cert/dir",
+						"/full/cert/dir",
+					}))
+				})
+			})
+			Context("Watch only mount path", func() {
+				It("should return host certificates", func() {
+					hostCertificates, err := x.NewHostCertificates(
+						"/absolute/mount/path",
+						[]string{},
+						[]string{},
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(hostCertificates.MountPath).To(Equal("/absolute/mount/path"))
+					Expect(hostCertificates.CertificatePaths).To(BeEmpty())
+					Expect(hostCertificates.CertificateDirPaths).To(Equal([]x.CertificateDirPath{"/absolute/mount/path"}))
+				})
+			})
+		})
+		Describe("Converted to args", func() {
+			Context("HostCertificates with multiple certificates and directories", func() {
+				It("should return args", func() {
+					hostCertificates, err := x.NewHostCertificates(
+						"/absolute/mount/path",
+						[]string{"/full/cert/path", "relative/cert/path"},
+						[]string{"/full/cert/dir", "relative/cert/dir"},
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(hostCertificates.AsArgs()).To(Equal([]string{
+						"--watch-file=/absolute/mount/path/relative/cert/path",
+						"--watch-file=/full/cert/path",
+						"--watch-dir=/absolute/mount/path/relative/cert/dir",
+						"--watch-dir=/full/cert/dir",
+					}))
+				})
+			})
+		})
+	})
+	Describe("SecretType", func() {
+		It("should return string", func() {
+			Expect(x.SecretType{Type: "my-type", Key: "my-key"}.String()).To(Equal("my-type:my-key"))
+		})
+		It("should return arg string", func() {
+			Expect(x.SecretType{Type: "my-type", Key: "my-key"}.AsArg()).To(Equal("--secret-type=my-type:my-key"))
+		})
+	})
+	Describe("SecretTypeList", func() {
+		It("should return arg string", func() {
+			Expect(x.SecretTypeList{
+				{Type: "type1", Key: "key1"},
+				{Type: "type2", Key: "key2"},
+			}.AsArgs()).To(Equal([]string{"--secret-type=type1:key1", "--secret-type=type2:key2"}))
+		})
+	})
+	Describe("IncludeLabels", func() {
+		It("should return arg string", func() {
+			Expect(x.IncludeLabels{"label1": "", "label2": "val2"}.AsArgs()).To(Equal([]string{
+				"--include-label=label1",
+				"--include-label=label2=val2",
+			}))
+		})
+	})
+	Describe("ExcludeLabels", func() {
+		It("should return arg string", func() {
+			Expect(x.ExcludeLabels{"label1": "", "label2": "val2"}.AsArgs()).To(Equal([]string{
+				"--exclude-label=label1",
+				"--exclude-label=label2=val2",
+			}))
+		})
+	})
+})

--- a/pkg/component/observability/plutono/dashboards/garden/x509-certificate-exporter.json
+++ b/pkg/component/observability/plutono/dashboards/garden/x509-certificate-exporter.json
@@ -1,0 +1,3414 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "plutono"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Unified dashboard for checking certificates expiration: Kubernetes Secrets, certificate files on nodes, or on any server.",
+  "editable": true,
+  "gnetId": 13922,
+  "graphTooltip": 0,
+  "iteration": 1734678596955,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 24,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Up",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "text": "Down",
+              "to": "",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "from": "",
+              "id": 3,
+              "text": "Not available",
+              "to": "",
+              "type": 1,
+              "value": "-1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "rgb(85, 94, 94)",
+                "value": -1
+              },
+              {
+                "color": "dark-red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "up{job=\"x509-certificate-exporter-runtime\"} OR on() vector(-1)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Up (incluster certificates)",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Up",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "text": "Not available",
+              "to": "",
+              "type": 1,
+              "value": "-1"
+            },
+            {
+              "from": "",
+              "id": 3,
+              "text": "Down",
+              "to": "",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "rgb(85, 94, 94)",
+                "value": -1
+              },
+              {
+                "color": "dark-red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "up{job=\"x509-certificate-exporter-node-runtime\"} OR on() vector(-1)\n",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Up (node certificates)",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 49,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.35",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum (container_memory_working_set_bytes{pod=~\"x509-certificate-exporter-runtime-.*\"}) by (pod)",
+          "interval": "10s",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory usage (in cluster)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:321",
+          "format": "bytes",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:322",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 56,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.35",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"x509-certificate-exporter-runtime-.*\"}[1m])) by (pod)",
+          "interval": "10s",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU usage (in cluster)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:321",
+          "format": "bytes",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:322",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 57,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.35",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"x509-certificate-exporter-runtime-.*\"}[1m])) by (pod) ",
+          "interval": "10s",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "- sum(rate(container_network_transmit_bytes_total{pod=~\"x509-certificate-exporter-runtime-.*\"}[1m])) by (pod) ",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network IO (in cluster)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:321",
+          "format": "bytes",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:322",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 54,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.35",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum (container_memory_working_set_bytes{pod=~\"x509-certificate-exporter-node-runtime-.*\"}) by (pod)",
+          "interval": "10s",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory usage (node)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:321",
+          "format": "bytes",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:322",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 55,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.35",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"x509-certificate-exporter-node-runtime-.*\"}[1m])) by (pod)",
+          "interval": "10s",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU usage (node)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:321",
+          "format": "bytes",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:322",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 58,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.35",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"x509-certificate-exporter-node-runtime-.*\"}[1m])) by (pod) ",
+          "interval": "10s",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "- sum(rate(container_network_transmit_bytes_total{pod=~\"x509-certificate-exporter-node-runtime-.*\"}[1m])) by (pod) ",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network IO (in cluster)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:321",
+          "format": "bytes",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:322",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 0,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "count(x509_cert_not_after)",
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Certificates",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 5,
+        "y": 7
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "sum(((x509_cert_not_after - time()) / 86400) < bool 0)",
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Expired",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 8,
+        "y": 7
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "exemplar": true,
+          "expr": "sum(0 < ((x509_cert_not_after - time()) / 86400) < bool $critical_threshold)",
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Expiring within $critical_threshold days",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 11,
+        "y": 7
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "sum(0 < ((x509_cert_not_after - time()) / 86400) < bool $warning_threshold)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Expiring within $warning_threshold days",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 7,
+        "x": 14,
+        "y": 7
+      },
+      "id": 8,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "count(x509_cert_not_after{secret_name!=\"\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kubernetes Secret",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "count(x509_cert_not_after{filepath!=\"\",embedded_key!=\"\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kubeconfig Embedded",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "count(x509_cert_not_after{filepath!=\"\",embedded_key=\"\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Certificate File",
+          "refId": "C"
+        }
+      ],
+      "title": "Media",
+      "type": "piechart"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 7
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "count(x509_read_errors)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Exporters",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 10
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "sum(x509_read_errors)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Exporter Errors",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Expiration",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time Left"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
+              },
+              {
+                "id": "custom.filterable",
+                "value": false
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "dark-red",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 7
+                    },
+                    {
+                      "color": "green",
+                      "value": 28
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "d"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 46,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "exemplar": false,
+          "expr": "sort(((x509_cert_not_after{secret_name!=\"\"} - time()) / 86400) < $list_threshold)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Kubernetes Secrets (time left < $list_threshold days)",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(subject_CN|secret_namespace|secret_name|Value)$"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Value": 3,
+              "secret_name": 2,
+              "secret_namespace": 1,
+              "subject_CN": 0
+            },
+            "renameByName": {
+              "Value": "Time Left",
+              "secret_name": "Secret Name",
+              "secret_namespace": "Secret Namespace",
+              "subject_CN": "Subject CN"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time Left"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
+              },
+              {
+                "id": "custom.filterable",
+                "value": false
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "dark-red",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 7
+                    },
+                    {
+                      "color": "green",
+                      "value": 28
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "d"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 47,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "exemplar": false,
+          "expr": "sort(((x509_cert_not_after{filepath!=\"\"} - time()) / 86400) < $list_threshold)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Host Files (time left < $list_threshold days)",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(subject_CN|instance|filepath|Value)$"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Value": 3,
+              "filepath": 2,
+              "instance": 1,
+              "subject_CN": 0
+            },
+            "renameByName": {
+              "Value": "Time Left",
+              "filepath": "File Path",
+              "instance": "Instance",
+              "subject_CN": "Subject CN"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Charts",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Certificate Count"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "topk(10, sort_desc(count by (issuer_CN) (x509_cert_not_after)))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Issuers",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "issuer_CN",
+                "Value"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Certificate Count",
+              "issuer_CN": "Issuer CN"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Certificate Count"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "id": 15,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "topk(10, sort_desc(count by (secret_namespace) (x509_cert_not_after{secret_namespace!=\"\"})))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Namespaces (Kubernetes Secrets)",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Value",
+                "secret_namespace"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Certificate Count",
+              "secret_namespace": "Namespace"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Certificate Count"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "id": 16,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "topk(10, sort_desc(count by (instance) (x509_cert_not_after{filepath!=\"\"})))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Instances (Host Paths)",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Value",
+                "instance"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Certificate Count",
+              "instance": "Instance"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Days"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Secret Namespace"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 258
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 31,
+      "options": {
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "bottomk(10, (x509_cert_not_after{secret_name!=\"\"} - x509_cert_not_before) / 86400)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Kubernetes Secrets : Shortest Validity Period",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(subject_CN|secret_namespace|secret_name|Value)$"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Value": 3,
+              "secret_name": 2,
+              "secret_namespace": 1,
+              "subject_CN": 0
+            },
+            "renameByName": {
+              "Value": "Days",
+              "secret_name": "Secret Name",
+              "secret_namespace": "Secret Namespace",
+              "subject_CN": "Subject CN"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Days"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 33,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "bottomk(10, (x509_cert_not_after{filepath!=\"\"} - x509_cert_not_before) / 86400)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Host Paths : Shortest Validity Period",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(subject_CN|instance|filepath|Value)$"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Value": 3,
+              "filepath": 2,
+              "instance": 1,
+              "subject_CN": 0
+            },
+            "renameByName": {
+              "Value": "Days",
+              "filepath": "File Path",
+              "instance": "Instance",
+              "subject_CN": "Subject CN"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Days"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 28,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "topk(10, (x509_cert_not_after{secret_name!=\"\"} - x509_cert_not_before) / 86400)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Kubernetes Secrets : Longest Validity Period",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(subject_CN|secret_namespace|secret_name|Value)$"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Value": 3,
+              "secret_name": 2,
+              "secret_namespace": 1,
+              "subject_CN": 0
+            },
+            "renameByName": {
+              "Value": "Days",
+              "secret_name": "Secret Name",
+              "secret_namespace": "Secret Namespace",
+              "subject_CN": "Subject CN"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Days"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "id": 32,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.35",
+      "targets": [
+        {
+          "datasource": {
+            "uid": ""
+          },
+          "expr": "topk(10, (x509_cert_not_after{filepath!=\"\"} - x509_cert_not_before) / 86400)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Host Paths : Longest Validity Period",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(subject_CN|instance|filepath|Value)$"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Value": 3,
+              "filepath": 2,
+              "instance": 1,
+              "subject_CN": 0
+            },
+            "renameByName": {
+              "Value": "Days",
+              "filepath": "File Path",
+              "instance": "Instance",
+              "subject_CN": "Subject CN"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 35,
+      "panels": [
+        {
+          "aliasColors": {},
+          "autoMigrateFrom": "graph",
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 65
+          },
+          "hiddenSeries": false,
+          "id": 38,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltipOptions": {
+              "mode": "single"
+            }
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": ""
+              },
+              "expr": "count(x509_read_errors)",
+              "interval": "",
+              "legendFormat": "exporters",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Reporting Exporters",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "timeseries",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$hashKey": "object:237",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$hashKey": "object:238",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {
+            "exporters with errors": "red"
+          },
+          "autoMigrateFrom": "graph",
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 65
+          },
+          "hiddenSeries": false,
+          "id": 39,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltipOptions": {
+              "mode": "single"
+            }
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": ""
+              },
+              "expr": "sum (x509_read_errors > bool 0)",
+              "interval": "",
+              "legendFormat": "exporters with errors",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Exporters with Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "timeseries",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$hashKey": "object:237",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$hashKey": "object:238",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {
+            "error rate": "red",
+            "errors": "red"
+          },
+          "autoMigrateFrom": "graph",
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 73
+          },
+          "hiddenSeries": false,
+          "id": 41,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltipOptions": {
+              "mode": "single"
+            }
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": ""
+              },
+              "expr": "sum(rate(x509_read_errors[15m]))",
+              "interval": "",
+              "legendFormat": "error rate",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Error Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "timeseries",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$hashKey": "object:237",
+              "format": "cps",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$hashKey": "object:238",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {
+            "errors": "red"
+          },
+          "autoMigrateFrom": "graph",
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 73
+          },
+          "hiddenSeries": false,
+          "id": 40,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltipOptions": {
+              "mode": "single"
+            }
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": ""
+              },
+              "expr": "sum(x509_read_errors)",
+              "interval": "",
+              "legendFormat": "errors",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Cumulative Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "timeseries",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$hashKey": "object:237",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$hashKey": "object:238",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": null,
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Rate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  },
+                  {
+                    "id": "custom.align",
+                    "value": "center"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 81
+          },
+          "id": 43,
+          "options": {
+            "showHeader": true
+          },
+          "pluginVersion": "7.5.35",
+          "targets": [
+            {
+              "datasource": {
+                "uid": ""
+              },
+              "expr": "topk(10, rate(x509_read_errors[6h]))",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "title": "Top Exporters by Error Rate",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(instance|Value)$"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Rate",
+                  "instance": "Instance"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": null,
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Errors"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  },
+                  {
+                    "id": "custom.align",
+                    "value": "center"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 12,
+            "y": 81
+          },
+          "id": 44,
+          "options": {
+            "showHeader": true
+          },
+          "pluginVersion": "7.5.35",
+          "targets": [
+            {
+              "datasource": {
+                "uid": ""
+              },
+              "expr": "topk(10, x509_read_errors)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "title": "Top Exporters by Cumulative Errors",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(instance|Value)$"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Errors",
+                  "instance": "Instance"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Exporters",
+      "type": "row"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "7",
+          "value": "7"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Critical Threshold (days)",
+        "multi": false,
+        "name": "critical_threshold",
+        "options": [
+          {
+            "selected": false,
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "selected": true,
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "selected": false,
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "selected": false,
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "selected": false,
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "selected": false,
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "selected": false,
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "selected": false,
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "selected": false,
+            "text": "180",
+            "value": "180"
+          },
+          {
+            "selected": false,
+            "text": "365",
+            "value": "365"
+          }
+        ],
+        "query": "1,7,14,15,28,30,60,90,180,365",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "14",
+          "value": "14"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Warning Threshold (days)",
+        "multi": false,
+        "name": "warning_threshold",
+        "options": [
+          {
+            "selected": false,
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "selected": false,
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "selected": true,
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "selected": false,
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "selected": false,
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "selected": false,
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "selected": false,
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "selected": false,
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "selected": false,
+            "text": "180",
+            "value": "180"
+          },
+          {
+            "selected": false,
+            "text": "365",
+            "value": "365"
+          }
+        ],
+        "query": "1,7,14,15,28,30,60,90,180,365",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "60",
+          "value": "60"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "List expiring in less than (days)",
+        "multi": false,
+        "name": "list_threshold",
+        "options": [
+          {
+            "selected": false,
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "selected": false,
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "selected": false,
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "selected": false,
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "selected": true,
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "selected": false,
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "selected": false,
+            "text": "180",
+            "value": "180"
+          },
+          {
+            "selected": false,
+            "text": "365",
+            "value": "365"
+          },
+          {
+            "selected": false,
+            "text": "730",
+            "value": "730"
+          },
+          {
+            "selected": false,
+            "text": "1095",
+            "value": "1095"
+          },
+          {
+            "selected": false,
+            "text": "1460",
+            "value": "1460"
+          },
+          {
+            "selected": false,
+            "text": "1825",
+            "value": "1825"
+          },
+          {
+            "selected": false,
+            "text": "3650",
+            "value": "3650"
+          },
+          {
+            "selected": false,
+            "text": "7300",
+            "value": "7300"
+          }
+        ],
+        "query": "1,7,15,30,60,90,180,365,730,1095,1460,1825,3650,7300",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Certificates Expiration (X509 Certificate Exporter)",
+  "uid": "lHnsYlPGk",
+  "version": 1
+}

--- a/pkg/component/shared/x509certificateexporter.go
+++ b/pkg/component/shared/x509certificateexporter.go
@@ -35,12 +35,12 @@ func NewX509CertificateExporter(
 	}
 
 	return x.New(c, nil, gardebNamespaceName, x.Values{
-		// TODO(mimiteto): Handle configmaps
 		// TODO(mimiteto): Allow host mounts
 		SecretTypes: x.SecretTypeList{
 			x.SecretType{Type: "kubernetes.io/tls", Key: `.*.crt`},
 			x.SecretType{Type: "istio.io/ca-root", Key: `.*cert.*\.pem`},
 		},
+		ConfigMapKeys:             x.ConfigMapKeys{"ca.crt", "root-cert.pem"},
 		CacheDuration:             metav1.Duration{Duration: 24 * time.Hour},
 		Image:                     image.String(),
 		PriorityClassName:         priorityClassName,

--- a/pkg/component/shared/x509certificateexporter.go
+++ b/pkg/component/shared/x509certificateexporter.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/imagevector"
+	"github.com/gardener/gardener/pkg/component"
+	x "github.com/gardener/gardener/pkg/component/observability/monitoring/x509certificateexporter"
+	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
+)
+
+// NewX509CertificateExporter instantiates a new `x509-certificate-exporter` component.
+func NewX509CertificateExporter(
+	c client.Client,
+	gardebNamespaceName string,
+	runtimeVersion *semver.Version,
+	priorityClassName string,
+	suffix string,
+	prometheusInstanceName string,
+) (
+	component.DeployWaiter,
+	error,
+) {
+	image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameX509CertificateExporter, imagevectorutils.TargetVersion(runtimeVersion.String()))
+	if err != nil {
+		return nil, err
+	}
+
+	return x.New(c, nil, gardebNamespaceName, x.Values{
+		// TODO(mimiteto): Handle configmaps
+		// TODO(mimiteto): Allow host mounts
+		SecretTypes: x.SecretTypeList{
+			x.SecretType{Type: "kubernetes.io/tls", Key: `.*.crt`},
+			x.SecretType{Type: "istio.io/ca-root", Key: `.*cert.*\.pem`},
+		},
+		CacheDuration:             metav1.Duration{Duration: 24 * time.Hour},
+		Image:                     image.String(),
+		PriorityClassName:         priorityClassName,
+		Replicas:                  1,
+		NameSuffix:                suffix,
+		CertificateRenewalDays:    14,
+		CertificateExpirationDays: 7,
+		PrometheusInstance:        prometheusInstanceName,
+	}), nil
+}

--- a/pkg/component/shared/x509certificateexporter.go
+++ b/pkg/component/shared/x509certificateexporter.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	x "github.com/gardener/gardener/pkg/component/observability/monitoring/x509certificateexporter"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
@@ -20,11 +21,12 @@ import (
 // NewX509CertificateExporter instantiates a new `x509-certificate-exporter` component.
 func NewX509CertificateExporter(
 	c client.Client,
-	gardebNamespaceName string,
+	gardenNamespaceName string,
 	runtimeVersion *semver.Version,
 	priorityClassName string,
 	suffix string,
 	prometheusInstanceName string,
+	workerGroups map[string]operatorv1alpha1.WorkerGroup,
 ) (
 	component.DeployWaiter,
 	error,
@@ -34,8 +36,7 @@ func NewX509CertificateExporter(
 		return nil, err
 	}
 
-	return x.New(c, nil, gardebNamespaceName, x.Values{
-		// TODO(mimiteto): Allow host mounts
+	return x.New(c, nil, gardenNamespaceName, x.Values{
 		SecretTypes: x.SecretTypeList{
 			x.SecretType{Type: "kubernetes.io/tls", Key: `.*.crt`},
 			x.SecretType{Type: "istio.io/ca-root", Key: `.*cert.*\.pem`},
@@ -49,5 +50,6 @@ func NewX509CertificateExporter(
 		CertificateRenewalDays:    14,
 		CertificateExpirationDays: 7,
 		PrometheusInstance:        prometheusInstanceName,
+		WorkerGroups:              workerGroups,
 	}), nil
 }

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -314,7 +314,7 @@ func (r *Reconciler) instantiateComponents(
 		return
 	}
 
-	c.x509CertificateExporter, err = r.newx509CertificateExporter()
+	c.x509CertificateExporter, err = r.newx509CertificateExporter(garden)
 	if err != nil {
 		return
 	}
@@ -1433,7 +1433,7 @@ func (r *Reconciler) newExtensions(ctx context.Context, log logr.Logger, garden 
 	return extension.New(log, r.RuntimeClientSet.Client(), values, extension.DefaultInterval, extension.DefaultSevereThreshold, extension.DefaultTimeout), nil
 }
 
-func (r *Reconciler) newx509CertificateExporter() (component.DeployWaiter, error) {
+func (r *Reconciler) newx509CertificateExporter(garden *operatorv1alpha1.Garden) (component.DeployWaiter, error) {
 	return sharedcomponent.NewX509CertificateExporter(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
@@ -1441,5 +1441,6 @@ func (r *Reconciler) newx509CertificateExporter() (component.DeployWaiter, error
 		v1beta1constants.PriorityClassNameGardenSystem100,
 		x509certificateexporter.SuffixRuntime,
 		"garden",
+		garden.Spec.RuntimeCluster.WorkerGroups,
 	)
 }

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -76,7 +76,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/x509certificateexporter"
 	"github.com/gardener/gardener/pkg/component/observability/plutono"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
-	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
@@ -606,8 +606,10 @@ func (r *Reconciler) newKubeAPIServer(
 			Name:       "seed-authorizer",
 			Kubeconfig: kubeconfig,
 			WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
-				AuthorizedTTL:                            metav1.Duration{Duration: time.Duration(0)},
-				UnauthorizedTTL:                          metav1.Duration{Duration: time.Duration(0)},
+				// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
+				// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
+				AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
+				UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
 				Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
 				FailurePolicy:                            apiserverv1beta1.FailurePolicyDeny,
 				SubjectAccessReviewVersion:               "v1",
@@ -1035,7 +1037,7 @@ func (r *Reconciler) newGardenerControllerManager(garden *operatorv1alpha1.Garde
 		}
 
 		for _, defaultProjectQuota := range config.DefaultProjectQuotas {
-			values.Quotas = append(values.Quotas, controllermanagerv1alpha1.QuotaConfiguration{
+			values.Quotas = append(values.Quotas, controllermanagerconfigv1alpha1.QuotaConfiguration{
 				Config:          defaultProjectQuota.Config,
 				ProjectSelector: defaultProjectQuota.ProjectSelector,
 			})

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -73,9 +73,10 @@ import (
 	gardenprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
 	longtermprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/longterm"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/x509certificateexporter"
 	"github.com/gardener/gardener/pkg/component/observability/plutono"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
-	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
@@ -135,6 +136,7 @@ type components struct {
 	prometheusGarden              prometheus.Interface
 	prometheusLongTerm            prometheus.Interface
 	blackboxExporter              component.DeployWaiter
+	x509CertificateExporter       component.DeployWaiter
 }
 
 func (r *Reconciler) instantiateComponents(
@@ -308,6 +310,11 @@ func (r *Reconciler) instantiateComponents(
 		return
 	}
 	c.blackboxExporter, err = r.newBlackboxExporter(garden, secretsManager, wildcardCertSecretName)
+	if err != nil {
+		return
+	}
+
+	c.x509CertificateExporter, err = r.newx509CertificateExporter()
 	if err != nil {
 		return
 	}
@@ -599,10 +606,8 @@ func (r *Reconciler) newKubeAPIServer(
 			Name:       "seed-authorizer",
 			Kubeconfig: kubeconfig,
 			WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
-				// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
-				// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
-				AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
-				UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
+				AuthorizedTTL:                            metav1.Duration{Duration: time.Duration(0)},
+				UnauthorizedTTL:                          metav1.Duration{Duration: time.Duration(0)},
 				Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
 				FailurePolicy:                            apiserverv1beta1.FailurePolicyDeny,
 				SubjectAccessReviewVersion:               "v1",
@@ -1030,7 +1035,7 @@ func (r *Reconciler) newGardenerControllerManager(garden *operatorv1alpha1.Garde
 		}
 
 		for _, defaultProjectQuota := range config.DefaultProjectQuotas {
-			values.Quotas = append(values.Quotas, controllermanagerconfigv1alpha1.QuotaConfiguration{
+			values.Quotas = append(values.Quotas, controllermanagerv1alpha1.QuotaConfiguration{
 				Config:          defaultProjectQuota.Config,
 				ProjectSelector: defaultProjectQuota.ProjectSelector,
 			})
@@ -1426,4 +1431,15 @@ func (r *Reconciler) newExtensions(ctx context.Context, log logr.Logger, garden 
 	}
 
 	return extension.New(log, r.RuntimeClientSet.Client(), values, extension.DefaultInterval, extension.DefaultSevereThreshold, extension.DefaultTimeout), nil
+}
+
+func (r *Reconciler) newx509CertificateExporter() (component.DeployWaiter, error) {
+	return sharedcomponent.NewX509CertificateExporter(
+		r.RuntimeClientSet.Client(),
+		r.GardenNamespace,
+		r.RuntimeVersion,
+		v1beta1constants.PriorityClassNameGardenSystem100,
+		x509certificateexporter.SuffixRuntime,
+		"garden",
+	)
 }

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -77,6 +77,10 @@ func (r *Reconciler) delete(
 			Name: "Destroying Kube State Metrics",
 			Fn:   component.OpDestroyAndWait(c.kubeStateMetrics).Destroy,
 		})
+		_ = g.Add(flow.Task{
+			Name: "Destroying x509 certificate exporter",
+			Fn:   component.OpDestroyAndWait(c.x509CertificateExporter).Destroy,
+		})
 		destroyAlertmanager = g.Add(flow.Task{
 			Name: "Destroying Alertmanager",
 			Fn:   component.OpDestroyAndWait(c.alertManager).Destroy,

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -611,14 +611,14 @@ func (r *Reconciler) reconcile(
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilKubeAPIServerIsReady, waitUntilGardenerAPIServerReady),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Deploying Plutono",
-			Fn:           c.plutono.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
-		})
-		_ = g.Add(flow.Task{
 			Name:         "Deploying x509 certificate exporter",
 			Fn:           c.x509CertificateExporter.Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying Plutono",
+			Fn:           c.plutono.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 	)
 

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -615,6 +615,11 @@ func (r *Reconciler) reconcile(
 			Fn:           c.plutono.Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying x509 certificate exporter",
+			Fn:           c.x509CertificateExporter.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployPrometheusCRD),
+		})
 	)
 
 	gardenCopy := garden.DeepCopy()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
PR setups the x509 certificate exporter on the runtime cluster.
With this PR operators have an overview and alerts on the expiration dates for certificates found within the cluster

**Which issue(s) this PR fixes**:
Fixes #10394

**Special notes for your reviewer**:
PR was tested with operator-local setups.
The Garden API is modified so operators can configure monitoring for worker groups on the runtime cluster with different mounts (if needed).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
x509 certificate monitoring is configured for the runtime cluster
```
