### PR TITLE
chore(deps): bump up logging to 0.65.0 with fluent-bit 3.2.5

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -505,7 +505,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-operator
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
-  tag: "v3.1.8"
+  tag: "v3.2.5"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -524,7 +524,7 @@ images:
     name: fluent-bit-to-vali
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-  tag: "v0.64.0"
+  tag: "v0.65.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -559,7 +559,7 @@ images:
 - name: vali-curator
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-  tag: "v0.64.0"
+  tag: "v0.65.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -615,7 +615,7 @@ images:
     name: telegraf-iptables
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-  tag: "v0.64.0"
+  tag: "v0.65.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -635,7 +635,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-  tag: "v0.64.0"
+  tag: "v0.65.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -652,7 +652,7 @@ images:
 - name: tune2fs
   sourceRepository: github.com/gardener/logging
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-  tag: "v0.64.0"
+  tag: "v0.65.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind enhancement

This PR brings component updates in the logging stack.

- [fluent-bit 3.2.5](https://fluentbit.io/announcements/v3.2.5/)
- [gardener/logging](https://github.com/gardener/logging/releases/tag/v0.65.0)

```other operator
The logging stack is now updated with the latest released components.
```
