### PR TITLE
Make observability components deployment depending on GRM

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -293,6 +293,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Dependencies: flow.NewTaskIDs(waitUntilRequiredExtensionsReady),
 		})
 		syncPointReadyForSystemComponents = flow.NewTaskIDs(
+			deployGardenerResourceManager,
 			deployClusterIdentity,
 			cleanupOrphanedExposureClassHandlers,
 		)
@@ -453,16 +454,19 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 		})
 		_ = g.Add(flow.Task{
-			Name: "Deploying seed Prometheus",
-			Fn:   c.seedPrometheus.Deploy,
+			Name:         "Deploying seed Prometheus",
+			Fn:           c.seedPrometheus.Deploy,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 		})
 		_ = g.Add(flow.Task{
-			Name: "Deploying aggregate Prometheus",
-			Fn:   c.aggregatePrometheus.Deploy,
+			Name:         "Deploying aggregate Prometheus",
+			Fn:           c.aggregatePrometheus.Deploy,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 		})
 		_ = g.Add(flow.Task{
-			Name: "Deploying Alertmanager",
-			Fn:   c.alertManager.Deploy,
+			Name:         "Deploying Alertmanager",
+			Fn:           c.alertManager.Deploy,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 		})
 	)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
Otherwise, we'll see logs like in
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11399/pull-gardener-integration/1891433205781762048:

```
  {"level":"error","ts":"2025-02-17T10:28:56.343Z","msg":"Error","controller":"seed","namespace":"","name":"seed-garden-8vvgd","reconcileID":"7fe71584-0187-49eb-9028-455058206239","flow":"Seed reconciliation","task":"Deploying Alertmanager","error":"could not get managed resource 'garden-8vvgd/alertmanager-seed': no matches for kind \"ManagedResource\" in version \"resources.gardener.cloud/v1alpha1\"","stacktrace":"github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func2\n\t/home/prow/go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:239"}
```

Part of https://github.com/gardener/gardener/issues/11386

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
