### PR TITLE
[GEP-30] Prevent ACL extension incompatibility

### DIFF
--- a/docs/proposals/30-apiserver-proxy.md
+++ b/docs/proposals/30-apiserver-proxy.md
@@ -277,8 +277,9 @@ For the detailed implementation steps, see the corresponding [umbrella issue](ht
 The first part is related to reworking the API server proxy to drop the proxy protocol:
 
 1. Prepare the existing VPN network infrastructure for reuse by the API server proxy.
-   - Handle the new `X-Gardener-Destination` header as described in [this section](#reconfiguring-the-istio-ingress-gateway).
+   - Extend the header matcher for the `Reversed-VPN` header to also allow the API server as a valid destination.
 2. Reconfigure the API server proxy as described in [this section](#reconfiguring-the-api-server-proxy).
+   - Reuse the existing `Reversed-VPN` header for now to keep backward compatibility with the ACL extension.
    - Report a new constraint `APIServerProxyUsesHTTPProxy` in the `Shoot` status once the API server proxy has been reconfigured to use the new protocol.
    - Can be released together with the previous step.
 3. Introduce a new feature gate `RemoveAPIServerProxyLegacyPort` to gardenlet.
@@ -291,7 +292,7 @@ After these steps, the proxy protocol is no longer used and the related network 
 The remaining steps are related to unifying the HTTP proxy infrastructure:
 
 1. Introduce the unified HTTP proxy network infrastructure as described in [this section](#unifying-the-http-proxy-infrastructure).
-   - Reconfigure the API server proxy and shoot VPN client to connect to the unified port.
+   - Reconfigure the API server proxy and shoot VPN client to connect to the unified port using the new `X-Gardener-Destination` header.
    - Report a new constraint `UsesUnifiedHTTPProxyPort` in the `Shoot` status once both components have been reconfigured to use the new port.
 2. Introduce a new feature gate `RemoveHTTPProxyLegacyPort` to gardenlet.
    - If enabled, gardenlet removes the old HTTP proxy network infrastructure on the seed side (ingress gateway port `tls-tunnel`, `Gateway`, `EnvoyFilter`, etc.)

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -270,7 +270,7 @@ var _ = Describe("APIServerProxy", func() {
 
 		Context("IPv4", func() {
 			It("should deploy the managed resource successfully", func() {
-				test("d383e1bb")
+				test("6049033b")
 			})
 		})
 
@@ -281,7 +281,7 @@ var _ = Describe("APIServerProxy", func() {
 			})
 
 			It("should deploy the managed resource successfully", func() {
-				test("331c4e9c")
+				test("5460b295")
 			})
 		})
 	})
@@ -469,7 +469,7 @@ static_resources:
             hostname: "api.internal.local.:443"
             headers_to_add:
             - header:
-                key: X-Gardener-Destination
+                key: Reversed-VPN
                 value: "outbound|443||kube-apiserver.shoot--internal--internal.svc.cluster.local"
           access_log:
           - name: envoy.access_loggers.stdout

--- a/pkg/component/networking/apiserverproxy/templates/envoy.yaml.tpl
+++ b/pkg/component/networking/apiserverproxy/templates/envoy.yaml.tpl
@@ -56,7 +56,7 @@ static_resources:
             hostname: "{{ .proxySeedServerHost }}:443"
             headers_to_add:
             - header:
-                key: X-Gardener-Destination
+                key: Reversed-VPN
                 value: "outbound|443||kube-apiserver.{{ .seedNamespace }}.svc.cluster.local"
           access_log:
           - name: envoy.access_loggers.stdout

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -32,21 +32,9 @@ spec:
                     - name: Reversed-VPN
                       string_match:
                         safe_regex:
-                          regex: '^outbound\|1194\|\|vpn-seed-server(-[0-4])?\..*\.svc\.cluster\.local$'
-                route:
-                  cluster_header: Reversed-VPN
-                  upgrade_configs:
-                  - connect_config: {}
-                    upgrade_type: CONNECT
-              - match:
-                  connect_matcher: {}
-                  headers:
-                    - name: X-Gardener-Destination
-                      string_match:
-                        safe_regex:
                           regex: '^outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local$'
                 route:
-                  cluster_header: X-Gardener-Destination
+                  cluster_header: Reversed-VPN
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT

--- a/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -31,21 +31,9 @@ spec:
                     - name: Reversed-VPN
                       string_match:
                         safe_regex:
-                          regex: '^outbound\|1194\|\|vpn-seed-server(-[0-4])?\..*\.svc\.cluster\.local$'
-                route:
-                  cluster_header: Reversed-VPN
-                  upgrade_configs:
-                  - connect_config: {}
-                    upgrade_type: CONNECT
-              - match:
-                  connect_matcher: {}
-                  headers:
-                    - name: X-Gardener-Destination
-                      string_match:
-                        safe_regex:
                           regex: '^outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local$'
                 route:
-                  cluster_header: X-Gardener-Destination
+                  cluster_header: Reversed-VPN
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR fixes an oversight introduced with https://github.com/gardener/gardener/pull/11364
The mentioned PR reconfigures the API server proxy to use HTTP Connect instead of Proxy Protocol. It already starts using the new X-Gardener-Destination header and allows using it on the existing Istio tls-tunnel port for the VPN connection (EnvoyFilter reversed-vpn).

The current version of the ACL extension (https://github.com/stackitcloud/gardener-extension-acl/releases/tag/v1.5.0) adds an inverse matcher to the HTTP Connect path that allows all requests that don't match the shoots-specific Reversed-VPN header value: [https://github.com/stackitcloud/gardener-extension-acl/blob/2533753cdf8a01ae74cc96[…]g/envoyfilters/testdata/vpnEnvoyFilterSpecWithOneAllowRule.yaml](https://github.com/stackitcloud/gardener-extension-acl/blob/2533753cdf8a01ae74cc96637f8ace467574f493/pkg/envoyfilters/testdata/vpnEnvoyFilterSpecWithOneAllowRule.yaml#L16-L26). This exists because we don't want to block traffic for other shoots.

We are unsure what Envoy does if the Reversed-VPN header is not present, but the X-Gardener-Destination header has a valid value. Either Envoy allows all traffic or no traffic at all. I.e., either there is a new vulnerability (ACL config can be circumvented) or a disruption (API server proxy cannot connect to API server anymore).

Both cases would be – to say the least – unfortunate.


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:
Ideally, we should not release g/g@v1.113 without this change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
