### PR TITLE
Make sure flags come before arguments in calls to `ctr` to be compatible with containerd 2.0

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -128,7 +128,7 @@ unmount() {
 trap unmount EXIT
 
 echo "> Pull gardener-node-agent image and mount it to the temporary directory"
-ctr images pull  "` + image + `" --hosts-dir "/etc/containerd/certs.d"
+ctr images pull --hosts-dir "/etc/containerd/certs.d" "` + image + `"
 ctr images mount "` + image + `" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -12,7 +12,7 @@ unmount() {
 trap unmount EXIT
 
 echo "> Pull gardener-node-agent image and mount it to the temporary directory"
-ctr images pull  "{{ .image }}" --hosts-dir "/etc/containerd/certs.d"
+ctr images pull --hosts-dir "/etc/containerd/certs.d" "{{ .image }}"
 ctr images mount "{{ .image }}" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host ({{ .binaryDirectory }}) and make it executable"

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -347,7 +347,7 @@ deploy:
                 image="$(cat /tmp/.skaffold-image)"
 
                 echo "> Pull gardenadm image and mount it to the temporary directory"
-                ctr images pull  "$image" --hosts-dir "/etc/containerd/certs.d"
+                ctr images pull --hosts-dir "/etc/containerd/certs.d" "$image"
                 ctr images mount "$image" "$tmp_dir"
 
                 echo "> Copy gardenadm binary to host (/gardenadm) and make it executable"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:

With containerd 2.0, the `ctr` binary [was migrated](https://github.com/containerd/containerd/pull/9809) to v2 of the [urfave/cli](https://github.com/urfave/cli) library which no longer supports submitting flags after arguments (see [this issue](https://github.com/urfave/cli/issues/976)). With that change, supplying the `--hosts-dir` flag after the image reference in a `ctr image pull` will result in the `--hosts-dir` flag to be ignored and thus, nodes with containerd 2.0 cannot be properly bootstrapped to join a cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
To be compatible with containerd 2.0, calls to the `ctr` binary now have flags before arguments when pulling images from a registry during node bootstrap.
```
