### PR TITLE
Avoid unnecessary `containerd` restarts (II)

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -494,6 +494,13 @@ func (r *Reconciler) executeUnitCommands(ctx context.Context, log logr.Logger, n
 				return fmt.Errorf("unable to restart unit %q: %w", unitName, err)
 			}
 			log.Info("Successfully restarted unit", "unitName", unitName)
+
+			if unitName == v1beta1constants.OperatingSystemConfigUnitNameContainerDService {
+				if err := oscChanges.completedContainerdConfigFileChange(); err != nil {
+					return err
+				}
+			}
+
 			return oscChanges.completedUnitCommand(unitName)
 		}
 
@@ -536,10 +543,7 @@ func (r *Reconciler) executeUnitCommands(ctx context.Context, log logr.Logger, n
 
 	if oscChanges.Containerd.ConfigFileChanged && !containerdChanged {
 		fns = append(fns, func(ctx context.Context) error {
-			if err := restart(ctx, v1beta1constants.OperatingSystemConfigUnitNameContainerDService); err != nil {
-				return err
-			}
-			return oscChanges.completedContainerdConfigFileChange()
+			return restart(ctx, v1beta1constants.OperatingSystemConfigUnitNameContainerDService)
 		})
 	}
 

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -465,6 +465,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service", "#existingunit", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service.d/existing-dropin.conf", "#existingdropin", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+existingUnitDropIn.Name+".d/"+existingUnitDropIn.DropIns[0].Name, "#unit11drop", 0600)
+		test.AssertFileOnDisk(fakeFS, "/var/lib/gardener-node-agent/last-computed-osc-changes.yaml", "containerd:\n  configFileChanged: false\n  registries: {}\nfiles: {}\nmustRestartNodeAgent: false\noperatingSystemConfigChecksum: 43b154622b6da9c7a28d3337eececad055a1f7eeaed5420c405c83c11b1ab6c4\nunits: {}\n", 0600)
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
Fixes a consecutive restart of `containerd` on new nodes. Please see https://github.com/gardener/gardener/pull/11120 for more information why this is critical.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```operator bugfix
NONE
```
