### PR TITLE
Install `runc` from container filesystem when running in prow

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -368,7 +368,12 @@ for node in $nodes; do
 
   # TODO(marc1404): Remove once kindest/node uses runc >= v1.2.4
   # workaround issue with runc v1.2.3 provided by kindest/node:v1.32.0 by installing runc v1.2.4 manually (https://github.com/opencontainers/runc/pull/4555)
-  docker exec -i "$node" sh -c "bash -" < "$(dirname "$0")/../pkg/provider-local/node/patch-runc.sh"
+  if [ -n "${CI:-}" ]; then
+    echo "Installing runc on node $node from container filesystem"
+    docker cp /get-runc/runc "$node":/usr/local/sbin/runc
+  else
+    docker exec -i "$node" sh -c "bash -" < "$(dirname "$0")/../pkg/provider-local/node/patch-runc.sh"
+  fi
 done
 
 if [[ "$KUBECONFIG" != "$PATH_KUBECONFIG" ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Since PR https://github.com/gardener/ci-infra/pull/3250 was merged `runc` binary is available in `krte` image.
Thus, let's copy it into the nodes instead of downloading it if the local setup runs in prow.
This avoids errors like [this one](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11085/pull-gardener-e2e-kind-ipv6/1892860255633674240#1:build-log.txt%3A399).

**Which issue(s) this PR fixes**:
Part of #11386

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
