### PR TITLE
Fix `Seed` labels in `ManagedSeed` spec

### DIFF
--- a/pkg/apis/core/helper/seed.go
+++ b/pkg/apis/core/helper/seed.go
@@ -126,27 +126,31 @@ func ConvertSeedExternal(obj runtime.Object) (*gardencorev1beta1.Seed, error) {
 // ConvertSeedTemplate converts the given external SeedTemplate version to an internal version.
 func ConvertSeedTemplate(obj *gardencorev1beta1.SeedTemplate) (*core.SeedTemplate, error) {
 	seed, err := ConvertSeed(&gardencorev1beta1.Seed{
-		Spec: obj.Spec,
+		ObjectMeta: obj.ObjectMeta,
+		Spec:       obj.Spec,
 	})
 	if err != nil {
 		return nil, errors.New("could not convert SeedTemplate to internal version")
 	}
 
 	return &core.SeedTemplate{
-		Spec: seed.Spec,
+		ObjectMeta: seed.ObjectMeta,
+		Spec:       seed.Spec,
 	}, nil
 }
 
 // ConvertSeedTemplateExternal converts the given internal SeedTemplate version to an external version.
 func ConvertSeedTemplateExternal(obj *core.SeedTemplate) (*gardencorev1beta1.SeedTemplate, error) {
 	seed, err := ConvertSeedExternal(&core.Seed{
-		Spec: obj.Spec,
+		ObjectMeta: obj.ObjectMeta,
+		Spec:       obj.Spec,
 	})
 	if err != nil {
 		return nil, errors.New("could not convert SeedTemplate to external version")
 	}
 
 	return &gardencorev1beta1.SeedTemplate{
-		Spec: seed.Spec,
+		ObjectMeta: seed.ObjectMeta,
+		Spec:       seed.Spec,
 	}, nil
 }

--- a/pkg/apis/core/helper/seed_test.go
+++ b/pkg/apis/core/helper/seed_test.go
@@ -236,7 +236,8 @@ var _ = Describe("Helper", func() {
 		It("should convert the external SeedTemplate version to an internal one", func() {
 			Expect(ConvertSeedTemplate(&gardencorev1beta1.SeedTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"foo": "bar"},
+					Labels:      map[string]string{"foo": "bar"},
+					Annotations: map[string]string{"baz": "boo"},
 				},
 				Spec: gardencorev1beta1.SeedSpec{
 					Provider: gardencorev1beta1.SeedProvider{
@@ -245,7 +246,8 @@ var _ = Describe("Helper", func() {
 				},
 			})).To(Equal(&core.SeedTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"foo": "bar"},
+					Labels:      map[string]string{"foo": "bar"},
+					Annotations: map[string]string{"baz": "boo"},
 				},
 				Spec: core.SeedSpec{
 					Provider: core.SeedProvider{
@@ -260,7 +262,8 @@ var _ = Describe("Helper", func() {
 		It("should convert the internal SeedTemplate version to an external one", func() {
 			Expect(ConvertSeedTemplateExternal(&core.SeedTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"foo": "bar"},
+					Labels:      map[string]string{"foo": "bar"},
+					Annotations: map[string]string{"baz": "boo"},
 				},
 				Spec: core.SeedSpec{
 					Provider: core.SeedProvider{
@@ -269,7 +272,8 @@ var _ = Describe("Helper", func() {
 				},
 			})).To(Equal(&gardencorev1beta1.SeedTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"foo": "bar"},
+					Labels:      map[string]string{"foo": "bar"},
+					Annotations: map[string]string{"baz": "boo"},
 				},
 				Spec: gardencorev1beta1.SeedSpec{
 					Provider: gardencorev1beta1.SeedProvider{

--- a/pkg/apis/core/helper/seed_test.go
+++ b/pkg/apis/core/helper/seed_test.go
@@ -235,12 +235,18 @@ var _ = Describe("Helper", func() {
 	Describe("#ConvertSeedTemplate", func() {
 		It("should convert the external SeedTemplate version to an internal one", func() {
 			Expect(ConvertSeedTemplate(&gardencorev1beta1.SeedTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
 				Spec: gardencorev1beta1.SeedSpec{
 					Provider: gardencorev1beta1.SeedProvider{
 						Type: "local",
 					},
 				},
 			})).To(Equal(&core.SeedTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
 				Spec: core.SeedSpec{
 					Provider: core.SeedProvider{
 						Type: "local",
@@ -253,12 +259,18 @@ var _ = Describe("Helper", func() {
 	Describe("#ConvertSeedTemplateExternal", func() {
 		It("should convert the internal SeedTemplate version to an external one", func() {
 			Expect(ConvertSeedTemplateExternal(&core.SeedTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
 				Spec: core.SeedSpec{
 					Provider: core.SeedProvider{
 						Type: "local",
 					},
 				},
 			})).To(Equal(&gardencorev1beta1.SeedTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
 				Spec: gardencorev1beta1.SeedSpec{
 					Provider: gardencorev1beta1.SeedProvider{
 						Type: "local",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:

In https://github.com/gardener/gardener/pull/11101, I broke specifying `Seed` labels in `ManagedSeed.spec.gardenlet.config.seedConfig.metadata.labels`.
The `ManagedSeed` admission plugin removes the labels when [admitting the seed spec](https://github.com/gardener/gardener/blob/e12a5b6fb47fb4a1e4a24b9d82bbb35f6e6969b7/plugin/pkg/managedseed/validator/admission.go#L328-L349).
That's because the `gardencorehelper.ConvertSeedTemplate*` functions silently drop the `SeedTemplate.ObjectMeta`.

**Which issue(s) this PR fixes**:
Fixes n/a

**Steps to reproduce**:

1. Create a shoot in the `garden` namespace: 
```
k create -f example/provider-local/managedseeds/shoot-managedseed.yaml
```
2. Add Labels to `ManagedSeed.spec.gardenlet.config.seedConfig.metadata.labels` in `example/provider-local/managedseeds/managedseed.yaml`:
```diff
       apiVersion: gardenlet.config.gardener.cloud/v1alpha1
       kind: GardenletConfiguration
       seedConfig:
+        metadata:
+          labels:
+            foo: bar
         spec:
           settings:
             excessCapacityReservation:
```
3. Observe that gardener-apiserver removes the labels during admission:
```
$ k create -f example/provider-local/managedseeds/managedseed.yaml --dry-run=server -oyaml | yq .spec.gardenlet.config.seedConfig.metadata
creationTimestamp: null
```

**Special notes for your reviewer**:

Thanks @rfranzke for reporting.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Specifying `Seed` labels in `ManagedSeed.spec.gardenlet.config.seedConfig.metadata.labels` is fixed.
```
