### PR TITLE
Fix calculation maintenance time window in e2e tests

### DIFF
--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -160,6 +160,6 @@ func getDelayedShootMaintenance() *gardencorev1beta1.Maintenance {
 
 	return &gardencorev1beta1.Maintenance{TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
 		Begin: timewindow.NewMaintenanceTime(hour, 0, 0).Formatted(),
-		End:   timewindow.NewMaintenanceTime(hour+1, 0, 0).Formatted(),
+		End:   timewindow.NewMaintenanceTime((hour+1)%24, 0, 0).Formatted(),
 	}}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:
PR #11437 introduced a regression when calculating the end of a maintenance time window in e2e tests. It can become 24 which is not correct.
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11460/pull-gardener-e2e-kind/1892300210709729280
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11460/pull-gardener-e2e-kind-ha-single-zone/1892300209434660864
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11460/pull-gardener-e2e-kind-upgrade/1892300209979920384

This PR fixes the calculation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
