### PR TITLE
Consider `status.seedName` instead of `spec.seedName`

### DIFF
--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -139,7 +139,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	)
 
 	shootList := &gardencorev1beta1.ShootList{}
-	if err := r.Client.List(ctx, shootList, client.MatchingFields{core.ShootSeedName: seed.Name}); err != nil {
+	if err := r.Client.List(ctx, shootList, client.MatchingFields{core.ShootStatusSeedName: seed.Name}); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controllermanager/controller/shoot/migration/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/migration/reconciler.go
@@ -46,7 +46,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	patch := client.MergeFrom(shoot.DeepCopy())
+	patch := client.StrategicMergeFrom(shoot.DeepCopy())
 
 	if !v1beta1helper.ShouldPrepareShootForMigration(shoot) {
 		if v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootReadyForMigration) == nil {

--- a/pkg/gardenlet/controller/shoot/care/add.go
+++ b/pkg/gardenlet/controller/shoot/care/add.go
@@ -119,5 +119,5 @@ func (r *Reconciler) ShootPredicate() predicate.Predicate {
 }
 
 func seedGotAssigned(oldShoot, newShoot *gardencorev1beta1.Shoot) bool {
-	return oldShoot.Spec.SeedName == nil && newShoot.Spec.SeedName != nil
+	return oldShoot.Status.SeedName == nil && newShoot.Status.SeedName != nil
 }

--- a/pkg/gardenlet/controller/shoot/care/add_test.go
+++ b/pkg/gardenlet/controller/shoot/care/add_test.go
@@ -157,21 +157,21 @@ var _ = Describe("Add", func() {
 			})
 
 			It("should return false when the seed name is unchanged in the Shoot spec", func() {
-				shoot.Spec.SeedName = ptr.To("test-seed")
+				shoot.Status.SeedName = ptr.To("test-seed")
 				oldShoot := shoot.DeepCopy()
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeFalse())
 			})
 
 			It("should return false when the seed name is changed in the Shoot spec", func() {
-				shoot.Spec.SeedName = ptr.To("test-seed")
+				shoot.Status.SeedName = ptr.To("test-seed")
 				oldShoot := shoot.DeepCopy()
-				shoot.Spec.SeedName = ptr.To("test-seed1")
+				shoot.Status.SeedName = ptr.To("test-seed1")
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeFalse())
 			})
 
 			It("should return true when seed gets assigned to shoot", func() {
 				oldShoot := shoot.DeepCopy()
-				shoot.Spec.SeedName = ptr.To("test-seed")
+				shoot.Status.SeedName = ptr.To("test-seed")
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeTrue())
 			})
 		})

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
 	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -66,12 +67,15 @@ var _ = Describe("Shoot Care Control", func() {
 				Namespace: shootNamespace,
 			},
 			Spec: gardencorev1beta1.ShootSpec{
-				SeedName: &seedName,
+				SeedName: ptr.To(seedName),
 				Provider: gardencorev1beta1.Provider{
 					Workers: []gardencorev1beta1.Worker{
 						{Name: "foo"},
 					},
 				},
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				SeedName: ptr.To(seedName),
 			},
 		}
 
@@ -253,10 +257,8 @@ var _ = Describe("Shoot Care Control", func() {
 						Status: gardencorev1beta1.ConditionFalse,
 					}
 
-					shoot.Status = gardencorev1beta1.ShootStatus{
-						Conditions:  []gardencorev1beta1.Condition{apiServerCondition},
-						Constraints: []gardencorev1beta1.Condition{hibernationConstraint},
-					}
+					shoot.Status.Conditions = []gardencorev1beta1.Condition{apiServerCondition}
+					shoot.Status.Constraints = []gardencorev1beta1.Condition{hibernationConstraint}
 					Expect(gardenClient.Status().Update(ctx, shoot)).To(Succeed())
 
 					Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
@@ -303,10 +305,8 @@ var _ = Describe("Shoot Care Control", func() {
 						Status: gardencorev1beta1.ConditionFalse,
 					}
 
-					shoot.Status = gardencorev1beta1.ShootStatus{
-						Conditions:  []gardencorev1beta1.Condition{apiServerCondition},
-						Constraints: []gardencorev1beta1.Condition{hibernationConstraint},
-					}
+					shoot.Status.Conditions = []gardencorev1beta1.Condition{apiServerCondition}
+					shoot.Status.Constraints = []gardencorev1beta1.Condition{hibernationConstraint}
 					Expect(gardenClient.Status().Update(ctx, shoot)).To(Succeed())
 
 					Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
@@ -393,10 +393,8 @@ var _ = Describe("Shoot Care Control", func() {
 							Status: gardencorev1beta1.ConditionFalse,
 						}
 
-						shoot.Status = gardencorev1beta1.ShootStatus{
-							Conditions:  []gardencorev1beta1.Condition{apiServerCondition},
-							Constraints: []gardencorev1beta1.Condition{hibernationConstraint},
-						}
+						shoot.Status.Conditions = []gardencorev1beta1.Condition{apiServerCondition}
+						shoot.Status.Constraints = []gardencorev1beta1.Condition{hibernationConstraint}
 						Expect(gardenClient.Update(ctx, shoot)).To(Succeed())
 
 						Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
@@ -410,11 +408,9 @@ var _ = Describe("Shoot Care Control", func() {
 
 				Context("when shoot has a successful last operation", func() {
 					BeforeEach(func() {
-						shoot.Status = gardencorev1beta1.ShootStatus{
-							LastOperation: &gardencorev1beta1.LastOperation{
-								Type:  gardencorev1beta1.LastOperationTypeReconcile,
-								State: gardencorev1beta1.LastOperationStateSucceeded,
-							},
+						shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
+							Type:  gardencorev1beta1.LastOperationTypeReconcile,
+							State: gardencorev1beta1.LastOperationStateSucceeded,
 						}
 					})
 
@@ -481,11 +477,9 @@ var _ = Describe("Shoot Care Control", func() {
 
 				Context("when shoot has a successful last operation", func() {
 					BeforeEach(func() {
-						shoot.Status = gardencorev1beta1.ShootStatus{
-							LastOperation: &gardencorev1beta1.LastOperation{
-								Type:  gardencorev1beta1.LastOperationTypeReconcile,
-								State: gardencorev1beta1.LastOperationStateSucceeded,
-							},
+						shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
+							Type:  gardencorev1beta1.LastOperationTypeReconcile,
+							State: gardencorev1beta1.LastOperationStateSucceeded,
 						}
 					})
 

--- a/pkg/gardenlet/controller/shoot/care/types.go
+++ b/pkg/gardenlet/controller/shoot/care/types.go
@@ -163,7 +163,7 @@ var defaultNewOperationFunc = func(
 		WithGardenClusterIdentity(gardenClusterIdentity).
 		WithSecrets(secrets).
 		WithGardenFrom(gardenClient, shoot.Namespace).
-		WithSeedFrom(gardenClient, *shoot.Spec.SeedName).
+		WithSeedFrom(gardenClient, *shoot.Status.SeedName).
 		WithShootFromCluster(seedClientSet, shoot).
 		Build(ctx, gardenClient, seedClientSet, shootClientMap)
 }

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -739,7 +739,7 @@ func (r *Reconciler) patchShootStatusOperationSuccess(
 				gardencorev1beta1.ShootMaintenancePreconditionsSatisfied:
 				if constr.Status != gardencorev1beta1.ConditionFalse {
 					shoot.Status.Constraints[i].Status = gardencorev1beta1.ConditionProgressing
-					shoot.Status.Conditions[i].LastUpdateTime = metav1.Now()
+					shoot.Status.Constraints[i].LastUpdateTime = metav1.Now()
 				}
 			}
 		}

--- a/test/integration/controllermanager/seed/lifecycle/lifecycle_suite_test.go
+++ b/test/integration/controllermanager/seed/lifecycle/lifecycle_suite_test.go
@@ -112,7 +112,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Setup field indexes")
-	Expect(indexer.AddShootSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+	Expect(indexer.AddShootStatusSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
 	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now())

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 			Spec: gardencorev1beta1.ShootSpec{
 				SecretBindingName: ptr.To(secretBinding.Name),
 				CloudProfileName:  ptr.To("cloudprofile1"),
-				SeedName:          &seedName,
+				SeedName:          ptr.To(seedName),
 				Region:            "europe-central-1",
 				Provider: gardencorev1beta1.Provider{
 					Type: "foo-provider",
@@ -139,6 +139,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 
 		By("Patch shoot status")
 		patch := client.MergeFrom(shoot.DeepCopy())
+		shoot.Status.SeedName = ptr.To(seedName)
 		shoot.Status.Gardener.Version = "1.2.3"
 		shoot.Status.TechnicalID = testNamespace.Name
 		Expect(testClient.Status().Patch(ctx, shoot, patch)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:

Both the shoot care and seed lifecycle controller should consider `status.seedName` instead of `spec.seedName` when determining whether a seed is currently responsible for a given shoot.
Otherwise, the conditions/constraints of a shoot might incorrectly transition to `Unknown`, e.g., when a shoot control plane migration has been triggered but not started yet.

Along the way, this PR fixes two minor bugs: using a plain merge patch on `shoot.status.constraints` and missing an update to `shoot.status.contraints[*].lastUpdateTime` when finishing a shoot reconciliation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

@Wieneo and I observed this bug while working on https://github.com/gardener/gardener/pull/11515.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where the destination gardenlet acted on shoots in control plane migration too early.
```
