### PR TITLE
Increase timeout for migration to `20m`

### DIFF
--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -99,7 +99,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			Expect(f.HibernateShoot(ctx, f.Shoot)).To(Succeed())
 
 			By("Wake up Shoot")
-			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 			defer cancel()
 			Expect(f.WakeUpShoot(ctx, f.Shoot)).To(Succeed())
 

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -44,9 +44,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				Expect(f.GardenClient.Client().Create(ctx, namespacedCloudProfile)).To(Succeed())
 				DeferCleanup(func() {
 					By("Delete NamespacedCloudProfile")
-					ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
-					defer cancel()
-					Expect(f.GardenClient.Client().Delete(ctx, namespacedCloudProfile)).To(Or(Succeed(), BeNotFoundError()))
+					Expect(f.GardenClient.Client().Delete(parentCtx, namespacedCloudProfile)).To(Or(Succeed(), BeNotFoundError()))
 				})
 
 				By("Wait for new NamespacedCloudProfile to be reconciled")

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -108,7 +108,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			}
 
 			By("Delete Shoot")
-			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 			defer cancel()
 			Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 		})

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -54,7 +54,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 			Expect(t.VerifyMigration(ctx)).To(Succeed())
 
 			By("Delete Shoot")
-			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 			defer cancel()
 			Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 		})

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -46,7 +46,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 			}
 
 			By("Migrate Shoot")
-			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 			defer cancel()
 			t, err := newDefaultShootMigrationTest(ctx, f.Shoot, f.GardenerFramework)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/gardener/shoot/internal/shoot.go
+++ b/test/e2e/gardener/shoot/internal/shoot.go
@@ -136,7 +136,7 @@ func ItShouldWaitForShootToBeDeleted(s *ShootContext) {
 		}).WithPolling(30 * time.Second).Should(BeNotFoundError())
 
 		s.Log.Info("Shoot has been deleted")
-	}, SpecTimeout(15*time.Minute))
+	}, SpecTimeout(20*time.Minute))
 }
 
 // ItShouldInitializeShootClient requests a kubeconfig for the shoot and initializes the context's shoot clients.

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
@@ -38,7 +38,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			}
 
 			By("Upgrade Shoot (non-HA to HA with failure tolerance type 'node')")
-			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel = context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 			highavailability.UpgradeAndVerify(ctx, f.ShootFramework, gardencorev1beta1.FailureToleranceTypeNode)
 

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
@@ -47,7 +47,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			}
 
 			By("Delete Shoot")
-			ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 			defer cancel()
 			Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 		})

--- a/test/e2e/gardener/upgrade/upgrade.go
+++ b/test/e2e/gardener/upgrade/upgrade.go
@@ -43,22 +43,18 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 		f.Shoot.Namespace = projectNamespace
 
 		When("Pre-Upgrade (Gardener version:'"+gardenerPreviousVersion+"', Git version:'"+gardenerPreviousGitVersion+"')", Ordered, Offset(1), Label("pre-upgrade"), func() {
-			var (
-				ctx    context.Context
-				cancel context.CancelFunc
-			)
-
-			BeforeAll(func() {
-				ctx, cancel = context.WithTimeout(parentCtx, 30*time.Minute)
-				DeferCleanup(cancel)
-			})
-
 			It("should create a shoot", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
+				defer cancel()
+
 				Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 				f.Verify()
 			})
 
 			It("deploying zero-downtime validator job to ensure no downtime while after upgrading gardener", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 5*time.Minute)
+				defer cancel()
+
 				controlPlaneNamespace := f.Shoot.Status.TechnicalID
 				job, err = highavailability.DeployZeroDownTimeValidatorJob(
 					ctx,
@@ -75,33 +71,29 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 		})
 
 		When("Post-Upgrade (Gardener version:'"+gardenerCurrentVersion+"', Git version:'"+gardenerCurrentGitVersion+"')", Ordered, Offset(1), Label("post-upgrade"), func() {
-			var (
-				ctx        context.Context
-				cancel     context.CancelFunc
-				seedClient client.Client
-			)
+			var seedClient client.Client
 
 			BeforeAll(func() {
-				ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
-				DeferCleanup(cancel)
-				Expect(f.GetShoot(ctx, f.Shoot)).To(Succeed())
-				f.ShootFramework, err = f.NewShootFramework(ctx, f.Shoot)
+				Expect(f.GetShoot(parentCtx, f.Shoot)).To(Succeed())
+				f.ShootFramework, err = f.NewShootFramework(parentCtx, f.Shoot)
 				Expect(err).NotTo(HaveOccurred())
 				seedClient = f.ShootFramework.SeedClient.Client()
 			})
 
 			It("verifying no downtime while upgrading gardener", func() {
-				job = &batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "zero-down-time-validator-update",
-						Namespace: f.Shoot.Status.TechnicalID,
-					}}
+				ctx, cancel := context.WithTimeout(parentCtx, 5*time.Minute)
+				defer cancel()
+
+				job = &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "zero-down-time-validator-update", Namespace: f.Shoot.Status.TechnicalID}}
 				Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(job), job)).To(Succeed())
 				Expect(job.Status.Failed).Should(BeZero())
 				Expect(seedClient.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
 			})
 
 			It("should be able to delete a shoot which was created in previous release", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
+				defer cancel()
+
 				Expect(f.Shoot.Status.Gardener.Version).Should(Equal(gardenerPreviousVersion))
 				Expect(f.GardenerFramework.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 			})
@@ -130,41 +122,33 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 		f.Shoot.Spec.ControlPlane = nil
 
 		When("(Gardener version:'"+gardenerPreviousVersion+"', Git version:'"+gardenerPreviousGitVersion+"')", Ordered, Offset(1), Label("pre-upgrade"), func() {
-			var (
-				ctx    context.Context
-				cancel context.CancelFunc
-			)
-
-			BeforeAll(func() {
-				ctx, cancel = context.WithTimeout(parentCtx, 30*time.Minute)
-				DeferCleanup(cancel)
-			})
-
 			It("should create a shoot", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
+				defer cancel()
+
 				Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 				f.Verify()
 			})
 		})
 
 		When("Post-Upgrade (Gardener version:'"+gardenerCurrentVersion+"', Git version:'"+gardenerCurrentGitVersion+"')", Ordered, Offset(1), Label("post-upgrade"), func() {
-			var (
-				ctx    context.Context
-				cancel context.CancelFunc
-			)
-
 			BeforeAll(func() {
-				ctx, cancel = context.WithTimeout(parentCtx, 60*time.Minute)
-				DeferCleanup(cancel)
-				Expect(f.GetShoot(ctx, f.Shoot)).To(Succeed())
-				f.ShootFramework, err = f.NewShootFramework(ctx, f.Shoot)
+				Expect(f.GetShoot(parentCtx, f.Shoot)).To(Succeed())
+				f.ShootFramework, err = f.NewShootFramework(parentCtx, f.Shoot)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should be able to upgrade a non-HA shoot which was created in previous gardener release to HA with failure tolerance type '"+os.Getenv("SHOOT_FAILURE_TOLERANCE_TYPE")+"'", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
+				defer cancel()
+
 				highavailability.UpgradeAndVerify(ctx, f.ShootFramework, getFailureToleranceType())
 			})
 
 			It("should be able to delete a shoot which was created in previous gardener release", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
+				defer cancel()
+
 				Expect(f.Shoot.Status.Gardener.Version).Should(Equal(gardenerPreviousVersion))
 				Expect(f.GardenerFramework.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 			})
@@ -191,49 +175,45 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 		f.Shoot.Namespace = projectNamespace
 
 		When("Pre-upgrade (Gardener version:'"+gardenerCurrentVersion+"', Git version:'"+gardenerCurrentGitVersion+"')", Ordered, Offset(1), Label("pre-upgrade"), func() {
-			var (
-				ctx    context.Context
-				cancel context.CancelFunc
-			)
-
-			BeforeAll(func() {
-				ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
-				DeferCleanup(cancel)
-			})
-
 			It("should create a shoot", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
+				defer cancel()
+
 				Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 				f.Verify()
 			})
 
 			It("should hibernate a shoot", func() {
-				Expect(f.GetShoot(ctx, f.Shoot)).To(Succeed())
-				f.ShootFramework, err = f.NewShootFramework(ctx, f.Shoot)
+				Expect(f.GetShoot(parentCtx, f.Shoot)).To(Succeed())
+				f.ShootFramework, err = f.NewShootFramework(parentCtx, f.Shoot)
 				Expect(err).NotTo(HaveOccurred())
+
+				ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
+				defer cancel()
+
 				Expect(f.HibernateShoot(ctx, f.Shoot)).To(Succeed())
 			})
 		})
 
 		When("Post-upgrade (Gardener version:'"+gardenerCurrentVersion+"', Git version:'"+gardenerCurrentGitVersion+"')", Ordered, Offset(1), Label("post-upgrade"), func() {
-			var (
-				ctx    context.Context
-				cancel context.CancelFunc
-			)
-
 			BeforeAll(func() {
-				ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
-				DeferCleanup(cancel)
-				Expect(f.GetShoot(ctx, f.Shoot)).To(Succeed())
-				f.ShootFramework, err = f.NewShootFramework(ctx, f.Shoot)
+				Expect(f.GetShoot(parentCtx, f.Shoot)).To(Succeed())
+				f.ShootFramework, err = f.NewShootFramework(parentCtx, f.Shoot)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should be able to wake up a shoot which was hibernated in previous gardener release", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
+				defer cancel()
+
 				Expect(f.Shoot.Status.Gardener.Version).Should(Equal(gardenerPreviousVersion))
 				Expect(f.WakeUpShoot(ctx, f.Shoot)).To(Succeed())
 			})
 
 			It("should delete a shoot which was created in previous gardener release", func() {
+				ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
+				defer cancel()
+
 				Expect(f.Shoot.Status.Gardener.Version).Should(Equal(gardenerCurrentVersion))
 				Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Increase timeout for migration/wake-up to `20m` since such operations also require to roll KAPI twice (due to node-agent authorizer), see also https://github.com/gardener/gardener/pull/11430.

Example flakes:
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11432/pull-gardener-e2e-kind-migration-ha-single-zone/1892173373270659072
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11432/pull-gardener-e2e-kind-migration-ha-single-zone/1892173373270659072

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11386

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
