### PR TITLE
Revisit the `VerticalPodAutoscalerCappedRecommendation` alert

### DIFF
--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -673,11 +673,18 @@ var _ = Describe("KubeStateMetrics", func() {
 						Replacement: ptr.To("kube-state-metrics"),
 					},
 				},
-				MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
-					SourceLabels: []monitoringv1.LabelName{"pod"},
-					Regex:        `^.+\.tf-pod.+$`,
-					Action:       "drop",
-				}},
+				MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+					{
+						SourceLabels: []monitoringv1.LabelName{"namespace"},
+						Regex:        `shoot-.+`,
+						Action:       "drop",
+					},
+					{
+						SourceLabels: []monitoringv1.LabelName{"pod"},
+						Regex:        `^.+\.tf-pod.+$`,
+						Action:       "drop",
+					},
+				},
 			},
 		}
 		scrapeConfigShoot = &monitoringv1alpha1.ScrapeConfig{

--- a/pkg/component/observability/monitoring/kubestatemetrics/resources.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/resources.go
@@ -589,11 +589,18 @@ func (k *kubeStateMetrics) scrapeConfigGarden() *monitoringv1alpha1.ScrapeConfig
 				Replacement: ptr.To("kube-state-metrics"),
 			},
 		},
-		MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
-			SourceLabels: []monitoringv1.LabelName{"pod"},
-			Regex:        `^.+\.tf-pod.+$`,
-			Action:       "drop",
-		}},
+		MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+			{
+				SourceLabels: []monitoringv1.LabelName{"namespace"},
+				Regex:        `shoot-.+`,
+				Action:       "drop",
+			},
+			{
+				SourceLabels: []monitoringv1.LabelName{"pod"},
+				Regex:        `^.+\.tf-pod.+$`,
+				Action:       "drop",
+			},
+		},
 	}
 
 	return scrapeConfig

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -80,9 +80,15 @@ func CentralPrometheusRules(seedIsGarden bool) []*monitoringv1.PrometheusRule {
 		rules = append(rules, monitoringv1.Rule{
 			Alert: "VerticalPodAutoscalerCappedRecommendation",
 			Expr: intstr.FromString(`
-    {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
->
-    {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}`),
+  count_over_time(
+    (
+        {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
+      >
+        {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}
+    )[5m:]
+  )
+==
+  5`),
 			Labels: map[string]string{
 				"severity":   "warning",
 				"type":       "seed",

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -90,9 +90,15 @@ var _ = Describe("PrometheusRules", func() {
 				vpaRule := monitoringv1.Rule{
 					Alert: "VerticalPodAutoscalerCappedRecommendation",
 					Expr: intstr.FromString(`
-    {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
->
-    {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}`),
+  count_over_time(
+    (
+        {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
+      >
+        {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}
+    )[5m:]
+  )
+==
+  5`),
 					Labels: map[string]string{
 						"severity":   "warning",
 						"type":       "seed",

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -324,7 +324,7 @@ spec:
           The seed cluster {{$labels.name}} in {{$externalLabels.landscape}}
           has a failing condition: {{$labels.condition}}.
 
-    - alert: SeedVerticalPodAutoscalerCappedRecommendation
+    - alert: SeedVerticalPodAutoscalerCappedRecommendationCount
       expr: |
           count(
             count by (seed) (ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="seed", alertstate="firing"})
@@ -335,4 +335,7 @@ spec:
         description: >-
           There are {{ .Value }} seeds in {{ $externalLabels.landscape }} with a VPA that shows
           an uncapped target recommendation larger than the regular target recommendation. Query
-          for this alert in the garden Prometheus for more details.
+          in the garden Prometheus for more details:
+
+
+          ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="seed"}

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
@@ -112,7 +112,7 @@ spec:
           The seed cluster: {{$labels.project}}/{{$labels.name}} has a filesystem mounted at {{ $labels.mountpoint }}
           on node {{ $labels.node }} that has only {{ printf "%.2f" $value }}% available inodes left.
 
-    - alert: ShootVerticalPodAutoscalerCappedRecommendation
+    - alert: ShootVerticalPodAutoscalerCappedRecommendationCount
       expr: |
           count(
             count by (cluster) (ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="shoot", alertstate="firing"})
@@ -123,4 +123,7 @@ spec:
         description: >-
           There are {{ .Value }} shoots in {{ $externalLabels.landscape }} with a VPA that shows
           an uncapped target recommendation larger than the regular target recommendation. Query
-          for this alert in the garden Prometheus for more details.
+          in the garden Prometheus for more details:
+
+
+          ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="shoot"}

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -155,7 +155,7 @@ tests:
                 The seed cluster seed-four in landscape-unit-tests
                 has a failing condition: APIServerUnavailable.
 
-  - name: SeedVerticalPodAutoscalerCappedRecommendation
+  - name: SeedVerticalPodAutoscalerCappedRecommendationCount
     interval: 1m
     input_series:
       - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
@@ -197,7 +197,7 @@ tests:
     external_labels:
       landscape: landscape-unit-tests
     alert_rule_test:
-    - alertname: SeedVerticalPodAutoscalerCappedRecommendation
+    - alertname: SeedVerticalPodAutoscalerCappedRecommendationCount
       eval_time: 0m # test the alert fires immediately
       exp_alerts:
         - exp_labels:
@@ -207,4 +207,7 @@ tests:
             description: >-
               There are 2 seeds in landscape-unit-tests with a VPA that shows an uncapped
               target recommendation larger than the regular target recommendation. Query
-              for this alert in the garden Prometheus for more details.
+              in the garden Prometheus for more details:
+
+
+              ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="seed"}

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/shoot.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/shoot.prometheusrule.test.yaml
@@ -3,7 +3,7 @@ rule_files:
 
 tests:
 
-  - name: ShootVerticalPodAutoscalerCappedRecommendation
+  - name: ShootVerticalPodAutoscalerCappedRecommendationCount
     interval: 1m
     input_series:
       - series: ALERTS{alertname             = "VerticalPodAutoscalerCappedRecommendation",
@@ -49,7 +49,7 @@ tests:
     external_labels:
       landscape: landscape-unit-tests
     alert_rule_test:
-    - alertname: ShootVerticalPodAutoscalerCappedRecommendation
+    - alertname: ShootVerticalPodAutoscalerCappedRecommendationCount
       eval_time: 0m # test the alert fires immediately
       exp_alerts:
         - exp_labels:
@@ -59,4 +59,7 @@ tests:
             description: >-
               There are 2 shoots in landscape-unit-tests with a VPA that shows an uncapped
               target recommendation larger than the regular target recommendation. Query
-              for this alert in the garden Prometheus for more details.
+              in the garden Prometheus for more details:
+
+
+              ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="shoot"}

--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/verticalpodautoscaler.yaml
@@ -8,9 +8,15 @@ spec:
     rules:
     - alert: VerticalPodAutoscalerCappedRecommendation
       expr: |2-
-          {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
-        >
-          {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}
+          count_over_time(
+            (
+                {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
+              >
+                {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}
+            )[5m:]
+          )
+        ==
+          5
       labels:
         severity: warning
         type: shoot

--- a/pkg/component/observability/monitoring/prometheus/shoot/testdata/verticalpodautoscaler.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/testdata/verticalpodautoscaler.prometheusrule.test.yaml
@@ -9,26 +9,26 @@ tests:
                                                                                                                         namespace             = "namespace-test",
                                                                                                                         container             = "container-test",
                                                                                                                         unit                  = "core"}
-    values: "2"
+    values: 2x4
   - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{verticalpodautoscaler = "vpa-test",
                                                                                                                 namespace             = "namespace-test",
                                                                                                                 container             = "container-test",
                                                                                                                 unit                  = "core"}
-    values: "1"
+    values: 1x4
   - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_memory{verticalpodautoscaler = "vpa-test",
                                                                                                                            namespace             = "namespace-test",
                                                                                                                            container             = "container-test",
                                                                                                                            unit                  = "byte"}
-    values: "2"
+    values: 2x4
   - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{verticalpodautoscaler = "vpa-test",
                                                                                                                    namespace             = "namespace-test",
                                                                                                                    container             = "container-test",
                                                                                                                    unit                  = "byte"}
-    values: "1"
+    values: 1x4
   external_labels:
     cluster: cluster-test
   alert_rule_test:
-  - eval_time: 0m # test the alert fires immediately
+  - eval_time: 4m
     alertname: VerticalPodAutoscalerCappedRecommendation
     exp_alerts:
     - exp_labels:
@@ -63,3 +63,24 @@ tests:
           - namespace = namespace-test
           - vpa = vpa-test
           - container = container-test
+
+# test for the race condition when prometheus scrapes the VPA metric between the instant when the kube-state-metrics updated the gauge value for the
+# new uncapped target recommendation but not the regular target recommendation
+- name: VerticalPodAutoscalerCappedRecommendation:PrometheusScrapeRaceCondition
+  interval: 1m
+  input_series:
+  - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_cpu{verticalpodautoscaler = "vpa-test",
+                                                                                                                        namespace             = "namespace-test",
+                                                                                                                        container             = "container-test",
+                                                                                                                        unit                  = "core"}
+    values: 1 1 1 2 2
+  - series: kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{verticalpodautoscaler = "vpa-test",
+                                                                                                                namespace             = "namespace-test",
+                                                                                                                container             = "container-test",
+                                                                                                                unit                  = "core"}
+    values: 1 1 1 1 2
+  external_labels:
+    cluster: cluster-test
+  alert_rule_test:
+  - eval_time: 3m
+    alertname: VerticalPodAutoscalerCappedRecommendation


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

https://github.com/gardener/gardener/pull/11136 introduced a new `VerticalPodAutoscalerCappedRecommendation` alert that aims at alerting when a VPA uncapped recommendation is larger than the regular recommendation. The reasoning for this alert is to make it more visible when containers need more resources than their maximum allowed. 

Such an alert, however, is affected by a race condition which was not detected during the development phase. When a VPA updates its status, both the uncapped and regular recommendations are updated. The uncapped recommendation matches the regular if it is within the boundaries. However, `kube-state-metrics` refreshes the metric values independently of each other. In consequence, the uncapped recommendation metric can be refreshed before the regular recommendation metric. If the Prometheus scrape occurs during that interval, there will be a data point for one scrape in Prometheus when the uncapped recommendation will be larger than the regular one and the alert will fire.

This PR not only fixes that but also revisits other smaller aspects of this alert:
- It fixes a bug when the alert is fired twice if the garden cluster is also a seed.
- It improves the alert summary and description.

**Special notes for your reviewer**:

/cc @istvanballok @rickardsjp @chrkl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Revisit the `VerticalPodAutoscalerCappedRecommendation` alert to fix a race condition and other small improvements
```
