### PR TITLE
Document how the ManagedResource Secret data can be decompressed

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -254,6 +254,13 @@ A decent compression algorithm helps to reduce the footprint of such `Secret`s a
 We found [Brotli](https://github.com/google/brotli) to be a suitable candidate for most use cases (see comparison table [here](https://github.com/gardener/gardener/pull/9868)).
 When the `gardener-resource-manager` detects a data key with the known suffix `.br`, it automatically un-compresses the data first before processing the contained manifest.
 
+To decompress a ManagedResource Secret use:
+```
+kubectl -n <namespace> get secret <managed-resource-secret> -o jsonpath='{.data.data\.yaml\.br}' | base64 -d | brotli -d
+```
+
+On macOS, the brotli binary can be installed via homebrew using the [brotli formula](https://formulae.brew.sh/formula/brotli).
+
 ### [`health` Controller](../../pkg/resourcemanager/controller/health)
 
 This controller processes `ManagedResource`s that were reconciled by the main [ManagedResource Controller](#managedResource-controller) at least once.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Maybe there is no added value in the docs for everyone as some people may know how to do it.
I didn't know how to do it and I was looking for such docs. 
That's why I decided to such docs.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
