### PR TITLE
chore: Enhance release notes for grouped Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -426,24 +426,19 @@
       enabled: true,
     },
     {
-      // Add PR footer with release notes for docker releases.
-      matchDatasources: [
-        'docker',
+      // Add PR footer with release notes.
+      matchUpdateTypes: [
+        'major',
+        'minor',
+        'patch',
       ],
-      matchFileNames: [
-        'imagevector/**',
-      ],
-      prFooter: '**Release note**:\n```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`.\n```',
-    },
-    {
-      // Add PR footer with release notes link for github-releases.
-      matchDatasources: [
-        'github-releases',
-      ],
-      matchFileNames: [
-        'imagevector/**',
-      ],
-      prFooter: '**Release note**:\n```other dependency\nThe `{{depName}}` image has been updated to `{{newVersion}}`. [Release Notes](https://github.com/{{depName}}/releases/tag/{{newVersion}})\n```',
+      prFooter: "**Release note**:\n\
+```other dependency\n\
+The following dependencies have been updated:\n\
+{{#each upgrades as |upgrade|}}\n\
+- `{{upgrade.depName}}` from `{{upgrade.currentVersion}}` to `{{upgrade.newVersion}}`. {{#if (equals upgrade.datasource 'github-releases')}}[Release Notes](https://github.com/{{upgrade.depName}}/releases/tag/{{upgrade.newVersion}}){{/if}}\n\
+{{/each}}\n\
+```",
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -427,6 +427,9 @@
     },
     {
       // Add PR footer with release notes.
+      matchFileNames: [
+        'imagevector/**',
+      ],
       matchUpdateTypes: [
         'major',
         'minor',


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR replaces two Renovate package rules with a new combined rule.
The new package rule adds a `prFooter` to `major`, `minor`, and `patch` Renovate updates that follows the structure of our usual release notes block.
It lists all dependencies that are being updated and if the update stems from a GitHub release it adds a link to the respective release notes.

To see the configuration in action please check the PRs that Renovate generated against my fork below:
* https://github.com/marc1404/gardener/pull/50 – two updates with a slightly different name
* https://github.com/marc1404/gardener/pull/49 – only one update but with GitHub release notes
* https://github.com/marc1404/gardener/pull/48 – two updates with the same name

As you can see in the last referenced example PR the template will list dependencies with the same name multiple times.
Unfortunately, I didn't find a way with the [inbuilt Handlebars helpers](https://handlebarsjs.com/guide/builtin-helpers.html) or the [registered helpers by Renovate](https://docs.renovatebot.com/templates/#additional-handlebars-helpers) to filter duplicates from the list. However, I think that release notes with duplicates are better than no release notes at all.

**Which issue(s) this PR fixes**:
Fixes #11177

**Special notes for your reviewer**:

/cc @oliver-goetz 

Kudos to https://github.com/gardener/gardener/pull/11172 as its release notes have been used as the template for the `prFooter`. 🥂 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
