### PR TITLE
[release-v1.110] Automated cherry pick of #11118: [Extensions] Check for class and type should be the first predicates

### DIFF
--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -58,8 +58,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // and Start it when the Manager is Started.
 func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 	return add(ctx, mgr, args, predicates)
 }
 

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -58,8 +58,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // and Start it when the Manager is Started.
 func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 	return add(ctx, mgr, args, predicates)
 }
 

--- a/extensions/pkg/controller/bastion/controller.go
+++ b/extensions/pkg/controller/bastion/controller.go
@@ -51,8 +51,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator, args.ConfigValidator)
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 	return add(mgr, args, predicates)
 }
 

--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -68,8 +68,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(

--- a/extensions/pkg/controller/controlplane/controller.go
+++ b/extensions/pkg/controller/controlplane/controller.go
@@ -62,8 +62,7 @@ func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(

--- a/extensions/pkg/controller/dnsrecord/controller.go
+++ b/extensions/pkg/controller/dnsrecord/controller.go
@@ -70,8 +70,7 @@ func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(

--- a/extensions/pkg/controller/extension/controller.go
+++ b/extensions/pkg/controller/extension/controller.go
@@ -68,8 +68,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -192,8 +192,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	log.Log.Info("Registered health check controller", "kind", args.registeredExtension.groupVersionKind.Kind, "type", args.Type, "conditionTypes", args.registeredExtension.healthConditionTypes, "syncPeriod", args.SyncPeriod.Duration.String())
 
 	// add type predicate to only watch registered resource (e.g. ControlPlane) with a certain type (e.g. aws)
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	if err := ctrl.Watch(source.Kind[client.Object](mgr.GetCache(), args.registeredExtension.getExtensionObjFunc(), &handler.EnqueueRequestForObject{}, predicates...)); err != nil {
 		return err

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -74,8 +74,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	if err := ctrl.Watch(source.Kind[client.Object](mgr.GetCache(), &extensionsv1alpha1.Infrastructure{}, &handler.EnqueueRequestForObject{}, predicates...)); err != nil {
 		return err

--- a/extensions/pkg/controller/network/controller.go
+++ b/extensions/pkg/controller/network/controller.go
@@ -66,8 +66,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(

--- a/extensions/pkg/controller/operatingsystemconfig/controller.go
+++ b/extensions/pkg/controller/operatingsystemconfig/controller.go
@@ -47,8 +47,7 @@ type AddArgs struct {
 // Add adds an operatingsystemconfig controller to the given manager using the given AddArgs.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Types...)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Types...)
 	return add(mgr, args.ControllerOptions, predicates)
 }
 

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -57,8 +57,7 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
 
-	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	predicates = append(predicates, extensionspredicate.HasClass(args.ExtensionClass))
+	predicates := extensionspredicate.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClass, args.Type)
 
 	ctrl, err := controller.New(ControllerName, mgr, args.ControllerOptions)
 	if err != nil {

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -29,15 +29,21 @@ func HasType(typeName string) predicate.Predicate {
 	})
 }
 
-// AddTypePredicate returns a new slice which contains a type predicate and the given `predicates`.
-// if more than one extensionTypes is given all given types are or combined
-func AddTypePredicate(predicates []predicate.Predicate, extensionTypes ...string) []predicate.Predicate {
-	resultPredicates := make([]predicate.Predicate, 0, len(predicates)+1)
+// AddTypeAndClassPredicates returns a new slice which contains a HasClass, a type predicate and the given `predicates`.
+// If more than one extensionTypes is given they are combined with an OR.
+func AddTypeAndClassPredicates(predicates []predicate.Predicate, extensionClass extensionsv1alpha1.ExtensionClass, extensionTypes ...string) []predicate.Predicate {
+	resultPredicates := make([]predicate.Predicate, 0, len(predicates)+2)
+	resultPredicates = append(resultPredicates, HasClass(extensionClass))
+	resultPredicates = append(resultPredicates, HasOneOfTypesPredicate(extensionTypes...))
 	resultPredicates = append(resultPredicates, predicates...)
+	return resultPredicates
+}
 
+// HasOneOfTypesPredicate returns a new slice which contains a type predicate.
+// If more than one extensionTypes is given they are combined with an OR.
+func HasOneOfTypesPredicate(extensionTypes ...string) predicate.Predicate {
 	if len(extensionTypes) == 1 {
-		resultPredicates = append(resultPredicates, HasType(extensionTypes[0]))
-		return resultPredicates
+		return HasType(extensionTypes[0])
 	}
 
 	orPreds := make([]predicate.Predicate, 0, len(extensionTypes))
@@ -45,7 +51,7 @@ func AddTypePredicate(predicates []predicate.Predicate, extensionTypes ...string
 		orPreds = append(orPreds, HasType(extensionType))
 	}
 
-	return append(resultPredicates, predicate.Or(orPreds...))
+	return predicate.Or(orPreds...)
 }
 
 // HasClass filters the incoming objects for the given extension class.


### PR DESCRIPTION
/kind bug
/area control-plane

Cherry pick of #11118 on release-v1.110.

#11118: [Extensions] Check for class and type should be the first predicates

**Release Notes:**
```other developer
The order of the predicates for extension controllers has been changed to ensure that class and types are checked first. 
This avoids side effects by the passed predicates especially if the controller runs on the runtime cluster.
```