### PR TITLE
[node-agent] Avoid unnecessary containerd restarts

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -153,13 +153,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed reloading systemd daemon: %w", err)
 	}
 
-	// The containerd service stops as soon as units were removed that were required to run before (via containerd.service dropin).
-	// We want to start the service here explicitly (again) as a precautious measure.
-	log.Info("Starting containerd", "unitName", v1beta1constants.OperatingSystemConfigUnitNameContainerDService)
-	if err := r.DBus.Start(ctx, r.Recorder, node, v1beta1constants.OperatingSystemConfigUnitNameContainerDService); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed starting containerd: %w", err)
-	}
-
 	log.Info("Executing unit commands (start/stop)", "unitCommands", len(oscChanges.Units.Commands))
 	if err := r.executeUnitCommands(ctx, log, node, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed executing unit commands: %w", err)

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -468,7 +468,6 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
-			fakedbus.SystemdAction{Action: fakedbus.ActionStart, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit1.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDisable, UnitNames: []string{unit2.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit3.Name}},
@@ -553,13 +552,11 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit1.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit2.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
-			fakedbus.SystemdAction{Action: fakedbus.ActionStart, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionStop, UnitNames: []string{unit1.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit2.Name}},
 			// failure was injected here, so we expect the next attempt to only retry the failed action (restart unit2)
 			// and the actions that are taken on every reconcile.
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
-			fakedbus.SystemdAction{Action: fakedbus.ActionStart, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{unit2.Name}},
 		))
 	})
@@ -675,7 +672,6 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
-			fakedbus.SystemdAction{Action: fakedbus.ActionStart, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit2.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit5.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{unit6.Name}},
@@ -757,7 +753,6 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
-			fakedbus.SystemdAction{Action: fakedbus.ActionStart, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"containerd.service"}},
 		))
@@ -821,7 +816,6 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
-			fakedbus.SystemdAction{Action: fakedbus.ActionStart, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"containerd.service"}},
 		))
@@ -883,7 +877,6 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
-			fakedbus.SystemdAction{Action: fakedbus.ActionStart, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 			fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"containerd.service"}},
 		))
@@ -928,7 +921,6 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
-			fakedbus.SystemdAction{Action: fakedbus.ActionStart, UnitNames: []string{"containerd.service"}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{gnaUnit.Name}},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 		))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
Currently, `gardener-node-agent` is restarting `containerd.service` on every OSC reconciliation.
According to a source code comment this is supposed to be a precautious measure. However, since https://github.com/gardener/gardener/pull/11015 this measure is not needed anymore, because `gardener-node-agent` does not delete and stop systemd services created by other parties anymore.
`gardener-node-agent` was designed to avoid unnecessary restarts of systemd services, so we should continue to follow this approach if possible.

Restarting containerd during the bootstrap process of a node might cause some trouble anyway.
We sometimes notice `apiserver-proxy` pods where only one container is running. The corresponding nodes are unhealthy in these cases.
In these [gardener-node-agent logs](https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/11085/pull-gardener-e2e-kind/1876720302570868736/artifacts/shoot--local--e2e-default/machine-shoot--local--e2e-default-local3-68d49-h9tr6/gardener-node-agent.log) of a [failing test](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11085/pull-gardener-e2e-kind/1876720302570868736), you see that `gardener-node-agent` restarted `containerd.service` at 20:17:47. This restart is not required because there have been no changes in containerd configuration during this reconciliation.
At the same the we see containerd restarting in its [logs](https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/11085/pull-gardener-e2e-kind/1876720302570868736/artifacts/shoot--local--e2e-default/machine-shoot--local--e2e-default-local3-68d49-h9tr6/containerd.log). Before the restart an `apiserver-proxy` sandbox with sandbox id `f700472b1348b779544f0953267fdfbb4e61e6b139b1e52d101598973526930a` has been started. Just in the second of container restart, this sandbox created a container. After the restart, neither the sandbox id nor `apiserver-proxy` or its uid `3d849b05-b855-4f82-9935-c30b11ce1cd0` appears again in the logs.
Instead there are some suspicious log entries.
```
...
Jan 07 20:17:47 machine-shoot--local--e2e-default-local3-68d49-h9tr6 systemd[1]: containerd.service: Unit process 2005 (containerd-shim) remains running after unit stopped.
...
Jan 07 20:17:48 machine-shoot--local--e2e-default-local3-68d49-h9tr6 systemd[1]: containerd.service: Found left-over process 2005 (containerd-shim) in control group while starting unit. Ignoring.
Jan 07 20:17:48 machine-shoot--local--e2e-default-local3-68d49-h9tr6 systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
...
```
When seeing these lines, I have the impression that the restart of containerd disturbed the start of `apiserver-server` pod in a way, that it was not able to recover automatically.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardener-node-agent` does not restart `containerd.service` on every OSC reconciliation anymore.
```
