### PR TITLE
Drop `NodeNotHealthy` alert

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -47,20 +47,6 @@ func CentralPrometheusRules(seedIsGarden bool) []*monitoringv1.PrometheusRule {
 			},
 		},
 		{
-			Alert: "NodeNotHealthy",
-			Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!~"node.kubernetes.io/unschedulable|deployment.machine.sapcloud.io/prefer-no-schedule|node-role.kubernetes.io/control-plane|ToBeDeletedByClusterAutoscaler|` + v1beta1constants.TaintNodeCriticalComponentsNotReady + `"}))[30m:]) > 9`),
-			For:   ptr.To(monitoringv1.Duration("0m")),
-			Labels: map[string]string{
-				"severity":   "warning",
-				"type":       "seed",
-				"visibility": "operator",
-			},
-			Annotations: map[string]string{
-				"description": "Node {{$labels.node}} in seed {{$externalLabels.seed}} was not healthy for ten scrapes in the past 30 mins.",
-				"summary":     "A node is not healthy.",
-			},
-		},
-		{
 			Alert: "TooManyEtcdSnapshotCompactionJobsFailing",
 			Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
 			Labels: map[string]string{

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -14,7 +14,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 )
 

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -35,20 +35,6 @@ var _ = Describe("PrometheusRules", func() {
 				},
 			},
 			{
-				Alert: "NodeNotHealthy",
-				Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!~"node.kubernetes.io/unschedulable|deployment.machine.sapcloud.io/prefer-no-schedule|node-role.kubernetes.io/control-plane|ToBeDeletedByClusterAutoscaler|` + v1beta1constants.TaintNodeCriticalComponentsNotReady + `"}))[30m:]) > 9`),
-				For:   ptr.To(monitoringv1.Duration("0m")),
-				Labels: map[string]string{
-					"severity":   "warning",
-					"type":       "seed",
-					"visibility": "operator",
-				},
-				Annotations: map[string]string{
-					"description": "Node {{$labels.node}} in seed {{$externalLabels.seed}} was not healthy for ten scrapes in the past 30 mins.",
-					"summary":     "A node is not healthy.",
-				},
-			},
-			{
 				Alert: "TooManyEtcdSnapshotCompactionJobsFailing",
 				Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
 				Labels: map[string]string{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind cleanup

**What this PR does / why we need it**:
As part of this PR, we drop the `NodeNotHealthy` alert, as the checks it performs are along the same lines with `EveryNodeReady` running as part of the [shoot health status condition](https://github.com/gardener/gardener/blob/master/docs/extensions/shoot-health-status-conditions.md?plain=1#L8).
**Which issue(s) this PR fixes**:

Fixes #
- 
**Special notes for your reviewer**:
/invite @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Drop `NodeNotHealthy' alert
```
