### PR TITLE
Update etcd-druid to `v0.27.0`

### DIFF
--- a/example/seed-crds/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/example/seed-crds/10-crd-druid.gardener.cloud_etcds.yaml
@@ -404,6 +404,13 @@ spec:
                         description: Labels specify the labels that should be added
                           to the client service
                         type: object
+                      trafficDistribution:
+                        description: |-
+                          TrafficDistribution defines the traffic distribution preference that should be added to the client service.
+                          More info: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution
+                        enum:
+                        - PreferClose
+                        type: string
                     type: object
                   clientUrlTls:
                     description: ClientUrlTLS contains the ca, server TLS and client
@@ -1834,12 +1841,6 @@ spec:
           status:
             description: EtcdStatus defines the observed state of Etcd.
             properties:
-              clusterSize:
-                description: |-
-                  Cluster size is the current size of the etcd cluster.
-                  Deprecated: this field will not be populated with any value and will be removed in the future.
-                format: int32
-                type: integer
               conditions:
                 description: Conditions represents the latest available observations
                   of an etcd's current state.
@@ -1949,11 +1950,6 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              lastError:
-                description: |-
-                  LastError represents the last occurred error.
-                  Deprecated: Use LastErrors instead.
-                type: string
               lastErrors:
                 description: LastErrors captures errors that occurred during the last
                   operation.
@@ -2066,17 +2062,6 @@ spec:
                 type: integer
               replicas:
                 description: Replicas is the replica count of the etcd cluster.
-                format: int32
-                type: integer
-              serviceName:
-                description: |-
-                  ServiceName is the name of the etcd service.
-                  Deprecated: this field will be removed in the future.
-                type: string
-              updatedReplicas:
-                description: |-
-                  UpdatedReplicas is the count of updated replicas in the etcd cluster.
-                  Deprecated: this field will be removed in the future.
                 format: int32
                 type: integer
             type: object

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fluent/fluent-operator/v2 v2.9.0
 	github.com/gardener/cert-management v0.17.3
 	github.com/gardener/dependency-watchdog v1.3.0
-	github.com/gardener/etcd-druid v0.26.1
+	github.com/gardener/etcd-druid v0.27.0
 	github.com/gardener/machine-controller-manager v0.56.0
 	github.com/gardener/terminal-controller-manager v0.34.0
 	github.com/go-jose/go-jose/v4 v4.0.4

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/gardener/cert-management v0.17.3 h1:QZwM0jEjlZjJsGUcHuo2sXDd+9kuSNhYT
 github.com/gardener/cert-management v0.17.3/go.mod h1:LW26oGAdRqPqg0E/roJ3muX7s+fOgVkcyTKS0lrSFJ4=
 github.com/gardener/dependency-watchdog v1.3.0 h1:C5EO/4GKv1TosvqVepJfzGssu8dDR06q1y05b11ozqI=
 github.com/gardener/dependency-watchdog v1.3.0/go.mod h1:KNUla1c54x6AGh7SXK/OlM0LrghMXXZG0f+d7+XojaA=
-github.com/gardener/etcd-druid v0.26.1 h1:x8mZfcIkZS29bJKupy0PVTsIrPUNVxvcJlLAXKb0agw=
-github.com/gardener/etcd-druid v0.26.1/go.mod h1:SKjfV8bvdLGF1ynFbWF4ioK2a6M33g7N6lct45p50J8=
+github.com/gardener/etcd-druid v0.27.0 h1:vqcusx1O3G01BU3CHke6nZEYvDfiFqgCGS59mQCK0LM=
+github.com/gardener/etcd-druid v0.27.0/go.mod h1:SKjfV8bvdLGF1ynFbWF4ioK2a6M33g7N6lct45p50J8=
 github.com/gardener/machine-controller-manager v0.56.0 h1:Qf/i53/KCgmQ5o1+jKF9XO+RRhaNWsy/IlIX0tWM3bw=
 github.com/gardener/machine-controller-manager v0.56.0/go.mod h1:eCng7De6OE15rndmMm6Q1fwMQI39esASCd3WKZ/lLmY=
 github.com/gardener/terminal-controller-manager v0.34.0 h1:qE8xIKsOFnVr1yZ2meesRR0q65uZ1Nyf5oSluAiLTeM=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -68,7 +68,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
-  tag: "v0.26.1"
+  tag: "v0.27.0"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog

--- a/pkg/component/etcd/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
+++ b/pkg/component/etcd/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
@@ -406,6 +406,13 @@ spec:
                         description: Labels specify the labels that should be added
                           to the client service
                         type: object
+                      trafficDistribution:
+                        description: |-
+                          TrafficDistribution defines the traffic distribution preference that should be added to the client service.
+                          More info: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution
+                        enum:
+                        - PreferClose
+                        type: string
                     type: object
                   clientUrlTls:
                     description: ClientUrlTLS contains the ca, server TLS and client
@@ -1836,12 +1843,6 @@ spec:
           status:
             description: EtcdStatus defines the observed state of Etcd.
             properties:
-              clusterSize:
-                description: |-
-                  Cluster size is the current size of the etcd cluster.
-                  Deprecated: this field will not be populated with any value and will be removed in the future.
-                format: int32
-                type: integer
               conditions:
                 description: Conditions represents the latest available observations
                   of an etcd's current state.
@@ -1951,11 +1952,6 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              lastError:
-                description: |-
-                  LastError represents the last occurred error.
-                  Deprecated: Use LastErrors instead.
-                type: string
               lastErrors:
                 description: LastErrors captures errors that occurred during the last
                   operation.
@@ -2068,17 +2064,6 @@ spec:
                 type: integer
               replicas:
                 description: Replicas is the replica count of the etcd cluster.
-                format: int32
-                type: integer
-              serviceName:
-                description: |-
-                  ServiceName is the name of the etcd service.
-                  Deprecated: this field will be removed in the future.
-                type: string
-              updatedReplicas:
-                description: |-
-                  UpdatedReplicas is the count of updated replicas in the etcd cluster.
-                  Deprecated: this field will be removed in the future.
                 format: int32
                 type: integer
             type: object

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -44,7 +44,6 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 	e := NewEtcd(
 		b.Logger,
 		b.SeedClientSet.Client(),
-		b.SeedClientSet.APIReader(),
 		b.Shoot.SeedNamespace,
 		b.SecretsManager,
 		etcd.Values{

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -120,7 +120,6 @@ var _ = Describe("Etcd", func() {
 
 						validator := &newEtcdValidator{
 							expectedClient:                  Equal(c),
-							expectedReader:                  Equal(reader),
 							expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 							expectedNamespace:               Equal(namespace),
 							expectedSecretsManager:          Equal(sm),
@@ -153,7 +152,6 @@ var _ = Describe("Etcd", func() {
 			It("should successfully create an etcd interface (normal class)", func() {
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
-					expectedReader:                  Equal(reader),
 					expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 					expectedNamespace:               Equal(namespace),
 					expectedSecretsManager:          Equal(sm),
@@ -180,7 +178,6 @@ var _ = Describe("Etcd", func() {
 
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
-					expectedReader:                  Equal(reader),
 					expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 					expectedNamespace:               Equal(namespace),
 					expectedSecretsManager:          Equal(sm),
@@ -503,7 +500,6 @@ type newEtcdValidator struct {
 	etcd.Interface
 
 	expectedClient                  gomegatypes.GomegaMatcher
-	expectedReader                  gomegatypes.GomegaMatcher
 	expectedLogger                  gomegatypes.GomegaMatcher
 	expectedNamespace               gomegatypes.GomegaMatcher
 	expectedSecretsManager          gomegatypes.GomegaMatcher
@@ -519,14 +515,12 @@ type newEtcdValidator struct {
 func (v *newEtcdValidator) NewEtcd(
 	log logr.Logger,
 	client client.Client,
-	reader client.Reader,
 	namespace string,
 	secretsManager secretsmanager.Interface,
 	values etcd.Values,
 ) etcd.Interface {
 	Expect(log).To(v.expectedLogger)
 	Expect(client).To(v.expectedClient)
-	Expect(reader).To(v.expectedReader)
 	Expect(namespace).To(v.expectedNamespace)
 	Expect(secretsManager).To(v.expectedSecretsManager)
 	Expect(values.Role).To(v.expectedRole)

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -489,7 +489,6 @@ func (r *Reconciler) newEtcd(
 	return etcd.New(
 		log,
 		r.RuntimeClientSet.Client(),
-		r.RuntimeClientSet.APIReader(),
 		r.GardenNamespace,
 		secretsManager,
 		etcd.Values{

--- a/pkg/utils/kubernetes/health/checker/checker.go
+++ b/pkg/utils/kubernetes/health/checker/checker.go
@@ -116,8 +116,8 @@ func (h *HealthChecker) checkEtcds(condition gardencorev1beta1.Condition, object
 				codes   []gardencorev1beta1.ErrorCode
 			)
 
-			if lastError := object.Status.LastError; lastError != nil {
-				message = fmt.Sprintf("%s (%s)", message, *lastError)
+			if len(object.Status.LastErrors) != 0 {
+				message = fmt.Sprintf("%s (%+v)", message, object.Status.LastErrors)
 			}
 
 			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "EtcdUnhealthy", message, codes...)

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -363,8 +363,7 @@ func (f *GardenerFramework) HibernateShoot(ctx context.Context, shoot *gardencor
 	if err := retry.UntilTimeout(ctx, 10*time.Second, 2*time.Minute, func(ctx context.Context) (done bool, err error) {
 		// Verify no running pods after hibernation
 		if err := f.VerifyNoRunningPods(ctx, shoot); err != nil {
-			//return fmt.Errorf("failed to verify no running pods after hibernation: %v", err)
-			return retry.MinorError(err)
+			return retry.MinorError(fmt.Errorf("failed to verify no running pods after hibernation: %v", err))
 		}
 		return retry.Ok()
 	}); err != nil {

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -345,15 +345,14 @@ func (f *GardenerFramework) HibernateShoot(ctx context.Context, shoot *gardencor
 		return nil
 	}
 
-	err := retry.UntilTimeout(ctx, 20*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
+	if err := retry.UntilTimeout(ctx, 20*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
 		patch := client.MergeFrom(shoot.DeepCopy())
 		setHibernation(shoot, true)
 		if err := f.GardenClient.Client().Patch(ctx, shoot, patch); err != nil {
 			return retry.MinorError(err)
 		}
 		return retry.Ok()
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -361,9 +360,15 @@ func (f *GardenerFramework) HibernateShoot(ctx context.Context, shoot *gardencor
 		return err
 	}
 
-	// Verify no running pods after hibernation
-	if err := f.VerifyNoRunningPods(ctx, shoot); err != nil {
-		return fmt.Errorf("failed to verify no running pods after hibernation: %v", err)
+	if err := retry.UntilTimeout(ctx, 10*time.Second, 2*time.Minute, func(ctx context.Context) (done bool, err error) {
+		// Verify no running pods after hibernation
+		if err := f.VerifyNoRunningPods(ctx, shoot); err != nil {
+			//return fmt.Errorf("failed to verify no running pods after hibernation: %v", err)
+			return retry.MinorError(err)
+		}
+		return retry.Ok()
+	}); err != nil {
+		return err
 	}
 
 	log.Info("Shoot was hibernated successfully")

--- a/test/integration/operator/garden/care/care_test.go
+++ b/test/integration/operator/garden/care/care_test.go
@@ -533,10 +533,11 @@ func updateETCDStatusToHealthy(name string) {
 	ExpectWithOffset(1, testClient.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
 
 	etcd.Status.ObservedGeneration = &etcd.Generation
-	etcd.Status.Ready = ptr.To(true)
 	etcd.Status.Conditions = []druidv1alpha1.Condition{
 		{Type: druidv1alpha1.ConditionTypeBackupReady, Status: druidv1alpha1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+		{Type: druidv1alpha1.ConditionTypeAllMembersUpdated, Status: druidv1alpha1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
 	}
+	etcd.Status.Ready = ptr.To(true)
 	ExpectWithOffset(1, testClient.Status().Update(ctx, etcd)).To(Succeed())
 }
 

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -550,6 +550,7 @@ spec:
 
 				patch := client.MergeFrom(etcd.DeepCopy())
 				etcd.Status.ObservedGeneration = &etcd.Generation
+				etcd.Status.Conditions = []druidv1alpha1.Condition{{Type: druidv1alpha1.ConditionTypeAllMembersUpdated, Status: druidv1alpha1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now()}}
 				etcd.Status.Ready = ptr.To(true)
 				g.Expect(testClient.Status().Patch(ctx, etcd, patch)).To(Succeed(), "for "+etcd.Name)
 			}


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane backup quality 
/kind enhancement bug

This PR contains the following changes:
- etcd-druid image: `v0.26.1` ->`v0.27.0`
- etcd-druid dependency: `v0.26.1` ->`v0.27.0`
- Etcd CRDs updated
- Replace usage of Etcd `status.lastError` with `status.lastErrors`
- Use new Etcd status condition `AllMembersUpdated` to check for etcd health
- Revert band-aid fix from https://github.com/gardener/gardener/pull/11231(cc @timuthy)
- Add `spec.backup.compactionResources` to Etcd resources 

### Release Notes

<details>
<summary>gardener/etcd-druid (gardener/etcd-druid)</summary>
### [`v0.27.0`](https://redirect.github.com/gardener/etcd-druid/releases/tag/v0.27.0)
[Compare Source](https://redirect.github.com/gardener/etcd-druid/compare/v0.26.1...v0.27.0)

### [gardener/etcd-backup-restore]
#### 📰 Noteworthy
* `[OPERATOR]` Ensure the integrity of the full snapshot prior to uploading it to the object store, thereby reducing the potential restoration failures. by [@​ishan16696](https://redirect.github.com/ishan16696) [[gardener/etcd-backup-restore#779](https://redirect.github.com/gardener/etcd-backup-restore/issues/779)]

#### 🏃 Others
* `[DEPENDENCY]` Update golang version to `1.23.5`. by [@​shreyas-s-rao](https://redirect.github.com/shreyas-s-rao) [[gardener/etcd-backup-restore#831](https://redirect.github.com/gardener/etcd-backup-restore/issues/831)]
* `[USER]` Use etcdbr `latest` tagged image in the helm charts by [@​anveshreddy18](https://redirect.github.com/anveshreddy18) [[gardener/etcd-backup-restore#830](https://redirect.github.com/gardener/etcd-backup-restore/issues/830)]

### [gardener/etcd-druid]
#### ⚠️ Breaking Changes
* `[OPERATOR]` Remove deprecated CLI flag `ignore-operation-annotation`. by [@​shreyas-s-rao](https://redirect.github.com/shreyas-s-rao) [[#​990](https://redirect.github.com/gardener/etcd-druid/issues/990)]
* `[USER]` Remove support for deprecated annotation `druid.gardener.cloud/ignore-reconciliation`. by [@​shreyas-s-rao](https://redirect.github.com/shreyas-s-rao) [[#​990](https://redirect.github.com/gardener/etcd-druid/issues/990)]
* `[USER]` Remove deprecated status fields `ServiceName`, `ClusterSize`, `UpdatedReplicas` and `LastError`. by [@​shreyas-s-rao](https://redirect.github.com/shreyas-s-rao) [[#​990](https://redirect.github.com/gardener/etcd-druid/issues/990)]

#### 📰 Noteworthy
* `[USER]` Introduce new Etcd status condition `AllMembersUpdated`. by [@​shreyas-s-rao](https://redirect.github.com/shreyas-s-rao) [[#​987](https://redirect.github.com/gardener/etcd-druid/issues/987)]
* `[DEVELOPER]` Condition statuses `Progressing` and `ConditionCheckError` are now deprecated and will soon be removed, since druid conditions will be replaced by `metav1.Condition` in the future. by [@​shreyas-s-rao](https://redirect.github.com/shreyas-s-rao) [[#​987](https://redirect.github.com/gardener/etcd-druid/issues/987)]

#### 🐛 Bug Fixes
* `[USER]` Updation of `status.observedGeneration` and optional removal of the `gardener.cloud/operation: reconcile` annotation on the Etcd resource are now executed after the reconciliation of the Etcd status, to depict accurate state of the cluster at any given point in time. Users must wait for the `status.observedGeneration` field to be updated (and additionally for the removal of the `gardener.cloud/operation: reconcile` annotation is CLI flag `enable-spec-auto-reconcile` is set to false) to confirm completion of reconciliation. by [@​shreyas-s-rao](https://redirect.github.com/shreyas-s-rao) [[#​996](https://redirect.github.com/gardener/etcd-druid/issues/996)]

#### 🏃 Others
* `[OPERATOR]` The Etcd resource now allows specifying etcd client Service traffic distribution preferences via the `spec.etcd.clientService.trafficDistribution` field. by [@​ialidzhikov](https://redirect.github.com/ialidzhikov) [[#​973](https://redirect.github.com/gardener/etcd-druid/issues/973)]

#### 📖 Documentation
* `[OPERATOR]` Add DEP-06: Immutable ETCD Backups by [@​seshachalam-yv](https://redirect.github.com/seshachalam-yv) [[#​884](https://redirect.github.com/gardener/etcd-druid/issues/884)]

### [gardener/etcd-wrapper]
#### 🏃 Others
* `[DEVELOPER]` Update golang images to v1.23.5. by [@​shreyas-s-rao](https://redirect.github.com/shreyas-s-rao) [[gardener/etcd-wrapper#42](https://redirect.github.com/gardener/etcd-wrapper/issues/42)]

#### Docker Images
* etcd-druid: `europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid:v0.27.0`
</details>

**Release note**:

```
The following dependencies have been updated:
- `gardener/etcd-druid` from `v0.26.1` to `v0.27.0`. [Release Notes](https://redirect.github.com/gardener/etcd-druid/releases/tag/v0.27.0)
```

