### PR TITLE
[release-v1.110] Automated cherry pick of #11479: Rename `seed.gardener.cloud/` prefix to `name.seed.gardener.cloud/`

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -242,6 +242,10 @@ func (g *garden) Start(ctx context.Context) error {
 				&gardencorev1beta1.ControllerInstallation{}: {
 					Field: fields.SelectorFromSet(fields.Set{gardencore.SeedRefName: g.config.SeedConfig.SeedTemplate.Name}),
 				},
+				// TODO(rfranzke): Enable the label selector for Seeds after Gardener v1.114 has been released.
+				// &gardencorev1beta1.Seed{}: {
+				// 	Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.SeedTemplate.Name: "true"}),
+				// },
 				&gardencorev1beta1.Shoot{}: {
 					Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.SeedTemplate.Name: "true"}),
 				},

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -88,7 +88,7 @@ It prevents creating `Project`s with a non-empty `.spec.namespace` if the value 
 _(enabled by default)_
 
 This admission controller enables [object count ResourceQuotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/#object-count-quota) for Gardener resources, e.g. `Shoots`, `SecretBindings`, `Projects`, etc.
-> :warning: In addition to this admission plugin, the [ResourceQuota controller](https://github.com/kubernetes/kubernetes/blob/release-1.2/docs/design/admission_control_resource_quota.md#resource-quota-controller) must be enabled for the Kube-Controller-Manager of your Garden cluster. 
+> :warning: In addition to this admission plugin, the [ResourceQuota controller](https://github.com/kubernetes/kubernetes/blob/release-1.2/docs/design/admission_control_resource_quota.md#resource-quota-controller) must be enabled for the Kube-Controller-Manager of your Garden cluster.
 
 ## `ResourceReferenceManager`
 
@@ -155,7 +155,7 @@ Operators can provide an optional label selector via the `selector` field to lim
 _(disabled by default)_
 
 This admission controller reacts on `CREATE` operations for `Shoot`s.
-If enabled, it will enable the managed `VerticalPodAutoscaler` components (for more information, see [Vertical Pod Auto-Scaling](../usage/autoscaling/shoot_autoscaling.md#vertical-pod-auto-scaling)) 
+If enabled, it will enable the managed `VerticalPodAutoscaler` components (for more information, see [Vertical Pod Auto-Scaling](../usage/autoscaling/shoot_autoscaling.md#vertical-pod-auto-scaling))
 by setting `spec.kubernetes.verticalPodAutoscaler.enabled=true` for newly created Shoots.
 Already existing Shoots and new Shoots that explicitly disable VPA (`spec.kubernetes.verticalPodAutoscaler.enabled=false`)
 will not be affected by this admission plugin.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -449,7 +449,7 @@ const (
 	// LabelCredentialsBindingReference is used to identify credentials which are referred by a CredentialsBinding (not necessarily in the same namespace).
 	LabelCredentialsBindingReference = "reference.gardener.cloud/credentialsbinding"
 	// LabelPrefixSeedName is the prefix for the label key describing the name of a seed, e.g. seed.gardener.cloud/my-seed=true.
-	LabelPrefixSeedName = "seed.gardener.cloud/"
+	LabelPrefixSeedName = "name.seed.gardener.cloud/"
 
 	// LabelExtensionExtensionTypePrefix is used to prefix extension label for extension types.
 	LabelExtensionExtensionTypePrefix = "extensions.extensions.gardener.cloud/"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -448,7 +448,7 @@ const (
 	LabelSecretBindingReference = "reference.gardener.cloud/secretbinding"
 	// LabelCredentialsBindingReference is used to identify credentials which are referred by a CredentialsBinding (not necessarily in the same namespace).
 	LabelCredentialsBindingReference = "reference.gardener.cloud/credentialsbinding"
-	// LabelPrefixSeedName is the prefix for the label key describing the name of a seed, e.g. seed.gardener.cloud/my-seed=true.
+	// LabelPrefixSeedName is the prefix for the label key describing the name of a seed, e.g. name.seed.gardener.cloud/my-seed=true.
 	LabelPrefixSeedName = "name.seed.gardener.cloud/"
 
 	// LabelExtensionExtensionTypePrefix is used to prefix extension label for extension types.

--- a/pkg/apiserver/registry/core/backupentry/strategy_test.go
+++ b/pkg/apiserver/registry/core/backupentry/strategy_test.go
@@ -118,16 +118,16 @@ var _ = Describe("#Canonicalize", func() {
 	Context("seed names", func() {
 		It("should correctly add the seed labels", func() {
 			metav1.SetMetaDataLabel(&backupEntry.ObjectMeta, "foo", "bar")
-			metav1.SetMetaDataLabel(&backupEntry.ObjectMeta, "seed.gardener.cloud/foo", "true")
+			metav1.SetMetaDataLabel(&backupEntry.ObjectMeta, "name.seed.gardener.cloud/foo", "true")
 			backupEntry.Spec.SeedName = ptr.To("spec-seed")
 			backupEntry.Status.SeedName = ptr.To("status-seed")
 
 			backupentryregistry.NewStrategy().Canonicalize(backupEntry)
 
 			Expect(backupEntry.Labels).To(Equal(map[string]string{
-				"foo":                             "bar",
-				"seed.gardener.cloud/spec-seed":   "true",
-				"seed.gardener.cloud/status-seed": "true",
+				"foo":                                  "bar",
+				"name.seed.gardener.cloud/spec-seed":   "true",
+				"name.seed.gardener.cloud/status-seed": "true",
 			}))
 		})
 	})

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -815,16 +815,16 @@ var _ = Describe("Strategy", func() {
 		Context("seed names", func() {
 			It("should correctly add the seed labels", func() {
 				metav1.SetMetaDataLabel(&shoot.ObjectMeta, "foo", "bar")
-				metav1.SetMetaDataLabel(&shoot.ObjectMeta, "seed.gardener.cloud/foo", "true")
+				metav1.SetMetaDataLabel(&shoot.ObjectMeta, "name.seed.gardener.cloud/foo", "true")
 				shoot.Spec.SeedName = ptr.To("spec-seed")
 				shoot.Status.SeedName = ptr.To("status-seed")
 
 				strategy.Canonicalize(shoot)
 
 				Expect(shoot.Labels).To(Equal(map[string]string{
-					"foo":                             "bar",
-					"seed.gardener.cloud/spec-seed":   "true",
-					"seed.gardener.cloud/status-seed": "true",
+					"foo":                                  "bar",
+					"name.seed.gardener.cloud/spec-seed":   "true",
+					"name.seed.gardener.cloud/status-seed": "true",
 				}))
 			})
 		})

--- a/pkg/utils/gardener/identity_test.go
+++ b/pkg/utils/gardener/identity_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Identity", func() {
 	Describe("#MaintainSeedNameLabels", func() {
 		It("should maintain the labels", func() {
 			obj := &gardencorev1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"seed.gardener.cloud/old-seed": "true"}},
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"name.seed.gardener.cloud/old-seed": "true"}},
 				Spec:       gardencorev1beta1.ShootSpec{SeedName: ptr.To("spec-seed")},
 				Status:     gardencorev1beta1.ShootStatus{SeedName: ptr.To("status-seed")},
 			}
@@ -26,8 +26,8 @@ var _ = Describe("Identity", func() {
 			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)
 
 			Expect(obj.Labels).To(And(
-				HaveKeyWithValue("seed.gardener.cloud/spec-seed", "true"),
-				HaveKeyWithValue("seed.gardener.cloud/status-seed", "true"),
+				HaveKeyWithValue("name.seed.gardener.cloud/spec-seed", "true"),
+				HaveKeyWithValue("name.seed.gardener.cloud/status-seed", "true"),
 			))
 		})
 
@@ -39,12 +39,12 @@ var _ = Describe("Identity", func() {
 
 			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)
 
-			Expect(obj.Labels).To(HaveKeyWithValue("seed.gardener.cloud/seed", "true"))
+			Expect(obj.Labels).To(HaveKeyWithValue("name.seed.gardener.cloud/seed", "true"))
 		})
 
 		It("should maintain the labels when spec and status names are empty", func() {
 			obj := &gardencorev1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "seed.gardener.cloud/old-seed": "true"}},
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "name.seed.gardener.cloud/old-seed": "true"}},
 			}
 
 			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -287,7 +287,6 @@ var _ = Describe("ControllerInstallation controller tests", func() {
     labels:
       ` + testID + `: ` + testRunID + `
       dnsrecord.extensions.gardener.cloud/` + seed.Spec.DNS.Provider.Type + `: "true"
-      name.seed.gardener.cloud/` + seed.Name + `: "true"
       provider.extensions.gardener.cloud/` + seed.Spec.Provider.Type + `: "true"
     name: ` + seed.Name + `
     networks:

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -287,6 +287,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
     labels:
       ` + testID + `: ` + testRunID + `
       dnsrecord.extensions.gardener.cloud/` + seed.Spec.DNS.Provider.Type + `: "true"
+      name.seed.gardener.cloud/` + seed.Name + `: "true"
       provider.extensions.gardener.cloud/` + seed.Spec.Provider.Type + `: "true"
     name: ` + seed.Name + `
     networks:


### PR DESCRIPTION
/area usability
/kind regression

Cherry pick of #11479 on release-v1.110.

#11479: Rename `seed.gardener.cloud/` prefix to `name.seed.gardener.cloud/`

**Release Notes:**
```bugfix operator
A bug which prevented usage of labels with `seed.gardener.cloud/` prefix on, `BackupEntry`, and `Shoot` resources has been fixed.
```