### PR TITLE
[GEP-30] e2e: verify in-cluster access to API server

### DIFF
--- a/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
@@ -60,7 +60,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			MatchError(ContainSubstring("pods %q is forbidden: violates PodSecurity %q", "nginx", "restricted:latest")),
 		))
 
-		inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+		inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
@@ -17,6 +17,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
@@ -58,6 +59,8 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			BeForbiddenError(),
 			MatchError(ContainSubstring("pods %q is forbidden: violates PodSecurity %q", "nginx", "restricted:latest")),
 		))
+
+		inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
 
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/provider-local/apis/local/install"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/node"
 )
 
@@ -79,6 +80,8 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			By("Create Shoot")
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
+
+			inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
 				By("Verify Bootstrapping of Nodes with node-critical components")

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -82,7 +82,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			f.Verify()
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
@@ -90,7 +90,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				// We verify the node readiness feature in this specific e2e test because it uses a single-node shoot cluster.
 				// The default shoot e2e test deals with multiple nodes, deleting all of them and waiting for them to be recreated
 				// might increase the test duration undesirably.
-				node.VerifyNodeCriticalComponentsBootstrapping(ctx, f.ShootFramework)
+				node.VerifyNodeCriticalComponentsBootstrapping(parentCtx, f.ShootFramework)
 			}
 
 			By("Hibernate Shoot")
@@ -104,7 +104,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			Expect(f.WakeUpShoot(ctx, f.Shoot)).To(Succeed())
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Delete Shoot")

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -88,8 +88,6 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				// We verify the node readiness feature in this specific e2e test because it uses a single-node shoot cluster.
 				// The default shoot e2e test deals with multiple nodes, deleting all of them and waiting for them to be recreated
 				// might increase the test duration undesirably.
-				ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
-				defer cancel()
 				node.VerifyNodeCriticalComponentsBootstrapping(ctx, f.ShootFramework)
 			}
 

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -81,7 +81,9 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 
-			inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+			if !v1beta1helper.IsWorkerless(f.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+			}
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
 				By("Verify Bootstrapping of Nodes with node-critical components")
@@ -100,6 +102,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
 			defer cancel()
 			Expect(f.WakeUpShoot(ctx, f.Shoot)).To(Succeed())
+
+			if !v1beta1helper.IsWorkerless(f.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+			}
 
 			By("Delete Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -36,7 +36,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 			f.Verify()
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) && !v1beta1helper.HibernationIsEnabled(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Migrate Shoot")
@@ -48,7 +48,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 			Expect(t.VerifyMigration(ctx)).To(Succeed())
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) && !v1beta1helper.HibernationIsEnabled(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Delete Shoot")

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -220,7 +220,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			f.Verify()
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			// isolated test for ssh key rotation (does not trigger node rolling update)
@@ -295,7 +295,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			}
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Delete Shoot")

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -294,6 +294,9 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				testCredentialRotationWithoutWorkersRollout(parentCtx, v, f)
 			}
 
+			By("Renew shoot client after credentials rotation")
+			Expect(f.ShootFramework.AddShoot(parentCtx, f.Shoot.Name, f.Shoot.Namespace)).To(Succeed())
+
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
 				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -137,7 +137,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 					}
 				}).Should(Succeed())
 
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Update Shoot")
@@ -149,7 +149,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			}, nil, nil)
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Add skip readiness annotation")

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/access"
 	shootupdatesuite "github.com/gardener/gardener/test/utils/shoots/update"
@@ -117,11 +118,9 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 						}
 					}
 				}).Should(Succeed())
-			}
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				// For workerless shoots, the status.networking section is not reported. Skip its verification accordingly.
 				By("Verify reported CIDRs")
+				// For workerless shoots, the status.networking section is not reported. Skip its verification accordingly.
 				Eventually(func(g Gomega) {
 					g.Expect(f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)).To(Succeed())
 
@@ -137,6 +136,8 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 						g.Expect(networking.Pods).To(ConsistOf(*pods))
 					}
 				}).Should(Succeed())
+
+				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
 			}
 
 			By("Update Shoot")
@@ -146,6 +147,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				GardenerFramework: f.GardenerFramework,
 				Shoot:             f.Shoot,
 			}, nil, nil)
+
+			if !v1beta1helper.IsWorkerless(f.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+			}
 
 			By("Add skip readiness annotation")
 			ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"maps"
 	"net"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -80,7 +81,7 @@ func verifyAccessFromPod(ctx context.Context, f *framework.ShootFramework, podNa
 	Eventually(
 		execute(ctx, f.ShootClient, podName, "/kubectl", "cluster-info"),
 	).Should(Say(
-		"Kubernetes control plane is running at %s", expectedAddress,
+		"Kubernetes control plane is running at %s", regexp.QuoteMeta(expectedAddress),
 	))
 
 	By("Verify a typical API request works")

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -80,9 +80,9 @@ func verifyAccessFromPod(ctx context.Context, f *framework.ShootFramework, podNa
 
 	By("Verify a typical API request works")
 	Eventually(
-		execute(ctx, f.ShootClient, podName, "/kubectl", "get", "pod", podName),
+		execute(ctx, f.ShootClient, podName, "/kubectl", "get", "service", "kubernetes"),
 	).Should(Say(
-		podName,
+		`NAME.+\nkubernetes.+\n`,
 	))
 }
 
@@ -255,7 +255,7 @@ func getRBACObjects() []client.Object {
 	}
 	objects = append(objects, serviceAccount)
 
-	// permissions used by the test command: kubectl get pod *
+	// permissions used by the test command: kubectl get service kubernetes
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -264,7 +264,7 @@ func getRBACObjects() []client.Object {
 		},
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
-			Resources: []string{"pods"},
+			Resources: []string{"services"},
 			Verbs:     []string{"get"},
 		}},
 	}

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -6,9 +6,10 @@ package inclusterclient
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"maps"
+	"net"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -118,7 +119,7 @@ func getInClusterAPIServerAddress(ctx context.Context, c client.Client) string {
 	}
 	Expect(port).NotTo(BeZero())
 
-	return fmt.Sprintf("https://%s:%d", clusterIP, port)
+	return "https://" + net.JoinHostPort(clusterIP, strconv.FormatInt(int64(port), 10))
 }
 
 func prepareObjects(ctx context.Context, c client.Client, kubernetesVersion string) func() {

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
@@ -191,6 +192,19 @@ func getObjects(kubernetesVersion string) []client.Object {
 					Name:  "TERM",
 					Value: "dumb",
 				}},
+				// allow running this pod on the "unprivileged" shoot
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: ptr.To(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+					RunAsUser:    ptr.To[int64](65532),
+					RunAsGroup:   ptr.To[int64](65532),
+					RunAsNonRoot: ptr.To(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 			}},
 			ServiceAccountName: name,
 		},

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package inclusterclient
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/imagevector"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
+	"github.com/gardener/gardener/test/framework"
+)
+
+const (
+	name      = "e2e-test-in-cluster-client"
+	namespace = metav1.NamespaceDefault
+
+	podNameDirect                 = name + "-direct"
+	podNameAPIServerProxyIP       = name + "-apiserver-proxy-ip"
+	podNameAPIServerProxyHostname = name + "-apiserver-proxy-hostname"
+	containerName                 = "kubectl"
+)
+
+var labels = map[string]string{"e2e-test": "in-cluster-client"}
+
+// VerifyInClusterAccessToAPIServer verifies access to the shoot API server from in-cluster clients.
+// It verifies the following paths:
+// - direct path using the KUBERNETES_SERVICE_HOST env var injected by gardener
+// - via the API server proxy's clusterIP
+// - via the API server proxy's hostname kubernetes.default.svc
+// For this, it deploys pods with the hyperkube image that contains the kubectl binary serving as a test client.
+// See docs/usage/networking/shoot_kubernetes_service_host_injection.md and docs/proposals/08-shoot-apiserver-via-sni.md
+func VerifyInClusterAccessToAPIServer(parentCtx context.Context, f *framework.ShootFramework) {
+	ctx, cancel := context.WithTimeout(parentCtx, 2*time.Minute)
+	defer cancel()
+
+	objects := getObjects(f.Shoot.Spec.Kubernetes.Version)
+	prepareObjects(ctx, f.ShootClient.Client(), objects...)
+
+	By("Verify in-cluster access to API server via direct path")
+	// this pod connects to the API server directly, i.e., uses the KUBERNETES_SERVICE_HOST env var injected by gardener
+	verifyAccessFromPod(ctx, f, podNameDirect, getInternalAPIServerAddress(f.Shoot))
+
+	By("Verify in-cluster access to API server via API server proxy IP")
+	// this pod connects via the API server proxy using the KUBERNETES_SERVICE_HOST env var injected by kubelet, i.e.,
+	// via the clusterIP of kubernetes.default.svc
+	verifyAccessFromPod(ctx, f, podNameAPIServerProxyIP, getInClusterAPIServerAddress(ctx, f.ShootClient.Client()))
+
+	By("Verify in-cluster access to API server via API server proxy hostname")
+	// this pod connects via the API server proxy hostname, i.e., via kubernetes.default.svc
+	verifyAccessFromPod(ctx, f, podNameAPIServerProxyHostname, "https://kubernetes.default.svc.cluster.local:443")
+}
+
+func verifyAccessFromPod(ctx context.Context, f *framework.ShootFramework, podName, expectedAddress string) {
+	By("Verify we are using the expected path")
+	Eventually(
+		execute(ctx, f.ShootClient, podName, "/kubectl", "cluster-info"),
+	).Should(Say(
+		"Kubernetes control plane is running at %s", expectedAddress,
+	))
+
+	By("Verify a typical API request works")
+	Eventually(
+		execute(ctx, f.ShootClient, podName, "/kubectl", "get", "pod", podName),
+	).Should(Say(
+		podName,
+	))
+}
+
+func getInternalAPIServerAddress(shoot *gardencorev1beta1.Shoot) string {
+	GinkgoHelper()
+
+	var address string
+	for _, a := range shoot.Status.AdvertisedAddresses {
+		if a.Name == v1beta1constants.AdvertisedAddressInternal {
+			address = a.URL
+			break
+		}
+	}
+	Expect(address).NotTo(BeEmpty())
+
+	return address + ":443"
+}
+
+func getInClusterAPIServerAddress(ctx context.Context, c client.Client) string {
+	GinkgoHelper()
+
+	service := corev1.Service{}
+	Expect(c.Get(ctx, client.ObjectKey{Name: "kubernetes", Namespace: metav1.NamespaceDefault}, &service)).To(Succeed())
+
+	clusterIP := service.Spec.ClusterIP
+	Expect(clusterIP).NotTo(BeEmpty())
+
+	var port int32
+	for _, p := range service.Spec.Ports {
+		if p.Name == "https" {
+			port = p.Port
+			break
+		}
+	}
+	Expect(port).NotTo(BeZero())
+
+	return fmt.Sprintf("https://%s:%d", clusterIP, port)
+}
+
+func prepareObjects(ctx context.Context, c client.Client, objects ...client.Object) {
+	By("Create test objects for verifying in-cluster access to API server")
+	for _, obj := range objects {
+		Expect(client.IgnoreAlreadyExists(c.Create(ctx, obj))).To(Succeed(), "should create %T %q", obj, client.ObjectKeyFromObject(obj))
+	}
+
+	DeferCleanup(func() {
+		By("Cleaning up test objects for verifying in-cluster access to API server")
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		for _, obj := range objects {
+			Expect(client.IgnoreNotFound(c.Delete(cleanupCtx, obj))).To(Succeed(), "should delete %T %q", obj, client.ObjectKeyFromObject(obj))
+		}
+	})
+
+	By("Wait for test pods to be ready")
+	for _, obj := range objects {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok {
+			continue
+		}
+
+		Eventually(func(g Gomega) {
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+		}).WithContext(ctx).WithTimeout(time.Minute).Should(Succeed(), "%T %q should get ready", obj, client.ObjectKeyFromObject(obj))
+	}
+}
+
+func execute(ctx context.Context, clientSet kubernetes.Interface, podName string, command ...string) *Buffer {
+	GinkgoHelper()
+	var stdOutBuffer, stdErrBuffer = NewBuffer(), NewBuffer()
+
+	Expect(clientSet.PodExecutor().ExecuteWithStreams(
+		ctx,
+		namespace,
+		podName,
+		containerName,
+		nil,
+		io.MultiWriter(stdOutBuffer, gexec.NewPrefixedWriter("[out] ", GinkgoWriter)),
+		io.MultiWriter(stdErrBuffer, gexec.NewPrefixedWriter("[err] ", GinkgoWriter)),
+		command...,
+	)).To(Succeed())
+
+	return stdOutBuffer
+}
+
+func getObjects(kubernetesVersion string) []client.Object {
+	objects := getRBACObjects()
+
+	image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameHyperkube, imagevectorutils.TargetVersion(kubernetesVersion))
+	Expect(err).NotTo(HaveOccurred())
+
+	podDirect := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podNameDirect,
+			Namespace: namespace,
+			Labels:    maps.Clone(labels),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  containerName,
+				Image: image.String(),
+				Env: []corev1.EnvVar{{
+					// disable color output of `kubectl cluster-info` to make it simpler to assert
+					// ref https://github.com/daviddengcn/go-colortext/blob/v1.0.0/ct_ansi.go#L12
+					Name:  "TERM",
+					Value: "dumb",
+				}},
+			}},
+			ServiceAccountName: name,
+		},
+	}
+	objects = append(objects, podDirect)
+
+	podAPIServerProxyIP := podDirect.DeepCopy()
+	podAPIServerProxyIP.Name = podNameAPIServerProxyIP
+	// disable gardener's injection of the KUBERNETES_SERVICE_HOST env var
+	podAPIServerProxyIP.Labels[resourcesv1alpha1.KubernetesServiceHostInject] = "disable"
+	objects = append(objects, podAPIServerProxyIP)
+
+	podAPIServerProxyHostname := podDirect.DeepCopy()
+	podAPIServerProxyHostname.Name = podNameAPIServerProxyHostname
+	// manually set the KUBERNETES_SERVICE_HOST env var, gardener does not overwrite it if present
+	container := podAPIServerProxyHostname.Spec.Containers[0]
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  "KUBERNETES_SERVICE_HOST",
+		Value: "kubernetes.default.svc.cluster.local",
+	})
+	podAPIServerProxyHostname.Spec.Containers[0] = container
+	objects = append(objects, podAPIServerProxyHostname)
+
+	return objects
+}
+
+func getRBACObjects() []client.Object {
+	var objects []client.Object
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    maps.Clone(labels),
+		},
+	}
+	objects = append(objects, serviceAccount)
+
+	// permissions used by the test command: kubectl get pod *
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    maps.Clone(labels),
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get"},
+		}},
+	}
+	objects = append(objects, role)
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    maps.Clone(labels),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     name,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      name,
+			Namespace: namespace,
+		}},
+	}
+	objects = append(objects, roleBinding)
+
+	// permissions used by the test command: kubectl cluster-info
+	roleSystem := role.DeepCopy()
+	roleSystem.Namespace = metav1.NamespaceSystem
+	roleSystem.Rules = []rbacv1.PolicyRule{{
+		APIGroups: []string{""},
+		Resources: []string{"services"},
+		Verbs:     []string{"list"},
+	}}
+	objects = append(objects, roleSystem)
+
+	roleBindingSystem := roleBinding.DeepCopy()
+	roleBindingSystem.Namespace = metav1.NamespaceSystem
+	objects = append(objects, roleBindingSystem)
+
+	return objects
+}

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -59,7 +59,7 @@ var labels = map[string]string{"e2e-test": "in-cluster-client"}
 // - one pod explicitly overwrites the env var
 // See docs/usage/networking/shoot_kubernetes_service_host_injection.md and docs/proposals/08-shoot-apiserver-via-sni.md
 func VerifyInClusterAccessToAPIServer(parentCtx context.Context, f *framework.ShootFramework) {
-	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Minute)
+	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 	defer cancel()
 
 	defer prepareObjects(ctx, f.ShootClient.Client(), f.Shoot.Spec.Kubernetes.Version)()
@@ -168,7 +168,7 @@ func executeKubectl(ctx context.Context, clientSet kubernetes.Interface, podName
 	// Retry the command execution with a short timeout to reduce flakiness. We better timeout quickly and succeed on the
 	// next try than being stuck in on try.
 	Eventually(func(g Gomega, ctx context.Context) {
-		timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()
 
 		stdOutBuffer := NewBuffer()
@@ -187,7 +187,7 @@ func executeKubectl(ctx context.Context, clientSet kubernetes.Interface, podName
 
 		// we don't need Eventually here, because the buffer is already closed
 		g.Expect(stdOutBuffer).To(matcher)
-	}).WithContext(ctx).WithTimeout(time.Minute).Should(Succeed())
+	}).WithContext(ctx).WithTimeout(5 * time.Minute).Should(Succeed())
 }
 
 func getObjects(kubernetesVersion string) []client.Object {

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -71,7 +71,8 @@ func VerifyInClusterAccessToAPIServer(parentCtx context.Context, f *framework.Sh
 	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 	defer cancel()
 
-	defer prepareObjects(ctx, f.ShootClient.Client(), f.Shoot.Spec.Kubernetes.Version)()
+	cleanupObjects := prepareObjects(ctx, f.ShootClient.Client(), f.Shoot.Spec.Kubernetes.Version)
+	defer cleanupObjects()
 
 	By("Verify access via direct path")
 	// this pod connects to the API server directly, i.e., uses the KUBERNETES_SERVICE_HOST env var injected by gardener

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -34,7 +34,10 @@ const waitForCSINodeAnnotation = v1beta1constants.AnnotationPrefixWaitForCSINode
 const driverName = "foo.driver.example.org"
 
 // VerifyNodeCriticalComponentsBootstrapping tests the node readiness feature (see docs/usage/advanced/node-readiness.md).
-func VerifyNodeCriticalComponentsBootstrapping(ctx context.Context, f *framework.ShootFramework) {
+func VerifyNodeCriticalComponentsBootstrapping(parentCtx context.Context, f *framework.ShootFramework) {
+	ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+	defer cancel()
+
 	shootClientSet, err := access.CreateShootClientFromAdminKubeconfig(ctx, f.GardenClient, f.Shoot)
 	ExpectWithOffset(1, err).To(Succeed())
 

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
@@ -12,7 +12,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/utils/shoots/update/highavailability"
 )
 
@@ -31,10 +33,18 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 
+			if !v1beta1helper.IsWorkerless(f.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+			}
+
 			By("Upgrade Shoot (non-HA to HA with failure tolerance type 'node')")
 			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
 			defer cancel()
 			highavailability.UpgradeAndVerify(ctx, f.ShootFramework, gardencorev1beta1.FailureToleranceTypeNode)
+
+			if !v1beta1helper.IsWorkerless(f.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+			}
 
 			By("Delete Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
@@ -34,7 +34,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			f.Verify()
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Upgrade Shoot (non-HA to HA with failure tolerance type 'node')")
@@ -43,7 +43,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			highavailability.UpgradeAndVerify(ctx, f.ShootFramework, gardencorev1beta1.FailureToleranceTypeNode)
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Delete Shoot")

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_zone.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_zone.go
@@ -12,7 +12,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/utils/shoots/update/highavailability"
 )
 
@@ -31,10 +33,18 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 
+			if !v1beta1helper.IsWorkerless(f.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+			}
+
 			By("Upgrade Shoot (non-HA to HA with failure tolerance type 'zone')")
 			ctx, cancel = context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 			highavailability.UpgradeAndVerify(ctx, f.ShootFramework, gardencorev1beta1.FailureToleranceTypeZone)
+
+			if !v1beta1helper.IsWorkerless(f.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+			}
 
 			By("Delete Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_zone.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_zone.go
@@ -34,7 +34,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			f.Verify()
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Upgrade Shoot (non-HA to HA with failure tolerance type 'zone')")
@@ -43,7 +43,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			highavailability.UpgradeAndVerify(ctx, f.ShootFramework, gardencorev1beta1.FailureToleranceTypeZone)
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(ctx, f.ShootFramework)
+				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
 			}
 
 			By("Delete Shoot")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind test

**What this PR does / why we need it**:

In preparation for the upcoming changes to the API server proxy, this PR adds e2e test checks that verify in-cluster clients can connect to the API server via different supported paths.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
