### PR TITLE
Fix the example `NamespacedCloudProfile` to be directly applicable

### DIFF
--- a/example/35-namespacedcloudprofile.yaml
+++ b/example/35-namespacedcloudprofile.yaml
@@ -11,7 +11,7 @@ spec:
     name: local # could be any CloudProfile
   kubernetes:
     versions:
-    - version: 1.29.0
+    - version: 1.31.1
       expirationDate: "2025-02-28T23:59:59Z"
   machineTypes:
   - name: local-large
@@ -30,8 +30,9 @@ spec:
     - version: 1.0.0
       expirationDate: "2024-12-31T23:59:59Z"
   - name: ubuntu-custom
+    updateStrategy: major
     versions:
-    - version: 18.04.201906170
+    - version: 18.4.201906170
       architectures:
       - amd64
       cri:
@@ -46,6 +47,6 @@ spec:
         image: local-skaffold/gardener-extension-provider-local-node:v1.0.1-dev
     - name: ubuntu-custom
       versions:
-      - version: 18.04.201906170
+      - version: 18.4.201906170
         image: local-skaffold/gardener-extension-provider-ubuntu-node:18.04.201906170
   # volumeTypes: # add additional volume types if necessary


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Fix the example `NamespacedCloudProfile` so that e.g. developers can apply it to a local dev cluster directly.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
