### PR TITLE
Increase bit size of rsa key in unit test

### DIFF
--- a/pkg/utils/secrets/rsa_private_key_test.go
+++ b/pkg/utils/secrets/rsa_private_key_test.go
@@ -21,7 +21,7 @@ var _ = Describe("RSA Private Key Secrets", func() {
 
 		BeforeEach(func() {
 			rsaPrivateKeyConfig = &RSASecretConfig{
-				Bits: 16,
+				Bits: 3072,
 				Name: "rsa-secret",
 			}
 		})
@@ -57,7 +57,7 @@ var _ = Describe("RSA Private Key Secrets", func() {
 		)
 		BeforeEach(func() {
 			var err error
-			key, err = rsa.GenerateKey(rand.Reader, 16)
+			key, err = rsa.GenerateKey(rand.Reader, 3072)
 			Expect(err).NotTo(HaveOccurred())
 
 			rsaKeys = &RSAKeys{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR increases the bit size of keys in the rsa key in unit tests.

Otherwise, the test will fail in Go 1.24 with this message:
```
  [FAILED] Unexpected error:
      <*errors.errorString | 0xc00089e630>: 
      rsa: key too small
      {
          s: "rsa: key too small",
      }
  occurred
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
