### PR TITLE
Fix `etcd` readiness check

### DIFF
--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -110,6 +110,7 @@ type Interface interface {
 func New(
 	log logr.Logger,
 	c client.Client,
+	reader client.Reader,
 	namespace string,
 	secretsManager secretsmanager.Interface,
 	values Values,
@@ -119,6 +120,7 @@ func New(
 
 	return &etcd{
 		client:         c,
+		apiReader:      reader,
 		log:            log,
 		namespace:      namespace,
 		secretsManager: secretsManager,
@@ -134,6 +136,7 @@ func New(
 
 type etcd struct {
 	client         client.Client
+	apiReader      client.Reader
 	log            logr.Logger
 	namespace      string
 	secretsManager secretsmanager.Interface

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -674,7 +674,7 @@ var _ = Describe("Etcd", func() {
 
 		By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd", Namespace: testNamespace}})).To(Succeed())
-		etcd = New(log, c, testNamespace, sm, Values{
+		etcd = New(log, c, c, testNamespace, sm, Values{
 			Role:                    testRole,
 			Class:                   class,
 			Replicas:                replicas,
@@ -760,7 +760,7 @@ var _ = Describe("Etcd", func() {
 				existingReplicas int32 = 245
 			)
 
-			etcd = New(log, c, testNamespace, sm, Values{
+			etcd = New(log, c, c, testNamespace, sm, Values{
 				Role:                    testRole,
 				Class:                   class,
 				Replicas:                nil,
@@ -831,7 +831,7 @@ var _ = Describe("Etcd", func() {
 				existingReplicas int32 = 245
 			)
 
-			etcd = New(log, c, testNamespace, sm, Values{
+			etcd = New(log, c, c, testNamespace, sm, Values{
 				Role:                    testRole,
 				Class:                   class,
 				Replicas:                nil,
@@ -1083,7 +1083,7 @@ var _ = Describe("Etcd", func() {
 					evictionRequirement = v1beta1constants.EvictionRequirementNever
 				}
 
-				etcd = New(log, c, testNamespace, sm, Values{
+				etcd = New(log, c, c, testNamespace, sm, Values{
 					Role:                    testRole,
 					Class:                   class,
 					Replicas:                replicas,
@@ -1565,7 +1565,7 @@ var _ = Describe("Etcd", func() {
 
 				replicas = ptr.To[int32](1)
 
-				etcd = New(log, c, testNamespace, sm, Values{
+				etcd = New(log, c, c, testNamespace, sm, Values{
 					Role:                        testRole,
 					Class:                       class,
 					Replicas:                    replicas,
@@ -1626,7 +1626,7 @@ var _ = Describe("Etcd", func() {
 
 				replicas = ptr.To[int32](1)
 
-				etcd = New(log, c, testNamespace, sm, Values{
+				etcd = New(log, c, c, testNamespace, sm, Values{
 					Role:                        testRole,
 					Class:                       class,
 					Replicas:                    replicas,
@@ -1707,7 +1707,7 @@ var _ = Describe("Etcd", func() {
 		)
 
 		JustBeforeEach(func() {
-			etcd = New(log, c, testNamespace, sm, Values{
+			etcd = New(log, c, c, testNamespace, sm, Values{
 				Role:                    testRole,
 				Class:                   class,
 				Replicas:                ptr.To[int32](1),
@@ -1960,7 +1960,7 @@ var _ = Describe("Etcd", func() {
 		var highAvailability bool
 
 		JustBeforeEach(func() {
-			etcd = New(log, c, testNamespace, sm, Values{
+			etcd = New(log, c, c, testNamespace, sm, Values{
 				Role:                    testRole,
 				Class:                   class,
 				Replicas:                replicas,

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -43,6 +43,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 	e := NewEtcd(
 		b.Logger,
 		b.SeedClientSet.Client(),
+		b.SeedClientSet.APIReader(),
 		b.Shoot.SeedNamespace,
 		b.SecretsManager,
 		etcd.Values{

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -120,6 +120,7 @@ var _ = Describe("Etcd", func() {
 
 						validator := &newEtcdValidator{
 							expectedClient:                  Equal(c),
+							expectedReader:                  Equal(reader),
 							expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 							expectedNamespace:               Equal(namespace),
 							expectedSecretsManager:          Equal(sm),
@@ -152,6 +153,7 @@ var _ = Describe("Etcd", func() {
 			It("should successfully create an etcd interface (normal class)", func() {
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
+					expectedReader:                  Equal(reader),
 					expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 					expectedNamespace:               Equal(namespace),
 					expectedSecretsManager:          Equal(sm),
@@ -178,6 +180,7 @@ var _ = Describe("Etcd", func() {
 
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
+					expectedReader:                  Equal(reader),
 					expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 					expectedNamespace:               Equal(namespace),
 					expectedSecretsManager:          Equal(sm),
@@ -500,6 +503,7 @@ type newEtcdValidator struct {
 	etcd.Interface
 
 	expectedClient                  gomegatypes.GomegaMatcher
+	expectedReader                  gomegatypes.GomegaMatcher
 	expectedLogger                  gomegatypes.GomegaMatcher
 	expectedNamespace               gomegatypes.GomegaMatcher
 	expectedSecretsManager          gomegatypes.GomegaMatcher
@@ -515,12 +519,14 @@ type newEtcdValidator struct {
 func (v *newEtcdValidator) NewEtcd(
 	log logr.Logger,
 	client client.Client,
+	reader client.Reader,
 	namespace string,
 	secretsManager secretsmanager.Interface,
 	values etcd.Values,
 ) etcd.Interface {
 	Expect(log).To(v.expectedLogger)
 	Expect(client).To(v.expectedClient)
+	Expect(reader).To(v.expectedReader)
 	Expect(namespace).To(v.expectedNamespace)
 	Expect(secretsManager).To(v.expectedSecretsManager)
 	Expect(values.Role).To(v.expectedRole)

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -489,6 +489,7 @@ func (r *Reconciler) newEtcd(
 	return etcd.New(
 		log,
 		r.RuntimeClientSet.Client(),
+		r.RuntimeClientSet.APIReader(),
 		r.GardenNamespace,
 		secretsManager,
 		etcd.Values{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Band-aid for https://github.com/gardener/etcd-druid/issues/985

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
~Will remain in draft until double checked with Etcd-Druid maintainers.~ Plan for fixing https://github.com/gardener/etcd-druid/issues/985 is settled (see https://github.com/gardener/etcd-druid/issues/985#issuecomment-2611712512). In the meantime we can continue with the band-aid in this PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed checking `etcd` cluster readiness when rolling out spec changes. On rare occasions this led to failing credential rotations.
```
