### PR TITLE
Add missing `pod` variable to API server dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
+++ b/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
@@ -1611,7 +1611,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_total{verb=~\"$verb\"}[$__rate_interval])) by(resource,verb,subresource)",
+          "expr": "sum(rate(apiserver_request_total{verb=~\"$verb\",pod=~\"$pod\"}[$__rate_interval])) by(resource,verb,subresource)",
           "format": "time_series",
           "instant": false,
           "interval": "",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

The API server dashboard for the Garden cluster contains a panel `API Server Request Rates Per Verb And Resource` which is missing the `pod` variable in its filter. The variable itself is already configured. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`API Server Request Rates Per Verb And Resource` supports selection per Pod
```
