### PR TITLE
Allow tests to specify the IP families to use for the tests.

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -29,6 +29,7 @@ spec:
     -networking-provider-config-filepath=$NETWORKING_PROVIDER_CONFIG_FILEPATH
     -workers-config-filepath=$WORKERS_CONFIG_FILEPATH
     -worker-zone=$ZONE
+    -ip-families=$IP_FAMILIES
     -networking-type=$NETWORKING_TYPE
     -networking-pods=$NETWORKING_PODS
     -networking-services=$NETWORKING_SERVICES

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -272,6 +272,15 @@ func setShootNetworkingSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreati
 		clearDNS = false
 	}
 
+	if strings.Contains(cfg.ipFamilies, ",") {
+		shoot.Spec.Networking.IPFamilies = nil
+		for _, part := range strings.Split(cfg.ipFamilies, ",") {
+			shoot.Spec.Networking.IPFamilies = append(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamily(part))
+		}
+	} else if StringSet(cfg.ipFamilies) {
+		shoot.Spec.Networking.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamily(cfg.ipFamilies)}
+	}
+
 	if StringSet(cfg.networkingType) {
 		shoot.Spec.Networking.Type = ptr.To(cfg.networkingType)
 	}

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -42,6 +42,7 @@ type ShootCreationConfig struct {
 	shootK8sVersion              string
 	externalDomain               string
 	workerZone                   string
+	ipFamilies                   string
 	networkingType               string
 	networkingPods               string
 	networkingServices           string
@@ -242,6 +243,10 @@ func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreati
 		base.workerZone = overwrite.workerZone
 	}
 
+	if StringSet(overwrite.ipFamilies) {
+		base.ipFamilies = overwrite.ipFamilies
+	}
+
 	if StringSet(overwrite.networkingType) {
 		base.networkingType = overwrite.networkingType
 	}
@@ -315,6 +320,7 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	flag.StringVar(&newCfg.shootK8sVersion, "k8s-version", "", "kubernetes version to use for the shoot.")
 	flag.StringVar(&newCfg.externalDomain, "external-domain", "", "external domain to use for the shoot. If not set, will use the default domain.")
 	flag.StringVar(&newCfg.workerZone, "worker-zone", "", "zone to use for every worker of the shoot.")
+	flag.StringVar(&newCfg.ipFamilies, "ip-families", "", "the spec.networking.ipFamilies to use for this shoot. Optional. Defaults to an empty string resulting in IPv4. Use a comma separated list to provide multiple values, e.g. 'IPv6,IPv4'.")
 	flag.StringVar(&newCfg.networkingType, "networking-type", "calico", "the spec.networking.type to use for this shoot. Optional. Defaults to calico.")
 	flag.StringVar(&newCfg.networkingPods, "networking-pods", "", "the spec.networking.pods to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.networkingServices, "networking-services", "", "the spec.networking.services to use for this shoot. Optional.")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area testing
/kind enhancement

**What this PR does / why we need it**:

Allow tests to specify the IP families to use for the tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow specifying the IP families for the shoot creation tests.
```

/cc @hendrikKahl 