### PR TITLE
Change `prometheus` label of `vpa` `ServiceMonitors` from `seed` to `garden` when deployed by `garden operator` 

### DIFF
--- a/pkg/component/autoscaling/vpa/recommender.go
+++ b/pkg/component/autoscaling/vpa/recommender.go
@@ -358,8 +358,11 @@ func (v *vpa) reconcileRecommenderService(service *corev1.Service) {
 
 	switch v.values.ClusterType {
 	case component.ClusterTypeSeed:
-		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, metricsNetworkPolicyPort))
-
+		if v.values.IsGardenCluster {
+			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, metricsNetworkPolicyPort))
+		} else {
+			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, metricsNetworkPolicyPort))
+		}
 	case component.ClusterTypeShoot:
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, metricsNetworkPolicyPort))
 	}

--- a/pkg/component/autoscaling/vpa/vpa.go
+++ b/pkg/component/autoscaling/vpa/vpa.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	vpaconstants "github.com/gardener/gardener/pkg/component/autoscaling/vpa/constants"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/seed"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
@@ -88,6 +89,8 @@ type Values struct {
 	// resources (like Deployment, Service, etc.) are being deployed directly (with the client). All other application-
 	// related resources (like RBAC roles, CRD, etc.) are deployed as part of a ManagedResource.
 	ClusterType component.ClusterType
+	// IsGardenCluster specifies if the VPA is being deployed in a cluster registered as a Garden.
+	IsGardenCluster bool
 	// Enabled specifies if VPA is enabled.
 	Enabled bool
 	// SecretNameServerCA is the name of the server CA secret.
@@ -319,6 +322,9 @@ func (v *vpa) injectAPIServerConnectionSpec(deployment *appsv1.Deployment, name 
 
 func (v *vpa) getPrometheusLabel() string {
 	if v.values.ClusterType == component.ClusterTypeSeed {
+		if v.values.IsGardenCluster {
+			return garden.Label
+		}
 		return seed.Label
 	}
 	return shoot.Label

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1405,27 +1405,19 @@ var _ = Describe("VPA", func() {
 	Describe("#Deploy", func() {
 		Context("cluster type seed", func() {
 			BeforeEach(func() {
-				vpa = New(c, namespace, sm, Values{
-					ClusterType:              component.ClusterTypeSeed,
-					Enabled:                  true,
-					SecretNameServerCA:       secretNameCA,
-					RuntimeKubernetesVersion: runtimeKubernetesVersion,
-					AdmissionController:      valuesAdmissionController,
-					Recommender:              valuesRecommender,
-					Updater:                  valuesUpdater,
-				})
+				vpa = vpaFor(component.ClusterTypeSeed, false)
 				managedResourceName = "vpa"
 			})
 
-			Context("Different ServiceMonitor labels", func() {
-				Context("when used with Garden cluster", func() {
+			Context("when deploying ServiceMonitors", func() {
+				Context("in a garden cluster", func() {
 					BeforeEach(func() {
 						isGardenCluster := true
 						vpa = vpaFor(component.ClusterTypeSeed, isGardenCluster)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
-					It("should label `admission-controller` with `prometheus=garden`", func() {
+					It("should label vpa-admission-controller ServiceMonitor with `prometheus=garden`", func() {
 						serviceMonitorAdmissionController.ObjectMeta.Name = "garden-vpa-admission-controller"
 						serviceMonitorAdmissionController.ObjectMeta.Labels = map[string]string{
 							"prometheus": "garden",
@@ -1433,7 +1425,7 @@ var _ = Describe("VPA", func() {
 						Expect(managedResource).To(contain(serviceMonitorAdmissionController))
 					})
 
-					It("should label `recommender` with `prometheus=garden`", func() {
+					It("should label vpa-recommender ServiceMonitor with `prometheus=garden`", func() {
 						serviceMonitorRecommender := serviceMonitorRecommenderFor(component.ClusterTypeSeed)
 						serviceMonitorRecommender.ObjectMeta.Name = "garden-vpa-recommender"
 						serviceMonitorRecommender.ObjectMeta.Labels = map[string]string{
@@ -1443,18 +1435,16 @@ var _ = Describe("VPA", func() {
 					})
 				})
 
-				Context("when used with non-Garden cluster", func() {
+				Context("when not deployed in a garden cluster", func() {
 					BeforeEach(func() {
-						isGardenCluster := false
-						vpa = vpaFor(component.ClusterTypeSeed, isGardenCluster)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
-					It("should label `admission-controller` with `prometheus=seed`", func() {
+					It("should label vpa-admission-controller ServiceMonitor with `prometheus=seed`", func() {
 						Expect(managedResource).To(contain(serviceMonitorAdmissionController))
 					})
 
-					It("should label `recommender` with `prometheus=seed`", func() {
+					It("should label vpa-recommender ServiceMonitor with `prometheus=seed`", func() {
 						serviceMonitorRecommender := serviceMonitorRecommenderFor(component.ClusterTypeSeed)
 						Expect(managedResource).To(contain(serviceMonitorRecommender))
 					})

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1441,7 +1441,6 @@ var _ = Describe("VPA", func() {
 						}
 						Expect(managedResource).To(contain(serviceMonitorRecommender))
 					})
-
 				})
 
 				Context("when used with non-Garden cluster", func() {
@@ -1459,9 +1458,7 @@ var _ = Describe("VPA", func() {
 						serviceMonitorRecommender := serviceMonitorRecommenderFor(component.ClusterTypeSeed)
 						Expect(managedResource).To(contain(serviceMonitorRecommender))
 					})
-
 				})
-
 			})
 
 			Context("Different Kubernetes versions", func() {
@@ -1789,6 +1786,7 @@ var _ = Describe("VPA", func() {
 						serviceMonitorExpected.ResourceVersion = "1"
 
 					})
+
 					It("when IsGardenCluster=true", func() {
 						isGardenCluster := true
 						vpa = vpaFor(component.ClusterTypeShoot, isGardenCluster)
@@ -1819,7 +1817,6 @@ var _ = Describe("VPA", func() {
 						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
 					})
 				})
-
 			})
 
 			Context("Different Kubernetes versions", func() {

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1740,9 +1740,7 @@ var _ = Describe("VPA", func() {
 			})
 
 			Context("Different ServiceMonitor labels", func() {
-
 				Context("should always attach `prometheus=shoot` to `admission-controller`", func() {
-
 					BeforeEach(func() {
 						serviceMonitorAdmissionController.TypeMeta = metav1.TypeMeta{}
 						serviceMonitorAdmissionController.ResourceVersion = "1"
@@ -1784,11 +1782,11 @@ var _ = Describe("VPA", func() {
 				})
 
 				Context("should always attach `prometheus=shoot` to `recommender`", func() {
-					var serviceMonitor = &monitoringv1.ServiceMonitor{}
+					var serviceMonitorExpected = &monitoringv1.ServiceMonitor{}
 
 					BeforeEach(func() {
-						serviceMonitor = serviceMonitorRecommenderFor(component.ClusterTypeShoot)
-						serviceMonitor.ResourceVersion = "1"
+						serviceMonitorExpected = serviceMonitorRecommenderFor(component.ClusterTypeShoot)
+						serviceMonitorExpected.ResourceVersion = "1"
 
 					})
 					It("when IsGardenCluster=true", func() {
@@ -1796,14 +1794,14 @@ var _ = Describe("VPA", func() {
 						vpa = vpaFor(component.ClusterTypeShoot, isGardenCluster)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 
-						serviceMonitor := &monitoringv1.ServiceMonitor{}
-						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-recommender"}, serviceMonitor)).To(Succeed())
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-recommender"}, serviceMonitorActual)).To(Succeed())
 
 						By("verify Prometheus label")
-						Expect(serviceMonitor.Labels).To(Equal(serviceMonitor.ObjectMeta.Labels))
+						Expect(serviceMonitorActual.Labels).To(Equal(serviceMonitorExpected.ObjectMeta.Labels))
 
 						By("verify object")
-						Expect(serviceMonitor).To(Equal(serviceMonitor))
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
 					})
 
 					It("when IsGardenCluster=false", func() {
@@ -1811,14 +1809,14 @@ var _ = Describe("VPA", func() {
 						vpa = vpaFor(component.ClusterTypeShoot, isGardenCluster)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 
-						serviceMonitor := &monitoringv1.ServiceMonitor{}
-						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-recommender"}, serviceMonitor)).To(Succeed())
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-recommender"}, serviceMonitorActual)).To(Succeed())
 
 						By("verify Prometheus label")
-						Expect(serviceMonitor.Labels).To(Equal(serviceMonitor.ObjectMeta.Labels))
+						Expect(serviceMonitorActual.Labels).To(Equal(serviceMonitorExpected.ObjectMeta.Labels))
 
 						By("verify object")
-						Expect(serviceMonitor).To(Equal(serviceMonitor))
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
 					})
 				})
 

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1781,7 +1781,7 @@ var _ = Describe("VPA", func() {
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
-					It("should label `prometheus=shoot` to vpa-admission-controller ServiceMonitor", func() {
+					It("should label vpa-admission-controller ServiceMonitor with `prometheus=shoot`", func() {
 						serviceMonitor := &monitoringv1.ServiceMonitor{}
 						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-admission-controller"}, serviceMonitor)).To(Succeed())
 
@@ -1789,7 +1789,7 @@ var _ = Describe("VPA", func() {
 						Expect(serviceMonitor).To(Equal(serviceMonitorAdmissionController))
 					})
 
-					It("should label `prometheus=shoot` to vpa-recommender ServiceMonitor", func() {
+					It("should label vpa-recommender ServiceMonitor with `prometheus=shoot`", func() {
 						serviceMonitorExpected := serviceMonitorRecommenderFor(component.ClusterTypeShoot, true)
 						serviceMonitorExpected.ResourceVersion = "1"
 
@@ -1806,7 +1806,7 @@ var _ = Describe("VPA", func() {
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
-					It("should label `prometheus=shoot` to vpa-admission-controller ServiceMonitor", func() {
+					It("should label vpa-admission-controller ServiceMonitor with `prometheus=shoot`", func() {
 						serviceMonitor := &monitoringv1.ServiceMonitor{}
 						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-admission-controller"}, serviceMonitor)).To(Succeed())
 
@@ -1814,7 +1814,7 @@ var _ = Describe("VPA", func() {
 						Expect(serviceMonitor).To(Equal(serviceMonitorAdmissionController))
 					})
 
-					It("should label `prometheus=shoot` to vpa-recommender ServiceMonitor", func() {
+					It("should label vpa-recommender ServiceMonitor with `prometheus=shoot`", func() {
 						serviceMonitorRecommender := serviceMonitorRecommenderFor(component.ClusterTypeShoot, false)
 						serviceMonitorRecommender.ResourceVersion = "1"
 

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1240,7 +1240,6 @@ var _ = Describe("VPA", func() {
 			if clusterType == component.ClusterTypeShoot {
 				obj.Labels = map[string]string{"prometheus": "shoot"}
 				obj.Name = "shoot-vpa-admission-controller"
-				obj.ResourceVersion = "1"
 			}
 
 			return obj
@@ -1782,11 +1781,13 @@ var _ = Describe("VPA", func() {
 					})
 
 					It("should label vpa-admission-controller ServiceMonitor with `prometheus=shoot`", func() {
-						serviceMonitor := &monitoringv1.ServiceMonitor{}
-						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-admission-controller"}, serviceMonitor)).To(Succeed())
+						serviceMonitorExpected := serviceMonitorAdmissionControllerFor(component.ClusterTypeShoot, true)
+						serviceMonitorExpected.ResourceVersion = "1"
 
-						serviceMonitorAdmissionController := serviceMonitorAdmissionControllerFor(component.ClusterTypeShoot, true)
-						Expect(serviceMonitor).To(Equal(serviceMonitorAdmissionController))
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-admission-controller"}, serviceMonitorActual)).To(Succeed())
+
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
 					})
 
 					It("should label vpa-recommender ServiceMonitor with `prometheus=shoot`", func() {
@@ -1807,21 +1808,23 @@ var _ = Describe("VPA", func() {
 					})
 
 					It("should label vpa-admission-controller ServiceMonitor with `prometheus=shoot`", func() {
-						serviceMonitor := &monitoringv1.ServiceMonitor{}
-						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-admission-controller"}, serviceMonitor)).To(Succeed())
+						serviceMonitorExpected := serviceMonitorAdmissionControllerFor(component.ClusterTypeShoot, false)
+						serviceMonitorExpected.ResourceVersion = "1"
 
-						serviceMonitorAdmissionController := serviceMonitorAdmissionControllerFor(component.ClusterTypeShoot, false)
-						Expect(serviceMonitor).To(Equal(serviceMonitorAdmissionController))
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-admission-controller"}, serviceMonitorActual)).To(Succeed())
+
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
 					})
 
 					It("should label vpa-recommender ServiceMonitor with `prometheus=shoot`", func() {
-						serviceMonitorRecommender := serviceMonitorRecommenderFor(component.ClusterTypeShoot, false)
-						serviceMonitorRecommender.ResourceVersion = "1"
+						serviceMonitorExpected := serviceMonitorRecommenderFor(component.ClusterTypeShoot, false)
+						serviceMonitorExpected.ResourceVersion = "1"
 
-						serviceMonitor := &monitoringv1.ServiceMonitor{}
-						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-recommender"}, serviceMonitor)).To(Succeed())
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-recommender"}, serviceMonitorActual)).To(Succeed())
 
-						Expect(serviceMonitor).To(Equal(serviceMonitorRecommender))
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
 					})
 				})
 			})

--- a/pkg/component/shared/vpa.go
+++ b/pkg/component/shared/vpa.go
@@ -30,6 +30,7 @@ func NewVerticalPodAutoscaler(
 	priorityClassNameAdmissionController string,
 	priorityClassNameRecommender string,
 	priorityClassNameUpdater string,
+	isGardenCluster bool,
 ) (
 	component.DeployWaiter,
 	error,
@@ -55,6 +56,7 @@ func NewVerticalPodAutoscaler(
 		secretsManager,
 		vpa.Values{
 			ClusterType:              component.ClusterTypeSeed,
+			IsGardenCluster:          isGardenCluster,
 			Enabled:                  enabled,
 			SecretNameServerCA:       secretNameServerCA,
 			RuntimeKubernetesVersion: runtimeVersion,

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -157,7 +157,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.verticalPodAutoscaler, err = r.newVerticalPodAutoscaler(seed.GetInfo().Spec.Settings, secretsManager)
+	c.verticalPodAutoscaler, err = r.newVerticalPodAutoscaler(seed.GetInfo().Spec.Settings, secretsManager, seedIsGarden)
 	if err != nil {
 		return
 	}
@@ -689,7 +689,7 @@ func (r *Reconciler) newFluentCustomResources(seedIsGarden bool) (deployer compo
 	)
 }
 
-func (r *Reconciler) newVerticalPodAutoscaler(settings *gardencorev1beta1.SeedSettings, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+func (r *Reconciler) newVerticalPodAutoscaler(settings *gardencorev1beta1.SeedSettings, secretsManager secretsmanager.Interface, isGardenCluster bool) (component.DeployWaiter, error) {
 	return sharedcomponent.NewVerticalPodAutoscaler(
 		r.SeedClientSet.Client(),
 		r.GardenNamespace,
@@ -700,6 +700,7 @@ func (r *Reconciler) newVerticalPodAutoscaler(settings *gardencorev1beta1.SeedSe
 		v1beta1constants.PriorityClassNameSeedSystem800,
 		v1beta1constants.PriorityClassNameSeedSystem700,
 		v1beta1constants.PriorityClassNameSeedSystem700,
+		isGardenCluster,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -382,7 +382,6 @@ func (r *Reconciler) newVirtualGardenGardenerResourceManager(secretsManager secr
 }
 
 func (r *Reconciler) newVerticalPodAutoscaler(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
-	IsGardenCluster := true
 	return sharedcomponent.NewVerticalPodAutoscaler(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
@@ -393,7 +392,7 @@ func (r *Reconciler) newVerticalPodAutoscaler(garden *operatorv1alpha1.Garden, s
 		v1beta1constants.PriorityClassNameGardenSystem300,
 		v1beta1constants.PriorityClassNameGardenSystem200,
 		v1beta1constants.PriorityClassNameGardenSystem200,
-		IsGardenCluster,
+		true,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -382,6 +382,7 @@ func (r *Reconciler) newVirtualGardenGardenerResourceManager(secretsManager secr
 }
 
 func (r *Reconciler) newVerticalPodAutoscaler(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+	IsGardenCluster := true
 	return sharedcomponent.NewVerticalPodAutoscaler(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
@@ -392,6 +393,7 @@ func (r *Reconciler) newVerticalPodAutoscaler(garden *operatorv1alpha1.Garden, s
 		v1beta1constants.PriorityClassNameGardenSystem300,
 		v1beta1constants.PriorityClassNameGardenSystem200,
 		v1beta1constants.PriorityClassNameGardenSystem200,
+		IsGardenCluster,
 	)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

This PR updates the `prometheus=seed` label of `vpa-admission-controller` and `vpa-recommender` `ServiceMonitors` entries with `prometheus=garden`, when the components are deployed in a **`Garden` cluster that is also a `Seed`**.

 Since the `Garden` cluster has a `Prometheus` setup, configured to match `ServiceMonitors` with `prometheus=garden` label:

```sh
➜ gardener git:(master) ✗ kubectl -n=garden get prometheus garden -o yaml | yq -r '.spec.serviceMonitorSelector'
matchLabels:
  prometheus: garden
```

we are not collecting metrics from the `vpa-admission-controller` and `vpa-recommender` components.
With the change introduced in this PR, both `ServiceMonitors` get their `prometheus` label updated, 
enabling the `Garden` cluster `Prometheus` matching.

**Which issue(s) this PR fixes**:

Fixes https://github.com/gardener/gardener/issues/11270

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update `prometheus` label of `vpa-admission-controller` and `vpa-recommender` `ServiceMonitors` from `seed` to `garden` when deployed by the `garden-operator`. With this change, the `Garden` cluster `Prometheus` will match the `ServiceMonitors` and start collecting metrics from the configured services.
```
