### PR TITLE
[release-v1.112] Automated cherry pick of #11400: Fix availability of Gardener `APIService`s

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -3148,7 +3148,7 @@ kind: AuthorizationConfiguration
 						"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 						"--requestheader-group-headers=X-Remote-Group",
 						"--requestheader-username-headers=X-Remote-User",
-						"--runtime-config=apps/v1=false,autoscaling/v2=false,batch/v1=false,policy/v1/poddisruptionbudgets=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
+						"--runtime-config=apps/v1=false,autoscaling/v2=false,batch/v1=false,discovery.k8s.io/v1=false,policy/v1=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
 						"--secure-port=443",
 						"--service-cluster-ip-range="+serviceNetworkCIDRs[0].String()+","+serviceNetworkCIDRs[1].String(),
 						"--service-account-issuer="+serviceAccountIssuer,
@@ -3871,7 +3871,7 @@ kind: AuthenticationConfiguration
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
-						"--runtime-config=apps/v1=true,autoscaling/v2=false,bar=false,batch/v1=false,policy/v1/poddisruptionbudgets=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
+						"--runtime-config=apps/v1=true,autoscaling/v2=false,bar=false,batch/v1=false,discovery.k8s.io/v1=false,policy/v1=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
 					))
 				})
 

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -419,12 +419,13 @@ func (k *kubeAPIServer) computeKubeAPIServerArgs() []string {
 
 	if k.values.IsWorkerless {
 		disableAPIs := map[string]bool{
-			"autoscaling/v2":                 false,
-			"batch/v1":                       false,
-			"apps/v1":                        false,
-			"policy/v1/poddisruptionbudgets": false,
-			"storage.k8s.io/v1/csidrivers":   false,
-			"storage.k8s.io/v1/csinodes":     false,
+			"apps/v1":                      false,
+			"autoscaling/v2":               false,
+			"batch/v1":                     false,
+			"discovery.k8s.io/v1":          false,
+			"policy/v1":                    false,
+			"storage.k8s.io/v1/csidrivers": false,
+			"storage.k8s.io/v1/csinodes":   false,
 		}
 
 		// Allow users to explicitly enable disabled APIs via RuntimeConfig.

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -724,12 +724,15 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		}
 
 		controllersToDisable.Insert(
+			"attachdetach",
+			"cloud-node-lifecycle",
+			"endpoint",
+			"ephemeral-volume",
 			"nodeipam",
 			"nodelifecycle",
-			"cloud-node-lifecycle",
-			"attachdetach",
 			"persistentvolume-binder",
 			"persistentvolume-expander",
+			"pv-protection",
 			"ttl",
 		)
 	}

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -772,7 +772,7 @@ namespace: kube-system
 				configWithNodeMonitorGracePeriod,
 				nil,
 				true,
-				"--controllers=*,bootstrapsigner,tokencleaner,-attachdetach,-cloud-node-lifecycle,-nodeipam,-nodelifecycle,-persistentvolume-binder,-persistentvolume-expander,-ttl",
+				"--controllers=*,bootstrapsigner,tokencleaner,-attachdetach,-cloud-node-lifecycle,-endpoint,-ephemeral-volume,-nodeipam,-nodelifecycle,-persistentvolume-binder,-persistentvolume-expander,-pv-protection,-ttl",
 			),
 			Entry("with disabled APIs (workerless)",
 				configWithNodeMonitorGracePeriod,
@@ -780,7 +780,7 @@ namespace: kube-system
 					"apps/v1": false,
 				},
 				true,
-				"--controllers=*,bootstrapsigner,tokencleaner,-attachdetach,-cloud-node-lifecycle,-daemonset,-deployment,-nodeipam,-nodelifecycle,-persistentvolume-binder,-persistentvolume-expander,-replicaset,-statefulset,-ttl",
+				"--controllers=*,bootstrapsigner,tokencleaner,-attachdetach,-cloud-node-lifecycle,-daemonset,-deployment,-endpoint,-ephemeral-volume,-nodeipam,-nodelifecycle,-persistentvolume-binder,-persistentvolume-expander,-pv-protection,-replicaset,-statefulset,-ttl",
 			),
 			Entry("with non-disabled APIs (workerless)",
 				configWithNodeMonitorGracePeriod,
@@ -788,7 +788,7 @@ namespace: kube-system
 					"apps/v1": true,
 				},
 				true,
-				"--controllers=*,bootstrapsigner,tokencleaner,-attachdetach,-cloud-node-lifecycle,-nodeipam,-nodelifecycle,-persistentvolume-binder,-persistentvolume-expander,-ttl",
+				"--controllers=*,bootstrapsigner,tokencleaner,-attachdetach,-cloud-node-lifecycle,-endpoint,-ephemeral-volume,-nodeipam,-nodelifecycle,-persistentvolume-binder,-persistentvolume-expander,-pv-protection,-ttl",
 			),
 			Entry("with disabled APIs",
 				configWithNodeMonitorGracePeriod,
@@ -1065,6 +1065,8 @@ func commandForKubernetesVersion(
 		controllers = append(controllers,
 			"-attachdetach",
 			"-cloud-node-lifecycle",
+			"-endpoint",
+			"-ephemeral-volume",
 		)
 
 		if controllerWorkers.Namespace != nil && *controllerWorkers.Namespace == 0 {
@@ -1076,6 +1078,7 @@ func commandForKubernetesVersion(
 			"-nodelifecycle",
 			"-persistentvolume-binder",
 			"-persistentvolume-expander",
+			"-pv-protection",
 		)
 
 		if controllerWorkers.ResourceQuota != nil && *controllerWorkers.ResourceQuota == 0 {

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -34,7 +34,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		f := defaultShootCreationFramework()
 		f.Shoot = shoot
 		f.Shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
-			Resources: []string{"services", "endpointslices.discovery.k8s.io"},
+			Resources: []string{"services", "clusterroles.rbac.authorization.k8s.io"},
 		}
 
 		// explicitly use one version below the latest supported minor version so that Kubernetes version update test can be
@@ -80,7 +80,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				g.Expect(readOnlyShootClient.Client().List(ctx, &corev1.ConfigMapList{})).To(Succeed())
 				g.Expect(readOnlyShootClient.Client().List(ctx, &corev1.SecretList{})).To(BeForbiddenError())
 				g.Expect(readOnlyShootClient.Client().List(ctx, &corev1.ServiceList{})).To(BeForbiddenError())
-				g.Expect(readOnlyShootClient.Client().List(ctx, &discoveryv1.EndpointSliceList{})).To(BeForbiddenError())
+				g.Expect(readOnlyShootClient.Client().List(ctx, &rbacv1.ClusterRoleList{})).To(BeForbiddenError())
 				g.Expect(readOnlyShootClient.Client().Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-", Namespace: metav1.NamespaceDefault}})).To(BeForbiddenError())
 				g.Expect(readOnlyShootClient.Client().Update(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "kube-root-ca.crt", Namespace: metav1.NamespaceDefault}})).To(BeForbiddenError())
 				g.Expect(readOnlyShootClient.Client().Patch(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "kube-root-ca.crt", Namespace: metav1.NamespaceDefault}}, client.RawPatch(types.MergePatchType, []byte("{}")))).To(BeForbiddenError())


### PR DESCRIPTION
/kind bug
/area control-plane

Cherry pick of #11400 on release-v1.112.

#11400: Fix availability of Gardener `APIService`s

**Release Notes:**
```bugfix operator
An issue was fixed that caused a downtime of Gardener API services up to `1m` every time the `virtual-garden-kube-controller-manager` changed its leader. 
```