### PR TITLE
Add convenience to generate `Extension` examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ check: $(GO_ADD_LICENSE) $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(
 logcheck-symlinks:
 	@LOGCHECK_DIR=$(LOGCHECK_DIR) ./hack/generate-logcheck-symlinks.sh
 
-tools-for-generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(HELM) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC) $(PROTOC_GEN_GOGO) $(YQ) $(VGOPATH)
+tools-for-generate: $(CONTROLLER_GEN) $(EXTENSION_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(HELM) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC) $(PROTOC_GEN_GOGO) $(YQ) $(VGOPATH)
 
 define GENERATE_HELP_INFO
 # Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_DIRS="<folders>"]

--- a/example/provider-local/garden/operator/doc.go
+++ b/example/provider-local/garden/operator/doc.go
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:generate extension-generator --name=provider-local --provider-type=local --component-category=provider-extension --component-category=operating-system --extension-oci-repository=local-skaffold/gardener-extension-provider-local/charts/extension:v0.0.0 --admission-runtime-oci-repository=local-skaffold/gardener-extension-admission-local/charts/runtime:v0.0.0 --admission-application-oci-repository=local-skaffold/gardener-extension-admission-local/charts/application:v0.0.0 --destination=$PWD/extension.yaml
+
+package operator

--- a/example/provider-local/garden/operator/extension-patch.yaml
+++ b/example/provider-local/garden/operator/extension-patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: provider-local
+  annotations:
+    security.gardener.cloud/pod-security-enforce: privileged
+spec:
+  deployment:
+    extension:
+      runtimeClusterValues:
+        logLevel: debug
+      values:
+        logLevel: debug
+        imageVectorOverwrite:
+          images:
+          - name: machine-controller-manager-provider-local
+            ref: local-skaffold/machine-controller-manager-provider-local
+    admission:
+      values:
+        logLevel: debug

--- a/example/provider-local/garden/operator/extension.yaml
+++ b/example/provider-local/garden/operator/extension.yaml
@@ -2,22 +2,8 @@ apiVersion: operator.gardener.cloud/v1alpha1
 kind: Extension
 metadata:
   name: provider-local
-  annotations:
-    security.gardener.cloud/pod-security-enforce: privileged
 spec:
   deployment:
-    extension:
-      helm:
-        ociRepository:
-          ref: local-skaffold/gardener-extension-provider-local/charts/extension:v0.0.0
-      runtimeClusterValues:
-        logLevel: debug
-      values:
-        logLevel: debug
-        imageVectorOverwrite:
-          images:
-          - name: machine-controller-manager-provider-local
-            ref: local-skaffold/machine-controller-manager-provider-local
     admission:
       runtimeCluster:
         helm:
@@ -27,34 +13,24 @@ spec:
         helm:
           ociRepository:
             ref: local-skaffold/gardener-extension-admission-local/charts/application:v0.0.0
-      values:
-        logLevel: debug
+    extension:
+      helm:
+        ociRepository:
+          ref: local-skaffold/gardener-extension-provider-local/charts/extension:v0.0.0
   resources:
-    - kind: BackupBucket
-      type: local
-    - kind: BackupEntry
-      type: local
-    - kind: DNSRecord
-      type: local
-    - kind: ControlPlane
-      type: local
-    - kind: Infrastructure
-      type: local
-    - kind: OperatingSystemConfig
-      type: local
-    - kind: Worker
-      type: local
-    - kind: Extension
-      lifecycle:
-        delete: AfterKubeAPIServer
-        migrate: AfterKubeAPIServer
-        reconcile: BeforeKubeAPIServer
-      type: local-ext-seed
-      workerlessSupported: true
-    - kind: Extension
-      type: local-ext-shoot
-      workerlessSupported: true
-    - kind: Extension
-      lifecycle:
-        reconcile: AfterWorker
-      type: local-ext-shoot-after-worker
+  - kind: BackupBucket
+    type: local
+  - kind: BackupEntry
+    type: local
+  - kind: Bastion
+    type: local
+  - kind: ControlPlane
+    type: local
+  - kind: DNSRecord
+    type: local
+  - kind: Infrastructure
+    type: local
+  - kind: Worker
+    type: local
+  - kind: OperatingSystemConfig
+    type: local

--- a/example/provider-local/garden/operator/kustomization.yaml
+++ b/example/provider-local/garden/operator/kustomization.yaml
@@ -5,4 +5,41 @@ resources:
 - extension.yaml
 
 patches:
+- path: extension-patch.yaml
 - path: patch-extension-prow.yaml
+- target:
+    version: v1alpha1
+    group: operator.gardener.cloud
+    kind: Extension
+    name: provider-local
+  patch: |
+    - op: remove
+      path: /spec/resources/2
+    - op: add
+      path: /spec/resources/-
+      value: {
+        "kind": "Extension",
+        "lifecycle": {
+          "delete": "AfterKubeAPIServer",
+          "migrate": "AfterKubeAPIServer",
+          "reconcile": "BeforeKubeAPIServer"
+        },
+        "type": "local-ext-seed",
+        "workerlessSupported": true
+      }
+    - op: add
+      path: /spec/resources/-
+      value: {
+        "kind": "Extension",
+        "type": "local-ext-shoot",
+        "workerlessSupported": true
+      }
+    - op: add
+      path: /spec/resources/-
+      value: {
+        "kind": "Extension",
+        "lifecycle": {
+          "reconcile": "AfterWorker"
+        },
+        "type": "local-ext-shoot-after-worker"
+      }

--- a/hack/check-generate.sh
+++ b/hack/check-generate.sh
@@ -77,6 +77,11 @@ if which git &>/dev/null; then
   git commit -q --allow-empty -m 'checkpoint'
 
   old_status="$(git status -s)"
+  if ! out=$(make -f "$makefile" tools-for-generate 2>&1); then
+    echo "Error during calling make tools-for-generate: $out"
+    exit 1
+  fi
+
   if ! out=$(make -f "$makefile" clean 2>&1); then
     echo "Error during calling make clean: $out"
     exit 1

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -22,6 +22,7 @@ SYSTEM_NAME                := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 SYSTEM_ARCH                := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin/$(SYSTEM_NAME)-$(SYSTEM_ARCH)
 CONTROLLER_GEN             := $(TOOLS_BIN_DIR)/controller-gen
+EXTENSION_GEN              := $(TOOLS_BIN_DIR)/extension-generator
 GEN_CRD_API_REFERENCE_DOCS := $(TOOLS_BIN_DIR)/gen-crd-api-reference-docs
 GINKGO                     := $(TOOLS_BIN_DIR)/ginkgo
 GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
@@ -240,6 +241,14 @@ $(OIDC_METADATA): $(TOOLS_PKG_PATH)/oidcmeta/*.go
 else
 $(OIDC_METADATA): go.mod
 	go build -o $(OIDC_METADATA) github.com/gardener/gardener/hack/tools/oidcmeta
+endif
+
+ifeq ($(strip $(shell go list -m 2>/dev/null)),github.com/gardener/gardener)
+$(EXTENSION_GEN): $(TOOLS_PKG_PATH)/extension-generator/*.go
+	go build -o $(EXTENSION_GEN) $(TOOLS_PKG_PATH)/extension-generator
+else
+$(EXTENSION_GEN): go.mod
+	go build -o $(EXTENSION_GEN) github.com/gardener/gardener/hack/tools/extension-generator
 endif
 
 $(SETUP_ENVTEST): $(call tool_version_file,$(SETUP_ENVTEST),$(CONTROLLER_RUNTIME_VERSION))

--- a/hack/tools/extension-generator/extension.go
+++ b/hack/tools/extension-generator/extension.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+)
+
+// GenerateExtension generates the extension in YAML format.
+func GenerateExtension(opts *Options) ([]byte, error) {
+	extension := newBaseExtension(opts)
+
+	if opts.AdmissionRuntimeOCIRepository != "" && opts.AdmissionApplicationOCIRepository != "" {
+		ensureAdmission(extension, opts)
+	}
+
+	if err := ensureResources(extension, opts); err != nil {
+		return nil, err
+	}
+
+	yamlBytes, err := yaml.Marshal(extension)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove known empty values as a workaround for https://github.com/kubernetes/kubernetes/issues/67610.
+	yamlBytes = bytes.Replace(yamlBytes, []byte("  creationTimestamp: null\n"), []byte(""), -1)
+	yamlBytes = bytes.Replace(yamlBytes, []byte("status: {}\n"), []byte(""), -1)
+
+	return yamlBytes, nil
+}
+
+func newBaseExtension(opts *Options) *operatorv1alpha1.Extension {
+	return &operatorv1alpha1.Extension{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: operatorv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "Extension",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: opts.ExtensionName,
+		},
+		Spec: operatorv1alpha1.ExtensionSpec{
+			Deployment: &operatorv1alpha1.Deployment{
+				ExtensionDeployment: &operatorv1alpha1.ExtensionDeploymentSpec{
+					DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{
+								Ref: &opts.ExtensionOCIRepository,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ensureAdmission(extension *operatorv1alpha1.Extension, opts *Options) {
+	extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+		RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
+			Helm: &operatorv1alpha1.ExtensionHelm{
+				OCIRepository: &gardencorev1.OCIRepository{
+					Ref: &opts.AdmissionRuntimeOCIRepository,
+				},
+			},
+		},
+		VirtualCluster: &operatorv1alpha1.DeploymentSpec{
+			Helm: &operatorv1alpha1.ExtensionHelm{
+				OCIRepository: &gardencorev1.OCIRepository{
+					Ref: &opts.AdmissionApplicationOCIRepository,
+				},
+			},
+		},
+	}
+}
+
+func ensureResources(extension *operatorv1alpha1.Extension, opts *Options) error {
+	for _, category := range opts.ComponentCategories {
+		fn, ok := categoryToEnsurer[category]
+		if !ok {
+			return fmt.Errorf("unsupported component category: %s", category)
+		}
+
+		fn(extension, opts)
+	}
+	return nil
+}
+
+var categoryToEnsurer = map[string]func(extension *operatorv1alpha1.Extension, opts *Options){
+	"container-runtime":  ensureContainerRuntimeExtension,
+	"extension":          ensureGenericExtension,
+	"network":            ensureNetworkExtension,
+	"operating-system":   ensureOperatingSystemExtension,
+	"provider-extension": ensureProviderExtension,
+}
+
+func ensureContainerRuntimeExtension(extension *operatorv1alpha1.Extension, opts *Options) {
+	extension.Spec.Resources = append(extension.Spec.Resources,
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.ContainerRuntimeResource, Type: opts.ProviderType},
+	)
+}
+
+func ensureGenericExtension(extension *operatorv1alpha1.Extension, opts *Options) {
+	extension.Spec.Resources = append(extension.Spec.Resources,
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.ExtensionResource, Type: opts.ProviderType},
+	)
+}
+
+func ensureNetworkExtension(extension *operatorv1alpha1.Extension, opts *Options) {
+	extension.Spec.Resources = append(extension.Spec.Resources,
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.NetworkResource, Type: opts.ProviderType},
+	)
+}
+
+func ensureOperatingSystemExtension(extension *operatorv1alpha1.Extension, opts *Options) {
+	extension.Spec.Resources = append(extension.Spec.Resources,
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.OperatingSystemConfigResource, Type: opts.ProviderType},
+	)
+}
+
+func ensureProviderExtension(extension *operatorv1alpha1.Extension, opts *Options) {
+	extension.Spec.Resources = append(extension.Spec.Resources,
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.BackupBucketResource, Type: opts.ProviderType},
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.BackupEntryResource, Type: opts.ProviderType},
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.BastionResource, Type: opts.ProviderType},
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.ControlPlaneResource, Type: opts.ProviderType},
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.DNSRecordResource, Type: opts.ProviderType},
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.InfrastructureResource, Type: opts.ProviderType},
+		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.WorkerResource, Type: opts.ProviderType},
+	)
+}

--- a/hack/tools/extension-generator/main.go
+++ b/hack/tools/extension-generator/main.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use: "extension-generator",
+
+		Short: "Generate an Extension (operator.gardener.cloud) manifest.",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			extensionYaml, err := GenerateExtension(opts)
+			if err != nil {
+				return err
+			}
+
+			return os.WriteFile(opts.Destination, extensionYaml, 0644)
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack/tools/extension-generator/options.go
+++ b/hack/tools/extension-generator/options.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	flag "github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Options contain the generate configuration.
+type Options struct {
+	ExtensionName       string
+	ProviderType        string
+	ComponentCategories []string
+	Destination         string
+
+	ExtensionOCIRepository            string
+	AdmissionRuntimeOCIRepository     string
+	AdmissionApplicationOCIRepository string
+}
+
+var validCategories = sets.New(slices.Collect(maps.Keys(categoryToEnsurer))...)
+
+// AddFlags adds the cmd flags to the given FlagSet.
+func (o *Options) AddFlags(flags *flag.FlagSet) {
+	flags.StringVar(&o.ExtensionName, "name", "", "Name is the name of the extension")
+	flags.StringVar(&o.ProviderType, "provider-type", "", "Type of the provider")
+	flags.StringArrayVar(&o.ComponentCategories, "component-category", nil, fmt.Sprintf("Category of the component, one of %v", validCategories.UnsortedList()))
+	flags.StringVar(&o.Destination, "destination", "", "The path the extension manifest is written to")
+	flags.StringVar(&o.ExtensionOCIRepository, "extension-oci-repository", "", "URL to OCI image containing the extension chart")
+	flags.StringVar(&o.AdmissionRuntimeOCIRepository, "admission-runtime-oci-repository", "", "OPTIONAL: URL to OCI image containing the admission runtime chart")
+	flags.StringVar(&o.AdmissionApplicationOCIRepository, "admission-application-oci-repository", "", "OPTIONAL: URL to OCI image containing the admission application chart")
+}
+
+// Validate returns an error if the Options configuration is incomplete.
+func (o *Options) Validate() error {
+	var errs []error
+
+	if len(o.ExtensionName) == 0 {
+		errs = append(errs, fmt.Errorf("extension name is required"))
+	}
+
+	if len(o.ProviderType) == 0 {
+		errs = append(errs, fmt.Errorf("provider type is required"))
+	}
+
+	if o.ComponentCategories == nil {
+		errs = append(errs, fmt.Errorf("component categories is required"))
+	} else if !validCategories.HasAll(o.ComponentCategories...) {
+		errs = append(errs, fmt.Errorf("at least one component category is invalid, must be one of %v", validCategories.UnsortedList()))
+	}
+
+	if len(o.Destination) == 0 {
+		errs = append(errs, fmt.Errorf("destination is required"))
+	}
+
+	if len(o.ExtensionOCIRepository) == 0 {
+		errs = append(errs, fmt.Errorf("extension oci repository is required"))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%v", errs)
+	}
+	return nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area ops-productivity
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new tool `hack/tools/extension-generator` that is supposed to be used by gardener extensions to generate `Extension` example manifests (similar to `ControllerRegistration`, see [example](https://github.com/gardener/gardener-extension-provider-aws/blob/master/example/controller-registration.yaml)).

A few examples were prepared along the way:
- `provider-local` (54fcfeaf49db05aa7501ec50c6cd05a2cc34ecb4)
- `provider-aws` (https://github.com/timuthy/gardener-extension-provider-aws/commit/a1b7d16a9996a4ad4b7ff22ab9ba6448dd07eea8)

**Which issue(s) this PR fixes**:
Part of #9635

**Special notes for your reviewer**:
/cc @MartinWeindel

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
A new convenience tool `extension-generator` was added to generate `Extension` example manifests. Gardener extensions can execute this script in the scope of the build process to always check in and provide an up-to-date example in their repositories.
```
