### PR TITLE
[e2e] Increase timeout for credentials rotation w/o workers rollout test

### DIFF
--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -95,7 +95,7 @@ func testCredentialRotationComplete(parentCtx context.Context, v rotationutils.V
 }
 
 func testCredentialRotationWithoutWorkersRollout(parentCtx context.Context, v rotationutils.Verifiers, f *framework.ShootCreationFramework) {
-	ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
+	ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
 	defer cancel()
 
 	By("Before credential rotation")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Unlike the "credentials rotation w/ workers rollout" test, this one is split into multiple stages. In stage one, the credentials rotation is started which rolls ETCD and KAPI. Then there is another stage where a worker pool is removed (which causes some time), and only in the third stage, the worker pools are getting rolled out.

The "credentials rotation w/ workers rollout" test rolls ETCD + machines in the first stage, which is overall faster (hence, the `20m` there are sufficient).

Example flake: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11393/pull-gardener-e2e-kind-ha-multi-zone/1893027216988573696

**Which issue(s) this PR fixes**:
Part of #11386 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
