### PR TITLE
refactor: Rename utils.TimeElapsed to utils.HasTimeElapsed

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -795,7 +795,7 @@ func (r *Reconciler) patchShootStatusOperationError(
 	var (
 		now          = metav1.NewTime(r.Clock.Now().UTC())
 		state        = gardencorev1beta1.LastOperationStateError
-		willNotRetry = v1beta1helper.HasNonRetryableErrorCode(lastErrors...) || utils.TimeElapsed(shoot.Status.RetryCycleStartTime, r.Config.Controllers.Shoot.RetryDuration.Duration)
+		willNotRetry = v1beta1helper.HasNonRetryableErrorCode(lastErrors...) || utils.HasTimeElapsed(shoot.Status.RetryCycleStartTime, r.Config.Controllers.Shoot.RetryDuration.Duration)
 	)
 
 	statusPatch := client.StrategicMergeFrom(shoot.DeepCopy())

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -83,9 +83,9 @@ func CreateMapFromSlice[K comparable, T any](arr []T, keyFunc func(T) K) map[K]T
 	return mapped
 }
 
-// TimeElapsed takes a <timestamp> and a <duration> checks whether the elapsed time until now is less than the <duration>.
+// HasTimeElapsed takes a <timestamp> and a <duration> checks whether the elapsed time until now is less than the <duration>.
 // If yes, it returns true, otherwise it returns false.
-func TimeElapsed(timestamp *metav1.Time, duration time.Duration) bool {
+func HasTimeElapsed(timestamp *metav1.Time, duration time.Duration) bool {
 	if timestamp == nil {
 		return true
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

Follow-up to https://github.com/gardener/gardener/pull/11144.

The function name reads as if it returns the time that has elapsed between two timestamps.
However, it returns a boolean value instead that indicates whether the time between the timestamp until now is greater than the duration given as the second parameter.

The utility function is only used in the shoot reconciler of the `gardenlet` today. 
However, I decided against 'inlining' the function as it's generic enough to stay in the `utils` package.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
