### PR TITLE
Add alerts for capped VPA recommendations

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -19,6 +19,49 @@ import (
 
 var _ = Describe("PrometheusRules", func() {
 	Describe("#CentralPrometheusRules", func() {
+		rules := []monitoringv1.Rule{
+			{
+				Alert: "PodStuckInPending",
+				Expr:  intstr.FromString(`sum_over_time(kube_pod_status_phase{phase="Pending"}[5m]) > 0`),
+				For:   ptr.To(monitoringv1.Duration("10m")),
+				Labels: map[string]string{
+					"severity":   "warning",
+					"type":       "seed",
+					"visibility": "operator",
+				},
+				Annotations: map[string]string{
+					"description": "Pod {{$labels.pod}} in namespace {{$labels.namespace}} was stuck in Pending state for more than 10 minutes.",
+					"summary":     "A pod is stuck in pending",
+				},
+			},
+			{
+				Alert: "NodeNotHealthy",
+				Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!~"node.kubernetes.io/unschedulable|deployment.machine.sapcloud.io/prefer-no-schedule|ToBeDeletedByClusterAutoscaler|` + v1beta1constants.TaintNodeCriticalComponentsNotReady + `"}))[30m:]) > 9`),
+				For:   ptr.To(monitoringv1.Duration("0m")),
+				Labels: map[string]string{
+					"severity":   "warning",
+					"type":       "seed",
+					"visibility": "operator",
+				},
+				Annotations: map[string]string{
+					"description": "Node {{$labels.node}} in seed {{$externalLabels.seed}} was not healthy for ten scrapes in the past 30 mins.",
+					"summary":     "A node is not healthy.",
+				},
+			},
+			{
+				Alert: "TooManyEtcdSnapshotCompactionJobsFailing",
+				Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
+				Labels: map[string]string{
+					"severity":   "warning",
+					"type":       "seed",
+					"visibility": "operator",
+				},
+				Annotations: map[string]string{
+					"description": "Seed {{$externalLabels.seed}} has too many etcd snapshot compaction jobs failing in the past 3 hours.",
+					"summary":     "Too many etcd snapshot compaction jobs are failing in the seed.",
+				},
+			},
+		}
 		It("should return the expected objects", func() {
 			Expect(aggregate.CentralPrometheusRules()).To(HaveExactElements(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -29,50 +72,8 @@ var _ = Describe("PrometheusRules", func() {
 					ObjectMeta: metav1.ObjectMeta{Name: "seed"},
 					Spec: monitoringv1.PrometheusRuleSpec{
 						Groups: []monitoringv1.RuleGroup{{
-							Name: "seed.rules",
-							Rules: []monitoringv1.Rule{
-								{
-									Alert: "PodStuckInPending",
-									Expr:  intstr.FromString(`sum_over_time(kube_pod_status_phase{phase="Pending"}[5m]) > 0`),
-									For:   ptr.To(monitoringv1.Duration("10m")),
-									Labels: map[string]string{
-										"severity":   "warning",
-										"type":       "seed",
-										"visibility": "operator",
-									},
-									Annotations: map[string]string{
-										"description": "Pod {{$labels.pod}} in namespace {{$labels.namespace}} was stuck in Pending state for more than 10 minutes.",
-										"summary":     "A pod is stuck in pending",
-									},
-								},
-								{
-									Alert: "NodeNotHealthy",
-									Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!~"node.kubernetes.io/unschedulable|deployment.machine.sapcloud.io/prefer-no-schedule|ToBeDeletedByClusterAutoscaler|` + v1beta1constants.TaintNodeCriticalComponentsNotReady + `"}))[30m:]) > 9`),
-									For:   ptr.To(monitoringv1.Duration("0m")),
-									Labels: map[string]string{
-										"severity":   "warning",
-										"type":       "seed",
-										"visibility": "operator",
-									},
-									Annotations: map[string]string{
-										"description": "Node {{$labels.node}} in seed {{$externalLabels.seed}} was not healthy for ten scrapes in the past 30 mins.",
-										"summary":     "A node is not healthy.",
-									},
-								},
-								{
-									Alert: "TooManyEtcdSnapshotCompactionJobsFailing",
-									Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
-									Labels: map[string]string{
-										"severity":   "warning",
-										"type":       "seed",
-										"visibility": "operator",
-									},
-									Annotations: map[string]string{
-										"description": "Seed {{$externalLabels.seed}} has too many etcd snapshot compaction jobs failing in the past 3 hours.",
-										"summary":     "Too many etcd snapshot compaction jobs are failing in the seed.",
-									},
-								},
-							},
+							Name:  "seed.rules",
+							Rules: rules,
 						}},
 					},
 				}),

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -63,64 +63,68 @@ var _ = Describe("PrometheusRules", func() {
 			},
 		}
 
-		It("should return the expected objects when the seed is also the garden cluster", func() {
-			seedIsGarden := true
-			Expect(aggregate.CentralPrometheusRules(seedIsGarden)).To(HaveExactElements(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
-					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("metering-stateful")}),
-				})),
-				Equal(&monitoringv1.PrometheusRule{
-					ObjectMeta: metav1.ObjectMeta{Name: "seed"},
-					Spec: monitoringv1.PrometheusRuleSpec{
-						Groups: []monitoringv1.RuleGroup{{
-							Name:  "seed.rules",
-							Rules: rules,
-						}},
-					},
-				}),
-			))
+		Context("the seed is also the garden cluster", func() {
+			It("should return the expected objects", func() {
+				seedIsGarden := true
+				Expect(aggregate.CentralPrometheusRules(seedIsGarden)).To(HaveExactElements(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("metering-stateful")}),
+					})),
+					Equal(&monitoringv1.PrometheusRule{
+						ObjectMeta: metav1.ObjectMeta{Name: "seed"},
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{{
+								Name:  "seed.rules",
+								Rules: rules,
+							}},
+						},
+					}),
+				))
+			})
 		})
 
-		It("should return the expected objects when the seed and the garden clusters are different", func() {
-			seedIsGarden := false
-			vpaRule := monitoringv1.Rule{
-				Alert: "VerticalPodAutoscalerCappedRecommendation",
-				Expr: intstr.FromString(`
+		Context("the seed and the garden clusters are different", func() {
+			It("should return the expected objects", func() {
+				seedIsGarden := false
+				vpaRule := monitoringv1.Rule{
+					Alert: "VerticalPodAutoscalerCappedRecommendation",
+					Expr: intstr.FromString(`
     {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
 >
     {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}`),
-				Labels: map[string]string{
-					"severity":   "warning",
-					"type":       "seed",
-					"visibility": "operator",
-				},
-				Annotations: map[string]string{
-					"summary": "A VPA recommendation in a seed is capped.",
-					"description": "The following VPA from a seed shows a " +
-						"{{ if eq .Labels.unit \"core\" -}} CPU {{- else if eq .Labels.unit \"byte\" -}} memory {{- end }} " +
-						"uncapped target recommendation larger than the regular target recommendation:\n" +
-						"- seed = {{ $externalLabels.seed }}\n" +
-						"- namespace = {{ $labels.namespace }}\n" +
-						"- vpa = {{ $labels.verticalpodautoscaler }}\n" +
-						"- container = {{ $labels.container }}",
-				},
-			}
-			Expect(aggregate.CentralPrometheusRules(seedIsGarden)).To(HaveExactElements(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
-					"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("metering-stateful")}),
-				})),
-				Equal(&monitoringv1.PrometheusRule{
-					ObjectMeta: metav1.ObjectMeta{Name: "seed"},
-					Spec: monitoringv1.PrometheusRuleSpec{
-						Groups: []monitoringv1.RuleGroup{{
-							Name:  "seed.rules",
-							Rules: append(rules, vpaRule),
-						}},
+					Labels: map[string]string{
+						"severity":   "warning",
+						"type":       "seed",
+						"visibility": "operator",
 					},
-				}),
-			))
+					Annotations: map[string]string{
+						"summary": "A VPA recommendation in a seed is capped.",
+						"description": "The following VPA from a seed shows a " +
+							"{{ if eq .Labels.unit \"core\" -}} CPU {{- else if eq .Labels.unit \"byte\" -}} memory {{- end }} " +
+							"uncapped target recommendation larger than the regular target recommendation:\n" +
+							"- seed = {{ $externalLabels.seed }}\n" +
+							"- namespace = {{ $labels.namespace }}\n" +
+							"- vpa = {{ $labels.verticalpodautoscaler }}\n" +
+							"- container = {{ $labels.container }}",
+					},
+				}
+				Expect(aggregate.CentralPrometheusRules(seedIsGarden)).To(HaveExactElements(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"TypeMeta":   MatchFields(IgnoreExtras, Fields{"APIVersion": Equal("monitoring.coreos.com/v1"), "Kind": Equal("PrometheusRule")}),
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("metering-stateful")}),
+					})),
+					Equal(&monitoringv1.PrometheusRule{
+						ObjectMeta: metav1.ObjectMeta{Name: "seed"},
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{{
+								Name:  "seed.rules",
+								Rules: append(rules, vpaRule),
+							}},
+						},
+					}),
+				))
+			})
 		})
 	})
 })

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -323,3 +323,16 @@ spec:
         description: >-
           The seed cluster {{$labels.name}} in {{$externalLabels.landscape}}
           has a failing condition: {{$labels.condition}}.
+
+    - alert: SeedVerticalPodAutoscalerCappedRecommendation
+      expr: |
+          count(
+            count by (seed) (ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="seed", alertstate="firing"})
+          )
+      annotations:
+        summary: >-
+          A VPA recommendation in a seed is capped.
+        description: >-
+          There are {{ .Value }} seeds in {{ $externalLabels.landscape }} with a VPA that shows
+          an uncapped target recommendation larger than the regular target recommendation. Query
+          for this alert in the garden Prometheus for more details.

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
@@ -111,3 +111,16 @@ spec:
         description: >-
           The seed cluster: {{$labels.project}}/{{$labels.name}} has a filesystem mounted at {{ $labels.mountpoint }}
           on node {{ $labels.node }} that has only {{ printf "%.2f" $value }}% available inodes left.
+
+    - alert: ShootVerticalPodAutoscalerCappedRecommendation
+      expr: |
+          count(
+            count by (cluster) (ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="shoot", alertstate="firing"})
+          )
+      annotations:
+        summary: >-
+          A VPA recommendation in a shoot is capped.
+        description: >-
+          There are {{ .Value }} shoots in {{ $externalLabels.landscape }} with a VPA that shows
+          an uncapped target recommendation larger than the regular target recommendation. Query
+          for this alert in the garden Prometheus for more details.

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
@@ -219,6 +219,23 @@ func gardenPrometheusRule(isGardenerDiscoveryServerEnabled bool) *monitoringv1.P
 					"{{$externalLabels.landscape}} has not been scraped for 10 minutes.",
 			},
 		},
+		{
+			Alert: "VerticalPodAutoscalerCappedRecommendation",
+			Expr: intstr.FromString(`
+count(
+  count by (verticalpodautoscaler) (
+      {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
+    >
+      {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}
+  )
+)`),
+			Annotations: map[string]string{
+				"summary": "A VPA recommendation in the garden cluster is capped.",
+				"description": "There are {{ .Value }} VPAs in the garden cluster from {{ $externalLabels.landscape }} " +
+					"that show an uncapped target recommendation larger than the regular target recommendation. " +
+					"Query for this alert in the garden Prometheus for more details.",
+			},
+		},
 	}
 
 	if isGardenerDiscoveryServerEnabled {

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules_test.go
@@ -52,6 +52,7 @@ var _ = ginkgo.Describe("PrometheusRules", func() {
 
 			test.PrometheusRule(metering, "testdata/metering-meta.prometheusrule.test.yaml")
 			test.PrometheusRule(seed, "testdata/seed.prometheusrule.test.yaml")
+			test.PrometheusRule(shoot, "testdata/shoot.prometheusrule.test.yaml")
 			test.PrometheusRule(etcd, "testdata/etcd.prometheusrule.test.yaml")
 		},
 			ginkgo.Entry("when gardener discovery server is enabled", true),

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -154,3 +154,57 @@ tests:
               description: >-
                 The seed cluster seed-four in landscape-unit-tests
                 has a failing condition: APIServerUnavailable.
+
+  - name: SeedVerticalPodAutoscalerCappedRecommendation
+    interval: 1m
+    input_series:
+      - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
+                       type                  = "seed",
+                       alertstate            = "firing",
+                       verticalpodautoscaler = "vpa-unit-tests",
+                       namespace             = "ns-unit-tests",
+                       seed                  = "seed-unit-tests",
+                       unit                  = "core",
+                       container             = "container-unit-tests"}
+        values: "1"
+      - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
+                       type                  = "seed",
+                       alertstate            = "firing",
+                       verticalpodautoscaler = "vpa-unit-tests",
+                       namespace             = "ns-unit-tests",
+                       seed                  = "seed-unit-tests",
+                       unit                  = "byte",
+                       container             = "container-unit-tests"}
+        values: "1"
+      - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
+                       type                  = "seed",
+                       alertstate            = "firing",
+                       verticalpodautoscaler = "vpa-unit-tests",
+                       namespace             = "ns-unit-tests",
+                       seed                  = "seed-unit-tests-2",
+                       unit                  = "core",
+                       container             = "container-unit-tests"}
+        values: "1"
+      - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
+                       type                  = "seed",
+                       alertstate            = "firing",
+                       verticalpodautoscaler = "vpa-unit-tests",
+                       namespace             = "ns-unit-tests",
+                       seed                  = "seed-unit-tests-2",
+                       unit                  = "byte",
+                       container             = "container-unit-tests"}
+        values: "1"
+    external_labels:
+      landscape: landscape-unit-tests
+    alert_rule_test:
+    - alertname: SeedVerticalPodAutoscalerCappedRecommendation
+      eval_time: 0m # test the alert fires immediately
+      exp_alerts:
+        - exp_labels:
+          exp_annotations:
+            summary: >-
+              A VPA recommendation in a seed is capped.
+            description: >-
+              There are 2 seeds in landscape-unit-tests with a VPA that shows an uncapped
+              target recommendation larger than the regular target recommendation. Query
+              for this alert in the garden Prometheus for more details.

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/shoot.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/shoot.prometheusrule.test.yaml
@@ -1,0 +1,62 @@
+rule_files:
+- shoot.prometheusrule.yaml
+
+tests:
+
+  - name: ShootVerticalPodAutoscalerCappedRecommendation
+    interval: 1m
+    input_series:
+      - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
+                       type                  = "shoot",
+                       alertstate            = "firing",
+                       verticalpodautoscaler = "vpa-unit-tests",
+                       namespace             = "ns-unit-tests",
+                       cluster               = "cluster-unit-tests",
+                       unit                  = "core",
+                       container             = "container-unit-tests",
+                       seed                  = "seed-unit-tests"}
+        values: "1"
+      - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
+                       type                  = "shoot",
+                       alertstate            = "firing",
+                       verticalpodautoscaler = "vpa-unit-tests",
+                       namespace             = "ns-unit-tests",
+                       cluster               = "cluster-unit-tests",
+                       unit                  = "byte",
+                       container             = "container-unit-tests",
+                       seed                  = "seed-unit-tests"}
+        values: "1"
+      - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
+                       type                  = "shoot",
+                       alertstate            = "firing",
+                       verticalpodautoscaler = "vpa-unit-tests",
+                       namespace             = "ns-unit-tests",
+                       cluster               = "cluster-unit-tests-2",
+                       unit                  = "core",
+                       container             = "container-unit-tests",
+                       seed                  = "seed-unit-tests"}
+        values: "1"
+      - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
+                       type                  = "shoot",
+                       alertstate            = "firing",
+                       verticalpodautoscaler = "vpa-unit-tests",
+                       namespace             = "ns-unit-tests",
+                       cluster               = "cluster-unit-tests-2",
+                       unit                  = "byte",
+                       container             = "container-unit-tests",
+                       seed                  = "seed-unit-tests"}
+        values: "1"
+    external_labels:
+      landscape: landscape-unit-tests
+    alert_rule_test:
+    - alertname: ShootVerticalPodAutoscalerCappedRecommendation
+      eval_time: 0m # test the alert fires immediately
+      exp_alerts:
+        - exp_labels:
+          exp_annotations:
+            summary: >-
+              A VPA recommendation in a shoot is capped.
+            description: >-
+              There are 2 shoots in landscape-unit-tests with a VPA that shows an uncapped
+              target recommendation larger than the regular target recommendation. Query
+              for this alert in the garden Prometheus for more details.

--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: verticalpodautoscaler
+spec:
+  groups:
+  - name: verticalpodautoscaler.rules
+    rules:
+    - alert: VerticalPodAutoscalerCappedRecommendation
+      expr: |2-
+          {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
+        >
+          {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}
+      labels:
+        severity: warning
+        type: shoot
+        visibility: operator
+      annotations:
+        summary: A VPA recommendation in a shoot is capped.
+        description: |-
+          The following VPA from a shoot shows a
+          {{- if eq .Labels.unit "core" }} CPU {{ else if eq .Labels.unit "byte" }} memory {{ end -}}
+          uncapped target recommendation larger than the regular target recommendation:
+          - cluster = {{ $externalLabels.cluster }}
+          - namespace = {{ $labels.namespace }}
+          - vpa = {{ $labels.verticalpodautoscaler }}
+          - container = {{ $labels.container }}

--- a/pkg/component/observability/monitoring/prometheus/shoot/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/prometheusrules.go
@@ -19,6 +19,9 @@ var (
 	//go:embed assets/prometheusrules/prometheus.yaml
 	prometheusYAML []byte
 	prometheus     *monitoringv1.PrometheusRule
+	//go:embed assets/prometheusrules/verticalpodautoscaler.yaml
+	vpaYAML []byte
+	vpa     *monitoringv1.PrometheusRule
 
 	// optional rules
 	//go:embed assets/prometheusrules/optional/alertmanager.yaml
@@ -49,6 +52,8 @@ func init() {
 	// general rules
 	prometheus = &monitoringv1.PrometheusRule{}
 	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, prometheusYAML, prometheus))
+	vpa = &monitoringv1.PrometheusRule{}
+	utilruntime.Must(runtime.DecodeInto(monitoringutils.Decoder, vpaYAML, vpa))
 
 	// optional rules
 	alertManager = &monitoringv1.PrometheusRule{}
@@ -71,7 +76,10 @@ func init() {
 
 // CentralPrometheusRules returns the central PrometheusRule resources for the shoot prometheus.
 func CentralPrometheusRules(isWorkerless, wantsAlertmanager bool) []*monitoringv1.PrometheusRule {
-	out := []*monitoringv1.PrometheusRule{prometheus.DeepCopy()}
+	out := []*monitoringv1.PrometheusRule{
+		prometheus.DeepCopy(),
+		vpa.DeepCopy(),
+	}
 
 	if isWorkerless {
 		out = append(out, workerlessKubePods.DeepCopy(), workerlessNetworking.DeepCopy())

--- a/pkg/component/observability/monitoring/prometheus/shoot/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/prometheusrules_test.go
@@ -28,14 +28,15 @@ var _ = ginkgo.Describe("PrometheusRules", func() {
 				Expect(CentralPrometheusRules(isWorkerless, wantsAlertmanager)).To(HaveExactElements(matchers...))
 			},
 
-			ginkgo.Entry("workerless, w/o alertmanager", true, false, []string{"prometheus", "kube-pods", "networking"}),
-			ginkgo.Entry("workerless, w/ alertmanager", true, true, []string{"prometheus", "kube-pods", "networking", "alertmanager"}),
-			ginkgo.Entry("w/ workers, w/o alertmanager", false, false, []string{"prometheus", "kube-kubelet", "kube-pods", "networking"}),
-			ginkgo.Entry("w/ workers, w/ alertmanager", false, true, []string{"prometheus", "kube-kubelet", "kube-pods", "networking", "alertmanager"}),
+			ginkgo.Entry("workerless, w/o alertmanager", true, false, []string{"prometheus", "verticalpodautoscaler", "kube-pods", "networking"}),
+			ginkgo.Entry("workerless, w/ alertmanager", true, true, []string{"prometheus", "verticalpodautoscaler", "kube-pods", "networking", "alertmanager"}),
+			ginkgo.Entry("w/ workers, w/o alertmanager", false, false, []string{"prometheus", "verticalpodautoscaler", "kube-kubelet", "kube-pods", "networking"}),
+			ginkgo.Entry("w/ workers, w/ alertmanager", false, true, []string{"prometheus", "verticalpodautoscaler", "kube-kubelet", "kube-pods", "networking", "alertmanager"}),
 		)
 
 		ginkgo.It("should run the rules tests", func() {
 			test.PrometheusRule(prometheus, "testdata/prometheus.prometheusrule.test.yaml")
+			test.PrometheusRule(vpa, "testdata/verticalpodautoscaler.prometheusrule.test.yaml")
 			test.PrometheusRule(workerKubeKubelet, "testdata/worker/kube-kubelet.prometheusrule.test.yaml")
 			test.PrometheusRule(workerKubePods, "testdata/worker/kube-pods.prometheusrule.test.yaml")
 		})

--- a/pkg/component/observability/monitoring/prometheus/shoot/testdata/verticalpodautoscaler.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/testdata/verticalpodautoscaler.prometheusrule.test.yaml
@@ -1,0 +1,65 @@
+rule_files:
+- verticalpodautoscaler.prometheusrule.yaml
+
+tests:
+- name: VerticalPodAutoscalerCappedRecommendation
+  interval: 1m
+  input_series:
+  - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_cpu{verticalpodautoscaler = "vpa-test",
+                                                                                                                        namespace             = "namespace-test",
+                                                                                                                        container             = "container-test",
+                                                                                                                        unit                  = "core"}
+    values: "2"
+  - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{verticalpodautoscaler = "vpa-test",
+                                                                                                                namespace             = "namespace-test",
+                                                                                                                container             = "container-test",
+                                                                                                                unit                  = "core"}
+    values: "1"
+  - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_memory{verticalpodautoscaler = "vpa-test",
+                                                                                                                           namespace             = "namespace-test",
+                                                                                                                           container             = "container-test",
+                                                                                                                           unit                  = "byte"}
+    values: "2"
+  - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{verticalpodautoscaler = "vpa-test",
+                                                                                                                   namespace             = "namespace-test",
+                                                                                                                   container             = "container-test",
+                                                                                                                   unit                  = "byte"}
+    values: "1"
+  external_labels:
+    cluster: cluster-test
+  alert_rule_test:
+  - eval_time: 0m # test the alert fires immediately
+    alertname: VerticalPodAutoscalerCappedRecommendation
+    exp_alerts:
+    - exp_labels:
+        verticalpodautoscaler: vpa-test
+        namespace: namespace-test
+        container: container-test
+        unit: core
+        type: shoot
+        visibility: operator
+        severity: warning
+      exp_annotations:
+        summary: A VPA recommendation in a shoot is capped.
+        description: |-
+          The following VPA from a shoot shows a CPU uncapped target recommendation larger than the regular target recommendation:
+          - cluster = cluster-test
+          - namespace = namespace-test
+          - vpa = vpa-test
+          - container = container-test
+    - exp_labels:
+        verticalpodautoscaler: vpa-test
+        namespace: namespace-test
+        container: container-test
+        unit: byte
+        type: shoot
+        visibility: operator
+        severity: warning
+      exp_annotations:
+        summary: A VPA recommendation in a shoot is capped.
+        description: |-
+          The following VPA from a shoot shows a memory uncapped target recommendation larger than the regular target recommendation:
+          - cluster = cluster-test
+          - namespace = namespace-test
+          - vpa = vpa-test
+          - container = container-test

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -223,7 +223,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.aggregatePrometheus, err = r.newAggregatePrometheus(log, seed, secretsManager, globalMonitoringSecretSeed, wildCardCertSecret, alertingSMTPSecret)
+	c.aggregatePrometheus, err = r.newAggregatePrometheus(log, seed, seedIsGarden, secretsManager, globalMonitoringSecretSeed, wildCardCertSecret, alertingSMTPSecret)
 	if err != nil {
 		return
 	}
@@ -577,7 +577,7 @@ func (r *Reconciler) newSeedPrometheus(log logr.Logger, seed *seedpkg.Seed) (com
 	})
 }
 
-func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed, secretsManager secretsmanager.Interface, globalMonitoringSecret, wildcardCertSecret, alertingSMTPSecret *corev1.Secret) (component.DeployWaiter, error) {
+func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed, seedIsGarden bool, secretsManager secretsmanager.Interface, globalMonitoringSecret, wildcardCertSecret, alertingSMTPSecret *corev1.Secret) (component.DeployWaiter, error) {
 	values := prometheus.Values{
 		Name:              "aggregate",
 		PriorityClassName: v1beta1constants.PriorityClassNameSeedSystem600,
@@ -588,7 +588,7 @@ func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed,
 		ExternalLabels:    map[string]string{"seed": seed.GetInfo().Name},
 		VPAMinAllowed:     &corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1000M")},
 		CentralConfigs: prometheus.CentralConfigs{
-			PrometheusRules: aggregateprometheus.CentralPrometheusRules(),
+			PrometheusRules: aggregateprometheus.CentralPrometheusRules(seedIsGarden),
 			ScrapeConfigs:   aggregateprometheus.CentralScrapeConfigs(),
 			ServiceMonitors: aggregateprometheus.CentralServiceMonitors(),
 		},

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -176,8 +176,8 @@ build:
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml
-            - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machines.yaml
+            - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
             - pkg/component/observability/logging/vali/constants
             - pkg/component/observability/monitoring/alertmanager
             - pkg/component/observability/monitoring/prometheus/shoot
@@ -185,9 +185,9 @@ build:
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/networking.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
             - pkg/component/observability/monitoring/utils
             - pkg/controller/service
             - pkg/controllerutils

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -183,6 +183,7 @@ build:
             - pkg/component/observability/monitoring/prometheus/shoot
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -196,6 +196,7 @@ build:
             - pkg/component/observability/monitoring/prometheus/shoot
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
@@ -1085,6 +1086,7 @@ build:
             - pkg/component/observability/monitoring/prometheus/shoot
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -113,6 +113,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/utils
+            - pkg/component/garden/system/runtime
+            - pkg/component/garden/system/virtual
             - pkg/component/gardener/access
             - pkg/component/gardener/admissioncontroller
             - pkg/component/gardener/apiserver
@@ -126,8 +128,6 @@ build:
             - pkg/component/gardener/resourcemanager/assets/crd-resources.gardener.cloud_managedresources.yaml
             - pkg/component/gardener/resourcemanager/constants
             - pkg/component/gardener/scheduler
-            - pkg/component/garden/system/runtime
-            - pkg/component/garden/system/virtual
             - pkg/component/kubernetes/apiserver
             - pkg/component/kubernetes/apiserver/constants
             - pkg/component/kubernetes/apiserverexposure
@@ -192,6 +192,15 @@ build:
             - pkg/component/observability/monitoring/prometheus/longterm
             - pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/recording.yaml
             - pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/sla.yaml
+            - pkg/component/observability/monitoring/prometheus/seed
+            - pkg/component/observability/monitoring/prometheus/shoot
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/networking.yaml
             - pkg/component/observability/monitoring/prometheusoperator
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_alertmanagerconfigs.yaml
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_alertmanagers.yaml
@@ -203,15 +212,6 @@ build:
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_scrapeconfigs.yaml
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_servicemonitors.yaml
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_thanosrulers.yaml
-            - pkg/component/observability/monitoring/prometheus/seed
-            - pkg/component/observability/monitoring/prometheus/shoot
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/networking.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
             - pkg/component/observability/monitoring/utils
             - pkg/component/observability/plutono
             - pkg/component/observability/plutono/dashboards/common
@@ -221,19 +221,19 @@ build:
             - pkg/component/observability/plutono/dashboards/shoot
             - pkg/component/shared
             - pkg/controller/gardenletdeployer
-            - pkg/controllermanager/apis/config
-            - pkg/controllermanager/apis/config/v1alpha1
             - pkg/controller/networkpolicy
             - pkg/controller/networkpolicy/helper
             - pkg/controller/networkpolicy/hostnameresolver
             - pkg/controller/reference
             - pkg/controller/service
+            - pkg/controller/vpaevictionrequirements
+            - pkg/controllermanager/apis/config
+            - pkg/controllermanager/apis/config/v1alpha1
             - pkg/controllerutils
             - pkg/controllerutils/mapper
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/controllerutils/routes
-            - pkg/controller/vpaevictionrequirements
             - pkg/extensions
             - pkg/features
             - pkg/gardenlet/apis/config
@@ -258,8 +258,8 @@ build:
             - pkg/operator/controller/garden
             - pkg/operator/controller/garden/care
             - pkg/operator/controller/garden/garden
-            - pkg/operator/controller/gardenlet
             - pkg/operator/controller/garden/reference
+            - pkg/operator/controller/gardenlet
             - pkg/operator/controller/virtual
             - pkg/operator/controller/virtual/access
             - pkg/operator/controller/virtual/cluster
@@ -458,6 +458,32 @@ build:
             - pkg/apis/core/v1beta1/constants
             - pkg/apis/core/v1beta1/helper
             - pkg/apis/core/validation
+            - pkg/apis/extensions
+            - pkg/apis/extensions/v1alpha1
+            - pkg/apis/operations
+            - pkg/apis/operations/install
+            - pkg/apis/operations/v1alpha1
+            - pkg/apis/operations/validation
+            - pkg/apis/operator
+            - pkg/apis/operator/v1alpha1
+            - pkg/apis/resources
+            - pkg/apis/resources/v1alpha1
+            - pkg/apis/security
+            - pkg/apis/security/install
+            - pkg/apis/security/v1alpha1
+            - pkg/apis/security/v1alpha1/constants
+            - pkg/apis/security/validation
+            - pkg/apis/seedmanagement
+            - pkg/apis/seedmanagement/encoding
+            - pkg/apis/seedmanagement/helper
+            - pkg/apis/seedmanagement/install
+            - pkg/apis/seedmanagement/v1alpha1
+            - pkg/apis/seedmanagement/v1alpha1/helper
+            - pkg/apis/seedmanagement/validation
+            - pkg/apis/settings
+            - pkg/apis/settings/install
+            - pkg/apis/settings/v1alpha1
+            - pkg/apis/settings/validation
             - pkg/apiserver
             - pkg/apiserver/admission/initializer
             - pkg/apiserver/features
@@ -490,9 +516,9 @@ build:
             - pkg/apiserver/registry/core/seed
             - pkg/apiserver/registry/core/seed/storage
             - pkg/apiserver/registry/core/shoot
+            - pkg/apiserver/registry/core/shoot/storage
             - pkg/apiserver/registry/core/shootstate
             - pkg/apiserver/registry/core/shootstate/storage
-            - pkg/apiserver/registry/core/shoot/storage
             - pkg/apiserver/registry/operations/bastion
             - pkg/apiserver/registry/operations/bastion/storage
             - pkg/apiserver/registry/operations/rest
@@ -504,9 +530,9 @@ build:
             - pkg/apiserver/registry/seedmanagement/gardenlet
             - pkg/apiserver/registry/seedmanagement/gardenlet/storage
             - pkg/apiserver/registry/seedmanagement/managedseed
+            - pkg/apiserver/registry/seedmanagement/managedseed/storage
             - pkg/apiserver/registry/seedmanagement/managedseedset
             - pkg/apiserver/registry/seedmanagement/managedseedset/storage
-            - pkg/apiserver/registry/seedmanagement/managedseed/storage
             - pkg/apiserver/registry/seedmanagement/rest
             - pkg/apiserver/registry/settings/clusteropenidconnectpreset
             - pkg/apiserver/registry/settings/clusteropenidconnectpreset/storage
@@ -514,32 +540,6 @@ build:
             - pkg/apiserver/registry/settings/openidconnectpreset/storage
             - pkg/apiserver/registry/settings/rest
             - pkg/apiserver/storage
-            - pkg/apis/extensions
-            - pkg/apis/extensions/v1alpha1
-            - pkg/apis/operations
-            - pkg/apis/operations/install
-            - pkg/apis/operations/v1alpha1
-            - pkg/apis/operations/validation
-            - pkg/apis/operator
-            - pkg/apis/operator/v1alpha1
-            - pkg/apis/resources
-            - pkg/apis/resources/v1alpha1
-            - pkg/apis/security
-            - pkg/apis/security/install
-            - pkg/apis/security/v1alpha1
-            - pkg/apis/security/v1alpha1/constants
-            - pkg/apis/security/validation
-            - pkg/apis/seedmanagement
-            - pkg/apis/seedmanagement/encoding
-            - pkg/apis/seedmanagement/helper
-            - pkg/apis/seedmanagement/install
-            - pkg/apis/seedmanagement/v1alpha1
-            - pkg/apis/seedmanagement/v1alpha1/helper
-            - pkg/apis/seedmanagement/validation
-            - pkg/apis/settings
-            - pkg/apis/settings/install
-            - pkg/apis/settings/v1alpha1
-            - pkg/apis/settings/validation
             - pkg/chartrenderer
             - pkg/client/core/clientset/versioned
             - pkg/client/core/clientset/versioned/scheme
@@ -694,6 +694,7 @@ build:
             - pkg/client/kubernetes/cache
             - pkg/component
             - pkg/component/garden/projectrbac
+            - pkg/controller/reference
             - pkg/controllermanager/apis/config
             - pkg/controllermanager/apis/config/v1alpha1
             - pkg/controllermanager/apis/config/validation
@@ -733,7 +734,6 @@ build:
             - pkg/controllermanager/controller/shoot/retry
             - pkg/controllermanager/controller/shoot/statuslabel
             - pkg/controllermanager/features
-            - pkg/controller/reference
             - pkg/controllerutils
             - pkg/controllerutils/mapper
             - pkg/controllerutils/predicate
@@ -1078,8 +1078,8 @@ build:
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml
-            - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machines.yaml
+            - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
             - pkg/component/observability/logging/vali/constants
             - pkg/component/observability/monitoring/alertmanager
             - pkg/component/observability/monitoring/prometheus/shoot
@@ -1087,9 +1087,9 @@ build:
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/networking.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
             - pkg/component/observability/monitoring/utils
             - pkg/controller/service
             - pkg/controllerutils

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -726,6 +726,7 @@ build:
             - pkg/component/observability/monitoring/prometheus/shoot
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
@@ -1160,6 +1161,7 @@ build:
             - pkg/component/observability/monitoring/prometheus/shoot
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -56,6 +56,32 @@ build:
             - pkg/apis/core/v1beta1/constants
             - pkg/apis/core/v1beta1/helper
             - pkg/apis/core/validation
+            - pkg/apis/extensions
+            - pkg/apis/extensions/v1alpha1
+            - pkg/apis/operations
+            - pkg/apis/operations/install
+            - pkg/apis/operations/v1alpha1
+            - pkg/apis/operations/validation
+            - pkg/apis/operator
+            - pkg/apis/operator/v1alpha1
+            - pkg/apis/resources
+            - pkg/apis/resources/v1alpha1
+            - pkg/apis/security
+            - pkg/apis/security/install
+            - pkg/apis/security/v1alpha1
+            - pkg/apis/security/v1alpha1/constants
+            - pkg/apis/security/validation
+            - pkg/apis/seedmanagement
+            - pkg/apis/seedmanagement/encoding
+            - pkg/apis/seedmanagement/helper
+            - pkg/apis/seedmanagement/install
+            - pkg/apis/seedmanagement/v1alpha1
+            - pkg/apis/seedmanagement/v1alpha1/helper
+            - pkg/apis/seedmanagement/validation
+            - pkg/apis/settings
+            - pkg/apis/settings/install
+            - pkg/apis/settings/v1alpha1
+            - pkg/apis/settings/validation
             - pkg/apiserver
             - pkg/apiserver/admission/initializer
             - pkg/apiserver/features
@@ -88,9 +114,9 @@ build:
             - pkg/apiserver/registry/core/seed
             - pkg/apiserver/registry/core/seed/storage
             - pkg/apiserver/registry/core/shoot
+            - pkg/apiserver/registry/core/shoot/storage
             - pkg/apiserver/registry/core/shootstate
             - pkg/apiserver/registry/core/shootstate/storage
-            - pkg/apiserver/registry/core/shoot/storage
             - pkg/apiserver/registry/operations/bastion
             - pkg/apiserver/registry/operations/bastion/storage
             - pkg/apiserver/registry/operations/rest
@@ -102,9 +128,9 @@ build:
             - pkg/apiserver/registry/seedmanagement/gardenlet
             - pkg/apiserver/registry/seedmanagement/gardenlet/storage
             - pkg/apiserver/registry/seedmanagement/managedseed
+            - pkg/apiserver/registry/seedmanagement/managedseed/storage
             - pkg/apiserver/registry/seedmanagement/managedseedset
             - pkg/apiserver/registry/seedmanagement/managedseedset/storage
-            - pkg/apiserver/registry/seedmanagement/managedseed/storage
             - pkg/apiserver/registry/seedmanagement/rest
             - pkg/apiserver/registry/settings/clusteropenidconnectpreset
             - pkg/apiserver/registry/settings/clusteropenidconnectpreset/storage
@@ -112,32 +138,6 @@ build:
             - pkg/apiserver/registry/settings/openidconnectpreset/storage
             - pkg/apiserver/registry/settings/rest
             - pkg/apiserver/storage
-            - pkg/apis/extensions
-            - pkg/apis/extensions/v1alpha1
-            - pkg/apis/operations
-            - pkg/apis/operations/install
-            - pkg/apis/operations/v1alpha1
-            - pkg/apis/operations/validation
-            - pkg/apis/operator
-            - pkg/apis/operator/v1alpha1
-            - pkg/apis/resources
-            - pkg/apis/resources/v1alpha1
-            - pkg/apis/security
-            - pkg/apis/security/install
-            - pkg/apis/security/v1alpha1
-            - pkg/apis/security/v1alpha1/constants
-            - pkg/apis/security/validation
-            - pkg/apis/seedmanagement
-            - pkg/apis/seedmanagement/encoding
-            - pkg/apis/seedmanagement/helper
-            - pkg/apis/seedmanagement/install
-            - pkg/apis/seedmanagement/v1alpha1
-            - pkg/apis/seedmanagement/v1alpha1/helper
-            - pkg/apis/seedmanagement/validation
-            - pkg/apis/settings
-            - pkg/apis/settings/install
-            - pkg/apis/settings/v1alpha1
-            - pkg/apis/settings/validation
             - pkg/chartrenderer
             - pkg/client/core/clientset/versioned
             - pkg/client/core/clientset/versioned/scheme
@@ -292,6 +292,7 @@ build:
             - pkg/client/kubernetes/cache
             - pkg/component
             - pkg/component/garden/projectrbac
+            - pkg/controller/reference
             - pkg/controllermanager/apis/config
             - pkg/controllermanager/apis/config/v1alpha1
             - pkg/controllermanager/apis/config/validation
@@ -331,7 +332,6 @@ build:
             - pkg/controllermanager/controller/shoot/retry
             - pkg/controllermanager/controller/shoot/statuslabel
             - pkg/controllermanager/features
-            - pkg/controller/reference
             - pkg/controllerutils
             - pkg/controllerutils/mapper
             - pkg/controllerutils/predicate
@@ -719,8 +719,8 @@ build:
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml
-            - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machines.yaml
+            - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
             - pkg/component/observability/logging/vali/constants
             - pkg/component/observability/monitoring/alertmanager
             - pkg/component/observability/monitoring/prometheus/shoot
@@ -728,9 +728,9 @@ build:
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
             - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/networking.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
             - pkg/component/observability/monitoring/utils
             - pkg/controller/service
             - pkg/controllerutils
@@ -1104,8 +1104,8 @@ build:
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml
-            - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machines.yaml
+            - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
             - pkg/component/nodemanagement/nodeproblemdetector
             - pkg/component/observability/logging
             - pkg/component/observability/logging/eventlogger
@@ -1156,6 +1156,15 @@ build:
             - pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
             - pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
             - pkg/component/observability/monitoring/prometheus/garden/assets/scrapeconfigs/cadvisor.yaml
+            - pkg/component/observability/monitoring/prometheus/seed
+            - pkg/component/observability/monitoring/prometheus/shoot
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
+            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/networking.yaml
             - pkg/component/observability/monitoring/prometheusoperator
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_alertmanagerconfigs.yaml
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_alertmanagers.yaml
@@ -1167,15 +1176,6 @@ build:
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_scrapeconfigs.yaml
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_servicemonitors.yaml
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_thanosrulers.yaml
-            - pkg/component/observability/monitoring/prometheus/seed
-            - pkg/component/observability/monitoring/prometheus/shoot
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/optional/alertmanager.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/prometheus.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-kubelet.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/networking.yaml
-            - pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/networking.yaml
             - pkg/component/observability/monitoring/utils
             - pkg/component/observability/plutono
             - pkg/component/observability/plutono/dashboards/common
@@ -1192,12 +1192,12 @@ build:
             - pkg/controller/networkpolicy/helper
             - pkg/controller/networkpolicy/hostnameresolver
             - pkg/controller/tokenrequestor
+            - pkg/controller/vpaevictionrequirements
             - pkg/controllerutils
             - pkg/controllerutils/mapper
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/controllerutils/routes
-            - pkg/controller/vpaevictionrequirements
             - pkg/extensions
             - pkg/features
             - pkg/gardenlet/apis/config


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR adds a new set of alerts that fire as soon as a VPA recommendation is capped. A capped VPA recommendation will typically occur when the target recommendation exceeds the maximum allowed. In such a situation, the VPA will show a target recommendation that matches the maximum allowed and an uncapped target recommendation with the proposed value. This approach aims at making it more visible when a container's resource usage is abnormal.

These alerts cover every VPA deployed by Gardener. These can be found in both the kube-system and control-plane namespaces of shoots, in seeds and in garden clusters. In consequence, these alerts need to be defined in the shoot, aggregate and garden Prometheus. Not only that, the alerts from the shoot and aggregate Prometheus are federated into the garden Prometheus, where they are enriched with additional labels such as the landscape and sent via the garden Alertmanager. However, the alerts sent by the garden Prometheus, including the federated ones, serve as a minimal notification that a VPA recommendation hit its cap. Once operators receive this notification, they can query the garden Prometheus to find more details. This way, we avoid alert saturation in case multiple VPA recommendations across different components, seeds and shoots are capped.

This PR deploys such alerts in the corresponding Prometheus but they are not yet processed by the Alertmanagers. First, we want to assess how frequently they trigger. Thus, there will be a follow up PR enabling them into the Alertmanagers by setting the corresponding labels.

Note that https://github.com/gardener/gardener/issues/9934 removes the `maxAllowed` property from the API server's VPA. While this change is likely to decrease the frequency of this alert triggering, we believe it is still important to assert that this condition remains true in the future. 

**Special notes for your reviewer**:

/cc @istvanballok @chrkl @rickardsjp 

**Release note**:

```other operator
Add alerts for capped VPA recommendations
```
