### PR TITLE
Use proper field path for dashboard oidc config

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1083,8 +1083,8 @@ spec:
                             - error
                             type: string
                           oidcConfig:
-                            description: OIDC contains configuration for the OIDC
-                              provider. This field must be provided when EnableTokenLogin
+                            description: OIDCConfig contains configuration for the
+                              OIDC provider. This field must be provided when EnableTokenLogin
                               is false.
                             properties:
                               additionalScopes:

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -2144,7 +2144,7 @@ DashboardOIDC
 </td>
 <td>
 <em>(Optional)</em>
-<p>OIDC contains configuration for the OIDC provider. This field must be provided when EnableTokenLogin is false.</p>
+<p>OIDCConfig contains configuration for the OIDC provider. This field must be provided when EnableTokenLogin is false.</p>
 </td>
 </tr>
 <tr>

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1083,8 +1083,8 @@ spec:
                             - error
                             type: string
                           oidcConfig:
-                            description: OIDC contains configuration for the OIDC
-                              provider. This field must be provided when EnableTokenLogin
+                            description: OIDCConfig contains configuration for the
+                              OIDC provider. This field must be provided when EnableTokenLogin
                               is false.
                             properties:
                               additionalScopes:

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -590,9 +590,9 @@ type GardenerDashboardConfig struct {
 	// +kubebuilder:default=info
 	// +optional
 	LogLevel *string `json:"logLevel,omitempty"`
-	// OIDC contains configuration for the OIDC provider. This field must be provided when EnableTokenLogin is false.
+	// OIDCConfig contains configuration for the OIDC provider. This field must be provided when EnableTokenLogin is false.
 	// +optional
-	OIDC *DashboardOIDC `json:"oidcConfig,omitempty"`
+	OIDCConfig *DashboardOIDC `json:"oidcConfig,omitempty"`
 	// Terminal contains configuration for the terminal settings.
 	// +optional
 	Terminal *DashboardTerminal `json:"terminal,omitempty"`

--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -410,15 +410,15 @@ func validateGardenerDashboardConfig(config *operatorv1alpha1.GardenerDashboardC
 		return allErrs
 	}
 
-	if !ptr.Deref(config.EnableTokenLogin, true) && config.OIDC == nil {
+	if !ptr.Deref(config.EnableTokenLogin, true) && config.OIDCConfig == nil {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableTokenLogin"), "OIDC must be configured when token login is disabled"))
 	}
 
-	if oidc := config.OIDC; oidc != nil {
+	if oidc := config.OIDCConfig; oidc != nil {
 		oidcPath := fldPath.Child("oidcConfig")
 
 		if kubeAPIServerConfig == nil || (kubeAPIServerConfig.OIDCConfig == nil && kubeAPIServerConfig.StructuredAuthentication == nil) {
-			allErrs = append(allErrs, field.Invalid(oidcPath, config.OIDC, "must set OIDC configuration in .spec.virtualCluster.kubernetes.kubeAPIServer when configuring OIDC config for dashboard"))
+			allErrs = append(allErrs, field.Invalid(oidcPath, config.OIDCConfig, "must set OIDC configuration in .spec.virtualCluster.kubernetes.kubeAPIServer when configuring OIDC config for dashboard"))
 		}
 
 		if oidc.IssuerURL == nil {

--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -415,7 +415,7 @@ func validateGardenerDashboardConfig(config *operatorv1alpha1.GardenerDashboardC
 	}
 
 	if oidc := config.OIDC; oidc != nil {
-		oidcPath := fldPath.Child("oidc")
+		oidcPath := fldPath.Child("oidcConfig")
 
 		if kubeAPIServerConfig == nil || (kubeAPIServerConfig.OIDCConfig == nil && kubeAPIServerConfig.StructuredAuthentication == nil) {
 			allErrs = append(allErrs, field.Invalid(oidcPath, config.OIDC, "must set OIDC configuration in .spec.virtualCluster.kubernetes.kubeAPIServer when configuring OIDC config for dashboard"))

--- a/pkg/apis/operator/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation_test.go
@@ -1974,7 +1974,7 @@ var _ = Describe("Validation Tests", func() {
 
 					Context("OIDC config", func() {
 						It("should complain when OIDC config is configured while it is unset in kube-apiserver config", func() {
-							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{}}
+							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDCConfig: &operatorv1alpha1.DashboardOIDC{}}
 
 							Expect(ValidateGarden(garden)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 								"Type":  Equal(field.ErrorTypeInvalid),
@@ -1983,7 +1983,7 @@ var _ = Describe("Validation Tests", func() {
 						})
 
 						It("should complain when clientID is missing in OIDC config", func() {
-							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{
+							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDCConfig: &operatorv1alpha1.DashboardOIDC{
 								IssuerURL: ptr.To("https://example.com"),
 							}}
 
@@ -1994,7 +1994,7 @@ var _ = Describe("Validation Tests", func() {
 						})
 
 						It("should complain when clientID is missing in OIDC config but given in kube-apiserver config", func() {
-							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{
+							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDCConfig: &operatorv1alpha1.DashboardOIDC{
 								IssuerURL: ptr.To("https://example.com"),
 							}}
 							garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{OIDCConfig: &gardencorev1beta1.OIDCConfig{
@@ -2008,7 +2008,7 @@ var _ = Describe("Validation Tests", func() {
 						})
 
 						It("should complain when issuerURL is missing in OIDC config", func() {
-							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{
+							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDCConfig: &operatorv1alpha1.DashboardOIDC{
 								ClientIDPublic: ptr.To("my-client-id"),
 							}}
 
@@ -2019,7 +2019,7 @@ var _ = Describe("Validation Tests", func() {
 						})
 
 						It("should complain when issuerURL is missing in OIDC config but given in kube-apiserver config", func() {
-							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{
+							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDCConfig: &operatorv1alpha1.DashboardOIDC{
 								ClientIDPublic: ptr.To("my-client-id"),
 							}}
 							garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{OIDCConfig: &gardencorev1beta1.OIDCConfig{
@@ -2034,7 +2034,7 @@ var _ = Describe("Validation Tests", func() {
 
 						It("should not complain when OIDC config is configured in both gardener-dashboard and kube-apiserver via structured authentication", func() {
 							garden.Spec.VirtualCluster.Kubernetes.Version = "1.30.0"
-							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{
+							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDCConfig: &operatorv1alpha1.DashboardOIDC{
 								IssuerURL:      ptr.To("https://example.com"),
 								ClientIDPublic: ptr.To("my-client-id"),
 							}}
@@ -2046,7 +2046,7 @@ var _ = Describe("Validation Tests", func() {
 						})
 
 						It("should not complain when OIDC config is configured in both gardener-dashboard and kube-apiserver via OIDC config", func() {
-							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{
+							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDCConfig: &operatorv1alpha1.DashboardOIDC{
 								IssuerURL:      ptr.To("https://example.com"),
 								ClientIDPublic: ptr.To("my-client-id"),
 							}}
@@ -2056,7 +2056,7 @@ var _ = Describe("Validation Tests", func() {
 						})
 
 						It("should not complain when OIDC config is configured in both gardener-dashboard and kube-apiserver via OIDC config IssuerURL and ClientID", func() {
-							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDC: &operatorv1alpha1.DashboardOIDC{}}
+							garden.Spec.VirtualCluster.Gardener.Dashboard = &operatorv1alpha1.GardenerDashboardConfig{OIDCConfig: &operatorv1alpha1.DashboardOIDC{}}
 							garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{OIDCConfig: &gardencorev1beta1.OIDCConfig{
 								IssuerURL: ptr.To("https://example.com"),
 								ClientID:  ptr.To("my-client-id"),

--- a/pkg/apis/operator/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation_test.go
@@ -1978,7 +1978,7 @@ var _ = Describe("Validation Tests", func() {
 
 							Expect(ValidateGarden(garden)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 								"Type":  Equal(field.ErrorTypeInvalid),
-								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidc"),
+								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidcConfig"),
 							}))))
 						})
 
@@ -1989,7 +1989,7 @@ var _ = Describe("Validation Tests", func() {
 
 							Expect(ValidateGarden(garden)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 								"Type":  Equal(field.ErrorTypeRequired),
-								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidc.clientIDPublic"),
+								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidcConfig.clientIDPublic"),
 							}))))
 						})
 
@@ -2003,7 +2003,7 @@ var _ = Describe("Validation Tests", func() {
 
 							Expect(ValidateGarden(garden)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 								"Type":  Equal(field.ErrorTypeRequired),
-								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidc.clientIDPublic"),
+								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidcConfig.clientIDPublic"),
 							}))))
 						})
 
@@ -2014,7 +2014,7 @@ var _ = Describe("Validation Tests", func() {
 
 							Expect(ValidateGarden(garden)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 								"Type":  Equal(field.ErrorTypeRequired),
-								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidc.issuerURL"),
+								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidcConfig.issuerURL"),
 							}))))
 						})
 
@@ -2028,7 +2028,7 @@ var _ = Describe("Validation Tests", func() {
 
 							Expect(ValidateGarden(garden)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 								"Type":  Equal(field.ErrorTypeRequired),
-								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidc.issuerURL"),
+								"Field": Equal("spec.virtualCluster.gardener.gardenerDashboard.oidcConfig.issuerURL"),
 							}))))
 						})
 

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -1057,8 +1057,8 @@ func (in *GardenerDashboardConfig) DeepCopyInto(out *GardenerDashboardConfig) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.OIDC != nil {
-		in, out := &in.OIDC, &out.OIDC
+	if in.OIDCConfig != nil {
+		in, out := &in.OIDCConfig, &out.OIDCConfig
 		*out = new(DashboardOIDC)
 		(*in).DeepCopyInto(*out)
 	}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1098,19 +1098,19 @@ func (r *Reconciler) newGardenerDashboard(garden *operatorv1alpha1.Garden, secre
 			values.Terminal = &gardenerdashboard.TerminalValues{DashboardTerminal: *config.Terminal}
 		}
 
-		if config.OIDC != nil {
-			issuerURL := config.OIDC.IssuerURL
+		if config.OIDCConfig != nil {
+			issuerURL := config.OIDCConfig.IssuerURL
 			if issuerURL == nil {
 				issuerURL = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.OIDCConfig.IssuerURL
 			}
 
-			clientIDPublic := config.OIDC.ClientIDPublic
+			clientIDPublic := config.OIDCConfig.ClientIDPublic
 			if clientIDPublic == nil {
 				clientIDPublic = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.OIDCConfig.ClientID
 			}
 
 			values.OIDC = &gardenerdashboard.OIDCValues{
-				DashboardOIDC:  *config.OIDC,
+				DashboardOIDC:  *config.OIDCConfig,
 				IssuerURL:      *issuerURL,
 				ClientIDPublic: *clientIDPublic,
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/blob/7f803b6effd28611d825ffccd3c7b024a58a6462/pkg/apis/operator/v1alpha1/types_garden.go#L590

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @timuthy @petersutter 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A misleading error message appearing when an operator has wrongly configured OIDC config for the Gardener Dashboard in the Garden resource was fixed.
```
