### PR TITLE
Fix nil pointer exception in shoot deletion and migration flows if `shoot.status.networking == nil`

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -139,7 +139,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 	)
 
 	var (
-		hasNodesCIDR            = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil && o.Shoot.GetInfo().Status.Networking != nil
+		hasNodesCIDR            = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil
 		useDNS                  = botanist.ShootUsesDNS()
 		nonTerminatingNamespace = botanist.SeedNamespaceObject.UID != "" && botanist.SeedNamespaceObject.Status.Phase != corev1.NamespaceTerminating
 		cleanupShootResources   = nonTerminatingNamespace && kubeAPIServerDeploymentFound && (infrastructure != nil || o.Shoot.IsWorkerless)

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
@@ -98,7 +98,7 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 	)
 
 	var (
-		hasNodesCIDR            = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil && o.Shoot.GetInfo().Status.Networking != nil
+		hasNodesCIDR            = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil
 		nonTerminatingNamespace = botanist.SeedNamespaceObject.UID != "" && botanist.SeedNamespaceObject.Status.Phase != corev1.NamespaceTerminating
 		cleanupShootResources   = nonTerminatingNamespace && kubeAPIServerDeploymentFound
 		wakeupRequired          = (o.Shoot.GetInfo().Status.IsHibernated || o.Shoot.HibernationEnabled) && cleanupShootResources


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind regression

**What this PR does / why we need it**:
Since PR #11038 running the shoot delete and migration flow for shoots where `shoot.status.networking == nil` leads to a nil pointer exception.
This happens because the internal variable `o.Shoot.Networks` is not set, but it is require when deploying kube-apiserver ([ref](https://github.com/gardener/gardener/blob/2d0d9df48da962a90fd4c7aa048874fbb6d2767d/pkg/gardenlet/operation/botanist/kubeapiserver.go#L218-L220)) 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x247c500]

goroutine 17432 [running]:
github.com/gardener/gardener/pkg/gardenlet/operation/botanist.(*Botanist).DeployKubeAPIServer(0xc035c3a170, {0x388d6e8, 0xc014332d90})
	/go/src/github.com/gardener/gardener/pkg/gardenlet/operation/botanist/kubeapiserver.go:225 +0x7a0
github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot.(*Reconciler).runDeleteShootFlow.TaskFn.RetryUntilTimeout.func47.1({0x388d6e8?, 0xc014332d90?})
	/go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:46 +0x22
github.com/gardener/gardener/pkg/utils/retry.UntilFor({0x388d6e8, 0xc014332d90}, 0xc01c202580, {0x3880800, 0xc01dd4ad80}, 0xc01dd4ad70)
	/go/src/github.com/gardener/gardener/pkg/utils/retry/retry.go:132 +0x49
github.com/gardener/gardener/pkg/utils/retry.(*ops).Until(0xc0000e6690, {0x388d6e8, 0xc014332d90}, 0x2901400?, 0xc01dd4ad70)
	/go/src/github.com/gardener/gardener/pkg/utils/retry/retry.go:176 +0x6f
github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot.(*Reconciler).runDeleteShootFlow.TaskFn.RetryUntilTimeout.func47({0x388d640?, 0xc01dc00420?})
	/go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:45 +0xb2
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func2()
	/go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:234 +0x17d
created by github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode in goroutine 2055
	/go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:231 +0x629
```

This PR fixes this issue. It is still possible to delete and migrate shoots where infrastructure creation has been never carried out successful because [`shoot.ToNetworks` function does not fail when `shoot.status.networking == nil`](https://github.com/gardener/gardener/blob/2d0d9df48da962a90fd4c7aa048874fbb6d2767d/pkg/gardenlet/operation/shoot/shoot.go#L587-L603). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which leads to a gardenlet nil pointer exception when running shoot deletion or migration flow for shoots where `shoot.status.networking == nil` has been fixed.
```
