### PR TITLE
Allow IPv6-only tests in test machinery to create shoot cluster.

### DIFF
--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -281,6 +281,11 @@ func setShootNetworkingSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreati
 		shoot.Spec.Networking.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamily(cfg.ipFamilies)}
 	}
 
+	if gardencorev1beta1.IsIPv6SingleStack(shoot.Spec.Networking.IPFamilies) {
+		// Node IP range will be set by the infrastructure and should not be provided
+		shoot.Spec.Networking.Nodes = nil
+	}
+
 	if StringSet(cfg.networkingType) {
 		shoot.Spec.Networking.Type = ptr.To(cfg.networkingType)
 	}

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -284,6 +284,8 @@ func setShootNetworkingSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreati
 	if gardencorev1beta1.IsIPv6SingleStack(shoot.Spec.Networking.IPFamilies) {
 		// Node IP range will be set by the infrastructure and should not be provided
 		shoot.Spec.Networking.Nodes = nil
+	} else if StringSet(cfg.networkingNodes) {
+		shoot.Spec.Networking.Nodes = &cfg.networkingNodes
 	}
 
 	if StringSet(cfg.networkingType) {
@@ -296,10 +298,6 @@ func setShootNetworkingSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreati
 
 	if StringSet(cfg.networkingServices) {
 		shoot.Spec.Networking.Services = &cfg.networkingServices
-	}
-
-	if StringSet(cfg.networkingNodes) {
-		shoot.Spec.Networking.Nodes = &cfg.networkingNodes
 	}
 
 	if clearDNS {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area testing
/kind enhancement

**What this PR does / why we need it**:

Allow IPv6-only tests in test machinery to create shoot cluster.

On real infrastructures, we assume that the infrastructure will provide the IPv6 ranges. Therefore, no node IP range should be specified for those tests.
To keep the changes minimal, the default IPv4 range is kept in place, but it is removed for IPv6-only clusters so that the cluster creation succeeds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Disable default node range in test machinery tests for IPv6-only tests.
```
