### PR TITLE
[GEP-30] Add `UseUnifiedHTTPProxyPort` feature gate to rollout plan

### DIFF
--- a/docs/proposals/30-apiserver-proxy.md
+++ b/docs/proposals/30-apiserver-proxy.md
@@ -291,13 +291,15 @@ The first part is related to reworking the API server proxy to drop the proxy pr
 After these steps, the proxy protocol is no longer used and the related network infrastructure (including the `proxy` port 8443) is removed.
 The remaining steps are related to unifying the HTTP proxy infrastructure:
 
-1. Introduce the unified HTTP proxy network infrastructure as described in [this section](#unifying-the-http-proxy-infrastructure).
-   - Reconfigure the API server proxy and shoot VPN client to connect to the unified port using the new `X-Gardener-Destination` header.
-   - Report a new constraint `UsesUnifiedHTTPProxyPort` in the `Shoot` status once both components have been reconfigured to use the new port.
-2. Introduce a new feature gate `RemoveHTTPProxyLegacyPort` to gardenlet.
+1. Introduce a new feature gate `UseUnifiedHTTPProxyPort` to gardenlet.
+   - If enabled, gardenlet sets up the unified HTTP proxy network infrastructure as described in [this section](#unifying-the-http-proxy-infrastructure). It also reconfigures the API server proxy and shoot VPN client to connect to the unified port using the new `X-Gardener-Destination` header.
+   - Report a new constraint `UsesUnifiedHTTPProxyPort` in the `Shoot` status once both shoot components have been reconfigured to use the new port.
+2. Graduate the `UseUnifiedHTTPProxyPort` feature gate.
+   - Before the feature gate can be enabled or graduated to beta, the ACL extension needs to be adapted to handle the new `http-proxy` port.
+3. Introduce a new feature gate `RemoveHTTPProxyLegacyPort` to gardenlet.
    - If enabled, gardenlet removes the old HTTP proxy network infrastructure on the seed side (ingress gateway port `tls-tunnel`, `Gateway`, `EnvoyFilter`, etc.)
    - The gardenlet only allows activating the feature gate if all shoot clusters on its seed cluster report that the API server proxy and shoot VPN client have been reconfigured.
-3. Graduate the `RemoveHTTPProxyLegacyPort` feature gate to GA and lock to `True`.
+4. Graduate the `RemoveHTTPProxyLegacyPort` feature gate to GA and lock to `True`.
    - Remove the `UsesUnifiedHTTPProxyPort` constraint in the `Shoot` status.
 
 After these steps, the legacy VPN network infrastructure on the seed side (including the `tls-tunnel` port 8132) is removed. Instead, the unifying infrastructure using the `http-proxy` port 8443 is used.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

This PR refines the GEP-30 rollout plan by adding an additional feature gate `UseUnifiedHTTPProxyPort`.
The umbrella issue has been updated accordingly.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:

- [x] In draft until https://github.com/gardener/gardener/pull/11429 has been merged, because that PR changes the same GEP section.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
