### PR TITLE
Component config: add validation for `{ClientConnection,LeaderElection}Configuration`

### DIFF
--- a/pkg/admissioncontroller/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/validation/validation.go
@@ -7,39 +7,19 @@ package validation
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	componentbaseconfig "k8s.io/component-base/config"
-	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	componentbaseconfigvalidation "k8s.io/component-base/config/validation"
 
 	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
+	validationutils "github.com/gardener/gardener/pkg/utils/validation"
 )
-
-var configScheme = runtime.NewScheme()
-
-func init() {
-	schemeBuilder := runtime.NewSchemeBuilder(
-		admissioncontrollerconfigv1alpha1.AddToScheme,
-		componentbaseconfigv1alpha1.AddToScheme,
-	)
-	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
-}
 
 // ValidateAdmissionControllerConfiguration validates the given `AdmissionControllerConfiguration`.
 func ValidateAdmissionControllerConfiguration(config *admissioncontrollerconfigv1alpha1.AdmissionControllerConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	clientConnectionPath := field.NewPath("gardenClientConnection")
-	internalClientConnectionConfig := &componentbaseconfig.ClientConnectionConfiguration{}
-	if err := configScheme.Convert(&config.GardenClientConnection, internalClientConnectionConfig, nil); err != nil {
-		allErrs = append(allErrs, field.InternalError(clientConnectionPath, err))
-	} else {
-		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateClientConnectionConfiguration(internalClientConnectionConfig, clientConnectionPath)...)
-	}
+	allErrs = append(allErrs, validationutils.ValidateClientConnectionConfiguration(&config.GardenClientConnection, field.NewPath("gardenClientConnection"))...)
 
 	if !sets.New(logger.AllLogLevels...).Has(config.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), config.LogLevel, logger.AllLogLevels))

--- a/pkg/controllermanager/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/validation/validation.go
@@ -6,49 +6,20 @@ package validation
 
 import (
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	componentbaseconfig "k8s.io/component-base/config"
-	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	componentbaseconfigvalidation "k8s.io/component-base/config/validation"
 
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
+	validationutils "github.com/gardener/gardener/pkg/utils/validation"
 )
-
-var configScheme = runtime.NewScheme()
-
-func init() {
-	schemeBuilder := runtime.NewSchemeBuilder(
-		controllermanagerconfigv1alpha1.AddToScheme,
-		componentbaseconfigv1alpha1.AddToScheme,
-	)
-	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
-}
 
 // ValidateControllerManagerConfiguration validates the given `ControllerManagerConfiguration`.
 func ValidateControllerManagerConfiguration(conf *controllermanagerconfigv1alpha1.ControllerManagerConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	clientConnectionPath := field.NewPath("gardenClientConnection")
-	internalClientConnectionConfig := &componentbaseconfig.ClientConnectionConfiguration{}
-	if err := configScheme.Convert(&conf.GardenClientConnection, internalClientConnectionConfig, nil); err != nil {
-		allErrs = append(allErrs, field.InternalError(clientConnectionPath, err))
-	} else {
-		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateClientConnectionConfiguration(internalClientConnectionConfig, clientConnectionPath)...)
-	}
-
-	if conf.LeaderElection != nil {
-		leaderElectionPath := field.NewPath("leaderElection")
-		internalLeaderElectionConfig := &componentbaseconfig.LeaderElectionConfiguration{}
-		if err := configScheme.Convert(conf.LeaderElection, internalLeaderElectionConfig, nil); err != nil {
-			allErrs = append(allErrs, field.InternalError(leaderElectionPath, err))
-		} else {
-			allErrs = append(allErrs, componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(internalLeaderElectionConfig, leaderElectionPath)...)
-		}
-	}
+	allErrs = append(allErrs, validationutils.ValidateClientConnectionConfiguration(&conf.GardenClientConnection, field.NewPath("gardenClientConnection"))...)
+	allErrs = append(allErrs, validationutils.ValidateLeaderElectionConfiguration(conf.LeaderElection, field.NewPath("leaderElection"))...)
 
 	if conf.LogLevel != "" {
 		if !sets.New(logger.AllLogLevels...).Has(conf.LogLevel) {

--- a/pkg/nodeagent/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/nodeagent/apis/config/v1alpha1/validation/validation.go
@@ -8,40 +8,20 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	componentbaseconfig "k8s.io/component-base/config"
-	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	componentbaseconfigvalidation "k8s.io/component-base/config/validation"
 
 	"github.com/gardener/gardener/pkg/logger"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	validationutils "github.com/gardener/gardener/pkg/utils/validation"
 	"github.com/gardener/gardener/pkg/utils/validation/kubernetesversion"
 )
-
-var configScheme = runtime.NewScheme()
-
-func init() {
-	schemeBuilder := runtime.NewSchemeBuilder(
-		nodeagentconfigv1alpha1.AddToScheme,
-		componentbaseconfigv1alpha1.AddToScheme,
-	)
-	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
-}
 
 // ValidateNodeAgentConfiguration validates the given `NodeAgentConfiguration`.
 func ValidateNodeAgentConfiguration(conf *nodeagentconfigv1alpha1.NodeAgentConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	clientConnectionPath := field.NewPath("clientConnection")
-	internalClientConnectionConfig := &componentbaseconfig.ClientConnectionConfiguration{}
-	if err := configScheme.Convert(&conf.ClientConnection, internalClientConnectionConfig, nil); err != nil {
-		allErrs = append(allErrs, field.InternalError(clientConnectionPath, err))
-	} else {
-		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateClientConnectionConfiguration(internalClientConnectionConfig, clientConnectionPath)...)
-	}
+	allErrs = append(allErrs, validationutils.ValidateClientConnectionConfiguration(&conf.ClientConnection, field.NewPath("clientConnection"))...)
 
 	if conf.LogLevel != "" && !sets.New(logger.AllLogLevels...).Has(conf.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))

--- a/pkg/operator/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/operator/apis/config/v1alpha1/validation/validation.go
@@ -10,43 +10,22 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	componentbaseconfig "k8s.io/component-base/config"
-	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	componentbaseconfigvalidation "k8s.io/component-base/config/validation"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/logger"
 	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
+	validationutils "github.com/gardener/gardener/pkg/utils/validation"
 )
-
-var configScheme = runtime.NewScheme()
-
-func init() {
-	schemeBuilder := runtime.NewSchemeBuilder(
-		operatorconfigv1alpha1.AddToScheme,
-		componentbaseconfigv1alpha1.AddToScheme,
-	)
-	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
-}
 
 // ValidateOperatorConfiguration validates the given `OperatorConfiguration`.
 func ValidateOperatorConfiguration(conf *operatorconfigv1alpha1.OperatorConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, validateClientConnection(&conf.RuntimeClientConnection, field.NewPath("runtimeClientConnection"))...)
-	allErrs = append(allErrs, validateClientConnection(&conf.VirtualClientConnection, field.NewPath("virtualClientConnection"))...)
-
-	leaderElectionPath := field.NewPath("leaderElection")
-	internalLeaderElectionConfig := &componentbaseconfig.LeaderElectionConfiguration{}
-	if err := configScheme.Convert(&conf.LeaderElection, internalLeaderElectionConfig, nil); err != nil {
-		allErrs = append(allErrs, field.InternalError(leaderElectionPath, err))
-	} else {
-		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(internalLeaderElectionConfig, leaderElectionPath)...)
-	}
+	allErrs = append(allErrs, validationutils.ValidateClientConnectionConfiguration(&conf.RuntimeClientConnection, field.NewPath("runtimeClientConnection"))...)
+	allErrs = append(allErrs, validationutils.ValidateClientConnectionConfiguration(&conf.VirtualClientConnection, field.NewPath("virtualClientConnection"))...)
+	allErrs = append(allErrs, validationutils.ValidateLeaderElectionConfiguration(&conf.LeaderElection, field.NewPath("leaderElection"))...)
 
 	if conf.LogLevel != "" && !sets.New(logger.AllLogLevels...).Has(conf.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))
@@ -58,19 +37,6 @@ func ValidateOperatorConfiguration(conf *operatorconfigv1alpha1.OperatorConfigur
 
 	allErrs = append(allErrs, validateControllerConfiguration(conf.Controllers, field.NewPath("controllers"))...)
 	allErrs = append(allErrs, validateNodeTolerationConfiguration(conf.NodeToleration, field.NewPath("nodeToleration"))...)
-
-	return allErrs
-}
-
-func validateClientConnection(conf *componentbaseconfigv1alpha1.ClientConnectionConfiguration, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	internalClientConnectionConfig := &componentbaseconfig.ClientConnectionConfiguration{}
-	if err := configScheme.Convert(conf, internalClientConnectionConfig, nil); err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath, err))
-	} else {
-		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateClientConnectionConfiguration(internalClientConnectionConfig, fldPath)...)
-	}
 
 	return allErrs
 }

--- a/pkg/operator/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/operator/apis/config/v1alpha1/validation/validation.go
@@ -10,17 +10,43 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	componentbaseconfigvalidation "k8s.io/component-base/config/validation"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/logger"
 	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 )
 
+var configScheme = runtime.NewScheme()
+
+func init() {
+	schemeBuilder := runtime.NewSchemeBuilder(
+		operatorconfigv1alpha1.AddToScheme,
+		componentbaseconfigv1alpha1.AddToScheme,
+	)
+	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
+}
+
 // ValidateOperatorConfiguration validates the given `OperatorConfiguration`.
 func ValidateOperatorConfiguration(conf *operatorconfigv1alpha1.OperatorConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateClientConnection(&conf.RuntimeClientConnection, field.NewPath("runtimeClientConnection"))...)
+	allErrs = append(allErrs, validateClientConnection(&conf.VirtualClientConnection, field.NewPath("virtualClientConnection"))...)
+
+	leaderElectionPath := field.NewPath("leaderElection")
+	internalLeaderElectionConfig := &componentbaseconfig.LeaderElectionConfiguration{}
+	if err := configScheme.Convert(&conf.LeaderElection, internalLeaderElectionConfig, nil); err != nil {
+		allErrs = append(allErrs, field.InternalError(leaderElectionPath, err))
+	} else {
+		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(internalLeaderElectionConfig, leaderElectionPath)...)
+	}
 
 	if conf.LogLevel != "" && !sets.New(logger.AllLogLevels...).Has(conf.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))
@@ -32,6 +58,19 @@ func ValidateOperatorConfiguration(conf *operatorconfigv1alpha1.OperatorConfigur
 
 	allErrs = append(allErrs, validateControllerConfiguration(conf.Controllers, field.NewPath("controllers"))...)
 	allErrs = append(allErrs, validateNodeTolerationConfiguration(conf.NodeToleration, field.NewPath("nodeToleration"))...)
+
+	return allErrs
+}
+
+func validateClientConnection(conf *componentbaseconfigv1alpha1.ClientConnectionConfiguration, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	internalClientConnectionConfig := &componentbaseconfig.ClientConnectionConfiguration{}
+	if err := configScheme.Convert(conf, internalClientConnectionConfig, nil); err != nil {
+		allErrs = append(allErrs, field.InternalError(fldPath, err))
+	} else {
+		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateClientConnectionConfiguration(internalClientConnectionConfig, fldPath)...)
+	}
 
 	return allErrs
 }

--- a/pkg/resourcemanager/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/validation/validation.go
@@ -42,8 +42,6 @@ func ValidateResourceManagerConfiguration(conf *resourcemanagerconfigv1alpha1.Re
 		allErrs = append(allErrs, validateClientConnection(*conf.TargetClientConnection, field.NewPath("targetClientConnection"))...)
 	}
 
-	allErrs = append(allErrs, validateServerConfiguration(conf.Server, field.NewPath("server"))...)
-
 	leaderElectionPath := field.NewPath("leaderElection")
 	internalLeaderElectionConfig := &componentbaseconfig.LeaderElectionConfiguration{}
 	if err := configScheme.Convert(&conf.LeaderElection, internalLeaderElectionConfig, nil); err != nil {
@@ -51,6 +49,8 @@ func ValidateResourceManagerConfiguration(conf *resourcemanagerconfigv1alpha1.Re
 	} else {
 		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(internalLeaderElectionConfig, leaderElectionPath)...)
 	}
+
+	allErrs = append(allErrs, validateServerConfiguration(conf.Server, field.NewPath("server"))...)
 
 	if !sets.New(logger.AllLogLevels...).Has(conf.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))

--- a/pkg/scheduler/apis/config/v1alpha1/types.go
+++ b/pkg/scheduler/apis/config/v1alpha1/types.go
@@ -50,7 +50,7 @@ type CandidateDeterminationStrategy string
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// SchedulerConfiguration provides the configuration for the SeedManager admission plugin.
+// SchedulerConfiguration defines the configuration for the Gardener scheduler.
 type SchedulerConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 	// ClientConnection specifies the kubeconfig file and client connection

--- a/pkg/scheduler/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/scheduler/apis/config/v1alpha1/validation/validation.go
@@ -6,16 +6,49 @@ package validation
 
 import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	componentbaseconfigvalidation "k8s.io/component-base/config/validation"
 
 	"github.com/gardener/gardener/pkg/logger"
 	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
 )
 
+var configScheme = runtime.NewScheme()
+
+func init() {
+	schemeBuilder := runtime.NewSchemeBuilder(
+		schedulerconfigv1alpha1.AddToScheme,
+		componentbaseconfigv1alpha1.AddToScheme,
+	)
+	utilruntime.Must(schemeBuilder.AddToScheme(configScheme))
+}
+
 // ValidateConfiguration validates the configuration.
 func ValidateConfiguration(config *schedulerconfigv1alpha1.SchedulerConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	clientConnectionPath := field.NewPath("clientConnection")
+	internalClientConnectionConfig := &componentbaseconfig.ClientConnectionConfiguration{}
+	if err := configScheme.Convert(&config.ClientConnection, internalClientConnectionConfig, nil); err != nil {
+		allErrs = append(allErrs, field.InternalError(clientConnectionPath, err))
+	} else {
+		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateClientConnectionConfiguration(internalClientConnectionConfig, clientConnectionPath)...)
+	}
+
+	if config.LeaderElection != nil {
+		leaderElectionPath := field.NewPath("leaderElection")
+		internalLeaderElectionConfig := &componentbaseconfig.LeaderElectionConfiguration{}
+		if err := configScheme.Convert(config.LeaderElection, internalLeaderElectionConfig, nil); err != nil {
+			allErrs = append(allErrs, field.InternalError(leaderElectionPath, err))
+		} else {
+			allErrs = append(allErrs, componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(internalLeaderElectionConfig, leaderElectionPath)...)
+		}
+	}
 
 	allErrs = append(allErrs, validateSchedulerControllerConfiguration(config.Schedulers, field.NewPath("schedulers"))...)
 

--- a/pkg/scheduler/apis/config/v1alpha1/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/validation/validation_test.go
@@ -14,84 +14,82 @@ import (
 	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
 )
 
-var _ = Describe("gardener-scheduler", func() {
-	Describe("#ValidateConfiguration", func() {
-		var defaultAdmissionConfiguration schedulerconfigv1alpha1.SchedulerConfiguration
+var _ = Describe("#ValidateConfiguration", func() {
+	var conf *schedulerconfigv1alpha1.SchedulerConfiguration
 
-		BeforeEach(func() {
-			defaultAdmissionConfiguration = schedulerconfigv1alpha1.SchedulerConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "scheduler.config.gardener.cloud/v1alpha1",
-					Kind:       "SchedulerConfiguration",
+	BeforeEach(func() {
+		conf = &schedulerconfigv1alpha1.SchedulerConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "scheduler.config.gardener.cloud/v1alpha1",
+				Kind:       "SchedulerConfiguration",
+			},
+			Schedulers: schedulerconfigv1alpha1.SchedulerControllerConfiguration{
+				BackupBucket: &schedulerconfigv1alpha1.BackupBucketSchedulerConfiguration{
+					ConcurrentSyncs: 2,
 				},
-				Schedulers: schedulerconfigv1alpha1.SchedulerControllerConfiguration{
-					BackupBucket: &schedulerconfigv1alpha1.BackupBucketSchedulerConfiguration{
-						ConcurrentSyncs: 2,
-					},
-					Shoot: &schedulerconfigv1alpha1.ShootSchedulerConfiguration{
-						ConcurrentSyncs: 2,
-						Strategy:        schedulerconfigv1alpha1.SameRegion,
-					},
+				Shoot: &schedulerconfigv1alpha1.ShootSchedulerConfiguration{
+					ConcurrentSyncs: 2,
+					Strategy:        schedulerconfigv1alpha1.SameRegion,
 				},
-			}
+			},
+		}
+	})
+
+	Context("scheduler controller configuration", func() {
+		It("should pass because the Gardener Scheduler Configuration with the 'Same Region' Strategy is a valid configuration", func() {
+			sameRegionConfiguration := conf.DeepCopy()
+			sameRegionConfiguration.Schedulers.Shoot.Strategy = schedulerconfigv1alpha1.SameRegion
+			err := ValidateConfiguration(sameRegionConfiguration)
+
+			Expect(err).To(BeEmpty())
 		})
 
-		Context("Validate Admission Plugin SchedulerConfiguration", func() {
-			It("should pass because the Gardener Scheduler Configuration with the 'Same Region' Strategy is a valid configuration", func() {
-				sameRegionConfiguration := defaultAdmissionConfiguration
-				sameRegionConfiguration.Schedulers.Shoot.Strategy = schedulerconfigv1alpha1.SameRegion
-				err := ValidateConfiguration(&sameRegionConfiguration)
+		It("should pass because the Gardener Scheduler Configuration with the 'Minimal Distance' Strategy is a valid configuration", func() {
+			minimalDistanceConfiguration := conf.DeepCopy()
+			minimalDistanceConfiguration.Schedulers.Shoot.Strategy = schedulerconfigv1alpha1.MinimalDistance
+			err := ValidateConfiguration(minimalDistanceConfiguration)
 
-				Expect(err).To(BeEmpty())
-			})
+			Expect(err).To(BeEmpty())
+		})
 
-			It("should pass because the Gardener Scheduler Configuration with the 'Minimal Distance' Strategy is a valid configuration", func() {
-				minimalDistanceConfiguration := defaultAdmissionConfiguration
-				minimalDistanceConfiguration.Schedulers.Shoot.Strategy = schedulerconfigv1alpha1.MinimalDistance
-				err := ValidateConfiguration(&minimalDistanceConfiguration)
+		It("should pass because the Gardener Scheduler Configuration with the default Strategy is a valid configuration", func() {
+			err := ValidateConfiguration(conf)
+			Expect(err).To(BeEmpty())
+		})
 
-				Expect(err).To(BeEmpty())
-			})
+		It("should fail because the Gardener Scheduler Configuration contains an invalid strategy", func() {
+			invalidConfiguration := conf.DeepCopy()
+			invalidConfiguration.Schedulers.Shoot.Strategy = "invalidStrategy"
+			err := ValidateConfiguration(invalidConfiguration)
 
-			It("should pass because the Gardener Scheduler Configuration with the default Strategy is a valid configuration", func() {
-				err := ValidateConfiguration(&defaultAdmissionConfiguration)
-				Expect(err).To(BeEmpty())
-			})
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("schedulers.shoot.strategy"),
+			}))))
+		})
 
-			It("should fail because the Gardener Scheduler Configuration contains an invalid strategy", func() {
-				invalidConfiguration := defaultAdmissionConfiguration
-				invalidConfiguration.Schedulers.Shoot.Strategy = "invalidStrategy"
-				err := ValidateConfiguration(&invalidConfiguration)
+		It("should fail because backupBucket concurrentSyncs are negative", func() {
+			invalidConfiguration := conf.DeepCopy()
+			invalidConfiguration.Schedulers.BackupBucket.ConcurrentSyncs = -1
 
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeNotSupported),
-					"Field": Equal("schedulers.shoot.strategy"),
-				}))))
-			})
+			err := ValidateConfiguration(invalidConfiguration)
 
-			It("should fail because backupBucket concurrentSyncs are negative", func() {
-				invalidConfiguration := defaultAdmissionConfiguration
-				invalidConfiguration.Schedulers.BackupBucket.ConcurrentSyncs = -1
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("schedulers.backupBucket.concurrentSyncs"),
+			}))))
+		})
 
-				err := ValidateConfiguration(&invalidConfiguration)
+		It("should fail because shoot concurrentSyncs are negative", func() {
+			invalidConfiguration := conf.DeepCopy()
+			invalidConfiguration.Schedulers.Shoot.ConcurrentSyncs = -1
 
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("schedulers.backupBucket.concurrentSyncs"),
-				}))))
-			})
+			err := ValidateConfiguration(invalidConfiguration)
 
-			It("should fail because shoot concurrentSyncs are negative", func() {
-				invalidConfiguration := defaultAdmissionConfiguration
-				invalidConfiguration.Schedulers.Shoot.ConcurrentSyncs = -1
-
-				err := ValidateConfiguration(&invalidConfiguration)
-
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("schedulers.shoot.concurrentSyncs"),
-				}))))
-			})
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("schedulers.shoot.concurrentSyncs"),
+			}))))
 		})
 	})
 })

--- a/pkg/utils/validation/componentbaseconfig.go
+++ b/pkg/utils/validation/componentbaseconfig.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	componentbaseconfig "k8s.io/component-base/config"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	componentbaseconfigvalidation "k8s.io/component-base/config/validation"
+)
+
+var configScheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(componentbaseconfigv1alpha1.AddToScheme(configScheme))
+}
+
+// ValidateClientConnectionConfiguration validates a componentbaseconfigv1alpha1.ClientConnectionConfiguration by
+// converting it to the internal version and calling the validation from the k8s.io/component-base/config/validation
+// package.
+func ValidateClientConnectionConfiguration(config *componentbaseconfigv1alpha1.ClientConnectionConfiguration, fldPath *field.Path) field.ErrorList {
+	if config == nil {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+
+	internalClientConnectionConfig := &componentbaseconfig.ClientConnectionConfiguration{}
+	if err := configScheme.Convert(config, internalClientConnectionConfig, nil); err != nil {
+		allErrs = append(allErrs, field.InternalError(fldPath, err))
+	} else {
+		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateClientConnectionConfiguration(internalClientConnectionConfig, fldPath)...)
+	}
+
+	return allErrs
+}
+
+// ValidateLeaderElectionConfiguration validates a componentbaseconfigv1alpha1.LeaderElectionConfiguration by
+// converting it to the internal version and calling the validation from the k8s.io/component-base/config/validation
+// package.
+func ValidateLeaderElectionConfiguration(config *componentbaseconfigv1alpha1.LeaderElectionConfiguration, fldPath *field.Path) field.ErrorList {
+	if config == nil {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+
+	internalLeaderElectionConfig := &componentbaseconfig.LeaderElectionConfiguration{}
+	if err := configScheme.Convert(config, internalLeaderElectionConfig, nil); err != nil {
+		allErrs = append(allErrs, field.InternalError(fldPath, err))
+	} else {
+		allErrs = append(allErrs, componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(internalLeaderElectionConfig, fldPath)...)
+	}
+
+	return allErrs
+}

--- a/pkg/utils/validation/componentbaseconfig_test.go
+++ b/pkg/utils/validation/componentbaseconfig_test.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/gardener/gardener/pkg/utils/validation"
+)
+
+var _ = Describe("componentbaseconfig validation helpers", func() {
+	Describe("#ValidateClientConnectionConfiguration", func() {
+		var (
+			fldPath *field.Path
+			config  *componentbaseconfigv1alpha1.ClientConnectionConfiguration
+		)
+
+		BeforeEach(func() {
+			fldPath = field.NewPath("clientConnection")
+
+			config = &componentbaseconfigv1alpha1.ClientConnectionConfiguration{}
+		})
+
+		It("should ignore a nil config", func() {
+			Expect(ValidateClientConnectionConfiguration(nil, fldPath)).To(BeEmpty())
+		})
+
+		It("should allow an empty config", func() {
+			Expect(ValidateClientConnectionConfiguration(config, fldPath)).To(BeEmpty())
+		})
+
+		It("should allow default configuration", func() {
+			componentbaseconfigv1alpha1.RecommendedDefaultClientConnectionConfiguration(config)
+
+			Expect(ValidateClientConnectionConfiguration(config, fldPath)).To(BeEmpty())
+		})
+
+		It("should reject invalid fields", func() {
+			config.Burst = -1
+
+			Expect(ValidateClientConnectionConfiguration(config, fldPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal(fldPath.Child("burst").String()),
+				})),
+			))
+		})
+	})
+
+	Describe("#ValidateLeaderElectionConfiguration", func() {
+		var (
+			fldPath *field.Path
+			config  *componentbaseconfigv1alpha1.LeaderElectionConfiguration
+		)
+
+		BeforeEach(func() {
+			fldPath = field.NewPath("leaderElection")
+
+			config = &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+				LeaderElect: ptr.To(true),
+			}
+		})
+
+		It("should ignore a nil config", func() {
+			Expect(ValidateLeaderElectionConfiguration(nil, fldPath)).To(BeEmpty())
+		})
+
+		It("should allow not enabling leader election", func() {
+			config.LeaderElect = nil
+
+			Expect(ValidateLeaderElectionConfiguration(nil, fldPath)).To(BeEmpty())
+		})
+
+		It("should allow disabling leader election", func() {
+			config.LeaderElect = ptr.To(false)
+
+			Expect(ValidateLeaderElectionConfiguration(config, fldPath)).To(BeEmpty())
+		})
+
+		It("should reject config with missing required fields", func() {
+			componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(config)
+			config.ResourceName = "foo"
+
+			Expect(ValidateLeaderElectionConfiguration(config, fldPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal(fldPath.Child("resourceNamespace").String()),
+				})),
+			))
+		})
+
+		It("should allow default configuration with required fields", func() {
+			componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(config)
+			config.ResourceName = "foo"
+			config.ResourceNamespace = "bar"
+
+			Expect(ValidateLeaderElectionConfiguration(config, fldPath)).To(BeEmpty())
+		})
+
+		It("should allow config with required fields", func() {
+			config.ResourceName = "foo"
+			config.ResourceNamespace = "bar"
+			config.ResourceLock = "leases"
+			config.LeaseDuration.Duration = 2 * time.Minute
+			config.RenewDeadline.Duration = time.Minute
+			config.RetryPeriod.Duration = time.Minute
+
+			Expect(ValidateLeaderElectionConfiguration(config, fldPath)).To(BeEmpty())
+		})
+
+		It("should reject leader election config with missing required fields", func() {
+			config.ResourceName = "foo"
+			config.ResourceNamespace = "bar"
+			config.ResourceLock = "leases"
+			config.RenewDeadline.Duration = time.Minute
+			config.RetryPeriod.Duration = time.Minute
+
+			// invalid value, must be greater than renewDeadline
+			config.LeaseDuration.Duration = time.Minute
+
+			Expect(ValidateLeaderElectionConfiguration(config, fldPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal(fldPath.Child("leaseDuration").String()),
+				})),
+			))
+		})
+	})
+})

--- a/pkg/utils/validation/validation_suite_test.go
+++ b/pkg/utils/validation/validation_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validation Utils Suite")
+}

--- a/pkg/utils/validation/validation_suite_test.go
+++ b/pkg/utils/validation/validation_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Validation Utils Suite")
+	RunSpecs(t, "Utils Validation Suite")
 }

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -303,6 +303,7 @@ build:
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
             - pkg/utils/validation/apigroups
             - pkg/utils/validation/cidr
@@ -412,6 +413,7 @@ build:
             - pkg/utils/secrets
             - pkg/utils/time
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/cidr
             - pkg/utils/validation/kubernetes/core
             - pkg/utils/validation/kubernetesversion
@@ -594,6 +596,7 @@ build:
             - pkg/utils/secrets
             - pkg/utils/time
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
             - pkg/utils/validation/apigroups
             - pkg/utils/validation/cidr
@@ -752,6 +755,7 @@ build:
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
             - pkg/utils/validation/features
             - pkg/utils/validation/kubernetesversion
@@ -821,6 +825,7 @@ build:
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/cidr
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
@@ -904,6 +909,7 @@ build:
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
             - pkg/webhook/authorizer

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -197,6 +197,7 @@ build:
             - pkg/utils/secrets
             - pkg/utils/time
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
             - pkg/utils/validation/apigroups
             - pkg/utils/validation/cidr
@@ -355,6 +356,7 @@ build:
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
             - pkg/utils/validation/features
             - pkg/utils/validation/kubernetesversion
@@ -424,6 +426,7 @@ build:
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/cidr
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
@@ -507,6 +510,7 @@ build:
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
             - pkg/webhook/authorizer
@@ -1280,6 +1284,7 @@ build:
             - pkg/utils/secrets/manager
             - pkg/utils/time
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
             - pkg/utils/validation/apigroups
             - pkg/utils/validation/cidr
@@ -1411,6 +1416,7 @@ build:
             - pkg/utils/secrets
             - pkg/utils/time
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/cidr
             - pkg/utils/validation/kubernetes/core
             - pkg/utils/validation/kubernetesversion
@@ -1526,6 +1532,7 @@ build:
             - pkg/utils/secrets
             - pkg/utils/structuredmap
             - pkg/utils/timewindow
+            - pkg/utils/validation
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
             - third_party/gopkg.in/yaml.v2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind cleanup

**What this PR does / why we need it**:

This PR adds validation for `{ClientConnection,LeaderElection}Configuration` in all component config APIs.
So far, we only had this in the resource-manager's config API.

**Which issue(s) this PR fixes**:
Last part of https://github.com/gardener/gardener/issues/11043

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `ClientConnectionConfiguration` and `LeaderElectionConfiguration` in the component config APIs are now validated.
```
