### PR TITLE
chore: Group VPA components Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -200,7 +200,7 @@
         '/.+gardener-discovery-server$/'
       ],
     },
-        {
+    {
       // Group machine-controller-manager updates in one PR.
       groupName: 'machine-controller-manager',
       matchDatasources: [
@@ -209,6 +209,18 @@
       ],
       matchPackageNames: [
         '/.*gardener\/machine-controller-manager$/'
+      ],
+    },
+    {
+      // Group Vertical Pod Autoscaler (VPA) component updates in one PR.
+      groupName: 'vpa-components',
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        'registry.k8s.io/autoscaling/vpa-admission-controller',
+        'registry.k8s.io/autoscaling/vpa-recommender',
+        'registry.k8s.io/autoscaling/vpa-updater',
       ],
     },
     {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

See https://github.com/gardener/gardener/issues/11171 👀 

**Which issue(s) this PR fixes**:
Fixes #11171

**Special notes for your reviewer**:

/cc @ialidzhikov @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
