### PR TITLE
Drop temporary helper functions for `k8s.io/component-base/config.ClientConnectionConfiguration`

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	componentbaseconfig "k8s.io/component-base/config"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -127,28 +126,6 @@ func NewClientFromSecretObject(secret *corev1.Secret, fns ...ConfigFunc) (Interf
 		return NewClientFromBytes(kubeconfig, fns...)
 	}
 	return nil, errors.New("the secret does not contain a field with name 'kubeconfig'")
-}
-
-// RESTConfigFromInternalClientConnectionConfiguration creates a *rest.Config from a componentbaseconfig.ClientConnectionConfiguration and the configured kubeconfig.
-// It takes an optional list of additionally allowed kubeconfig fields.
-// Deprecated: use RESTConfigFromClientConnectionConfiguration instead.
-// TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
-func RESTConfigFromInternalClientConnectionConfiguration(cfg *componentbaseconfig.ClientConnectionConfiguration, kubeconfig []byte, allowedFields ...string) (*rest.Config, error) {
-	return RESTConfigFromClientConnectionConfiguration(ConvertClientConnectionConfigurationToExternal(cfg), kubeconfig, allowedFields...)
-}
-
-// ConvertClientConnectionConfigurationToExternal converts a componentbaseconfig.ClientConnectionConfiguration to componentbaseconfigv1alpha1.ClientConnectionConfiguration.
-// This function is added for supporting the transition to the external version while dropping the internal version of config APIs.
-// Deprecated: use the external version of ClientConnectionConfiguration directly instead.
-// TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
-func ConvertClientConnectionConfigurationToExternal(cfg *componentbaseconfig.ClientConnectionConfiguration) *componentbaseconfigv1alpha1.ClientConnectionConfiguration {
-	return &componentbaseconfigv1alpha1.ClientConnectionConfiguration{
-		Kubeconfig:         cfg.Kubeconfig,
-		AcceptContentTypes: cfg.AcceptContentTypes,
-		ContentType:        cfg.ContentType,
-		QPS:                cfg.QPS,
-		Burst:              cfg.Burst,
-	}
 }
 
 // RESTConfigFromClientConnectionConfiguration creates a *rest.Config from a componentbaseconfigv1alpha1.ClientConnectionConfiguration and the configured kubeconfig.

--- a/pkg/client/kubernetes/clientmap/builder/garden_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/garden_builder.go
@@ -8,11 +8,9 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
-	componentbaseconfig "k8s.io/component-base/config"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 )
 
@@ -33,13 +31,6 @@ func NewGardenClientMapBuilder() *GardenClientMapBuilder {
 func (b *GardenClientMapBuilder) WithRuntimeClient(client client.Client) *GardenClientMapBuilder {
 	b.runtimeClient = client
 	return b
-}
-
-// WithInternalClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.
-// Deprecated: use WithClientConnectionConfig instead
-// TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
-func (b *GardenClientMapBuilder) WithInternalClientConnectionConfig(cfg *componentbaseconfig.ClientConnectionConfiguration) *GardenClientMapBuilder {
-	return b.WithClientConnectionConfig(kubernetes.ConvertClientConnectionConfigurationToExternal(cfg))
 }
 
 // WithClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.

--- a/pkg/client/kubernetes/clientmap/builder/shoot_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/shoot_builder.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	componentbaseconfig "k8s.io/component-base/config"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 )
 
@@ -39,13 +37,6 @@ func (b *ShootClientMapBuilder) WithGardenClient(client client.Client) *ShootCli
 func (b *ShootClientMapBuilder) WithSeedClient(client client.Client) *ShootClientMapBuilder {
 	b.seedClient = client
 	return b
-}
-
-// WithInternalClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.
-// Deprecated: use WithClientConnectionConfig instead
-// TODO(timebertt): delete this when finalizing https://github.com/gardener/gardener/issues/11043
-func (b *ShootClientMapBuilder) WithInternalClientConnectionConfig(cfg *componentbaseconfig.ClientConnectionConfiguration) *ShootClientMapBuilder {
-	return b.WithClientConnectionConfig(kubernetes.ConvertClientConnectionConfigurationToExternal(cfg))
 }
 
 // WithClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

This PR cleans up the temporary helper functions introduced in https://github.com/gardener/gardener/pull/11052 for a smooth refactoring in multiple PRs for https://github.com/gardener/gardener/issues/11043.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11043

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The temporary helper functions `github.com/gardener/gardener/pkg/client/kubernetes.{ConvertClientConnectionConfigurationToExternal,RESTConfigFromInternalClientConnectionConfiguration}` have been removed. Please use the external version of `k8s.io/component-base/config.ClientConnectionConfiguration` directly.
```
