### PR TITLE
refactor: Update comment of utils.HasTimeElapsed

### DIFF
--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -84,7 +84,7 @@ func CreateMapFromSlice[K comparable, T any](arr []T, keyFunc func(T) K) map[K]T
 }
 
 // HasTimeElapsed takes a <timestamp> and a <duration> checks whether the elapsed time until now is less than the <duration>.
-// If yes, it returns true, otherwise it returns false.
+// If yes, it returns false (i.e. the <duration> has not elapsed yet), otherwise it returns true (i.e. the <duration> has elapsed).
 func HasTimeElapsed(timestamp *metav1.Time, duration time.Duration) bool {
 	if timestamp == nil {
 		return true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

Follow-up to https://github.com/gardener/gardener/pull/11152

The comment of `utils.HasTimeElapsed` is inverted by accident.
This 🤏 PR updates the comment to represent the logic correctly.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
