### PR TITLE
[release-v1.112] Automated cherry pick of #11421: fix(deps): update machine-controller-manager to v0.56.1 (patch) - autoclosed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gardener/cert-management v0.17.3
 	github.com/gardener/dependency-watchdog v1.3.0
 	github.com/gardener/etcd-druid v0.26.1
-	github.com/gardener/machine-controller-manager v0.56.0
+	github.com/gardener/machine-controller-manager v0.56.1
 	github.com/gardener/terminal-controller-manager v0.34.0
 	github.com/go-jose/go-jose/v4 v4.0.4
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/gardener/dependency-watchdog v1.3.0 h1:C5EO/4GKv1TosvqVepJfzGssu8dDR0
 github.com/gardener/dependency-watchdog v1.3.0/go.mod h1:KNUla1c54x6AGh7SXK/OlM0LrghMXXZG0f+d7+XojaA=
 github.com/gardener/etcd-druid v0.26.1 h1:x8mZfcIkZS29bJKupy0PVTsIrPUNVxvcJlLAXKb0agw=
 github.com/gardener/etcd-druid v0.26.1/go.mod h1:SKjfV8bvdLGF1ynFbWF4ioK2a6M33g7N6lct45p50J8=
-github.com/gardener/machine-controller-manager v0.56.0 h1:Qf/i53/KCgmQ5o1+jKF9XO+RRhaNWsy/IlIX0tWM3bw=
-github.com/gardener/machine-controller-manager v0.56.0/go.mod h1:eCng7De6OE15rndmMm6Q1fwMQI39esASCd3WKZ/lLmY=
+github.com/gardener/machine-controller-manager v0.56.1 h1:8L+69IArB0+r+ma+CJe/6SE7NMDs2GU9095RGSzwydk=
+github.com/gardener/machine-controller-manager v0.56.1/go.mod h1:eCng7De6OE15rndmMm6Q1fwMQI39esASCd3WKZ/lLmY=
 github.com/gardener/terminal-controller-manager v0.34.0 h1:qE8xIKsOFnVr1yZ2meesRR0q65uZ1Nyf5oSluAiLTeM=
 github.com/gardener/terminal-controller-manager v0.34.0/go.mod h1:g1PHUb95LzP/iMFF6aU6yBxGLXpw+yuisvfHcxYQoYY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -150,7 +150,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager
-  tag: "v0.56.0"
+  tag: "v0.56.1"
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
/kind enhancement

Cherry pick of #11421 on release-v1.112.

#11421: fix(deps): update machine-controller-manager to v0.56.1 (patch) - autoclosed

**Release Notes:**
```other dependency
The following dependencies have been updated:
- `gardener/machine-controller-manager` from `v0.56.0` to `v0.56.1`. [Release Notes](https://redirect.github.com/gardener/machine-controller-manager/releases/tag/v0.56.1)
- `github.com/gardener/machine-controller-manager` from `v0.56.0` to `v0.56.1`. 
```