### PR TITLE
Fix initial release of `CredentialsRotationWithoutWorkersRollout` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -27,7 +27,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
 | NewVPN                                   | `false` | `Alpha` | `1.104` |         |
 | NodeAgentAuthorizer                      | `false` | `Alpha` | `1.109` |         |
-| CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.111` |         |
+| CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -65,7 +65,7 @@ const (
 	// a rolling update of all worker nodes. Instead, the rolling update can be triggered manually by the user at a
 	// later point in time of their convenience.
 	// owner: @rfranzke
-	// alpha: v1.111.0
+	// alpha: v1.112.0
 	CredentialsRotationWithoutWorkersRollout featuregate.Feature = "CredentialsRotationWithoutWorkersRollout"
 )
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
PR #11027 which includes feature gate `CredentialsRotationWithoutWorkersRollout` is not part of Gardener v1.111 but it will be part of Gardener v1.112.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
