### PR TITLE
Deploy runtime extension in own namespace

### DIFF
--- a/test/integration/operator/extension/extension/extension_suite_test.go
+++ b/test/integration/operator/extension/extension/extension_suite_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,6 +42,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	gardenerenvtest "github.com/gardener/gardener/test/envtest"
 	"github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 )
 
 func TestExtension(t *testing.T) {

--- a/test/integration/operator/extension/extension/extension_suite_test.go
+++ b/test/integration/operator/extension/extension/extension_suite_test.go
@@ -5,11 +5,16 @@
 package extension_test
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -18,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -208,8 +214,63 @@ var _ = BeforeSuite(func() {
 		Expect(mgr.Start(mgrContext)).To(Succeed())
 	}()
 
+	go func() {
+		defer GinkgoRecover()
+		namespaceDeleter(mgrContext)
+	}()
+
 	DeferCleanup(func() {
 		By("Stop manager")
 		mgrCancel()
 	})
 })
+
+// namespaceDeleter finalises deletion of namespaces.
+// This is normally done by the kube-controller-manager which is not running in the integration test environment.
+func namespaceDeleter(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			namespaces := &corev1.NamespaceList{}
+			Expect(testClient.List(ctx, namespaces)).To(Succeed())
+			for _, ns := range namespaces.Items {
+				if ns.DeletionTimestamp != nil && ns.Status.Phase == corev1.NamespaceTerminating {
+					clone := ns.DeepCopy()
+					clone.Spec.Finalizers = nil
+					data, err := json.Marshal(clone)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Send the finalizer request
+					req, err := http.NewRequest("PUT", fmt.Sprintf("%sapi/v1/namespaces/%s/finalize", restConfig.Host, ns.Name), bytes.NewBuffer(data))
+					req.Header.Set("Content-Type", "application/json")
+					tlsConfig, err := rest.TLSConfigFor(restConfig)
+					Expect(err).NotTo(HaveOccurred())
+					client := &http.Client{
+						Transport: &http.Transport{
+							TLSClientConfig: tlsConfig,
+						},
+					}
+					resp, err := client.Do(req)
+					Expect(err).NotTo(HaveOccurred())
+					defer resp.Body.Close()
+
+					// Read the response
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						Expect(err).NotTo(HaveOccurred(), string(body))
+					}
+					if resp.StatusCode != http.StatusOK {
+						Expect(fmt.Errorf("unexpected status code: %d", resp.StatusCode)).NotTo(HaveOccurred(), string(body))
+					} else {
+						log.Info("Finalized Namespace", "namespace", ns.Name)
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/operator/extension/extension/extension_test.go
+++ b/test/integration/operator/extension/extension/extension_test.go
@@ -426,7 +426,7 @@ var _ = Describe("Extension controller tests", func() {
 
 		Eventually(func() error {
 			return testClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRegistrationFoo), &resourcesv1alpha1.ManagedResource{})
-		}).Should(BeNotFoundError())
+		}).WithPolling(1 * time.Second).WithTimeout(5 * time.Second).Should(BeNotFoundError())
 		Eventually(func() error {
 			return testClient.Get(ctx, client.ObjectKey{Namespace: testNamespace.Name, Name: "extension-admission-runtime-provider-foo"}, &resourcesv1alpha1.ManagedResource{})
 		}).Should(BeNotFoundError())
@@ -462,7 +462,7 @@ var _ = Describe("Extension controller tests", func() {
 		}).Should(BeNotFoundError())
 		Eventually(func() error {
 			return mgrClient.Get(ctx, client.ObjectKeyFromObject(extensionFoo), extensionFoo)
-		}).Should(BeNotFoundError())
+		}).WithPolling(1 * time.Second).WithTimeout(5 * time.Second).Should(BeNotFoundError())
 
 		By("Delete garden")
 		Expect(testClient.Delete(ctx, garden)).To(Succeed())

--- a/test/integration/operator/extension/extension/extension_test.go
+++ b/test/integration/operator/extension/extension/extension_test.go
@@ -426,7 +426,7 @@ var _ = Describe("Extension controller tests", func() {
 
 		Eventually(func() error {
 			return testClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRegistrationFoo), &resourcesv1alpha1.ManagedResource{})
-		}).WithPolling(1 * time.Second).WithTimeout(5 * time.Second).Should(BeNotFoundError())
+		}).Should(BeNotFoundError())
 		Eventually(func() error {
 			return testClient.Get(ctx, client.ObjectKey{Namespace: testNamespace.Name, Name: "extension-admission-runtime-provider-foo"}, &resourcesv1alpha1.ManagedResource{})
 		}).Should(BeNotFoundError())
@@ -462,7 +462,7 @@ var _ = Describe("Extension controller tests", func() {
 		}).Should(BeNotFoundError())
 		Eventually(func() error {
 			return mgrClient.Get(ctx, client.ObjectKeyFromObject(extensionFoo), extensionFoo)
-		}).WithPolling(1 * time.Second).WithTimeout(5 * time.Second).Should(BeNotFoundError())
+		}).Should(BeNotFoundError())
 
 		By("Delete garden")
 		Expect(testClient.Delete(ctx, garden)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The extensions for the Garden runtime cluster are now deployed in an own namespace. Its name  starts with `runtime-extension-`.
The main reason is that it allows to use the namespace as the owner reference for any extension webhook configuration and ensures its deletion on the deletion of the extension.
Note: If the runtime extension deploys an admission controller, it is still deployed in the `garden` namespace. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Deploy runtime extension in own namespace.
```
