### PR TITLE
Replace wildcard from terraform RBAC role verbs

### DIFF
--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -309,7 +309,7 @@ func (t *terraformer) ensureRole(ctx context.Context) error {
 		role.Rules = []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
 			Resources: []string{"configmaps", "secrets"},
-			Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
+			Verbs:     []string{"create", "get", "list", "watch", "patch", "update"},
 		}}
 		return nil
 	})

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -309,7 +309,7 @@ func (t *terraformer) ensureRole(ctx context.Context) error {
 		role.Rules = []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
 			Resources: []string{"configmaps", "secrets"},
-			Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
+			Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete", "deletecollection"},
 		}}
 		return nil
 	})

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -309,7 +309,7 @@ func (t *terraformer) ensureRole(ctx context.Context) error {
 		role.Rules = []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
 			Resources: []string{"configmaps", "secrets"},
-			Verbs:     []string{"*"},
+			Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 		}}
 		return nil
 	})

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -309,7 +309,7 @@ func (t *terraformer) ensureRole(ctx context.Context) error {
 		role.Rules = []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
 			Resources: []string{"configmaps", "secrets"},
-			Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete", "deletecollection"},
+			Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 		}}
 		return nil
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This PR removed use of wildcard `*` for terraform RBAC role verbs. This change is needed in order to remove wildcard `*`  from the different providers RBAC `ClusterRoles`.

This issue is in sync with Diki's [Security Hardened Kubernetes Cluster Guide](https://github.com/gardener/diki/blob/main/docs/rulesets/security-hardened-k8s/ruleset.md). See rules [2006](https://github.com/gardener/diki/blob/main/docs/rulesets/security-hardened-k8s/ruleset.md#2006---limit-the-use-of-wildcards-in-rbac-resources) and [2007](https://github.com/gardener/diki/blob/main/docs/rulesets/security-hardened-k8s/ruleset.md#2007---limit-the-use-of-wildcards-in-rbac-verbs) for more details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
