### PR TITLE
[release-v1.110] Automated cherry pick of #11397: Scale kube-apiserver after switching to node-agent-authorizer

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -328,5 +328,6 @@ func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context, enableNodeAgentAutho
 
 // ScaleKubeAPIServerToOne scales kube-apiserver replicas to one.
 func (b *Botanist) ScaleKubeAPIServerToOne(ctx context.Context) error {
+	b.Shoot.Components.ControlPlane.KubeAPIServer.SetAutoscalingReplicas(ptr.To[int32](1))
 	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.SeedNamespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, 1)
 }

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -645,6 +645,8 @@ users:
 			Expect(seedClient.Create(ctx, deployment)).To(Succeed())
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 
+			kubeAPIServer.EXPECT().SetAutoscalingReplicas(gomock.Any())
+
 			Expect(botanist.ScaleKubeAPIServerToOne(ctx)).To(Succeed())
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())


### PR DESCRIPTION
/kind bug
/area control-plane

Cherry pick of #11397 on release-v1.110.

#11397: Scale kube-apiserver after switching to node-agent-authorizer

**Release Notes:**
```bugfix operator
Fixed a bug that caused the Gardenlet to crash when deleting a hibernated shoot if the NodeAgentAuthorizer feature gate was enabled
```