### PR TITLE
Forbid container privilege escalations for Seed and Garden cluster components

### DIFF
--- a/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
@@ -75,3 +75,5 @@ spec:
         resources:
 {{ toYaml .Values.resources | nindent 10 }}
 {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -94,6 +94,8 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -316,6 +316,8 @@ spec:
         dnsConfig:
 {{ toYaml .Values.global.apiserver.dnsConfig | indent 10 }}
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         {{- if .Values.global.apiserver.encryption.config }}
         - name: gardener-apiserver-encryption-config
@@ -409,6 +411,8 @@ spec:
         resources:
           requests:
             cpu: 200m
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: etcd
           mountPath: /var/etcd/data

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -106,6 +106,8 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -93,6 +93,8 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -132,6 +132,8 @@ spec:
         dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 10 }}
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -980,6 +980,9 @@ func ComputeExpectedGardenletDeploymentSpec(
 								corev1.ResourceMemory: resource.MustParse("100Mi"),
 							},
 						},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+						},
 						TerminationMessagePath:   "/dev/termination-log",
 						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 						VolumeMounts: []corev1.VolumeMount{{

--- a/charts/gardener/operator/templates/deployment.yaml
+++ b/charts/gardener/operator/templates/deployment.yaml
@@ -123,6 +123,8 @@ spec:
         dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 10 }}
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
 {{ toYaml .Values.resources | nindent 10 }}
 {{- end }}
         securityContext:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalations: false
         volumeMounts:
         {{- if .Values.imageVectorOverwrite }}
         - name: imagevector-overwrite

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
 {{ toYaml .Values.resources | nindent 10 }}
 {{- end }}
         securityContext:
-          allowPrivilegeEscalations: false
+          allowPrivilegeEscalation: false
         volumeMounts:
         {{- if .Values.imageVectorOverwrite }}
         - name: imagevector-overwrite

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -125,6 +125,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | nindent 10 }}
 {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         {{- if .Values.imageVectorOverwrite }}
         - name: imagevector-overwrite

--- a/charts/gardener/resource-manager/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/resource-manager/charts/runtime/templates/deployment.yaml
@@ -80,6 +80,8 @@ spec:
             port: {{ .Values.global.config.server.healthProbes.port }}
             scheme: HTTP
           initialDelaySeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: config
           mountPath: /etc/gardener-resource-manager/config

--- a/example/gardener-local/etcd/statefulset.yaml
+++ b/example/gardener-local/etcd/statefulset.yaml
@@ -38,6 +38,8 @@ spec:
           containerPort: 2379
         - name: discovery
           containerPort: 2380
+        securityContext:   
+          allowPrivilegeEscalation: false
       volumes:
       - name: tls
         secret:

--- a/example/gardener-local/registry/base/registry.yaml
+++ b/example/gardener-local/registry/base/registry.yaml
@@ -20,6 +20,8 @@ spec:
         env:
         - name: REGISTRY_HTTP_ADDR
           value: :5001
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: cache
           mountPath: /var/lib/registry

--- a/example/provider-extensions/gardener-discovery-server/server/server.yaml
+++ b/example/provider-extensions/gardener-discovery-server/server/server.yaml
@@ -70,6 +70,8 @@ spec:
           requests:
             cpu: "50m"
             memory: "64Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: gardener-discovery-server-tls
           mountPath: /var/run/secrets/gardener.cloud/gardener-discovery-server/tls

--- a/example/provider-extensions/registry-seed/registry/registry.yaml
+++ b/example/provider-extensions/registry-seed/registry/registry.yaml
@@ -47,6 +47,8 @@ spec:
         ports:
         - name: registry
           containerPort: 5000
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: registry-volume
           mountPath: /var/lib/registry

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -461,6 +461,9 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 								Ports: []corev1.ContainerPort{{
 									ContainerPort: metricsPort,
 								}},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptr.To(false),
+								},
 								VolumeMounts: []corev1.VolumeMount{
 									{
 										Name:      webhookServerTLSCertVolumeName,

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -338,6 +338,9 @@ var _ = Describe("Etcd", func() {
 												corev1.ResourceMemory: resource.MustParse("128Mi"),
 											},
 										},
+										SecurityContext: &corev1.SecurityContext{
+											AllowPrivilegeEscalation: ptr.To(false),
+										},
 										VolumeMounts: []corev1.VolumeMount{
 											{
 												MountPath: "/etc/webhook-server-tls",
@@ -449,6 +452,9 @@ var _ = Describe("Etcd", func() {
 											corev1.ResourceCPU:    resource.MustParse("50m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
+									},
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: ptr.To(false),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -637,6 +637,9 @@ func deployment(namespace, configSecretName, serverCertSecretName string, testVa
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      5,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "gardener-admission-controller-cert",

--- a/pkg/component/gardener/admissioncontroller/deployment.go
+++ b/pkg/component/gardener/admissioncontroller/deployment.go
@@ -100,6 +100,9 @@ func (a *gardenerAdmissionController) deployment(secretServerCert, secretGeneric
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      5,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      volumeNameCerts,

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -458,6 +458,9 @@ var _ = Describe("GardenerAPIServer", func() {
 								PeriodSeconds:       10,
 								TimeoutSeconds:      15,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "gardener-apiserver-workload-identity",

--- a/pkg/component/gardener/apiserver/deployment.go
+++ b/pkg/component/gardener/apiserver/deployment.go
@@ -141,6 +141,9 @@ func (g *gardenerAPIServer) deployment(
 							PeriodSeconds:       10,
 							TimeoutSeconds:      15,
 						},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+						},
 					}},
 				},
 			},

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -837,6 +837,9 @@ func deployment(namespace, configSecretName string, testValues Values) *appsv1.D
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      5,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "gardener-controller-manager-config",

--- a/pkg/component/gardener/controllermanager/deployment.go
+++ b/pkg/component/gardener/controllermanager/deployment.go
@@ -97,6 +97,9 @@ func (g *gardenerControllerManager) deployment(secretGenericTokenKubeconfig, sec
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      5,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      volumeNameConfig,

--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -435,6 +435,9 @@ frontend:
 										SuccessThreshold:    1,
 										PeriodSeconds:       10,
 									},
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: ptr.To(false),
+									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "gardener-dashboard-sessionsecret",

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -187,6 +187,9 @@ func (g *gardenerDashboard) deployment(
 								SuccessThreshold:    1,
 								PeriodSeconds:       readinessProbePeriodSeconds,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      volumeNameSession,

--- a/pkg/component/gardener/discoveryserver/deployment.go
+++ b/pkg/component/gardener/discoveryserver/deployment.go
@@ -138,6 +138,9 @@ func (g *gardenerDiscoveryServer) deployment(
 								SuccessThreshold:    1,
 								PeriodSeconds:       10,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      volumeNameTLS,

--- a/pkg/component/gardener/discoveryserver/discoveryserver_test.go
+++ b/pkg/component/gardener/discoveryserver/discoveryserver_test.go
@@ -278,6 +278,9 @@ var _ = Describe("GardenerDiscoveryServer", func() {
 									SuccessThreshold:    1,
 									PeriodSeconds:       10,
 								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptr.To(false),
+								},
 								VolumeMounts: []corev1.VolumeMount{
 									{
 										Name:      "gardener-discovery-server-tls",

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -900,6 +900,9 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 							},
 							InitialDelaySeconds: 10,
 						},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      volumeNameAPIServerAccess,

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -588,6 +588,9 @@ var _ = Describe("ResourceManager", func() {
 											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: ptr.To(false),
+									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											MountPath: secretMountPathAPIAccess,

--- a/pkg/component/gardener/scheduler/deployment.go
+++ b/pkg/component/gardener/scheduler/deployment.go
@@ -95,6 +95,9 @@ func (g *gardenerScheduler) deployment(secretGenericTokenKubeconfig, secretVirtu
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      5,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      volumeNameConfig,

--- a/pkg/component/gardener/scheduler/scheduler_test.go
+++ b/pkg/component/gardener/scheduler/scheduler_test.go
@@ -841,6 +841,9 @@ func deployment(namespace, configSecretName string, testValues Values) *appsv1.D
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      5,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "gardener-scheduler-config",

--- a/pkg/component/networking/nginxingress/nginxingress.go
+++ b/pkg/component/networking/nginxingress/nginxingress.go
@@ -473,6 +473,9 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 						}},
 						TerminationGracePeriodSeconds: ptr.To[int64](60),
 					},

--- a/pkg/component/networking/nginxingress/nginxingress_test.go
+++ b/pkg/component/networking/nginxingress/nginxingress_test.go
@@ -446,6 +446,8 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
       priorityClassName: gardener-system-600
       securityContext:
         fsGroup: 65534
@@ -1010,6 +1012,8 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
       priorityClassName: gardener-shoot-system-600

--- a/pkg/component/networking/vpn/authzserver/authzserver.go
+++ b/pkg/component/networking/vpn/authzserver/authzserver.go
@@ -116,6 +116,9 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 						},
 					},
 				},

--- a/pkg/component/networking/vpn/authzserver/authzserver_test.go
+++ b/pkg/component/networking/vpn/authzserver/authzserver_test.go
@@ -127,6 +127,9 @@ var _ = Describe("ExtAuthzServer", func() {
 										corev1.ResourceMemory: resource.MustParse("100Mi"),
 									},
 								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptr.To(false),
+								},
 							},
 						},
 					},

--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
@@ -412,6 +412,9 @@ func (b *bootstrapper) getDeployment(serviceAccountName string, configMapName st
 								corev1.ResourceMemory: resource.MustParse("512Mi"),
 							},
 						},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+						},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      volumeName,
 							MountPath: volumeMountPath,

--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap_test.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap_test.go
@@ -352,6 +352,8 @@ spec:
           requests:
             cpu: 200m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/dependency-watchdog/config
           name: config

--- a/pkg/component/observability/logging/fluentbit/fluentbit.go
+++ b/pkg/component/observability/logging/fluentbit/fluentbit.go
@@ -371,6 +371,9 @@ func (f *fluentBit) getFluentBit() *fluentbitv1alpha2.FluentBit {
 				"-c",
 				"/fluent-bit/config/fluent-bit.conf",
 			},
+			ContainerSecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.To(false),
+			},
 			PriorityClassName: f.values.PriorityClassName,
 			Ports: []corev1.ContainerPort{
 				{
@@ -463,6 +466,9 @@ func (f *fluentBit) getFluentBit() *fluentbitv1alpha2.FluentBit {
 						"cp",
 						"/source/plugins/.",
 						"/plugins",
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator.go
@@ -230,6 +230,9 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 										corev1.ResourceMemory: resource.MustParse("50Mi"),
 									},
 								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptr.To(false),
+								},
 								VolumeMounts: []corev1.VolumeMount{
 									{
 										Name:      "env",

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
@@ -259,6 +259,9 @@ var _ = Describe("Fluent Operator", func() {
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "env",

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
@@ -57,7 +57,8 @@ func (g *gardenerMetricsExporter) deployment(secretGenericTokenKubeconfig, secre
 								"--port=" + strconv.Itoa(probePort),
 							},
 							SecurityContext: &corev1.SecurityContext{
-								ReadOnlyRootFilesystem: ptr.To(true),
+								AllowPrivilegeEscalation: ptr.To(false),
+								ReadOnlyRootFilesystem:   ptr.To(true),
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -652,7 +652,8 @@ func deployment(namespace string, testValues Values) *appsv1.Deployment {
 								"--port=2718",
 							},
 							SecurityContext: &corev1.SecurityContext{
-								ReadOnlyRootFilesystem: ptr.To(true),
+								AllowPrivilegeEscalation: ptr.To(false),
+								ReadOnlyRootFilesystem:   ptr.To(true),
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{

--- a/pkg/component/observability/monitoring/prometheus/cortex.go
+++ b/pkg/component/observability/monitoring/prometheus/cortex.go
@@ -42,7 +42,10 @@ func (p *prometheus) cortexContainer() corev1.Container {
 			ContainerPort: portCortex,
 			Protocol:      corev1.ProtocolTCP,
 		}},
-		SecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(true)},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -1103,7 +1103,10 @@ query_range:
 							ContainerPort: 9091,
 							Protocol:      corev1.ProtocolTCP,
 						}},
-						SecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(true)},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+							ReadOnlyRootFilesystem:   ptr.To(true),
+						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/pkg/component/seed/system/system.go
+++ b/pkg/component/seed/system/system.go
@@ -143,6 +143,9 @@ func (s *seedSystem) addReserveExcessCapacityDeployment(registry *managedresourc
 								Requests: config.Resources,
 								Limits:   config.Resources,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 						}},
 						NodeSelector:      config.NodeSelector,
 						PriorityClassName: v1beta1constants.PriorityClassNameReserveExcessCapacity,

--- a/pkg/component/seed/system/system_test.go
+++ b/pkg/component/seed/system/system_test.go
@@ -82,6 +82,8 @@ spec:
           requests:
             cpu: "2"
             memory: 6Gi
+        securityContext:
+          allowPrivilegeEscalation: false
       priorityClassName: gardener-reserve-excess-capacity
       terminationGracePeriodSeconds: 5
 status: {}
@@ -123,6 +125,8 @@ spec:
           requests:
             cpu: "4"
             memory: 8Gi
+        securityContext:
+          allowPrivilegeEscalation: false
       nodeSelector:
         foo: bar
       priorityClassName: gardener-reserve-excess-capacity

--- a/pkg/provider-local/charts/shoot-system-components/charts/local-path-provisioner/templates/deployment.yaml
+++ b/pkg/provider-local/charts/shoot-system-components/charts/local-path-provisioner/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /etc/config/
               name: config-volume


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR sets `securityContext.allowPrivilegeEscalation` to false for every `Seed` and `Garden` cluster component container, which does not have `securityContext.Privileged` set to `true` or one of `CAP_SYS_ADMIN/SYS_ADMIN` capabilities added.

**Which issue(s) this PR fixes**:
Part of #11139

**Special notes for your reviewer**:
/ cc @AleksandarSavchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Garden and Seed cluster component containers, which do not require privilege escalations, now forbid privilege escalation explicitly.
```
