### PR TITLE
Restrict the update of Shoot CA bundles

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -576,6 +576,7 @@ const (
 	LabelShootUID = "shoot.gardener.cloud/uid"
 
 	// LabelPublicKeys is a constant for a label key that indicates that a resource contains public keys.
+	// Deprecated: Use LabelDiscoveryPublic instead.
 	LabelPublicKeys = "authentication.gardener.cloud/public-keys" // TODO(dimityrmirchev): Deprecate in favour of LabelDiscoveryPublic
 	// LabelPublicKeysServiceAccount is a constant for a label value that indicates that a resource contains service account public keys.
 	LabelPublicKeysServiceAccount = "serviceaccount"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -572,11 +572,18 @@ const (
 	LabelShootNamespace = "shoot.gardener.cloud/namespace"
 	// LabelShootName is a constant for a label key that indicates a relationship to a shoot with the specified name.
 	LabelShootName = "shoot.gardener.cloud/name"
+	// LabelShootUID is a constant for a label key that indicates a relationship to a shoot with the specified UID.
+	LabelShootUID = "shoot.gardener.cloud/uid"
 
 	// LabelPublicKeys is a constant for a label key that indicates that a resource contains public keys.
-	LabelPublicKeys = "authentication.gardener.cloud/public-keys"
+	LabelPublicKeys = "authentication.gardener.cloud/public-keys" // TODO(dimityrmirchev): Deprecate in favour of LabelDiscoveryPublic
 	// LabelPublicKeysServiceAccount is a constant for a label value that indicates that a resource contains service account public keys.
 	LabelPublicKeysServiceAccount = "serviceaccount"
+
+	// LabelDiscoveryPublic is a constant for a label key that indicates that the labeled resource is of interest to the Gardener Discovery Server.
+	LabelDiscoveryPublic = "discovery.gardener.cloud/public"
+	// DiscoveryShootCA is a constant for a label value that indicates that the labeled resource contains shoot cluster certificate authority.
+	DiscoveryShootCA = "shoot-ca"
 
 	// LabelExposureClassHandlerName is the label key for exposure class handler names.
 	LabelExposureClassHandlerName = "handler.exposureclass.gardener.cloud/name"

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -218,7 +218,13 @@ func (b *Botanist) generateCertificateAuthorities(ctx context.Context) error {
 	if err := b.syncShootConfigMapToGarden(
 		ctx,
 		gardenerutils.ShootProjectConfigMapSuffixCACluster,
-		map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleCACluster},
+		map[string]string{
+			v1beta1constants.GardenRole:             v1beta1constants.GardenRoleCACluster,
+			v1beta1constants.LabelDiscoveryPublic:   v1beta1constants.DiscoveryShootCA,
+			v1beta1constants.LabelShootName:         b.Shoot.GetInfo().Name,
+			v1beta1constants.LabelShootUID:          string(b.Shoot.GetInfo().UID),
+			v1beta1constants.LabelUpdateRestriction: "true",
+		},
 		nil,
 		map[string]string{secretsutils.DataKeyCertificateCA: string(caBundle)},
 	); err != nil {

--- a/pkg/gardenlet/operation/botanist/secrets_test.go
+++ b/pkg/gardenlet/operation/botanist/secrets_test.go
@@ -196,7 +196,15 @@ var _ = Describe("Secrets", func() {
 
 				gardenConfigMap := &corev1.ConfigMap{}
 				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ca-cluster"}, gardenConfigMap)).To(Succeed())
-				Expect(gardenConfigMap.Labels).To(HaveKeyWithValue("gardener.cloud/role", "ca-cluster"))
+				Expect(gardenConfigMap.Labels).To(Equal(
+					map[string]string{
+						"discovery.gardener.cloud/public":   "shoot-ca",
+						"gardener.cloud/role":               "ca-cluster",
+						"gardener.cloud/update-restriction": "true",
+						"shoot.gardener.cloud/name":         "bar",
+						"shoot.gardener.cloud/uid":          "daa71cd9-c81a-45ac-a3d3-8bc2f4926a30",
+					},
+				))
 
 				gardenSecret := &corev1.Secret{}
 				Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: gardenNamespace, Name: shootName + ".ca-cluster"}, gardenSecret)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Protect the shoot CA bundle configmaps so that they can be safely served by the Gardener Discovery Server.

For https://github.com/gardener/gardener-discovery-server/issues/31

Related to https://github.com/gardener/gardener/pull/11108

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Users are no longer able to modify shoot CA bundle configmaps. Such system resources are considered sensitive to modification because the data stored in them cannot be trusted unless its authenticity is guaranteed.
```
