### PR TITLE
First steps towards local dual-stack setup

### DIFF
--- a/example/gardener-local/gardenlet/values-dual.yaml
+++ b/example/gardener-local/gardenlet/values-dual.yaml
@@ -3,16 +3,16 @@ config:
     spec:
       networks:
         ipFamilies:
-        - IPv4
         - IPv6
-        nodes: 172.18.0.0/16
+        - IPv4
+        nodes: fd00:10::/64
         # Those CIDRs must match those specified in the kind Cluster configuration.
-        pods: 10.1.0.0/16
-        services: 10.2.0.0/16
+        pods: fd00:10:1::/56
+        services: fd00:10:2::/112
         shootDefaults:
           ipFamilies:
-          - IPv4
           - IPv6
+          - IPv4
           pods: fd00:10:3::/56
           services: fd00:10:4::/112
 

--- a/example/gardener-local/kind/cluster/templates/_kubeadm_config_patches.tpl
+++ b/example/gardener-local/kind/cluster/templates/_kubeadm_config_patches.tpl
@@ -22,7 +22,7 @@
       hostPath: /etc/gardener-local/kube-apiserver/authz-config-with-seedauthorizer.yaml
     - name: authz-webhook-kubeconfig
       mountPath: /etc/gardener-local/kube-apiserver/authz-webhook-kubeconfig.yaml
-      hostPath: /etc/gardener-local/kube-apiserver/authz-webhook-kubeconfig-{{ if eq .Values.networking.ipFamily "dual" }}ipv4{{ else }}{{ .Values.networking.ipFamily }}{{ end }}.yaml
+      hostPath: /etc/gardener-local/kube-apiserver/authz-webhook-kubeconfig-{{ if eq .Values.networking.ipFamily "dual" }}ipv6{{ else }}{{ .Values.networking.ipFamily }}{{ end }}.yaml
       readOnly: true
       pathType: File
 {{- else }}

--- a/example/gardener-local/kind/cluster/values-dual.yaml
+++ b/example/gardener-local/kind/cluster/values-dual.yaml
@@ -7,5 +7,5 @@ gardener:
 
 networking:
   ipFamily: dual
-  podSubnet: "10.1.0.0/16,fd00:10:1::/56"
-  serviceSubnet: "10.2.0.0/16,fd00:10:2::/112"
+  podSubnet: "fd00:10:1::/56,10.1.0.0/16"
+  serviceSubnet: "fd00:10:2::/112,10.2.0.0/16"

--- a/example/provider-local/seed-kind/local-dual/patch-seed.yaml
+++ b/example/provider-local/seed-kind/local-dual/patch-seed.yaml
@@ -2,8 +2,8 @@
   path: /spec/networks
   value:
     ipFamilies:
-      - IPv4
       - IPv6
+      - IPv4
     nodes: fd00:10::/64
     pods: fd00:10:1::/56
     services: fd00:10:2::/112

--- a/pkg/component/kubernetes/apiserverexposure/service_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/service_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -36,7 +37,7 @@ var _ = Describe("#Service", func() {
 
 		ingressIP        string
 		clusterIP        string
-		clusterIPFunc    func(string)
+		clusterIPsFunc   func([]string)
 		ingressIPFunc    func(string)
 		namePrefix       string
 		namespace        string
@@ -58,7 +59,7 @@ var _ = Describe("#Service", func() {
 		namespace = "test-namespace"
 		expectedName = "test-kube-apiserver"
 		sniServiceObjKey = client.ObjectKey{Name: "foo", Namespace: "bar"}
-		clusterIPFunc = func(c string) { clusterIP = c }
+		clusterIPsFunc = func(c []string) { clusterIP = c[0] }
 		ingressIPFunc = func(c string) { ingressIP = c }
 
 		expected = &corev1.Service{
@@ -86,7 +87,9 @@ var _ = Describe("#Service", func() {
 					"app":  "kubernetes",
 					"role": "apiserver",
 				},
-				ClusterIP: "1.1.1.1",
+				ClusterIP:      "1.1.1.1",
+				ClusterIPs:     []string{"1.1.1.1"},
+				IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 			},
 		}
 
@@ -119,7 +122,7 @@ var _ = Describe("#Service", func() {
 			},
 			func() client.ObjectKey { return sniServiceObjKey },
 			&retryfake.Ops{MaxAttempts: 1},
-			clusterIPFunc,
+			clusterIPsFunc,
 			ingressIPFunc,
 		)
 	})
@@ -196,7 +199,7 @@ var _ = Describe("#Service", func() {
 					},
 					func() client.ObjectKey { return sniServiceObjKey },
 					&retryfake.Ops{MaxAttempts: 1},
-					clusterIPFunc,
+					clusterIPsFunc,
 					ingressIPFunc,
 				)
 

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -138,6 +138,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          {{- if eq .Values.dualStack true }}
+          - name: ISTIO_DUAL_STACK
+            value: "true"
+          {{- end }}
           volumeMounts:
           - name: workload-socket
             mountPath: /var/run/secrets/workload-spiffe-uds

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -588,6 +588,7 @@ profiles:
   - name: ipv6
     activation:
       - env: IPFAMILY=ipv6
+      - env: IPFAMILY=dual
     patches:
       - op: add
         path: /deploy/helm/releases/0/setValues


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

First steps towards local dual-stack setup.

These changes adapt the existing local dual-stack setup to use IPv6 as primary address family to catch IPv6 related issues earlier. As a result of this, istio is configured correctly, i.e. listens now on both address families in case of a dual-stack setup. Furthermore, the `kube-apiserver` service is now a dual-stack service in dual-stack seeds. This allows IPv4 single-stack shoot clusters on dual-stack seeds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Please note that these changes allow to create a local dual-stack setup with `IPFAMILY=dual`, but only single-stack IPv6 shoot clusters work completely. For single-stack IPv4 shoot clusters, the back-route in `vpn-shoot` is incorrect due to the seed pod network not covering the IPv4 range. Dual-stack shoot clusters do not work due to provider-local not supporting dual-stack, yet.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Local dual-stack setup for development now running with IPv6 as primary address family.
```

/cc @DockToFuture @axel7born 