### PR TITLE
Update VPA to 1.2.2

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -657,7 +657,7 @@ images:
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
   repository: registry.k8s.io/autoscaling/vpa-admission-controller
-  tag: "1.2.1"
+  tag: "1.2.2"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -670,7 +670,7 @@ images:
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
   repository: registry.k8s.io/autoscaling/vpa-recommender
-  tag: "1.2.1"
+  tag: "1.2.2"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -683,7 +683,7 @@ images:
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
   repository: registry.k8s.io/autoscaling/vpa-updater
-  tag: "1.2.1"
+  tag: "1.2.2"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
VPA 1.2.2 contains the a cherry-pick (https://github.com/kubernetes/autoscaler/pull/7657) of the following bugfix https://github.com/kubernetes/autoscaler/pull/7640.

Right now, both etcd and kube-apiserver have sidecar containers that don't enable autoscaling - the `backup-restore` sidecar for etcd, the vpn sidecars for kube-apiserver.

Hence, right now etcd and kube-apiserver can be evicted for scale down despite the eviction requirement they have set (eviction to happen only for scale up, when recommendation is higher than the Pod's current resource requests).

With VPA 1.2.2 this issue is fixed and such etcd or kube-apiserver evictions for scale down should no longer occur outside of maintenance time window.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The following images have been updated:
- `registry.k8s.io/autoscaling/vpa-admission-controller`: 1.2.1 -> 1.2.2
- `registry.k8s.io/autoscaling/vpa-recommender`: 1.2.1 -> 1.2.2
- `registry.k8s.io/autoscaling/vpa-updater`: 1.2.1 -> 1.2.2
```
