### PR TITLE
Remove CPU resource from VPA control for components that don't need it

### DIFF
--- a/pkg/component/networking/vpn/authzserver/authzserver.go
+++ b/pkg/component/networking/vpn/authzserver/authzserver.go
@@ -115,7 +115,6 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},
@@ -223,6 +222,7 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 					MinAllowed: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("100Mi"),
 					},
+					ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 				},
 			},
 		}

--- a/pkg/component/networking/vpn/authzserver/authzserver_test.go
+++ b/pkg/component/networking/vpn/authzserver/authzserver_test.go
@@ -128,7 +128,6 @@ var _ = Describe("ExtAuthzServer", func() {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("100m"),
 										corev1.ResourceMemory: resource.MustParse("100Mi"),
 									},
 								},
@@ -242,6 +241,7 @@ var _ = Describe("ExtAuthzServer", func() {
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("100Mi"),
 							},
+							ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 						},
 					},
 				},

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager.go
@@ -39,7 +39,6 @@ func (a *alertManager) alertManager() *monitoringv1.Alertmanager {
 			Version:           a.values.Version,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("5m"),
 					corev1.ResourceMemory: resource.MustParse("20Mi"),
 				},
 			},

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -185,7 +185,6 @@ var _ = Describe("Alertmanager", func() {
 				Version:           version,
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("5m"),
 						corev1.ResourceMemory: resource.MustParse("20Mi"),
 					},
 				},
@@ -236,10 +235,10 @@ var _ = Describe("Alertmanager", func() {
 								corev1.ResourceMemory: resource.MustParse("20Mi"),
 							},
 							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("500m"),
 								corev1.ResourceMemory: resource.MustParse("200Mi"),
 							},
-							ControlledValues: &vpaControlledValuesRequestsOnly,
+							ControlledValues:    &vpaControlledValuesRequestsOnly,
+							ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 						},
 						{
 							ContainerName: "config-reloader",

--- a/pkg/component/observability/monitoring/alertmanager/vpa.go
+++ b/pkg/component/observability/monitoring/alertmanager/vpa.go
@@ -44,10 +44,10 @@ func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 							corev1.ResourceMemory: resource.MustParse("20Mi"),
 						},
 						MaxAllowed: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("500m"),
 							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
-						ControlledValues: &controlledValuesRequestsOnly,
+						ControlledValues:    &controlledValuesRequestsOnly,
+						ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 					},
 					{
 						ContainerName: "config-reloader",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
This PR removes the CPU resources from VPA control for `alertmanager` and `vpn-authzserver`, as they have minimal CPU usage even on huge clusters, such that no `minAllowed` value bumps up the usage artificially.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove CPU as controlled resource from VPA for alertmanager and vpn-authzserver.
Remove CPU requests from alertmanager and vpn-authzserver.
```
