### PR TITLE
Increase timeout for waiting until CRD gets ready significantly to reduce random test failures.

### DIFF
--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -19,8 +19,12 @@ import (
 
 var (
 	// WaitTimeout specifies the total time to wait for CRDs to become ready or to be deleted. Exposed for testing.
-	// While waiting for CRD readiness is parallelized (see WaitUntilCRDManifestsReady below), the controllers responsible for populating the "readiness" status into the CRD only have one worker each (e.g., see https://github.com/kubernetes/apiextensions-apiserver/blob/376adbc0c7f0bc548dbbf2ad7c4f3e53840aa08f/pkg/controller/establish/establishing_controller.go#L88-L89). Therefore, we need to wait for a longer time here  (basically proportional to the
-	// amount of CRDs) in case we create a lot of CRDs in parallel (which happens at Garden or Seed creation), since they are processed sequentially.
+	// While waiting for CRD readiness is parallelized (see WaitUntilCRDManifestsReady below), the controllers
+	// responsible for populating the "readiness" status into the CRD only have one worker each (e.g., see
+	// https://github.com/kubernetes/apiextensions-apiserver/blob/376adbc0c7f0bc548dbbf2ad7c4f3e53840aa08f/pkg/controller/establish/establishing_controller.go#L88-L89).
+	// Therefore, we need to wait for a longer time here  (basically proportional to the
+	// amount of CRDs) in case we create a lot of CRDs in parallel (which happens at Garden or Seed creation), since
+	// they are processed sequentially.
 	WaitTimeout = 2 * time.Minute
 )
 
@@ -31,6 +35,7 @@ func WaitUntilCRDManifestsReady(ctx context.Context, c client.Client, crdNames .
 		fns = append(fns, func(ctx context.Context) error {
 			timeoutCtx, cancel := context.WithTimeout(ctx, WaitTimeout)
 			defer cancel()
+
 			return retry.Until(timeoutCtx, 1*time.Second, func(ctx context.Context) (done bool, err error) {
 				crd := &apiextensionsv1.CustomResourceDefinition{}
 

--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -19,6 +19,9 @@ import (
 
 var (
 	// WaitTimeout specifies the total time to wait for CRDs to become ready or to be deleted. Exposed for testing.
+	// While waiting for CRD readiness is parallelized (see WaitUntilCRDManifestsReady below), the component checking
+	// it in kube-apiserver is not. Therefore, we need to wait for a longer time here  (basically proportional to the
+	// amount of CRDs).
 	WaitTimeout = 2 * time.Minute
 )
 

--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -19,9 +19,8 @@ import (
 
 var (
 	// WaitTimeout specifies the total time to wait for CRDs to become ready or to be deleted. Exposed for testing.
-	// While waiting for CRD readiness is parallelized (see WaitUntilCRDManifestsReady below), the component checking
-	// it in kube-apiserver is not. Therefore, we need to wait for a longer time here  (basically proportional to the
-	// amount of CRDs).
+	// While waiting for CRD readiness is parallelized (see WaitUntilCRDManifestsReady below), the controllers responsible for populating the "readiness" status into the CRD only have one worker each (e.g., see https://github.com/kubernetes/apiextensions-apiserver/blob/376adbc0c7f0bc548dbbf2ad7c4f3e53840aa08f/pkg/controller/establish/establishing_controller.go#L88-L89). Therefore, we need to wait for a longer time here  (basically proportional to the
+	// amount of CRDs) in case we create a lot of CRDs in parallel (which happens at Garden or Seed creation), since they are processed sequentially.
 	WaitTimeout = 2 * time.Minute
 )
 

--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// WaitTimeout specifies the total time to wait for CRDs to become ready or to be deleted. Exposed for testing.
-	WaitTimeout = 15 * time.Second
+	WaitTimeout = 2 * time.Minute
 )
 
 // WaitUntilCRDManifestsReady takes names of CRDs and waits for them to get ready with a timeout of 15 seconds.
@@ -29,7 +29,6 @@ func WaitUntilCRDManifestsReady(ctx context.Context, c client.Client, crdNames .
 		fns = append(fns, func(ctx context.Context) error {
 			timeoutCtx, cancel := context.WithTimeout(ctx, WaitTimeout)
 			defer cancel()
-
 			return retry.Until(timeoutCtx, 1*time.Second, func(ctx context.Context) (done bool, err error) {
 				crd := &apiextensionsv1.CustomResourceDefinition{}
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -45,6 +45,7 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	seedcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -572,12 +573,12 @@ var _ = Describe("Seed controller tests", func() {
 						crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 						g.Expect(testClient.List(ctx, crdList)).To(Succeed())
 						return crdList.Items
-					}).Should(ContainElements(crdsOnlyForSeedClusters))
+					}).WithTimeout(kubernetesutils.WaitTimeout).Should(ContainElements(crdsOnlyForSeedClusters))
 
 					By("Verify that VPA was created for gardenlet")
 					Eventually(func() error {
 						return testClient.Get(ctx, client.ObjectKey{Name: "gardenlet-vpa", Namespace: testNamespace.Name}, &vpaautoscalingv1.VerticalPodAutoscaler{})
-					}).Should(Succeed())
+					}).WithTimeout(kubernetesutils.WaitTimeout).Should(Succeed())
 
 					if !seedIsGarden {
 						By("Verify that the CRDs shared with the garden cluster have been deployed")

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -57,6 +57,7 @@ import (
 	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 	gardencontroller "github.com/gardener/gardener/pkg/operator/controller/garden/garden"
 	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -399,7 +400,7 @@ spec:
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
 			return crdList.Items
-		}).Should(ContainElements(
+		}).WithTimeout(kubernetesutils.WaitTimeout).Should(ContainElements(
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

Increase timeout for waiting until CRD gets ready significantly to reduce random test failures.

Unfortunately, adding CRDs is a serial effort in kube-apiserver, which cannot be scaled to multiple workers. This limits scalability in test scenarios, especially under heavy load. Increasing the timeout reduces the amount of flaky test failures significantly. However, under load also other timeouts may be too restrictive. Therefore, this improves the situation for one kind of test failure, but may show errors down the line.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11386

**Special notes for your reviewer**:

On my 12 core system, running the seed/garden integration test with 24 parallel instances caused a 100% error rate before. With this change, the error rate went down to 30% (seed) and 50% (garden). The new errors were down the line, i.e. other timeouts, e.g. during shutdown. We need to check whether those actually happen often enough to investigate further.

Checking two days of prow tests revealed that the seed/garden test failures were the primary issue. From those failures, CRDs-not-getting-ready-in-time was the primary failure reason. The situation should improve with this change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase timeout used for waiting for CRD readiness to 2 minutes
```
