### PR TITLE
Use ServiceTrafficDistribution to make Services topology-aware when runtime Kubernetes >= 1.31

### DIFF
--- a/charts/gardener/admission-local/charts/runtime/templates/service.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/service.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
-    {{- if .Values.service.topologyAwareRouting.enabled }}
+    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
     service.kubernetes.io/topology-mode: "auto"
     {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}
-    {{- if .Values.service.topologyAwareRouting.enabled }}
+    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
     endpoint-slice-hints.resources.gardener.cloud/consider: "true"
     {{- end }}
 spec:
@@ -21,3 +21,6 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.webhookConfig.serverPort }}
+  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+  trafficDistribution: PreferClose
+  {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gardener-admission-controller
   namespace: garden
   annotations:
-    {{- if .Values.global.admission.service.topologyAwareRouting.enabled }}
+    {{- if and .Values.global.admission.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
     service.kubernetes.io/topology-mode: "auto"
     {{- end }}
   labels:
@@ -14,7 +14,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    {{- if .Values.global.admission.service.topologyAwareRouting.enabled }}
+    {{- if and .Values.global.admission.service.topologyAwareRouting.enabled (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
     endpoint-slice-hints.resources.gardener.cloud/consider: "true"
     {{- end }}
 spec:
@@ -37,4 +37,7 @@ spec:
     protocol: TCP
     port: {{ required ".Values.global.admission.config.server.metrics.port is required" .Values.global.admission.config.server.metrics.port }}
     targetPort: {{ required ".Values.global.admission.config.server.metrics.port is required" .Values.global.admission.config.server.metrics.port }}
+  {{- if and .Values.global.admission.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+  trafficDistribution: PreferClose
+  {{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gardener-apiserver
   namespace: garden
   annotations:
-    {{- if .Values.global.apiserver.service.topologyAwareRouting.enabled }}
+    {{- if and .Values.global.apiserver.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
     service.kubernetes.io/topology-mode: "auto"
     {{- end }}
   labels:
@@ -14,7 +14,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    {{- if .Values.global.apiserver.service.topologyAwareRouting.enabled }}
+    {{- if and .Values.global.apiserver.service.topologyAwareRouting.enabled (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
     endpoint-slice-hints.resources.gardener.cloud/consider: "true"
     {{- end }}
 spec:
@@ -30,4 +30,7 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.global.apiserver.securePort | default 8443 }}
+  {{- if and .Values.global.apiserver.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+  trafficDistribution: PreferClose
+  {{- end }}
 {{- end }}

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -32,7 +32,7 @@ Kubernetes runs a primary "agent" on every node, the kubelet,
 which is responsible for managing pods and containers on its particular node.
 Decentralizing the responsibility to the kubelet has the advantage that the overall system
 is scalable. Gardener achieves the same for cluster management by using a **gardenlet**
-as а primary "agent" on every seed cluster, and is only responsible for shoot clusters
+as a primary "agent" on every seed cluster, and is only responsible for shoot clusters
 located in its particular seed cluster:
 
 ![Counterparts in the Gardener Architecture and the Kubernetes Architecture](images/gardenlet-architecture-similarities.png)

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -1116,6 +1116,9 @@ endpoints:
 The webhook aims to circumvent issues with the Kubernetes `TopologyAwareHints` feature that currently does not allow to achieve a deterministic topology-aware traffic routing. For more details, see the following issue [kubernetes/kubernetes#113731](https://github.com/kubernetes/kubernetes/issues/113731) that describes drawbacks of the `TopologyAwareHints` feature for our use case.
 If the above-mentioned issue gets resolved and there is a native support for deterministic topology-aware traffic routing in Kubernetes, then this webhook can be dropped in favor of the native Kubernetes feature.
 
+> [!NOTE]  
+> The EndpointSlice Hints webhook is disabled when the runtime Kubernetes version is >= 1.32. Instead, the `ServiceTrafficDistribution` feature is used. See more details in [Topology-Aware Traffic Routing](../operations/topology_aware_routing.md).
+
 ### Validating Webhooks
 
 #### Unconfirmed Deletion Prevention For Custom Resources And Definitions

--- a/docs/operations/topology_aware_routing.md
+++ b/docs/operations/topology_aware_routing.md
@@ -44,14 +44,14 @@ We reported the drawbacks related to the `TopologyAwareHints` feature in [kubern
 
 The `ServiceTrafficDistribution` allows expressing preferences for how traffic should be routed to Service endpoints. For more details, see [upstream documentation](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution) of the feature.
 
-The `PreferClose` strategy with kube-proxy of `ServiceTrafficDistribution` allows traffic to be routed to Service endpoints in topology-aware and predictable manner.
+The `PreferClose` strategy allows traffic to be routed to Service endpoints in topology-aware and predictable manner.
 It is simpler than `service.kubernetes.io/topology-mode: auto` - if there are Service endpoints which reside in the same zone as the client, traffic is routed to one of the endpoints within the same zone as the client. If the client's zone does not have any available Service endpoints, traffic is routed to any available endpoint within the cluster.
 
 ## How to make a Service topology-aware
 
-### How to make a Service topology-aware using `TopologyAwareHints` (Kubernetes < 1.31)
+### How to make a Service topology-aware in Kubernetes < 1.31
 
-In Kubernetes < 1.31, to make a Service topology-aware the following annotation and label have to be added to the Service:
+In Kubernetes < 1.31, `TopologyAwareHints` and EndpointSlice Hints mutating webhook are being used to make a Service topology-aware. The following annotation and label have to be added to the Service:
 
 ```yaml
 apiVersion: v1
@@ -68,9 +68,9 @@ The `endpoint-slice-hints.resources.gardener.cloud/consider=true` label is neede
 
 The Gardener extensions can use this approach to make a Service they deploy topology-aware.
 
-### How to make a Service topology-aware using `ServiceTrafficDistribution` (Kubernetes == 1.31)
+### How to make a Service topology-aware in Kubernetes 1.31
 
-In Kubernetes 1.31, to make a Service topology-aware the `.spec.trafficDistribution` field has to be set to `PreferClose` and the label `endpoint-slice-hints.resources.gardener.cloud/consider=true` needs to be added:
+In Kubernetes 1.31, `ServiceTrafficDistribution` and EndpointSlice Hints mutating webhook are being used to make a Service topology-aware. The `.spec.trafficDistribution` field has to be set to `PreferClose` and the label `endpoint-slice-hints.resources.gardener.cloud/consider=true` needs to be added:
 
 ```yaml
 apiVersion: v1
@@ -82,9 +82,9 @@ spec:
   trafficDistribution: PreferClose
 ```
 
-### How to make a Service topology-aware using `ServiceTrafficDistribution` (Kubernetes >= 1.31)
+### How to make a Service topology-aware in Kubernetes >= 1.32
 
-In Kubernetes >= 1.31, to make a Service topology-aware the `.spec.trafficDistribution` field has to be set to `PreferClose`:
+In Kubernetes >= 1.32, `ServiceTrafficDistribution` is being used to make a Service topology-aware. The `.spec.trafficDistribution` field has to be set to `PreferClose`:
 
 ```yaml
 apiVersion: v1

--- a/pkg/component/autoscaling/vpa/admissioncontroller.go
+++ b/pkg/component/autoscaling/vpa/admissioncontroller.go
@@ -143,7 +143,7 @@ func (v *vpa) reconcileAdmissionControllerService(service *corev1.Service) {
 		metav1.SetMetaDataLabel(&service.ObjectMeta, label, value)
 	}
 	topologyAwareRoutingEnabled := v.values.AdmissionController.TopologyAwareRoutingEnabled && v.values.ClusterType == component.ClusterTypeShoot
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(service, topologyAwareRoutingEnabled)
+	gardenerutils.ReconcileTopologyAwareRoutingSettings(service, topologyAwareRoutingEnabled, v.values.RuntimeKubernetesVersion)
 
 	switch v.values.ClusterType {
 	case component.ClusterTypeSeed:

--- a/pkg/component/gardener/admissioncontroller/admission_controller.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
@@ -52,6 +53,8 @@ type Values struct {
 	Image string
 	// ResourceAdmissionConfiguration is the configuration for gardener-admission-controller's resource-size validator.
 	ResourceAdmissionConfiguration *admissioncontrollerconfigv1alpha1.ResourceAdmissionConfiguration
+	// RuntimeVersion is the Kubernetes version of the runtime cluster.
+	RuntimeVersion *semver.Version
 	// SeedRestrictionEnabled specifies whether the seed-restriction webhook is enabled.
 	SeedRestrictionEnabled bool
 	// TopologyAwareRoutingEnabled determines whether topology aware hints are intended for the gardener-admission-controller.

--- a/pkg/component/gardener/admissioncontroller/service.go
+++ b/pkg/component/gardener/admissioncontroller/service.go
@@ -54,7 +54,7 @@ func (a *gardenerAdmissionController) service() *corev1.Service {
 		Protocol: ptr.To(corev1.ProtocolTCP),
 	}))
 
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(svc, a.values.TopologyAwareRoutingEnabled)
+	gardenerutils.ReconcileTopologyAwareRoutingSettings(svc, a.values.TopologyAwareRoutingEnabled, a.values.RuntimeVersion)
 
 	return svc
 }

--- a/pkg/component/gardener/apiserver/service.go
+++ b/pkg/component/gardener/apiserver/service.go
@@ -24,7 +24,7 @@ func (g *gardenerAPIServer) serviceRuntime() *corev1.Service {
 	service := g.service()
 	service.Namespace = g.namespace
 
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(service, g.values.TopologyAwareRoutingEnabled)
+	gardenerutils.ReconcileTopologyAwareRoutingSettings(service, g.values.TopologyAwareRoutingEnabled, g.values.RuntimeVersion)
 	// allow gardener-apiserver being reached from kube-apiserver
 	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForWebhookTargets(service, networkingv1.NetworkPolicyPort{
 		Port:     ptr.To(intstr.FromInt32(port)),

--- a/pkg/component/gardener/dashboard/terminal/service.go
+++ b/pkg/component/gardener/dashboard/terminal/service.go
@@ -52,7 +52,7 @@ func (t *terminal) service() *corev1.Service {
 		Protocol: ptr.To(corev1.ProtocolTCP),
 	}))
 
-	gardenerutils.ReconcileTopologyAwareRoutingMetadata(svc, t.values.TopologyAwareRoutingEnabled)
+	gardenerutils.ReconcileTopologyAwareRoutingSettings(svc, t.values.TopologyAwareRoutingEnabled, t.values.RuntimeVersion)
 
 	return svc
 }

--- a/pkg/component/gardener/dashboard/terminal/terminal.go
+++ b/pkg/component/gardener/dashboard/terminal/terminal.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -43,6 +44,8 @@ var TimeoutWaitForManagedResource = 5 * time.Minute
 type Values struct {
 	// Image defines the container image of terminal-controller-manager.
 	Image string
+	// RuntimeVersion is the Kubernetes version of the runtime cluster.
+	RuntimeVersion *semver.Version
 	// TopologyAwareRoutingEnabled determines whether topology aware hints are intended.
 	TopologyAwareRoutingEnabled bool
 }

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -291,6 +292,8 @@ type Values struct {
 	// WatchedNamespace restricts the gardener-resource-manager to only watch ManagedResources in the defined namespace.
 	// If not set the gardener-resource-manager controller watches for ManagedResources in all namespaces
 	WatchedNamespace *string
+	// RuntimeKubernetesVersion is the Kubernetes version of the runtime cluster.
+	RuntimeKubernetesVersion *semver.Version
 	// SchedulingProfile is the kube-scheduler profile configured for the Shoot.
 	SchedulingProfile *gardencorev1beta1.SchedulingProfile
 	// DefaultSeccompProfileEnabled specifies if the defaulting seccomp profile webhook of GRM should be enabled or not.
@@ -748,7 +751,7 @@ func (r *resourceManager) ensureService(ctx context.Context) error {
 		}
 
 		topologyAwareRoutingEnabled := r.values.TopologyAwareRoutingEnabled && r.values.ResponsibilityMode == ForTarget
-		gardenerutils.ReconcileTopologyAwareRoutingMetadata(service, topologyAwareRoutingEnabled)
+		gardenerutils.ReconcileTopologyAwareRoutingSettings(service, topologyAwareRoutingEnabled, r.values.RuntimeKubernetesVersion)
 
 		service.Spec.Selector = r.appLabel()
 		service.Spec.Type = corev1.ServiceTypeClusterIP

--- a/pkg/component/kubernetes/apiserverexposure/service.go
+++ b/pkg/component/kubernetes/apiserverexposure/service.go
@@ -61,6 +61,7 @@ type serviceValues struct {
 	namePrefix                  string
 	nameSuffix                  string
 	topologyAwareRoutingEnabled bool
+	runtimeKubernetesVersion    *semver.Version
 }
 
 // NewService creates a new instance of DeployWaiter for the Service used to expose the kube-apiserver.
@@ -101,6 +102,7 @@ func NewService(
 		internalValues.namePrefix = values.NamePrefix
 		internalValues.nameSuffix = values.NameSuffix
 		internalValues.topologyAwareRoutingEnabled = values.TopologyAwareRoutingEnabled
+		internalValues.runtimeKubernetesVersion = values.RuntimeKubernetesVersion
 	}
 
 	return &service{
@@ -155,7 +157,7 @@ func (s *service) Deploy(ctx context.Context) error {
 		}
 
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyNamespaceSelectors(obj, namespaceSelectors...))
-		gardenerutils.ReconcileTopologyAwareRoutingMetadata(obj, s.values.topologyAwareRoutingEnabled)
+		gardenerutils.ReconcileTopologyAwareRoutingSettings(obj, s.values.topologyAwareRoutingEnabled, s.values.runtimeKubernetesVersion)
 
 		obj.Labels = utils.MergeStringMaps(obj.Labels, getLabels())
 		obj.Spec.Type = corev1.ServiceTypeClusterIP

--- a/pkg/component/kubernetes/apiserverexposure/service_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,7 @@ var _ = Describe("#Service", func() {
 		c   client.Client
 
 		defaultDepWaiter component.DeployWaiter
+		values           *ServiceValues
 		expected         *corev1.Service
 
 		ingressIP        string
@@ -62,6 +64,10 @@ var _ = Describe("#Service", func() {
 		clusterIPsFunc = func(c []string) { clusterIP = c[0] }
 		ingressIPFunc = func(c string) { ingressIP = c }
 
+		values = &ServiceValues{
+			AnnotationsFunc: func() map[string]string { return map[string]string{"foo": "bar"} },
+			NamePrefix:      namePrefix,
+		}
 		expected = &corev1.Service{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: corev1.SchemeGroupVersion.String(),
@@ -116,10 +122,7 @@ var _ = Describe("#Service", func() {
 			log,
 			c,
 			namespace,
-			&ServiceValues{
-				AnnotationsFunc: func() map[string]string { return map[string]string{"foo": "bar"} },
-				NamePrefix:      namePrefix,
-			},
+			values,
 			func() client.ObjectKey { return sniServiceObjKey },
 			&retryfake.Ops{MaxAttempts: 1},
 			clusterIPsFunc,
@@ -184,44 +187,55 @@ var _ = Describe("#Service", func() {
 		assertService()
 	})
 
-	Describe("#Deploy", func() {
-		Context("when TopologyAwareRoutingEnabled=true", func() {
-			It("should successfully deploy with expected kube-apiserver service annotations and labels", func() {
-				defaultDepWaiter = NewService(
-					log,
-					c,
-					namespace,
-					&ServiceValues{
-						AnnotationsFunc:             func() map[string]string { return map[string]string{"foo": "bar"} },
-						NamePrefix:                  namePrefix,
-						TopologyAwareRoutingEnabled: true,
-						RuntimeKubernetesVersion:    semver.MustParse("1.31.1"),
-					},
-					func() client.ObjectKey { return sniServiceObjKey },
-					&retryfake.Ops{MaxAttempts: 1},
-					clusterIPsFunc,
-					ingressIPFunc,
-				)
+	Context("when TopologyAwareRoutingEnabled=true", func() {
+		BeforeEach(func() {
+			values.TopologyAwareRoutingEnabled = true
+		})
 
+		When("runtime Kubernetes version is >= 1.32", func() {
+			BeforeEach(func() {
+				values.RuntimeKubernetesVersion = semver.MustParse("1.32.1")
+			})
+
+			It("should successfully deploy with expected kube-apiserver service annotation, label and spec field", func() {
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				actual := &corev1.Service{}
 				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, actual)).To(Succeed())
 
-				expected.Annotations = map[string]string{
-					"foo":                          "bar",
-					"networking.istio.io/exportTo": "*",
-					"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
-					"networking.resources.gardener.cloud/namespace-selectors":                          `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
-					"service.kubernetes.io/topology-mode":                                              "auto",
-				}
-				expected.Labels = map[string]string{
-					"app": "kubernetes",
-					"endpoint-slice-hints.resources.gardener.cloud/consider": "true",
-					"role": "apiserver",
-				}
-				expected.Spec.Type = corev1.ServiceTypeClusterIP
-				Expect(actual).To(DeepEqual(expected))
+				Expect(actual.Spec.TrafficDistribution).To(PointTo(Equal(corev1.ServiceTrafficDistributionPreferClose)))
+			})
+		})
+
+		When("runtime Kubernetes version is 1.31", func() {
+			BeforeEach(func() {
+				values.RuntimeKubernetesVersion = semver.MustParse("1.31.1")
+			})
+
+			It("should successfully deploy with expected kube-apiserver service annotation, label and spec field", func() {
+				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+				actual := &corev1.Service{}
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, actual)).To(Succeed())
+
+				Expect(actual.Spec.TrafficDistribution).To(PointTo(Equal(corev1.ServiceTrafficDistributionPreferClose)))
+				Expect(actual.Labels).To(HaveKeyWithValue("endpoint-slice-hints.resources.gardener.cloud/consider", "true"))
+			})
+		})
+
+		Context("when K8s version < 1.31", func() {
+			BeforeEach(func() {
+				values.RuntimeKubernetesVersion = semver.MustParse("1.30.3")
+			})
+
+			It("should successfully deploy with expected kube-apiserver service annotation, label and spec field", func() {
+				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+				actual := &corev1.Service{}
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: expectedName}, actual)).To(Succeed())
+
+				Expect(actual.Annotations).To(HaveKeyWithValue("service.kubernetes.io/topology-mode", "auto"))
+				Expect(actual.Labels).To(HaveKeyWithValue("endpoint-slice-hints.resources.gardener.cloud/consider", "true"))
 			})
 		})
 	})

--- a/pkg/component/kubernetes/apiserverexposure/service_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/service_test.go
@@ -223,7 +223,7 @@ var _ = Describe("#Service", func() {
 			})
 		})
 
-		Context("when K8s version < 1.31", func() {
+		When("runtime Kubernetes version < 1.31", func() {
 			BeforeEach(func() {
 				values.RuntimeKubernetesVersion = semver.MustParse("1.30.3")
 			})

--- a/pkg/gardenadm/botanist.go
+++ b/pkg/gardenadm/botanist.go
@@ -61,7 +61,7 @@ func NewBotanist(
 	return botanistpkg.New(ctx, &operation.Operation{
 		Logger:        log,
 		GardenClient:  newFakeGardenClient(),
-		SeedClientSet: newFakeSeedClientSet(),
+		SeedClientSet: newFakeSeedClientSet(seedObj.KubernetesVersion.String()),
 		Garden:        gardenObj,
 		Seed:          seedObj,
 		Shoot:         shootObj,
@@ -117,7 +117,7 @@ func newFakeGardenClient() client.Client {
 		Build()
 }
 
-func newFakeSeedClientSet() kubernetes.Interface {
+func newFakeSeedClientSet(kubernetesVersion string) kubernetes.Interface {
 	return fakekubernetes.
 		NewClientSetBuilder().
 		WithClient(fakeclient.
@@ -126,5 +126,6 @@ func newFakeSeedClientSet() kubernetes.Interface {
 			Build(),
 		).
 		WithRESTConfig(&rest.Config{}).
+		WithVersion(kubernetesVersion).
 		Build()
 }

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -70,6 +70,7 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 type components struct {
@@ -257,11 +258,13 @@ func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, se
 		additionalNetworkPolicyNamespaceSelectors = config.AdditionalNamespaceSelectors
 	}
 
+	endpointSliceHintsEnabled := v1beta1helper.SeedSettingTopologyAwareRoutingEnabled(seed.Spec.Settings) && versionutils.ConstraintK8sLess132.Check(r.SeedVersion)
+
 	return sharedcomponent.NewRuntimeGardenerResourceManager(r.SeedClientSet.Client(), r.GardenNamespace, secretsManager, resourcemanager.Values{
 		DefaultSeccompProfileEnabled:              features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
 		DefaultNotReadyToleration:                 defaultNotReadyTolerationSeconds,
 		DefaultUnreachableToleration:              defaultUnreachableTolerationSeconds,
-		EndpointSliceHintsEnabled:                 v1beta1helper.SeedSettingTopologyAwareRoutingEnabled(seed.Spec.Settings),
+		EndpointSliceHintsEnabled:                 endpointSliceHintsEnabled,
 		LogLevel:                                  r.Config.LogLevel,
 		LogFormat:                                 r.Config.LogFormat,
 		NetworkPolicyAdditionalNamespaceSelectors: additionalNetworkPolicyNamespaceSelectors,

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -67,6 +67,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 			StorageCapacity:             b.Seed.GetValidVolumeSize("10Gi"),
 			DefragmentationSchedule:     &defragmentationSchedule,
 			CARotationPhase:             v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials),
+			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,
 			MaintenanceTimeWindow:       *b.Shoot.GetInfo().Spec.Maintenance.TimeWindow,
 			EvictionRequirement:         getEvictionRequirement(class, b.Shoot),
 			PriorityClassName:           v1beta1constants.PriorityClassNameShootControlPlane500,

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -94,6 +94,9 @@ var _ = Describe("Etcd", func() {
 			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{})
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.27.2",
+					},
 					Maintenance: &gardencorev1beta1.Maintenance{
 						TimeWindow: &maintenanceTimeWindow,
 					},

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -368,6 +368,7 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		ManagedResourceLabels:                     map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)},
 		NetworkPolicyAdditionalNamespaceSelectors: r.Config.Controllers.NetworkPolicy.AdditionalNamespaceSelectors,
 		PriorityClassName:                         v1beta1constants.PriorityClassNameGardenSystemCritical,
+		RuntimeKubernetesVersion:                  r.RuntimeVersion,
 		SecretNameServerCA:                        operatorv1alpha1.SecretNameCARuntime,
 		Zones:                                     garden.Spec.RuntimeCluster.Provider.Zones,
 	})
@@ -375,13 +376,14 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 
 func (r *Reconciler) newVirtualGardenGardenerResourceManager(secretsManager secretsmanager.Interface) (resourcemanager.Interface, error) {
 	return sharedcomponent.NewTargetGardenerResourceManager(r.RuntimeClientSet.Client(), r.GardenNamespace, secretsManager, resourcemanager.Values{
-		IsWorkerless:       true,
-		LogLevel:           r.Config.LogLevel,
-		LogFormat:          r.Config.LogFormat,
-		NamePrefix:         namePrefix,
-		PriorityClassName:  v1beta1constants.PriorityClassNameGardenSystem400,
-		SecretNameServerCA: operatorv1alpha1.SecretNameCARuntime,
-		TargetNamespaces:   []string{v1beta1constants.GardenNamespace, metav1.NamespaceSystem, gardencorev1beta1.GardenerShootIssuerNamespace, gardencorev1beta1.GardenerSystemPublicNamespace},
+		IsWorkerless:             true,
+		LogLevel:                 r.Config.LogLevel,
+		LogFormat:                r.Config.LogFormat,
+		NamePrefix:               namePrefix,
+		PriorityClassName:        v1beta1constants.PriorityClassNameGardenSystem400,
+		RuntimeKubernetesVersion: r.RuntimeVersion,
+		SecretNameServerCA:       operatorv1alpha1.SecretNameCARuntime,
+		TargetNamespaces:         []string{v1beta1constants.GardenNamespace, metav1.NamespaceSystem, gardencorev1beta1.GardenerShootIssuerNamespace, gardencorev1beta1.GardenerSystemPublicNamespace},
 	})
 }
 
@@ -499,6 +501,7 @@ func (r *Reconciler) newEtcd(
 			StorageClassName:            storageClassName,
 			DefragmentationSchedule:     &defragmentationSchedule,
 			CARotationPhase:             helper.GetCARotationPhase(garden.Status.Credentials),
+			RuntimeKubernetesVersion:    r.RuntimeVersion,
 			MaintenanceTimeWindow:       garden.Spec.VirtualCluster.Maintenance.TimeWindow,
 			EvictionRequirement:         evictionRequirement,
 			PriorityClassName:           v1beta1constants.PriorityClassNameGardenSystem500,
@@ -1018,6 +1021,7 @@ func (r *Reconciler) newGardenerAdmissionController(garden *operatorv1alpha1.Gar
 	values := gardeneradmissioncontroller.Values{
 		Image:                       image.String(),
 		LogLevel:                    logger.InfoLevel,
+		RuntimeVersion:              r.RuntimeVersion,
 		SeedRestrictionEnabled:      enableSeedRestriction,
 		TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
 	}
@@ -1156,6 +1160,7 @@ func (r *Reconciler) newTerminalControllerManager(garden *operatorv1alpha1.Garde
 
 	values := terminal.Values{
 		Image:                       image.String(),
+		RuntimeVersion:              r.RuntimeVersion,
 		TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
 	}
 

--- a/pkg/utils/gardener/topology_aware_routing.go
+++ b/pkg/utils/gardener/topology_aware_routing.go
@@ -5,21 +5,47 @@
 package gardener
 
 import (
+	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
-// ReconcileTopologyAwareRoutingMetadata adds (or removes) the required annotation and label to make a Service topology-aware.
-func ReconcileTopologyAwareRoutingMetadata(service *corev1.Service, topologyAwareRoutingEnabled bool) {
-	if topologyAwareRoutingEnabled {
-		metav1.SetMetaDataAnnotation(&service.ObjectMeta, corev1.AnnotationTopologyMode, "auto")
-		delete(service.Annotations, corev1.DeprecatedAnnotationTopologyAwareHints)
+// ReconcileTopologyAwareRoutingSettings adds or removes the required annotation, label and spec field to make a Service topology-aware.
+//
+// <k8sVersion> is the runtime cluster's Kubernetes version.
+func ReconcileTopologyAwareRoutingSettings(service *corev1.Service, topologyAwareRoutingEnabled bool, k8sVersion *semver.Version) {
+	delete(service.Annotations, corev1.AnnotationTopologyMode)
+	delete(service.Annotations, corev1.DeprecatedAnnotationTopologyAwareHints)
+	delete(service.Labels, resourcesv1alpha1.EndpointSliceHintsConsider)
+	service.Spec.TrafficDistribution = nil
+
+	if !topologyAwareRoutingEnabled {
+		return
+	}
+
+	if versionutils.ConstraintK8sGreaterEqual132.Check(k8sVersion) {
+		// For Kubernetes >= 1.32, only use the PreferClose strategy of the ServiceTrafficDistribution feature.
+		service.Spec.TrafficDistribution = ptr.To(corev1.ServiceTrafficDistributionPreferClose)
+	} else if versionutils.ConstraintK8sEqual131.Check(k8sVersion) {
+		// For Kubernetes 1.31, use the PreferClose strategy of the ServiceTrafficDistribution feature in combination with the GRM's endpoints-slice-hints webhook.
+		//
+		// The webhook is still used to cover the migration case to prevent disabling the topology-aware routing feature during Kubernetes 1.30 -> 1.31 migration
+		// for Services until they are reconciled in the next maintenance time window of the Shoot.
+		service.Spec.TrafficDistribution = ptr.To(corev1.ServiceTrafficDistributionPreferClose)
 		metav1.SetMetaDataLabel(&service.ObjectMeta, resourcesv1alpha1.EndpointSliceHintsConsider, "true")
 	} else {
-		delete(service.Annotations, corev1.AnnotationTopologyMode)
-		delete(service.Annotations, corev1.DeprecatedAnnotationTopologyAwareHints)
-		delete(service.Labels, resourcesv1alpha1.EndpointSliceHintsConsider)
+		// For Kubernetes < 1.31, use the TopologyAwareHints feature (with the new annotation key) in combination with the GRM's endpoints-slice-hints webhook.
+		metav1.SetMetaDataAnnotation(&service.ObjectMeta, corev1.AnnotationTopologyMode, "auto")
+		metav1.SetMetaDataLabel(&service.ObjectMeta, resourcesv1alpha1.EndpointSliceHintsConsider, "true")
 	}
 }
+
+// ReconcileTopologyAwareRoutingMetadata adds or removes the required annotation, label and spec field to make a Service topology-aware.
+//
+// TODO(ialidzhikov): Remove this function after Gardener v1.119 has been released.
+// Deprecated: Use ReconcileTopologyAwareRoutingSettings instead.
+var ReconcileTopologyAwareRoutingMetadata = ReconcileTopologyAwareRoutingSettings

--- a/pkg/utils/gardener/topology_aware_routing_test.go
+++ b/pkg/utils/gardener/topology_aware_routing_test.go
@@ -5,8 +5,10 @@
 package gardener_test
 
 import (
+	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -14,39 +16,65 @@ import (
 )
 
 var _ = Describe("TopologyAwareRouting", func() {
-	Describe("#ReconcileTopologyAwareRoutingMetadata", func() {
-		It("should add the required annotation and label when topology-aware routing is enabled", func() {
-			service := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"service.kubernetes.io/topology-aware-hints": "auto",
+	Describe("#ReconcileTopologyAwareRoutingSettings", func() {
+		Context("when K8s version >= 1.32", func() {
+			It("should set traffic distribution field when topology-aware routing is enabled", func() {
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"service.kubernetes.io/topology-aware-hints": "auto",
+							"service.kubernetes.io/topology-mode":        "auto",
+						},
+						Labels: map[string]string{"endpoint-slice-hints.resources.gardener.cloud/consider": "true"},
 					},
-				},
-			}
+				}
 
-			ReconcileTopologyAwareRoutingMetadata(service, true)
+				ReconcileTopologyAwareRoutingSettings(service, true, semver.MustParse("1.32.1"))
 
-			Expect(service.Annotations).To(HaveKeyWithValue("service.kubernetes.io/topology-mode", "auto"))
-			Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-aware-hints"))
-			Expect(service.Labels).To(HaveKeyWithValue("endpoint-slice-hints.resources.gardener.cloud/consider", "true"))
+				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-mode"))
+				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-aware-hints"))
+				Expect(service.Labels).NotTo(HaveKey("endpoint-slice-hints.resources.gardener.cloud/consider"))
+				Expect(service.Spec.TrafficDistribution).To(PointTo(Equal(corev1.ServiceTrafficDistributionPreferClose)))
+			})
 		})
 
-		It("should remove the annotations and label when topology-aware routing is disabled", func() {
-			service := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"service.kubernetes.io/topology-aware-hints": "auto",
-						"service.kubernetes.io/topology-mode":        "auto",
+		Context("when K8s version = 1.31", func() {
+			It("should set traffic distribution field and add label when topology-aware routing is enabled", func() {
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"service.kubernetes.io/topology-aware-hints": "auto",
+							"service.kubernetes.io/topology-mode":        "auto",
+						},
 					},
-					Labels: map[string]string{"endpoint-slice-hints.resources.gardener.cloud/consider": "true"},
-				},
-			}
+				}
 
-			ReconcileTopologyAwareRoutingMetadata(service, false)
+				ReconcileTopologyAwareRoutingSettings(service, true, semver.MustParse("1.31.1"))
 
-			Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-aware-hints"))
-			Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-mode"))
-			Expect(service.Labels).NotTo(HaveKey("endpoint-slice-hints.resources.gardener.cloud/consider"))
+				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-mode"))
+				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-aware-hints"))
+				Expect(service.Labels).To(HaveKeyWithValue("endpoint-slice-hints.resources.gardener.cloud/consider", "true"))
+				Expect(service.Spec.TrafficDistribution).To(PointTo(Equal(corev1.ServiceTrafficDistributionPreferClose)))
+			})
+		})
+
+		Context("when K8s version < 1.31", func() {
+			It("should add the required annotation and label when topology-aware routing is enabled", func() {
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"service.kubernetes.io/topology-aware-hints": "auto",
+						},
+					},
+				}
+
+				ReconcileTopologyAwareRoutingSettings(service, true, semver.MustParse("1.27.1"))
+
+				Expect(service.Annotations).To(HaveKeyWithValue("service.kubernetes.io/topology-mode", "auto"))
+				Expect(service.Annotations).NotTo(HaveKey("service.kubernetes.io/topology-aware-hints"))
+				Expect(service.Labels).To(HaveKeyWithValue("endpoint-slice-hints.resources.gardener.cloud/consider", "true"))
+				Expect(service.Spec.TrafficDistribution).To(BeNil())
+			})
 		})
 	})
 })

--- a/pkg/utils/gardener/topology_aware_routing_test.go
+++ b/pkg/utils/gardener/topology_aware_routing_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("TopologyAwareRouting", func() {
 	Describe("#ReconcileTopologyAwareRoutingSettings", func() {
-		Context("when K8s version >= 1.32", func() {
+		When("K8s version >= 1.32", func() {
 			It("should set traffic distribution field when topology-aware routing is enabled", func() {
 				service := &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
@@ -38,7 +38,7 @@ var _ = Describe("TopologyAwareRouting", func() {
 			})
 		})
 
-		Context("when K8s version = 1.31", func() {
+		When("K8s version = 1.31", func() {
 			It("should set traffic distribution field and add label when topology-aware routing is enabled", func() {
 				service := &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
@@ -58,7 +58,7 @@ var _ = Describe("TopologyAwareRouting", func() {
 			})
 		})
 
-		Context("when K8s version < 1.31", func() {
+		When("K8s version < 1.31", func() {
 			It("should add the required annotation and label when topology-aware routing is enabled", func() {
 				service := &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -23,6 +23,8 @@ var (
 	ConstraintK8sGreaterEqual130 *semver.Constraints
 	// ConstraintK8sLess131 is a version constraint for versions < 1.31.
 	ConstraintK8sLess131 *semver.Constraints
+	// ConstraintK8sEqual131 is a version constraint for versions == 1.31.
+	ConstraintK8sEqual131 *semver.Constraints
 	// ConstraintK8sGreaterEqual131 is a version constraint for versions >= 1.31.
 	ConstraintK8sGreaterEqual131 *semver.Constraints
 	// ConstraintK8sLess132 is a version constraint for versions < 1.32.
@@ -46,6 +48,8 @@ func init() {
 	ConstraintK8sGreaterEqual130, err = semver.NewConstraint(">= 1.30-0")
 	utilruntime.Must(err)
 	ConstraintK8sLess131, err = semver.NewConstraint("< 1.31-0")
+	utilruntime.Must(err)
+	ConstraintK8sEqual131, err = semver.NewConstraint("~ 1.31.x-0")
 	utilruntime.Must(err)
 	ConstraintK8sGreaterEqual131, err = semver.NewConstraint(">= 1.31-0")
 	utilruntime.Must(err)

--- a/pkg/utils/version/version_test.go
+++ b/pkg/utils/version/version_test.go
@@ -44,6 +44,11 @@ var _ = Describe("Version", func() {
 		Entry("ConstraintK8sLess131, success w/ suffix", ConstraintK8sLess131, semver.MustParse("v1.30.1-foo.12"), BeTrue()),
 		Entry("ConstraintK8sLess131, failure w/ suffix", ConstraintK8sLess131, semver.MustParse("v1.31.0-foo.12"), BeFalse()),
 
+		Entry("ConstraintK8sEqual131, success", ConstraintK8sEqual131, semver.MustParse("1.31.1"), BeTrue()),
+		Entry("ConstraintK8sEqual131, failure", ConstraintK8sEqual131, semver.MustParse("1.30.0"), BeFalse()),
+		Entry("ConstraintK8sEqual131, success w/ suffix", ConstraintK8sEqual131, semver.MustParse("v1.31.1-foo.12"), BeTrue()),
+		Entry("ConstraintK8sEqual131, failure w/ suffix", ConstraintK8sEqual131, semver.MustParse("v1.30.0-foo.12"), BeFalse()),
+
 		Entry("ConstraintK8sGreaterEqual131, success", ConstraintK8sGreaterEqual131, semver.MustParse("1.31.0"), BeTrue()),
 		Entry("ConstraintK8sGreaterEqual131, failure", ConstraintK8sGreaterEqual131, semver.MustParse("1.30.0"), BeFalse()),
 		Entry("ConstraintK8sGreaterEqual131, success w/ suffix", ConstraintK8sGreaterEqual131, semver.MustParse("v1.31.0-foo.12"), BeTrue()),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR is based on @dergeberl's work in https://github.com/gardener/gardener/pull/10973. The topic was worked on during Gardener Hackathon 2024/2.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10421

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The [`ServiceTrafficDistribution`](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution) feature is being used on to make Services topology-aware when the runtime Kubernetes version is 1.31+.
```

```breaking developer
The `github.com/gardener/gardener/pkg/utils/gardener.ReconcileTopologyAwareRoutingMetadata` func in deperecated in favor of `github.com/gardener/gardener/pkg/utils/gardener.ReconcileTopologyAwareRoutingSettings`.
```
