### PR TITLE
Allow generic-garbage-collector serviceaccount to delete update restricted resources

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/handler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -21,6 +22,16 @@ type Handler struct{}
 // Handle checks if the request is issued by a gardenlet
 // and rejects the request if that is not the case.
 func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Response {
+	// Allow the garbage-collector-controller to delete resources.
+	// This is required as KCM is used to GC resources
+	// that might be considered stale as their owner object is already gone.
+	if req.UserInfo.Username == "system:serviceaccount:kube-system:generic-garbage-collector" {
+		if req.Operation == admissionv1.Delete {
+			return admission.Allowed("")
+		}
+		return admission.Denied(fmt.Sprintf("user %q is not allowed to %s system %s", req.UserInfo.Username, req.Operation, req.Resource.Resource))
+	}
+
 	if !slices.Contains(req.UserInfo.Groups, v1beta1constants.SeedsGroup) {
 		return admission.Denied(fmt.Sprintf("user %q is not allowed to modify system %s", req.UserInfo.Username, req.Resource.Resource))
 	}

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/handler_test.go
@@ -65,5 +65,39 @@ var _ = Describe("handler", func() {
 				},
 			}))
 		})
+
+		It("should allow the delete request as it is made by the generic-garbage-collector serviceaccount", func() {
+			req.UserInfo = authenticationv1.UserInfo{
+				Username: "system:serviceaccount:kube-system:generic-garbage-collector",
+			}
+			req.Operation = admissionv1.Delete
+			resp := handler.Handle(ctx, req)
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.AdmissionResponse).To(Equal(admissionv1.AdmissionResponse{
+				Allowed: true,
+				Result: &metav1.Status{
+					Code:    int32(200),
+					Reason:  "",
+					Message: "",
+				},
+			}))
+		})
+
+		It("should not allow the update request even if it is made by the generic-garbage-collector serviceaccount", func() {
+			req.UserInfo = authenticationv1.UserInfo{
+				Username: "system:serviceaccount:kube-system:generic-garbage-collector",
+			}
+			req.Operation = admissionv1.Update
+			resp := handler.Handle(ctx, req)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.AdmissionResponse).To(Equal(admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Code:    int32(403),
+					Reason:  "Forbidden",
+					Message: "user \"system:serviceaccount:kube-system:generic-garbage-collector\" is not allowed to UPDATE system configmaps",
+				},
+			}))
+		})
 	})
 })

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/handler_test.go
@@ -34,6 +34,7 @@ var _ = Describe("handler", func() {
 		req.Resource = metav1.GroupVersionResource{
 			Resource: "configmaps",
 		}
+		req.Operation = admissionv1.Update
 	})
 
 	Describe("#Handle", func() {
@@ -45,7 +46,7 @@ var _ = Describe("handler", func() {
 				Result: &metav1.Status{
 					Code:    int32(200),
 					Reason:  "",
-					Message: "",
+					Message: "gardenlet is allowed to modify system resources",
 				},
 			}))
 		})
@@ -61,7 +62,7 @@ var _ = Describe("handler", func() {
 				Result: &metav1.Status{
 					Code:    int32(403),
 					Reason:  "Forbidden",
-					Message: "user \"not-gardenlet\" is not allowed to modify system configmaps",
+					Message: "user \"not-gardenlet\" is not allowed to UPDATE system configmaps",
 				},
 			}))
 		})
@@ -78,7 +79,7 @@ var _ = Describe("handler", func() {
 				Result: &metav1.Status{
 					Code:    int32(200),
 					Reason:  "",
-					Message: "",
+					Message: "generic-garbage-collector is allowed to delete system resources",
 				},
 			}))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
See #11211 for reasoning.

**Which issue(s) this PR fixes**:
Fixes #11211

**Special notes for your reviewer**:
cc @vpnachev @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
