### PR TITLE
e2e: refactor `Create and Delete Hibernated Shoot` test to ordered containers

### DIFF
--- a/test/e2e/gardener/context.go
+++ b/test/e2e/gardener/context.go
@@ -85,8 +85,10 @@ func (t *TestContext) ForShoot(shoot *gardencorev1beta1.Shoot) *ShootContext {
 }
 
 // ShootContext is a test case-specific TestContext that carries test state and helpers through multiple steps of the
-// same test case, i.e., within the same ordered container. Accordingly, ShootContext values must not be reused across
-// multiple test cases (ordered containers).
+// same test case, i.e., within the same ordered container.
+// Accordingly, ShootContext values must not be reused across multiple test cases (ordered containers). Make sure to
+// declare ShootContext variables within the ordered container and initialize them during ginkgo tree construction,
+// e.g., in a BeforeTestSetup node or when invoking a shared `test` func.
 //
 // A ShootContext can be initialized using TestContext.ForShoot.
 type ShootContext struct {

--- a/test/e2e/gardener/context.go
+++ b/test/e2e/gardener/context.go
@@ -105,6 +105,20 @@ type ShootContext struct {
 	//    HaveField("Items", HaveLen(1)),
 	//  )
 	ShootKomega komega.Komega
+
+	// Seed is the responsible Seed of the shoot.
+	Seed *gardencorev1beta1.Seed
+
+	// SeedClientSet is a client for the seed cluster. It must be initialized via WithSeedClientSet.
+	SeedClientSet kubernetes.Interface
+	// SeedClient is the controller-runtime client of the SeedClientSet. This is a more convenient equivalent of
+	// SeedClientSet.Client().
+	SeedClient client.Client
+	// SeedKomega is a Komega instance for writing assertions on objects in the seed cluster. E.g.,
+	//  Eventually(ctx, s.SeedKomega.ObjectList(&corev1.NodeList{})).Should(
+	//    HaveField("Items", HaveLen(1)),
+	//  )
+	SeedKomega komega.Komega
 }
 
 // WithShootClientSet initializes the shoot clients of this ShootContext from the given client set.
@@ -112,5 +126,13 @@ func (s *ShootContext) WithShootClientSet(clientSet kubernetes.Interface) *Shoot
 	s.ShootClientSet = clientSet
 	s.ShootClient = clientSet.Client()
 	s.ShootKomega = komega.New(s.ShootClient)
+	return s
+}
+
+// WithSeedClientSet initializes the seed clients of this ShootContext from the given client set.
+func (s *ShootContext) WithSeedClientSet(clientSet kubernetes.Interface) *ShootContext {
+	s.SeedClientSet = clientSet
+	s.SeedClient = clientSet.Client()
+	s.SeedKomega = komega.New(s.SeedClient)
 	return s
 }

--- a/test/e2e/gardener/shoot/create_and_delete_failed.go
+++ b/test/e2e/gardener/shoot/create_and_delete_failed.go
@@ -18,10 +18,10 @@ import (
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	var s *ShootContext
-
 	Describe("Create and Delete Failed Shoot", func() {
 		Context("Shoot with invalid DNS configuration", Ordered, func() {
+			var s *ShootContext
+
 			BeforeTestSetup(func() {
 				shoot := DefaultShoot("e2e-invalid-dns")
 				shoot.Spec.DNS = &gardencorev1beta1.DNS{

--- a/test/e2e/gardener/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/gardener/shoot/create_and_delete_hibernated.go
@@ -5,48 +5,52 @@
 package shoot
 
 import (
-	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	. "github.com/gardener/gardener/test/e2e"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+	. "github.com/gardener/gardener/test/e2e/gardener/shoot/internal"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	test := func(shoot *gardencorev1beta1.Shoot) {
-		f := defaultShootCreationFramework()
-		f.Shoot = shoot
+	Describe("Create and Delete Hibernated Shoot", Label("hibernated"), func() {
+		test := func(s *ShootContext) {
+			BeforeTestSetup(func() {
+				s.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+					Enabled: ptr.To(true),
+				}
+			})
 
-		f.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
-			Enabled: ptr.To(true),
+			ItShouldCreateShoot(s)
+			ItShouldWaitForShootToBeReconciledAndHealthy(s)
+			ItShouldGetResponsibleSeed(s)
+			ItShouldInitializeSeedClient(s)
+
+			It("should not have any control plane pods", func(ctx SpecContext) {
+				Eventually(ctx,
+					s.SeedKomega.ObjectList(&corev1.PodList{}, client.InNamespace(s.Shoot.Status.TechnicalID)),
+				).Should(
+					HaveField("Items", BeEmpty()),
+				)
+			}, SpecTimeout(time.Minute))
+
+			ItShouldDeleteShoot(s)
+			ItShouldWaitForShootToBeDeleted(s)
 		}
 
-		It("Create and Delete Hibernated Shoot", Offset(1), Label("hibernated"), func() {
-			By("Create Shoot")
-			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
-			defer cancel()
-			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
-			f.Verify()
-
-			By("Verify no running pods")
-			Expect(f.GardenerFramework.VerifyNoRunningPods(ctx, f.Shoot)).To(Succeed())
-
-			By("Delete Shoot")
-			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
-			defer cancel()
-			Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
+		Context("Shoot with workers", Ordered, func() {
+			test(NewTestContext().ForShoot(DefaultShoot("e2e-hib")))
 		})
-	}
 
-	Context("Shoot with workers", func() {
-		test(e2e.DefaultShoot("e2e-hib"))
-	})
-
-	Context("Workerless Shoot", Label("workerless"), func() {
-		test(e2e.DefaultWorkerlessShoot("e2e-hib"))
+		Context("Workerless Shoot", Label("workerless"), Ordered, func() {
+			test(NewTestContext().ForShoot(DefaultWorkerlessShoot("e2e-hib")))
+		})
 	})
 })

--- a/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
@@ -21,9 +21,9 @@ import (
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	var s *ShootContext
-
 	Describe("Create and Delete Unprivileged Shoot", Ordered, Label("unprivileged", "basic"), func() {
+		var s *ShootContext
+
 		BeforeTestSetup(func() {
 			shoot := DefaultShoot("e2e-unpriv")
 			shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{

--- a/test/e2e/gardener/shoot/internal/shoot.go
+++ b/test/e2e/gardener/shoot/internal/shoot.go
@@ -17,7 +17,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/gardener"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/framework"
@@ -92,7 +92,7 @@ func ItShouldDeleteShoot(s *ShootContext) {
 		s.Log.Info("Deleting Shoot")
 
 		Eventually(ctx, func(g Gomega) {
-			g.Expect(gardener.ConfirmDeletion(ctx, s.GardenClient, s.Shoot)).To(Succeed())
+			g.Expect(gardenerutils.ConfirmDeletion(ctx, s.GardenClient, s.Shoot)).To(Succeed())
 			g.Expect(s.GardenClient.Delete(ctx, s.Shoot)).To(Succeed())
 		}).Should(Succeed())
 	}, SpecTimeout(time.Minute))
@@ -162,7 +162,7 @@ func ItShouldGetResponsibleSeed(s *ShootContext) {
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(s.GardenKomega.Get(s.Shoot)()).To(Succeed())
 
-			s.Seed.Name = gardener.GetResponsibleSeedName(gardener.GetShootSeedNames(s.Shoot))
+			s.Seed.Name = gardenerutils.GetResponsibleSeedName(gardenerutils.GetShootSeedNames(s.Shoot))
 			g.Expect(s.Seed.Name).NotTo(BeEmpty())
 			g.Expect(s.GardenKomega.Get(s.Seed)()).To(Succeed())
 		}).Should(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR tackles the next e2e test refactoring. The `create_and_delete_hibernated.go` file is not much more complex than the previous tests in https://github.com/gardener/gardener/pull/11422, but it contains multiple test cases and uses seed clients.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:

While working on the file with multiple test cases, I noticed that declaring the `ShootContext` variable in a top-level container is a trap. The last commit reflects the learning in the `ShootContext` doc string and adapts the already refactored tests accordingly.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
