### PR TITLE
Do not specify `command` for the containers of the VPA components

### DIFF
--- a/pkg/component/autoscaling/vpa/admissioncontroller.go
+++ b/pkg/component/autoscaling/vpa/admissioncontroller.go
@@ -200,20 +200,8 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 					Name:            "admission-controller",
 					Image:           v.values.AdmissionController.Image,
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         v.computeAdmissionControllerCommands(),
-					Args: []string{
-						"--v=2",
-						"--stderrthreshold=info",
-						"--kube-api-qps=100",
-						"--kube-api-burst=120",
-						fmt.Sprintf("--client-ca-file=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyCertificateBundle),
-						fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyCertificate),
-						fmt.Sprintf("--tls-private-key=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyPrivateKey),
-						"--address=:8944",
-						fmt.Sprintf("--port=%d", vpaconstants.AdmissionControllerPort),
-						"--register-webhook=false",
-					},
-					LivenessProbe: newDefaultLivenessProbe(),
+					Args:            v.computeAdmissionControllerArgs(),
+					LivenessProbe:   newDefaultLivenessProbe(),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -315,8 +303,19 @@ func (v *vpa) reconcileAdmissionControllerVPA(vpa *vpaautoscalingv1.VerticalPodA
 	}
 }
 
-func (v *vpa) computeAdmissionControllerCommands() []string {
-	out := []string{"./admission-controller"}
+func (v *vpa) computeAdmissionControllerArgs() []string {
+	out := []string{
+		"--v=2",
+		"--stderrthreshold=info",
+		"--kube-api-qps=100",
+		"--kube-api-burst=120",
+		fmt.Sprintf("--client-ca-file=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyCertificateBundle),
+		fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyCertificate),
+		fmt.Sprintf("--tls-private-key=%s/%s", volumeMountPathCertificates, secretsutils.DataKeyPrivateKey),
+		"--address=:8944",
+		fmt.Sprintf("--port=%d", vpaconstants.AdmissionControllerPort),
+		"--register-webhook=false",
+	}
 
 	if v.values.ClusterType == component.ClusterTypeShoot {
 		out = append(out, "--kubeconfig="+gardenerutils.PathGenericKubeconfig)

--- a/pkg/component/autoscaling/vpa/recommender.go
+++ b/pkg/component/autoscaling/vpa/recommender.go
@@ -258,31 +258,8 @@ func (v *vpa) reconcileRecommenderDeployment(deployment *appsv1.Deployment, serv
 					Name:            "recommender",
 					Image:           v.values.Recommender.Image,
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         v.computeRecommenderCommands(),
-					Args: []string{
-						"--v=3",
-						"--stderrthreshold=info",
-						"--pod-recommendation-min-cpu-millicores=5",
-						"--pod-recommendation-min-memory-mb=10",
-						fmt.Sprintf("--recommendation-margin-fraction=%f", ptr.Deref(v.values.Recommender.RecommendationMarginFraction, gardencorev1beta1.DefaultRecommendationMarginFraction)),
-						fmt.Sprintf("--recommender-interval=%s", ptr.Deref(v.values.Recommender.Interval, gardencorev1beta1.DefaultRecommenderInterval).Duration),
-						"--kube-api-qps=100",
-						"--kube-api-burst=120",
-						"--memory-saver=true",
-						fmt.Sprintf("--target-cpu-percentile=%f", ptr.Deref(v.values.Recommender.TargetCPUPercentile, gardencorev1beta1.DefaultTargetCPUPercentile)),
-						fmt.Sprintf("--recommendation-lower-bound-cpu-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationLowerBoundCPUPercentile, gardencorev1beta1.DefaultRecommendationLowerBoundCPUPercentile)),
-						fmt.Sprintf("--recommendation-upper-bound-cpu-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationUpperBoundCPUPercentile, gardencorev1beta1.DefaultRecommendationUpperBoundCPUPercentile)),
-						fmt.Sprintf("--cpu-histogram-decay-half-life=%s", ptr.Deref(v.values.Recommender.CPUHistogramDecayHalfLife, gardencorev1beta1.DefaultCPUHistogramDecayHalfLife).Duration),
-						fmt.Sprintf("--target-memory-percentile=%f", ptr.Deref(v.values.Recommender.TargetMemoryPercentile, gardencorev1beta1.DefaultTargetMemoryPercentile)),
-						fmt.Sprintf("--recommendation-lower-bound-memory-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationLowerBoundMemoryPercentile, gardencorev1beta1.DefaultRecommendationLowerBoundMemoryPercentile)),
-						fmt.Sprintf("--recommendation-upper-bound-memory-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationUpperBoundMemoryPercentile, gardencorev1beta1.DefaultRecommendationUpperBoundMemoryPercentile)),
-						fmt.Sprintf("--memory-histogram-decay-half-life=%s", ptr.Deref(v.values.Recommender.MemoryHistogramDecayHalfLife, gardencorev1beta1.DefaultMemoryHistogramDecayHalfLife).Duration),
-						fmt.Sprintf("--memory-aggregation-interval=%s", ptr.Deref(v.values.Recommender.MemoryAggregationInterval, gardencorev1beta1.DefaultMemoryAggregationInterval).Duration),
-						fmt.Sprintf("--memory-aggregation-interval-count=%d", ptr.Deref(v.values.Recommender.MemoryAggregationIntervalCount, gardencorev1beta1.DefaultMemoryAggregationIntervalCount)),
-						"--leader-elect=true",
-						fmt.Sprintf("--leader-elect-resource-namespace=%s", v.namespaceForApplicationClassResource()),
-					},
-					LivenessProbe: newDefaultLivenessProbe(),
+					Args:            v.computeRecommenderArgs(),
+					LivenessProbe:   newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          serverPortName,
@@ -341,12 +318,35 @@ func (v *vpa) reconcileRecommenderVPA(vpa *vpaautoscalingv1.VerticalPodAutoscale
 	}
 }
 
-func (v *vpa) computeRecommenderCommands() []string {
-	out := []string{"./recommender"}
+func (v *vpa) computeRecommenderArgs() []string {
+	out := []string{
+		"--v=3",
+		"--stderrthreshold=info",
+		"--pod-recommendation-min-cpu-millicores=5",
+		"--pod-recommendation-min-memory-mb=10",
+		fmt.Sprintf("--recommendation-margin-fraction=%f", ptr.Deref(v.values.Recommender.RecommendationMarginFraction, gardencorev1beta1.DefaultRecommendationMarginFraction)),
+		fmt.Sprintf("--recommender-interval=%s", ptr.Deref(v.values.Recommender.Interval, gardencorev1beta1.DefaultRecommenderInterval).Duration),
+		"--kube-api-qps=100",
+		"--kube-api-burst=120",
+		"--memory-saver=true",
+		fmt.Sprintf("--target-cpu-percentile=%f", ptr.Deref(v.values.Recommender.TargetCPUPercentile, gardencorev1beta1.DefaultTargetCPUPercentile)),
+		fmt.Sprintf("--recommendation-lower-bound-cpu-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationLowerBoundCPUPercentile, gardencorev1beta1.DefaultRecommendationLowerBoundCPUPercentile)),
+		fmt.Sprintf("--recommendation-upper-bound-cpu-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationUpperBoundCPUPercentile, gardencorev1beta1.DefaultRecommendationUpperBoundCPUPercentile)),
+		fmt.Sprintf("--cpu-histogram-decay-half-life=%s", ptr.Deref(v.values.Recommender.CPUHistogramDecayHalfLife, gardencorev1beta1.DefaultCPUHistogramDecayHalfLife).Duration),
+		fmt.Sprintf("--target-memory-percentile=%f", ptr.Deref(v.values.Recommender.TargetMemoryPercentile, gardencorev1beta1.DefaultTargetMemoryPercentile)),
+		fmt.Sprintf("--recommendation-lower-bound-memory-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationLowerBoundMemoryPercentile, gardencorev1beta1.DefaultRecommendationLowerBoundMemoryPercentile)),
+		fmt.Sprintf("--recommendation-upper-bound-memory-percentile=%f", ptr.Deref(v.values.Recommender.RecommendationUpperBoundMemoryPercentile, gardencorev1beta1.DefaultRecommendationUpperBoundMemoryPercentile)),
+		fmt.Sprintf("--memory-histogram-decay-half-life=%s", ptr.Deref(v.values.Recommender.MemoryHistogramDecayHalfLife, gardencorev1beta1.DefaultMemoryHistogramDecayHalfLife).Duration),
+		fmt.Sprintf("--memory-aggregation-interval=%s", ptr.Deref(v.values.Recommender.MemoryAggregationInterval, gardencorev1beta1.DefaultMemoryAggregationInterval).Duration),
+		fmt.Sprintf("--memory-aggregation-interval-count=%d", ptr.Deref(v.values.Recommender.MemoryAggregationIntervalCount, gardencorev1beta1.DefaultMemoryAggregationIntervalCount)),
+		"--leader-elect=true",
+		fmt.Sprintf("--leader-elect-resource-namespace=%s", v.namespaceForApplicationClassResource()),
+	}
 
 	if v.values.ClusterType == component.ClusterTypeShoot {
 		out = append(out, "--kubeconfig="+gardenerutils.PathGenericKubeconfig)
 	}
+
 	return out
 }
 

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -357,7 +357,6 @@ var _ = Describe("VPA", func() {
 								Name:            "updater",
 								Image:           imageUpdater,
 								ImagePullPolicy: corev1.PullIfNotPresent,
-								Command:         []string{"./updater"},
 								Args: []string{
 									"--min-replicas=1",
 									fmt.Sprintf("--eviction-tolerance=%s", flagEvictionToleranceValue),
@@ -411,7 +410,7 @@ var _ = Describe("VPA", func() {
 			} else {
 				obj.Labels["gardener.cloud/role"] = "controlplane"
 				obj.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(false)
-				obj.Spec.Template.Spec.Containers[0].Command = append(obj.Spec.Template.Spec.Containers[0].Command, "--kubeconfig="+pathGenericKubeconfig)
+				obj.Spec.Template.Spec.Containers[0].Args = append(obj.Spec.Template.Spec.Containers[0].Args, "--kubeconfig="+pathGenericKubeconfig)
 
 				Expect(gardenerutils.InjectGenericKubeconfig(obj, genericTokenKubeconfigSecretName, shootAccessSecretUpdater.Name)).To(Succeed())
 			}
@@ -726,7 +725,6 @@ var _ = Describe("VPA", func() {
 								Name:            "recommender",
 								Image:           imageRecommender,
 								ImagePullPolicy: corev1.PullIfNotPresent,
-								Command:         []string{"./recommender"},
 								Args: []string{
 									"--v=3",
 									"--stderrthreshold=info",
@@ -781,7 +779,7 @@ var _ = Describe("VPA", func() {
 			} else {
 				obj.Labels["gardener.cloud/role"] = "controlplane"
 				obj.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(false)
-				obj.Spec.Template.Spec.Containers[0].Command = append(obj.Spec.Template.Spec.Containers[0].Command, "--kubeconfig="+pathGenericKubeconfig)
+				obj.Spec.Template.Spec.Containers[0].Args = append(obj.Spec.Template.Spec.Containers[0].Args, "--kubeconfig="+pathGenericKubeconfig)
 
 				Expect(gardenerutils.InjectGenericKubeconfig(obj, genericTokenKubeconfigSecretName, shootAccessSecretRecommender.Name)).To(Succeed())
 			}
@@ -1026,7 +1024,6 @@ var _ = Describe("VPA", func() {
 								Name:            "admission-controller",
 								Image:           imageAdmissionController,
 								ImagePullPolicy: corev1.PullIfNotPresent,
-								Command:         []string{"./admission-controller"},
 								Args: []string{
 									"--v=2",
 									"--stderrthreshold=info",
@@ -1121,7 +1118,7 @@ var _ = Describe("VPA", func() {
 			} else {
 				obj.Labels["gardener.cloud/role"] = "controlplane"
 				obj.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(false)
-				obj.Spec.Template.Spec.Containers[0].Command = append(obj.Spec.Template.Spec.Containers[0].Command, "--kubeconfig="+pathGenericKubeconfig)
+				obj.Spec.Template.Spec.Containers[0].Args = append(obj.Spec.Template.Spec.Containers[0].Args, "--kubeconfig="+pathGenericKubeconfig)
 
 				Expect(gardenerutils.InjectGenericKubeconfig(obj, genericTokenKubeconfigSecretName, shootAccessSecretAdmissionController.Name)).To(Succeed())
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
This PR changes Pod template of VPA components from:
```yaml
- command:
  - ./recommender
  - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
  args:
  - --v=3
  - --stderrthreshold=info
  - --pod-recommendation-min-cpu-millicores=5
  - --pod-recommendation-min-memory-mb=10
  - --recommendation-margin-fraction=0.150000
  - --recommender-interval=1m0s
  - --kube-api-qps=100
  - --kube-api-burst=120
  - --memory-saver=true
  - --target-cpu-percentile=0.900000
  - --recommendation-lower-bound-cpu-percentile=0.500000
  - --recommendation-upper-bound-cpu-percentile=0.950000
  - --cpu-histogram-decay-half-life=24h0m0s
  - --target-memory-percentile=0.900000
  - --recommendation-lower-bound-memory-percentile=0.500000
  - --recommendation-upper-bound-memory-percentile=0.950000
  - --memory-histogram-decay-half-life=24h0m0s
  - --leader-elect=true
  - --leader-elect-resource-namespace=kube-system
```

to:

```yaml
- args:
  - --v=3
  - --stderrthreshold=info
  - --pod-recommendation-min-cpu-millicores=5
  - --pod-recommendation-min-memory-mb=10
  - --recommendation-margin-fraction=0.150000
  - --recommender-interval=1m0s
  - --kube-api-qps=100
  - --kube-api-burst=120
  - --memory-saver=true
  - --target-cpu-percentile=0.900000
  - --recommendation-lower-bound-cpu-percentile=0.500000
  - --recommendation-upper-bound-cpu-percentile=0.950000
  - --cpu-histogram-decay-half-life=24h0m0s
  - --target-memory-percentile=0.900000
  - --recommendation-lower-bound-memory-percentile=0.500000
  - --recommendation-upper-bound-memory-percentile=0.950000
  - --memory-histogram-decay-half-life=24h0m0s
  - --leader-elect=true
  - --leader-elect-resource-namespace=kube-system
  - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
```

VPA container images have correct entrypoints, see:
- https://github.com/kubernetes/autoscaler/blob/cf115af954b7c5d6dcfc20784e862e2ab4cafc81/vertical-pod-autoscaler/pkg/updater/Dockerfile#L39
- https://github.com/kubernetes/autoscaler/blob/cf115af954b7c5d6dcfc20784e862e2ab4cafc81/vertical-pod-autoscaler/pkg/recommender/Dockerfile#L39
- https://github.com/kubernetes/autoscaler/blob/cf115af954b7c5d6dcfc20784e862e2ab4cafc81/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile#L39

There is no need to specify a command to overwrite this entrypoint.
Additionally, `-kubeconfig` is an arg and it belongs to `args`, not to `command`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
