### PR TITLE
Adapt shoot flow to not get stuck on seeds with `BackupBucket`s configured to have immutability settings (write-once-read-many)

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -287,17 +287,11 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			SkipIf:       o.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
-		destroySourceBackupEntry = g.Add(flow.Task{
+		_ = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
 			Fn:           botanist.DestroySourceBackupEntry,
 			SkipIf:       !allowBackup || !botanist.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Waiting until source backup entry has been deleted",
-			Fn:           botanist.Shoot.Components.SourceBackupEntry.WaitCleanup,
-			SkipIf:       !allowBackup || skipReadiness || !botanist.IsRestorePhase(),
-			Dependencies: flow.NewTaskIDs(destroySourceBackupEntry),
 		})
 		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
 			Name:         "Deploying extension resources before kube-apiserver",

--- a/pkg/gardenlet/operation/botanist/backupentry.go
+++ b/pkg/gardenlet/operation/botanist/backupentry.go
@@ -84,9 +84,5 @@ func (b *Botanist) DeploySourceBackupEntry(ctx context.Context) error {
 
 // DestroySourceBackupEntry destroys the source BackupEntry.
 func (b *Botanist) DestroySourceBackupEntry(ctx context.Context) error {
-	if err := b.Shoot.Components.SourceBackupEntry.SetForceDeletionAnnotation(ctx); err != nil {
-		return err
-	}
-
 	return b.Shoot.Components.SourceBackupEntry.Destroy(ctx)
 }

--- a/pkg/gardenlet/operation/botanist/backupentry_test.go
+++ b/pkg/gardenlet/operation/botanist/backupentry_test.go
@@ -74,8 +74,7 @@ var _ = Describe("BackupEntry", func() {
 	})
 
 	Describe("#DestroySourceBackupEntry", func() {
-		It("should set force-deletion annotation and destroy the SourceBackupEntry component", func() {
-			sourceBackupEntry.EXPECT().SetForceDeletionAnnotation(ctx)
+		It("should destroy the SourceBackupEntry component", func() {
 			sourceBackupEntry.EXPECT().Destroy(ctx)
 
 			Expect(botanist.DestroySourceBackupEntry(ctx)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration backup ops-productivity
/kind enhancement

**What this PR does / why we need it**:

The intent of this PR is to ensure control plane migration does not get stuck in seeds with certain configurations:

* Shoots with etcd backups enabled which are scheduled on seeds with `BackupBucket`s configured with immutable settings (write-once-read-many) will have these backups in an immutable state for the duration of the policy set on the bucket. Relevant issue: #10866.

  With such buckets, it is not possible to force-delete the `BackupEntry` during the shoot reconciliation (which is the current flow) - the immutable duration *has* to be respected during the deletion of the `BackupEntry`.
  Currently, if a control plane migration is triggered on a shoot which is currently scheduled on such a seed, the control plane migration will get stuck since the source `BackupEntry` *can not* be deleted.
  
  Thus, force-deletion of the `BackupEntry`s by setting the `backupentry.core.gardener.cloud/force-deletion` is removed from the flow, and is now replaced by normal deletion of the `BackupEntry` which respects the grace period set on the `BackupEntry`.

* The task which waited for the source `BackupEntry` to be deleted during shoot reconciliation is now removed, since `BackupEntry`s are not force deleted during shoot reconciliation.

This PR also brings the following enhancement:

* etcd cluster readiness is waited for before the source `BackupEntry` is deleted. This is to ensure etcd backups are not deleted in the source until the etcd cluster is successfully restored in the destination.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @plkokanov @shreyas-s-rao @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt shoot flow to ensure control plane migration does not get stuck with shoots which have their (etcd) backups present on buckets configured with immutability settings (write-once-read-many).
```
```other operator
Adapt shoot flow to not initiate deletion of source `BackupEntry`s until the shoot's etcd cluster reports readiness to enhance disaster recovery.
```
