### PR TITLE
Create a wrapper for `OperatingSystemConfig` provisioning bash script to ensure that it is executed only once

### DIFF
--- a/extensions/pkg/controller/operatingsystemconfig/bash.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash.go
@@ -72,30 +72,34 @@ mkdir -p "` + unitDropInsDirectoryPath + `"`
 
 // WrapProvisionOSCIntoOneshotScript wraps the given script into an oneshot script which exits early when it is called again after finishing successfully.
 func WrapProvisionOSCIntoOneshotScript(script string) string {
-	var wrappedLines []string
+	var (
+		wrappedLines []string
+		nextLine     int
+	)
 
 	lines := strings.Split(script, "\n")
 
-	for i, line := range lines {
-		if strings.HasPrefix(line, "#") {
-			wrappedLines = append(wrappedLines, line)
-			continue
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "#") {
+			break
 		}
 
-		wrappedLines = append(wrappedLines,
-			`if [ -f "/var/lib/osc/provision-osc-applied" ]; then`,
-			`  echo "Provision OSC already applied, exiting..."`,
-			`  exit 0`,
-			`fi`,
-			``,
-		)
-
-		wrappedLines = append(wrappedLines, lines[i:]...)
-
-		break
+		wrappedLines = append(wrappedLines, line)
+		nextLine++
 	}
 
 	wrappedLines = append(wrappedLines,
+		`if [ -f "/var/lib/osc/provision-osc-applied" ]; then`,
+		`  echo "Provision OSC already applied, exiting..."`,
+		`  exit 0`,
+		`fi`,
+		``,
+	)
+
+	wrappedLines = append(wrappedLines, lines[nextLine:]...)
+
+	wrappedLines = append(wrappedLines,
+		``,
 		`mkdir -p /var/lib/osc`,
 		`touch /var/lib/osc/provision-osc-applied`,
 		``,

--- a/extensions/pkg/controller/operatingsystemconfig/bash.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -67,6 +68,40 @@ mkdir -p "` + unitDropInsDirectoryPath + `"`
 	}
 
 	return out
+}
+
+// WrapProvisionOSCIntoOneshotScript wraps the given script into an oneshot script which exits early when it is called again after finishing successfully.
+func WrapProvisionOSCIntoOneshotScript(script string) string {
+	var wrappedLines []string
+
+	lines := strings.Split(script, "\n")
+
+	for i, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			wrappedLines = append(wrappedLines, line)
+			continue
+		}
+
+		wrappedLines = append(wrappedLines,
+			`if [ -f "/var/lib/osc/provision-osc-applied" ]; then`,
+			`  echo "Provision OSC already applied, exiting..."`,
+			`  exit 0`,
+			`fi`,
+			``,
+		)
+
+		wrappedLines = append(wrappedLines, lines[i:]...)
+
+		break
+	}
+
+	wrappedLines = append(wrappedLines,
+		`mkdir -p /var/lib/osc`,
+		`touch /var/lib/osc/provision-osc-applied`,
+		``,
+	)
+
+	return strings.Join(wrappedLines, "\n")
 }
 
 func dataForFileContent(ctx context.Context, c client.Reader, namespace string, content *extensionsv1alpha1.FileContent) ([]byte, error) {

--- a/extensions/pkg/controller/operatingsystemconfig/bash_test.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash_test.go
@@ -222,6 +222,42 @@ EOF`))
 			)
 		})
 	})
+
+	Describe("#WrapProvisionOSCIntoOneshotScript", func() {
+		It("should wrap the script into an oneshot script", func() {
+			script := `echo "Hello, World!"
+`
+			Expect(WrapProvisionOSCIntoOneshotScript(script)).To(Equal(`if [ -f "/var/lib/osc/provision-osc-applied" ]; then
+  echo "Provision OSC already applied, exiting..."
+  exit 0
+fi
+
+echo "Hello, World!"
+
+mkdir -p /var/lib/osc
+touch /var/lib/osc/provision-osc-applied
+`))
+		})
+
+		It("should wrap the script with shebang and comments into an oneshot script", func() {
+			script := `#/bin/bash
+# This is a hello world script
+echo "Hello, World!"
+`
+			Expect(WrapProvisionOSCIntoOneshotScript(script)).To(Equal(`#/bin/bash
+# This is a hello world script
+if [ -f "/var/lib/osc/provision-osc-applied" ]; then
+  echo "Provision OSC already applied, exiting..."
+  exit 0
+fi
+
+echo "Hello, World!"
+
+mkdir -p /var/lib/osc
+touch /var/lib/osc/provision-osc-applied
+`))
+		})
+	})
 })
 
 func runScriptAndCheckFiles(script string, filePaths ...string) {

--- a/extensions/pkg/controller/operatingsystemconfig/bash_test.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash_test.go
@@ -234,6 +234,7 @@ fi
 
 echo "Hello, World!"
 
+
 mkdir -p /var/lib/osc
 touch /var/lib/osc/provision-osc-applied
 `))
@@ -252,6 +253,7 @@ if [ -f "/var/lib/osc/provision-osc-applied" ]; then
 fi
 
 echo "Hello, World!"
+
 
 mkdir -p /var/lib/osc
 touch /var/lib/osc/provision-osc-applied

--- a/pkg/provider-local/controller/operatingsystemconfig/actuator.go
+++ b/pkg/provider-local/controller/operatingsystemconfig/actuator.go
@@ -76,7 +76,7 @@ systemctl daemon-reload
 `, unit.Name, unit.Name)
 	}
 
-	return script, nil
+	return operatingsystemconfig.WrapProvisionOSCIntoOneshotScript(script), nil
 }
 
 func (a *actuator) handleReconcileOSC(_ *extensionsv1alpha1.OperatingSystemConfig) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity robustness
/kind enhancement

**What this PR does / why we need it**:
This PR implements a  wrapper function for the `OperatingSystemConfig` provisioning bash script. It ensures that the script is executed only once.
If the provisioning `OperatingSystemConfig`  is applied via `userdata` to provider VMs, its script is executed every time a VM reboots (at least for certain providers like GCP). Using the wrapper ensures that the script exits early in case it has been executed successfully before. The provisioning OSC should be applied only once. Otherwise, the configuration of the node can be tampered (see #11194). 

The wrapper is implemented in the `extensions` package and can be used by OS extensions like:
- [gardener-extension-os-gardenenlinux](https://github.com/gardener/gardener-extension-os-gardenlinux/blob/84bd8b75ce78e28b4dd2ce6f3cf1302e6e4fb473/pkg/controller/operatingsystemconfig/actuator.go#L85)
- [gardener-extension-os-suse-chost](https://github.com/gardener/gardener-extension-os-suse-chost/blob/0b2b4912041fc3c2c6db88bd75c821167bee55c9/pkg/controller/operatingsystemconfig/actuator.go#L141)
- [gardener-extension-os-ubuntu](https://github.com/gardener/gardener-extension-os-ubuntu/blob/3dc86b6a335e93fae7f7f397dab0cda4fba1e0f7/pkg/controller/operatingsystemconfig/actuator.go#L108)
- [gardener-extension-os-coreos](https://github.com/gardener/gardener-extension-os-coreos/blob/2beda1d5dc4f5aa6814a046510b46676405a4e15/pkg/controller/operatingsystemconfig/actuator.go#L130)

It has been added to OSC controller of `provider-local` as an example in this PR.

**Which issue(s) this PR fixes**:
Part of #11194

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
A wrapper function for `OperatingSystemConfig` provisioning bash script has been implemented. Using the wrapper ensures that the script exits early in case it has been executed successfully before.
```
