### PR TITLE
fix gardenlet crash when force deleting workerless shoot

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_force_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_force_delete.go
@@ -106,22 +106,26 @@ func (r *Reconciler) runForceDeleteShootFlow(ctx context.Context, log logr.Logge
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.ControlPlane.MachineControllerManager.Destroy(ctx)
 			}),
+			SkipIf: botanist.Shoot.IsWorkerless,
 		})
 		waitUntilMachineControllerManagerDeleted = g.Add(flow.Task{
 			Name: "Waiting until machine-controller-manager has been deleted",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.ControlPlane.MachineControllerManager.WaitCleanup(ctx)
 			}),
+			SkipIf:       botanist.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deleteMachineControllerManager),
 		})
 		deleteMachineResources = g.Add(flow.Task{
 			Name:         "Deleting machine resources",
 			Fn:           flow.TaskFn(cleaner.DeleteMachineResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       botanist.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilMachineControllerManagerDeleted),
 		})
 		waitUntilMachineResourcesDeleted = g.Add(flow.Task{
 			Name:         "Waiting until machine resources have been deleted",
 			Fn:           flow.TaskFn(cleaner.WaitUntilMachineResourcesDeleted).Timeout(defaultTimeout),
+			SkipIf:       botanist.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deleteMachineResources),
 		})
 		setKeepObjectsForManagedResources = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area robustness
/kind bug

**What this PR does / why we need it**:
A bug has been found in https://github.com/gardener/gardener/pull/11456 which causes the gardenlet to panic when a workerless shot is force deleted.
This is because the force-delete reconcile flow always tries to delete the machine-controller-manager and machine objects, even if the shoot is workerless.
The graceful shoot delete flow respects the workerless property.

**Special notes for your reviewer**:
This should probably be picked into all currently maintained Gardener versions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed gardenlet crashing when trying to force-delete a workerless shoot
```
