### PR TITLE
Expand e2e test suite timeout by `30m`

### DIFF
--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -160,4 +160,4 @@ case $TYPE in
     ;;
 esac
 
-GO111MODULE=on ginkgo run --timeout=1h $ginkgo_flags --v --show-node-events "$@"
+GO111MODULE=on ginkgo run --timeout=90m $ginkgo_flags --v --show-node-events "$@"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Follow-up of https://github.com/gardener/gardener/pull/11430 - if we increase individual timeouts, we should also increase the suite timeout.

Example flake:
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11442/pull-gardener-e2e-kind-ha-multi-zone/1892121870740754432
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11434/pull-gardener-e2e-kind-ha-single-zone/1891857808500985856
- and more

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11386
