### PR TITLE
Add the "kube-apiserver" latency alert to prometheus "garden"

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -703,7 +703,7 @@ var _ = Describe("KubeAPIServer", func() {
 								// API server request duration greater than 1s percentage
 								{
 									Record: "shoot:apiserver_latency:percentage",
-									Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",resource="apiservices"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",resource="apiservices"}[1h]))`),
+									Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",scope="resource"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",scope="resource"}[1h]))`),
 								},
 
 								{

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -703,7 +703,7 @@ var _ = Describe("KubeAPIServer", func() {
 								// API server request duration greater than 1s percentage
 								{
 									Record: "shoot:apiserver_latency:percentage",
-									Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h]))`),
+									Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",resource="apiservices"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",resource="apiservices"}[1h]))`),
 								},
 
 								{

--- a/pkg/component/kubernetes/apiserver/prometheusrule.go
+++ b/pkg/component/kubernetes/apiserver/prometheusrule.go
@@ -180,7 +180,7 @@ func (k *kubeAPIServer) reconcilePrometheusRule(ctx context.Context, prometheusR
 					// API server request duration greater than 1s percentage
 					{
 						Record: "shoot:apiserver_latency:percentage",
-						Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h]))`),
+						Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",resource="apiservices"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",resource="apiservices"}[1h]))`),
 					},
 
 					{

--- a/pkg/component/kubernetes/apiserver/prometheusrule.go
+++ b/pkg/component/kubernetes/apiserver/prometheusrule.go
@@ -180,7 +180,7 @@ func (k *kubeAPIServer) reconcilePrometheusRule(ctx context.Context, prometheusR
 					// API server request duration greater than 1s percentage
 					{
 						Record: "shoot:apiserver_latency:percentage",
-						Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",resource="apiservices"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",resource="apiservices"}[1h]))`),
+						Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",scope="resource"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH",scope="resource"}[1h]))`),
 					},
 
 					{

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -339,3 +339,17 @@ spec:
 
 
           ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="seed"}
+
+    - alert: SeedKubeApiServerLatency
+      expr: |
+        ((1 - sum(shoot:apiserver_latency:percentage{project="garden"}) by (name)) * 100) < 99.5
+      for: 30m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: >-
+          Seed Kube API server Latency
+        description: >-
+          The seed cluster {{$labels.name}} in {{$externalLabels.landscape}}
+          Kube API server has latency issue. 

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -352,4 +352,4 @@ spec:
           Seed Kube API server Latency
         description: >-
           The seed cluster {{$labels.name}} in {{$externalLabels.landscape}}
-          Kube API server has latency issues. 
+          Kube API server has latency issues.

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -342,7 +342,7 @@ spec:
 
     - alert: SeedKubeApiServerLatency
       expr: |
-        ((1 - sum(shoot:apiserver_latency:percentage{project="garden"}) by (name)) * 100) < 99.5
+        shoot:apiserver_latency:percentage{project="garden"} > 0.01
       for: 30m
       labels:
         severity: warning
@@ -352,4 +352,4 @@ spec:
           Seed Kube API server Latency
         description: >-
           The seed cluster {{$labels.name}} in {{$externalLabels.landscape}}
-          Kube API server has latency issue. 
+          Kube API server has latency issues. 

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -211,3 +211,26 @@ tests:
 
 
               ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="seed"}
+
+  - name: SeedKubeApiServerLatency
+    interval: 1m
+    input_series:
+      - series: shoot:apiserver_latency:percentage{project="garden", name="seed-one"}
+        values: "1x31"
+    external_labels:
+      landscape: landscape-unit-tests
+    alert_rule_test:
+      - alertname: SeedKubeApiServerLatency
+        eval_time: 31m # test the alert fires immediately
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              topology: garden
+              name: seed-one
+              project: garden
+            exp_annotations:
+              summary: >-
+                Seed Kube API server Latency
+              description: >-
+                The seed cluster seed-one in landscape-unit-tests
+                Kube API server has latency issues.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Latency is one component of the 4 golden signals, create the alerting rule for `kube-apiserver`, and send it to Alert channel. 
The recording rule `shoot:apiserver_latency` is to get the percentage of `kube-apiserver` requests which are greater than 1 s, and federate this latency metrics to garden-prometheus, right now adding one latency alert for it, and the alert will be sent to  Alert channel to help to detect the issue ahead of time. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
