### PR TITLE
[GEP-30] Drop usage of ext authz server

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -44,8 +44,9 @@ spec:
               # the other is for all non-CONNECT requests
               - match:
                   connect_matcher: {}
-                direct_response:
-                  status: 403
+                redirect:
+                  https_redirect: true
+                  port_redirect: 443
               # Redirect requests to the https port to make probing more painful/cost intensive
               - match:
                   prefix: "/"

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -28,11 +28,20 @@ spec:
               routes:
               - match:
                   connect_matcher: {}
+                  headers:
+                    - name: Reversed-VPN
+                      string_match:
+                        safe_regex:
+                          regex: '^outbound\|1194\|\|vpn-seed-server(-[0-4])?\..*\.svc\.cluster\.local$'
                 route:
                   cluster_header: Reversed-VPN
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+              - match:
+                  connect_matcher: {}
+                direct_response:
+                  status: 403
               # Redirect requests to the https port to make probing more painful/cost intensive
               - match:
                   prefix: "/"
@@ -44,12 +53,6 @@ spec:
                 redirect:
                   https_redirect: true
                   port_redirect: 443
-                typed_per_filter_config:
-                  # No need to bother the external authorization server with the request
-                  # as it will most likely reject it anyway.
-                  envoy.filters.http.ext_authz:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
-                    disabled: true
             # Redirect all other requests to the https port to make probing more painful/cost intensive
             - domains:
               - "*"
@@ -65,34 +68,6 @@ spec:
                 redirect:
                   https_redirect: true
                   port_redirect: 443
-                typed_per_filter_config:
-                  # No need to bother the external authorization server with the request
-                  # as it will most likely reject it anyway.
-                  envoy.filters.http.ext_authz:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
-                    disabled: true
-  - applyTo: HTTP_FILTER
-    match:
-      context: GATEWAY
-      listener:
-        portNumber: 8132
-        filterChain:
-          filter:
-            name: "envoy.filters.network.http_connection_manager"
-            subFilter:
-              name: "envoy.filters.http.router"
-    patch:
-      operation: INSERT_BEFORE
-      filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
-      value:
-        name: envoy.filters.http.ext_authz
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-          transport_api_version: V3
-          grpc_service:
-            envoy_grpc:
-              cluster_name: outbound|9001||reversed-vpn-auth-server.garden.svc.cluster.local
-            timeout: 0.250s
   workloadSelector:
     labels:
 {{ .Values.labels | toYaml | indent 6 }}

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -23,7 +23,7 @@ spec:
           route_config:
             virtual_hosts:
             - domains:
-              - api.*
+              - "*"
               name: reversed-vpn
               routes:
               - match:
@@ -38,6 +38,10 @@ spec:
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+              # need to have two catch-all rules here
+              # one for CONNECT requests as they don't have a path in HTTP 1.1
+              #   see: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routematch -> connect_matcher
+              # the other is for all non-CONNECT requests
               - match:
                   connect_matcher: {}
                 direct_response:
@@ -45,26 +49,6 @@ spec:
               # Redirect requests to the https port to make probing more painful/cost intensive
               - match:
                   prefix: "/"
-                  headers:
-                    - name: ":method"
-                      string_match:
-                        exact: CONNECT
-                      invert_match: true
-                redirect:
-                  https_redirect: true
-                  port_redirect: 443
-            # Redirect all other requests to the https port to make probing more painful/cost intensive
-            - domains:
-              - "*"
-              name: all
-              routes:
-              - match:
-                  prefix: "/"
-                  headers:
-                  - name: ":method"
-                    string_match:
-                      exact: CONNECT
-                    invert_match: true
                 redirect:
                   https_redirect: true
                   port_redirect: 443

--- a/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -22,7 +22,7 @@ spec:
           route_config:
             virtual_hosts:
             - domains:
-              - api.*
+              - "*"
               name: reversed-vpn
               routes:
               - match:
@@ -37,6 +37,10 @@ spec:
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+              # need to have two catch-all rules here
+              # one for CONNECT requests as they don't have a path in HTTP 1.1
+              #   see: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routematch -> connect_matcher
+              # the other is for all non-CONNECT requests
               - match:
                   connect_matcher: {}
                 direct_response:
@@ -44,26 +48,6 @@ spec:
               # Redirect requests to the https port to make probing more painful/cost intensive
               - match:
                   prefix: "/"
-                  headers:
-                    - name: ":method"
-                      string_match:
-                        exact: CONNECT
-                      invert_match: true
-                redirect:
-                  https_redirect: true
-                  port_redirect: 443
-            # Redirect all other requests to the https port to make probing more painful/cost intensive
-            - domains:
-              - "*"
-              name: all
-              routes:
-              - match:
-                  prefix: "/"
-                  headers:
-                  - name: ":method"
-                    string_match:
-                      exact: CONNECT
-                    invert_match: true
                 redirect:
                   https_redirect: true
                   port_redirect: 443

--- a/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -43,8 +43,9 @@ spec:
               # the other is for all non-CONNECT requests
               - match:
                   connect_matcher: {}
-                direct_response:
-                  status: 403
+                redirect:
+                  https_redirect: true
+                  port_redirect: 443
               # Redirect requests to the https port to make probing more painful/cost intensive
               - match:
                   prefix: "/"

--- a/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -27,11 +27,20 @@ spec:
               routes:
               - match:
                   connect_matcher: {}
+                  headers:
+                    - name: Reversed-VPN
+                      string_match:
+                        safe_regex:
+                          regex: '^outbound\|1194\|\|vpn-seed-server(-[0-4])?\..*\.svc\.cluster\.local$'
                 route:
                   cluster_header: Reversed-VPN
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+              - match:
+                  connect_matcher: {}
+                direct_response:
+                  status: 403
               # Redirect requests to the https port to make probing more painful/cost intensive
               - match:
                   prefix: "/"
@@ -43,12 +52,6 @@ spec:
                 redirect:
                   https_redirect: true
                   port_redirect: 443
-                typed_per_filter_config:
-                  # No need to bother the external authorization server with the request
-                  # as it will most likely reject it anyway.
-                  envoy.filters.http.ext_authz:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
-                    disabled: true
             # Redirect all other requests to the https port to make probing more painful/cost intensive
             - domains:
               - "*"
@@ -64,34 +67,6 @@ spec:
                 redirect:
                   https_redirect: true
                   port_redirect: 443
-                typed_per_filter_config:
-                  # No need to bother the external authorization server with the request
-                  # as it will most likely reject it anyway.
-                  envoy.filters.http.ext_authz:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
-                    disabled: true
-  - applyTo: HTTP_FILTER
-    match:
-      context: GATEWAY
-      listener:
-        portNumber: 8132
-        filterChain:
-          filter:
-            name: "envoy.filters.network.http_connection_manager"
-            subFilter:
-              name: "envoy.filters.http.router"
-    patch:
-      operation: INSERT_BEFORE
-      filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
-      value:
-        name: envoy.filters.http.ext_authz
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-          transport_api_version: V3
-          grpc_service:
-            envoy_grpc:
-              cluster_name: outbound|9001||reversed-vpn-auth-server.garden.svc.cluster.local
-            timeout: 0.250s
   workloadSelector:
     labels:
       app: istio-ingressgateway


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR removes the dependency on the ext-authz-server for authenticating reverse VPN connections.
We need this in preparation for the changes to the apiserver-proxy

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:
The "reversed-vpn-auth-server" deployment will be removed later on.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Incoming reverse VPN connections no longer get authenticated by the reversed-vpn-auth-server as the authentication logic was moved to envoy itself.
```
