### PR TITLE
Update authorisation graph for shoot after recreating secret- or credentialbinding

### DIFF
--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_shoot.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_shoot.go
@@ -78,17 +78,13 @@ func (g *graph) hasExpectedShootBindingEdges(shoot *gardencorev1beta1.Shoot) boo
 	defer g.lock.RUnlock()
 
 	isEdgeMissingFrom := func(vertexType VertexType, bindingName *string) bool {
-		if bindingName != nil {
-			shootVertex, found := g.getVertex(VertexTypeShoot, shoot.Namespace, shoot.Name)
-			if !found {
-				return true
-			}
-			bindingVertex, found := g.getVertex(vertexType, shoot.Namespace, *bindingName)
-			if !found || !g.graph.HasEdgeFromTo(bindingVertex.id, shootVertex.id) {
-				return true
-			}
+		if bindingName == nil {
+			return false
 		}
-		return false
+
+		shootVertex, foundShootVertex := g.getVertex(VertexTypeShoot, shoot.Namespace, shoot.Name)
+		bindingVertex, foundBindingVertex := g.getVertex(vertexType, shoot.Namespace, *bindingName)
+		return !foundShootVertex || !foundBindingVertex || !g.graph.HasEdgeFromTo(bindingVertex.id, shootVertex.id)
 	}
 
 	if isEdgeMissingFrom(VertexTypeSecretBinding, shoot.Spec.SecretBindingName) {

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/graph.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/graph.go
@@ -87,6 +87,8 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 }
 
 func (g *graph) HasVertex(vertexType VertexType, vertexNamespace, vertexName string) bool {
+	g.lock.RLock()
+	defer g.lock.RUnlock()
 	_, ok := g.getVertex(vertexType, vertexNamespace, vertexName)
 	return ok
 }

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
@@ -1034,7 +1034,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		Expect(graph.HasPathFrom(VertexTypeShootState, shoot1.Namespace, shoot1.Name, VertexTypeShoot, shoot1.Namespace, shoot1.Name)).To(BeFalse())
 	})
 
-	It("should restore edges on recreating SecretBinding and CredentialBinding for gardenercorev1beta1.Shoot", func() {
+	It("should restore edges on recreating SecretBinding and CredentialsBinding for gardenercorev1beta1.Shoot", func() {
 		By("Add")
 		fakeInformerShoot.Add(shoot1)
 		Expect(graph.HasPathFrom(VertexTypeSecretBinding, shoot1.Namespace, *shoot1.Spec.SecretBindingName, VertexTypeShoot, shoot1.Namespace, shoot1.Name)).To(BeTrue())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
After forceful deletion of secretbinding or credentialbinding used by a shoot and recreating it, the shoot cannot be reconciled anymore as the graph of the SeedAuthorizer is incomplete.
This PR adds an additional check on the shoot update to trigger update of the graph. 

Additionally it adds missing read lock for `graph.HasVertex`.

**Which issue(s) this PR fixes**:
Fixes #10874 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing Shoot reconciliation to fail with `no relationship found` when the referenced SecretBinding/CredentialsBinding is forcefully deleted (its finalizer is removed by the end user) and then recreated with the same name is now fixed. gardener-admission-controller's  authorisation graph is now updated for a Shoot after forceful deletion and recreation of the referenced Secretbinding/CredentialsBinding.
```
