### PR TITLE
RootPodExecutor: Do not require output from command execution

### DIFF
--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -6,7 +6,6 @@ package framework
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
 
@@ -92,11 +91,7 @@ func (e *rootPodExecutor) Execute(ctx context.Context, command ...string) ([]byt
 		return stderrBytes, err
 	}
 
-	if len(stdoutBytes) > 0 {
-		return stdoutBytes, nil
-	}
-
-	return nil, fmt.Errorf("no output from command execution")
+	return stdoutBytes, nil
 }
 
 // deploy deploys a root pod on the specified node and waits until it is running


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
N/A

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11249

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
testing framework: The RootPodExecutor no longer requires output from command execution to interpret the command execution as successful.
```
