### PR TITLE
Move extension content from `controllerregistration.md` to `admission.md`

### DIFF
--- a/docs/extensions/admission.md
+++ b/docs/extensions/admission.md
@@ -4,7 +4,7 @@ title: Resource Admission in the Garden Cluster
 
 # Validating and Mutating Resources in the Garden Cluster
 
-The `Shoot` resource itself can contain some extension-specific data blobs.
+The `Shoot` resource itself can contain some extension-specific data blobs:
 
 ```yaml
 apiVersion: core.gardener.cloud/v1beta1
@@ -35,14 +35,14 @@ spec:
 ...
 ```
 
-In the above example, Gardener itself does not understand the AWS-specific provider configuration for the infrastructure. However, if this part of the `Shoot` resource should be validated, then you should run an AWS-specific component in the garden cluster that registers a webhook. You can do it similarly if you want to default some fields of a resource (by using a `MutatingWebhookConfiguration`). Similar to how Gardener is deployed to the garden cluster, these components must be deployed and managed by the Gardener administrator.
+In the above example, Gardener itself does not understand the AWS-specific provider configuration for the infrastructure. However, if this part of the `Shoot` resource should be validated, then you should run an AWS-specific component in the garden cluster that registers a webhook. You can do it similarly if you want to default some fields of a resource (by using a `MutatingWebhookConfiguration`). Similarly to how Gardener is deployed to the garden cluster, these components must be deployed and managed by the Gardener administrator.
 
 Examples of extensions performing validation:
-- [provider extensions](../../extensions/README.md#infrastructure-provider) would validate `spec.provider.infrastructureConfig` and `spec.provider.controlPlaneConfig` in the `Shoot` resource and `spec.providerConfig` in the `CloudProfile` resource
+- [provider extensions](../../extensions/README.md#infrastructure-provider) would validate `spec.provider.infrastructureConfig` and `spec.provider.controlPlaneConfig` in the `Shoot` resource and `spec.providerConfig` in the `CloudProfile` resource.
 - [networking extensions](../../extensions/README.md#network-plugin) would validate `spec.networking.providerConfig` in the `Shoot` resource.
 
-As best practice, the validation should be performed only if there is a change in the `spec` of the resource. Please find an exemplary implementation in the [gardener/gardener-extension-provider-aws](https://github.com/gardener/gardener-extension-provider-aws/tree/master/pkg/admission/validator) repository.
+As a best practice, the validation should be performed only if there is a change in the `spec` of the resource. Please find an exemplary implementation in the [gardener/gardener-extension-provider-aws](https://github.com/gardener/gardener-extension-provider-aws/tree/master/pkg/admission/validator) repository.
 
-## `extensions.gardener.cloud` labeling
+## `extensions.gardener.cloud` Labeling
 
-When a admission relevant resource (like `BackupEntry`s, `BackupBucket`s, `CloudProfile`s, `Seed`s, `SecretBinding`s and `Shoot`s) is newly created or updated in the garden cluster, Gardener adds an extension label to it. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for a provider extension type `aws` looks like `provider.extensions.gardener.cloud/aws : "true"`. The extensions should add object selectors in their admission webhooks for these labels to filter out the objects they are responsible for. Please see the [types_constants.go](../../pkg/apis/core/v1beta1/constants/types_constants.go) file for the full list of extension labels.
+When an admission relevant resource (e.g., `BackupEntry`s, `BackupBucket`s, `CloudProfile`s, `Seed`s, `SecretBinding`s, and `Shoot`s) is newly created or updated in the garden cluster, Gardener adds an extension label to it. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for a provider extension type `aws` looks like `provider.extensions.gardener.cloud/aws : "true"`. The extensions should add object selectors in their admission webhooks for these labels to filter out the objects they are responsible for. Please see the [types_constants.go](../../pkg/apis/core/v1beta1/constants/types_constants.go) file for the full list of extension labels.

--- a/docs/extensions/admission.md
+++ b/docs/extensions/admission.md
@@ -1,5 +1,48 @@
-# Extension Admission
+---
+title: Resource Admission in the Garden Cluster
+---
 
-The extensions are expected to validate their respective resources for their extension specific configurations, when the resources are newly created or updated. For example, [provider extensions](../../extensions/README.md#infrastructure-provider) would validate `spec.provider.infrastructureConfig` and `spec.provider.controlPlaneConfig` in the `Shoot` resource and `spec.providerConfig` in the `CloudProfile` resource, [networking extensions](../../extensions/README.md#network-plugin) would validate `spec.networking.providerConfig` in the `Shoot` resource. As best practice, the validation should be performed only if there is a change in the `spec` of the resource. Please find an exemplary implementation in the [gardener/gardener-extension-provider-aws](https://github.com/gardener/gardener-extension-provider-aws/tree/master/pkg/admission/validator) repository.
+# Validating and Mutating Resources in the Garden Cluster
 
-When a resource is newly created or updated, Gardener adds an extension label for all the extension types referenced in the `spec` of the resource. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for a provider extension type `aws` looks like `provider.extensions.gardener.cloud/aws : "true"`. The extensions should add object selectors in their admission webhooks for these labels, to filter out the objects they are responsible for. At present, these labels are added to `BackupEntry`s, `BackupBucket`s, `CloudProfile`s, `Seed`s, `SecretBinding`s and `Shoot`s. Please see the [types_constants.go](../../pkg/apis/core/v1beta1/constants/types_constants.go) file for the full list of extension labels.
+The `Shoot` resource itself can contain some extension-specific data blobs.
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+metadata:
+  name: johndoe-aws
+  namespace: garden-dev
+spec:
+  ...
+  region: eu-west-1
+  provider:
+    type: aws
+    providerConfig:
+      apiVersion: aws.cloud.gardener.cloud/v1alpha1
+      kind: InfrastructureConfig
+      networks:
+        vpc: # specify either 'id' or 'cidr'
+        # id: vpc-123456
+          cidr: 10.250.0.0/16
+        internal:
+        - 10.250.112.0/22
+        public:
+        - 10.250.96.0/22
+        workers:
+        - 10.250.0.0/19
+      zones:
+      - eu-west-1a
+...
+```
+
+In the above example, Gardener itself does not understand the AWS-specific provider configuration for the infrastructure. However, if this part of the `Shoot` resource should be validated, then you should run an AWS-specific component in the garden cluster that registers a webhook. You can do it similarly if you want to default some fields of a resource (by using a `MutatingWebhookConfiguration`). Similar to how Gardener is deployed to the garden cluster, these components must be deployed and managed by the Gardener administrator.
+
+Examples of extensions performing validation:
+- [provider extensions](../../extensions/README.md#infrastructure-provider) would validate `spec.provider.infrastructureConfig` and `spec.provider.controlPlaneConfig` in the `Shoot` resource and `spec.providerConfig` in the `CloudProfile` resource
+- [networking extensions](../../extensions/README.md#network-plugin) would validate `spec.networking.providerConfig` in the `Shoot` resource.
+
+As best practice, the validation should be performed only if there is a change in the `spec` of the resource. Please find an exemplary implementation in the [gardener/gardener-extension-provider-aws](https://github.com/gardener/gardener-extension-provider-aws/tree/master/pkg/admission/validator) repository.
+
+## `extensions.gardener.cloud` labeling
+
+When a admission relevant resource (like `BackupEntry`s, `BackupBucket`s, `CloudProfile`s, `Seed`s, `SecretBinding`s and `Shoot`s) is newly created or updated in the garden cluster, Gardener adds an extension label to it. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for a provider extension type `aws` looks like `provider.extensions.gardener.cloud/aws : "true"`. The extensions should add object selectors in their admission webhooks for these labels to filter out the objects they are responsible for. Please see the [types_constants.go](../../pkg/apis/core/v1beta1/constants/types_constants.go) file for the full list of extension labels.

--- a/docs/extensions/admission.md
+++ b/docs/extensions/admission.md
@@ -4,7 +4,7 @@ title: Resource Admission in the Garden Cluster
 
 # Validating and Mutating Resources in the Garden Cluster
 
-The `Shoot` resource itself can contain some extension-specific data blobs:
+The `Shoot` resource itself can contain some extension-specific data blobs (see `providerConfig`):
 
 ```yaml
 apiVersion: core.gardener.cloud/v1beta1

--- a/docs/extensions/admission.md
+++ b/docs/extensions/admission.md
@@ -2,7 +2,7 @@
 title: Resource Admission in the Garden Cluster
 ---
 
-# Validating and Mutating Resources in the Garden Cluster
+# Resource Admission in the Garden Cluster
 
 The `Shoot` resource itself can contain some extension-specific data blobs (see `providerConfig`):
 
@@ -35,7 +35,7 @@ spec:
 ...
 ```
 
-In the above example, Gardener itself does not understand the AWS-specific provider configuration for the infrastructure. However, if this part of the `Shoot` resource should be validated, then you should run an AWS-specific component in the garden cluster that registers a webhook. You can do it similarly if you want to default some fields of a resource (by using a `MutatingWebhookConfiguration`). Similarly to how Gardener is deployed to the garden cluster, these components must be deployed and managed by the Gardener administrator.
+In the above example, Gardener itself does not understand the AWS-specific provider configuration for the infrastructure. However, if this part of the `Shoot` resource should be validated, then you should run an AWS-specific component in the garden cluster that registers a webhook. The same is true for values defaulting via `MutatingWebhookConfiguration`. Similarly to how Gardener is deployed to the garden cluster, these components must be deployed and managed by the Gardener administrator.
 
 Examples of extensions performing validation:
 - [provider extensions](../../extensions/README.md#infrastructure-provider) would validate `spec.provider.infrastructureConfig` and `spec.provider.controlPlaneConfig` in the `Shoot` resource and `spec.providerConfig` in the `CloudProfile` resource.

--- a/docs/extensions/controllerregistration.md
+++ b/docs/extensions/controllerregistration.md
@@ -1,5 +1,5 @@
 ---
-title: ControllerRegistration
+title: Registering Extension Controllers
 ---
 
 # Registering Extension Controllers
@@ -197,45 +197,6 @@ There are the following policies:
 Also, the `.spec.deployment.seedSelector` allows to specify a label selector for seed clusters.
 Only if it matches the labels of a seed, then it will be deployed to it.
 Please note that a seed selector can only be specified for secondary controllers (`primary=false` for all `.spec.resources[]`).
-
-## Extensions in the Garden Cluster Itself
-
-The `Shoot` resource itself will contain some provider-specific data blobs.
-As a result, some extensions might also want to run in the garden cluster, e.g., to provide `ValidatingWebhookConfiguration`s for validating the correctness of their provider-specific blobs:
-
-```yaml
-apiVersion: core.gardener.cloud/v1beta1
-kind: Shoot
-metadata:
-  name: johndoe-aws
-  namespace: garden-dev
-spec:
-  ...
-  cloud:
-    type: aws
-    region: eu-west-1
-    providerConfig:
-      apiVersion: aws.cloud.gardener.cloud/v1alpha1
-      kind: InfrastructureConfig
-      networks:
-        vpc: # specify either 'id' or 'cidr'
-        # id: vpc-123456
-          cidr: 10.250.0.0/16
-        internal:
-        - 10.250.112.0/22
-        public:
-        - 10.250.96.0/22
-        workers:
-        - 10.250.0.0/19
-      zones:
-      - eu-west-1a
-...
-```
-
-In the above example, Gardener itself does not understand the AWS-specific provider configuration for the infrastructure.
-However, if this part of the `Shoot` resource should be validated, then you should run an AWS-specific component in the garden cluster that registers a webhook. You can do it similarly if you want to default some fields of a resource (by using a `MutatingWebhookConfiguration`).
-
-Again, similar to how Gardener is deployed to the garden cluster, these components must be deployed and managed by the Gardener administrator.
 
 ### `Extension` Resource Configurations
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
The section `## Extensions in the Garden Cluster Itself` of `controllerregistration.md` is not related to registering of  extension controllers and is more fit to be part of `admission.md`

This PR contains:
- Move of `## Extensions in the Garden Cluster Itself` into `admission.md`
- More accurate titles for `admission.md` and `controllerregistration.md`
- Better wording and structure of `admission.md` required for the merge of content to be coherent

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
