### PR TITLE
fix(renovate): Fix `allowedVersions` (again)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -298,7 +298,7 @@
       matchPackageNames: [
         'gopkg.in/yaml.v2'
       ],
-      allowedVersions: "^v2\\..+",
+      allowedVersions: "/^v2\\..+/",
     },
     {
       // Only patch level updates for golang-test image. Minor and major versions are updated manually.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

Follow-up to https://github.com/gardener/gardener/pull/11339

If Renovate should interpret a string as a regular expression it needs to be wrapped in `//` ([ref](https://docs.renovatebot.com/configuration-options/#using-regular-expressions)).

**Which issue(s) this PR fixes**:
Fixes #11336

**Special notes for your reviewer**:

/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
