### PR TITLE
[operator] Ensure Garden environment is clean when `Garden` is deleted

### DIFF
--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -715,17 +715,22 @@ status:
 
 	Describe("#Destroy", func() {
 		It("should successfully destroy all resources", func() {
+			dashboardConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "plutono-dashboards", Namespace: namespace}}
+
 			component = New(c, namespace, fakeSecretManager, values)
 			Expect(c.Create(ctx, managedResource)).To(Succeed())
 			Expect(c.Create(ctx, managedResourceSecret)).To(Succeed())
+			Expect(c.Create(ctx, dashboardConfigMap)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardConfigMap), dashboardConfigMap)).To(Succeed())
 
 			Expect(component.Destroy(ctx)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardConfigMap), dashboardConfigMap)).To(BeNotFoundError())
 		})
 	})
 

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -47,7 +47,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 		Expect(runtimeClient.Create(ctx, backupSecret)).To(Succeed())
 		Expect(runtimeClient.Create(ctx, garden)).To(Succeed())
 
-		waitForGardenToBeReconciled(ctx, garden)
+		waitForGardenToBeReconciledAndHealthy(ctx, garden)
 
 		DeferCleanup(func() {
 			ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)

--- a/test/e2e/operator/garden/create_rotate_delete.go
+++ b/test/e2e/operator/garden/create_rotate_delete.go
@@ -39,7 +39,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 		By("Create Garden")
 		Expect(runtimeClient.Create(ctx, backupSecret)).To(Succeed())
 		Expect(runtimeClient.Create(ctx, garden)).To(Succeed())
-		waitForGardenToBeReconciled(ctx, garden)
+		waitForGardenToBeReconciledAndHealthy(ctx, garden)
 
 		DeferCleanup(func() {
 			ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
@@ -202,7 +202,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 			v.ExpectPreparingStatus(g)
 		}).Should(Succeed())
 
-		waitForGardenToBeReconciled(ctx, garden)
+		waitForGardenToBeReconciledAndHealthy(ctx, garden)
 
 		Eventually(func() error {
 			return runtimeClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)
@@ -226,7 +226,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 			v.ExpectCompletingStatus(g)
 		}).Should(Succeed())
 
-		waitForGardenToBeReconciled(ctx, garden)
+		waitForGardenToBeReconciledAndHealthy(ctx, garden)
 
 		Eventually(func(g Gomega) {
 			g.Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -959,6 +959,17 @@ spec:
 			return secretList.Items
 		}).Should(BeEmpty())
 
+		By("Verify that garbage-collectable resources have been deleted")
+		Eventually(func(g Gomega) {
+			secretList := &corev1.SecretList{}
+			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name), client.MatchingLabels{"resources.gardener.cloud/garbage-collectable-reference": "true"})).To(Succeed())
+			g.Expect(secretList.Items).To(BeEmpty())
+
+			configMapList := &corev1.ConfigMapList{}
+			g.Expect(testClient.List(ctx, configMapList, client.InNamespace(testNamespace.Name), client.MatchingLabels{"resources.gardener.cloud/garbage-collectable-reference": "true"})).To(Succeed())
+			g.Expect(configMapList.Items).To(BeEmpty())
+		}).Should(Succeed())
+
 		By("Ensure Garden is gone")
 		Eventually(func() error {
 			return testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement flake

**What this PR does / why we need it**:
When deleting a `Garden`, a lot of resources remain in the system (mostly garbage-collectable `ConfigMap`s/`Secret`s). This PR adds an explicit deletion step for such resources at the end of `gardener-operator`'s `Garden` deletion flow.

In addition, it augments the `plutono` component to also delete the dashboards `ConfigMap` (this is not part of the `ManagedResource` and created directly with the client).

In addition, it improves `provider-local`'s `BackupBucket` controller to delete the generated `BackupBucket` secret.

Finally, it improves the e2e wait-for-garden function to also consider the conditions, i.e., to wait until it is not only reconciled but also healthy.

**Special notes for your reviewer**:
We (@LucaBernstein) investigated a flake (link lost) and thought that this was caused due to the dirty environment after `Garden` deletion, but we couldn't fully comprehend it. Nevertheless, it makes sense to leave the environment as clean as possible when a `Garden` is deleted.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
