### PR TITLE
fix release responsible week numbers

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -21,23 +21,23 @@ Hotfixes are usually maintained for the latest three minor releases, though, the
 
 ### Release Responsible Plan
 
-Version | Week No     | Begin Validation Phase | Due Date           | Release Responsible                                |
-------- | ----------- | ---------------------- | -------------------| -------------------------------------------------- |
-v1.101  | Week 31-32  | July 29, 2024          | August 11, 2024    | [@rfranzke](https://github.com/rfranzke)           |
-v1.102  | Week 33-34  | August 12, 2024        | August 25, 2024    | [@plkokanov](https://github.com/plkokanov)         |
-v1.103  | Week 35-36  | August 26, 2024        | September 8, 2024  | [@oliver-goetz](https://github.com/oliver-goetz)   |
-v1.104  | Week 37-38  | September 9, 2024      | September 22, 2024 | [@ialidzhikov](https://github.com/ialidzhikov)     |
-v1.105  | Week 39-40  | September 23, 2024     | October 6, 2024    | [@acumino](https://github.com/acumino)             |
-v1.106  | Week 41-42  | October 7, 2024        | October 20, 2024   | [@timuthy](https://github.com/timuthy)             |
-v1.107  | Week 43-44  | October 21, 2024       | November 3, 2024   | [@LucaBernstein](https://github.com/LucaBernstein) |
-v1.108  | Week 45-46  | November 4, 2024       | November 17, 2024  | [@shafeeqes](https://github.com/shafeeqes)         |
-v1.109  | Week 47-48  | November 18, 2024      | December 1, 2024   | [@ary1992](https://github.com/ary1992)             |
-v1.110  | Week 48-49  | December 2, 2024       | December 15, 2024  | [@ScheererJ](https://github.com/ScheererJ)         |
-v1.111  | Week 50-51  | December 30, 2024      | January 26, 2025   | [@oliver-goetz](https://github.com/oliver-goetz)   |
-v1.112  | Week 01-04  | January 27, 2025       | February 9, 2025   | [@tobschli](https://github.com/tobschli)           |
-v1.113  | Week 05-06  | February 10, 2025      | February 23, 2025  | [@plkokanov](https://github.com/plkokanov)         |
-v1.114  | Week 07-08  | February 24, 2025      | March 9, 2025      | [@rfranzke](https://github.com/rfranzke)           |
-v1.115  | Week 09-10  | March 10, 2025         | March 23, 2025     | [@ialidzhikov](https://github.com/ialidzhikov)     |
+Version | Week No    | Begin Validation Phase | Due Date           | Release Responsible                                |
+------- |------------| ---------------------- | -------------------|----------------------------------------------------|
+v1.101  | Week 31-32 | July 29, 2024          | August 11, 2024    | [@rfranzke](https://github.com/rfranzke)           |
+v1.102  | Week 33-34 | August 12, 2024        | August 25, 2024    | [@plkokanov](https://github.com/plkokanov)         |
+v1.103  | Week 35-36 | August 26, 2024        | September 8, 2024  | [@oliver-goetz](https://github.com/oliver-goetz)   |
+v1.104  | Week 37-38 | September 9, 2024      | September 22, 2024 | [@ialidzhikov](https://github.com/ialidzhikov)     |
+v1.105  | Week 39-40 | September 23, 2024     | October 6, 2024    | [@acumino](https://github.com/acumino)             |
+v1.106  | Week 41-42 | October 7, 2024        | October 20, 2024   | [@timuthy](https://github.com/timuthy)             |
+v1.107  | Week 43-44 | October 21, 2024       | November 3, 2024   | [@LucaBernstein](https://github.com/LucaBernstein) |
+v1.108  | Week 45-46 | November 4, 2024       | November 17, 2024  | [@shafeeqes](https://github.com/shafeeqes)         |
+v1.109  | Week 47-48 | November 18, 2024      | December 1, 2024   | [@ary1992](https://github.com/ary1992)             |
+v1.110  | Week 49-50 | December 2, 2024       | December 15, 2024  | [@ScheererJ](https://github.com/ScheererJ)         |
+v1.111  | Week 01-04 | December 30, 2024      | January 26, 2025   | [@oliver-goetz](https://github.com/oliver-goetz)   |
+v1.112  | Week 05-06 | January 27, 2025       | February 9, 2025   | [@tobschli](https://github.com/tobschli)           |
+v1.113  | Week 07-08 | February 10, 2025      | February 23, 2025  | [@plkokanov](https://github.com/plkokanov)         |
+v1.114  | Week 09-10 | February 24, 2025      | March 9, 2025      | [@rfranzke](https://github.com/rfranzke)           |
+v1.115  | Week 11-12 | March 10, 2025         | March 23, 2025     | [@ialidzhikov](https://github.com/ialidzhikov)     |
 
 Apart from the release of the next version, the release responsible is also taking care of potential hotfix releases of the last three minor versions.
 The release responsible is the main contact person for coordinating new feature PRs for the next minor versions or cherry-pick PRs for the last three minor versions.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Fix the week numbers in the release responsible schedule.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
