### PR TITLE
Graduate feature gate `UseNamespacedCloudProfile` to `Beta`

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1794,7 +1794,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>CloudProfileName is a name of a CloudProfile object.
-This field will be deprecated soon, use <code>CloudProfile</code> instead.</p>
+Deprecated: This field will be removed in a future version of Gardener. Use <code>CloudProfile</code> instead.
+Until removed, this field is synced with the <code>CloudProfile</code> field.</p>
 </td>
 </tr>
 <tr>
@@ -12035,7 +12036,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>CloudProfileName is a name of a CloudProfile object.
-This field will be deprecated soon, use <code>CloudProfile</code> instead.</p>
+Deprecated: This field will be removed in a future version of Gardener. Use <code>CloudProfile</code> instead.
+Until removed, this field is synced with the <code>CloudProfile</code> field.</p>
 </td>
 </tr>
 <tr>
@@ -12748,7 +12750,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>CloudProfileName is a name of a CloudProfile object.
-This field will be deprecated soon, use <code>CloudProfile</code> instead.</p>
+Deprecated: This field will be removed in a future version of Gardener. Use <code>CloudProfile</code> instead.
+Until removed, this field is synced with the <code>CloudProfile</code> field.</p>
 </td>
 </tr>
 <tr>

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -21,7 +21,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | Feature                                  | Default | Stage   | Since   | Until   |
 |------------------------------------------|---------|---------|---------|---------|
 | DefaultSeccompProfile                    | `false` | `Alpha` | `1.54`  |         |
-| UseNamespacedCloudProfile                | `false` | `Alpha` | `1.92`  |         |
+| UseNamespacedCloudProfile                | `false` | `Alpha` | `1.92`  | `1.111` |
+| UseNamespacedCloudProfile                | `true`  | `Beta`  | `1.112` |         |
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -159,7 +159,6 @@ global:
         policy: ""
     featureGates:
       ShootForceDeletion: true
-      UseNamespacedCloudProfile: true
       CredentialsRotationWithoutWorkersRollout: true
     resources: {}
     podLabels:

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -55,7 +55,8 @@ type ShootSpec struct {
 	// Addons contains information about enabled/disabled addons and their configuration.
 	Addons *Addons
 	// CloudProfileName is a name of a CloudProfile object.
-	// This field will be deprecated soon, use `CloudProfile` instead.
+	// Deprecated: This field will be removed in a future version of Gardener. Use `CloudProfile` instead.
+	// Until removed, this field is synced with the `CloudProfile` field.
 	CloudProfileName *string
 	// DNS contains information about the DNS settings of the Shoot.
 	DNS *DNS

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2992,7 +2992,8 @@ message ShootSpec {
   optional Addons addons = 1;
 
   // CloudProfileName is a name of a CloudProfile object.
-  // This field will be deprecated soon, use `CloudProfile` instead.
+  // Deprecated: This field will be removed in a future version of Gardener. Use `CloudProfile` instead.
+  // Until removed, this field is synced with the `CloudProfile` field.
   // +optional
   optional string cloudProfileName = 2;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -64,7 +64,8 @@ type ShootSpec struct {
 	// +optional
 	Addons *Addons `json:"addons,omitempty" protobuf:"bytes,1,opt,name=addons"`
 	// CloudProfileName is a name of a CloudProfile object.
-	// This field will be deprecated soon, use `CloudProfile` instead.
+	// Deprecated: This field will be removed in a future version of Gardener. Use `CloudProfile` instead.
+	// Until removed, this field is synced with the `CloudProfile` field.
 	// +optional
 	CloudProfileName *string `json:"cloudProfileName,omitempty" protobuf:"bytes,2,opt,name=cloudProfileName"`
 	// DNS contains information about the DNS settings of the Shoot.

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -8844,7 +8844,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"cloudProfileName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudProfileName is a name of a CloudProfile object. This field will be deprecated soon, use `CloudProfile` instead.",
+							Description: "CloudProfileName is a name of a CloudProfile object. Deprecated: This field will be removed in a future version of Gardener. Use `CloudProfile` instead. Until removed, this field is synced with the `CloudProfile` field.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -34,6 +34,7 @@ const (
 	// nodes.
 	// owner: @timuthy @benedictweis @LucaBernstein
 	// alpha: v1.92.0
+	// beta: v1.112.0
 	UseNamespacedCloudProfile featuregate.Feature = "UseNamespacedCloudProfile"
 
 	// ShootCredentialsBinding enables the usage of the CredentialsBindingName API in shoot spec.
@@ -96,7 +97,7 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:                    {Default: false, PreRelease: featuregate.Alpha},
 	ShootForceDeletion:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	UseNamespacedCloudProfile:                {Default: false, PreRelease: featuregate.Alpha},
+	UseNamespacedCloudProfile:                {Default: true, PreRelease: featuregate.Beta},
 	ShootCredentialsBinding:                  {Default: true, PreRelease: featuregate.Beta},
 	NewWorkerPoolHash:                        {Default: false, PreRelease: featuregate.Alpha},
 	NewVPN:                                   {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Graduate feature gate `UseNamespacedCloudProfile` to `Beta`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9504.

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The feature gate `UseNamespacedCloudProfile` has been graduated to `Beta` and is now enabled by default.
```
