### PR TITLE
[release-v1.110] Automated cherry pick of #11281: Ensure `node-agent-authorizer` webhook configuration is added exactly once

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -60,7 +60,7 @@ type Interface interface {
 	// AppendAuthorizationWebhook appends an AuthorizationWebhook to AuthorizationWebhooks in the Values of the deployer.
 	// TODO(oliver-goetz): Consider removing this method when we support Kubernetes version with structured authorization only.
 	//  See https://github.com/gardener/gardener/pull/10682#discussion_r1816324389 for more information.
-	AppendAuthorizationWebhook(AuthorizationWebhook)
+	AppendAuthorizationWebhook(AuthorizationWebhook) error
 	// SetExternalHostname sets the ExternalHostname field in the Values of the deployer.
 	SetExternalHostname(string)
 	// SetExternalServer sets the ExternalServer field in the Values of the deployer.
@@ -547,8 +547,16 @@ func (k *kubeAPIServer) GetAutoscalingReplicas() *int32 {
 	return k.values.Autoscaling.Replicas
 }
 
-func (k *kubeAPIServer) AppendAuthorizationWebhook(webhook AuthorizationWebhook) {
+func (k *kubeAPIServer) AppendAuthorizationWebhook(webhook AuthorizationWebhook) error {
+	for _, existingWebhook := range k.values.AuthorizationWebhooks {
+		if existingWebhook.Name == webhook.Name {
+			return fmt.Errorf("authorization webhook with name %q already exists", webhook.Name)
+		}
+	}
+
 	k.values.AuthorizationWebhooks = append(k.values.AuthorizationWebhooks, webhook)
+
+	return nil
 }
 
 func (k *kubeAPIServer) SetAutoscalingReplicas(replicas *int32) {

--- a/pkg/component/kubernetes/apiserver/mock/mocks.go
+++ b/pkg/component/kubernetes/apiserver/mock/mocks.go
@@ -45,9 +45,11 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // AppendAuthorizationWebhook mocks base method.
-func (m *MockInterface) AppendAuthorizationWebhook(arg0 apiserver0.AuthorizationWebhook) {
+func (m *MockInterface) AppendAuthorizationWebhook(arg0 apiserver0.AuthorizationWebhook) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AppendAuthorizationWebhook", arg0)
+	ret := m.ctrl.Call(m, "AppendAuthorizationWebhook", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AppendAuthorizationWebhook indicates an expected call of AppendAuthorizationWebhook.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -307,7 +307,9 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployKubeAPIServer = g.Add(flow.Task{
 			Name: "Deploying Kubernetes API server",
-			Fn:   flow.TaskFn(botanist.DeployKubeAPIServer).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.DeployKubeAPIServer(ctx, nodeAgentAuthorizerWebhookReady && features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer))
+			}).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
 			Dependencies: flow.NewTaskIDs(
 				initializeSecretsManagement,
 				deployETCD,
@@ -350,8 +352,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		//  1.30+ clusters. This is similar to kube-apiserver deployment in gardener-operator.
 		//  See https://github.com/gardener/gardener/pull/10682#discussion_r1816324389 for more information.
 		deployKubeAPIServerWithNodeAgentAuthorizer = g.Add(flow.Task{
-			Name:         "Deploying Kubernetes API server with node-agent-authorizer",
-			Fn:           flow.TaskFn(botanist.DeployKubeAPIServer).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
+			Name: "Deploying Kubernetes API server with node-agent-authorizer",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.DeployKubeAPIServer(ctx, true)
+			}).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
 			SkipIf:       !features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) || nodeAgentAuthorizerWebhookReady,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -157,7 +157,7 @@ func (b *Botanist) computeKubeAPIServerSNIConfig() kubeapiserver.SNIConfig {
 }
 
 // DeployKubeAPIServer deploys the Kubernetes API server.
-func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
+func (b *Botanist) DeployKubeAPIServer(ctx context.Context, enableNodeAgentAuthorizer bool) error {
 	externalServer := b.Shoot.ComputeOutOfClusterAPIServerAddress(false)
 
 	externalHostname := b.Shoot.ComputeOutOfClusterAPIServerAddress(true)
@@ -166,49 +166,44 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		return err
 	}
 
-	if features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) {
-		nodeAgentAuthorizerWebhookReady, err := b.NodeAgentAuthorizerWebhookReady(ctx)
-		if err != nil {
-			return err
+	if enableNodeAgentAuthorizer {
+		caSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameCACluster)
+		if !found {
+			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
 		}
 
-		if nodeAgentAuthorizerWebhookReady {
-			caSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameCACluster)
-			if !found {
-				return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
-			}
+		kubeconfig, err := runtime.Encode(clientcmdlatest.Codec, kubernetesutils.NewKubeconfig(
+			"authorization-webhook",
+			clientcmdv1.Cluster{
+				Server:                   fmt.Sprintf("https://%s/webhooks/auth/nodeagent", resourcemanagerconstants.ServiceName),
+				CertificateAuthorityData: caSecret.Data[secretsutils.DataKeyCertificateBundle],
+			},
+			clientcmdv1.AuthInfo{},
+		))
+		if err != nil {
+			return fmt.Errorf("failed generating authorization webhook kubeconfig: %w", err)
+		}
 
-			kubeconfig, err := runtime.Encode(clientcmdlatest.Codec, kubernetesutils.NewKubeconfig(
-				"authorization-webhook",
-				clientcmdv1.Cluster{
-					Server:                   fmt.Sprintf("https://%s/webhooks/auth/nodeagent", resourcemanagerconstants.ServiceName),
-					CertificateAuthorityData: caSecret.Data[secretsutils.DataKeyCertificateBundle],
+		if err := b.Shoot.Components.ControlPlane.KubeAPIServer.AppendAuthorizationWebhook(
+			kubeapiserver.AuthorizationWebhook{
+				Name:       "node-agent-authorizer",
+				Kubeconfig: kubeconfig,
+				WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
+					// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
+					// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
+					AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
+					UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
+					Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
+					FailurePolicy:                            apiserverv1beta1.FailurePolicyDeny,
+					SubjectAccessReviewVersion:               "v1",
+					MatchConditionSubjectAccessReviewVersion: "v1",
+					MatchConditions: []apiserverv1beta1.WebhookMatchCondition{{
+						// Only intercept request node-agents
+						Expression: fmt.Sprintf("'%s' in request.groups", v1beta1constants.NodeAgentsGroup),
+					}},
 				},
-				clientcmdv1.AuthInfo{},
-			))
-			if err != nil {
-				return fmt.Errorf("failed generating authorization webhook kubeconfig: %w", err)
-			}
-
-			b.Shoot.Components.ControlPlane.KubeAPIServer.AppendAuthorizationWebhook(
-				kubeapiserver.AuthorizationWebhook{
-					Name:       "node-agent-authorizer",
-					Kubeconfig: kubeconfig,
-					WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
-						// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
-						// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
-						AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
-						UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
-						Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
-						FailurePolicy:                            apiserverv1beta1.FailurePolicyDeny,
-						SubjectAccessReviewVersion:               "v1",
-						MatchConditionSubjectAccessReviewVersion: "v1",
-						MatchConditions: []apiserverv1beta1.WebhookMatchCondition{{
-							// Only intercept request node-agents
-							Expression: fmt.Sprintf("'%s' in request.groups", v1beta1constants.NodeAgentsGroup),
-						}},
-					},
-				})
+			}); err != nil {
+			return fmt.Errorf("failed appending node-agent-authorizer webhook config to kube-apiserver: %w", err)
 		}
 	}
 
@@ -310,7 +305,7 @@ func (b *Botanist) DeleteKubeAPIServer(ctx context.Context) error {
 }
 
 // WakeUpKubeAPIServer creates a service and ensures API Server is scaled up
-func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context) error {
+func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context, enableNodeAgentAuthorizer bool) error {
 	if err := b.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy(ctx); err != nil {
 		return err
 	}
@@ -322,7 +317,7 @@ func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := b.DeployKubeAPIServer(ctx); err != nil {
+	if err := b.DeployKubeAPIServer(ctx, enableNodeAgentAuthorizer); err != nil {
 		return err
 	}
 	if err := kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, 1); err != nil {

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -304,7 +304,7 @@ var _ = Describe("KubeAPIServer", func() {
 					kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 					kubeAPIServer.EXPECT().Deploy(ctx)
 
-					Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+					Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 				},
 
 				Entry("no need for internal DNS",
@@ -375,7 +375,7 @@ var _ = Describe("KubeAPIServer", func() {
 					kubeAPIServer.EXPECT().SetServiceAccountConfig(expectedConfig)
 					kubeAPIServer.EXPECT().Deploy(ctx)
 
-					Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+					Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 				},
 
 				Entry("should default the issuer",
@@ -486,7 +486,7 @@ var _ = Describe("KubeAPIServer", func() {
 					ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{},
 				}
 
-				err := botanist.DeployKubeAPIServer(ctx)
+				err := botanist.DeployKubeAPIServer(ctx, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("shoot requires managed issuer, but gardener does not have shoot service account hostname configured"))
 			})
@@ -508,7 +508,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
 
-			Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+			Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 
 			kubeconfigSecret := &corev1.Secret{}
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, kubeconfigSecret)).To(Succeed())
@@ -556,7 +556,7 @@ var _ = Describe("KubeAPIServer", func() {
 			}
 			botanist.Shoot.SetInfo(shootCopy)
 
-			Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+			Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
 		})

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -559,6 +560,58 @@ var _ = Describe("KubeAPIServer", func() {
 			Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
+		})
+
+		It("should append the node-agent-authorizer webhook configuration if it is enabled", func() {
+			expectedKubeconfig := []byte(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://gardener-resource-manager/webhooks/auth/nodeagent
+  name: authorization-webhook
+contexts:
+- context:
+    cluster: authorization-webhook
+    user: authorization-webhook
+  name: authorization-webhook
+current-context: authorization-webhook
+kind: Config
+preferences: {}
+users:
+- name: authorization-webhook
+  user: {}
+`)
+
+			expectedAuthorizationWebhook := kubeapiserver.AuthorizationWebhook{
+				Name:       "node-agent-authorizer",
+				Kubeconfig: expectedKubeconfig,
+				WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
+					AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
+					UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
+					Timeout:                                  metav1.Duration{Duration: 10 * time.Second},
+					FailurePolicy:                            "Deny",
+					SubjectAccessReviewVersion:               "v1",
+					MatchConditionSubjectAccessReviewVersion: "v1",
+					MatchConditions: []apiserverv1beta1.WebhookMatchCondition{{
+						Expression: "'gardener.cloud:node-agents' in request.groups",
+					}},
+				},
+			}
+
+			kubeAPIServer.EXPECT().GetValues()
+			kubeAPIServer.EXPECT().SetAutoscalingReplicas(gomock.Any())
+			kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
+			kubeAPIServer.EXPECT().SetETCDEncryptionConfig(gomock.Any())
+			kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
+			kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+			kubeAPIServer.EXPECT().SetNodeNetworkCIDRs(gomock.Any())
+			kubeAPIServer.EXPECT().SetPodNetworkCIDRs(gomock.Any())
+			kubeAPIServer.EXPECT().SetServiceNetworkCIDRs(gomock.Any())
+			kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
+			kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
+			kubeAPIServer.EXPECT().AppendAuthorizationWebhook(expectedAuthorizationWebhook)
+			kubeAPIServer.EXPECT().Deploy(ctx)
+
+			Expect(botanist.DeployKubeAPIServer(ctx, true)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
/kind bug
/area robustness

Cherry pick of #11281 on release-v1.110.

#11281: Ensure `node-agent-authorizer` webhook configuration is added exactly once

**Release Notes:**
```bugfix operator
A bug which might lead to duplicate config entries for `node-agent-authorizer` webhook has been fixed.
```