### PR TITLE
[renovate] Group terminal-controller-manager updates in one PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,7 +102,7 @@
       // Run make generate when Go API packages have been changed because CRDs might have changed.
       matchDatasources: [
         'go',
-        'github-releases', // Required for the `etc-druid` and `machine-controller-manager` groups.
+        'github-releases', // Required for the gardener groups.
       ],
       postUpgradeTasks: {
         commands: [
@@ -113,8 +113,9 @@
       matchPackageNames: [
         '/.+/api/.+/',
         '/.+/apis/.+/',
-        '/.*gardener\/machine-controller-manager$/',
         '/.*gardener\/etcd-druid$/',
+        '/.*gardener\/machine-controller-manager$/',
+        '/.*gardener\/terminal-controller-manager$/',
       ],
     },
     {
@@ -209,6 +210,17 @@
       ],
       matchPackageNames: [
         '/.*gardener\/machine-controller-manager$/'
+      ],
+    },
+        {
+      // Group terminal-controller-manager updates in one PR.
+      groupName: 'terminal-controller-manager',
+      matchDatasources: [
+        'github-releases',
+        'go',
+      ],
+      matchPackageNames: [
+        '/.*gardener\/terminal-controller-manager$/'
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -212,7 +212,7 @@
         '/.*gardener\/machine-controller-manager$/'
       ],
     },
-        {
+    {
       // Group terminal-controller-manager updates in one PR.
       groupName: 'terminal-controller-manager',
       matchDatasources: [


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR group terminal-controller-manager updates in one PR.
- #11205
- #11206

Additionally, it invokes `make generate` after the update as it might contain changed CRDs ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11205/pull-gardener-unit/1881277795259125760)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
