### PR TITLE
Add `VPA` dashboards to `plutono` running in a `Garden` cluster with enabled VPA

### DIFF
--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -75,8 +75,6 @@ var (
 	gardenAndShootDashboards embed.FS
 	//go:embed dashboards/common
 	commonDashboards embed.FS
-	//go:embed dashboards/common/vpa
-	commonVpaDashboards embed.FS
 
 	gardenDashboardsPath         = filepath.Join("dashboards", "garden")
 	seedDashboardsPath           = filepath.Join("dashboards", "seed")
@@ -390,7 +388,7 @@ func (p *plutono) getDashboardConfigMap() (*corev1.ConfigMap, error) {
 	if p.values.IsGardenCluster {
 		requiredDashboards = map[string]embed.FS{gardenDashboardsPath: gardenDashboards, gardenAndShootDashboardsPath: gardenAndShootDashboards}
 		if p.values.VPAEnabled {
-			requiredDashboards[commonVpaDashboardsPath] = commonVpaDashboards
+			requiredDashboards[commonVpaDashboardsPath] = commonDashboards
 		}
 	} else if p.values.ClusterType == component.ClusterTypeSeed {
 		requiredDashboards = map[string]embed.FS{seedDashboardsPath: seedDashboards, commonDashboardsPath: commonDashboards}

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -75,12 +75,15 @@ var (
 	gardenAndShootDashboards embed.FS
 	//go:embed dashboards/common
 	commonDashboards embed.FS
+	//go:embed dashboards/common/vpa
+	commonVpaDashboards embed.FS
 
 	gardenDashboardsPath         = filepath.Join("dashboards", "garden")
 	seedDashboardsPath           = filepath.Join("dashboards", "seed")
 	shootDashboardsPath          = filepath.Join("dashboards", "shoot")
 	gardenAndShootDashboardsPath = filepath.Join("dashboards", "garden-shoot")
 	commonDashboardsPath         = filepath.Join("dashboards", "common")
+	commonVpaDashboardsPath      = filepath.Join(commonDashboardsPath, "vpa")
 )
 
 // Interface contains functions for a Plutono Deployer
@@ -386,6 +389,9 @@ func (p *plutono) getDashboardConfigMap() (*corev1.ConfigMap, error) {
 
 	if p.values.IsGardenCluster {
 		requiredDashboards = map[string]embed.FS{gardenDashboardsPath: gardenDashboards, gardenAndShootDashboardsPath: gardenAndShootDashboards}
+		if p.values.VPAEnabled {
+			requiredDashboards[commonVpaDashboardsPath] = commonVpaDashboards
+		}
 	} else if p.values.ClusterType == component.ClusterTypeSeed {
 		requiredDashboards = map[string]embed.FS{seedDashboardsPath: seedDashboards, commonDashboardsPath: commonDashboards}
 		if !p.values.IncludeIstioDashboards {

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -673,6 +673,16 @@ status:
 					values.IsGardenCluster = true
 				})
 
+				Context("with VPAEnabled=true", func() {
+					BeforeEach(func() {
+						values.VPAEnabled = true
+					})
+
+					It("should successfully deploy all resources", func() {
+						checkDeployedResources("plutono-dashboards-garden", 26)
+					})
+				})
+
 				It("should successfully deploy all resources", func() {
 					checkDeployedResources("plutono-dashboards-garden", 23)
 				})

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -287,7 +287,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.plutono, err = r.newPlutono(secretsManager, primaryIngressDomain.Name, wildcardCertSecretName)
+	c.plutono, err = r.newPlutono(garden, secretsManager, primaryIngressDomain.Name, wildcardCertSecretName)
 	if err != nil {
 		return
 	}
@@ -877,7 +877,7 @@ func (r *Reconciler) newGardenerMetricsExporter(secretsManager secretsmanager.In
 	return gardenermetricsexporter.New(r.RuntimeClientSet.Client(), r.GardenNamespace, secretsManager, gardenermetricsexporter.Values{Image: image.String()}), nil
 }
 
-func (r *Reconciler) newPlutono(secretsManager secretsmanager.Interface, ingressDomain string, wildcardCertSecretName *string) (plutono.Interface, error) {
+func (r *Reconciler) newPlutono(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressDomain string, wildcardCertSecretName *string) (plutono.Interface, error) {
 	return sharedcomponent.NewPlutono(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
@@ -891,7 +891,7 @@ func (r *Reconciler) newPlutono(secretsManager secretsmanager.Interface, ingress
 		false,
 		true,
 		false,
-		false,
+		vpaEnabled(garden.Spec.RuntimeCluster.Settings),
 		wildcardCertSecretName,
 	)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR adds `VPA` dashboards to `plutono` running within a `Garden` cluster with `VPAEnabled=true` configuration. As part of https://github.com/gardener/gardener/pull/11318 we'll start collecting `vpa-admission-controller` and `vpa-recommender` metrics for `Garden` clusters, hence introducing the additional dashboards.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11356

**Special notes for your reviewer**:
The functionality in this PR depends on https://github.com/gardener/gardener/pull/11318 and should be considered after being `rebased`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Include `VPA` dashboards in `plutono` running within a `Garden` cluster with enabled VPA configuration.
```
