### PR TITLE
Fix gardenlet permissions to allow reading events for istio ingress service

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -101,6 +101,16 @@ rules:
   verbs:
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/charts/gardener/gardenlet/templates/role-garden-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/role-garden-gardenlet.yaml
@@ -12,16 +12,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - get
-  - list
-  - create
-  - patch
-  - update
-- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -179,6 +179,11 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				Verbs:         []string{"delete"},
 			},
 			{
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+				Verbs:     []string{"get", "list", "create", "patch", "update"},
+			},
+			{
 				APIGroups: []string{"admissionregistration.k8s.io"},
 				Resources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"},
 				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
@@ -480,11 +485,6 @@ func getGardenGardenletRole(labels map[string]string) *rbacv1.Role {
 			ResourceVersion: "1",
 		},
 		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"events"},
-				Verbs:     []string{"get", "list", "create", "patch", "update"},
-			},
 			{
 				APIGroups: []string{"apps"},
 				Resources: []string{"daemonsets"},


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:
Fix gardenlet permissions to allow reading events for istio ingress service.

While inspecting the [logs](https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/11154/pull-gardener-e2e-kind-ha-single-zone/1878838878438166528/artifacts/gardener-local-ha-single-zone/gardener-local-ha-single-zone-worker2/containers/gardenlet-548875cd95-4z26j_garden_gardenlet-8db2885ea8490f6baf78ed61b699bb52b90c1f53fd6c9346a6fac092fb312fe4.log) from a test failure from #11154 I found the following error message

```
2025-01-13T16:28:44.818130321Z stderr F 
{
  "level": "error",
  "ts": "2025-01-13T16:28:44.818Z",
  "msg": "Error while fetching events for load balancer service",
  "controller": "seed",
  "namespace": "",
  "name": "local-ha-single-zone",
  "reconcileID": "eb3d91c0-a6f0-434c-966f-f58ae8d310b7",
  "service": {
    "name": "istio-ingressgateway",
    "namespace": "istio-ingress"
  },
  "error": "error 'events is forbidden: User \"system:serviceaccount:garden:gardenlet\" cannot list resource \"events\" in API group \"\" in the namespace \"istio-ingress\"' occurred while fetching more details",
  "stacktrace": 
    "github.com/gardener/gardener/pkg/utils/kubernetes.WaitUntilLoadBalancerIsReady
        github.com/gardener/gardener/pkg/utils/kubernetes/kubernetes.go:176
    github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed.(*Reconciler).deployNginxIngressAndWaitForIstioServiceAndGetDNSComponent
        github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go:688
    github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed.(*Reconciler).runReconcileSeedFlow.func5
        github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go:308
    github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func2
        github.com/gardener/gardener/pkg/utils/flow/flow.go:234"
}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix bug where gardenlet was missing permissions to read `v1.Events` in the istio ingress namespace in the seed cluster.
```
