### PR TITLE
Do not skip KCM deployment in Shoot deletion flow if controlplane is deployed

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -328,13 +328,13 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		deployKubeControllerManager = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes controller manager",
 			Fn:           flow.TaskFn(botanist.DeployKubeControllerManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       !cleanupShootResources || (!kubeControllerManagerDeploymentFound && !controlPlaneDeploymentNeeded),
+			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilControlPlaneReady, initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Scaling up Kubernetes controller manager",
 			Fn:           botanist.ScaleKubeControllerManagerToOne,
-			SkipIf:       !cleanupShootResources || (!kubeControllerManagerDeploymentFound && !controlPlaneDeploymentNeeded),
+			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager),
 		})
 		deleteAlertmanager = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -328,13 +328,13 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		deployKubeControllerManager = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes controller manager",
 			Fn:           flow.TaskFn(botanist.DeployKubeControllerManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       !cleanupShootResources || !kubeControllerManagerDeploymentFound,
+			SkipIf:       !cleanupShootResources || (!kubeControllerManagerDeploymentFound && !controlPlaneDeploymentNeeded),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilControlPlaneReady, initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Scaling up Kubernetes controller manager",
 			Fn:           botanist.ScaleKubeControllerManagerToOne,
-			SkipIf:       !cleanupShootResources || !kubeControllerManagerDeploymentFound,
+			SkipIf:       !cleanupShootResources || (!kubeControllerManagerDeploymentFound && !controlPlaneDeploymentNeeded),
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager),
 		})
 		deleteAlertmanager = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
This PR unskips KCM deployment in the Shoot deletion flow if controlplane deployment is deployed before.

**Which issue(s) this PR fixes**:
Fixes #11283

**Special notes for your reviewer**:
~This doesn't fix the existing shoots stuck in deletion though since the controlplane already has a `deletionTimestamp`, so `controlPlaneDeploymentNeeded` is not true anymore.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug preventing the deletion of Shoots that previously failed to create due to an erroneous `kube-apiserver` has been fixed.
```
