### PR TITLE
docs: Simplify second seed cluster guide

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -306,21 +306,18 @@ To access an Ingress resource from the `Seed`, use the Ingress host with port `8
 
 ## (Optional): Setting Up a Second Seed Cluster
 
-There are cases where you would want to create a second seed cluster in your local setup. For example, if you want to test the [control plane migration](../operations/control_plane_migration.md) feature. The following steps describe how to do that.
+There are cases where you would want to create a second seed cluster in your local setup.
+For example, if you want to test the [control plane migration](../operations/control_plane_migration.md) feature.
+The following steps describe how to do that.
 
-If you are on macOS, add a new IP address on your loopback device which will be necessary for the new KinD cluster that you will create. On macOS, the default loopback device is `lo0`.
-
-```bash
-sudo ip addr add 172.18.255.2 dev lo0                                  # adding 172.18.255.2 ip to the loopback interface
-```
-
-Next, setup the second KinD cluster:
+Start by setting up the second KinD cluster:
 
 ```bash
 make kind2-up
 ```
 
 This command sets up a new KinD cluster named `gardener-local2` and stores its kubeconfig in the `./example/gardener-local/kind/local2/kubeconfig` file.
+It adds another IP address (`172.18.255.2`) to your loopback device which is necessary for you to reach the new cluster locally.
 
 In order to deploy required resources in the KinD cluster that you just created, run:
 
@@ -355,6 +352,12 @@ If you want to perform control plane migration, you can follow the steps outline
 
 ``` shell
 make kind2-down
+```
+
+On macOS, if you want to remove the additional IP address on your loopback device run the following script:
+
+```shell
+sudo ip addr del 172.18.255.2 dev lo0
 ```
 
 ## Tear Down the Gardener Environment


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area documentation
/kind cleanup

**What this PR does / why we need it**:

The section for [Setting Up a Second Seed Cluster](https://gardener.cloud/docs/gardener/deployment/getting_started_locally/#optional-setting-up-a-second-seed-cluster) in the [Getting Started Locally](https://gardener.cloud/docs/gardener/deployment/getting_started_locally) guide contains the following paragraph:
https://github.com/gardener/gardener/blob/679007b2040ce8ef440286ba2803292cd9a1e58b/docs/deployment/getting_started_locally.md#L311-L315

However, the additional IP address `172.18.255.2` is automatically added to the default loopback by the `kind-up.sh` script:
https://github.com/gardener/gardener/blob/26d505bd67ad85b126c595827edeb56cf8df3eee/hack/kind-up.sh#L302

This PR removes the part about adding the IP address manually. The remainder of the changes are Markdown formatting and explicitly mentioning that `make kind2-up` adds another IP and how to remove it again when tearing down.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

_n.a._

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
