### PR TITLE
Accept `client.Reader` instead of `client.Client` in the `managedresources.WaitUntilHealthy` func

### DIFF
--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -298,16 +298,16 @@ func deleteWithSecretNamePrefix(ctx context.Context, client client.Client, names
 var IntervalWait = 2 * time.Second
 
 // WaitUntilHealthy waits until the given managed resource is healthy.
-func WaitUntilHealthy(ctx context.Context, client client.Client, namespace, name string) error {
-	return waitUntilHealthy(ctx, client, namespace, name, false)
+func WaitUntilHealthy(ctx context.Context, reader client.Reader, namespace, name string) error {
+	return waitUntilHealthy(ctx, reader, namespace, name, false)
 }
 
 // WaitUntilHealthyAndNotProgressing waits until the given managed resource is healthy and not progressing.
-func WaitUntilHealthyAndNotProgressing(ctx context.Context, client client.Client, namespace, name string) error {
-	return waitUntilHealthy(ctx, client, namespace, name, true)
+func WaitUntilHealthyAndNotProgressing(ctx context.Context, reader client.Reader, namespace, name string) error {
+	return waitUntilHealthy(ctx, reader, namespace, name, true)
 }
 
-func waitUntilHealthy(ctx context.Context, c client.Client, namespace, name string, andNotProgressing bool) error {
+func waitUntilHealthy(ctx context.Context, reader client.Reader, namespace, name string, andNotProgressing bool) error {
 	obj := &resourcesv1alpha1.ManagedResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -316,7 +316,7 @@ func waitUntilHealthy(ctx context.Context, c client.Client, namespace, name stri
 	}
 
 	return retry.Until(ctx, IntervalWait, func(ctx context.Context) (done bool, err error) {
-		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+		if err := reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
 			return retry.SevereError(err)
 		}
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -816,7 +816,7 @@ func untilInTest(_ context.Context, _ time.Duration, _ retry.Func) error {
 	return nil
 }
 
-func waitUntilHealthyInTest(_ context.Context, _ client.Client, _, _ string) error {
+func waitUntilHealthyInTest(_ context.Context, _ client.Reader, _, _ string) error {
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
In the registry-cache extension, we discovered an issue that `managedresources.WaitUntilHealthy` does not really wait until the ManagedResource is healthy right after it is updated because the passed client is cached one. The cache is not yet populated with the recent ManagedResource update.

To fix this, we decided use `APIReader`. However, `mgr.GetAPIReader()` returns `client.Reader`:
https://github.com/kubernetes-sigs/controller-runtime/blob/2e8ba92873fd2a92ba473926f02e493619480771/pkg/cluster/cluster.go#L67C3-L70

A `client.Reader` cannot be used as arg of a func that accepts `client.Client`.
The `client.Client` embeds the `client.Reader` interface, hence the change is backwards-compatible and no adaptation is required in the usages of the func.

https://github.com/kubernetes-sigs/controller-runtime/blob/2e8ba92873fd2a92ba473926f02e493619480771/pkg/client/interfaces.go#L163-L178

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Corresponding PR in registry-cache side: https://github.com/gardener/gardener-extension-registry-cache/pull/344
For time being we copied locally the `managedresources.WaitUntilHealthy` and adapted it to accept `client.Reader`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`github.com/gardener/gardener/pkg/utils/managedresources.{WaitUntilHealthy,WaitUntilHealthyAndNotProgressing}` funcs now accept a `client.Reader` instead of a `client.Client`.
```
