### PR TITLE
Auto-remediate duplicate node ports in same service

### DIFF
--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -128,7 +128,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if err := r.Client.Patch(ctx, service, patch); err != nil {
-		if apierrors.IsInvalid(err) && strings.Contains(err.Error(), "port is already allocated") {
+		if (apierrors.IsInvalid(err) && strings.Contains(err.Error(), "port is already allocated")) ||
+			// for some reason this error is not of type "Invalid"
+			strings.Contains(err.Error(), "duplicate nodePort") {
 			log.Info("Patching nodePort failed because it is already allocated, enabling auto-remediation")
 			return reconcile.Result{Requeue: true}, r.remediateAllocatedNodePorts(ctx, log)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
In the rarest of all corner cases (see
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11400/pull-gardener-e2e-kind-operator-seed/1891835661812502528), it can happen that one of our hard-coded node ports is already allocated within the same `Service` (e.g., `istio-ingressgateway` `Service` has 3 ports, and one of them (not `tls`) could already use 30443).

In such a case, provider-local's auto-remediation logic does not trigger because the error message does not match (it only matches when ANOTHER `Service` allocates our hard-coded node port): https://github.com/gardener/gardener/blob/3c1157fe3a713647e3ceba4555c5619014f2cf0f/pkg/controller/service/reconciler.go#L131

This PR augments the error matching with the message that we receive for the rarest corner case (see also
https://github.com/kubernetes/kubernetes/blob/931ad2a9fdedaf1e47126f5b3e5880eb3708bfb2/pkg/registry/core/service/storage/alloc.go#L837).

Part of https://github.com/gardener/gardener/issues/11386

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
