### PR TITLE
e2e: refactor `VerifyInClusterAccessToAPIServer` to ordered containers

### DIFF
--- a/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
@@ -75,7 +75,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			}, NodeTimeout(time.Minute))
 
 			Eventually(ctx, func() error {
-				return s.ShootClient.Create(ctx, pod)
+				if err := s.ShootClient.Create(ctx, pod); err != nil {
+					return err
+				}
+				return StopTrying("pod was created")
 			}).Should(And(
 				BeForbiddenError(),
 				MatchError(ContainSubstring("pods %q is forbidden: violates PodSecurity %q", "nginx", "restricted:latest")),

--- a/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/gardener/gardener/test/e2e"
 	. "github.com/gardener/gardener/test/e2e/gardener"
 	. "github.com/gardener/gardener/test/e2e/gardener/shoot/internal"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
@@ -81,8 +82,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			))
 		}, SpecTimeout(time.Minute))
 
-		// TODO(timebertt): add back inclusterclient.VerifyInClusterAccessToAPIServer once it has been refactored to ordered
-		// containers
+		inclusterclient.VerifyInClusterAccessToAPIServer(s)
 
 		ItShouldDeleteShoot(s)
 		ItShouldWaitForShootToBeDeleted(s)

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/provider-local/apis/local/install"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/node"
 )
 
@@ -79,9 +78,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			if !v1beta1helper.IsWorkerless(f.Shoot) {
 				By("Verify Bootstrapping of Nodes with node-critical components")
@@ -101,9 +101,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			defer cancel()
 			Expect(f.WakeUpShoot(ctx, f.Shoot)).To(Succeed())
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, s)
+			// }
 
 			By("Delete Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -14,9 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	. "github.com/gardener/gardener/test/framework"
 )
 
@@ -36,14 +34,15 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) && !v1beta1helper.HibernationIsEnabled(f.Shoot) {
-				// We can only verify in-cluster access to the API server before the migration in local e2e tests.
-				// After the migration, the shoot API server's hostname still points to the source seed, because
-				// the /etc/hosts entry is never updated. Hence, we talk to the API server for starting in-cluster
-				// clients. That's also why the ShootMigrationTest is configured to skip all interactions with the
-				// shoot API server for local e2e tests.
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) && !v1beta1helper.HibernationIsEnabled(s.Shoot) {
+			// 	// We can only verify in-cluster access to the API server before the migration in local e2e tests.
+			// 	// After the migration, the shoot API server's hostname still points to the source seed, because
+			// 	// the /etc/hosts entry is never updated. Hence, we talk to the API server for starting in-cluster
+			// 	// clients. That's also why the ShootMigrationTest is configured to skip all interactions with the
+			// 	// shoot API server for local e2e tests.
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			By("Migrate Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/rotation"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/access"
@@ -211,9 +210,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			// isolated test for ssh key rotation (does not trigger node rolling update)
 			if !v1beta1helper.IsWorkerless(f.Shoot) && !withoutWorkersRollout {
@@ -288,9 +288,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			By("Renew shoot client after credentials rotation")
 			Expect(f.ShootFramework.AddShoot(parentCtx, f.Shoot.Name, f.Shoot.Namespace)).To(Succeed())
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			By("Delete Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/access"
 	shootupdatesuite "github.com/gardener/gardener/test/utils/shoots/update"
@@ -138,7 +137,8 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 					}
 				}).Should(Succeed())
 
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
+				// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+				// inclusterclient.VerifyInClusterAccessToAPIServer(s)
 			}
 
 			By("Update Shoot")
@@ -149,9 +149,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				Shoot:             f.Shoot,
 			}, nil, nil)
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			By("Add skip readiness annotation")
 			ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -32,7 +32,7 @@ import (
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	"github.com/gardener/gardener/test/framework"
+	. "github.com/gardener/gardener/test/e2e/gardener"
 )
 
 const (
@@ -59,8 +59,10 @@ var labels = map[string]string{"e2e-test": "in-cluster-client"}
 // - one pod disables injection and relies on the default service link env vars
 // - one pod explicitly overwrites the env var
 // See docs/usage/networking/shoot_kubernetes_service_host_injection.md and docs/proposals/08-shoot-apiserver-via-sni.md
-func VerifyInClusterAccessToAPIServer(parentCtx context.Context, f *framework.ShootFramework) {
-	if gardencorev1beta1.IsIPv6SingleStack(f.Shoot.Spec.Networking.IPFamilies) && len(f.Shoot.Spec.Provider.Workers) > 1 {
+func VerifyInClusterAccessToAPIServer(s *ShootContext) {
+	GinkgoHelper()
+
+	if gardencorev1beta1.IsIPv6SingleStack(s.Shoot.Spec.Networking.IPFamilies) && len(s.Shoot.Spec.Provider.Workers) > 1 {
 		// On local IPv6 single-stack clusters, the in-cluster DNS resolution can fail if it requires cross-node pod-to-pod
 		// communication, see https://github.com/gardener/gardener/pull/11287#discussion_r1950320268 and
 		// https://github.com/gardener/gardener/pull/11148#issuecomment-2653202171.
@@ -69,34 +71,101 @@ func VerifyInClusterAccessToAPIServer(parentCtx context.Context, f *framework.Sh
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
-	defer cancel()
+	Describe("in-cluster access to API server", func() {
+		It("should create test objects", func(ctx SpecContext) {
+			for _, obj := range getRBACObjects() {
+				Eventually(ctx, func() error {
+					return s.ShootClient.Create(ctx, obj)
+				}).Should(Or(Succeed(), BeAlreadyExistsError()), "should create %T %q", obj, client.ObjectKeyFromObject(obj))
+			}
+		}, SpecTimeout(time.Minute))
 
-	defer cleanupObjects(f.ShootClient.Client())
-	podNames := prepareObjects(ctx, f.ShootClient.Client(), f.Shoot.Spec.Kubernetes.Version)
+		var (
+			pods     []*corev1.Pod
+			podNames map[string]string
+		)
 
-	By("Verify access via direct path")
-	// this pod connects to the API server directly, i.e., uses the KUBERNETES_SERVICE_HOST env var injected by gardener
-	verifyAccessFromPod(ctx, f, podNames[podNameDirect], getInternalAPIServerAddress(f.Shoot))
+		It("should create test pods", func(ctx SpecContext) {
+			pods = getPods(s.Shoot.Spec.Kubernetes.Version)
+			podNames = make(map[string]string, len(pods))
 
-	By("Verify access via API server proxy via the kubernetes service's clusterIP")
-	// this pod connects via the API server proxy using the KUBERNETES_SERVICE_HOST env var injected by kubelet, i.e.,
-	// via the clusterIP of kubernetes.default.svc.cluster.local
-	verifyAccessFromPod(ctx, f, podNames[podNameAPIServerProxyIP], getInClusterAPIServerAddress(ctx, f.ShootClient.Client()))
+			for _, pod := range pods {
+				Eventually(ctx, func(g Gomega) {
+					// if pod has already been created, delete it and try again with a new generated name
+					if pod.Name != "" {
+						g.Expect(s.ShootClient.Delete(ctx, pod)).To(Or(Succeed(), BeNotFoundError()))
+						pod.Name = ""
+						pod.ResourceVersion = ""
+					}
 
-	By("Verify access via API server proxy via the kubernetes service's hostname")
-	// this pod connects via the API server proxy via the kubernetes.default.svc.cluster.local hostname
-	verifyAccessFromPod(ctx, f, podNames[podNameAPIServerProxyHostname], "https://kubernetes.default.svc.cluster.local:443")
+					g.Expect(s.ShootClient.Create(ctx, pod)).To(Succeed())
+					podNames[pod.GenerateName] = pod.Name
+
+					if pod.Labels[resourcesv1alpha1.KubernetesServiceHostInject] != "disable" {
+						// Verify that gardener successfully injected the KUBERNETES_SERVICE_HOST env var (if not disabled).
+						// The webhook has failurePolicy=Ignore, so we might need to delete the pod and try again until the injection
+						// succeeds.
+						g.Expect(pod.Spec.Containers).To(ConsistOf(
+							HaveField("Env", ContainElement(
+								HaveField("Name", "KUBERNETES_SERVICE_HOST"),
+							)),
+						), "gardener should inject the KUBERNETES_SERVICE_HOST env var into the containers of pod %s", pod.Name)
+					}
+				}).WithPolling(2*time.Second).Should(Succeed(), "should create pod %q", pod.GenerateName)
+			}
+		}, SpecTimeout(time.Minute))
+
+		It("should wait for test pods to be ready", func(ctx SpecContext) {
+			for _, pod := range pods {
+				Eventually(ctx, func(g Gomega) {
+					g.Expect(s.ShootKomega.Get(pod)()).To(Succeed())
+					g.Expect(health.IsPodReady(pod)).To(BeTrue())
+				}).Should(Succeed(), "pod %q should get ready", client.ObjectKeyFromObject(pod))
+			}
+		}, SpecTimeout(time.Minute))
+
+		It("should access the API server via direct path", func(ctx SpecContext) {
+			// this pod connects to the API server directly, i.e., uses the KUBERNETES_SERVICE_HOST env var injected by gardener
+			expectedAddress := getInternalAPIServerAddress(s.Shoot)
+			verifyAccessFromPod(ctx, s.ShootClientSet, podNames[podNameDirect], expectedAddress)
+		}, SpecTimeout(time.Minute))
+
+		It("should access the API server via the kubernetes service's clusterIP", func(ctx SpecContext) {
+			// this pod connects via the API server proxy using the KUBERNETES_SERVICE_HOST env var injected by kubelet, i.e.,
+			// via the clusterIP of kubernetes.default.svc.cluster.local
+			expectedAddress := getInClusterAPIServerAddress(ctx, s)
+			verifyAccessFromPod(ctx, s.ShootClientSet, podNames[podNameAPIServerProxyIP], expectedAddress)
+		}, SpecTimeout(time.Minute))
+
+		It("should access the API server via the kubernetes service's hostname", func(ctx SpecContext) {
+			// this pod connects via the API server proxy via the kubernetes.default.svc.cluster.local hostname
+			verifyAccessFromPod(ctx, s.ShootClientSet, podNames[podNameAPIServerProxyHostname], "https://kubernetes.default.svc.cluster.local:443")
+		}, SpecTimeout(time.Minute))
+
+		AfterAll(func(ctx SpecContext) {
+			By("Clean up test objects")
+			for _, obj := range getRBACObjects() {
+				Eventually(ctx, func() error {
+					return s.ShootClient.Delete(ctx, obj)
+				}).Should(Or(Succeed(), BeNotFoundError()), "should delete %T %q", obj, client.ObjectKeyFromObject(obj))
+			}
+
+			By("Clean up test pods")
+			Eventually(ctx, func() error {
+				return s.ShootClient.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(namespace), client.MatchingLabels(labels))
+			}).Should(Succeed(), "should delete all test pods")
+		}, NodeTimeout(time.Minute))
+	})
 }
 
-func verifyAccessFromPod(ctx context.Context, f *framework.ShootFramework, podName, expectedAddress string) {
+func verifyAccessFromPod(ctx context.Context, clientSet kubernetes.Interface, podName, expectedAddress string) {
 	By("Verify we are using the expected path")
-	executeKubectl(ctx, f.ShootClient, podName, []string{"/kubectl", "cluster-info"}, Say(
+	executeKubectl(ctx, clientSet, podName, []string{"/kubectl", "cluster-info"}, Say(
 		"Kubernetes control plane is running at %s", regexp.QuoteMeta(expectedAddress),
 	))
 
 	By("Verify a typical API request works")
-	executeKubectl(ctx, f.ShootClient, podName, []string{"/kubectl", "get", "service", "kubernetes"}, Say(
+	executeKubectl(ctx, clientSet, podName, []string{"/kubectl", "get", "service", "kubernetes"}, Say(
 		`NAME.+\nkubernetes.+\n`,
 	))
 }
@@ -111,19 +180,19 @@ func getInternalAPIServerAddress(shoot *gardencorev1beta1.Shoot) string {
 			break
 		}
 	}
-	Expect(address).NotTo(BeEmpty())
+	Expect(address).NotTo(BeEmpty(), "shoot should have an internal API server address")
 
 	return address + ":443"
 }
 
-func getInClusterAPIServerAddress(ctx context.Context, c client.Client) string {
+func getInClusterAPIServerAddress(ctx context.Context, s *ShootContext) string {
 	GinkgoHelper()
 
-	service := corev1.Service{}
-	Expect(c.Get(ctx, client.ObjectKey{Name: "kubernetes", Namespace: metav1.NamespaceDefault}, &service)).To(Succeed())
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "kubernetes", Namespace: metav1.NamespaceDefault}}
+	Eventually(ctx, s.ShootKomega.Get(service)).Should(Succeed())
 
 	clusterIP := service.Spec.ClusterIP
-	Expect(clusterIP).NotTo(BeEmpty())
+	Expect(clusterIP).NotTo(BeEmpty(), "kubernetes service should have a ClusterIP")
 
 	var port int32
 	for _, p := range service.Spec.Ports {
@@ -132,71 +201,9 @@ func getInClusterAPIServerAddress(ctx context.Context, c client.Client) string {
 			break
 		}
 	}
-	Expect(port).NotTo(BeZero())
+	Expect(port).NotTo(BeZero(), "kubernetes service should have a port named https")
 
 	return "https://" + net.JoinHostPort(clusterIP, strconv.FormatInt(int64(port), 10))
-}
-
-func prepareObjects(ctx context.Context, c client.Client, kubernetesVersion string) map[string]string {
-	By("Create test objects for verifying in-cluster access to API server")
-	for _, obj := range getRBACObjects() {
-		Eventually(func() error {
-			return client.IgnoreAlreadyExists(c.Create(ctx, obj))
-		}).WithContext(ctx).WithTimeout(time.Minute).Should(Succeed(), "should create %T %q", obj, client.ObjectKeyFromObject(obj))
-	}
-
-	pods := getPods(kubernetesVersion)
-	podGenerateNameToName := map[string]string{}
-	for _, pod := range pods {
-		Eventually(func(g Gomega) {
-			// if pod has already been created, delete it and try again with a new generated name
-			if pod.Name != "" {
-				g.Expect(c.Delete(ctx, pod)).To(Or(Succeed(), BeNotFoundError()))
-				pod.Name = ""
-				pod.ResourceVersion = ""
-			}
-
-			g.Expect(c.Create(ctx, pod)).To(Succeed())
-			podGenerateNameToName[pod.GenerateName] = pod.Name
-
-			if pod.Labels[resourcesv1alpha1.KubernetesServiceHostInject] != "disable" {
-				// Verify that gardener successfully injected the KUBERNETES_SERVICE_HOST env var (if not disabled).
-				// The webhook has failurePolicy=Ignore, so we might need to delete the pod and try again until the injection
-				// succeeds.
-				g.Expect(pod.Spec.Containers).To(ConsistOf(
-					HaveField("Env", ContainElement(
-						HaveField("Name", "KUBERNETES_SERVICE_HOST"),
-					)),
-				), "gardener should inject the KUBERNETES_SERVICE_HOST env var into the containers of pod %s", pod.Name)
-			}
-		}).WithContext(ctx).WithPolling(2*time.Second).WithTimeout(time.Minute).Should(Succeed(), "should create pod %q", pod.GenerateName)
-	}
-
-	By("Wait for test pods to be ready")
-	Eventually(func(g Gomega) {
-		for _, pod := range pods {
-			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
-			g.Expect(health.IsPodReady(pod)).To(BeTrue(), "pod %q should get ready", client.ObjectKeyFromObject(pod))
-		}
-	}).WithContext(ctx).WithTimeout(time.Minute).Should(Succeed())
-
-	return podGenerateNameToName
-}
-
-func cleanupObjects(c client.Client) {
-	By("Cleaning up test objects for verifying in-cluster access to API server")
-	cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	for _, obj := range getRBACObjects() {
-		Eventually(func() error {
-			return client.IgnoreNotFound(c.Delete(cleanupCtx, obj))
-		}).WithContext(cleanupCtx).Should(Succeed(), "should delete %T %q", obj, client.ObjectKeyFromObject(obj))
-	}
-
-	Eventually(func() error {
-		return c.DeleteAllOf(cleanupCtx, &corev1.Pod{}, client.InNamespace(namespace), client.MatchingLabels(labels))
-	}).WithContext(cleanupCtx).Should(Succeed(), "should delete all test pods")
 }
 
 func executeKubectl(ctx context.Context, clientSet kubernetes.Interface, podName string, command []string, matcher gomegatypes.GomegaMatcher) {
@@ -204,7 +211,7 @@ func executeKubectl(ctx context.Context, clientSet kubernetes.Interface, podName
 
 	// Retry the command execution with a short timeout to reduce flakiness. We better timeout quickly and succeed on the
 	// next try than being stuck in on try.
-	Eventually(func(g Gomega, ctx context.Context) {
+	Eventually(ctx, func(g Gomega) {
 		timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()
 
@@ -224,7 +231,7 @@ func executeKubectl(ctx context.Context, clientSet kubernetes.Interface, podName
 
 		// we don't need Eventually here, because the buffer is already closed
 		g.Expect(stdOutBuffer).To(matcher)
-	}).WithContext(ctx).WithTimeout(5 * time.Minute).Should(Succeed())
+	}).Should(Succeed())
 }
 
 func getPods(kubernetesVersion string) []*corev1.Pod {

--- a/test/e2e/gardener/shoot/internal/shoot.go
+++ b/test/e2e/gardener/shoot/internal/shoot.go
@@ -146,8 +146,12 @@ func ItShouldInitializeShootClient(s *ShootContext) {
 	It("Initialize Shoot client", func(ctx SpecContext) {
 		Eventually(ctx, func() error {
 			clientSet, err := access.CreateShootClientFromAdminKubeconfig(ctx, s.GardenClientSet, s.Shoot)
+			if err != nil {
+				return err
+			}
+
 			s.WithShootClientSet(clientSet)
-			return err
+			return nil
 		}).Should(Succeed())
 	}, SpecTimeout(time.Minute))
 }

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
@@ -12,9 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/utils/shoots/update/highavailability"
 )
 
@@ -33,18 +31,20 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			By("Upgrade Shoot (non-HA to HA with failure tolerance type 'node')")
 			ctx, cancel = context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 			highavailability.UpgradeAndVerify(ctx, f.ShootFramework, gardencorev1beta1.FailureToleranceTypeNode)
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			By("Delete Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_zone.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_zone.go
@@ -12,9 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/utils/shoots/update/highavailability"
 )
 
@@ -33,18 +31,20 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 			f.Verify()
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			By("Upgrade Shoot (non-HA to HA with failure tolerance type 'zone')")
 			ctx, cancel = context.WithTimeout(parentCtx, 30*time.Minute)
 			defer cancel()
 			highavailability.UpgradeAndVerify(ctx, f.ShootFramework, gardencorev1beta1.FailureToleranceTypeZone)
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) {
-				inclusterclient.VerifyInClusterAccessToAPIServer(parentCtx, f.ShootFramework)
-			}
+			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
+			// if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			// }
 
 			By("Delete Shoot")
 			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

This PR refactors the "sub test" `VerifyInClusterAccessToAPIServer` to ordered containers.
As this is not compatible with e2e tests that have not been refactored yet, we can only use it in a single test case for now. We will add it back to the other test cases as we progress with the refactoring, see https://github.com/gardener/gardener/issues/11379#issuecomment-2677622677.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
