### PR TITLE
Fix workload identity issuer URL calculation

### DIFF
--- a/pkg/component/gardener/discoveryserver/discoveryserver.go
+++ b/pkg/component/gardener/discoveryserver/discoveryserver.go
@@ -48,7 +48,7 @@ type Values struct {
 	Image string
 	// RuntimeVersion is the Kubernetes version of the runtime cluster.
 	RuntimeVersion *semver.Version
-	// Domain will be prefixed with "discovery." and used by the discovery server to serve metadata on.
+	// Domain will be used by the discovery server to serve metadata on.
 	Domain string
 	// TLSSecretName is the name of the secret that will be used by the discovery server to handle TLS.
 	// If not provided then self-signed certificate will be generated.
@@ -103,7 +103,7 @@ func (g *gardenerDiscoveryServer) Deploy(ctx context.Context) error {
 		ingressTLSSecret, err := g.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
 			Name:                        deploymentName + "-tls",
 			CommonName:                  deploymentName,
-			DNSNames:                    []string{g.hostname()},
+			DNSNames:                    []string{g.values.Domain},
 			CertType:                    secretsutils.ServerCert,
 			Validity:                    ptr.To(v1beta1constants.IngressTLSCertificateValidity),
 			SkipPublishingCACertificate: true,

--- a/pkg/component/gardener/discoveryserver/discoveryserver_test.go
+++ b/pkg/component/gardener/discoveryserver/discoveryserver_test.go
@@ -557,7 +557,7 @@ var _ = Describe("GardenerDiscoveryServer", func() {
 		values = discoveryserver.Values{
 			RuntimeVersion:              semver.MustParse("1.26.4"),
 			Image:                       image,
-			Domain:                      "local.gardener.cloud",
+			Domain:                      "discovery.local.gardener.cloud",
 			WorkloadIdentityTokenIssuer: workloadIdentityIssuer,
 		}
 		deployer = discoveryserver.New(fakeClient, namespace, fakeSecretManager, values)

--- a/pkg/component/gardener/discoveryserver/ingress.go
+++ b/pkg/component/gardener/discoveryserver/ingress.go
@@ -12,10 +12,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
-func (g *gardenerDiscoveryServer) hostname() string {
-	return "discovery." + g.values.Domain
-}
-
 func (g *gardenerDiscoveryServer) ingress() *networkingv1.Ingress {
 	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -29,7 +25,7 @@ func (g *gardenerDiscoveryServer) ingress() *networkingv1.Ingress {
 		Spec: networkingv1.IngressSpec{
 			IngressClassName: ptr.To(v1beta1constants.SeedNginxIngressClass),
 			Rules: []networkingv1.IngressRule{{
-				Host: g.hostname(),
+				Host: g.values.Domain,
 				IngressRuleValue: networkingv1.IngressRuleValue{
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{{

--- a/pkg/component/gardener/discoveryserver/secrets.go
+++ b/pkg/component/gardener/discoveryserver/secrets.go
@@ -42,7 +42,7 @@ func (g *gardenerDiscoveryServer) newServiceAccountIssuerConfigSecret() *corev1.
 			}),
 		},
 		StringData: map[string]string{
-			"hostname": g.hostname(),
+			"hostname": g.values.Domain,
 		},
 	}
 }

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -221,7 +221,8 @@ func (r *Reconciler) instantiateComponents(
 	c.virtualGardenGardenerAccess = r.newGardenerAccess(garden, secretsManager)
 
 	// gardener control plane components
-	workloadIdentityTokenIssuer := "https://" + primaryIngressDomain.Name + "/garden/workload-identity/issuer"
+	discoveryServerDomain := "discovery." + primaryIngressDomain.Name
+	workloadIdentityTokenIssuer := "https://" + discoveryServerDomain + "/garden/workload-identity/issuer"
 	c.gardenerAPIServer, err = r.newGardenerAPIServer(ctx, garden, secretsManager, workloadIdentityTokenIssuer)
 	if err != nil {
 		return
@@ -246,7 +247,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.gardenerDiscoveryServer, err = r.newGardenerDiscoveryServer(secretsManager, primaryIngressDomain.Name, wildcardCertSecretName, workloadIdentityTokenIssuer)
+	c.gardenerDiscoveryServer, err = r.newGardenerDiscoveryServer(secretsManager, discoveryServerDomain, wildcardCertSecretName, workloadIdentityTokenIssuer)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:
Fix workload identity issuer URL calculation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @dimityrmirchev 

Usually this would be a breaking change, but having in mind the state of the workload identity feature (it is still under active development) and that without this change the OIDC discovery documents are invalid, I think it is safe to apply the change without:
- migration path 
- announcement
- breaking release note 
Considering the same, we should cherry-pick the change to release branches. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix a bug in the gardener operator where the issuer URL domain for workload identity tokens was not prefixed with `discovery.` resulting in invalid OIDC tokens and discovery documents.
```
