### PR TITLE
fix: Add missing entries in `/etc/hosts` of remote local setup

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -98,6 +98,7 @@ spec:
             " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort      >> /etc/hosts
           echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
           echo "127.0.0.1 garden.local.gardener.cloud"                >> /etc/hosts
+          
           # Resolve e.g. gu-local--e2e-rotate{-wl}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:
           echo '
           address=/.seed.local.gardener.cloud/127.0.0.1

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -92,12 +92,12 @@ spec:
           bash -c "
             echo {{p,g}-seed,{gu,p,v}-local--local}.ingress.local.seed.local.gardener.cloud \
                  api.{e2e-managedseed.garden,local.local}.{internal,external}.local.gardener.cloud \
-                 api.e2e-{hib,upg-hib,wake-up,migrate,rotate,default,upd-node,upgrade}{,-wl}.local.{internal,external}.local.gardener.cloud \
-                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib}.local.{internal,external}.local.gardener.cloud
+                 api.e2e-{hib,upg-hib,wake-up,wake-up-ncp,migrate,rotate,default,upd-node,upgrade}{,-wl}.local.{internal,external}.local.gardener.cloud \
+                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib}.local.{internal,external}.local.gardener.cloud \
+                 gu-local--e2e-rotate{,-wl}.ingress.local.seed.local.gardener.cloud
             " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort      >> /etc/hosts
           echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
           echo "127.0.0.1 garden.local.gardener.cloud"                >> /etc/hosts
-
           # Resolve e.g. gu-local--e2e-rotate{-wl}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:
           echo '
           address=/.seed.local.gardener.cloud/127.0.0.1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

When using the [remote local setup](https://github.com/gardener/gardener/blob/2a6ab6e1241c908c01fc9be0742cc748faaf0f9b/docs/deployment/content/remote-local-setup.yaml#L92-L99) and trying to run E2E tests you receive the following error:
```shell
make test-e2e-local
./hack/test-e2e-local.sh --procs=5 --label-filter="default" ./test/e2e/gardener/...
> E2E Tests
Hostnames for the following Shoots are missing in /etc/hosts:
 - 172.18.255.1 api.e2e-wake-up-ncp.local.internal.local.gardener.cloud
 - 172.18.255.1 api.e2e-wake-up-ncp.local.external.local.gardener.cloud
 - 172.18.255.1 gu-local--e2e-rotate.ingress.local.seed.local.gardener.cloud
 - 172.18.255.1 gu-local--e2e-rotate-wl.ingress.local.seed.local.gardener.cloud
To access shoot clusters and run e2e tests, you have to extend your /etc/hosts file.
Please refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster

make: *** [Makefile:431: test-e2e-local] Error 1
```

This PR adds the missing entries to the remote local setup's `/etc/hosts`.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
