### PR TITLE
Deflake scheduler integration test

### DIFF
--- a/test/integration/scheduler/shoot/shoot_suite_test.go
+++ b/test/integration/scheduler/shoot/shoot_suite_test.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
 	schedulerfeatures "github.com/gardener/gardener/pkg/scheduler/features"
@@ -42,10 +41,10 @@ var (
 	ctx = context.Background()
 	log logr.Logger
 
-	restConfig          *rest.Config
-	testEnv             *gardenerenvtest.GardenerTestEnvironment
-	testClient          client.Client
-	versionedTestClient *gardencoreclientset.Clientset
+	restConfig *rest.Config
+	testEnv    *gardenerenvtest.GardenerTestEnvironment
+	testClient client.Client
+	mgrClient  client.Reader
 
 	testNamespace     *corev1.Namespace
 	testSecretBinding *gardencorev1beta1.SecretBinding
@@ -77,10 +76,6 @@ var _ = BeforeSuite(func() {
 	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(testClient).NotTo(BeNil())
-
-	versionedTestClient, err = gardencoreclientset.NewForConfig(restConfig)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(versionedTestClient).NotTo(BeNil())
 
 	By("Create test Namespace")
 	testNamespace = &corev1.Namespace{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Fixes the integration test flake by waiting for the manager cache to observe the resources.

**Which issue(s) this PR fixes**:
Fixes #
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11106/pull-gardener-integration/1877203310037962752
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10967/pull-gardener-integration/1874809672985219072

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
