### PR TITLE
chore: Change debug output for `generate-kustomize-patch-gardenlet.sh`

### DIFF
--- a/hack/generate-kustomize-patch-gardenlet.sh
+++ b/hack/generate-kustomize-patch-gardenlet.sh
@@ -5,17 +5,6 @@
 set -e
 set -o pipefail
 
-# TODO(marc1404): Remove when https://github.com/gardener/gardener/issues/11075 is resolved.
-# Start temp debugging
-error_handler() {
-    echo "An error occurred on line $1."
-    echo "$SKAFFOLD_IMAGE"
-    echo "$@"
-}
-
-trap 'error_handler $LINENO $@' ERR
-# End temp debugging
-
 dir="$(dirname $0)/../example/gardener-local/gardenlet/operator"
 type="${1:-image}"
 ref="$SKAFFOLD_IMAGE"
@@ -56,6 +45,7 @@ spec:
 EOF
   fi
 
+  cat "$patch_file" # TODO(marc1404): Remove when https://github.com/gardener/gardener/issues/11075 is resolved.
   images="$(yq e '.spec.deployment.imageVectorOverwrite' "$patch_file" | yq -o json)"
 
   images="$(echo "$images" | jq -r \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area testing
/kind task

**What this PR does / why we need it**:

The previously introduced debug output in [`generate-kustomize-patch-gardenlet.sh](./hack/generate-kustomize-patch-gardenlet.sh) narrowed the problem to the following line:
https://github.com/gardener/gardener/blob/2d0d9df48da962a90fd4c7aa048874fbb6d2767d/hack/generate-kustomize-patch-gardenlet.sh#L59

This PR prints the content of the `$patch_file` before the line where the error sporadically occurs.
The previous debug output is obsolete and has been removed.

**Which issue(s) this PR fixes**:

Part of #11075

**Special notes for your reviewer**:

/cc @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
