### PR TITLE
[resource-manager] Set sync period to `1h` for all deployments

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -288,8 +288,6 @@ type Values struct {
 	ResponsibilityMode ResponsibilityMode
 	// SecretNameServerCA is the name of the server CA secret.
 	SecretNameServerCA string
-	// SyncPeriod configures the duration of how often existing resources should be synced
-	SyncPeriod *metav1.Duration
 	// SystemComponentTolerations are the tolerations required for shoot system components.
 	SystemComponentTolerations []corev1.Toleration
 	// TargetDisableCache disables the cache for target cluster and always talk directly to the API server (defaults to false)
@@ -566,7 +564,7 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 			},
 			ManagedResource: resourcemanagerconfigv1alpha1.ManagedResourceControllerConfig{
 				ConcurrentSyncs: r.values.ConcurrentSyncs,
-				SyncPeriod:      r.values.SyncPeriod,
+				SyncPeriod:      &metav1.Duration{Duration: time.Hour},
 				AlwaysUpdate:    r.values.AlwaysUpdate,
 			},
 		},

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -93,7 +93,6 @@ var _ = Describe("ResourceManager", func() {
 		maxConcurrentCSRApproverWorkers      = 24
 		maxConcurrentNetworkPolicyWorkers    = 25
 		resourceClass                        = "fake-ResourceClass"
-		syncPeriod                           = metav1.Duration{Duration: time.Second * 80}
 		watchedNamespace                     = "fake-ns"
 		targetDisableCache                   = true
 		maxUnavailable                       = intstr.FromInt32(1)
@@ -322,7 +321,6 @@ var _ = Describe("ResourceManager", func() {
 			ResourceClass:                                    &resourceClass,
 			RuntimeKubernetesVersion:                         version,
 			SecretNameServerCA:                               "ca",
-			SyncPeriod:                                       &syncPeriod,
 			SystemComponentTolerations: []corev1.Toleration{
 				{Key: "a"},
 				{Key: "b"},
@@ -400,7 +398,7 @@ var _ = Describe("ResourceManager", func() {
 					},
 					ManagedResource: resourcemanagerconfigv1alpha1.ManagedResourceControllerConfig{
 						ConcurrentSyncs: &concurrentSyncs,
-						SyncPeriod:      &syncPeriod,
+						SyncPeriod:      &metav1.Duration{Duration: time.Hour},
 						AlwaysUpdate:    &alwaysUpdate,
 					},
 					TokenInvalidator: resourcemanagerconfigv1alpha1.TokenInvalidatorControllerConfig{

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -72,7 +72,6 @@ func NewRuntimeGardenerResourceManager(
 		Replicas:                            ptr.To[int32](2),
 		ResourceClass:                       ptr.To(v1beta1constants.SeedResourceManagerClass),
 		ResponsibilityMode:                  resourcemanager.ForSource,
-		SyncPeriod:                          &metav1.Duration{Duration: time.Hour},
 	}
 
 	applyDefaults(&values, defaultValues)
@@ -106,7 +105,6 @@ func NewTargetGardenerResourceManager(
 		MaxConcurrentTokenInvalidatorWorkers: ptr.To(5),
 		MaxConcurrentTokenRequestorWorkers:   ptr.To(5),
 		ResponsibilityMode:                   resourcemanager.ForTarget,
-		SyncPeriod:                           &metav1.Duration{Duration: time.Minute},
 		WatchedNamespace:                     &namespaceName,
 	}
 

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -75,7 +75,6 @@ var _ = Describe("ResourceManager", func() {
 				Replicas:                            ptr.To[int32](2),
 				ResourceClass:                       ptr.To("seed"),
 				ResponsibilityMode:                  resourcemanager.ForSource,
-				SyncPeriod:                          &metav1.Duration{Duration: time.Hour},
 			}))
 		})
 
@@ -97,7 +96,6 @@ var _ = Describe("ResourceManager", func() {
 				MaxConcurrentTokenInvalidatorWorkers: ptr.To(6),
 				MaxConcurrentTokenRequestorWorkers:   ptr.To(5),
 				ResponsibilityMode:                   resourcemanager.ForTarget,
-				SyncPeriod:                           &metav1.Duration{Duration: time.Minute},
 				TargetNamespaces:                     []string{},
 				WatchedNamespace:                     &namespace,
 			}))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
- This mainly affects the GRMs deployed virtual garden and shoot  clusters
- After https://github.com/gardener/gardener/pull/8483, we watch deployed resources in the `ManagedResource` controller anyways, i.e., we react instantly if a users tampers with any resource
- The `1m` sync period was meant to "reconcile fast" back then when we didn't have the watches/caches
- In order to reduce load on kube-apiserver and webhooks, we can now reduce the sync period to `1h`

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11341

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener-resource-manager` no longer syncs all resources every minute for virtual garden and shoot clusters. It already watches its desired resources anyways, i.e., it already reacts instantly, so there is no need to additionally apply them every minute.
```
