### PR TITLE
Fix TM test `Shoot container runtime testing`

### DIFF
--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -88,12 +88,8 @@ func (e *rootPodExecutor) Execute(ctx context.Context, command ...string) ([]byt
 		}
 	}
 
-	if err != nil {
+	if err != nil || len(stderrBytes) > 0 {
 		return stderrBytes, err
-	}
-
-	if len(stderrBytes) > 0 {
-		return stderrBytes, nil
 	}
 
 	if len(stdoutBytes) > 0 {

--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -76,14 +76,14 @@ func (e *rootPodExecutor) Execute(ctx context.Context, command ...string) ([]byt
 	if stderr != nil {
 		var err2 error
 		stderrBytes, err2 = io.ReadAll(stderr)
-		if err != nil {
+		if err2 != nil {
 			return nil, err2
 		}
 	}
 	if stdout != nil {
 		var err2 error
 		stdoutBytes, err2 = io.ReadAll(stdout)
-		if err != nil {
+		if err2 != nil {
 			return nil, err2
 		}
 	}

--- a/test/testmachinery/shoots/operations/containerruntime.go
+++ b/test/testmachinery/shoots/operations/containerruntime.go
@@ -93,23 +93,23 @@ var _ = Describe("Shoot container runtime testing", func() {
 
 		// check the configuration on the host
 		containerdServiceCommand := []string{"systemctl", "is-active", "containerd"}
-		executeCommand(ctx, rootPodExecutor, containerdServiceCommand, "active")
+		executeCommand(ctx, f, rootPodExecutor, containerdServiceCommand, "active")
 
 		// check that config.toml is configured
 		checkConfigurationCommand := []string{"sh", "-c", "cat /etc/systemd/system/containerd.service.d/11-exec_config.conf | grep 'usr/bin/containerd --config=/etc/containerd/config.toml' | echo $?"}
-		executeCommand(ctx, rootPodExecutor, checkConfigurationCommand, "0")
+		executeCommand(ctx, f, rootPodExecutor, checkConfigurationCommand, "0")
 
 		// check that config.toml exists
 		checkConfigCommand := []string{"sh", "-c", "[ -f /etc/containerd/config.toml ] && echo 'found' || echo 'Not found'"}
-		executeCommand(ctx, rootPodExecutor, checkConfigCommand, "found")
+		executeCommand(ctx, f, rootPodExecutor, checkConfigCommand, "found")
 	}, scaleWorkerTimeout)
 })
 
 // executeCommand executes a command on the host and checks the returned result
-func executeCommand(ctx context.Context, rootPodExecutor framework.RootPodExecutor, command []string, expected string) {
+func executeCommand(ctx context.Context, f *framework.ShootFramework, rootPodExecutor framework.RootPodExecutor, command []string, expected string) {
 	response, err := rootPodExecutor.Execute(ctx, command...)
 	if err != nil {
-		GinkgoWriter.Printf("Error executing command: %q returned %q\n", command, response)
+		f.Logger.Error(err, "Error executing command", "command", command, "response", response)
 	}
 	framework.ExpectNoError(err)
 	Expect(response).ToNot(BeNil())

--- a/test/testmachinery/shoots/operations/containerruntime.go
+++ b/test/testmachinery/shoots/operations/containerruntime.go
@@ -92,22 +92,25 @@ var _ = Describe("Shoot container runtime testing", func() {
 		rootPodExecutor := framework.NewRootPodExecutor(f.Logger, f.ShootClient, &nodeList.Items[0].Name, "kube-system")
 
 		// check the configuration on the host
-		containerdServiceCommand := fmt.Sprintf("systemctl is-active %s", "containerd")
+		containerdServiceCommand := []string{"systemctl", "is-active", "containerd"}
 		executeCommand(ctx, rootPodExecutor, containerdServiceCommand, "active")
 
 		// check that config.toml is configured
-		checkConfigurationCommand := "cat /etc/systemd/system/containerd.service.d/11-exec_config.conf | grep 'usr/bin/containerd --config=/etc/containerd/config.toml' |  echo $?"
+		checkConfigurationCommand := []string{"sh", "-c", "cat /etc/systemd/system/containerd.service.d/11-exec_config.conf | grep 'usr/bin/containerd --config=/etc/containerd/config.toml' | echo $?"}
 		executeCommand(ctx, rootPodExecutor, checkConfigurationCommand, "0")
 
 		// check that config.toml exists
-		checkConfigCommand := "[ -f /etc/containerd/config.toml ] && echo 'found' || echo 'Not found'"
+		checkConfigCommand := []string{"sh", "-c", "[ -f /etc/containerd/config.toml ] && echo 'found' || echo 'Not found'"}
 		executeCommand(ctx, rootPodExecutor, checkConfigCommand, "found")
 	}, scaleWorkerTimeout)
 })
 
 // executeCommand executes a command on the host and checks the returned result
-func executeCommand(ctx context.Context, rootPodExecutor framework.RootPodExecutor, command, expected string) {
-	response, err := rootPodExecutor.Execute(ctx, command)
+func executeCommand(ctx context.Context, rootPodExecutor framework.RootPodExecutor, command []string, expected string) {
+	response, err := rootPodExecutor.Execute(ctx, command...)
+	if err != nil {
+		GinkgoWriter.Printf("Error executing command: %q returned %q\n", command, response)
+	}
 	framework.ExpectNoError(err)
 	Expect(response).ToNot(BeNil())
 	Expect(string(response)).To(Equal(fmt.Sprintf("%s\n", expected)))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR fixes TM test `Shoot container runtime testing` which might be broken since https://github.com/gardener/gardener/pull/10977/commits/e1f25c9b439f7669bf38a0c0523949c7d802d7b5.
Thanks @timuthy for finding out 🚀 

Additionally, it logs the output of commands run by pod executor in case of errors. This might be helpful to identify errors in the future. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
