### PR TITLE
[Extensions] Check for class and type should be the first predicates

### DIFF
--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -55,8 +55,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new BackupBucket Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 	return add(mgr, args, predicates)
 }
 

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -55,8 +55,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new BackupEntry Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 	return add(mgr, args, predicates)
 }
 

--- a/extensions/pkg/controller/bastion/controller.go
+++ b/extensions/pkg/controller/bastion/controller.go
@@ -49,8 +49,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new Bastion Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 	return add(mgr, args, predicates)
 }
 

--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -62,8 +62,7 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 }
 
 func add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/controlplane/controller.go
+++ b/extensions/pkg/controller/controlplane/controller.go
@@ -55,8 +55,7 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 // Add creates a new ControlPlane Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/dnsrecord/controller.go
+++ b/extensions/pkg/controller/dnsrecord/controller.go
@@ -63,8 +63,7 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 
 // Add creates a new dnsrecord controller and adds it to the given Manager.
 func Add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/extension/controller.go
+++ b/extensions/pkg/controller/extension/controller.go
@@ -65,8 +65,7 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 }
 
 func add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -182,8 +182,7 @@ func add(mgr manager.Manager, args AddArgs, actuator HealthCheckActuator) error 
 	controllerName := fmt.Sprintf("%s-%s-%s-%s-%s", ControllerName, args.registeredExtension.groupVersionKind.Kind, args.registeredExtension.groupVersionKind.Group, args.registeredExtension.groupVersionKind.Version, str)
 
 	// add type predicate to only watch registered resource (e.g. ControlPlane) with a certain type (e.g. aws)
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	log.Log.Info("Registering health check controller", "kind", args.registeredExtension.groupVersionKind.Kind, "type", args.Type, "conditionTypes", args.registeredExtension.healthConditionTypes, "syncPeriod", args.SyncPeriod.Duration.String())
 

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -68,8 +68,7 @@ func Add(mgr manager.Manager, args AddArgs) error {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/network/controller.go
+++ b/extensions/pkg/controller/network/controller.go
@@ -60,8 +60,7 @@ func Add(mgr manager.Manager, args AddArgs) error {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/operatingsystemconfig/controller.go
+++ b/extensions/pkg/controller/operatingsystemconfig/controller.go
@@ -45,8 +45,7 @@ type AddArgs struct {
 
 // Add adds an operatingsystemconfig controller to the given manager using the given AddArgs.
 func Add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Types...)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Types...)
 
 	return builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -55,8 +55,7 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 // Add creates a new Worker Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -29,15 +29,21 @@ func HasType(typeName string) predicate.Predicate {
 	})
 }
 
-// AddTypePredicate returns a new slice which contains a type predicate and the given `predicates`.
-// if more than one extensionTypes is given all given types are or combined
-func AddTypePredicate(predicates []predicate.Predicate, extensionTypes ...string) []predicate.Predicate {
-	resultPredicates := make([]predicate.Predicate, 0, len(predicates)+1)
+// AddTypeAndClassPredicates returns a new slice which contains a HasClass, a type predicate and the given `predicates`.
+// If more than one extensionTypes is given they are combined with an OR.
+func AddTypeAndClassPredicates(predicates []predicate.Predicate, extensionClass extensionsv1alpha1.ExtensionClass, extensionTypes ...string) []predicate.Predicate {
+	resultPredicates := make([]predicate.Predicate, 0, len(predicates)+2)
+	resultPredicates = append(resultPredicates, HasClass(extensionClass))
+	resultPredicates = append(resultPredicates, HasOneOfTypesPredicate(extensionTypes...))
 	resultPredicates = append(resultPredicates, predicates...)
+	return resultPredicates
+}
 
+// HasOneOfTypesPredicate returns a new slice which contains a type predicate.
+// If more than one extensionTypes is given they are combined with an OR.
+func HasOneOfTypesPredicate(extensionTypes ...string) predicate.Predicate {
 	if len(extensionTypes) == 1 {
-		resultPredicates = append(resultPredicates, HasType(extensionTypes[0]))
-		return resultPredicates
+		return HasType(extensionTypes[0])
 	}
 
 	orPreds := make([]predicate.Predicate, 0, len(extensionTypes))
@@ -45,7 +51,7 @@ func AddTypePredicate(predicates []predicate.Predicate, extensionTypes ...string
 		orPreds = append(orPreds, HasType(extensionType))
 	}
 
-	return append(resultPredicates, predicate.Or(orPreds...))
+	return predicate.Or(orPreds...)
 }
 
 // HasClass filters the incoming objects for the given extension class.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The order of the predicates for extension controllers has been changed to ensure that class and types are checked first. 
This avoids side effects by the passed predicates especially if the controller runs on the runtime cluster.
For example, if runtime and seed are running on the same cluster, the `dnsrecord` controller of the provider may have a predicate requesting `Cluster` resources for `dnsrecord` resources in shoot control planes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The order of the predicates for extension controllers has been changed to ensure that class and types are checked first. 
This avoids side effects by the passed predicates especially if the controller runs on the runtime cluster.
```
