### PR TITLE
Ensure `istio-system` namespace is gone after delete

### DIFF
--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -635,6 +635,9 @@ var _ = Describe("Seed controller tests", func() {
 						DeferCleanup(func() {
 							Expect(applier.DeleteManifest(ctx, managedResourceCRDReader)).To(Succeed())
 							Expect(testClient.Delete(ctx, istioSystemNamespace)).To(Succeed())
+							Eventually(func() error {
+								return testClient.Get(ctx, client.ObjectKeyFromObject(istioSystemNamespace), istioSystemNamespace)
+							}).Should(BeNotFoundError())
 							Expect(istioCRDs.Destroy(ctx)).To(Succeed())
 							Expect(vpaCRD.Destroy(ctx)).To(Succeed())
 							Expect(fluentCRD.Destroy(ctx)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
The test fails because `istio-system` namespace already exists, this PR ensures that the namespace is gone before the next test starts.

Failure Links - 
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/batch/pull-gardener-integration/1891842958307627008
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11413/pull-gardener-integration/1891805585054109696
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11401/pull-gardener-integration/1891659367674023936

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11386

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
