### PR TITLE
Avoid calling `GetCluster` for non-shoot namespaces in `shootNotFailedPredicate` and `dnsrecord` controller.

### DIFF
--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/gardener/gardener/pkg/extensions"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 type reconciler struct {
@@ -62,11 +63,8 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	var cluster *extensions.Cluster
-	isShoot, err := extensionscontroller.IsShootNamespace(ctx, r.client, dns.Namespace)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if isShoot {
+	if gardenerutils.IsShootNamespace(dns.Namespace) {
+		var err error
 		cluster, err = extensionscontroller.GetCluster(ctx, r.client, dns.Namespace)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -63,23 +62,19 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	var cluster *extensions.Cluster
-	if dns.Namespace != v1beta1constants.GardenNamespace {
-		ns := &corev1.Namespace{}
-		if err := r.reader.Get(ctx, client.ObjectKey{Name: dns.Namespace}, ns); err != nil {
-			return reconcile.Result{}, fmt.Errorf("error retrieving namespace: %w", err)
+	isShoot, err := extensionscontroller.IsShootNamespace(ctx, r.client, dns.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if isShoot {
+		cluster, err = extensionscontroller.GetCluster(ctx, r.client, dns.Namespace)
+		if err != nil {
+			return reconcile.Result{}, err
 		}
 
-		if ns.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot {
-			var err error
-			cluster, err = extensionscontroller.GetCluster(ctx, r.client, dns.Namespace)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-
-			if extensionscontroller.IsFailed(cluster) {
-				log.Info("Skipping the reconciliation of DNSRecord of failed shoot")
-				return reconcile.Result{}, nil
-			}
+		if extensionscontroller.IsFailed(cluster) {
+			log.Info("Skipping the reconciliation of DNSRecord of failed shoot")
+			return reconcile.Result{}, nil
 		}
 	}
 

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -72,23 +71,19 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	var cluster *extensions.Cluster
-	if ex.Namespace != v1beta1constants.GardenNamespace {
-		ns := &corev1.Namespace{}
-		if err := r.reader.Get(ctx, client.ObjectKey{Name: ex.Namespace}, ns); err != nil {
-			return reconcile.Result{}, fmt.Errorf("error retrieving namespace: %w", err)
+	isShoot, err := extensionscontroller.IsShootNamespace(ctx, r.client, ex.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if isShoot {
+		cluster, err = extensionscontroller.GetCluster(ctx, r.client, ex.Namespace)
+		if err != nil {
+			return reconcile.Result{}, err
 		}
 
-		if ns.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot {
-			var err error
-			cluster, err = extensionscontroller.GetCluster(ctx, r.client, ex.Namespace)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-
-			if extensionscontroller.IsFailed(cluster) {
-				log.Info("Skipping the reconciliation of Extension of failed shoot")
-				return reconcile.Result{}, nil
-			}
+		if extensionscontroller.IsFailed(cluster) {
+			log.Info("Skipping the reconciliation of Extension of failed shoot")
+			return reconcile.Result{}, nil
 		}
 	}
 

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/gardener/gardener/pkg/extensions"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // reconciler reconciles Extension resources of Gardener's
@@ -71,11 +72,8 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	var cluster *extensions.Cluster
-	isShoot, err := extensionscontroller.IsShootNamespace(ctx, r.client, ex.Namespace)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if isShoot {
+	if gardenerutils.IsShootNamespace(ex.Namespace) {
+		var err error
 		cluster, err = extensionscontroller.GetCluster(ctx, r.client, ex.Namespace)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -150,18 +149,4 @@ func ShouldSkipOperation(operationType gardencorev1beta1.LastOperationType, obj 
 // If the object kind doesn't match the given reference kind this will result in an error.
 func GetObjectByReference(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, obj client.Object) error {
 	return c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.ReferencedResourcesPrefix + ref.Name}, obj)
-}
-
-// IsShootNamespace returns true if the namespace has the garden role shoot label.
-func IsShootNamespace(ctx context.Context, reader client.Reader, namespace string) (bool, error) {
-	if namespace == v1beta1constants.GardenNamespace {
-		return false, nil
-	}
-
-	ns := &corev1.Namespace{}
-	if err := reader.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
-		return false, fmt.Errorf("error retrieving namespace: %w", err)
-	}
-
-	return ns.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot, nil
 }

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -149,4 +150,18 @@ func ShouldSkipOperation(operationType gardencorev1beta1.LastOperationType, obj 
 // If the object kind doesn't match the given reference kind this will result in an error.
 func GetObjectByReference(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, obj client.Object) error {
 	return c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.ReferencedResourcesPrefix + ref.Name}, obj)
+}
+
+// IsShootNamespace returns true if the namespace has the garden role shoot label.
+func IsShootNamespace(ctx context.Context, reader client.Reader, namespace string) (bool, error) {
+	if namespace == v1beta1constants.GardenNamespace {
+		return false, nil
+	}
+
+	ns := &corev1.Namespace{}
+	if err := reader.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
+		return false, fmt.Errorf("error retrieving namespace: %w", err)
+	}
+
+	return ns.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot, nil
 }

--- a/extensions/pkg/predicate/preconditions.go
+++ b/extensions/pkg/predicate/preconditions.go
@@ -7,7 +7,6 @@ package predicate
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -41,9 +40,8 @@ func (p *shootNotFailedPredicate) Create(e event.CreateEvent) bool {
 		return false
 	}
 
-	ns := &corev1.Namespace{}
-	if err := p.reader.Get(p.ctx, client.ObjectKey{Name: e.Object.GetNamespace()}, ns); err == nil && ns.Labels[v1beta1constants.GardenRole] != v1beta1constants.GardenRoleShoot {
-		// there is no cluster resource for non-shoot namespaces (like extension or garden)
+	isShoot, err := extensionscontroller.IsShootNamespace(p.ctx, p.reader, e.Object.GetNamespace())
+	if err == nil && !isShoot {
 		return true
 	}
 

--- a/extensions/pkg/predicate/preconditions.go
+++ b/extensions/pkg/predicate/preconditions.go
@@ -14,6 +14,7 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // IsInGardenNamespacePredicate is a predicate which returns true when the provided object is in the 'garden' namespace.
@@ -40,8 +41,7 @@ func (p *shootNotFailedPredicate) Create(e event.CreateEvent) bool {
 		return false
 	}
 
-	isShoot, err := extensionscontroller.IsShootNamespace(p.ctx, p.reader, e.Object.GetNamespace())
-	if err == nil && !isShoot {
+	if !gardenerutils.IsShootNamespace(e.Object.GetNamespace()) {
 		return true
 	}
 

--- a/extensions/pkg/predicate/preconditions_test.go
+++ b/extensions/pkg/predicate/preconditions_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -18,6 +19,7 @@ import (
 
 	. "github.com/gardener/gardener/extensions/pkg/predicate"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
@@ -126,6 +128,37 @@ var _ = Describe("Preconditions", func() {
 							},
 						},
 					))).To(Succeed())
+
+					Expect(run()).To(BeFalse())
+				})
+
+				It("should return true if it is no shoot namespace", func() {
+					ns := &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: namespace,
+						},
+					}
+					Expect(fakeClient.Create(ctx, ns)).To(Succeed())
+					DeferCleanup(func() {
+						Expect(fakeClient.Delete(ctx, ns)).To(Succeed())
+					})
+
+					Expect(run()).To(BeTrue())
+				})
+
+				It("should return false if it is a shoot namespace, but cluster is not existing", func() {
+					ns := &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: namespace,
+							Labels: map[string]string{
+								v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot,
+							},
+						},
+					}
+					Expect(fakeClient.Create(ctx, ns)).To(Succeed())
+					DeferCleanup(func() {
+						Expect(fakeClient.Delete(ctx, ns)).To(Succeed())
+					})
 
 					Expect(run()).To(BeFalse())
 				})

--- a/extensions/pkg/predicate/preconditions_test.go
+++ b/extensions/pkg/predicate/preconditions_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Preconditions", func() {
 					Expect(run()).To(BeFalse())
 				})
 
-				It("should return true if it is no shoot namespace", func() {
+				It("should return true if it is not a shoot namespace", func() {
 					ns := &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: namespace,

--- a/extensions/pkg/predicate/preconditions_test.go
+++ b/extensions/pkg/predicate/preconditions_test.go
@@ -133,16 +133,7 @@ var _ = Describe("Preconditions", func() {
 				})
 
 				It("should return true if it is not a shoot namespace", func() {
-					ns := &corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: namespace,
-						},
-					}
-					Expect(fakeClient.Create(ctx, ns)).To(Succeed())
-					DeferCleanup(func() {
-						Expect(fakeClient.Delete(ctx, ns)).To(Succeed())
-					})
-
+					obj.SetNamespace("foo")
 					Expect(run()).To(BeTrue())
 				})
 

--- a/pkg/component/kubernetes/apiserverexposure/service.go
+++ b/pkg/component/kubernetes/apiserverexposure/service.go
@@ -7,7 +7,6 @@ package apiserverexposure
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -140,7 +139,7 @@ func (s *service) Deploy(ctx context.Context) error {
 		// For shoot namespaces the kube-apiserver service needs extra labels and annotations to create required network policies
 		// which allow a connection from istio-ingress components to kube-apiserver.
 		networkPolicyPort := networkingv1.NetworkPolicyPort{Port: ptr.To(intstr.FromInt32(kubeapiserverconstants.Port)), Protocol: ptr.To(corev1.ProtocolTCP)}
-		if isShootNamespace(obj.Namespace) {
+		if gardenerutils.IsShootNamespace(obj.Namespace) {
 			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(obj, networkPolicyPort))
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias, v1beta1constants.LabelNetworkPolicyShootNamespaceAlias)
 
@@ -218,8 +217,4 @@ func getLabels() map[string]string {
 		v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
 		v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer,
 	}
-}
-
-func isShootNamespace(namespace string) bool {
-	return strings.HasPrefix(namespace, v1beta1constants.TechnicalIDPrefix)
 }

--- a/pkg/provider-local/controller/networkpolicy/add.go
+++ b/pkg/provider-local/controller/networkpolicy/add.go
@@ -6,7 +6,6 @@ package networkpolicy
 
 import (
 	"context"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -17,6 +16,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/provider-local/local"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ControllerName is the name of the controller.
@@ -46,7 +46,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 // IsShootNamespace returns a predicate that returns true if the namespace is a shoot namespace.
 func IsShootNamespace() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return strings.HasPrefix(obj.GetName(), v1beta1constants.TechnicalIDPrefix)
+		return gardenerutils.IsShootNamespace(obj.GetName())
 	})
 }
 

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -739,6 +739,11 @@ func ComputeTechnicalID(projectName string, shoot *gardencorev1beta1.Shoot) stri
 	return fmt.Sprintf("%s-%s--%s", v1beta1constants.TechnicalIDPrefix, projectName, shoot.Name)
 }
 
+// IsShootNamespace returns true if the given namespace is a shoot namespace, i.e. it starts with the technical id prefix.
+func IsShootNamespace(namespace string) bool {
+	return strings.HasPrefix(namespace, v1beta1constants.TechnicalIDPrefix)
+}
+
 // GetShootConditionTypes returns all known shoot condition types.
 func GetShootConditionTypes(workerless bool) []gardencorev1beta1.ConditionType {
 	shootConditionTypes := []gardencorev1beta1.ConditionType{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Extensions running on a seed are typically working on resources in the control plane namespace of a shoot.
Due to new responsibilities of extensions, such as the `shoot-cert-service` extension providing the ingress wildcard TLS secret on the seeds, resources managed by an extension can also be found in other namespaces.
In such a case, predicates like the `shootNotFailedPredicate` should not try to get a `Cluster` resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Avoid calling `GetCluster` for non-shoot namespaces in `shootNotFailedPredicate` and `dnsrecord` controller.
```
