### PR TITLE
Fix interval parameter for `gardenlet` certificate rotation retrier

### DIFF
--- a/pkg/gardenlet/bootstrap/bootstrap_test.go
+++ b/pkg/gardenlet/bootstrap/bootstrap_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Bootstrap", func() {
 				Build()
 
 			_, _, _, err := RequestKubeconfigWithBootstrapClient(ctx, testLogger, seedClient, bootstrapClientSet, kubeconfigKey, bootstrapKubeconfigKey, seedName, nil)
-			Expect(err).To(MatchError(ContainSubstring("request is denied")))
+			Expect(err).To(MatchError(ContainSubstring("is denied")))
 		})
 
 		It("should return an error - the CSR failed", func() {
@@ -230,7 +230,7 @@ var _ = Describe("Bootstrap", func() {
 				Build()
 
 			_, _, _, err := RequestKubeconfigWithBootstrapClient(ctx, testLogger, seedClient, bootstrapClientSet, kubeconfigKey, bootstrapKubeconfigKey, seedName, nil)
-			Expect(err).To(MatchError(ContainSubstring("request failed")))
+			Expect(err).To(MatchError(ContainSubstring("failed")))
 		})
 	})
 

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Certificates", func() {
 			mockGardenInterface.EXPECT().Kubernetes().Return(kubeClient)
 
 			err := rotateCertificate(ctx, log, mockGardenInterface, mockSeedClient, gardenClientConnection, &certificateSubject, []string{}, []net.IP{})
-			Expect(err).To(MatchError(ContainSubstring("request is denied")))
+			Expect(err).To(MatchError(ContainSubstring("is denied")))
 		})
 
 		It("should return an error - CSR is failed", func() {
@@ -195,7 +195,7 @@ var _ = Describe("Certificates", func() {
 			mockGardenInterface.EXPECT().Kubernetes().Return(kubeClient)
 
 			err := rotateCertificate(ctx, log, mockGardenInterface, mockSeedClient, gardenClientConnection, &certificateSubject, []string{}, []net.IP{})
-			Expect(err).To(MatchError(ContainSubstring("request failed")))
+			Expect(err).To(MatchError(ContainSubstring("failed")))
 		})
 
 		It("should return an error - the CN of the x509 cert to be rotated is not set", func() {

--- a/pkg/utils/kubernetes/certificatesigningrequest/certificate_test.go
+++ b/pkg/utils/kubernetes/certificatesigningrequest/certificate_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Certificate", func() {
 			}(ctx)
 
 			_, _, _, err := RequestCertificate(ctx, log, clientSet, certificateSubject, dnsSANs, ipSANs, validityDuration, csrPrefix)
-			Expect(err).To(MatchError(ContainSubstring("certificate signing request is denied")))
+			Expect(err).To(MatchError(ContainSubstring("is denied")))
 		}, NodeTimeout(time.Second*5))
 
 		It("should return an error if the CSR failed", func(ctx context.Context) {
@@ -143,7 +143,7 @@ var _ = Describe("Certificate", func() {
 			}(ctx)
 
 			_, _, _, err := RequestCertificate(ctx, log, clientSet, certificateSubject, dnsSANs, ipSANs, validityDuration, csrPrefix)
-			Expect(err).To(MatchError(ContainSubstring("certificate signing request failed")))
+			Expect(err).To(MatchError(ContainSubstring("failed")))
 		}, NodeTimeout(time.Second*5))
 	})
 })

--- a/test/integration/nodeagent/certificate/certificate_test.go
+++ b/test/integration/nodeagent/certificate/certificate_test.go
@@ -63,7 +63,7 @@ var _ = Describe("RequestAndStoreKubeconfig", func() {
 			}).Should(Succeed())
 		}(ctx)
 
-		Expect(nodeagent.RequestAndStoreKubeconfig(ctx, log, fs, nodeAgentUser.Config(), machineName)).To(MatchError(ContainSubstring("certificate signing request is denied")))
+		Expect(nodeagent.RequestAndStoreKubeconfig(ctx, log, fs, nodeAgentUser.Config(), machineName)).To(MatchError(ContainSubstring("is denied")))
 	})
 
 	It("should handle a failed CSR", func(ctx context.Context) {
@@ -74,7 +74,7 @@ var _ = Describe("RequestAndStoreKubeconfig", func() {
 			}).Should(Succeed())
 		}(ctx)
 
-		Expect(nodeagent.RequestAndStoreKubeconfig(ctx, log, fs, nodeAgentUser.Config(), machineName)).To(MatchError(ContainSubstring("certificate signing request failed")))
+		Expect(nodeagent.RequestAndStoreKubeconfig(ctx, log, fs, nodeAgentUser.Config(), machineName)).To(MatchError(ContainSubstring("failed")))
 	})
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
When the certificate rotation fails, we have previously only retried after `15m` because we were using the timeout value as interval parameter. This can cause our e2e tests to fail.

Example: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11409/pull-gardener-e2e-kind/1891406660476342272

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11386

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
