### PR TITLE
Use vpa-recommender from upstream

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -667,16 +667,10 @@ images:
         confidentiality_requirement: 'low'
         integrity_requirement: 'high'
         availability_requirement: 'high'
-# We use a forked version of the vpa-recommender for the following reason:
-#   - It adds verbose logging when the vpa-recommender estimates memory values which are less than or equal to the minAllowed defined in the
-# corresponding VPA resource. A new metric is also included which counts how many times such estimations have occurred for each VPA resource.
-# (check https://github.com/gardener/autoscaler/pull/322 for more info).
-#
-# TODO(plkokanov): Switch back to the upstream vpa-recommender image when we no longer need to use the forked version.
 - name: vpa-recommender
-  sourceRepository: github.com/gardener/autoscaler
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender
-  tag: "1.2.1-gardener-build.3"
+  sourceRepository: github.com/kubernetes/autoscaler
+  repository: registry.k8s.io/autoscaling/vpa-recommender
+  tag: "1.2.1"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
This PR brings back `vpa-recommender` from the https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler upstream
Previously, we used a forked version of the `vpa-recommender` from https://github.com/gardener/autoscaler/tree/rel-vertical-pod-autoscaler with increased verbose logging to investigate an issue which was causing `vpa-recommender` to estimate memory values which are less than or equal to the `minAllowed` defined in the corresponding VPA resource by not respecting the actual usage.
We have gathered the necessary data and have a good idea on what the cause is, so the fork is not required any more.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switch `vpa-recommender` back to the image built from the [vertical-pod-autoscaler upstream repo](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) .
```
