### PR TITLE
Ensure `node-agent-authorizer` webhook configuration is added exactly once

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -60,7 +60,7 @@ type Interface interface {
 	// AppendAuthorizationWebhook appends an AuthorizationWebhook to AuthorizationWebhooks in the Values of the deployer.
 	// TODO(oliver-goetz): Consider removing this method when we support Kubernetes version with structured authorization only.
 	//  See https://github.com/gardener/gardener/pull/10682#discussion_r1816324389 for more information.
-	AppendAuthorizationWebhook(AuthorizationWebhook)
+	AppendAuthorizationWebhook(AuthorizationWebhook) error
 	// SetExternalHostname sets the ExternalHostname field in the Values of the deployer.
 	SetExternalHostname(string)
 	// SetExternalServer sets the ExternalServer field in the Values of the deployer.
@@ -547,8 +547,16 @@ func (k *kubeAPIServer) GetAutoscalingReplicas() *int32 {
 	return k.values.Autoscaling.Replicas
 }
 
-func (k *kubeAPIServer) AppendAuthorizationWebhook(webhook AuthorizationWebhook) {
+func (k *kubeAPIServer) AppendAuthorizationWebhook(webhook AuthorizationWebhook) error {
+	for _, existingWebhook := range k.values.AuthorizationWebhooks {
+		if existingWebhook.Name == webhook.Name {
+			return fmt.Errorf("authorization webhook with name %q already exists", webhook.Name)
+		}
+	}
+
 	k.values.AuthorizationWebhooks = append(k.values.AuthorizationWebhooks, webhook)
+
+	return nil
 }
 
 func (k *kubeAPIServer) SetAutoscalingReplicas(replicas *int32) {

--- a/pkg/component/kubernetes/apiserver/mock/mocks.go
+++ b/pkg/component/kubernetes/apiserver/mock/mocks.go
@@ -45,9 +45,11 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // AppendAuthorizationWebhook mocks base method.
-func (m *MockInterface) AppendAuthorizationWebhook(arg0 apiserver0.AuthorizationWebhook) {
+func (m *MockInterface) AppendAuthorizationWebhook(arg0 apiserver0.AuthorizationWebhook) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AppendAuthorizationWebhook", arg0)
+	ret := m.ctrl.Call(m, "AppendAuthorizationWebhook", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AppendAuthorizationWebhook indicates an expected call of AppendAuthorizationWebhook.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -20,6 +20,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
@@ -152,6 +153,11 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		o.Shoot.Networks = networks
 	}
 
+	nodeAgentAuthorizerWebhookReady, err := botanist.IsGardenerResourceManagerReady(ctx)
+	if err != nil {
+		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
+	}
+
 	var (
 		g = flow.NewGraph("Shoot cluster deletion")
 
@@ -252,8 +258,10 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
 		deployKubeAPIServer = g.Add(flow.Task{
-			Name:   "Deploying Kubernetes API server",
-			Fn:     flow.TaskFn(botanist.DeployKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Name: "Deploying Kubernetes API server",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.DeployKubeAPIServer(ctx, nodeAgentAuthorizerWebhookReady && features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer))
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(
 				initializeSecretsManagement,
@@ -296,17 +304,35 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
+		// TODO(oliver-goetz): Consider removing this two-step deployment once we only support Kubernetes 1.32+ (in this
+		//  version, the structured authorization feature has been promoted to GA). We already use structured authz for
+		//  1.30+ clusters. This is similar to kube-apiserver deployment in gardener-operator.
+		//  See https://github.com/gardener/gardener/pull/10682#discussion_r1816324389 for more information.
+		deployKubeAPIServerWithNodeAgentAuthorizer = g.Add(flow.Task{
+			Name: "Deploying Kubernetes API server with node-agent-authorizer",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.DeployKubeAPIServer(ctx, true)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       !features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) || !cleanupShootResources || nodeAgentAuthorizerWebhookReady,
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+		})
+		waitUntilKubeAPIServerWithNodeAgentAuthorizerIsReady = g.Add(flow.Task{
+			Name:         "Waiting until Kubernetes API server with node-agent-authorizer rolled out",
+			Fn:           botanist.Shoot.Components.ControlPlane.KubeAPIServer.Wait,
+			SkipIf:       !features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) || !cleanupShootResources || nodeAgentAuthorizerWebhookReady,
+			Dependencies: flow.NewTaskIDs(deployKubeAPIServerWithNodeAgentAuthorizer),
+		})
 		deployGardenerAccess = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       !cleanupShootResources,
-			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
+			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady, waitUntilKubeAPIServerWithNodeAgentAuthorizerIsReady),
 		})
 		deployControlPlaneExposure = g.Add(flow.Task{
 			Name:         "Deploying shoot control plane exposure components",
 			Fn:           flow.TaskFn(botanist.DeployControlPlaneExposure).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       botanist.Shoot.IsWorkerless || useDNS || !cleanupShootResources,
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerIsReady),
+			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerIsReady, waitUntilKubeAPIServerWithNodeAgentAuthorizerIsReady),
 		})
 		waitUntilControlPlaneExposureReady = g.Add(flow.Task{
 			Name: "Waiting until Shoot control plane exposure has been reconciled",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
@@ -16,6 +16,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
@@ -111,6 +112,11 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 		o.Shoot.Networks = networks
 	}
 
+	nodeAgentAuthorizerWebhookReady, err := botanist.IsGardenerResourceManagerReady(ctx)
+	if err != nil {
+		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
+	}
+
 	var (
 		g = flow.NewGraph("Shoot cluster preparation for migration")
 
@@ -144,8 +150,10 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 			Dependencies: flow.NewTaskIDs(deployETCD, scaleUpETCD),
 		})
 		wakeUpKubeAPIServer = g.Add(flow.Task{
-			Name:         "Scaling Kubernetes API Server up and waiting until ready",
-			Fn:           botanist.WakeUpKubeAPIServer,
+			Name: "Scaling Kubernetes API Server up and waiting until ready",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.WakeUpKubeAPIServer(ctx, nodeAgentAuthorizerWebhookReady && features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer))
+			}),
 			SkipIf:       !wakeupRequired,
 			Dependencies: flow.NewTaskIDs(deployETCD, scaleUpETCD, initializeSecretsManagement),
 		})
@@ -163,16 +171,28 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
+		// TODO(oliver-goetz): Consider removing this two-step deployment once we only support Kubernetes 1.32+ (in this
+		//  version, the structured authorization feature has been promoted to GA). We already use structured authz for
+		//  1.30+ clusters. This is similar to kube-apiserver deployment in gardener-operator.
+		//  See https://github.com/gardener/gardener/pull/10682#discussion_r1816324389 for more information.
+		wakeUpKubeAPIServerWithNodeAgentAuthorizer = g.Add(flow.Task{
+			Name: "Scaling Kubernetes API Server with node-agent-authorizer up and waiting until ready",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.WakeUpKubeAPIServer(ctx, true)
+			}),
+			SkipIf:       !wakeupRequired || nodeAgentAuthorizerWebhookReady || !features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer),
+			Dependencies: flow.NewTaskIDs(ensureResourceManagerScaledUp),
+		})
 		keepManagedResourcesObjectsInShoot = g.Add(flow.Task{
 			Name:         "Configuring Managed Resources objects to be kept in the Shoot",
 			Fn:           botanist.KeepObjectsForManagedResources,
 			SkipIf:       !cleanupShootResources,
-			Dependencies: flow.NewTaskIDs(ensureResourceManagerScaledUp),
+			Dependencies: flow.NewTaskIDs(ensureResourceManagerScaledUp, wakeUpKubeAPIServerWithNodeAgentAuthorizer),
 		})
 		deleteManagedResources = g.Add(flow.Task{
 			Name:         "Deleting all Managed Resources from the Shoot's namespace",
 			Fn:           botanist.DeleteManagedResources,
-			Dependencies: flow.NewTaskIDs(keepManagedResourcesObjectsInShoot, ensureResourceManagerScaledUp),
+			Dependencies: flow.NewTaskIDs(keepManagedResourcesObjectsInShoot, ensureResourceManagerScaledUp, wakeUpKubeAPIServerWithNodeAgentAuthorizer),
 		})
 		waitForManagedResourcesDeletion = g.Add(flow.Task{
 			Name:         "Waiting until ManagedResources are deleted",

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -29,7 +29,6 @@ import (
 	resourcemanagerconstants "github.com/gardener/gardener/pkg/component/gardener/resourcemanager/constants"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/component/shared"
-	"github.com/gardener/gardener/pkg/features"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -156,7 +155,7 @@ func (b *Botanist) computeKubeAPIServerSNIConfig() kubeapiserver.SNIConfig {
 }
 
 // DeployKubeAPIServer deploys the Kubernetes API server.
-func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
+func (b *Botanist) DeployKubeAPIServer(ctx context.Context, enableNodeAgentAuthorizer bool) error {
 	externalServer := b.Shoot.ComputeOutOfClusterAPIServerAddress(false)
 
 	externalHostname := b.Shoot.ComputeOutOfClusterAPIServerAddress(true)
@@ -165,49 +164,44 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		return err
 	}
 
-	if features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) {
-		nodeAgentAuthorizerWebhookReady, err := b.IsGardenerResourceManagerReady(ctx)
-		if err != nil {
-			return err
+	if enableNodeAgentAuthorizer {
+		caSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameCACluster)
+		if !found {
+			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
 		}
 
-		if nodeAgentAuthorizerWebhookReady {
-			caSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameCACluster)
-			if !found {
-				return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
-			}
+		kubeconfig, err := runtime.Encode(clientcmdlatest.Codec, kubernetesutils.NewKubeconfig(
+			"authorization-webhook",
+			clientcmdv1.Cluster{
+				Server:                   fmt.Sprintf("https://%s/webhooks/auth/nodeagent", resourcemanagerconstants.ServiceName),
+				CertificateAuthorityData: caSecret.Data[secretsutils.DataKeyCertificateBundle],
+			},
+			clientcmdv1.AuthInfo{},
+		))
+		if err != nil {
+			return fmt.Errorf("failed generating authorization webhook kubeconfig: %w", err)
+		}
 
-			kubeconfig, err := runtime.Encode(clientcmdlatest.Codec, kubernetesutils.NewKubeconfig(
-				"authorization-webhook",
-				clientcmdv1.Cluster{
-					Server:                   fmt.Sprintf("https://%s/webhooks/auth/nodeagent", resourcemanagerconstants.ServiceName),
-					CertificateAuthorityData: caSecret.Data[secretsutils.DataKeyCertificateBundle],
+		if err := b.Shoot.Components.ControlPlane.KubeAPIServer.AppendAuthorizationWebhook(
+			kubeapiserver.AuthorizationWebhook{
+				Name:       "node-agent-authorizer",
+				Kubeconfig: kubeconfig,
+				WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
+					// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
+					// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
+					AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
+					UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
+					Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
+					FailurePolicy:                            apiserverv1beta1.FailurePolicyDeny,
+					SubjectAccessReviewVersion:               "v1",
+					MatchConditionSubjectAccessReviewVersion: "v1",
+					MatchConditions: []apiserverv1beta1.WebhookMatchCondition{{
+						// Only intercept request node-agents
+						Expression: fmt.Sprintf("'%s' in request.groups", v1beta1constants.NodeAgentsGroup),
+					}},
 				},
-				clientcmdv1.AuthInfo{},
-			))
-			if err != nil {
-				return fmt.Errorf("failed generating authorization webhook kubeconfig: %w", err)
-			}
-
-			b.Shoot.Components.ControlPlane.KubeAPIServer.AppendAuthorizationWebhook(
-				kubeapiserver.AuthorizationWebhook{
-					Name:       "node-agent-authorizer",
-					Kubeconfig: kubeconfig,
-					WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
-						// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
-						// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
-						AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
-						UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
-						Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
-						FailurePolicy:                            apiserverv1beta1.FailurePolicyDeny,
-						SubjectAccessReviewVersion:               "v1",
-						MatchConditionSubjectAccessReviewVersion: "v1",
-						MatchConditions: []apiserverv1beta1.WebhookMatchCondition{{
-							// Only intercept request node-agents
-							Expression: fmt.Sprintf("'%s' in request.groups", v1beta1constants.NodeAgentsGroup),
-						}},
-					},
-				})
+			}); err != nil {
+			return fmt.Errorf("failed appending node-agent-authorizer webhook config to kube-apiserver: %w", err)
 		}
 	}
 
@@ -309,7 +303,7 @@ func (b *Botanist) DeleteKubeAPIServer(ctx context.Context) error {
 }
 
 // WakeUpKubeAPIServer creates a service and ensures API Server is scaled up
-func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context) error {
+func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context, enableNodeAgentAuthorizer bool) error {
 	if err := b.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy(ctx); err != nil {
 		return err
 	}
@@ -321,7 +315,7 @@ func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := b.DeployKubeAPIServer(ctx); err != nil {
+	if err := b.DeployKubeAPIServer(ctx, enableNodeAgentAuthorizer); err != nil {
 		return err
 	}
 	if err := kubernetesutils.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, 1); err != nil {

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -302,7 +302,7 @@ var _ = Describe("KubeAPIServer", func() {
 					kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 					kubeAPIServer.EXPECT().Deploy(ctx)
 
-					Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+					Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 				},
 
 				Entry("no need for internal DNS",
@@ -373,7 +373,7 @@ var _ = Describe("KubeAPIServer", func() {
 					kubeAPIServer.EXPECT().SetServiceAccountConfig(expectedConfig)
 					kubeAPIServer.EXPECT().Deploy(ctx)
 
-					Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+					Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 				},
 
 				Entry("should default the issuer",
@@ -449,7 +449,7 @@ var _ = Describe("KubeAPIServer", func() {
 					ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{},
 				}
 
-				err := botanist.DeployKubeAPIServer(ctx)
+				err := botanist.DeployKubeAPIServer(ctx, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("shoot requires managed issuer, but gardener does not have shoot service account hostname configured"))
 			})
@@ -471,7 +471,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
 
-			Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+			Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 
 			kubeconfigSecret := &corev1.Secret{}
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, kubeconfigSecret)).To(Succeed())
@@ -519,7 +519,7 @@ var _ = Describe("KubeAPIServer", func() {
 			}
 			botanist.Shoot.SetInfo(shootCopy)
 
-			Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+			Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
 		})

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -522,6 +523,58 @@ var _ = Describe("KubeAPIServer", func() {
 			Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
+		})
+
+		It("should append the node-agent-authorizer webhook configuration if it is enabled", func() {
+			expectedKubeconfig := []byte(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://gardener-resource-manager/webhooks/auth/nodeagent
+  name: authorization-webhook
+contexts:
+- context:
+    cluster: authorization-webhook
+    user: authorization-webhook
+  name: authorization-webhook
+current-context: authorization-webhook
+kind: Config
+preferences: {}
+users:
+- name: authorization-webhook
+  user: {}
+`)
+
+			expectedAuthorizationWebhook := kubeapiserver.AuthorizationWebhook{
+				Name:       "node-agent-authorizer",
+				Kubeconfig: expectedKubeconfig,
+				WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
+					AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
+					UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
+					Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
+					FailurePolicy:                            "Deny",
+					SubjectAccessReviewVersion:               "v1",
+					MatchConditionSubjectAccessReviewVersion: "v1",
+					MatchConditions: []apiserverv1beta1.WebhookMatchCondition{{
+						Expression: "'gardener.cloud:node-agents' in request.groups",
+					}},
+				},
+			}
+
+			kubeAPIServer.EXPECT().GetValues()
+			kubeAPIServer.EXPECT().SetAutoscalingReplicas(gomock.Any())
+			kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
+			kubeAPIServer.EXPECT().SetETCDEncryptionConfig(gomock.Any())
+			kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
+			kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+			kubeAPIServer.EXPECT().SetNodeNetworkCIDRs(gomock.Any())
+			kubeAPIServer.EXPECT().SetPodNetworkCIDRs(gomock.Any())
+			kubeAPIServer.EXPECT().SetServiceNetworkCIDRs(gomock.Any())
+			kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
+			kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
+			kubeAPIServer.EXPECT().AppendAuthorizationWebhook(expectedAuthorizationWebhook)
+			kubeAPIServer.EXPECT().Deploy(ctx)
+
+			Expect(botanist.DeployKubeAPIServer(ctx, true)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
In the current implementation there is a race in `gardenlet` shoot reconciler which can lead to duplicate kube-apiserver config entry for `node-agent-authorizer` webhook.
This happens when `gardener-resource-manager` is temporary unavailable when a shoot reconciliation is starting and is healthy again before the reconciliation reaches the deployment step of kube-apiserver.

This issue is fixed in this PR. Additionally, controlplane migration flow and deletion flow are adapted that they use the same logic as the reconciliation flow.

**Which issue(s) this PR fixes**:
Fixes #11280 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which might lead to duplicate config entries for `node-agent-authorizer` webhook has been fixed.
```
