### PR TITLE
Recheck `cancelFunc` has been called in `OperatingSystemConfig` test

### DIFF
--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -416,19 +416,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when there is no previous OSC", func() {
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		By("Assert that files and units have been created")
 		test.AssertFileOnDisk(fakeFS, file1.Path, "file1", 0777)
@@ -503,19 +492,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile only parts of the configuration that were not applied yet", func() {
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -534,19 +512,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
@@ -563,19 +530,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when there is a previous OSC", func() {
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -623,19 +579,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		By("Assert that files and units have been created")
 		test.AssertFileOnDisk(fakeFS, file1.Path, "file1", 0777)
@@ -700,19 +645,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when the containerd registries change", func() {
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -730,19 +664,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		By("Assert that files and directories have been created")
 		test.AssertDirectoryOnDisk(fakeFS, "/var/bin/containerruntimes")
@@ -763,19 +686,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when the containerd plugins change", func() {
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -798,19 +710,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		By("Assert that containerd config was updated properly")
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", "imports = [\"/etc/containerd/conf.d/*.toml\"]\n\n[plugins]\n\n  [plugins.bar]\n\n  [plugins.\"io.containerd.grpc.v1.cri\"]\n    sandbox_image = \"registry.k8s.io/pause:latest\"\n\n    [plugins.\"io.containerd.grpc.v1.cri\".containerd]\n\n      [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes]\n\n        [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc]\n\n          [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]\n            SystemdCgroup = true\n\n    [plugins.\"io.containerd.grpc.v1.cri\".registry]\n      config_path = \"/etc/containerd/certs.d\"\n", 0644)
@@ -826,19 +727,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when the cgroup driver changes", func() {
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -858,19 +748,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		By("Wait for node annotations to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Annotations
-		}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-		By("Wait for node labels to be updated")
-		Eventually(func(g Gomega) map[string]string {
-			updatedNode := &corev1.Node{}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-			return updatedNode.Labels
-		}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 		By("Assert that containerd config was updated properly")
 		expectedContainerdContent := strings.ReplaceAll(containerdConfigFileContent, "SystemdCgroup = true", "SystemdCgroup = false")
@@ -888,12 +767,12 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 	It("should call the cancel function when gardener-node-agent must be restarted itself", func() {
 		var lastAppliedOSC []byte
-		By("Wait last-applied OSC file to be persisted")
+		By("Wait until last-applied OSC file is persisted")
 		Eventually(func() error {
 			var err error
 			lastAppliedOSC, err = fakeFS.ReadFile("/var/lib/gardener-node-agent/last-applied-osc.yaml")
 			return err
-		}).Should(Succeed())
+		}).WithTimeout(2 * time.Second).Should(Succeed())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -910,12 +789,12 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		By("Wait last-applied OSC file to be updated")
+		By("Wait for last-applied OSC file to be updated")
 		Eventually(func(g Gomega) []byte {
 			content, err := fakeFS.ReadFile("/var/lib/gardener-node-agent/last-applied-osc.yaml")
 			g.Expect(err).NotTo(HaveOccurred())
 			return content
-		}).ShouldNot(Equal(lastAppliedOSC))
+		}).WithTimeout(2 * time.Second).ShouldNot(Equal(lastAppliedOSC))
 
 		By("Assert that files and units have been created")
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+gnaUnit.Name, "#gna", 0600)
@@ -936,19 +815,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		})
 
 		It("should not handle containerd configs", func() {
-			By("Wait for node annotations to be updated")
-			Eventually(func(g Gomega) map[string]string {
-				updatedNode := &corev1.Node{}
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-				return updatedNode.Annotations
-			}).Should(HaveKeyWithValue("checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw)))
-
-			By("Wait for node labels to be updated")
-			Eventually(func(g Gomega) map[string]string {
-				updatedNode := &corev1.Node{}
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
-				return updatedNode.Labels
-			}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", kubernetesVersion.String()))
+			waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
+			waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
 
 			By("Assert that files and units have been created")
 			test.AssertNoDirectoryOnDisk(fakeFS, "/var/bin/containerruntimes")
@@ -966,4 +834,22 @@ type cancelFuncEnsurer struct {
 
 func (c *cancelFuncEnsurer) cancel() {
 	c.called = true
+}
+
+func waitForUpdatedNodeAnnotation(node *corev1.Node, key, value string) {
+	By("Wait for node annotations to be updated")
+	EventuallyWithOffset(1, func(g Gomega) map[string]string {
+		updatedNode := &corev1.Node{}
+		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
+		return updatedNode.Annotations
+	}).WithTimeout(2 * time.Second).Should(HaveKeyWithValue(key, value))
+}
+
+func waitForUpdatedNodeLabel(node *corev1.Node, key, value string) {
+	By("Wait for node labels to be updated")
+	EventuallyWithOffset(1, func(g Gomega) map[string]string {
+		updatedNode := &corev1.Node{}
+		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
+		return updatedNode.Labels
+	}).Should(HaveKeyWithValue(key, value))
 }

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -927,7 +927,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		))
 
 		By("Expect that cancel func has been called")
-		Expect(cancelFunc.called).To(BeTrue())
+		Eventually(cancelFunc.called).WithTimeout(2 * time.Second).Should(BeTrue())
 	})
 
 	Context("when CRI is not containerd", func() {

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -772,7 +772,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			var err error
 			lastAppliedOSC, err = fakeFS.ReadFile("/var/lib/gardener-node-agent/last-applied-osc.yaml")
 			return err
-		}).WithTimeout(2 * time.Second).Should(Succeed())
+		}).Should(Succeed())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -794,7 +794,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			content, err := fakeFS.ReadFile("/var/lib/gardener-node-agent/last-applied-osc.yaml")
 			g.Expect(err).NotTo(HaveOccurred())
 			return content
-		}).WithTimeout(2 * time.Second).ShouldNot(Equal(lastAppliedOSC))
+		}).ShouldNot(Equal(lastAppliedOSC))
 
 		By("Assert that files and units have been created")
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+gnaUnit.Name, "#gna", 0600)
@@ -806,7 +806,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		))
 
 		By("Expect that cancel func has been called")
-		Eventually(cancelFunc.called).WithTimeout(2 * time.Second).Should(BeTrue())
+		Eventually(cancelFunc.called).Should(BeTrue())
 	})
 
 	Context("when CRI is not containerd", func() {
@@ -842,7 +842,7 @@ func waitForUpdatedNodeAnnotationCloudConfig(node *corev1.Node, value string) {
 		updatedNode := &corev1.Node{}
 		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
 		return updatedNode.Annotations
-	}).WithTimeout(2 * time.Second).Should(HaveKeyWithValue("checksum/cloud-config-data", value))
+	}).Should(HaveKeyWithValue("checksum/cloud-config-data", value))
 }
 
 func waitForUpdatedNodeLabelKubernetesVersion(node *corev1.Node, value string) {

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -416,8 +416,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when there is no previous OSC", func() {
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that files and units have been created")
 		test.AssertFileOnDisk(fakeFS, file1.Path, "file1", 0777)
@@ -492,8 +492,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile only parts of the configuration that were not applied yet", func() {
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -512,8 +512,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
@@ -530,8 +530,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when there is a previous OSC", func() {
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -579,8 +579,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that files and units have been created")
 		test.AssertFileOnDisk(fakeFS, file1.Path, "file1", 0777)
@@ -645,8 +645,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when the containerd registries change", func() {
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -664,8 +664,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that files and directories have been created")
 		test.AssertDirectoryOnDisk(fakeFS, "/var/bin/containerruntimes")
@@ -686,8 +686,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when the containerd plugins change", func() {
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -710,8 +710,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that containerd config was updated properly")
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", "imports = [\"/etc/containerd/conf.d/*.toml\"]\n\n[plugins]\n\n  [plugins.bar]\n\n  [plugins.\"io.containerd.grpc.v1.cri\"]\n    sandbox_image = \"registry.k8s.io/pause:latest\"\n\n    [plugins.\"io.containerd.grpc.v1.cri\".containerd]\n\n      [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes]\n\n        [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc]\n\n          [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]\n            SystemdCgroup = true\n\n    [plugins.\"io.containerd.grpc.v1.cri\".registry]\n      config_path = \"/etc/containerd/certs.d\"\n", 0644)
@@ -727,8 +727,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when the cgroup driver changes", func() {
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
 
@@ -748,8 +748,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-		waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that containerd config was updated properly")
 		expectedContainerdContent := strings.ReplaceAll(containerdConfigFileContent, "SystemdCgroup = true", "SystemdCgroup = false")
@@ -815,8 +815,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		})
 
 		It("should not handle containerd configs", func() {
-			waitForUpdatedNodeAnnotation(node, "checksum/cloud-config-data", utils.ComputeSHA256Hex(oscRaw))
-			waitForUpdatedNodeLabel(node, "worker.gardener.cloud/kubernetes-version", kubernetesVersion.String())
+			waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+			waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 			By("Assert that files and units have been created")
 			test.AssertNoDirectoryOnDisk(fakeFS, "/var/bin/containerruntimes")
@@ -836,20 +836,20 @@ func (c *cancelFuncEnsurer) cancel() {
 	c.called = true
 }
 
-func waitForUpdatedNodeAnnotation(node *corev1.Node, key, value string) {
+func waitForUpdatedNodeAnnotationCloudConfig(node *corev1.Node, value string) {
 	By("Wait for node annotations to be updated")
 	EventuallyWithOffset(1, func(g Gomega) map[string]string {
 		updatedNode := &corev1.Node{}
 		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
 		return updatedNode.Annotations
-	}).WithTimeout(2 * time.Second).Should(HaveKeyWithValue(key, value))
+	}).WithTimeout(2 * time.Second).Should(HaveKeyWithValue("checksum/cloud-config-data", value))
 }
 
-func waitForUpdatedNodeLabel(node *corev1.Node, key, value string) {
+func waitForUpdatedNodeLabelKubernetesVersion(node *corev1.Node, value string) {
 	By("Wait for node labels to be updated")
 	EventuallyWithOffset(1, func(g Gomega) map[string]string {
 		updatedNode := &corev1.Node{}
 		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
 		return updatedNode.Labels
-	}).Should(HaveKeyWithValue(key, value))
+	}).Should(HaveKeyWithValue("worker.gardener.cloud/kubernetes-version", value))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Example flake: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/10664/pull-gardener-integration/1892082164904759296

Local stress test showed a chance for a race between the call of the `cancelFunc` and the evaluated assertion. This PR rechecks whether `cancelFunc` has been called.

```
7m50s: 578 runs so far, 0 failures, 22 active
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11386.

**Special notes for your reviewer**:
/cc @rfranzke 