### PR TITLE
Rename `seed.gardener.cloud/` prefix to `name.seed.gardener.cloud/`

### DIFF
--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -11,15 +11,23 @@ import (
 	"net/http"
 	"os"
 	goruntime "runtime"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"go.uber.org/automaxprocs/maxprocs"
+	"golang.org/x/exp/maps"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -27,12 +35,17 @@ import (
 	"github.com/gardener/gardener/cmd/gardener-controller-manager/app/bootstrappers"
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/api/indexer"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllermanager/controller"
 	"github.com/gardener/gardener/pkg/controllerutils/routes"
 	"github.com/gardener/gardener/pkg/features"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // Name is a const for the name of this component.
@@ -142,6 +155,108 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 	log.Info("Adding controllers to manager")
 	if err := controller.AddToManager(ctx, mgr, cfg); err != nil {
 		return fmt.Errorf("failed adding controllers to manager: %w", err)
+	}
+
+	// TODO(rfranzke): Remove this after Gardener v1.114 has been released and add code that cleans up all legacy
+	//  `seed.gardener.cloud/<name>=true` labels from these objects.
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		var fns []flow.TaskFn
+
+		prepareEmptyPatchTasks := func(list client.ObjectList, seedNamesFromObject func(obj client.Object) ([]*string, error)) error {
+			if err := mgr.GetClient().List(ctx, list); err != nil {
+				return fmt.Errorf("failed listing objects: %w", err)
+			}
+
+			return meta.EachListItem(list, func(o runtime.Object) error {
+				fns = append(fns, func(ctx context.Context) error {
+					obj := o.(client.Object)
+
+					if slices.ContainsFunc(maps.Keys(obj.GetLabels()), func(s string) bool {
+						return strings.HasPrefix(s, v1beta1constants.LabelPrefixSeedName)
+					}) {
+						return nil
+					}
+
+					gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
+					if err != nil {
+						return fmt.Errorf("could not get GroupVersionKind from object %v: %w", obj, err)
+					}
+
+					mgr.GetLogger().Info("Adding new seed name labels", "gvk", gvk, "objectKey", client.ObjectKeyFromObject(obj))
+
+					seedNames, err := seedNamesFromObject(obj)
+					if err != nil {
+						return err
+					}
+
+					patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
+					gardenerutils.MaintainSeedNameLabels(obj, seedNames...)
+					return mgr.GetClient().Patch(ctx, obj, patch)
+				})
+				return nil
+			})
+		}
+
+		if err := prepareEmptyPatchTasks(&gardencorev1beta1.BackupEntryList{}, func(obj client.Object) ([]*string, error) {
+			backupEntry := obj.(*gardencorev1beta1.BackupEntry)
+			return []*string{backupEntry.Spec.SeedName, backupEntry.Status.SeedName}, nil
+		}); err != nil {
+			return fmt.Errorf("failed computing tasks for backup entries: %w", err)
+		}
+
+		if err := prepareEmptyPatchTasks(&gardencorev1beta1.ShootList{}, func(obj client.Object) ([]*string, error) {
+			shoot := obj.(*gardencorev1beta1.Shoot)
+			return []*string{shoot.Spec.SeedName, shoot.Status.SeedName}, nil
+		}); err != nil {
+			return fmt.Errorf("failed computing tasks for shoots: %w", err)
+		}
+
+		if err := prepareEmptyPatchTasks(&gardencorev1beta1.SeedList{}, func(obj client.Object) ([]*string, error) {
+			seed := obj.(*gardencorev1beta1.Seed)
+
+			seedNames := []*string{&seed.Name}
+
+			managedSeed := &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: seed.Name, Namespace: v1beta1constants.GardenNamespace}}
+			if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return nil, fmt.Errorf("failed to get managed seed %q: %v", seed.Name, err)
+				}
+			} else if managedSeed.Spec.Shoot != nil {
+				shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: managedSeed.Spec.Shoot.Name, Namespace: managedSeed.Namespace}}
+				if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+					return nil, fmt.Errorf("failed to get shoot %s for managed seed %q: %v", managedSeed.Spec.Shoot.Name, managedSeed.Name, err)
+				}
+				seedNames = append(seedNames, shoot.Spec.SeedName)
+			}
+
+			return seedNames, nil
+		}); err != nil {
+			return fmt.Errorf("failed computing tasks for seeds: %w", err)
+		}
+
+		if err := prepareEmptyPatchTasks(&seedmanagementv1alpha1.ManagedSeedList{}, func(obj client.Object) ([]*string, error) {
+			managedSeed := obj.(*seedmanagementv1alpha1.ManagedSeed)
+
+			if managedSeed.Spec.Shoot == nil {
+				return nil, nil
+			}
+
+			shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: managedSeed.Spec.Shoot.Name, Namespace: managedSeed.Namespace}}
+			if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil, nil
+				}
+				return nil, err
+			}
+
+			return []*string{shoot.Spec.SeedName}, nil
+		}); err != nil {
+			return fmt.Errorf("failed computing tasks for managed seeds: %w", err)
+		}
+
+		return flow.Parallel(fns...)(ctx)
+	})); err != nil {
+		return fmt.Errorf("failed adding seed name label migration runnable to manager: %w", err)
 	}
 
 	log.Info("Starting manager")

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -241,7 +241,7 @@ func (g *garden) Start(ctx context.Context) error {
 				&gardencorev1beta1.ControllerInstallation{}: {
 					Field: fields.SelectorFromSet(fields.Set{gardencore.SeedRefName: g.config.SeedConfig.SeedTemplate.Name}),
 				},
-				// TODO(rfranzke): Enable the label selector for Seeds after Gardener v1.113 has been released.
+				// TODO(rfranzke): Enable the label selector for Seeds after Gardener v1.114 has been released.
 				// &gardencorev1beta1.Seed{}: {
 				// 	Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.SeedTemplate.Name: "true"}),
 				// },

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -114,10 +114,10 @@ Rejects the deletion if `Shoot`(s) reference the seed cluster.
 _(enabled by default)_
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Seed`s.
-It maintains the `seed.gardener.cloud/<name>` labels for it.
-More specifically, it adds that the `seed.gardener.cloud/<name>=true` label where `<name>` is
-- the name of the `Seed` resource (a `Seed` named `foo` will get label `seed.gardener.cloud/foo=true`).
-- the name of the parent `Seed` resource in case it is a `ManagedSeed` (a `Seed` named `foo` that is created by a `ManagedSeed` which references a `Shoot` running a `Seed` called `bar` will get label `seed.gardener.cloud/bar=true`).
+It maintains the `name.seed.gardener.cloud/<name>` labels for it.
+More specifically, it adds that the `name.seed.gardener.cloud/<name>=true` label where `<name>` is
+- the name of the `Seed` resource (a `Seed` named `foo` will get label `name.seed.gardener.cloud/foo=true`).
+- the name of the parent `Seed` resource in case it is a `ManagedSeed` (a `Seed` named `foo` that is created by a `ManagedSeed` which references a `Shoot` running a `Seed` called `bar` will get label `name.seed.gardener.cloud/bar=true`).
 
 ## `ShootDNS`
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -465,7 +465,7 @@ const (
 	LabelSecretBindingReference = "reference.gardener.cloud/secretbinding"
 	// LabelCredentialsBindingReference is used to identify credentials which are referred by a CredentialsBinding (not necessarily in the same namespace).
 	LabelCredentialsBindingReference = "reference.gardener.cloud/credentialsbinding"
-	// LabelPrefixSeedName is the prefix for the label key describing the name of a seed, e.g. seed.gardener.cloud/my-seed=true.
+	// LabelPrefixSeedName is the prefix for the label key describing the name of a seed, e.g. name.seed.gardener.cloud/my-seed=true.
 	LabelPrefixSeedName = "name.seed.gardener.cloud/"
 
 	// LabelExtensionExtensionTypePrefix is used to prefix extension label for extension types.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -466,7 +466,7 @@ const (
 	// LabelCredentialsBindingReference is used to identify credentials which are referred by a CredentialsBinding (not necessarily in the same namespace).
 	LabelCredentialsBindingReference = "reference.gardener.cloud/credentialsbinding"
 	// LabelPrefixSeedName is the prefix for the label key describing the name of a seed, e.g. seed.gardener.cloud/my-seed=true.
-	LabelPrefixSeedName = "seed.gardener.cloud/"
+	LabelPrefixSeedName = "name.seed.gardener.cloud/"
 
 	// LabelExtensionExtensionTypePrefix is used to prefix extension label for extension types.
 	LabelExtensionExtensionTypePrefix = "extensions.extensions.gardener.cloud/"

--- a/pkg/apiserver/registry/core/backupentry/strategy_test.go
+++ b/pkg/apiserver/registry/core/backupentry/strategy_test.go
@@ -118,16 +118,16 @@ var _ = Describe("#Canonicalize", func() {
 	Context("seed names", func() {
 		It("should correctly add the seed labels", func() {
 			metav1.SetMetaDataLabel(&backupEntry.ObjectMeta, "foo", "bar")
-			metav1.SetMetaDataLabel(&backupEntry.ObjectMeta, "seed.gardener.cloud/foo", "true")
+			metav1.SetMetaDataLabel(&backupEntry.ObjectMeta, "name.seed.gardener.cloud/foo", "true")
 			backupEntry.Spec.SeedName = ptr.To("spec-seed")
 			backupEntry.Status.SeedName = ptr.To("status-seed")
 
 			backupentryregistry.NewStrategy().Canonicalize(backupEntry)
 
 			Expect(backupEntry.Labels).To(Equal(map[string]string{
-				"foo":                             "bar",
-				"seed.gardener.cloud/spec-seed":   "true",
-				"seed.gardener.cloud/status-seed": "true",
+				"foo":                                  "bar",
+				"name.seed.gardener.cloud/spec-seed":   "true",
+				"name.seed.gardener.cloud/status-seed": "true",
 			}))
 		})
 	})

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -840,16 +840,16 @@ var _ = Describe("Strategy", func() {
 		Context("seed names", func() {
 			It("should correctly add the seed labels", func() {
 				metav1.SetMetaDataLabel(&shoot.ObjectMeta, "foo", "bar")
-				metav1.SetMetaDataLabel(&shoot.ObjectMeta, "seed.gardener.cloud/foo", "true")
+				metav1.SetMetaDataLabel(&shoot.ObjectMeta, "name.seed.gardener.cloud/foo", "true")
 				shoot.Spec.SeedName = ptr.To("spec-seed")
 				shoot.Status.SeedName = ptr.To("status-seed")
 
 				strategy.Canonicalize(shoot)
 
 				Expect(shoot.Labels).To(Equal(map[string]string{
-					"foo":                             "bar",
-					"seed.gardener.cloud/spec-seed":   "true",
-					"seed.gardener.cloud/status-seed": "true",
+					"foo":                                  "bar",
+					"name.seed.gardener.cloud/spec-seed":   "true",
+					"name.seed.gardener.cloud/status-seed": "true",
 				}))
 			})
 		})

--- a/pkg/utils/gardener/identity_test.go
+++ b/pkg/utils/gardener/identity_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Identity", func() {
 	Describe("#MaintainSeedNameLabels", func() {
 		It("should maintain the labels", func() {
 			obj := &gardencorev1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"seed.gardener.cloud/old-seed": "true"}},
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"name.seed.gardener.cloud/old-seed": "true"}},
 				Spec:       gardencorev1beta1.ShootSpec{SeedName: ptr.To("spec-seed")},
 				Status:     gardencorev1beta1.ShootStatus{SeedName: ptr.To("status-seed")},
 			}
@@ -26,8 +26,8 @@ var _ = Describe("Identity", func() {
 			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)
 
 			Expect(obj.Labels).To(And(
-				HaveKeyWithValue("seed.gardener.cloud/spec-seed", "true"),
-				HaveKeyWithValue("seed.gardener.cloud/status-seed", "true"),
+				HaveKeyWithValue("name.seed.gardener.cloud/spec-seed", "true"),
+				HaveKeyWithValue("name.seed.gardener.cloud/status-seed", "true"),
 			))
 		})
 
@@ -39,12 +39,12 @@ var _ = Describe("Identity", func() {
 
 			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)
 
-			Expect(obj.Labels).To(HaveKeyWithValue("seed.gardener.cloud/seed", "true"))
+			Expect(obj.Labels).To(HaveKeyWithValue("name.seed.gardener.cloud/seed", "true"))
 		})
 
 		It("should maintain the labels when spec and status names are empty", func() {
 			obj := &gardencorev1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "seed.gardener.cloud/old-seed": "true"}},
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "name.seed.gardener.cloud/old-seed": "true"}},
 			}
 
 			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -379,18 +379,18 @@ var _ = Describe("ManagedSeed", func() {
 					Expect(admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)).To(Succeed())
 
 					Expect(managedSeed.Labels).To(And(
-						HaveKeyWithValue("seed.gardener.cloud/parent-seed", "true"),
+						HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
 					))
 				})
 
 				It("should remove unneeded labels", func() {
-					metav1.SetMetaDataLabel(&seed.ObjectMeta, "seed.gardener.cloud/foo", "true")
+					metav1.SetMetaDataLabel(&seed.ObjectMeta, "name.seed.gardener.cloud/foo", "true")
 
 					Expect(admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)).To(Succeed())
 
 					Expect(managedSeed.Labels).To(And(
-						HaveKeyWithValue("seed.gardener.cloud/parent-seed", "true"),
-						Not(HaveKey("seed.gardener.cloud/foo")),
+						HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
+						Not(HaveKey("name.seed.gardener.cloud/foo")),
 					))
 				})
 			})

--- a/plugin/pkg/seed/mutator/admission_test.go
+++ b/plugin/pkg/seed/mutator/admission_test.go
@@ -68,7 +68,7 @@ var _ = Describe("mutator", func() {
 				attrs := admission.NewAttributesRecord(seed, nil, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 				Expect(handler.Admit(ctx, attrs, nil)).To(Succeed())
 
-				Expect(seed.Labels).To(HaveKeyWithValue("seed.gardener.cloud/the-seed", "true"))
+				Expect(seed.Labels).To(HaveKeyWithValue("name.seed.gardener.cloud/the-seed", "true"))
 			})
 
 			It("should add the label for the parent seed name", func() {
@@ -79,8 +79,8 @@ var _ = Describe("mutator", func() {
 				Expect(handler.Admit(ctx, attrs, nil)).To(Succeed())
 
 				Expect(seed.Labels).To(And(
-					HaveKeyWithValue("seed.gardener.cloud/the-seed", "true"),
-					HaveKeyWithValue("seed.gardener.cloud/parent-seed", "true"),
+					HaveKeyWithValue("name.seed.gardener.cloud/the-seed", "true"),
+					HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
 				))
 			})
 		})
@@ -90,7 +90,7 @@ var _ = Describe("mutator", func() {
 				attrs := admission.NewAttributesRecord(seed, seed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 				Expect(handler.Admit(ctx, attrs, nil)).To(Succeed())
 
-				Expect(seed.Labels).To(HaveKeyWithValue("seed.gardener.cloud/the-seed", "true"))
+				Expect(seed.Labels).To(HaveKeyWithValue("name.seed.gardener.cloud/the-seed", "true"))
 			})
 
 			It("should add the label for the parent seed name", func() {
@@ -101,8 +101,8 @@ var _ = Describe("mutator", func() {
 				Expect(handler.Admit(ctx, attrs, nil)).To(Succeed())
 
 				Expect(seed.Labels).To(And(
-					HaveKeyWithValue("seed.gardener.cloud/the-seed", "true"),
-					HaveKeyWithValue("seed.gardener.cloud/parent-seed", "true"),
+					HaveKeyWithValue("name.seed.gardener.cloud/the-seed", "true"),
+					HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
 				))
 			})
 
@@ -110,15 +110,15 @@ var _ = Describe("mutator", func() {
 				Expect(seedManagementInformerFactory.Seedmanagement().V1alpha1().ManagedSeeds().Informer().GetStore().Add(managedSeed)).To(Succeed())
 				Expect(coreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
 
-				metav1.SetMetaDataLabel(&seed.ObjectMeta, "seed.gardener.cloud/foo", "true")
+				metav1.SetMetaDataLabel(&seed.ObjectMeta, "name.seed.gardener.cloud/foo", "true")
 
 				attrs := admission.NewAttributesRecord(seed, seed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 				Expect(handler.Admit(ctx, attrs, nil)).To(Succeed())
 
 				Expect(seed.Labels).To(And(
-					HaveKeyWithValue("seed.gardener.cloud/the-seed", "true"),
-					HaveKeyWithValue("seed.gardener.cloud/parent-seed", "true"),
-					Not(HaveKey("seed.gardener.cloud/foo")),
+					HaveKeyWithValue("name.seed.gardener.cloud/the-seed", "true"),
+					HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
+					Not(HaveKey("name.seed.gardener.cloud/foo")),
 				))
 			})
 		})

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -287,8 +287,8 @@ var _ = Describe("ControllerInstallation controller tests", func() {
     labels:
       ` + testID + `: ` + testRunID + `
       dnsrecord.extensions.gardener.cloud/` + seed.Spec.DNS.Provider.Type + `: "true"
+      name.seed.gardener.cloud/` + seed.Name + `: "true"
       provider.extensions.gardener.cloud/` + seed.Spec.Provider.Type + `: "true"
-      seed.gardener.cloud/` + seed.Name + `: "true"
     name: ` + seed.Name + `
     networks:
       ipFamilies:


### PR DESCRIPTION
due to potential naming conflicts when users also use `seed.gardener.cloud/` as prefix for their labels (not ideal, they should actually use a unique prefix (e.g., `seed.my.cool.domain.com/`), but we cannot prevent it for historic reasons

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind regression

**What this PR does / why we need it**:
This PR renames the `seed.gardener.cloud/` prefix to `name.seed.gardener.cloud/` due to potential naming conflicts when users also use`seed.gardener.cloud/` as prefix for their labels (not ideal, they should actually use a unique prefix (e.g., `seed.my.cool.domain.com/`), but we cannot prevent it for historic reasons.

**Which issue(s) this PR fixes**:
Follow-up of #11062

**Special notes for your reviewer**:
/cc @marc1404 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which prevented usage of labels with `seed.gardener.cloud/` prefix on `Seed`, `ManagedSeed`, `BackupEntry`, and `Shoot` resources has been fixed.
```
```noteworthy user
All `Seed`s are now automatically labeled with `name.seed.gardener.cloud/<name>=true` (⚠ no longer `seed.gardener.cloud/<name>=true`) where `<name>` is their own name, and (if applicable) the name of their parent seed in case they are managed seeds. This label can be used as selector for requests.
```
