### PR TITLE
[GEP-30] Drop proxy protocol from API server proxy

### DIFF
--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1907,7 +1907,7 @@ const (
 	// ShootCRDsWithProblematicConversionWebhooks is a constant for a condition type indicating that the Shoot cluster has
 	// CRDs with conversion webhooks and multiple stored versions which can break the reconciliation flow of the cluster.
 	ShootCRDsWithProblematicConversionWebhooks ConditionType = "CRDsWithProblematicConversionWebhooks"
-	// ShootAPIServerProxyUsesHTTPProxy is a constant for a condition type indicating that the Shoot cluster uses
+	// ShootAPIServerProxyUsesHTTPProxy is a constant for a constraint type indicating that the Shoot cluster uses
 	// the new HTTP proxy connection method for in-cluster API server traffic (See https://github.com/gardener/gardener/blob/master/docs/proposals/30-apiserver-proxy.md)
 	ShootAPIServerProxyUsesHTTPProxy ConditionType = "APIServerProxyUsesHTTPProxy"
 	// ShootReadyForMigration is a constant for a condition type indicating whether the Shoot can be migrated.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1907,6 +1907,9 @@ const (
 	// ShootCRDsWithProblematicConversionWebhooks is a constant for a condition type indicating that the Shoot cluster has
 	// CRDs with conversion webhooks and multiple stored versions which can break the reconciliation flow of the cluster.
 	ShootCRDsWithProblematicConversionWebhooks ConditionType = "CRDsWithProblematicConversionWebhooks"
+	// ShootAPIServerProxyUsesHTTPProxy is a constant for a condition type indicating that the Shoot cluster uses
+	// the new HTTP proxy connection method for in-cluster API server traffic (See https://github.com/gardener/gardener/blob/master/docs/proposals/30-apiserver-proxy.md)
+	ShootAPIServerProxyUsesHTTPProxy ConditionType = "APIServerProxyUsesHTTPProxy"
 	// ShootReadyForMigration is a constant for a condition type indicating whether the Shoot can be migrated.
 	ShootReadyForMigration ConditionType = "ReadyForMigration"
 )

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy.go
@@ -43,7 +43,7 @@ const (
 	name                = "apiserver-proxy"
 
 	adminPort           = 16910
-	proxySeedServerPort = 8443
+	proxySeedServerPort = 8132
 	portNameMetrics     = "metrics"
 
 	volumeNameConfig   = "proxy-config"
@@ -77,6 +77,8 @@ type Values struct {
 	DNSLookupFamily     string
 
 	advertiseIPAddress string
+
+	SeedNamespace string
 }
 
 // New creates a new instance of DeployWaiter for apiserver-proxy
@@ -207,6 +209,7 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 		"adminPort":           adminPort,
 		"proxySeedServerHost": a.values.ProxySeedServerHost,
 		"proxySeedServerPort": proxySeedServerPort,
+		"seedNamespace":       a.values.SeedNamespace,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -55,6 +55,7 @@ var _ = Describe("APIServerProxy", func() {
 		image               = "some-image:some-tag"
 		sidecarImage        = "sidecar-image:some-tag"
 		proxySeedServerHost = "api.internal.local."
+		seedNamespace       = "shoot--internal--internal"
 
 		service = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -190,6 +191,7 @@ var _ = Describe("APIServerProxy", func() {
 			SidecarImage:        sidecarImage,
 			ProxySeedServerHost: proxySeedServerHost,
 			DNSLookupFamily:     "V4_ONLY",
+			SeedNamespace:       seedNamespace,
 		}
 	})
 
@@ -268,7 +270,7 @@ var _ = Describe("APIServerProxy", func() {
 
 		Context("IPv4", func() {
 			It("should deploy the managed resource successfully", func() {
-				test("607149fb")
+				test("d383e1bb")
 			})
 		})
 
@@ -279,7 +281,7 @@ var _ = Describe("APIServerProxy", func() {
 			})
 
 			It("should deploy the managed resource successfully", func() {
-				test("3fdb1aaf")
+				test("331c4e9c")
 			})
 		})
 	})
@@ -462,6 +464,13 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           stat_prefix: kube_apiserver
           cluster: kube_apiserver
+          tunneling_config:
+            # hostname is irrelevant as it will be dropped by envoy, we still need it for the configuration though
+            hostname: "api.internal.local.:443"
+            headers_to_add:
+            - header:
+                key: X-Gardener-Destination
+                value: "outbound|443||kube-apiserver.shoot--internal--internal.svc.cluster.local"
           access_log:
           - name: envoy.access_loggers.stdout
             typed_config:
@@ -534,17 +543,7 @@ static_resources:
             address:
               socket_address:
                 address: api.internal.local.
-                port_value: 8443
-    transport_socket:
-      name: envoy.transport_sockets.upstream_proxy_protocol
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.proxy_protocol.v3.ProxyProtocolUpstreamTransport
-        config:
-          version: V2
-        transport_socket:
-          name: envoy.transport_sockets.raw_buffer
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
+                port_value: 8132
     upstream_connection_options:
       tcp_keepalive:
         keepalive_time: 7200

--- a/pkg/component/networking/apiserverproxy/templates/envoy.yaml.tpl
+++ b/pkg/component/networking/apiserverproxy/templates/envoy.yaml.tpl
@@ -51,6 +51,13 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           stat_prefix: kube_apiserver
           cluster: kube_apiserver
+          tunneling_config:
+            # hostname is irrelevant as it will be dropped by envoy, we still need it for the configuration though
+            hostname: "{{ .proxySeedServerHost }}:443"
+            headers_to_add:
+            - header:
+                key: X-Gardener-Destination
+                value: "outbound|443||kube-apiserver.{{ .seedNamespace }}.svc.cluster.local"
           access_log:
           - name: envoy.access_loggers.stdout
             typed_config:
@@ -124,16 +131,6 @@ static_resources:
               socket_address:
                 address: {{ .proxySeedServerHost }}
                 port_value: {{ .proxySeedServerPort }}
-    transport_socket:
-      name: envoy.transport_sockets.upstream_proxy_protocol
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.proxy_protocol.v3.ProxyProtocolUpstreamTransport
-        config:
-          version: V2
-        transport_socket:
-          name: envoy.transport_sockets.raw_buffer
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
     upstream_connection_options:
       tcp_keepalive:
         keepalive_time: 7200

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -44,7 +44,6 @@ spec:
                     - name: X-Gardener-Destination
                       string_match:
                         safe_regex:
-                          # see https://regex101.com/r/m0ZAAj/1
                           regex: '^outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local$'
                 route:
                   cluster_header: X-Gardener-Destination

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -38,6 +38,19 @@ spec:
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+              - match:
+                  connect_matcher: {}
+                  headers:
+                    - name: X-Gardener-Destination
+                      string_match:
+                        safe_regex:
+                          # see https://regex101.com/r/m0ZAAj/1
+                          regex: '^outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local$'
+                route:
+                  cluster_header: X-Gardener-Destination
+                  upgrade_configs:
+                  - connect_config: {}
+                    upgrade_type: CONNECT
               # need to have two catch-all rules here
               # one for CONNECT requests as they don't have a path in HTTP 1.1
               #   see: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routematch -> connect_matcher

--- a/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -43,7 +43,6 @@ spec:
                     - name: X-Gardener-Destination
                       string_match:
                         safe_regex:
-                          # see https://regex101.com/r/m0ZAAj/1
                           regex: '^outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local$'
                 route:
                   cluster_header: X-Gardener-Destination

--- a/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -37,6 +37,19 @@ spec:
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+              - match:
+                  connect_matcher: {}
+                  headers:
+                    - name: X-Gardener-Destination
+                      string_match:
+                        safe_regex:
+                          # see https://regex101.com/r/m0ZAAj/1
+                          regex: '^outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local$'
+                route:
+                  cluster_header: X-Gardener-Destination
+                  upgrade_configs:
+                  - connect_config: {}
+                    upgrade_type: CONNECT
               # need to have two catch-all rules here
               # one for CONNECT requests as they don't have a path in HTTP 1.1
               #   see: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routematch -> connect_matcher

--- a/pkg/gardenlet/operation/botanist/apiserverproxy.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy.go
@@ -6,8 +6,6 @@ package botanist
 
 import (
 	"context"
-	clock "k8s.io/utils/clock"
-
 	"github.com/gardener/gardener/imagevector"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -61,9 +59,8 @@ func (b *Botanist) DeployAPIServerProxy(ctx context.Context) error {
 	}
 
 	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
-		c := clock.RealClock{}
-		condition := v1beta1helper.GetOrInitConditionWithClock(c, shoot.Status.Constraints, gardencorev1beta1.ShootAPIServerProxyUsesHTTPProxy)
-		condition = v1beta1helper.UpdatedConditionWithClock(c, condition, gardencorev1beta1.ConditionTrue, "ApiserverProxyUsesHTTPProxy", "apiserver-proxy uses HTTP proxy method")
+		condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootAPIServerProxyUsesHTTPProxy)
+		condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, gardencorev1beta1.ConditionTrue, "APIServerProxyUsesHTTPProxy", "The API server proxy was reconfigured to use the HTTP proxy method.")
 		shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
 		return nil
 	})

--- a/pkg/gardenlet/operation/botanist/apiserverproxy.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy.go
@@ -40,6 +40,7 @@ func (b *Botanist) DefaultAPIServerProxy() (apiserverproxy.Interface, error) {
 		SidecarImage:        sidecarImage.String(),
 		ProxySeedServerHost: b.outOfClusterAPIServerFQDN(),
 		DNSLookupFamily:     dnsLookupFamily,
+		SeedNamespace:       b.Shoot.SeedNamespace,
 	}
 
 	return apiserverproxy.New(b.SeedClientSet.Client(), b.Shoot.SeedNamespace, b.SecretsManager, values), nil

--- a/pkg/gardenlet/operation/botanist/apiserverproxy.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy.go
@@ -6,6 +6,7 @@ package botanist
 
 import (
 	"context"
+
 	"github.com/gardener/gardener/imagevector"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"

--- a/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
@@ -2,6 +2,14 @@ package botanist_test
 
 import (
 	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
@@ -11,12 +19,6 @@ import (
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/clock"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("APIServerProxy", func() {

--- a/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
@@ -1,0 +1,115 @@
+package botanist_test
+
+import (
+	"context"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/garden"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("APIServerProxy", func() {
+	var (
+		ctrl *gomock.Controller
+		ctx  = context.TODO()
+
+		seedVersion = "1.26.0"
+
+		shoot *gardencorev1beta1.Shoot
+
+		gardenClient  client.Client
+		seedClient    client.Client
+		seedClientSet kubernetes.Interface
+
+		internalClusterDomain = "internal.foo.bar.com"
+		externalClusterDomain = "external.foo.bar.com"
+
+		advertiseIPAddress = "10.2.170.21"
+
+		botanist *Botanist
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "foo",
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				Networking: &gardencorev1beta1.Networking{
+					IPFamilies: []gardencorev1beta1.IPFamily{"IPv4"},
+				},
+				DNS: &gardencorev1beta1.DNS{
+					Domain: &externalClusterDomain,
+				},
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				LastOperation: &gardencorev1beta1.LastOperation{
+					Type: gardencorev1beta1.LastOperationTypeReconcile,
+				},
+			},
+		}
+
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithStatusSubresource(&gardencorev1beta1.Shoot{}).WithObjects(shoot).Build()
+		seedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		seedClientSet = fake.NewClientSetBuilder().WithClient(seedClient).WithVersion(seedVersion).Build()
+
+		botanist = &Botanist{
+			Operation: &operation.Operation{
+				GardenClient:       gardenClient,
+				APIServerClusterIP: advertiseIPAddress,
+				Garden: &garden.Garden{
+					InternalDomain: &gardenerutils.Domain{Provider: "some-provider"},
+				},
+				SeedClientSet: seedClientSet,
+				Shoot: &shootpkg.Shoot{
+					Components: &shootpkg.Components{
+						SystemComponents: &shootpkg.SystemComponents{},
+					},
+					InternalClusterDomain: internalClusterDomain,
+					ExternalClusterDomain: &externalClusterDomain,
+					ExternalDomain:        &gardenerutils.Domain{Provider: "some-external-provider"},
+				},
+			},
+		}
+
+		botanist.Shoot.SetInfo(shoot)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#DeployAPIServerProxy", func() {
+		It("should deploy apiserverproxy and set ShootAPIServerProxyUsesHTTPProxy constraint", func() {
+			comp, err := botanist.DefaultAPIServerProxy()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(comp).ToNot(BeNil())
+
+			botanist.Shoot.Components.SystemComponents.APIServerProxy = comp
+
+			Expect(botanist.DeployAPIServerProxy(ctx)).To(Succeed())
+
+			Expect(botanist.GardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+
+			Expect(shoot.Status.Constraints).To(ContainCondition(
+				OfType(gardencorev1beta1.ShootAPIServerProxyUsesHTTPProxy),
+				WithStatus(gardencorev1beta1.ConditionTrue),
+				WithReason("ApiserverProxyUsesHTTPProxy"),
+			))
+		})
+	})
+})

--- a/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
@@ -27,7 +27,7 @@ import (
 
 var _ = Describe("APIServerProxy", func() {
 	var (
-		ctx   = context.TODO()
+		ctx   = context.Background()
 		shoot *gardencorev1beta1.Shoot
 
 		botanist *Botanist

--- a/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package botanist_test
 
 import (

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -7,7 +7,6 @@ package operation
 import (
 	"context"
 	"fmt"
-	clockpkg "k8s.io/utils/clock"
 	"regexp"
 
 	"github.com/Masterminds/semver/v3"
@@ -16,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clockpkg "k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -15,7 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clockpkg "k8s.io/utils/clock"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -39,8 +39,8 @@ import (
 // NewBuilder returns a new Builder.
 func NewBuilder() *Builder {
 	return &Builder{
-		clockFunc: func() clockpkg.Clock {
-			return clockpkg.RealClock{}
+		clockFunc: func() clock.Clock {
+			return clock.RealClock{}
 		},
 		configFunc: func() (*gardenletconfigv1alpha1.GardenletConfiguration, error) {
 			return nil, fmt.Errorf("config is required but not set")
@@ -173,8 +173,8 @@ func (b *Builder) WithShootFromCluster(seedClientSet kubernetes.Interface, s *ga
 }
 
 // WithClock sets the clockFunc attribute at the Builder.
-func (b *Builder) WithClock(clock clockpkg.Clock) *Builder {
-	b.clockFunc = func() clockpkg.Clock { return clock }
+func (b *Builder) WithClock(c clock.Clock) *Builder {
+	b.clockFunc = func() clock.Clock { return c }
 	return b
 }
 

--- a/pkg/gardenlet/operation/types.go
+++ b/pkg/gardenlet/operation/types.go
@@ -6,6 +6,7 @@ package operation
 
 import (
 	"context"
+	"k8s.io/utils/clock"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -34,6 +35,7 @@ type Builder struct {
 	secretsFunc               func() (map[string]*corev1.Secret, error)
 	seedFunc                  func(context.Context) (*seed.Seed, error)
 	shootFunc                 func(context.Context, client.Reader, *garden.Garden, *seed.Seed, *corev1.Secret) (*shoot.Shoot, error)
+	clockFunc                 func() clock.Clock
 }
 
 // Operation contains all data required to perform an operation on a Shoot cluster.
@@ -42,6 +44,7 @@ type Operation struct {
 	secretsMutex   sync.RWMutex
 	SecretsManager secretsmanager.Interface
 
+	Clock                 clock.Clock
 	Config                *gardenletconfigv1alpha1.GardenletConfiguration
 	Logger                logr.Logger
 	GardenerInfo          *gardencorev1beta1.Gardener

--- a/pkg/gardenlet/operation/types.go
+++ b/pkg/gardenlet/operation/types.go
@@ -6,11 +6,11 @@ package operation
 
 import (
 	"context"
-	"k8s.io/utils/clock"
 	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR removes the dependency on proxy protocol for the apiserver-proxy component.
apiserver-proxy will now use the existing reversed-vpn envoy filter.

This PR also adds a new shoot constraint (APIServerProxyUsesHTTPProxy), which is set after the changes to the apiserver-proxy were rolled out on the shoot.
This will later be needed to ensure a smooth rollout -> See https://github.com/gardener/gardener/blob/master/docs/proposals/30-apiserver-proxy.md#rollout-plan

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The apiserver-proxy component does not use the proxy protocol anymore, see [GEP-30](https://github.com/gardener/gardener/blob/master/docs/proposals/30-apiserver-proxy.md).
```
