### PR TITLE
e2e: Refactor `Create Force Delete Shoot` test to ordered containers

### DIFF
--- a/test/e2e/gardener/shoot/create_and_force_delete.go
+++ b/test/e2e/gardener/shoot/create_and_force_delete.go
@@ -5,49 +5,69 @@
 package shoot
 
 import (
-	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	shootextensionactuator "github.com/gardener/gardener/pkg/provider-local/controller/extension/shoot"
-	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	. "github.com/gardener/gardener/test/e2e"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+	. "github.com/gardener/gardener/test/e2e/gardener/shoot/internal"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	test := func(shoot *gardencorev1beta1.Shoot) {
-		f := defaultShootCreationFramework()
-		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, shootextensionactuator.AnnotationTestForceDeleteShoot, "true")
-		f.Shoot = shoot
+	test := func(s *ShootContext) {
+		BeforeTestSetup(func() {
+			metav1.SetMetaDataAnnotation(&s.Shoot.ObjectMeta, shootextensionactuator.AnnotationTestForceDeleteShoot, "true")
+		})
 
-		It("Create and Force Delete Shoot", Label("force-delete"), func() {
-			By("Create Shoot")
-			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
-			defer cancel()
-			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
-			f.Verify()
+		Describe("Create and Force Delete Shoot", Label("force-delete"), func() {
+			ItShouldCreateShoot(s)
+			ItShouldWaitForShootToBeReconciledAndHealthy(s)
+			ItShouldSetShootAnnotation(s, v1beta1constants.ShootIgnore, "true")
+			ItShouldDeleteShoot(s)
 
-			By("Wait for Shoot to be force-deleted")
-			ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
-			defer cancel()
-			Expect(f.ForceDeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
+			It("Add ErrorInfraDependencies to LastErrors", func(ctx SpecContext) {
+				patch := client.MergeFrom(s.Shoot.DeepCopy())
+				s.Shoot.Status.LastErrors = []gardencorev1beta1.LastError{{
+					Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraDependencies},
+				}}
+
+				Eventually(ctx, func() error {
+					return s.GardenClient.Status().Patch(ctx, s.Shoot, patch)
+				}).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+
+			ItShouldSetShootAnnotation(s, v1beta1constants.AnnotationConfirmationForceDeletion, "true")
+			ItShouldSetShootAnnotation(s, v1beta1constants.ShootIgnore, "false")
+
+			// manually trigger reconcilation after stop ignoring the shoot
+			ItShouldSetShootAnnotation(s, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+
+			ItShouldWaitForShootToBeDeleted(s)
 		})
 	}
 
-	Context("Shoot", func() {
-		test(e2e.DefaultShoot("e2e-force-delete"))
+	Context("Shoot with workers", Ordered, func() {
+		test(NewTestContext().ForShoot(DefaultShoot("e2e-force-delete")))
 	})
 
-	Context("Hibernated Shoot", func() {
-		shoot := e2e.DefaultShoot("e2e-fd-hib")
+	Context("Hibernated Shoot", Ordered, func() {
+		shoot := DefaultShoot("e2e-fd-hib")
 		shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
 			Enabled: ptr.To(true),
 		}
 
-		test(shoot)
+		test(NewTestContext().ForShoot(shoot))
+	})
+
+	Context("Workerless Shoot", Ordered, func() {
+		test(NewTestContext().ForShoot(DefaultWorkerlessShoot("e2e-fd-wl")))
 	})
 })

--- a/test/e2e/gardener/shoot/create_and_force_delete.go
+++ b/test/e2e/gardener/shoot/create_and_force_delete.go
@@ -30,7 +30,9 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		Describe("Create and Force Delete Shoot", Label("force-delete"), func() {
 			ItShouldCreateShoot(s)
 			ItShouldWaitForShootToBeReconciledAndHealthy(s)
-			ItShouldSetShootAnnotation(s, v1beta1constants.ShootIgnore, "true")
+			ItShouldAnnotateShoot(s, map[string]string{
+				v1beta1constants.ShootIgnore: "true",
+			})
 			ItShouldDeleteShoot(s)
 
 			It("Add ErrorInfraDependencies to LastErrors", func(ctx SpecContext) {
@@ -44,11 +46,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				}).Should(Succeed())
 			}, SpecTimeout(time.Minute))
 
-			ItShouldSetShootAnnotation(s, v1beta1constants.AnnotationConfirmationForceDeletion, "true")
-			ItShouldSetShootAnnotation(s, v1beta1constants.ShootIgnore, "false")
-
-			// manually trigger reconcilation after stop ignoring the shoot
-			ItShouldSetShootAnnotation(s, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+			ItShouldAnnotateShoot(s, map[string]string{
+				v1beta1constants.AnnotationConfirmationForceDeletion: "true",
+				v1beta1constants.ShootIgnore:                         "false",
+			})
 
 			ItShouldWaitForShootToBeDeleted(s)
 		})

--- a/test/e2e/gardener/shoot/internal/shoot.go
+++ b/test/e2e/gardener/shoot/internal/shoot.go
@@ -197,15 +197,17 @@ func ItShouldInitializeSeedClient(s *ShootContext) {
 	}, SpecTimeout(time.Minute))
 }
 
-// ItShouldSetShootAnnotation sets the given annotation within the shoot metadata to the specified value and patches the shoot object
-func ItShouldSetShootAnnotation(s *ShootContext, annotation string, value string) {
+// ItShouldAnnotateShoot sets the given annotation within the shoot metadata to the specified value and patches the shoot object
+func ItShouldAnnotateShoot(s *ShootContext, annotations map[string]string) {
 	GinkgoHelper()
 
-	It("Set annotation for Shoot", func(ctx SpecContext) {
-		s.Log.Info("Setting annotation", "annotation", annotation, "value", value)
-
+	It("Annotate Shoot", func(ctx SpecContext) {
 		patch := client.MergeFrom(s.Shoot.DeepCopy())
-		metav1.SetMetaDataAnnotation(&s.Shoot.ObjectMeta, annotation, value)
+
+		for annotationKey, annotationValue := range annotations {
+			s.Log.Info("Setting annotation", "annotation", annotationKey, "value", annotationValue)
+			metav1.SetMetaDataAnnotation(&s.Shoot.ObjectMeta, annotationKey, annotationValue)
+		}
 
 		Eventually(ctx, func() error {
 			return s.GardenClient.Patch(ctx, s.Shoot, patch)

--- a/test/e2e/gardener/shoot/internal/shoot.go
+++ b/test/e2e/gardener/shoot/internal/shoot.go
@@ -196,3 +196,19 @@ func ItShouldInitializeSeedClient(s *ShootContext) {
 		s.WithSeedClientSet(clientSet)
 	}, SpecTimeout(time.Minute))
 }
+
+// ItShouldSetShootAnnotation sets the given annotation within the shoot metadata to the specified value and patches the shoot object
+func ItShouldSetShootAnnotation(s *ShootContext, annotation string, value string) {
+	GinkgoHelper()
+
+	It("Set annotation for Shoot", func(ctx SpecContext) {
+		s.Log.Info("Setting annotation", "annotation", annotation, "value", value)
+
+		patch := client.MergeFrom(s.Shoot.DeepCopy())
+		metav1.SetMetaDataAnnotation(&s.Shoot.ObjectMeta, annotation, value)
+
+		Eventually(ctx, func() error {
+			return s.GardenClient.Patch(ctx, s.Shoot, patch)
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the mentioned test to the ordered containers approach.
See https://github.com/gardener/gardener/issues/11379

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
