### PR TITLE
Align some resources for proper garbage-collection

### DIFF
--- a/pkg/component/observability/logging/fluentbit/fluentbit.go
+++ b/pkg/component/observability/logging/fluentbit/fluentbit.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,7 +29,6 @@ import (
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
@@ -280,8 +278,6 @@ end
 			},
 		}
 	)
-
-	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
 
 	resources := []client.Object{
 		configMap,

--- a/pkg/component/observability/logging/fluentbit/fluentbit_test.go
+++ b/pkg/component/observability/logging/fluentbit/fluentbit_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Fluent Bit", func() {
 			Expect(customResourcesManagedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(customResourcesManagedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-			test.ExpectKindWithNameAndNamespace(manifests, "ConfigMap", "fluent-bit-lua-config-684e0e58", namespace)
+			test.ExpectKindWithNameAndNamespace(manifests, "ConfigMap", "fluent-bit-lua-config", namespace)
 			test.ExpectKindWithNameAndNamespace(manifests, "FluentBit", "fluent-bit-8259c", namespace)
 			test.ExpectKindWithNameAndNamespace(manifests, "ClusterFluentBitConfig", "fluent-bit-config", "")
 			test.ExpectKindWithNameAndNamespace(manifests, "ClusterInput", "tail-kubernetes", "")

--- a/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate.go
@@ -15,7 +15,7 @@ import (
 const (
 	customResourceStateConfigMountDir      = "/config"
 	customResourceStateConfigMountFile     = "custom-resource-state.yaml"
-	customResourceStateConfigMapNamePrefix = "custom-resource-state-config"
+	customResourceStateConfigMapNamePrefix = "kube-state-metrics-custom-resource-state"
 )
 
 func newCustomResourceStateMetricNameForVPA(path, valuePath []string) string {

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -487,7 +487,7 @@ var _ = Describe("KubeStateMetrics", func() {
 				})
 			}
 
-			return &appsv1.Deployment{
+			deployment := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,
@@ -560,6 +560,9 @@ var _ = Describe("KubeStateMetrics", func() {
 					},
 				},
 			}
+
+			Expect(references.InjectAnnotations(deployment)).To(Succeed())
+			return deployment
 		}
 
 		scrapeConfigCacheFor = func(nameSuffix string) *monitoringv1alpha1.ScrapeConfig {
@@ -946,7 +949,7 @@ var _ = Describe("KubeStateMetrics", func() {
 
 				customResourceStateConfigMap = &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "custom-resource-state-config",
+						Name:      "kube-state-metrics-custom-resource-state",
 						Namespace: namespace,
 					},
 					Data: map[string]string{
@@ -1043,7 +1046,7 @@ var _ = Describe("KubeStateMetrics", func() {
 
 				customResourceStateConfigMap = &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "custom-resource-state-config",
+						Name:      "kube-state-metrics-custom-resource-state",
 						Namespace: namespace,
 					},
 					Data: map[string]string{
@@ -1135,7 +1138,7 @@ var _ = Describe("KubeStateMetrics", func() {
 
 				customResourceStateConfigMap = &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "custom-resource-state-config",
+						Name:      "kube-state-metrics-custom-resource-state",
 						Namespace: namespace,
 					},
 					Data: map[string]string{

--- a/pkg/component/observability/monitoring/kubestatemetrics/resources.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/resources.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/seed"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -297,6 +298,7 @@ func (k *kubeStateMetrics) deployment(
 		utilruntime.Must(gardenerutils.InjectGenericKubeconfig(deployment, genericTokenKubeconfigSecretName, shootAccessSecret.Secret.Name))
 	}
 
+	utilruntime.Must(references.InjectAnnotations(deployment))
 	return deployment
 }
 

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -10,11 +10,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/alertmanager"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -159,5 +161,6 @@ func (p *prometheus) prometheus(cortexConfigMap *corev1.ConfigMap) *monitoringv1
 		obj.Spec.Volumes = append(obj.Spec.Volumes, p.cortexVolume(cortexConfigMap.Name))
 	}
 
+	utilruntime.Must(references.InjectAnnotations(obj))
 	return obj
 }

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -1120,6 +1120,7 @@ query_range:
 						Name:         "cortex-config",
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: cortexConfigMap.Name}}},
 					})
+					Expect(references.InjectAnnotations(prometheusObj)).To(Succeed())
 
 					service.Spec.Ports[0].TargetPort = intstr.FromInt32(9091)
 
@@ -1220,7 +1221,6 @@ query_range:
 							},
 						}}
 
-						// A reference for the garbage collector of the GRM gets injected for the
 						Expect(references.InjectAnnotations(prometheusObj)).To(Succeed())
 
 						prometheusRule.Namespace = namespace

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -1220,6 +1220,9 @@ query_range:
 							},
 						}}
 
+						// A reference for the garbage collector of the GRM gets injected for the
+						Expect(references.InjectAnnotations(prometheusObj)).To(Succeed())
+
 						prometheusRule.Namespace = namespace
 						metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", name)
 						metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", name)

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -84,6 +85,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request
 			corev1.SchemeGroupVersion.WithKind("PodList"),
 			batchv1.SchemeGroupVersion.WithKind("CronJobList"),
 			resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"),
+			monitoringv1.SchemeGroupVersion.WithKind("PrometheusList"),
 		}
 	)
 
@@ -104,7 +106,6 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request
 			if objectKind == "" || objectName == "" {
 				continue
 			}
-
 			delete(objectsToGarbageCollect, objectId{objectKind, objectMeta.Namespace, objectName})
 		}
 	}

--- a/pkg/resourcemanager/controller/garbagecollector/references/references.go
+++ b/pkg/resourcemanager/controller/garbagecollector/references/references.go
@@ -145,15 +145,13 @@ func InjectAnnotations(obj runtime.Object, additional ...string) error {
 	case *resourcesv1alpha1.ManagedResource:
 		referenceAnnotations := computeAnnotationsFromLocalObjRefs(o.Spec.SecretRefs, KindSecret, additional...)
 		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+
 	case *monitoringv1.Prometheus:
-		var references []corev1.LocalObjectReference
-		for _, remoteWrite := range o.Spec.RemoteWrite {
-			if basicAuth := remoteWrite.BasicAuth; basicAuth != nil {
-				references = append(references, basicAuth.Username.LocalObjectReference)
-				references = append(references, basicAuth.Password.LocalObjectReference)
-			}
-		}
-		referenceAnnotations := computeAnnotationsFromLocalObjRefs(references, KindSecret, additional...)
+		referenceAnnotations := utils.MergeStringMaps(
+			computeAnnotationsFromContainers(o.Spec.Containers),
+			computeAnnotationsFromVolumes(o.Spec.Volumes),
+			computeAnnotationsFromLocalObjRefs(localObjectReferencesFromRemoteWrites(o.Spec.RemoteWrite), KindSecret, additional...),
+		)
 		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
 
 	default:
@@ -179,7 +177,21 @@ func computeAnnotationsFromLocalObjRefs(refs []corev1.LocalObjectReference, kind
 func computeAnnotations(spec corev1.PodSpec, additional ...string) map[string]string {
 	out := make(map[string]string)
 
-	for _, container := range spec.Containers {
+	out = utils.MergeStringMaps(out, computeAnnotationsFromContainers(spec.Containers))
+	out = utils.MergeStringMaps(out, computeAnnotationsFromVolumes(spec.Volumes))
+	out = utils.MergeStringMaps(out, computeAnnotationsFromLocalObjRefs(spec.ImagePullSecrets, KindSecret))
+
+	for _, v := range additional {
+		out[v] = ""
+	}
+
+	return out
+}
+
+func computeAnnotationsFromContainers(containers []corev1.Container) map[string]string {
+	out := make(map[string]string)
+
+	for _, container := range containers {
 		for _, env := range container.EnvFrom {
 			if env.SecretRef != nil {
 				out[AnnotationKey(KindSecret, env.SecretRef.Name)] = env.SecretRef.Name
@@ -201,7 +213,13 @@ func computeAnnotations(spec corev1.PodSpec, additional ...string) map[string]st
 		}
 	}
 
-	for _, volume := range spec.Volumes {
+	return out
+}
+
+func computeAnnotationsFromVolumes(volumes []corev1.Volume) map[string]string {
+	out := make(map[string]string)
+
+	for _, volume := range volumes {
 		if volume.Secret != nil {
 			out[AnnotationKey(KindSecret, volume.Secret.SecretName)] = volume.Secret.SecretName
 		}
@@ -223,14 +241,6 @@ func computeAnnotations(spec corev1.PodSpec, additional ...string) map[string]st
 		}
 	}
 
-	for _, imagePullSecret := range spec.ImagePullSecrets {
-		out[AnnotationKey(KindSecret, imagePullSecret.Name)] = imagePullSecret.Name
-	}
-
-	for _, v := range additional {
-		out[v] = ""
-	}
-
 	return out
 }
 
@@ -245,4 +255,17 @@ func mergeAnnotations(oldAnnotations, newAnnotations map[string]string) map[stri
 	}
 
 	return utils.MergeStringMaps(old, newAnnotations)
+}
+
+func localObjectReferencesFromRemoteWrites(remoteWrites []monitoringv1.RemoteWriteSpec) []corev1.LocalObjectReference {
+	var references []corev1.LocalObjectReference
+	for _, remoteWrite := range remoteWrites {
+		if basicAuth := remoteWrite.BasicAuth; basicAuth != nil {
+			references = append(references,
+				basicAuth.Username.LocalObjectReference,
+				basicAuth.Password.LocalObjectReference,
+			)
+		}
+	}
+	return references
 }

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -61,6 +61,8 @@ var _ = BeforeSuite(func() {
 		CRDInstallOptions: envtest.CRDInstallOptions{
 			Paths: []string{
 				filepath.Join("..", "..", "..", "..", "example", "resource-manager", "10-crd-resources.gardener.cloud_managedresources.yaml"),
+				filepath.Join("..", "..", "..", "..", "pkg", "component", "observability", "monitoring", "prometheusoperator", "templates", "crd-monitoring.coreos.com_prometheuses.yaml"),
+				filepath.Join("..", "..", "..", "..", "pkg", "component", "observability", "logging", "fluentoperator", "assets", "crd-fluentbit.fluent.io_clusterfilters.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

This PR adds annotations to the `Prometheus` and `kube-state-metrics` `Deployment` objects to be properly considered during garbage collection.

Furthermore, the `ConfigMap` of `ClusterFilter`s are not being made unique, as the namespace of the `ConfigMap` cannot be determined by the garbage-collector.

In addition to that, a `ConfigMap` of the `kube-state-metric` component is prefixed, so operators can more easily understand its connection to the component.

**Which issue(s) this PR fixes**:
Part of #11240 https://github.com/gardener/gardener/issues/11386

**Special notes for your reviewer**:

This will not fix the flake for good, as mentioned [here](https://github.com/gardener/gardener/issues/11240#issuecomment-2647914732). But I expect the test to be less flaky than before

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
