### PR TITLE
[GEP-28] Prepare `gardener/resourcemanager` component for "bootstrap control plane" case

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -328,7 +328,7 @@ var _ = Describe("ResourceManager", func() {
 				{Key: "b"},
 				{Key: "c"},
 			},
-			TargetDiffersFromSourceCluster:      true,
+			ResponsibilityMode:                  ForTarget,
 			TargetDisableCache:                  &targetDisableCache,
 			WatchedNamespace:                    &watchedNamespace,
 			SchedulingProfile:                   &binPackingSchedulingProfile,
@@ -2047,7 +2047,7 @@ subjects:
 		Context("target cluster != source cluster, watched namespace is nil", func() {
 			BeforeEach(func() {
 				clusterRole.Rules = allowManagedResources
-				cfg.TargetDiffersFromSourceCluster = true
+				cfg.ResponsibilityMode = ForTarget
 				cfg.TargetNamespaces = targetNamespaces
 				cfg.WatchedNamespace = nil
 				configMap = configMapFor(nil, ptr.To(gardenerutils.PathGenericKubeconfig), false)
@@ -2163,7 +2163,7 @@ subjects:
 		Context("target cluster != source cluster, workerless shoot", func() {
 			JustBeforeEach(func() {
 				clusterRole.Rules = allowManagedResources
-				cfg.TargetDiffersFromSourceCluster = true
+				cfg.ResponsibilityMode = ForTarget
 				cfg.TargetNamespaces = targetNamespaces
 				cfg.WatchedNamespace = nil
 				cfg.IsWorkerless = true
@@ -2276,7 +2276,7 @@ subjects:
 				cfg.DefaultSeccompProfileEnabled = true
 				cfg.EndpointSliceHintsEnabled = true
 				cfg.SchedulingProfile = nil
-				cfg.TargetDiffersFromSourceCluster = false
+				cfg.ResponsibilityMode = ForSource
 				resourceManager = New(c, deployNamespace, sm, cfg)
 				resourceManager.SetSecrets(secrets)
 			})
@@ -2540,7 +2540,7 @@ subjects:
 
 		Context("target equals source cluster", func() {
 			BeforeEach(func() {
-				cfg.TargetDiffersFromSourceCluster = false
+				cfg.ResponsibilityMode = ForSource
 				cfg.WatchedNamespace = nil
 				resourceManager = New(c, deployNamespace, sm, cfg)
 			})

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,86 +41,8 @@ import (
 func NewRuntimeGardenerResourceManager(
 	c client.Client,
 	gardenNamespaceName string,
-	runtimeVersion *semver.Version,
 	secretsManager secretsmanager.Interface,
-	logLevel, logFormat string,
-	secretNameServerCA string,
-	priorityClassName string,
-	defaultNotReadyToleration *int64,
-	defaultUnreachableToleration *int64,
-	defaultSeccompProfileEnabled bool,
-	endpointSliceHintsEnabled bool,
-	additionalNetworkPolicyNamespaceSelectors []metav1.LabelSelector,
-	zones []string,
-	managedResourceLabels map[string]string,
-) (
-	component.DeployWaiter,
-	error,
-) {
-	image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameGardenerResourceManager)
-	if err != nil {
-		return nil, err
-	}
-	image.WithOptionalTag(version.Get().GitVersion)
-
-	return resourcemanager.New(c, gardenNamespaceName, secretsManager, resourcemanager.Values{
-		ConcurrentSyncs:                           ptr.To(20),
-		DefaultSeccompProfileEnabled:              defaultSeccompProfileEnabled,
-		DefaultNotReadyToleration:                 defaultNotReadyToleration,
-		DefaultUnreachableToleration:              defaultUnreachableToleration,
-		EndpointSliceHintsEnabled:                 endpointSliceHintsEnabled,
-		MaxConcurrentNetworkPolicyWorkers:         ptr.To(20),
-		NetworkPolicyAdditionalNamespaceSelectors: additionalNetworkPolicyNamespaceSelectors,
-		NetworkPolicyControllerIngressControllerSelector: &resourcemanagerconfigv1alpha1.IngressControllerSelector{
-			Namespace: v1beta1constants.GardenNamespace,
-			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
-				v1beta1constants.LabelApp:      nginxingress.LabelAppValue,
-				nginxingress.LabelKeyComponent: nginxingress.LabelValueController,
-			}},
-		},
-		HealthSyncPeriod:                     &metav1.Duration{Duration: time.Minute},
-		Image:                                image.String(),
-		LogLevel:                             logLevel,
-		LogFormat:                            logFormat,
-		ManagedResourceLabels:                managedResourceLabels,
-		MaxConcurrentTokenInvalidatorWorkers: ptr.To(5),
-		// TODO(timuthy): Remove PodTopologySpreadConstraints webhook once for all seeds the
-		//  MatchLabelKeysInPodTopologySpread feature gate is beta and enabled by default (probably 1.26+).
-		PodTopologySpreadConstraintsEnabled: true,
-		PriorityClassName:                   priorityClassName,
-		Replicas:                            ptr.To[int32](2),
-		ResourceClass:                       ptr.To(v1beta1constants.SeedResourceManagerClass),
-		ResponsibilityMode:                  resourcemanager.ForSource,
-		SecretNameServerCA:                  secretNameServerCA,
-		SyncPeriod:                          &metav1.Duration{Duration: time.Hour},
-		RuntimeKubernetesVersion:            runtimeVersion,
-		Zones:                               zones,
-	}), nil
-}
-
-// NewTargetGardenerResourceManager instantiates a new `gardener-resource-manager` component
-// configured to reconcile object in a target (shoot) cluster.
-func NewTargetGardenerResourceManager(
-	c client.Client,
-	namespaceName string,
-	secretsManager secretsmanager.Interface,
-	clusterIdentity *string,
-	defaultNotReadyTolerationSeconds *int64,
-	defaultUnreachableTolerationSeconds *int64,
-	kubernetesVersion *semver.Version,
-	logLevel, logFormat string,
-	namePrefix string,
-	podTopologySpreadConstraintsEnabled bool,
-	priorityClassName string,
-	schedulingProfile *gardencorev1beta1.SchedulingProfile,
-	secretNameServerCA string,
-	systemComponentsToleration []corev1.Toleration,
-	topologyAwareRoutingEnabled bool,
-	kubernetesServiceHost *string,
-	isWorkerless bool,
-	targetNamespaces []string,
-	nodeAgentReconciliationMaxDelay *metav1.Duration,
-	nodeAgentAuthorizerEnabled bool,
+	values resourcemanager.Values,
 ) (
 	resourcemanager.Interface,
 	error,
@@ -131,44 +53,65 @@ func NewTargetGardenerResourceManager(
 	}
 	image.WithOptionalTag(version.Get().GitVersion)
 
-	cfg := resourcemanager.Values{
-		AlwaysUpdate:                         ptr.To(true),
-		ClusterIdentity:                      clusterIdentity,
+	defaultValues := resourcemanager.Values{
 		ConcurrentSyncs:                      ptr.To(20),
-		DefaultNotReadyToleration:            defaultNotReadyTolerationSeconds,
-		DefaultUnreachableToleration:         defaultUnreachableTolerationSeconds,
 		HealthSyncPeriod:                     &metav1.Duration{Duration: time.Minute},
 		Image:                                image.String(),
-		KubernetesServiceHost:                kubernetesServiceHost,
-		LogLevel:                             logLevel,
-		LogFormat:                            logFormat,
+		MaxConcurrentNetworkPolicyWorkers:    ptr.To(20),
+		MaxConcurrentTokenInvalidatorWorkers: ptr.To(5),
+		NetworkPolicyControllerIngressControllerSelector: &resourcemanagerconfigv1alpha1.IngressControllerSelector{
+			Namespace: v1beta1constants.GardenNamespace,
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+				v1beta1constants.LabelApp:      nginxingress.LabelAppValue,
+				nginxingress.LabelKeyComponent: nginxingress.LabelValueController,
+			}},
+		},
+		// TODO(timuthy): Remove PodTopologySpreadConstraints webhook once for all seeds the
+		//  MatchLabelKeysInPodTopologySpread feature gate is beta and enabled by default (probably 1.26+).
+		PodTopologySpreadConstraintsEnabled: true,
+		Replicas:                            ptr.To[int32](2),
+		ResourceClass:                       ptr.To(v1beta1constants.SeedResourceManagerClass),
+		ResponsibilityMode:                  resourcemanager.ForSource,
+		SyncPeriod:                          &metav1.Duration{Duration: time.Hour},
+	}
+
+	applyDefaults(&values, defaultValues)
+	return resourcemanager.New(c, gardenNamespaceName, secretsManager, values), nil
+}
+
+// NewTargetGardenerResourceManager instantiates a new `gardener-resource-manager` component
+// configured to reconcile object in a target (shoot) cluster.
+func NewTargetGardenerResourceManager(
+	c client.Client,
+	namespaceName string,
+	secretsManager secretsmanager.Interface,
+	values resourcemanager.Values,
+) (
+	resourcemanager.Interface,
+	error,
+) {
+	image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameGardenerResourceManager)
+	if err != nil {
+		return nil, err
+	}
+	image.WithOptionalTag(version.Get().GitVersion)
+
+	defaultValues := resourcemanager.Values{
+		AlwaysUpdate:                         ptr.To(true),
+		ConcurrentSyncs:                      ptr.To(20),
+		HealthSyncPeriod:                     &metav1.Duration{Duration: time.Minute},
+		Image:                                image.String(),
+		MaxConcurrentCSRApproverWorkers:      ptr.To(5),
 		MaxConcurrentHealthWorkers:           ptr.To(10),
 		MaxConcurrentTokenInvalidatorWorkers: ptr.To(5),
 		MaxConcurrentTokenRequestorWorkers:   ptr.To(5),
-		MaxConcurrentCSRApproverWorkers:      ptr.To(5),
-		NamePrefix:                           namePrefix,
-		PodTopologySpreadConstraintsEnabled:  podTopologySpreadConstraintsEnabled,
-		PriorityClassName:                    priorityClassName,
-		SchedulingProfile:                    schedulingProfile,
-		SecretNameServerCA:                   secretNameServerCA,
-		SyncPeriod:                           &metav1.Duration{Duration: time.Minute},
-		SystemComponentTolerations:           systemComponentsToleration,
 		ResponsibilityMode:                   resourcemanager.ForTarget,
-		TargetNamespaces:                     targetNamespaces,
-		RuntimeKubernetesVersion:             kubernetesVersion,
+		SyncPeriod:                           &metav1.Duration{Duration: time.Minute},
 		WatchedNamespace:                     &namespaceName,
-		TopologyAwareRoutingEnabled:          topologyAwareRoutingEnabled,
-		IsWorkerless:                         isWorkerless,
-		NodeAgentReconciliationMaxDelay:      nodeAgentReconciliationMaxDelay,
-		NodeAgentAuthorizerEnabled:           nodeAgentAuthorizerEnabled,
 	}
 
-	return resourcemanager.New(
-		c,
-		namespaceName,
-		secretsManager,
-		cfg,
-	), nil
+	applyDefaults(&values, defaultValues)
+	return resourcemanager.New(c, namespaceName, secretsManager, values), nil
 }
 
 var (
@@ -347,4 +290,20 @@ func waitUntilGardenerResourceManagerBootstrapped(ctx context.Context, c client.
 	}
 
 	return managedresources.WaitUntilHealthy(ctx, c, namespace, resourcemanager.ManagedResourceName)
+}
+
+func applyDefaults(userValues *resourcemanager.Values, defaultValues resourcemanager.Values) {
+	var (
+		vUser    = reflect.ValueOf(userValues).Elem()
+		vDefault = reflect.ValueOf(defaultValues)
+	)
+
+	for i := 0; i < vUser.NumField(); i++ {
+		userField := vUser.Field(i)
+		defaultField := vDefault.Field(i)
+
+		if reflect.DeepEqual(userField.Interface(), reflect.Zero(userField.Type()).Interface()) {
+			userField.Set(defaultField)
+		}
+	}
 }

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -90,6 +90,7 @@ func NewRuntimeGardenerResourceManager(
 		PriorityClassName:                   priorityClassName,
 		Replicas:                            ptr.To[int32](2),
 		ResourceClass:                       ptr.To(v1beta1constants.SeedResourceManagerClass),
+		ResponsibilityMode:                  resourcemanager.ForSource,
 		SecretNameServerCA:                  secretNameServerCA,
 		SyncPeriod:                          &metav1.Duration{Duration: time.Hour},
 		RuntimeKubernetesVersion:            runtimeVersion,

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -152,7 +152,7 @@ func NewTargetGardenerResourceManager(
 		SecretNameServerCA:                   secretNameServerCA,
 		SyncPeriod:                           &metav1.Duration{Duration: time.Minute},
 		SystemComponentTolerations:           systemComponentsToleration,
-		TargetDiffersFromSourceCluster:       true,
+		ResponsibilityMode:                   resourcemanager.ForTarget,
 		TargetNamespaces:                     targetNamespaces,
 		RuntimeKubernetesVersion:             kubernetesVersion,
 		WatchedNamespace:                     &namespaceName,

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -302,7 +302,7 @@ func applyDefaults(userValues *resourcemanager.Values, defaultValues resourceman
 		userField := vUser.Field(i)
 		defaultField := vDefault.Field(i)
 
-		if reflect.DeepEqual(userField.Interface(), reflect.Zero(userField.Type()).Interface()) {
+		if userField.IsZero() {
 			userField.Set(defaultField)
 		}
 	}

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -83,6 +83,7 @@ var _ = Describe("ResourceManager", func() {
 			resourceManager, err := NewTargetGardenerResourceManager(fakeClient, namespace, sm, resourcemanager.Values{
 				ClusterIdentity:                      ptr.To("foo"),
 				MaxConcurrentTokenInvalidatorWorkers: ptr.To(6),
+				TargetNamespaces:                     []string{},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resourceManager.GetValues()).To(Equal(resourcemanager.Values{
@@ -97,6 +98,7 @@ var _ = Describe("ResourceManager", func() {
 				MaxConcurrentTokenRequestorWorkers:   ptr.To(5),
 				ResponsibilityMode:                   resourcemanager.ForTarget,
 				SyncPeriod:                           &metav1.Duration{Duration: time.Minute},
+				TargetNamespaces:                     []string{},
 				WatchedNamespace:                     &namespace,
 			}))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR augments the `gardener/resourcemanager` component as follows:
- A new field `BootstrapControlPlane` is introduced in the `Values` which
  - sets `hostNetwork=true`
  - tolerate all taints
  - set API server address to `127.0.0.1`
- The existing `TargetDiffersFromSourceCluster` field is replaced with `ResponsibilityMode` which can be `ForSource`, `ForTarget`, or (new scenario) `ForSourceAndTarget`
  - In `ForSourceAndTarget`, certain webhooks are enabled that usually only run in the "responsible for shoot" mode

On the way, I improved the instantiation of a new GRM component via the `component/shared` package.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
