### PR TITLE
Refactor e2e test `create_migrate_delete` to use ordered `It` containers

### DIFF
--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -72,11 +72,13 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 		ItShouldInitializeSeedClient(s)
 
 		It("Verify that all secrets have been migrated without regeneration", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) {
-				secretsAfterMigration, err := GetPersistedSecrets(ctx, s.SeedClientSet.Client(), s.Shoot.Status.TechnicalID)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(ComparePersistedSecrets(secretsBeforeMigration, secretsAfterMigration)).To(Succeed())
+			var secretsAfterMigration map[string]corev1.Secret
+			Eventually(ctx, func() error {
+				var err error
+				secretsAfterMigration, err = GetPersistedSecrets(ctx, s.SeedClientSet.Client(), s.Shoot.Status.TechnicalID)
+				return err
 			}).Should(Succeed())
+			Expect(ComparePersistedSecrets(secretsBeforeMigration, secretsAfterMigration)).To(Succeed())
 		}, SpecTimeout(time.Minute))
 
 		It("Verify that there are no orphaned resources in the source seed", func(ctx SpecContext) {

--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -73,6 +73,8 @@ func VerifyInClusterAccessToAPIServer(s *ShootContext) {
 
 	Describe("in-cluster access to API server", func() {
 		It("should create test objects", func(ctx SpecContext) {
+			Expect(s.ShootClient).NotTo(BeNil(), "ItShouldInitializeShootClient should be called first")
+
 			for _, obj := range getRBACObjects() {
 				Eventually(ctx, func() error {
 					return s.ShootClient.Create(ctx, obj)

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -236,14 +236,14 @@ func (t *ShootMigrationTest) GetMachineDetails(ctx context.Context, seedClient k
 // GetPersistedSecrets uses the seedClient to fetch the data of all Secrets that have the `persist` label key set to true
 // from the Shoot's control plane namespace
 func (t *ShootMigrationTest) GetPersistedSecrets(ctx context.Context, seedClient kubernetes.Interface) (map[string]corev1.Secret, error) {
-	return GetPersistedSecrets(ctx, seedClient, t.SeedShootNamespace)
+	return GetPersistedSecrets(ctx, seedClient.Client(), t.SeedShootNamespace)
 }
 
 // GetPersistedSecrets uses the seedClient to fetch the data of all Secrets that have the `persist` label key set to true
 // from the Shoot's control plane namespace
-func GetPersistedSecrets(ctx context.Context, seedClient kubernetes.Interface, namespace string) (map[string]corev1.Secret, error) {
+func GetPersistedSecrets(ctx context.Context, seedClient client.Reader, namespace string) (map[string]corev1.Secret, error) {
 	secretList := &corev1.SecretList{}
-	if err := seedClient.Client().List(
+	if err := seedClient.List(
 		ctx,
 		secretList,
 		client.InNamespace(namespace),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR refactors the e2e test `create_migrate_delete` to ordered containers.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379.

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
