### PR TITLE
Fix shoot care controller removing conditions/constraints

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,9 +124,27 @@ var _ = Describe("Shoot Care Control", func() {
 
 		Context("when health check setup is broken", func() {
 			Context("when operation cannot be created", func() {
+				extraneousCondition := gardencorev1beta1.Condition{
+					Type:    "foo",
+					Status:  gardencorev1beta1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				}
+
+				extraneousConstraint := gardencorev1beta1.Condition{
+					Type:    "bar",
+					Status:  gardencorev1beta1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				}
+
 				JustBeforeEach(func() {
 					fakeErr := errors.New("foo")
 					DeferCleanup(test.WithVar(&NewOperation, opFunc(nil, fakeErr)))
+
+					shoot.Status.Conditions = append(shoot.Status.Conditions, extraneousCondition)
+					shoot.Status.Constraints = append(shoot.Status.Constraints, extraneousConstraint)
+					Expect(gardenClient.Status().Update(ctx, shoot)).To(Succeed())
 
 					reconciler = &Reconciler{
 						GardenClient:  gardenClient,
@@ -146,8 +163,20 @@ var _ = Describe("Shoot Care Control", func() {
 					It("should report a setup failure", func() {
 						updatedShoot := &gardencorev1beta1.Shoot{}
 						Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), updatedShoot)).To(Succeed())
-						Expect(updatedShoot.Status.Conditions).To(consistOfConditionsInUnknownStatus("Precondition failed: operation could not be initialized", v1beta1helper.IsWorkerless(shoot)))
-						Expect(updatedShoot.Status.Constraints).To(consistOfConstraintsInUnknownStatus("Precondition failed: operation could not be initialized"))
+						Expect(updatedShoot.Status.Conditions).To(containConditionsInUnknownStatus("Precondition failed: operation could not be initialized", v1beta1helper.IsWorkerless(shoot)))
+						Expect(updatedShoot.Status.Constraints).To(containConstraintsInUnknownStatus("Precondition failed: operation could not be initialized"))
+						Expect(updatedShoot.Status.Conditions).To(ContainCondition(
+							OfType(extraneousCondition.Type),
+							WithStatus(extraneousCondition.Status),
+							WithReason(extraneousCondition.Reason),
+							WithMessage(extraneousCondition.Message),
+						))
+						Expect(updatedShoot.Status.Constraints).To(ContainCondition(
+							OfType(extraneousConstraint.Type),
+							WithStatus(extraneousConstraint.Status),
+							WithReason(extraneousConstraint.Reason),
+							WithMessage(extraneousConstraint.Message),
+						))
 					})
 				})
 
@@ -159,8 +188,20 @@ var _ = Describe("Shoot Care Control", func() {
 					It("should report a setup failure", func() {
 						updatedShoot := &gardencorev1beta1.Shoot{}
 						Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), updatedShoot)).To(Succeed())
-						Expect(updatedShoot.Status.Conditions).To(consistOfConditionsInUnknownStatus("Precondition failed: operation could not be initialized", v1beta1helper.IsWorkerless(shoot)))
-						Expect(updatedShoot.Status.Constraints).To(consistOfConstraintsInUnknownStatus("Precondition failed: operation could not be initialized"))
+						Expect(updatedShoot.Status.Conditions).To(containConditionsInUnknownStatus("Precondition failed: operation could not be initialized", v1beta1helper.IsWorkerless(shoot)))
+						Expect(updatedShoot.Status.Constraints).To(containConstraintsInUnknownStatus("Precondition failed: operation could not be initialized"))
+						Expect(updatedShoot.Status.Conditions).To(ContainCondition(
+							OfType(extraneousCondition.Type),
+							WithStatus(extraneousCondition.Status),
+							WithReason(extraneousCondition.Reason),
+							WithMessage(extraneousCondition.Message),
+						))
+						Expect(updatedShoot.Status.Constraints).To(ContainCondition(
+							OfType(extraneousConstraint.Type),
+							WithStatus(extraneousConstraint.Status),
+							WithReason(extraneousConstraint.Reason),
+							WithMessage(extraneousConstraint.Message),
+						))
 					})
 				})
 			})
@@ -568,8 +609,8 @@ func nopGarbageCollectorFunc() NewGarbageCollectorFunc {
 	}
 }
 
-func consistOfConditionsInUnknownStatus(message string, isWorkerless bool) types.GomegaMatcher {
-	var expectedLength = 4
+func containConditionsInUnknownStatus(message string, isWorkerless bool) types.GomegaMatcher {
+	var expectedLength = 5
 	matcher := And(
 		ContainCondition(
 			OfType(gardencorev1beta1.ShootAPIServerAvailable),
@@ -593,7 +634,7 @@ func consistOfConditionsInUnknownStatus(message string, isWorkerless bool) types
 	)
 
 	if !isWorkerless {
-		expectedLength = 5
+		expectedLength = 6
 		matcher = And(matcher,
 			ContainCondition(
 				OfType(gardencorev1beta1.ShootEveryNodeReady),
@@ -606,27 +647,29 @@ func consistOfConditionsInUnknownStatus(message string, isWorkerless bool) types
 	return And(matcher, HaveLen(expectedLength))
 }
 
-func consistOfConstraintsInUnknownStatus(message string) types.GomegaMatcher {
-	return ConsistOf(
-		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootHibernationPossible),
-			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
-			"Message": Equal(message),
-		}),
-		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootMaintenancePreconditionsSatisfied),
-			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
-			"Message": Equal(message),
-		}),
-		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
-			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
-			"Message": Equal(message),
-		}),
-		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
-			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
-			"Message": Equal(message),
-		}),
+func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
+	var expectedLength = 5
+	matcher := And(
+		ContainCondition(
+			OfType(gardencorev1beta1.ShootHibernationPossible),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		),
+		ContainCondition(
+			OfType(gardencorev1beta1.ShootMaintenancePreconditionsSatisfied),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		),
+		ContainCondition(
+			OfType(gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		), ContainCondition(
+			OfType(gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		),
 	)
+
+	return And(matcher, HaveLen(expectedLength))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes an oversight within the shoot care controller, causing extraneous shoot constraints to be deleted from the shoot status.
We noticed this behavior bcs. of https://github.com/gardener/gardener/pull/11480, where gardenlet was crashing after getting restarted during a shoot migration.

The core of the problem is, that the function `v1beta1helper.BuildConditions` is only called when the reconcile operation could be initialized properly.
If an error occurred during the initialization, the code would jump to `patchStatusToUnknown` which would then jump straight to `patchStatus` without merging the conditions and constraints first.

This PR changes this behavior, so that conditions and constraints are always merged before sending the patch request.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which caused the shoot care controller to falsely remove shoot conditions and constraints from the shoot status
```
