### PR TITLE
chore: Ignore .git folder when checking license headers

### DIFF
--- a/hack/check-license-header.sh
+++ b/hack/check-license-header.sh
@@ -9,6 +9,7 @@ echo "> Checking if license header is present in all required files"
 
 missing_license_header_files="$(addlicense \
   -check \
+  -ignore ".git/**" \
   -ignore ".idea/**" \
   -ignore ".vscode/**" \
   -ignore "dev/**" \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

If there's a branch name that contains a `.` character `check-license-header.sh` will incorrectly interpret the branch reference in the `.git` folder as a file that needs a license header.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
