### PR TITLE
Add apiserver_request_total metric to the longterm prometheus instance

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
@@ -39,6 +39,7 @@ func CentralServiceMonitors() []*monitoringv1.ServiceMonitor {
 							`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,
 							`{__name__="kubeproxy_network_latency:quantile"}`,
 							`{__name__="kubeproxy_sync_proxy:quantile"}`,
+							`{__name__="apiserver_request_total"}`,
 						},
 					},
 					Port: prometheus.ServicePortName,

--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors_test.go
@@ -38,6 +38,7 @@ var _ = Describe("ServiceMonitors", func() {
 								`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,
 								`{__name__="kubeproxy_network_latency:quantile"}`,
 								`{__name__="kubeproxy_sync_proxy:quantile"}`,
+								`{__name__="apiserver_request_total"}`,
 							},
 						},
 						Port: "web",

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -68,6 +68,7 @@ func CentralScrapeConfigs(prometheusAggregateTargets []monitoringv1alpha1.Target
 						`{__name__="seed:persistentvolume:inconsistent_size"}`,
 						`{__name__="seed:kube_pod_container_status_restarts_total:max_by_namespace"}`,
 						`{__name__=~"metering:.+:(sum_by_namespace|sum_by_instance_type)"}`,
+						`{__name__="apiserver_request_total"}`,
 					},
 				},
 				TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
@@ -120,6 +120,7 @@ metric_relabel_configs:
 									`{__name__="seed:persistentvolume:inconsistent_size"}`,
 									`{__name__="seed:kube_pod_container_status_restarts_total:max_by_namespace"}`,
 									`{__name__=~"metering:.+:(sum_by_namespace|sum_by_instance_type)"}`,
+									`{__name__="apiserver_request_total"}`,
 								},
 							},
 							TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
@@ -62,7 +62,7 @@ func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
 						`{__name__="garden_seed_usage"}`,
 						`{__name__="garden_seed_capacity"}`,
 						`{__name__="etcdbr_snapshot_duration_seconds_count"}`,
-						`{__name__="apiserver_request_total", job="virtual-garden-kube-apiserver"}`,
+						`{__name__="apiserver_request_total"}`,
 					},
 				},
 				StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: []monitoringv1alpha1.Target{"prometheus-" + garden.Label}}},

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
@@ -63,7 +63,7 @@ var _ = Describe("PrometheusRules", func() {
 								`{__name__="garden_seed_usage"}`,
 								`{__name__="garden_seed_capacity"}`,
 								`{__name__="etcdbr_snapshot_duration_seconds_count"}`,
-								`{__name__="apiserver_request_total", job="virtual-garden-kube-apiserver"}`,
+								`{__name__="apiserver_request_total"}`,
 							},
 						},
 						StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: []monitoringv1alpha1.Target{"prometheus-garden"}}},


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR Federate apiserver_request_total metric to the aggregate prometheus instance

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is related to the Argus project and we had a few back and forth with @rickardsjp regarding this topic. 
cc.: @etiennnr 

**Release note**:

```other operator
Add apiserver_request_total metric to the longterm prometheus instance
```
