### PR TITLE
Fix Restore Error: ShootState.core.gardener.cloud "xxxxx" not found 

### DIFF
--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -333,7 +334,7 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 		lastOperation.Type == gardencorev1beta1.LastOperationTypeRestore &&
 		lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
 		shootState := &gardencorev1beta1.ShootState{ObjectMeta: metav1.ObjectMeta{Name: shootObject.Name, Namespace: shootObject.Namespace}}
-		if err := c.Get(ctx, client.ObjectKeyFromObject(shootState), shootState); err != nil {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(shootState), shootState); nil != err && !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 		shoot.SetShootState(shootState)


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes bug

**Which issue(s) this PR fixes**:
Occasionally, during cluster creation reconcile fails due to a race condition where call in https://github.com/gardener/gardener/blob/master/pkg/gardenlet/operation/shoot/shoot.go#L336 may return either nil or a not found error.

**Special notes for your reviewer**:
![Screenshot 2025-02-17 at 14 44 17](https://github.com/user-attachments/assets/949e7bf3-366b-47af-9632-49a6ec5993f8)

```yaml
Name:         tbr8hv
Namespace:    garden-430173-2c74a
Labels:       extensions.extensions.gardener.cloud/plusserver-api-check-extension=true
              extensions.extensions.gardener.cloud/plusserver-billing-extension=true
              extensions.extensions.gardener.cloud/plusserver-billing-v2-extension=true
              extensions.extensions.gardener.cloud/plusserver-rm-extension=true
              networking.extensions.gardener.cloud/calico=true
              operatingsystemconfig.extensions.gardener.cloud/flatcar=true
              provider.extensions.gardener.cloud/openstack=true
              seed.gardener.cloud/h501-stage=true
              shoot.gardener.cloud/status=unhealthy
Annotations:  confirmation.gardener.cloud/deletion: true
              deletion.gardener.cloud/confirmed-by: system:serviceaccount:garden-dashboard:admin
              gardener.cloud/created-by: kubecfg-root
              shoot.gardener.cloud/tasks:
                deployInfrastructure,deployDNSRecordInternal,deployDNSRecordExternal,deployDNSRecordIngress,restartControlPlanePods
API Version:  core.gardener.cloud/v1beta1
Kind:         Shoot
Metadata:
  Creation Timestamp:  2025-02-14T13:27:39Z
  Finalizers:
    gardener
  Generate Name:     t
  Generation:        6
  Resource Version:  67627927
  UID:               9b3f9db9-7cf8-4ced-8fed-1ef1f68f9b94
Spec:
  Addons:
    Kubernetes Dashboard:
      Authentication Mode:  token
      Enabled:              false
  Cloud Profile:
    Kind:              CloudProfile
    Name:              pluscloudopen-ham5
  Cloud Profile Name:  pluscloudopen-ham5
  Control Plane:
    High Availability:
      Failure Tolerance:
        Type:  node
  Dns:
    Domain:  tbr8hv.430173.projects.stage.gardener.get-cloud.io
  Kubernetes:
    Enable Static Token Kubeconfig:  false
    Kube API Server:
      Default Not Ready Toleration Seconds:    300
      Default Unreachable Toleration Seconds:  300
      Enable Anonymous Authentication:         false
      Event TTL:                               1h0m0s
      Logging:
        Verbosity:  2
      Requests:
        Max Mutating Inflight:      200
        Max Non Mutating Inflight:  400
    Kube Controller Manager:
      Node CIDR Mask Size:        24
      Node Monitor Grace Period:  40s
    Kube Proxy:
      Enabled:  true
      Mode:     IPTables
    Kube Scheduler:
      Profile:  balanced
    Kubelet:
      Fail Swap On:                     true
      Image GC High Threshold Percent:  50
      Image GC Low Threshold Percent:   40
      Kube Reserved:
        Cpu:                  80m
        Memory:               1Gi
        Pid:                  20k
      Serialize Image Pulls:  true
    Version:                  1.31.4
  Maintenance:
    Auto Update:
      Kubernetes Version:     true
      Machine Image Version:  true
    Time Window:
      Begin:  050000+0000
      End:    060000+0000
  Networking:
    Ip Families:
      IPv4
    Nodes:     10.250.0.0/16
    Pods:      10.96.0.0/12
    Services:  10.112.0.0/12
    Type:      calico
  Provider:
    Control Plane Config:
      API Version:             openstack.provider.extensions.gardener.cloud/v1alpha1
      Kind:                    ControlPlaneConfig
      Load Balancer Provider:  amphora
      Zone:                    az1
    Infrastructure Config:
      API Version:         openstack.provider.extensions.gardener.cloud/v1alpha1
      Floating Pool Name:  ext01
      Kind:                InfrastructureConfig
      Networks:
        Workers:  10.250.0.0/16
    Type:         openstack
    Workers:
      Cri:
        Name:  containerd
      Machine:
        Architecture:  amd64
        Image:
          Name:         flatcar
          Version:      3975.2.2
        Type:           SCS-2V-4
      Max Surge:        1
      Max Unavailable:  0
      Maximum:          3
      Minimum:          1
      Name:             workers
      System Components:
        Allow:  true
      Volume:
        Size:  20Gi
      Zones:
        az1
    Workers Settings:
      Ssh Access:
        Enabled:        true
  Purpose:              evaluation
  Region:               prod2
  Scheduler Name:       default-scheduler
  Secret Binding Name:  430173-1
  Seed Name:            h501-stage
  System Components:
    Core DNS:
      Autoscaling:
        Mode:  horizontal
Status:
  Advertised Addresses:
    Name:            external
    URL:             https://api.tbr8hv.430173.projects.stage.gardener.get-cloud.io
    Name:            internal
    URL:             https://api.tbr8hv.430173.internal.stage.gardener.get-cloud.io
    Name:            service-account-issuer
    URL:             https://api.tbr8hv.430173.internal.stage.gardener.get-cloud.io
  Cluster Identity:  shoot--430173--tbr8hv-9b3f9db9-7cf8-4ced-8fed-1ef1f68f9b94-gardener-stage
  Conditions:
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  APIServerAvailable
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  ControlPlaneHealthy
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  ObservabilityComponentsHealthy
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  EveryNodeReady
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  SystemComponentsHealthy
  Constraints:
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  HibernationPossible
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  MaintenancePreconditionsSatisfied
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  CACertificateValiditiesAcceptable
    Last Transition Time:  2025-02-14T13:44:29Z
    Last Update Time:      2025-02-14T13:44:29Z
    Message:               Precondition failed: operation could not be initialized
    Reason:                ConditionCheckError
    Status:                Unknown
    Type:                  CRDsWithProblematicConversionWebhooks
  Gardener:
    Id:        fLOPhx2y2tADHFnW5URLy6BzYAmT6VtAnlhdq620LWltGbhiJnd6c41qYdkffxxQ
    Name:      gardenlet-6d79d9f885-sqq9v
    Version:   v1.106.2
  Hibernated:  false
  Last Operation:
    Description:           Could not initialize a new operation for Shoot cluster: ShootState.core.gardener.cloud "tbr8hv" not found Operation will be retried.
    Last Update Time:      2025-02-17T15:38:21Z
    Progress:              0
    State:                 Error
    Type:                  Restore
  Observed Generation:     6
  Retry Cycle Start Time:  2025-02-17T10:28:12Z
  Seed Name:               h501-stage
  Technical ID:            shoot--430173--tbr8hv
  UID:                     9b3f9db9-7cf8-4ced-8fed-1ef1f68f9b94
Events:                    <none>
```

**Release note**:
Fix Reconcile Error during cluster creation.

Format of block header: bugfix user
```other operator

```
