### PR TITLE
Rescore nginx ingress controller

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -84,8 +84,8 @@ images:
       network_exposure: 'public'
       authentication_enforced: true
       user_interaction: 'end-user'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'low'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
       availability_requirement: 'low'
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
@@ -98,8 +98,8 @@ images:
       network_exposure: 'public'
       authentication_enforced: true
       user_interaction: 'end-user'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'low'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
       availability_requirement: 'low'
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
@@ -112,8 +112,8 @@ images:
       network_exposure: 'public'
       authentication_enforced: true
       user_interaction: 'end-user'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'low'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
       availability_requirement: 'low'
 - name: ingress-default-backend
   sourceRepository: github.com/gardener/ingress-default-backend


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Integrity should be rescored to high as the nginx ingress controller is used to serve (at least) the discovery documents of shoot clusters (+ https://github.com/gardener/gardener-discovery-server/issues/31 is on its way). The confidentiality requirement is a little trickier since Gardener does not explicitly store any personal info, but then we expose logs through the nginx ingress + the shoot addon exists and we do not know what users use it for. I would also score it as high just to be on the safe side.

cc @ScheererJ 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
