### PR TITLE
Consistently set shoot creation timeout to `30m` for all e2e tests

### DIFF
--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -57,7 +57,7 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 
 	It("Create Shoot, Create ManagedSeed, Delete ManagedSeed, Delete Shoot", func() {
 		By("Create Shoot")
-		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+		ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 		defer cancel()
 
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())

--- a/test/e2e/gardener/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/gardener/shoot/create_and_delete_hibernated.go
@@ -27,7 +27,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 		It("Create and Delete Hibernated Shoot", Offset(1), Label("hibernated"), func() {
 			By("Create Shoot")
-			ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()

--- a/test/e2e/gardener/shoot/create_and_force_delete.go
+++ b/test/e2e/gardener/shoot/create_and_force_delete.go
@@ -26,7 +26,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 		It("Create and Force Delete Shoot", Label("force-delete"), func() {
 			By("Create Shoot")
-			ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -34,7 +34,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		f.Shoot = shoot
 
 		It("Create, Hibernate, Wake up and Delete Shoot", Offset(1), func() {
-			ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 
 			if shoot.Spec.CloudProfileName == nil && shoot.Spec.CloudProfile != nil && shoot.Spec.CloudProfile.Kind == "NamespacedCloudProfile" {

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -30,8 +30,9 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 
 		It("Create, Migrate and Delete", Offset(1), func() {
 			By("Create Shoot")
-			ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
+
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -212,7 +212,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		f.Shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = ptr.To(true)
 
 		It("Create Shoot, Rotate Credentials and Delete Shoot", Offset(1), Label("credentials-rotation"), func() {
-			ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
+			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 
 			By("Create Shoot")

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -57,6 +57,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			By("Create Shoot")
 			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
+
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 

--- a/test/e2e/gardener/shoot/internal/shoot.go
+++ b/test/e2e/gardener/shoot/internal/shoot.go
@@ -112,7 +112,7 @@ func ItShouldWaitForShootToBeReconciledAndHealthy(s *ShootContext) {
 		}).WithPolling(30 * time.Second).Should(BeTrue())
 
 		s.Log.Info("Shoot has been reconciled and is healthy")
-	}, SpecTimeout(15*time.Minute))
+	}, SpecTimeout(30*time.Minute))
 }
 
 // ItShouldWaitForShootToBeDeleted waits for the shoot to be gone. If an existing shoot is specified, the step is

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
@@ -27,7 +27,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 
 		It("Create, Upgrade (non-HA to HA with failure tolerance type 'node') and Delete Shoot", Offset(1), func() {
 			By("Create Shoot")
-			ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/10781, `kube-apiserver`s might be rolled multiple times. The additional time this causes leads to reaching the timeout of `15m` sometimes ([example](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11397/pull-gardener-e2e-kind-migration-ha-single-zone/1891423071252779008)).
Let's increase the timeout to `30m` consistently for all tests to be on the safe side and reduce flakes.

Part of https://github.com/gardener/gardener/issues/11386

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
