### PR TITLE
Fix nil pointer deref in Structured Authn

### DIFF
--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1098,10 +1098,20 @@ func (r *Reconciler) newGardenerDashboard(garden *operatorv1alpha1.Garden, secre
 		}
 
 		if config.OIDC != nil {
+			issuerURL := config.OIDC.IssuerURL
+			if issuerURL == nil {
+				issuerURL = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.OIDCConfig.IssuerURL
+			}
+
+			clientIDPublic := config.OIDC.ClientIDPublic
+			if clientIDPublic == nil {
+				clientIDPublic = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.OIDCConfig.ClientID
+			}
+
 			values.OIDC = &gardenerdashboard.OIDCValues{
 				DashboardOIDC:  *config.OIDC,
-				IssuerURL:      ptr.Deref(garden.Spec.VirtualCluster.Gardener.Dashboard.OIDC.IssuerURL, *garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.OIDCConfig.IssuerURL),
-				ClientIDPublic: ptr.Deref(garden.Spec.VirtualCluster.Gardener.Dashboard.OIDC.ClientIDPublic, *garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.OIDCConfig.ClientID),
+				IssuerURL:      *issuerURL,
+				ClientIDPublic: *clientIDPublic,
 			}
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
Fixes a nil pointer deref when using structured authentication, see #11227.

**Which issue(s) this PR fixes**:
Fixes #11227

**Special notes for your reviewer**:
/cc @oliver-goetz first required backport ;)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue has been fixed that caused the `garden` reconciliation to stop when structured authentication was used in combination with the gardener-dashboard `oidcConfig`.
```
