### PR TITLE
Append to exported test resources instead of replacing

### DIFF
--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -53,7 +53,8 @@ export_resource_yamls_for() {
   # Loop over the resource types
   for resource_type in "$@"; do
     echo "> Exporting Resource '$resource_type' yaml > $ARTIFACTS/$resource_type.yaml"
-    kubectl get "$resource_type" -A -o yaml >"$ARTIFACTS/$resource_type.yaml" || true
+    echo -e "---\n# cluster name: $cluster_name" >> "$ARTIFACTS/$resource_type.yaml"
+    kubectl get "$resource_type" -A -o yaml >> "$ARTIFACTS/$resource_type.yaml" || true
   done
 }
 

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -43,11 +43,6 @@ export_artifacts() {
   cp /etc/hosts $ARTIFACTS/$cluster_name/hosts
 }
 
-export_events_for_kind() {
-  echo "> Exporting events of kind cluster '$1'"
-  export_events_for_cluster "$ARTIFACTS"
-}
-
 export_resource_yamls_for() {
   mkdir -p $ARTIFACTS
   # Loop over the resource types

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -48,7 +48,7 @@ export_resource_yamls_for() {
   # Loop over the resource types
   for resource_type in "$@"; do
     echo "> Exporting Resource '$resource_type' yaml > $ARTIFACTS/$resource_type.yaml"
-    echo -e "---\n# cluster name: $cluster_name" >> "$ARTIFACTS/$resource_type.yaml"
+    echo -e "---\n# cluster name: '${cluster_name:-}'" >> "$ARTIFACTS/$resource_type.yaml"
     kubectl get "$resource_type" -A -o yaml >> "$ARTIFACTS/$resource_type.yaml" || true
   done
 }

--- a/hack/ci-e2e-kind-ha-multi-zone.sh
+++ b/hack/ci-e2e-kind-ha-multi-zone.sh
@@ -19,10 +19,10 @@ ensure_glgc_resolves_to_localhost
 make kind-ha-multi-zone-up
 
 # export all container logs and events after test execution
-trap '{
-  export_artifacts "gardener-local-ha-multi-zone"
-  make kind-ha-multi-zone-down
-}' EXIT
+trap "
+  ( export_artifacts "gardener-local-ha-multi-zone" )
+  ( make kind-ha-multi-zone-down )
+" EXIT
 
 make gardener-ha-multi-zone-up
 make test-e2e-local-ha-multi-zone

--- a/hack/ci-e2e-kind-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-ha-single-zone.sh
@@ -19,10 +19,10 @@ ensure_glgc_resolves_to_localhost
 make kind-ha-single-zone-up
 
 # export all container logs and events after test execution
-trap '{
-  export_artifacts "gardener-local-ha-single-zone"
-  make kind-ha-single-zone-down
-}' EXIT
+trap "
+  ( export_artifacts "gardener-local-ha-single-zone" )
+  ( make kind-ha-single-zone-down )
+" EXIT
 
 make gardener-ha-single-zone-up
 make test-e2e-local-ha-single-zone

--- a/hack/ci-e2e-kind-migration-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-migration-ha-single-zone.sh
@@ -19,12 +19,12 @@ make kind-ha-single-zone-up
 make kind2-ha-single-zone-up
 
 # export all container logs and events after test execution
-trap '{
-  KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG export_artifacts "gardener-local-ha-single-zone"
-  KUBECONFIG=$GARDENER_LOCAL2_KUBECONFIG; export_artifacts "gardener-local2-ha-single-zone"
-  make kind-ha-single-zone-down
-  make kind2-ha-single-zone-down
-}' EXIT
+trap "
+  ( export KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG; export_artifacts "gardener-local-ha-single-zone" )
+  ( export KUBECONFIG=$GARDENER_LOCAL2_KUBECONFIG; export_artifacts "gardener-local2-ha-single-zone" )
+  ( make kind-ha-single-zone-down )
+  ( make kind2-ha-single-zone-down )
+" EXIT
 
 make gardener-ha-single-zone-up
 make gardenlet-kind2-ha-single-zone-up

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -19,12 +19,12 @@ make kind-up
 make kind2-up
 
 # export all container logs and events after test execution
-trap '{
-  KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG export_artifacts "gardener-local"
-  KUBECONFIG=$GARDENER_LOCAL2_KUBECONFIG; export_artifacts "gardener-local2"
-  make kind-down
-  make kind2-down
-}' EXIT
+trap "
+  ( export KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG; export_artifacts "gardener-local" )
+  ( export KUBECONFIG=$GARDENER_LOCAL2_KUBECONFIG; export_artifacts "gardener-local2" )
+  ( make kind-down )
+  ( make kind2-down )
+" EXIT
 
 make gardener-up
 make gardenlet-kind2-up

--- a/hack/ci-e2e-kind-operator-seed.sh
+++ b/hack/ci-e2e-kind-operator-seed.sh
@@ -20,7 +20,7 @@ make kind-operator-up
 # export all container logs and events after test execution
 trap "
   ( export KUBECONFIG=$PWD/example/gardener-local/kind/operator/kubeconfig; export_artifacts 'gardener-operator-local'; export_resource_yamls_for garden)
-  ( export KUBECONFIG=$PWD/example/operator/virtual-garden/kubeconfig; export_resource_yamls_for seeds shoots; export_events_for_shoots)
+  ( export KUBECONFIG=$PWD/example/operator/virtual-garden/kubeconfig; export cluster_name='virtual-garden'; export_resource_yamls_for seeds shoots; export_events_for_shoots)
   ( make kind-operator-down )
 " EXIT
 

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -210,11 +210,11 @@ export GARDENER_PREVIOUS_VERSION="$(cat $GARDENER_RELEASE_DOWNLOAD_PATH/gardener
 kind_up
 
 # export all container logs and events after test execution
-trap '{
-  rm -rf "$GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases"
-  export_artifacts "$CLUSTER_NAME"
-  kind_down
-}' EXIT
+trap "
+  ( rm -rf "$GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases" )
+  ( export_artifacts "$CLUSTER_NAME" )
+  ( kind_down )
+" EXIT
 
 echo "Installing gardener version '$GARDENER_PREVIOUS_RELEASE'"
 install_previous_release

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -18,10 +18,10 @@ ensure_glgc_resolves_to_localhost
 make kind-up
 
 # export all container logs and events after test execution
-trap '{
-  export_artifacts "gardener-local"
-  make kind-down
-}' EXIT
+trap "
+  ( export_artifacts "gardener-local" )
+  ( make kind-down )
+" EXIT
 
 make gardener-up
 make test-e2e-local


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Currently, for e2e tests with multiple clusters, the `shoots.yaml`, etc. files are stored empty, as they are replaced by the other cluster instead of appended ore stored separately. This makes debugging failed tests in prow harder.

This PR appends individual cluster exports to the same `shoots.yaml`, etc. file. It also adds a comment to specify the cluster name of the following output to make tracing back the resources to the respective cluster easier.

Example:
```
---
# cluster name: gardener-local
apiVersion: v1
items: []
kind: List
metadata:
  resourceVersion: ""
```

Also, this PR aligns debug artifact capturing with `trap` and fixes the `KUBECONFIG` exports.

**Special notes for your reviewer**:
/cc @rfranzke @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
