### PR TITLE
Minimize wildcards in RBAC roles

### DIFF
--- a/charts/gardener/provider-local/templates/rbac.yaml
+++ b/charts/gardener/provider-local/templates/rbac.yaml
@@ -47,7 +47,13 @@ rules:
   resources:
   - managedresources
   verbs:
-  - "*"
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -112,19 +118,42 @@ rules:
   - poddisruptionbudgets
   - ippools
   verbs:
-  - "*"
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
+  - deletecollection
 - apiGroups:
   - machine.sapcloud.io
   resources:
-  - "*"
+  - machineclasses
+  - machinedeployments
+  - machines
+  - machinesets
   verbs:
-  - "*"
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
+  - deletecollection
 - apiGroups:
   - autoscaling.k8s.io
   resources:
   - verticalpodautoscalers
   verbs:
-  - "*"
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -94,6 +94,7 @@ This document provides a checklist for them that you can walk through.
    Consequently, please define proper [RBAC roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) for it.
    This might include a combination of `ClusterRole`s and `Role`s.
    Please do not provide elevated privileges due to laziness (e.g., because there is already a `ClusterRole` that can be extended vs. creating a `Role` only when access to a single namespace is needed).
+   Please avoid using wildcards `*` where possible.
 
 4. **Use [`NetworkPolicy`s](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to restrict network traffic**
 

--- a/pkg/component/autoscaling/clusterautoscaler/bootstrap.go
+++ b/pkg/component/autoscaling/clusterautoscaler/bootstrap.go
@@ -47,7 +47,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{machinev1alpha1.GroupName},
-					Resources: []string{"*"},
+					Resources: []string{"machineclasses", "machinedeployments", "machines", "machinesets"},
 					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				},
 				{

--- a/pkg/component/autoscaling/clusterautoscaler/bootstrap_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/bootstrap_test.go
@@ -59,7 +59,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 				Rules: []rbacv1.PolicyRule{
 					{
 						APIGroups: []string{"machine.sapcloud.io"},
-						Resources: []string{"*"},
+						Resources: []string{"machineclasses", "machinedeployments", "machines", "machinesets"},
 						Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 					},
 					{

--- a/pkg/component/nodemanagement/machinecontrollermanager/bootstrap.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/bootstrap.go
@@ -49,13 +49,22 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{machinev1alpha1.GroupName},
-					Resources: []string{"*"},
-					Verbs:     []string{"*"},
+					Resources: []string{
+						"machineclasses",
+						"machineclasses/status",
+						"machinedeployments",
+						"machinedeployments/status",
+						"machines",
+						"machines/status",
+						"machinesets",
+						"machinesets/status",
+					},
+					Verbs: []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
 					Resources: []string{"configmaps", "secrets", "endpoints", "events", "pods"},
-					Verbs:     []string{"*"},
+					Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
 				},
 				{
 					APIGroups: []string{coordinationv1.GroupName},

--- a/pkg/component/nodemanagement/machinecontrollermanager/bootstrap_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/bootstrap_test.go
@@ -50,9 +50,23 @@ rules:
 - apiGroups:
   - machine.sapcloud.io
   resources:
-  - '*'
+  - machineclasses
+  - machineclasses/status
+  - machinedeployments
+  - machinedeployments/status
+  - machines
+  - machines/status
+  - machinesets
+  - machinesets/status
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - delete
+  - deletecollection
 - apiGroups:
   - ""
   resources:
@@ -62,7 +76,14 @@ rules:
   - events
   - pods
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - delete
+  - deletecollection
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -241,12 +241,12 @@ var _ = Describe("PrometheusOperator", func() {
 						"probes",
 						"prometheusrules",
 					},
-					Verbs: []string{"*"},
+					Verbs: []string{"create", "get", "list", "watch", "patch", "update", "delete", "deletecollection"},
 				},
 				{
 					APIGroups: []string{"apps"},
 					Resources: []string{"statefulsets"},
-					Verbs:     []string{"*"},
+					Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete", "deletecollection"},
 				},
 				{
 					APIGroups: []string{""},
@@ -254,7 +254,7 @@ var _ = Describe("PrometheusOperator", func() {
 						"configmaps",
 						"secrets",
 					},
-					Verbs: []string{"*"},
+					Verbs: []string{"create", "get", "list", "watch", "patch", "update", "delete", "deletecollection"},
 				},
 				{
 					APIGroups: []string{""},

--- a/pkg/component/observability/monitoring/prometheusoperator/rbac.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/rbac.go
@@ -44,12 +44,12 @@ func (p *prometheusOperator) clusterRole() *rbacv1.ClusterRole {
 					"probes",
 					"prometheusrules",
 				},
-				Verbs: []string{rbacv1.VerbAll},
+				Verbs: []string{"create", "get", "list", "watch", "patch", "update", "delete", "deletecollection"},
 			},
 			{
 				APIGroups: []string{appsv1.GroupName},
 				Resources: []string{"statefulsets"},
-				Verbs:     []string{rbacv1.VerbAll},
+				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete", "deletecollection"},
 			},
 			{
 				APIGroups: []string{corev1.GroupName},
@@ -57,7 +57,7 @@ func (p *prometheusOperator) clusterRole() *rbacv1.ClusterRole {
 					"configmaps",
 					"secrets",
 				},
-				Verbs: []string{rbacv1.VerbAll},
+				Verbs: []string{"create", "get", "list", "watch", "patch", "update", "delete", "deletecollection"},
 			},
 			{
 				APIGroups: []string{corev1.GroupName},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR replaces wildcards * in RBAC resource fields resources and verbs for the `provider-local`, `cluster-autoscaler`, `machine-controller-manager` and `prometheus-operator` components.

This issue is in sync with Diki's [Security Hardened Kubernetes Cluster Guide](https://github.com/gardener/diki/blob/main/docs/rulesets/security-hardened-k8s/ruleset.md). See rules [2006](https://github.com/gardener/diki/blob/main/docs/rulesets/security-hardened-k8s/ruleset.md#2006---limit-the-use-of-wildcards-in-rbac-resources) and [2007](https://github.com/gardener/diki/blob/main/docs/rulesets/security-hardened-k8s/ruleset.md#2007---limit-the-use-of-wildcards-in-rbac-verbs) for more details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove wildcards `*` from RBAC roles for the `cluster-autoscaler`, `machine-controller-manager` and `prometheus-operator` components.
```
