### PR TITLE
e2e: Refactor `Create Hibernate Wakeup Delete Shoot` test to ordered containers

### DIFF
--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/gardener/gardener/test/e2e"
 	. "github.com/gardener/gardener/test/e2e/gardener"
 	. "github.com/gardener/gardener/test/e2e/gardener/shoot/internal"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/node"
 )
 
@@ -34,7 +35,9 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			ItShouldGetResponsibleSeed(s)
 			ItShouldInitializeSeedClient(s)
 
-			// TODO(timebertt): add inclusterclient.VerifyInClusterAccessToAPIServer once it got refactored
+			if !v1beta1helper.IsWorkerless(s.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			}
 
 			if !v1beta1helper.IsWorkerless(s.Shoot) {
 				// We verify the node readiness feature in this specific e2e test because it uses a single-node shoot cluster.
@@ -63,7 +66,9 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 			ItShouldWaitForShootToBeReconciledAndHealthy(s)
 
-			// TODO(timebertt): add inclusterclient.VerifyInClusterAccessToAPIServer once it got refactored
+			if !v1beta1helper.IsWorkerless(s.Shoot) {
+				inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			}
 
 			ItShouldDeleteShoot(s)
 			ItShouldWaitForShootToBeDeleted(s)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the mentioned test to the ordered containers approach.
See https://github.com/gardener/gardener/issues/11379

It also refactors the helper function `VerifyNodeCriticalComponentsBootstrapping` to separate `It`s

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
