### PR TITLE
[GEP-28] Refactor gardenadm unit tests to `gbytes.Buffer`

### DIFF
--- a/pkg/gardenadm/cmd/bootstrap/bootstrap_test.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap_test.go
@@ -5,30 +5,28 @@
 package bootstrap_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/bootstrap"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Bootstrap", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -39,9 +37,7 @@ var _ = Describe("Bootstrap", func() {
 
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented as well"))
+			Eventually(stdErr).Should(Say("Not implemented as well"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/cmd_suite_test.go
+++ b/pkg/gardenadm/cmd/cmd_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package cmd_test
+package cmd
 
 import (
 	"testing"

--- a/pkg/gardenadm/cmd/cmd_suite_test.go
+++ b/pkg/gardenadm/cmd/cmd_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package cmd
+package cmd_test
 
 import (
 	"testing"

--- a/pkg/gardenadm/cmd/connect/connect_test.go
+++ b/pkg/gardenadm/cmd/connect/connect_test.go
@@ -5,30 +5,28 @@
 package connect_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/connect"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Connect", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -37,9 +35,7 @@ var _ = Describe("Connect", func() {
 		It("should return the expected output", func() {
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented"))
+			Eventually(stdErr).Should(Say("Not implemented"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/discover/discover_test.go
+++ b/pkg/gardenadm/cmd/discover/discover_test.go
@@ -5,30 +5,28 @@
 package discover_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/discover"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Discover", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -39,9 +37,7 @@ var _ = Describe("Discover", func() {
 
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented"))
+			Eventually(stdErr).Should(Say("Not implemented"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/init/init_test.go
+++ b/pkg/gardenadm/cmd/init/init_test.go
@@ -5,30 +5,28 @@
 package init_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/init"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Init", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -37,9 +35,7 @@ var _ = Describe("Init", func() {
 		It("should return the expected output", func() {
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented"))
+			Eventually(stdErr).Should(Say("Not implemented"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/join/join_test.go
+++ b/pkg/gardenadm/cmd/join/join_test.go
@@ -5,30 +5,28 @@
 package join_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/join"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Join", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -37,9 +35,7 @@ var _ = Describe("Join", func() {
 		It("should return the expected output", func() {
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented either"))
+			Eventually(stdErr).Should(Say("Not implemented either"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/options.go
+++ b/pkg/gardenadm/cmd/options.go
@@ -18,10 +18,11 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 )
 
-// Exposed for testing. `logf.SetLogger` discards all calls after the first invocation and there is no way of telling
-// from the outside whether it was called at all. Without a func alias, we cannot verify that Options.Complete correctly
-// initialized the global controller-runtime logger.
-var logfSetLogger = logf.SetLogger
+// LogfSetLogger is an alias for logf.SetLogger for testing purposes.
+// logf.SetLogger discards all calls after the first invocation and there is no way of telling from the outside whether
+// it was called at all. Without a func alias, we cannot verify that Options.Complete correctly initialized the global
+// controller-runtime logger.
+var LogfSetLogger = logf.SetLogger
 
 // Options contains persistent options for all commands.
 type Options struct {
@@ -56,7 +57,7 @@ func (o *Options) Complete() error {
 		return fmt.Errorf("error instantiating zap logger: %w", err)
 	}
 
-	logfSetLogger(o.Log)
+	LogfSetLogger(o.Log)
 	klog.SetLogger(o.Log)
 	return nil
 }

--- a/pkg/gardenadm/cmd/options.go
+++ b/pkg/gardenadm/cmd/options.go
@@ -18,6 +18,11 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 )
 
+// Exposed for testing. `logf.SetLogger` discards all calls after the first invocation and there is no way of telling
+// from the outside whether it was called at all. Without a func alias, we cannot verify that Options.Complete correctly
+// initialized the global controller-runtime logger.
+var logfSetLogger = logf.SetLogger
+
 // Options contains persistent options for all commands.
 type Options struct {
 	genericiooptions.IOStreams
@@ -51,7 +56,7 @@ func (o *Options) Complete() error {
 		return fmt.Errorf("error instantiating zap logger: %w", err)
 	}
 
-	logf.SetLogger(o.Log)
+	logfSetLogger(o.Log)
 	klog.SetLogger(o.Log)
 	return nil
 }

--- a/pkg/gardenadm/cmd/options_test.go
+++ b/pkg/gardenadm/cmd/options_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package cmd_test
+package cmd
 
 import (
 	"github.com/go-logr/logr"
@@ -70,6 +70,26 @@ var _ = Describe("Options", func() {
 			options.Log.Info("Some example log message")
 			Eventually(stdErr).Should(Say("Some example log message"))
 			Consistently(stdOut.Contents).Should(BeEmpty())
+		})
+
+		It("should initialize the global logger in controller-runtime", func() {
+			var logfLogger logr.Logger
+			DeferCleanup(test.WithVar(&logfSetLogger, func(l logr.Logger) {
+				logfLogger = l
+			}))
+
+			Expect(options.Complete()).To(Succeed())
+
+			Expect(logfLogger.GetSink()).NotTo(BeNil())
+			logfLogger.Info("Some example log message")
+			Eventually(stdErr).Should(Say("Some example log message"))
+		})
+
+		It("should initialize the global logger in klog", func() {
+			Expect(options.Complete()).To(Succeed())
+
+			klog.Info("Some example log message")
+			Eventually(stdErr).Should(Say("Some example log message"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/options_test.go
+++ b/pkg/gardenadm/cmd/options_test.go
@@ -5,14 +5,14 @@
 package cmd_test
 
 import (
-	"bytes"
-	"io"
-
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
+	. "github.com/onsi/gomega/gbytes"
+	"k8s.io/klog/v2"
 
-	. "github.com/gardener/gardener/pkg/gardenadm/cmd"
+	"github.com/gardener/gardener/pkg/utils/test"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Options", func() {
@@ -42,23 +42,16 @@ var _ = Describe("Options", func() {
 	})
 
 	Describe("#Complete", func() {
-		It("should succeed", func() {
-			var stdErr *bytes.Buffer
-			options.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		var stdOut, stdErr *Buffer
 
-			By("default logger does not log to stderr")
+		BeforeEach(func() {
+			options.IOStreams, _, stdOut, stdErr = clitest.NewTestIOStreams()
+		})
+
+		It("should not log anything if the logger is uninitialized", func() {
 			options.Log.Info("Some example log message")
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(BeEmpty())
-
-			Expect(options.Complete()).To(Succeed())
-
-			By("completed logger logs to stderr")
-			options.Log.Info("Some example log message")
-			output, err = io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Some example log message"))
+			Consistently(stdErr.Contents).Should(BeEmpty())
+			Consistently(stdOut.Contents).Should(BeEmpty())
 		})
 
 		It("should fail when log level is unknown", func() {
@@ -69,6 +62,14 @@ var _ = Describe("Options", func() {
 		It("should fail when log format is unknown", func() {
 			options.LogFormat = "foo"
 			Expect(options.Complete()).To(MatchError(ContainSubstring("error instantiating zap logger: invalid log format")))
+		})
+
+		It("should initialize the logger to write to stderr", func() {
+			Expect(options.Complete()).To(Succeed())
+
+			options.Log.Info("Some example log message")
+			Eventually(stdErr).Should(Say("Some example log message"))
+			Consistently(stdOut.Contents).Should(BeEmpty())
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/options_test.go
+++ b/pkg/gardenadm/cmd/options_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package cmd
+package cmd_test
 
 import (
 	"github.com/go-logr/logr"
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega/gbytes"
 	"k8s.io/klog/v2"
 
+	. "github.com/gardener/gardener/pkg/gardenadm/cmd"
 	"github.com/gardener/gardener/pkg/utils/test"
 	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
@@ -74,7 +75,7 @@ var _ = Describe("Options", func() {
 
 		It("should initialize the global logger in controller-runtime", func() {
 			var logfLogger logr.Logger
-			DeferCleanup(test.WithVar(&logfSetLogger, func(l logr.Logger) {
+			DeferCleanup(test.WithVar(&LogfSetLogger, func(l logr.Logger) {
 				logfLogger = l
 			}))
 

--- a/pkg/gardenadm/cmd/token/create/create_test.go
+++ b/pkg/gardenadm/cmd/token/create/create_test.go
@@ -5,30 +5,28 @@
 package create_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/token/create"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Create", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -37,9 +35,7 @@ var _ = Describe("Create", func() {
 		It("should return the expected output", func() {
 			Expect(command.RunE(command, []string{"some-token"})).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented"))
+			Eventually(stdErr).Should(Say("Not implemented"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/token/delete/delete_test.go
+++ b/pkg/gardenadm/cmd/token/delete/delete_test.go
@@ -5,30 +5,28 @@
 package delete_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/token/delete"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Delete", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -37,9 +35,7 @@ var _ = Describe("Delete", func() {
 		It("should return the expected output", func() {
 			Expect(command.RunE(command, []string{"some-token-id"})).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented"))
+			Eventually(stdErr).Should(Say("Not implemented"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/token/generate/generate_test.go
+++ b/pkg/gardenadm/cmd/token/generate/generate_test.go
@@ -5,30 +5,28 @@
 package generate_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/token/generate"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Generate", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -37,9 +35,7 @@ var _ = Describe("Generate", func() {
 		It("should return the expected output", func() {
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented"))
+			Eventually(stdErr).Should(Say("Not implemented"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/token/list/list_test.go
+++ b/pkg/gardenadm/cmd/token/list/list_test.go
@@ -5,30 +5,28 @@
 package list_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/token/list"
 	"github.com/gardener/gardener/pkg/logger"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("List", func() {
 	var (
 		globalOpts *cmd.Options
-		stdErr     *bytes.Buffer
+		stdErr     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, stdErr = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
 	})
@@ -37,9 +35,7 @@ var _ = Describe("List", func() {
 		It("should return the expected output", func() {
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			output, err := io.ReadAll(stdErr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Not implemented"))
+			Eventually(stdErr).Should(Say("Not implemented"))
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/token/token_test.go
+++ b/pkg/gardenadm/cmd/token/token_test.go
@@ -8,10 +8,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/token"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Token", func() {
@@ -22,7 +22,7 @@ var _ = Describe("Token", func() {
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, _, _ = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, _ = clitest.NewTestIOStreams()
 		command = NewCommand(globalOpts)
 	})
 

--- a/pkg/gardenadm/cmd/version/version_test.go
+++ b/pkg/gardenadm/cmd/version/version_test.go
@@ -5,28 +5,28 @@
 package version_test
 
 import (
-	"bytes"
-	"io"
+	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/version"
+	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Version", func() {
 	var (
 		globalOpts *cmd.Options
-		out        *bytes.Buffer
+		stdOut     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, out, _ = genericiooptions.NewTestIOStreams()
+		globalOpts.IOStreams, _, stdOut, _ = clitest.NewTestIOStreams()
 		command = NewCommand(globalOpts)
 	})
 
@@ -34,9 +34,7 @@ var _ = Describe("Version", func() {
 		It("should return the expected output", func() {
 			command.Run(command, nil)
 
-			output, err := io.ReadAll(out)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(Equal("gardenadm version v0.0.0-master+$Format:%H$\n"))
+			Eventually(stdOut).Should(Say(regexp.QuoteMeta("gardenadm version v0.0.0-master+$Format:%H$")))
 		})
 	})
 })

--- a/pkg/utils/test/cli/cli.go
+++ b/pkg/utils/test/cli/cli.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"github.com/onsi/gomega/gbytes"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
+
+// NewTestIOStreams returns a valid genericiooptions.IOStreams for tests, where all streams are a gbytes.Buffer for use
+// with the gbytes.Say matcher. Similar to genericiooptions.NewTestIOStreams but for use with gomega.
+func NewTestIOStreams() (genericiooptions.IOStreams, *gbytes.Buffer, *gbytes.Buffer, *gbytes.Buffer) {
+	in, out, errOut := gbytes.NewBuffer(), gbytes.NewBuffer(), gbytes.NewBuffer()
+
+	return genericiooptions.IOStreams{
+		In:     in,
+		Out:    out,
+		ErrOut: errOut,
+	}, in, out, errOut
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR follows-up on https://github.com/gardener/gardener/pull/11390 and refactors the gardenadm unit tests to use `gbytes.Buffer`. This pairs nicely with our use of ginkgo and gomega.

There is a new `clitest.NewTestIOStreams()` similar to `genericiooptions.NewTestIOStreams()` that initializes the buffers. Tests can then use `Eventually(stdErr).Should(Say("something"))` to assert logging outputs.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
