### PR TITLE
Fix `VPAEvictionRequirements` controller permissions

### DIFF
--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -153,6 +153,8 @@ rules:
   - get
   - list
   - watch
+  - patch
+  - update
 - apiGroups:
   - policy
   resources:

--- a/charts/gardener/operator/templates/role.yaml
+++ b/charts/gardener/operator/templates/role.yaml
@@ -55,8 +55,6 @@ rules:
   verbs:
   - create
   - delete
-  - patch
-  - update
 - apiGroups:
   - autoscaling
   resources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
In the "seed is garden" case, the `VPAEvictionRequirements` controller is responsible for shoot namespaces as well. Hence, it needs permissions to update/patch VPA resources in those namespaces.

**Special notes for your reviewer**:
/cc @voelzmo @LucaBernstein

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A permission issue was fixed that prevented the `VPAEvictionRequirements` controller to patch `VPA` resources in the garden runtime cluster, in case it is also registered as a seed.
```
