### PR TITLE
Deprecate the `shoot.gardener.cloud/managed-seed-api-server` annotation

### DIFF
--- a/docs/operations/managed_seed.md
+++ b/docs/operations/managed_seed.md
@@ -47,6 +47,8 @@ It is also possible to trigger the renewal on the secret directly, see [Rotate C
 
 ### Specifying `apiServer` `replicas` and `autoscaler` Options
 
+> 📌 **Deprecation Notice**: The annotation `shoot.gardener.cloud/managed-seed-api-server` is deprecated and will be removed in a future release. Instead, consider enabling high availability for the ManagedSeed's Shoot control plane.
+
 There are few configuration options that are not supported in a `Shoot` resource but due to backward compatibility reasons it is possible to specify them for a `Shoot` that is referred by a `ManagedSeed`. These options are:
 
 Option | Description

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 // GetWarnings returns warnings for the provided shoot.
@@ -35,6 +36,10 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 
 	if kubeControllerManager := shoot.Spec.Kubernetes.KubeControllerManager; kubeControllerManager != nil && kubeControllerManager.PodEvictionTimeout != nil {
 		warnings = append(warnings, "you are setting the spec.kubernetes.kubeControllerManager.podEvictionTimeout field. The field does not have effect since Kubernetes 1.13. Instead, use the spec.kubernetes.kubeAPIServer.(defaultNotReadyTolerationSeconds/defaultUnreachableTolerationSeconds) fields.")
+	}
+
+	if metav1.HasAnnotation(shoot.ObjectMeta, v1beta1constants.AnnotationManagedSeedAPIServer) && shoot.Namespace == v1beta1constants.GardenNamespace {
+		warnings = append(warnings, "annotation 'shoot.gardener.cloud/managed-seed-api-server' is deprecated, instead consider enabling high availability for the ManagedSeed's Shoot control plane")
 	}
 
 	return warnings

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -664,6 +664,10 @@ const (
 	// trigger force-deletion of the cluster. It can only be set if the Shoot has a deletion timestamp and contains an ErrorCode in the Shoot Status.
 	AnnotationConfirmationForceDeletion = "confirmation.gardener.cloud/force-deletion"
 	// AnnotationManagedSeedAPIServer is a constant for an annotation on a Shoot resource containing the API server settings for a managed seed.
+	//
+	// Deprecated: The annotation is deprecated and will be removed in a future release.
+	// Instead, consider enabling high availability for the ManagedSeed's Shoot control plane.
+	// TODO(ialidzhikov): Remove the support for the annotation in v1.119.
 	AnnotationManagedSeedAPIServer = "shoot.gardener.cloud/managed-seed-api-server"
 	// AnnotationShootIgnoreAlerts is the key for an annotation of a Shoot cluster whose value indicates
 	// if alerts for this cluster should be ignored

--- a/pkg/apis/core/v1beta1/helper/managedseed.go
+++ b/pkg/apis/core/v1beta1/helper/managedseed.go
@@ -54,6 +54,10 @@ func getFlagsAndSettings(annotation string) (map[string]struct{}, map[string]str
 }
 
 // ReadManagedSeedAPIServer reads the managed seed API server settings from the corresponding annotation.
+//
+// Deprecated: The "shoot.gardener.cloud/managed-seed-api-server" annotation is deprecated and will be removed in a future release.
+// Instead, consider enabling high availability for the ManagedSeed's Shoot control plane.
+// TODO(ialidzhikov): Remove the support for the annotation in v1.119.
 func ReadManagedSeedAPIServer(shoot *gardencorev1beta1.Shoot) (*ManagedSeedAPIServer, error) {
 	if shoot.Namespace != v1beta1constants.GardenNamespace || shoot.Annotations == nil {
 		return nil, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
See the motivation in https://github.com/gardener/gardener/issues/11217.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11217

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `shoot.gardener.cloud/managed-seed-api-server` annotation is deprecated and will be removed in a future release. Instead, consider enabling high availability for the ManagedSeed's Shoot control plane.
```
