### PR TITLE
Use lock file as mutex to only write imagevector override patch file sequentially

### DIFF
--- a/hack/generate-kustomize-patch-controllerdeployment-provider-local-prow.sh
+++ b/hack/generate-kustomize-patch-controllerdeployment-provider-local-prow.sh
@@ -6,6 +6,9 @@ set -e
 set -o pipefail
 set -o nounset
 
+source $(dirname "${0}")/lockfile.sh
+acquire_lockfile "/tmp/generate-kustomize-patch-controllerdeployment-provider-local-prow.sh.lock"
+
 patch_file=example/provider-local/garden/local/patch-controllerdeployment-prow.yaml
 
 cat <<EOF > $patch_file

--- a/hack/generate-kustomize-patch-controllerdeployment-provider-local.sh
+++ b/hack/generate-kustomize-patch-controllerdeployment-provider-local.sh
@@ -5,6 +5,9 @@
 set -e
 set -o pipefail
 
+source $(dirname "${0}")/lockfile.sh
+acquire_lockfile "/tmp/generate-kustomize-patch-controllerdeployment-provider-local.sh.lock"
+
 repository=$(echo $SKAFFOLD_IMAGE | rev | cut -d':' -f 2- | rev)
 tag=$(echo $SKAFFOLD_IMAGE | rev | cut -d':' -f 1 | rev)
 

--- a/hack/generate-kustomize-patch-extension-provider-local-prow.sh
+++ b/hack/generate-kustomize-patch-extension-provider-local-prow.sh
@@ -6,6 +6,9 @@ set -e
 set -o pipefail
 set -o nounset
 
+source $(dirname "${0}")/lockfile.sh
+acquire_lockfile "/tmp/generate-kustomize-patch-extension-provider-local-prow.sh.lock"
+
 patch_file=example/provider-local/garden/operator/patch-extension-prow.yaml
 
 cat <<EOF > $patch_file

--- a/hack/generate-kustomize-patch-extension-provider-local.sh
+++ b/hack/generate-kustomize-patch-extension-provider-local.sh
@@ -4,6 +4,9 @@
 
 set -e
 
+source $(dirname "${0}")/lockfile.sh
+acquire_lockfile "/tmp/generate-kustomize-patch-extension-provider-local.sh.lock"
+
 repository=$(echo $SKAFFOLD_IMAGE | rev | cut -d':' -f 2- | rev)
 tag=$(echo $SKAFFOLD_IMAGE | rev | cut -d':' -f 1 | rev)
 

--- a/hack/generate-kustomize-patch-gardenlet.sh
+++ b/hack/generate-kustomize-patch-gardenlet.sh
@@ -5,6 +5,9 @@
 set -e
 set -o pipefail
 
+source $(dirname "${0}")/lockfile.sh
+acquire_lockfile "/tmp/generate-kustomize-patch-gardenlet.sh.lock"
+
 dir="$(dirname $0)/../example/gardener-local/gardenlet/operator"
 type="${1:-image}"
 ref="$SKAFFOLD_IMAGE"
@@ -45,7 +48,6 @@ spec:
 EOF
   fi
 
-  cat "$patch_file" # TODO(marc1404): Remove when https://github.com/gardener/gardener/issues/11075 is resolved.
   images="$(yq e '.spec.deployment.imageVectorOverwrite' "$patch_file" | yq -o json)"
 
   images="$(echo "$images" | jq -r \

--- a/hack/lockfile.sh
+++ b/hack/lockfile.sh
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Try to acquire a lockfile for a subsequent script part.
+# E.g. to write a imagevector override patch sequentially as
+# else skaffold's concurrent execution can cause conflicting writes.
+acquire_lockfile() {
+  LOCKFILE=${1-/tmp/gardener-ci.lock}
+  LOCKFILE_DEST=""
+  # Try to acquire the lock in a loop
+  while ! ln -s "$$" "$LOCKFILE" 2>/dev/null; do
+    OLD_LOCKFILE_DEST=$LOCKFILE_DEST
+    LOCKFILE_DEST=$(readlink $LOCKFILE)
+    if [[ $OLD_LOCKFILE_DEST == $LOCKFILE_DEST ]]; then
+      echo "Lock file ($LOCKFILE) has not changed recently. Proceeding..."
+      break
+    fi
+    echo "Another instance ($LOCKFILE_DEST, lock file $LOCKFILE) is running. Waiting..."
+    sleep 1  # Wait before retrying
+  done
+  # Ensure lock is removed on exit
+  trap 'rm -f "$LOCKFILE"' EXIT
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
We build our Skaffold image artifacts in parallel ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11431/pull-gardener-e2e-kind/1891848295219728384#1:build-log.txt%3A163)) and thus it can happen, that the after-hook(s) to execute `hack/generate-kustomize-patch-gardenlet.sh` with the `image` parameter run in parallel, leading to conflicting writes and [partial overrides](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11431/pull-gardener-e2e-kind/1891848295219728384#1:build-log.txt%3A216-230).
To fix this problem, this PR creates a lock file to ensure that the generate script is only running once at a time.

Example flakes:
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11431/pull-gardener-e2e-kind/1891848295219728384#1:build-log.txt%3A230
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11435/pull-gardener-e2e-kind-migration-ha-single-zone/1891863395632680960#1:build-log.txt%3A621

**Which issue(s) this PR fixes**:
Fixes #11075

**Special notes for your reviewer**:
/cc @rfranzke @marc1404 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
