### PR TITLE
Fix the `shoot-annotated-seed-service-endpoints` scrape configuration

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -93,6 +93,7 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 						SourceLabels: []monitoringv1.LabelName{"__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"},
 						Action:       "replace",
 						Regex:        `([^:]+)(?::\d+)?;(\d+)`,
+						Replacement:  ptr.To("$1:$2"),
 						TargetLabel:  "__address__",
 					},
 					{

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -94,6 +94,7 @@ var _ = Describe("ScrapeConfigs", func() {
 								SourceLabels: []monitoringv1.LabelName{"__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"},
 								Action:       "replace",
 								Regex:        `([^:]+)(?::\d+)?;(\d+)`,
+								Replacement:  ptr.To("$1:$2"),
 								TargetLabel:  "__address__",
 							},
 							{


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR fixes an issue with the `shoot-annotated-seed-service-endpoints` scrape configuration where the address port to scrape was mistakenly dropped during the relabel configuration.

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:

```other operator
Fix the `shoot-annotated-seed-service-endpoints` scrape configuration by adding the address port
```
