### PR TITLE
[release-v1.109] Automated cherry pick of #11281: Ensure `node-agent-authorizer` webhook configuration is added exactly once

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -60,7 +60,7 @@ type Interface interface {
 	// AppendAuthorizationWebhook appends an AuthorizationWebhook to AuthorizationWebhooks in the Values of the deployer.
 	// TODO(oliver-goetz): Consider removing this method when we support Kubernetes version with structured authorization only.
 	//  See https://github.com/gardener/gardener/pull/10682#discussion_r1816324389 for more information.
-	AppendAuthorizationWebhook(AuthorizationWebhook)
+	AppendAuthorizationWebhook(AuthorizationWebhook) error
 	// SetExternalHostname sets the ExternalHostname field in the Values of the deployer.
 	SetExternalHostname(string)
 	// SetExternalServer sets the ExternalServer field in the Values of the deployer.
@@ -547,8 +547,16 @@ func (k *kubeAPIServer) GetAutoscalingReplicas() *int32 {
 	return k.values.Autoscaling.Replicas
 }
 
-func (k *kubeAPIServer) AppendAuthorizationWebhook(webhook AuthorizationWebhook) {
+func (k *kubeAPIServer) AppendAuthorizationWebhook(webhook AuthorizationWebhook) error {
+	for _, existingWebhook := range k.values.AuthorizationWebhooks {
+		if existingWebhook.Name == webhook.Name {
+			return fmt.Errorf("authorization webhook with name %q already exists", webhook.Name)
+		}
+	}
+
 	k.values.AuthorizationWebhooks = append(k.values.AuthorizationWebhooks, webhook)
+
+	return nil
 }
 
 func (k *kubeAPIServer) SetAutoscalingReplicas(replicas *int32) {

--- a/pkg/component/kubernetes/apiserver/mock/mocks.go
+++ b/pkg/component/kubernetes/apiserver/mock/mocks.go
@@ -45,9 +45,11 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // AppendAuthorizationWebhook mocks base method.
-func (m *MockInterface) AppendAuthorizationWebhook(arg0 apiserver0.AuthorizationWebhook) {
+func (m *MockInterface) AppendAuthorizationWebhook(arg0 apiserver0.AuthorizationWebhook) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AppendAuthorizationWebhook", arg0)
+	ret := m.ctrl.Call(m, "AppendAuthorizationWebhook", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AppendAuthorizationWebhook indicates an expected call of AppendAuthorizationWebhook.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -307,7 +307,9 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployKubeAPIServer = g.Add(flow.Task{
 			Name: "Deploying Kubernetes API server",
-			Fn:   flow.TaskFn(botanist.DeployKubeAPIServer).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.DeployKubeAPIServer(ctx, nodeAgentAuthorizerWebhookReady && features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer))
+			}).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
 			Dependencies: flow.NewTaskIDs(
 				initializeSecretsManagement,
 				deployETCD,
@@ -350,8 +352,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		//  1.30+ clusters. This is similar to kube-apiserver deployment in gardener-operator.
 		//  See https://github.com/gardener/gardener/pull/10682#discussion_r1816324389 for more information.
 		deployKubeAPIServerWithNodeAgentAuthorizer = g.Add(flow.Task{
-			Name:         "Deploying Kubernetes API server with node-agent-authorizer",
-			Fn:           flow.TaskFn(botanist.DeployKubeAPIServer).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
+			Name: "Deploying Kubernetes API server with node-agent-authorizer",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.DeployKubeAPIServer(ctx, true)
+			}).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
 			SkipIf:       !features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) || nodeAgentAuthorizerWebhookReady,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -304,7 +304,7 @@ var _ = Describe("KubeAPIServer", func() {
 					kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 					kubeAPIServer.EXPECT().Deploy(ctx)
 
-					Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+					Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 				},
 
 				Entry("no need for internal DNS",
@@ -375,7 +375,7 @@ var _ = Describe("KubeAPIServer", func() {
 					kubeAPIServer.EXPECT().SetServiceAccountConfig(expectedConfig)
 					kubeAPIServer.EXPECT().Deploy(ctx)
 
-					Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+					Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 				},
 
 				Entry("should default the issuer",
@@ -486,7 +486,7 @@ var _ = Describe("KubeAPIServer", func() {
 					ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{},
 				}
 
-				err := botanist.DeployKubeAPIServer(ctx)
+				err := botanist.DeployKubeAPIServer(ctx, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("shoot requires managed issuer, but gardener does not have shoot service account hostname configured"))
 			})
@@ -508,7 +508,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
 
-			Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+			Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 
 			kubeconfigSecret := &corev1.Secret{}
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, kubeconfigSecret)).To(Succeed())
@@ -556,7 +556,7 @@ var _ = Describe("KubeAPIServer", func() {
 			}
 			botanist.Shoot.SetInfo(shootCopy)
 
-			Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+			Expect(botanist.DeployKubeAPIServer(ctx, false)).To(Succeed())
 
 			Expect(gardenClient.Get(ctx, client.ObjectKey{Namespace: projectNamespace, Name: shootName + ".kubeconfig"}, &corev1.Secret{})).To(BeNotFoundError())
 		})


### PR DESCRIPTION
/kind bug
/area robustness

Cherry pick of #11281 on release-v1.109.

#11281: Ensure `node-agent-authorizer` webhook configuration is added exactly once

**Release Notes:**
```bugfix operator
A bug which might lead to duplicate config entries for `node-agent-authorizer` webhook has been fixed.
```