### PR TITLE
Issue 11505: CoreDNS not truly configurable / import *.override not working as intended

### DIFF
--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -294,9 +294,6 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
 			Data: map[string]string{
 				configDataKey: `.:` + strconv.Itoa(corednsconstants.PortServer) + ` {
   errors
-  log . {
-      class error
-  }
   health {
       lameduck 15s
   }
@@ -307,12 +304,17 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
       ttl 30
   }
   prometheus :` + strconv.Itoa(portMetrics) + `
+
+  import custom/*.override
+
+  log . {
+      class error
+  }
   forward . /etc/resolv.conf
-  cache 30
   loop
   reload
   loadbalance round_robin
-  import custom/*.override
+  cache 30
 }
 import custom/*.server
 `,

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -122,10 +122,7 @@ subjects:
 data:
   Corefile: |
     .:8053 {
-      errors
-      log . {
-          class error
-      }
+      errors      
       health {
           lameduck 15s
       }
@@ -150,12 +147,17 @@ data:
           ttl 30
       }
       prometheus :9153
+
+      import custom/*.override
+
+      log . {
+          class error
+      }
       forward . /etc/resolv.conf
-      cache 30
       loop
       reload
       loadbalance round_robin
-      import custom/*.override
+      cache 30
     }
     import custom/*.server
 kind: ConfigMap

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -334,7 +333,7 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 		lastOperation.Type == gardencorev1beta1.LastOperationTypeRestore &&
 		lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
 		shootState := &gardencorev1beta1.ShootState{ObjectMeta: metav1.ObjectMeta{Name: shootObject.Name, Namespace: shootObject.Namespace}}
-		if err := c.Get(ctx, client.ObjectKeyFromObject(shootState), shootState); nil != err && !apierrors.IsNotFound(err) {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(shootState), shootState); err != nil {
 			return nil, err
 		}
 		shoot.SetShootState(shootState)

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -333,7 +334,7 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 		lastOperation.Type == gardencorev1beta1.LastOperationTypeRestore &&
 		lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
 		shootState := &gardencorev1beta1.ShootState{ObjectMeta: metav1.ObjectMeta{Name: shootObject.Name, Namespace: shootObject.Namespace}}
-		if err := c.Get(ctx, client.ObjectKeyFromObject(shootState), shootState); err != nil {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(shootState), shootState); nil != err && !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 		shoot.SetShootState(shootState)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
/area networking
/king bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/11505

**Which issue(s) this PR fixes**:
https://github.com/gardener/gardener/issues/11505

**Special notes for your reviewer**:
@ScheererJ 
How do you like this? It is king of similar to https://github.com/gardener/gardener/blob/master/charts/gardener/provider-local/templates/coredns/configmap.yaml#L18

But the idea is to make sure that
- prometheus port is preserved
- specifying cache does not break anything else (by moving cache 30 to the bottom)

**Release note**:
Format of block header: bugfix user
