### PR TITLE
Fix the `should add worker pool with containerd` test

### DIFF
--- a/test/testmachinery/shoots/operations/containerruntime.go
+++ b/test/testmachinery/shoots/operations/containerruntime.go
@@ -95,10 +95,6 @@ var _ = Describe("Shoot container runtime testing", func() {
 		containerdServiceCommand := []string{"systemctl", "is-active", "containerd"}
 		executeCommand(ctx, f, rootPodExecutor, containerdServiceCommand, "active")
 
-		// check that config.toml is configured
-		checkConfigurationCommand := []string{"sh", "-c", "cat /etc/systemd/system/containerd.service.d/11-exec_config.conf | grep 'usr/bin/containerd --config=/etc/containerd/config.toml' | echo $?"}
-		executeCommand(ctx, f, rootPodExecutor, checkConfigurationCommand, "0")
-
 		// check that config.toml exists
 		checkConfigCommand := []string{"sh", "-c", "[ -f /etc/containerd/config.toml ] && echo 'found' || echo 'Not found'"}
 		executeCommand(ctx, f, rootPodExecutor, checkConfigCommand, "found")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Right now, the test fails with 
```
2025-02-03T09:01:32.821526143Z stdout F   [FAILED] Expected
2025-02-03T09:01:32.821529175Z stdout F       <string>: cat: /etc/systemd/system/containerd.service.d/11-exec_config.conf: No such file or directory\n
2025-02-03T09:01:32.82153201Z stdout F   to equal
2025-02-03T09:01:32.821535109Z stdout F       <string>: 0\n
2025-02-03T09:01:32.821537853Z stdout F   In [It] at: /src/test/testmachinery/shoots/operations/containerruntime.go:116 @ 02/03/25 09:01:27.469
```

The `/etc/systemd/system/containerd.service.d/11-exec_config.conf` file seems to be added by the OS extensions.
After https://github.com/gardener/gardener-extension-os-gardenlinux/pull/215, os-gardenlinux no longer creates this file and this causes the test to fail.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue causing the `should add worker pool with containerd` TM test to fail is now fixed.
```
