### PR TITLE
Increase log output when adding to/checking `/etc/hosts`

### DIFF
--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -38,6 +38,9 @@ export_artifacts() {
       kubectl cp "$namespace/$node":/var/log "$node_dir" || true
     done < <(kubectl -n "$namespace" get po -l app=machine -oname | cut -d/ -f2)
   done < <(kubectl get ns -l gardener.cloud/role=shoot -oname | cut -d/ -f2)
+
+  echo "> Exporting /etc/hosts"
+  cp /etc/hosts $ARTIFACTS/$cluster_name/hosts
 }
 
 export_events_for_kind() {
@@ -94,7 +97,9 @@ clamp_mss_to_pmtu() {
 # If running in prow, we need to ensure that garden.local.gardener.cloud resolves to localhost
 ensure_glgc_resolves_to_localhost() {
   if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
+    echo "> Adding garden.local.gardener.cloud to /etc/hosts..."
     printf "\n127.0.0.1 garden.local.gardener.cloud\n" >> /etc/hosts
     printf "\n::1 garden.local.gardener.cloud\n" >> /etc/hosts
+    echo "> Content of '/etc/hosts' after adding garden.local.gardener.cloud:\n$(cat /etc/hosts)"
   fi
 }

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -62,7 +62,7 @@ check_local_dns_records() {
     glgc_ip_address=$(dscacheutil -q host -a name garden.local.gardener.cloud | grep "ip_address" | head -n 1| cut -d' ' -f2 || true)
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Suppress exit code using "|| true"
-    glgc_ip_address="$(getent ahosts garden.local.gardener.cloud | cut -d' ' -f1 || true)"
+    glgc_ip_address="$(getent ahosts garden.local.gardener.cloud || true)"
   else
     echo "Warning: Unknown OS. Make sure garden.local.gardener.cloud resolves to 127.0.0.1"
     return 0
@@ -70,6 +70,8 @@ check_local_dns_records() {
     
   if ! echo "$glgc_ip_address" | grep -q "127.0.0.1" ; then
       echo "Error: garden.local.gardener.cloud does not resolve to 127.0.0.1. Please add a line for it in /etc/hosts"
+      echo "Command output: $glgc_ip_address"
+      echo "Content of '/etc/hosts':\n$(cat /etc/hosts)"
       exit 1
   fi
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

Increase log output when adding to/checking `/etc/hosts`

**Which issue(s) this PR fixes**:
Part of #11410
Part of https://github.com/gardener/gardener/issues/11386

**Special notes for your reviewer**:

Example log output from a prow job for `getent`:

```
# getent ahosts garden.local.gardener.cloud
::1             STREAM garden.local.gardener.cloud
::1             DGRAM
::1             RAW
::1             STREAM
::1             DGRAM
::1             RAW
127.0.0.1       STREAM
127.0.0.1       DGRAM
127.0.0.1       RAW
127.0.0.1       STREAM
127.0.0.1       DGRAM
127.0.0.1       RAW
```

Cutting the output is not necessary when using grep afterwards anyway, i.e. the removal of the `cut` step was done to simplify the code.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
