### PR TITLE
`extensions/pkg/controller/heartbeat`: Use `CreateOrGetAndMergePatch` like seed lease controller

### DIFF
--- a/charts/gardener/provider-local/templates/rbac.yaml
+++ b/charts/gardener/provider-local/templates/rbac.yaml
@@ -80,6 +80,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 - apiGroups:
   - ""
   - apps

--- a/extensions/pkg/controller/heartbeat/reconciler.go
+++ b/extensions/pkg/controller/heartbeat/reconciler.go
@@ -64,5 +64,5 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 
 	log.V(1).Info("Heartbeat Lease", "lease", client.ObjectKeyFromObject(lease), "operation", op)
 	// Ensure we update the lease much sooner to account for possible controller lag
-	return reconcile.Result{RequeueAfter: time.Duration(r.renewIntervalSeconds) * time.Second / 4}, nil
+	return reconcile.Result{RequeueAfter: time.Duration(r.renewIntervalSeconds) * time.Second}, nil
 }

--- a/extensions/pkg/controller/heartbeat/reconciler.go
+++ b/extensions/pkg/controller/heartbeat/reconciler.go
@@ -63,6 +63,5 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 
 	log.V(1).Info("Heartbeat Lease", "lease", client.ObjectKeyFromObject(lease), "operation", op)
-	// Ensure we update the lease much sooner to account for possible controller lag
 	return reconcile.Result{RequeueAfter: time.Duration(r.renewIntervalSeconds) * time.Second}, nil
 }

--- a/extensions/pkg/controller/heartbeat/reconciler.go
+++ b/extensions/pkg/controller/heartbeat/reconciler.go
@@ -12,11 +12,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 )
 
@@ -54,7 +54,7 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.client, lease, func() error {
+	op, err := controllerutils.CreateOrGetAndMergePatch(ctx, r.client, lease, func() error {
 		lease.Spec.RenewTime = &metav1.MicroTime{Time: r.clock.Now().UTC()}
 		return nil
 	})

--- a/extensions/pkg/controller/heartbeat/reconciler.go
+++ b/extensions/pkg/controller/heartbeat/reconciler.go
@@ -48,14 +48,14 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			Name:      extensions.HeartBeatResourceName,
 			Namespace: r.namespace,
 		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity:       &r.extensionName,
-			LeaseDurationSeconds: &r.renewIntervalSeconds,
-		},
 	}
 
 	op, err := controllerutils.CreateOrGetAndMergePatch(ctx, r.client, lease, func() error {
-		lease.Spec.RenewTime = &metav1.MicroTime{Time: r.clock.Now().UTC()}
+		lease.Spec = coordinationv1.LeaseSpec{
+			HolderIdentity:       &r.extensionName,
+			LeaseDurationSeconds: &r.renewIntervalSeconds,
+			RenewTime:            &metav1.MicroTime{Time: r.clock.Now().UTC()},
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR changes the way that the [extensions' heartbeat lease](https://github.com/gardener/gardener/blob/6a09ca4ccc222875549f7136e7da2159025d9731/docs/extensions/heartbeat.md?plain=1) is updated by using `controllerutils.CreateOrGetAndMergePatch`, similar to how it is done for the [seed lease controller](https://github.com/gardener/gardener/blob/6a09ca4ccc222875549f7136e7da2159025d9731/pkg/gardenlet/controller/seed/lease/reconciler.go#L98-L108).

**Special notes for your reviewer**:
If we want to update `RenewTime` after `r.client.Get` we can move only `HolderIdentity` and `LeaseDurationSeconds` into the object spec

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The extension heartbeat controller was changed so that the heartbeat lease it maintains is updated via the `github.com/gardener/gardener/pkg/controllerutils.CreateOrGetAndMergePatch` function. Extension controllers that enable the heartbeat controller must adapt the extension controller RBAC rules to allow `patch` of the `gardener-extension-heartbeat` lease.
```
