### PR TITLE
Use rand.Read for etcd key generation

### DIFF
--- a/pkg/component/apiserver/apiserver_suite_test.go
+++ b/pkg/component/apiserver/apiserver_suite_test.go
@@ -5,6 +5,7 @@
 package apiserver_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,10 @@ func TestAPIServer(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&secretsutils.GenerateRandomString, secretsutils.FakeGenerateRandomString))
+	DeferCleanup(test.WithVar(&secretsutils.Read, func(b []byte) (int, error) {
+		copy(b, []byte(strings.Repeat("_", len(b))))
+		return len(b), nil
+	}))
 	DeferCleanup(test.WithVar(&secretsutils.GenerateKey, secretsutils.FakeGenerateKey))
 	DeferCleanup(test.WithVar(&secretsutils.Clock, testclock.NewFakeClock(time.Time{})))
 })

--- a/pkg/component/apiserver/encryptionconfiguration.go
+++ b/pkg/component/apiserver/encryptionconfiguration.go
@@ -167,9 +167,16 @@ func etcdEncryptionAESKeys(keySecretCurrent, keySecretOld *corev1.Secret, encryp
 }
 
 func aesKeyFromSecretData(data map[string][]byte) apiserverconfigv1.Key {
+	var key string
+	if v, ok := data[secretsutils.DataKeyEncryptionSecretEncoding]; ok && string(v) == "none" {
+		// key is not encoded, so we need to encode it before passing it to the kube-apiserver
+		key = utils.EncodeBase64(data[secretsutils.DataKeyEncryptionSecret])
+	} else {
+		key = string(data[secretsutils.DataKeyEncryptionSecret])
+	}
 	return apiserverconfigv1.Key{
 		Name:   string(data[secretsutils.DataKeyEncryptionKeyName]),
-		Secret: string(data[secretsutils.DataKeyEncryptionSecret]),
+		Secret: key,
 	}
 }
 

--- a/pkg/component/apiserver/encryptionconfiguration_test.go
+++ b/pkg/component/apiserver/encryptionconfiguration_test.go
@@ -52,7 +52,7 @@ resources:
 - providers:
   - aescbc:
       keys:
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   - identity: {}
   resources:
@@ -113,7 +113,7 @@ resources:
 - providers:
   - aescbc:
       keys:
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   - identity: {}
   resources:
@@ -123,7 +123,7 @@ resources:
   - identity: {}
   - aescbc:
       keys:
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   resources:
   - bar
@@ -199,7 +199,7 @@ resources:
 
 				if encryptWithCurrentKey {
 					etcdEncryptionConfiguration += `
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret
@@ -207,7 +207,7 @@ resources:
 					etcdEncryptionConfiguration += `
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret + `
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=`
 				}
 

--- a/pkg/component/apiserver/encryptionconfiguration_test.go
+++ b/pkg/component/apiserver/encryptionconfiguration_test.go
@@ -52,8 +52,8 @@ resources:
 - providers:
   - aescbc:
       keys:
-      - name: key-62135596800
-        secret: ________________________________
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   - identity: {}
   resources:
   - foo
@@ -113,8 +113,8 @@ resources:
 - providers:
   - aescbc:
       keys:
-      - name: key-62135596800
-        secret: ________________________________
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   - identity: {}
   resources:
   - foo
@@ -123,8 +123,8 @@ resources:
   - identity: {}
   - aescbc:
       keys:
-      - name: key-62135596800
-        secret: ________________________________
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   resources:
   - bar
 `
@@ -199,16 +199,16 @@ resources:
 
 				if encryptWithCurrentKey {
 					etcdEncryptionConfiguration += `
-      - name: key-62135596800
-        secret: ________________________________
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret
 				} else {
 					etcdEncryptionConfiguration += `
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret + `
-      - name: key-62135596800
-        secret: ________________________________`
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=`
 				}
 
 				etcdEncryptionConfiguration += `

--- a/pkg/component/gardener/apiserver/apiserver_suite_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_suite_test.go
@@ -5,6 +5,7 @@
 package apiserver_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,10 @@ func TestAPIServer(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&secretsutils.GenerateRandomString, secretsutils.FakeGenerateRandomString))
+	DeferCleanup(test.WithVar(&secretsutils.Read, func(b []byte) (int, error) {
+		copy(b, []byte(strings.Repeat("_", len(b))))
+		return len(b), nil
+	}))
 	DeferCleanup(test.WithVar(&secretsutils.GenerateKey, secretsutils.FakeGenerateKey))
 	DeferCleanup(test.WithVar(&secretsutils.Clock, testclock.NewFakeClock(time.Time{})))
 })

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -352,7 +352,7 @@ var _ = Describe("GardenerAPIServer", func() {
 					"reference.resources.gardener.cloud/secret-47fc132b":    "gardener-apiserver-admission-kubeconfigs-e3b0c442",
 					"reference.resources.gardener.cloud/secret-389fbba5":    "etcd-client",
 					"reference.resources.gardener.cloud/secret-867d23cd":    "generic-token-kubeconfig",
-					"reference.resources.gardener.cloud/secret-e8e10ee7":    "gardener-apiserver-etcd-encryption-configuration-9c7403f0",
+					"reference.resources.gardener.cloud/secret-3af026bf":    "gardener-apiserver-etcd-encryption-configuration-fe8711ae",
 					"reference.resources.gardener.cloud/secret-3696832b":    "gardener-apiserver",
 					"reference.resources.gardener.cloud/secret-e01f5645":    "ca-etcd",
 					"reference.resources.gardener.cloud/secret-14294f8f":    "gardener-apiserver-workload-identity-signing-key-f70e59e4",
@@ -392,7 +392,7 @@ var _ = Describe("GardenerAPIServer", func() {
 							"reference.resources.gardener.cloud/secret-47fc132b":    "gardener-apiserver-admission-kubeconfigs-e3b0c442",
 							"reference.resources.gardener.cloud/secret-389fbba5":    "etcd-client",
 							"reference.resources.gardener.cloud/secret-867d23cd":    "generic-token-kubeconfig",
-							"reference.resources.gardener.cloud/secret-e8e10ee7":    "gardener-apiserver-etcd-encryption-configuration-9c7403f0",
+							"reference.resources.gardener.cloud/secret-3af026bf":    "gardener-apiserver-etcd-encryption-configuration-fe8711ae",
 							"reference.resources.gardener.cloud/secret-3696832b":    "gardener-apiserver",
 							"reference.resources.gardener.cloud/secret-e01f5645":    "ca-etcd",
 							"reference.resources.gardener.cloud/secret-14294f8f":    "gardener-apiserver-workload-identity-signing-key-f70e59e4",
@@ -583,7 +583,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								Name: "etcd-encryption-secret",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName:  "gardener-apiserver-etcd-encryption-configuration-9c7403f0",
+										SecretName:  "gardener-apiserver-etcd-encryption-configuration-fe8711ae",
 										DefaultMode: ptr.To[int32](0640),
 									},
 								},
@@ -788,7 +788,7 @@ resources:
 - providers:
   - aescbc:
       keys:
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   - identity: {}
   resources:
@@ -870,7 +870,7 @@ resources:
 
 							if encryptWithCurrentKey {
 								etcdEncryptionConfiguration += `
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret
@@ -878,7 +878,7 @@ resources:
 								etcdEncryptionConfiguration += `
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret + `
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=`
 							}
 

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -352,7 +352,7 @@ var _ = Describe("GardenerAPIServer", func() {
 					"reference.resources.gardener.cloud/secret-47fc132b":    "gardener-apiserver-admission-kubeconfigs-e3b0c442",
 					"reference.resources.gardener.cloud/secret-389fbba5":    "etcd-client",
 					"reference.resources.gardener.cloud/secret-867d23cd":    "generic-token-kubeconfig",
-					"reference.resources.gardener.cloud/secret-02452d55":    "gardener-apiserver-etcd-encryption-configuration-944a649a",
+					"reference.resources.gardener.cloud/secret-e8e10ee7":    "gardener-apiserver-etcd-encryption-configuration-9c7403f0",
 					"reference.resources.gardener.cloud/secret-3696832b":    "gardener-apiserver",
 					"reference.resources.gardener.cloud/secret-e01f5645":    "ca-etcd",
 					"reference.resources.gardener.cloud/secret-14294f8f":    "gardener-apiserver-workload-identity-signing-key-f70e59e4",
@@ -392,7 +392,7 @@ var _ = Describe("GardenerAPIServer", func() {
 							"reference.resources.gardener.cloud/secret-47fc132b":    "gardener-apiserver-admission-kubeconfigs-e3b0c442",
 							"reference.resources.gardener.cloud/secret-389fbba5":    "etcd-client",
 							"reference.resources.gardener.cloud/secret-867d23cd":    "generic-token-kubeconfig",
-							"reference.resources.gardener.cloud/secret-02452d55":    "gardener-apiserver-etcd-encryption-configuration-944a649a",
+							"reference.resources.gardener.cloud/secret-e8e10ee7":    "gardener-apiserver-etcd-encryption-configuration-9c7403f0",
 							"reference.resources.gardener.cloud/secret-3696832b":    "gardener-apiserver",
 							"reference.resources.gardener.cloud/secret-e01f5645":    "ca-etcd",
 							"reference.resources.gardener.cloud/secret-14294f8f":    "gardener-apiserver-workload-identity-signing-key-f70e59e4",
@@ -583,7 +583,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								Name: "etcd-encryption-secret",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName:  "gardener-apiserver-etcd-encryption-configuration-944a649a",
+										SecretName:  "gardener-apiserver-etcd-encryption-configuration-9c7403f0",
 										DefaultMode: ptr.To[int32](0640),
 									},
 								},
@@ -788,8 +788,8 @@ resources:
 - providers:
   - aescbc:
       keys:
-      - name: key-62135596800
-        secret: ________________________________
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   - identity: {}
   resources:
   - shootstates.core.gardener.cloud
@@ -870,16 +870,16 @@ resources:
 
 							if encryptWithCurrentKey {
 								etcdEncryptionConfiguration += `
-      - name: key-62135596800
-        secret: ________________________________
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret
 							} else {
 								etcdEncryptionConfiguration += `
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret + `
-      - name: key-62135596800
-        secret: ________________________________`
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=`
 							}
 
 							etcdEncryptionConfiguration += `

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -104,7 +104,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 		configMapNameAdmissionConfigs  = "kube-apiserver-admission-config-e38ff146"
 		secretNameAdmissionKubeconfigs = "kube-apiserver-admission-kubeconfigs-e3b0c442"
-		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-e9fa6fda"
+		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-b2b49c90"
 		configMapNameAuditPolicy       = "audit-policy-config-f5b578b4"
 		configMapNameEgressPolicy      = "kube-apiserver-egress-selector-config-53d92abc"
 
@@ -1088,7 +1088,7 @@ resources:
 - providers:
   - aescbc:
       keys:
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   - identity: {}
   resources:
@@ -1171,7 +1171,7 @@ resources:
 
 					if encryptWithCurrentKey {
 						etcdEncryptionConfiguration += `
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret
@@ -1179,7 +1179,7 @@ resources:
 						etcdEncryptionConfiguration += `
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret + `
-      - name: key-62135596800-0ebe2f
+      - name: key-62135596800
         secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=`
 					}
 
@@ -2397,7 +2397,7 @@ kind: AuthorizationConfiguration
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
-						"reference.resources.gardener.cloud/secret-0fe90827":    secretNameETCDEncryptionConfig,
+						"reference.resources.gardener.cloud/secret-c4700ce9":    secretNameETCDEncryptionConfig,
 						"reference.resources.gardener.cloud/configmap-130aa219": configMapNameAdmissionConfigs,
 						"reference.resources.gardener.cloud/secret-5613e39f":    secretNameAdmissionKubeconfigs,
 						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
@@ -2586,7 +2586,7 @@ kind: AuthorizationConfiguration
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
-						"reference.resources.gardener.cloud/secret-0fe90827":    secretNameETCDEncryptionConfig,
+						"reference.resources.gardener.cloud/secret-c4700ce9":    secretNameETCDEncryptionConfig,
 						"reference.resources.gardener.cloud/configmap-130aa219": configMapNameAdmissionConfigs,
 						"reference.resources.gardener.cloud/secret-5613e39f":    secretNameAdmissionKubeconfigs,
 						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -104,7 +104,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 		configMapNameAdmissionConfigs  = "kube-apiserver-admission-config-e38ff146"
 		secretNameAdmissionKubeconfigs = "kube-apiserver-admission-kubeconfigs-e3b0c442"
-		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-97e14df3"
+		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-e9fa6fda"
 		configMapNameAuditPolicy       = "audit-policy-config-f5b578b4"
 		configMapNameEgressPolicy      = "kube-apiserver-egress-selector-config-53d92abc"
 
@@ -1088,8 +1088,8 @@ resources:
 - providers:
   - aescbc:
       keys:
-      - name: key-62135596800
-        secret: ________________________________
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
   - identity: {}
   resources:
   - secrets
@@ -1171,16 +1171,16 @@ resources:
 
 					if encryptWithCurrentKey {
 						etcdEncryptionConfiguration += `
-      - name: key-62135596800
-        secret: ________________________________
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret
 					} else {
 						etcdEncryptionConfiguration += `
       - name: ` + oldKeyName + `
         secret: ` + oldKeySecret + `
-      - name: key-62135596800
-        secret: ________________________________`
+      - name: key-62135596800-0ebe2f
+        secret: X19fX19fX19fX19fX19fX19fX19fX19fX19fX19fX18=`
 					}
 
 					etcdEncryptionConfiguration += `
@@ -2397,7 +2397,7 @@ kind: AuthorizationConfiguration
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
-						"reference.resources.gardener.cloud/secret-a61a895c":    secretNameETCDEncryptionConfig,
+						"reference.resources.gardener.cloud/secret-0fe90827":    secretNameETCDEncryptionConfig,
 						"reference.resources.gardener.cloud/configmap-130aa219": configMapNameAdmissionConfigs,
 						"reference.resources.gardener.cloud/secret-5613e39f":    secretNameAdmissionKubeconfigs,
 						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
@@ -2586,7 +2586,7 @@ kind: AuthorizationConfiguration
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
-						"reference.resources.gardener.cloud/secret-a61a895c":    secretNameETCDEncryptionConfig,
+						"reference.resources.gardener.cloud/secret-0fe90827":    secretNameETCDEncryptionConfig,
 						"reference.resources.gardener.cloud/configmap-130aa219": configMapNameAdmissionConfigs,
 						"reference.resources.gardener.cloud/secret-5613e39f":    secretNameAdmissionKubeconfigs,
 						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -60,6 +60,10 @@ import (
 var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&secretsutils.GenerateRandomString, secretsutils.FakeGenerateRandomString))
 	DeferCleanup(test.WithVar(&secretsutils.GenerateKey, secretsutils.FakeGenerateKey))
+	DeferCleanup(test.WithVar(&secretsutils.Read, func(b []byte) (int, error) {
+		copy(b, []byte(strings.Repeat("_", len(b))))
+		return len(b), nil
+	}))
 	DeferCleanup(test.WithVar(&secretsutils.GenerateVPNKey, secretsutils.FakeGenerateVPNKey))
 	DeferCleanup(test.WithVar(&secretsutils.Clock, testclock.NewFakeClock(time.Time{})))
 })

--- a/pkg/utils/secrets/alias.go
+++ b/pkg/utils/secrets/alias.go
@@ -5,6 +5,7 @@
 package secrets
 
 import (
+	"crypto/rand"
 	"crypto/rsa"
 	"io"
 	"strings"
@@ -21,6 +22,9 @@ var (
 	FakeGenerateRandomString = func(n int) (string, error) {
 		return strings.Repeat("_", n), nil
 	}
+
+	// Read is an alias for crypto/rand.Read. Exposed for testing.
+	Read = rand.Read
 
 	// GenerateKey is an alias for rsa.GenerateKey. Exposed for testing.
 	GenerateKey = rsa.GenerateKey

--- a/pkg/utils/secrets/etcd_encryption_key.go
+++ b/pkg/utils/secrets/etcd_encryption_key.go
@@ -18,7 +18,7 @@ const (
 	//
 	// kube-apiserver's EncryptionConfiguration expects the key secret to be base64 encoded.
 	// Previously, a 32-byte key was generated and it was set in the EncryptionConfiguration without being base64 encoded.
-	// This resulted in 24-byte key to used by kube-apiserver after decoding the 32-byte key (that was expected to be base64 encoded but it was not).
+	// This resulted in 24-byte key to be used by the kube-apiserver after decoding the 32-byte key (that was expected to be base64 encoded but it was not).
 	// To fix this, new etcd encryption keys are generated with encoding=none. When encoding=none, the key set in the EncryptionConfiguration is base64 encoded.
 	// In this way, we make sure to use the same generated 32-byte key.
 	// For more information, see https://github.com/gardener/gardener/pull/11150.

--- a/pkg/utils/secrets/etcd_encryption_key.go
+++ b/pkg/utils/secrets/etcd_encryption_key.go
@@ -25,7 +25,7 @@ type ETCDEncryptionKeySecretConfig struct {
 type ETCDEncryptionKey struct {
 	Name   string
 	Key    string
-	Secret string
+	Secret []byte
 }
 
 // GetName returns the name of the secret.
@@ -35,7 +35,8 @@ func (s *ETCDEncryptionKeySecretConfig) GetName() string {
 
 // Generate implements ConfigInterface.
 func (s *ETCDEncryptionKeySecretConfig) Generate() (DataInterface, error) {
-	secret, err := GenerateRandomString(s.SecretLength)
+	key := make([]byte, s.SecretLength)
+	_, err := Read(key)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +44,7 @@ func (s *ETCDEncryptionKeySecretConfig) Generate() (DataInterface, error) {
 	return &ETCDEncryptionKey{
 		Name:   s.Name,
 		Key:    fmt.Sprintf("key%d", Clock.Now().Unix()),
-		Secret: secret,
+		Secret: key,
 	}, nil
 }
 
@@ -51,6 +52,6 @@ func (s *ETCDEncryptionKeySecretConfig) Generate() (DataInterface, error) {
 func (b *ETCDEncryptionKey) SecretData() map[string][]byte {
 	return map[string][]byte{
 		DataKeyEncryptionKeyName: []byte(b.Key),
-		DataKeyEncryptionSecret:  []byte(b.Secret),
+		DataKeyEncryptionSecret:  b.Secret,
 	}
 }

--- a/pkg/utils/secrets/etcd_encryption_key_test.go
+++ b/pkg/utils/secrets/etcd_encryption_key_test.go
@@ -41,8 +41,7 @@ var _ = Describe("Etcd Encryption Key Secrets", func() {
 				etcdEncryptionKey, ok := obj.(*ETCDEncryptionKey)
 				Expect(ok).To(BeTrue())
 
-				Expect(etcdEncryptionKey.Name).To(Equal(name))
-				Expect(etcdEncryptionKey.Key).To(Equal("key-62135596800"))
+				Expect(etcdEncryptionKey.KeyName).To(Equal("key-62135596800-058d93"))
 				Expect(etcdEncryptionKey.Secret).To(Equal([]byte("_________________")))
 			})
 		})
@@ -56,8 +55,9 @@ var _ = Describe("Etcd Encryption Key Secrets", func() {
 				Expect(ok).To(BeTrue())
 
 				Expect(etcdEncryptionKey.SecretData()).To(Equal(map[string][]byte{
-					"key":    []byte("key-62135596800"),
-					"secret": []byte("_________________"),
+					"key":      []byte("key-62135596800-058d93"),
+					"secret":   []byte("_________________"),
+					"encoding": []byte("none"),
 				}))
 			})
 		})

--- a/pkg/utils/secrets/etcd_encryption_key_test.go
+++ b/pkg/utils/secrets/etcd_encryption_key_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Etcd Encryption Key Secrets", func() {
 				etcdEncryptionKey, ok := obj.(*ETCDEncryptionKey)
 				Expect(ok).To(BeTrue())
 
-				Expect(etcdEncryptionKey.KeyName).To(Equal("key-62135596800-058d93"))
+				Expect(etcdEncryptionKey.KeyName).To(Equal("key-62135596800"))
 				Expect(etcdEncryptionKey.Secret).To(Equal([]byte("_________________")))
 			})
 		})
@@ -55,7 +55,7 @@ var _ = Describe("Etcd Encryption Key Secrets", func() {
 				Expect(ok).To(BeTrue())
 
 				Expect(etcdEncryptionKey.SecretData()).To(Equal(map[string][]byte{
-					"key":      []byte("key-62135596800-058d93"),
+					"key":      []byte("key-62135596800"),
 					"secret":   []byte("_________________"),
 					"encoding": []byte("none"),
 				}))

--- a/pkg/utils/secrets/etcd_encryption_key_test.go
+++ b/pkg/utils/secrets/etcd_encryption_key_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Etcd Encryption Key Secrets", func() {
 
 				Expect(etcdEncryptionKey.Name).To(Equal(name))
 				Expect(etcdEncryptionKey.Key).To(Equal("key-62135596800"))
-				Expect(etcdEncryptionKey.Secret).To(Equal("_________________"))
+				Expect(etcdEncryptionKey.Secret).To(Equal([]byte("_________________")))
 			})
 		})
 

--- a/pkg/utils/secrets/secrets_suite_test.go
+++ b/pkg/utils/secrets/secrets_suite_test.go
@@ -5,6 +5,7 @@
 package secrets_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -23,5 +24,9 @@ func TestSecrets(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&GenerateRandomString, FakeGenerateRandomString))
+	DeferCleanup(test.WithVar(&Read, func(b []byte) (int, error) {
+		copy(b, []byte(strings.Repeat("_", len(b))))
+		return len(b), nil
+	}))
 	DeferCleanup(test.WithVar(&Clock, testclock.NewFakeClock(time.Time{})))
 })

--- a/test/utils/rotation/etcd_encryption_key.go
+++ b/test/utils/rotation/etcd_encryption_key.go
@@ -76,7 +76,7 @@ func (v *ETCDEncryptionKeyVerifier) Before(ctx context.Context) {
 					Keys: []apiserverconfigv1.Key{{
 						// old key
 						Name:   string(v.secretsBefore[v.EncryptionKey][0].Data["key"]),
-						Secret: getEncodedETCDEncryptionKeyFromSecret(v.secretsBefore[v.EncryptionKey][0]),
+						Secret: getBase64EncodedETCDEncryptionKeyFromSecret(v.secretsBefore[v.EncryptionKey][0]),
 					}},
 				},
 			},
@@ -133,11 +133,11 @@ func (v *ETCDEncryptionKeyVerifier) AfterPrepared(ctx context.Context) {
 					Keys: []apiserverconfigv1.Key{{
 						// new key
 						Name:   string(v.secretsPrepared[v.EncryptionKey][1].Data["key"]),
-						Secret: getEncodedETCDEncryptionKeyFromSecret(v.secretsPrepared[v.EncryptionKey][1]),
+						Secret: getBase64EncodedETCDEncryptionKeyFromSecret(v.secretsPrepared[v.EncryptionKey][1]),
 					}, {
 						// old key
 						Name:   string(v.secretsPrepared[v.EncryptionKey][0].Data["key"]),
-						Secret: getEncodedETCDEncryptionKeyFromSecret(v.secretsPrepared[v.EncryptionKey][0]),
+						Secret: getBase64EncodedETCDEncryptionKeyFromSecret(v.secretsPrepared[v.EncryptionKey][0]),
 					}},
 				},
 			},
@@ -193,7 +193,7 @@ func (v *ETCDEncryptionKeyVerifier) AfterCompleted(ctx context.Context) {
 					Keys: []apiserverconfigv1.Key{{
 						// new key
 						Name:   string(v.secretsPrepared[v.EncryptionKey][1].Data["key"]),
-						Secret: getEncodedETCDEncryptionKeyFromSecret(v.secretsPrepared[v.EncryptionKey][1]),
+						Secret: getBase64EncodedETCDEncryptionKeyFromSecret(v.secretsPrepared[v.EncryptionKey][1]),
 					}},
 				},
 			},
@@ -204,7 +204,7 @@ func (v *ETCDEncryptionKeyVerifier) AfterCompleted(ctx context.Context) {
 	}).Should(Succeed(), "etcd encryption config should only have new key")
 }
 
-func getEncodedETCDEncryptionKeyFromSecret(secret corev1.Secret) string {
+func getBase64EncodedETCDEncryptionKeyFromSecret(secret corev1.Secret) string {
 	var key string
 	if encoding := secret.Data["encoding"]; string(encoding) == "none" {
 		key = utils.EncodeBase64(secret.Data["secret"])


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
[GenerateRandomString](https://github.com/gardener/gardener/blob/50828b680ca098ed33f617c5bc60bf1dce393124/pkg/utils/random.go#L20) is limited to a smaller set of characters. Key should be generated without this limitation. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A few observations:
- `ETCDEncryptionKey.Name` seems unused
- `ETCDEncryptionKey.Key` is not an actual key but it is [used as a name](https://github.com/gardener/gardener/blob/50828b680ca098ed33f617c5bc60bf1dce393124/pkg/component/apiserver/encryptionconfiguration.go#L171) (we have two names 🤔 ). `ETCDEncryptionKey.Key` does not uniquely identify the generated key as it includes a timestamp and not the hashed salted key
- Renaming of the fields is hard, because if `Key` is repurposed to be the actual key it can be potentially dangerous for users of this util that rely on the `Key` being the name


In addition to these changes I propose that we:
- remove the `Name` field
- properly document the `Key` field (and potentially rename it to `KeyName`) and make it unique (or at least include some randomness) per generated key

WDYT?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The ETCD encryption config now properly configures a 32-byte key.
```
