### PR TITLE
[operator] Wait for required `Extension`s

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -576,8 +576,8 @@ Currently, this logic handles the following scenarios:
 
 #### [`Required Runtime` Reconciler](../../pkg/operator/controller/extension/required/runtime)
 
-This reconciler reacts on events from `BackupBucket`, `DNSRecord` and `Extension` resources.
-Based on these resources and the related `Extension` specification, it is checked if the extension deployment is required in the garden runtime cluster.
+This reconciler reacts on `Garden` and `Extension` events.
+It is checked if the extension deployment is required in the garden runtime cluster based on the existing `Garden` specification.
 The result is then put into the `RequiredRuntime` condition and added to the `Extension` status.
 
 #### [`Required Virtual` Reconciler](../../pkg/operator/controller/extension/required/virtual)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -32,7 +32,9 @@ Ideally though, you would add the missing test cases for the current code as wel
   - Consider using `ExpectWithOffset` if the test uses assertions made in a helper function, among other assertions defined directly in the test (e.g. `expectSomethingWasCreated`): [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go#L732-L736)
   - Make sure to add additional descriptions to Gomega matchers if necessary (e.g. in a loop): [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/e2e/shoot/internal/rotation/certificate_authorities.go#L89-L93)
 - Introduce helper functions for assertions to make test more readable where applicable: [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/gardenlet/shootsecret/controller_test.go#L323-L331)
-- Introduce custom matchers to make tests more readable where applicable: [example matcher](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/pkg/utils/test/matchers/matchers.go#L51-L57)
+- Keep test code and output readable:
+  - Introduce custom matchers where applicable: [example matcher](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/pkg/utils/test/matchers/matchers.go#L51-L57)
+  - Prevent [gstruct matchers](https://pkg.go.dev/github.com/onsi/gomega/gstruct) on larger object list: [example test](https://github.com/gardener/gardener/blob/882c00c2c5835324f41a0ebde8c81f5ec6050074/test/integration/operator/garden/garden/garden_test.go#L415-L465). The failure output is often truncated and unclear.
 - Don't rely on accurate timing of `time.Sleep` and friends.
   - If doing so, CPU throttling in CI will make tests flaky, [example flake](https://github.com/gardener/gardener/issues/5410)
   - Use fake clocks instead, [example PR](https://github.com/gardener/gardener/pull/4569)

--- a/pkg/apis/operator/v1alpha1/helper/extension.go
+++ b/pkg/apis/operator/v1alpha1/helper/extension.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+import (
+	"fmt"
+)
+
+// ExtensionRuntimeManagedResourceName returns the name of the ManagedResource containing resources for the Garden runtime cluster.
+func ExtensionRuntimeManagedResourceName(extensionName string) string {
+	return fmt.Sprintf("extension-%s-garden", extensionName)
+}
+
+// ExtensionRuntimeNamespaceName returns the name of the namespace hosting resources for the Garden runtime cluster.
+func ExtensionRuntimeNamespaceName(extensionName string) string {
+	return fmt.Sprintf("runtime-extension-%s", extensionName)
+}

--- a/pkg/apis/operator/v1alpha1/helper/extension_test.go
+++ b/pkg/apis/operator/v1alpha1/helper/extension_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/apis/operator/v1alpha1/helper"
+)
+
+var _ = Describe("Extension", func() {
+	Describe("#ExtensionRuntimeManagedResourceName", func() {
+		It("should return the expected managed resource name", func() {
+			Expect(ExtensionRuntimeManagedResourceName("provider-test")).To(Equal("extension-provider-test-garden"))
+		})
+	})
+
+	Describe("#ExtensionRuntimeNamespaceName", func() {
+		It("should return the expected namespace name", func() {
+			Expect(ExtensionRuntimeNamespaceName("provider-test")).To(Equal("runtime-extension-provider-test"))
+		})
+	})
+})

--- a/pkg/apis/operator/v1alpha1/helper/garden.go
+++ b/pkg/apis/operator/v1alpha1/helper/garden.go
@@ -168,3 +168,20 @@ func HighAvailabilityEnabled(garden *operatorv1alpha1.Garden) bool {
 func TopologyAwareRoutingEnabled(settings *operatorv1alpha1.Settings) bool {
 	return settings != nil && settings.TopologyAwareRouting != nil && settings.TopologyAwareRouting.Enabled
 }
+
+// GetETCDMainBackup returns the backup configuration for etcd main of the given garden object or nil if not configured.
+func GetETCDMainBackup(garden *operatorv1alpha1.Garden) *operatorv1alpha1.Backup {
+	if garden != nil && garden.Spec.VirtualCluster.ETCD != nil && garden.Spec.VirtualCluster.ETCD.Main != nil {
+		return garden.Spec.VirtualCluster.ETCD.Main.Backup
+	}
+	return nil
+}
+
+// GetDNSProviders returns the DNS providers for the given garden object or nil if non are configured.
+func GetDNSProviders(garden *operatorv1alpha1.Garden) []operatorv1alpha1.DNSProvider {
+	if garden != nil && garden.Spec.DNS != nil {
+		return garden.Spec.DNS.Providers
+	}
+
+	return nil
+}

--- a/pkg/apis/operator/v1alpha1/helper/garden_test.go
+++ b/pkg/apis/operator/v1alpha1/helper/garden_test.go
@@ -215,4 +215,25 @@ var _ = Describe("helper", func() {
 		Entry("topology-aware routing enabled", &operatorv1alpha1.Settings{TopologyAwareRouting: &operatorv1alpha1.SettingTopologyAwareRouting{Enabled: true}}, true),
 		Entry("topology-aware routing disabled", &operatorv1alpha1.Settings{TopologyAwareRouting: &operatorv1alpha1.SettingTopologyAwareRouting{Enabled: false}}, false),
 	)
+
+	DescribeTable("#GetETCDMainBackup",
+		func(garden *operatorv1alpha1.Garden, expected *operatorv1alpha1.Backup) {
+			Expect(GetETCDMainBackup(garden)).To(Equal(expected))
+		},
+		Entry("no garden", nil, nil),
+		Entry("no ETCD config", &operatorv1alpha1.Garden{}, nil),
+		Entry("no ETCD Main config", &operatorv1alpha1.Garden{Spec: operatorv1alpha1.GardenSpec{VirtualCluster: operatorv1alpha1.VirtualCluster{ETCD: &operatorv1alpha1.ETCD{}}}}, nil),
+		Entry("no backup config", &operatorv1alpha1.Garden{Spec: operatorv1alpha1.GardenSpec{VirtualCluster: operatorv1alpha1.VirtualCluster{ETCD: &operatorv1alpha1.ETCD{Main: &operatorv1alpha1.ETCDMain{}}}}}, nil),
+		Entry("with backup config", &operatorv1alpha1.Garden{Spec: operatorv1alpha1.GardenSpec{VirtualCluster: operatorv1alpha1.VirtualCluster{ETCD: &operatorv1alpha1.ETCD{Main: &operatorv1alpha1.ETCDMain{Backup: &operatorv1alpha1.Backup{Provider: "test"}}}}}}, &operatorv1alpha1.Backup{Provider: "test"}),
+	)
+
+	DescribeTable("#GetDNSProviders",
+		func(garden *operatorv1alpha1.Garden, expected []operatorv1alpha1.DNSProvider) {
+			Expect(GetDNSProviders(garden)).To(Equal(expected))
+		},
+		Entry("no garden", nil, nil),
+		Entry("no DNS config", &operatorv1alpha1.Garden{}, nil),
+		Entry("no DNS providers", &operatorv1alpha1.Garden{Spec: operatorv1alpha1.GardenSpec{DNS: &operatorv1alpha1.DNSManagement{}}}, nil),
+		Entry("with DNS providers", &operatorv1alpha1.Garden{Spec: operatorv1alpha1.GardenSpec{DNS: &operatorv1alpha1.DNSManagement{Providers: []operatorv1alpha1.DNSProvider{{Name: "provider-1"}, {Name: "provider-2"}}}}}, []operatorv1alpha1.DNSProvider{{Name: "provider-1"}, {Name: "provider-2"}}),
+	)
 })

--- a/pkg/gardenlet/controller/controllerinstallation/required/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add.go
@@ -106,7 +106,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 
 // MapObjectKindToControllerInstallations returns a mapper function for the given extension kind that lists all existing
 // extension resources of the given kind and stores the respective types in the `KindToRequiredTypes` map. Afterwards,
-// it enqueue all ControllerInstallations for the seed that are referring to ControllerRegistrations responsible for
+// it enqueues all ControllerInstallations for the seed that are referring to ControllerRegistrations responsible for
 // the given kind.
 // The returned reconciler doesn't care about which object was created/updated/deleted, it just cares about being
 // triggered when some object of the kind, it is responsible for, is created/updated/deleted.

--- a/pkg/operator/controller/extension/extension/runtime/runtime.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime.go
@@ -19,6 +19,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/operator/v1alpha1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -90,7 +91,7 @@ func (d *deployer) createOrUpdateResources(ctx context.Context, extension *opera
 		}
 	}
 
-	namespace := namespaceName(extension)
+	namespace := helper.ExtensionRuntimeNamespaceName(extension.Name)
 	if err := d.ensureNamespace(ctx, namespace, extension); err != nil {
 		return fmt.Errorf("failed ensuring namespace %q: %w", namespace, err)
 	}
@@ -100,7 +101,7 @@ func (d *deployer) createOrUpdateResources(ctx context.Context, extension *opera
 		return fmt.Errorf("failed rendering Helm chart %q: %w", extension.Spec.Deployment.ExtensionDeployment.Helm.OCIRepository.GetURL(), err)
 	}
 
-	mrName := managedResourceName(extension)
+	mrName := helper.ExtensionRuntimeManagedResourceName(extension.Name)
 	if err := managedresources.CreateForSeed(ctx, d.runtimeClientSet.Client(), d.gardenNamespace, mrName, false, renderedChart.AsSecretData()); err != nil {
 		return fmt.Errorf("failed creating ManagedResource: %w", err)
 	}
@@ -112,8 +113,8 @@ func (d *deployer) createOrUpdateResources(ctx context.Context, extension *opera
 }
 
 func (d *deployer) deleteResources(ctx context.Context, log logr.Logger, extension *operatorv1alpha1.Extension) error {
-	mrName := managedResourceName(extension)
-	namespace := namespaceName(extension)
+	mrName := helper.ExtensionRuntimeManagedResourceName(extension.Name)
+	namespace := helper.ExtensionRuntimeNamespaceName(extension.Name)
 
 	log.Info("Deleting extension ManagedResource for runtime cluster if present", "managedResource", client.ObjectKey{Name: mrName, Namespace: d.gardenNamespace})
 	if err := client.IgnoreNotFound(managedresources.DeleteForSeed(ctx, d.runtimeClientSet.Client(), d.gardenNamespace, mrName)); err != nil {
@@ -175,14 +176,6 @@ func (d *deployer) deleteNamespace(ctx context.Context, name string) error {
 		return err
 	}
 	return kubernetesutils.WaitUntilResourceDeleted(ctx, d.runtimeClientSet.Client(), namespace, time.Second)
-}
-
-func managedResourceName(extension *operatorv1alpha1.Extension) string {
-	return fmt.Sprintf("extension-%s-garden", extension.Name)
-}
-
-func namespaceName(extension *operatorv1alpha1.Extension) string {
-	return fmt.Sprintf("runtime-extension-%s", extension.Name)
 }
 
 func extensionDeploymentSpecified(extension *operatorv1alpha1.Extension) bool {

--- a/pkg/operator/controller/extension/required/runtime/add.go
+++ b/pkg/operator/controller/extension/required/runtime/add.go
@@ -6,13 +6,11 @@ package runtime
 
 import (
 	"context"
-	"sync"
+	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -22,142 +20,66 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
-	apiextensions "github.com/gardener/gardener/pkg/api/extensions"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
-	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/extensions"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ControllerName is the name of this controller.
 const ControllerName = "extension-required-runtime"
-
-type extension struct {
-	objectKind        string
-	object            client.Object
-	newObjectListFunc func() client.ObjectList
-}
-
-var runtimeClusterExtensions = []extension{
-	{objectKind: extensionsv1alpha1.BackupBucketResource, object: &extensionsv1alpha1.BackupBucket{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.BackupBucketList{} }},
-	{objectKind: extensionsv1alpha1.DNSRecordResource, object: &extensionsv1alpha1.DNSRecord{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.DNSRecordList{} }},
-	{objectKind: extensionsv1alpha1.ExtensionResource, object: &extensionsv1alpha1.Extension{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.ExtensionList{} }},
-}
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
-	if r.KindToRequiredTypes == nil {
-		r.KindToRequiredTypes = map[string]sets.Set[string]{}
-	}
-	if r.Lock == nil {
-		r.Lock = &sync.RWMutex{}
-	}
 
 	r.clock = clock.RealClock{}
 
-	c, err := builder.
+	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(&operatorv1alpha1.Extension{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(
+			&operatorv1alpha1.Extension{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
+			&operatorv1alpha1.Garden{},
+			handler.EnqueueRequestsFromMapFunc(r.MapGardenToExtensions(mgr.GetLogger().WithValues("controller", ControllerName))),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: ptr.Deref(r.Config.ConcurrentSyncs, 0),
 		}).
-		Build(r)
-	if err != nil {
-		return err
-	}
-
-	for _, extension := range runtimeClusterExtensions {
-		eventHandler := handler.EnqueueRequestsFromMapFunc(r.MapObjectKindToExtensions(
-			mgr.GetLogger().WithValues("controller", ControllerName),
-			extension.objectKind,
-			extension.newObjectListFunc,
-		))
-
-		// Execute the mapper function at least once to initialize the `KindToRequiredTypes` map.
-		// This is necessary for extension kinds which are registered but for which no extension objects exist in the
-		// garden runtime cluster (e.g. when backups are disabled).
-		// In such cases, no regular watch event is triggered, and the mapping function will not be executed.
-		// Thus, the extension kind would never be part of the `KindToRequiredTypes` map
-		// and the reconciler would not be able to decide whether the  Extension is required.
-		if err = c.Watch(&controllerutils.HandleOnce[client.Object, reconcile.Request]{Handler: eventHandler}); err != nil {
-			return err
-		}
-
-		if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), extension.object, eventHandler, extensions.ObjectPredicate(), extensionspredicate.HasClass(extensionsv1alpha1.ExtensionClassGarden))); err != nil {
-			return err
-		}
-	}
-	return nil
+		Complete(r)
 }
 
-// MapObjectKindToExtensions returns a mapper function for the given 'extensions.gardener.cloud' extension kind
-// that lists all existing resources of the given kind and stores the respective types in the `KindToRequiredTypes` map.
-// Afterwards, it returns all 'operator.gardener.cloud' Extensions that responsible for the given kind.
-func (r *Reconciler) MapObjectKindToExtensions(log logr.Logger, objectKind string, newObjectListFunc func() client.ObjectList) handler.MapFunc {
-	return func(ctx context.Context, _ client.Object) []reconcile.Request {
-		log = log.WithValues("extensionKind", objectKind)
-
-		listObj := newObjectListFunc()
-		if err := r.Client.List(ctx, listObj); err != nil && !meta.IsNoMatchError(err) {
-			// Let's ignore bootstrap situations where extension CRDs were not yet applied. They will be deployed
-			// eventually by the garden controller.
-			log.Error(err, "Failed to list extension objects")
+// MapGardenToExtensions returns a mapping function that maps a given garden resource to all related extensions.
+func (r *Reconciler) MapGardenToExtensions(log logr.Logger) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		garden, ok := obj.(*operatorv1alpha1.Garden)
+		if !ok {
+			log.Error(fmt.Errorf("expected Garden but got %#v", obj), "Unable to convert to Garden")
 			return nil
 		}
 
-		r.Lock.RLock()
-		oldRequiredTypes, kindCalculated := r.KindToRequiredTypes[objectKind]
-		r.Lock.RUnlock()
-		newRequiredTypes := sets.New[string]()
-
-		if err := meta.EachListItem(listObj, func(o runtime.Object) error {
-			obj, err := apiextensions.Accessor(o)
-			if err != nil {
-				return err
-			}
-
-			if ptr.Deref(obj.GetExtensionSpec().GetExtensionClass(), extensionsv1alpha1.ExtensionClassShoot) != extensionsv1alpha1.ExtensionClassGarden {
-				return nil
-			}
-
-			newRequiredTypes.Insert(obj.GetExtensionSpec().GetExtensionType())
-			return nil
-		}); err != nil {
-			log.Error(err, "Failed while iterating over extension objects")
-			return nil
-		}
-
-		// if there is no difference compared to before then exit early
-		if kindCalculated && oldRequiredTypes.Equal(newRequiredTypes) {
-			return nil
-		}
-
-		r.Lock.Lock()
-		r.KindToRequiredTypes[objectKind] = newRequiredTypes
-		r.Lock.Unlock()
-
-		// List all extensions and queue those that are supporting resources for the
-		// extension kind this particular reconciler is responsible for.
 		extensionList := &operatorv1alpha1.ExtensionList{}
 		if err := r.Client.List(ctx, extensionList); err != nil {
-			log.Error(err, "Failed to list Extensions")
+			log.Error(err, "Failed to list extensions")
 			return nil
 		}
 
-		var requests []reconcile.Request
+		var (
+			requests           []reconcile.Request
+			requiredExtensions = gardenerutils.ComputeRequiredExtensionsForGarden(garden)
+		)
+
 		for _, extension := range extensionList.Items {
-			for _, resource := range extension.Spec.Resources {
-				if resource.Kind == objectKind {
-					requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: extension.Name}})
-					break
-				}
+			if slices.ContainsFunc(extension.Spec.Resources, func(resource gardencorev1beta1.ControllerResource) bool {
+				return requiredExtensions.Has(gardenerutils.ExtensionsID(resource.Kind, resource.Type))
+			}) {
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: extension.Name, Namespace: extension.Namespace}})
 			}
 		}
 

--- a/pkg/operator/controller/extension/required/runtime/add_test.go
+++ b/pkg/operator/controller/extension/required/runtime/add_test.go
@@ -6,15 +6,12 @@ package runtime_test
 
 import (
 	"context"
-	"sync"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -22,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
@@ -40,105 +36,89 @@ var _ = Describe("Add", func() {
 		BeforeEach(func() {
 			ctx = context.Background()
 			log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
-			reconciler = &Reconciler{
-				Lock: &sync.RWMutex{},
-			}
+			reconciler = &Reconciler{}
 		})
 
-		Describe("#MapObjectKindToExtensions", func() {
+		Describe("#MapGardenToExtensions", func() {
 			var (
-				fakeClient          client.Client
-				kindToRequiredTypes map[string]sets.Set[string]
-
+				fakeClient client.Client
+				garden     *operatorv1alpha1.Garden
 				mapperFunc handler.MapFunc
 			)
 
 			BeforeEach(func() {
-				kindToRequiredTypes = map[string]sets.Set[string]{}
 				fakeClient = fake.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
-
-				reconciler.KindToRequiredTypes = kindToRequiredTypes
 				reconciler.Client = fakeClient
 
-				mapperFunc = reconciler.MapObjectKindToExtensions(log, "BackupBucket", func() client.ObjectList { return &extensionsv1alpha1.BackupBucketList{} })
+				garden = &operatorv1alpha1.Garden{
+					Spec: operatorv1alpha1.GardenSpec{
+						DNS: &operatorv1alpha1.DNSManagement{
+							Providers: []operatorv1alpha1.DNSProvider{
+								{Type: "local-dns"},
+							},
+						},
+						Extensions: []operatorv1alpha1.GardenExtension{
+							{Type: "local-extension-1"},
+							{Type: "local-extension-2"},
+						},
+						VirtualCluster: operatorv1alpha1.VirtualCluster{
+							ETCD: &operatorv1alpha1.ETCD{
+								Main: &operatorv1alpha1.ETCDMain{
+									Backup: &operatorv1alpha1.Backup{
+										Provider: "local-infrastructure",
+									},
+								},
+							},
+						},
+					},
+				}
+
+				mapperFunc = reconciler.MapGardenToExtensions(log)
 			})
 
 			Context("without extensions", func() {
 				It("should not return any requests", func() {
-					Expect(mapperFunc(ctx, nil)).To(BeEmpty())
+					Expect(mapperFunc(ctx, garden)).To(BeEmpty())
 				})
 			})
 
 			Context("with extensions", func() {
 				var (
-					testExtension1, testExtension2 *operatorv1alpha1.Extension
-
-					requiredExtensionKind string
-					requiredExtensionType string
+					infraExtension, dnsExtension *operatorv1alpha1.Extension
 				)
 
 				BeforeEach(func() {
-					requiredExtensionKind = "BackupBucket"
-					requiredExtensionType = "local"
-
-					testExtension1 = &operatorv1alpha1.Extension{
+					infraExtension = &operatorv1alpha1.Extension{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-extension-1",
+							Name: "local-infra",
 						},
 						Spec: operatorv1alpha1.ExtensionSpec{
 							Resources: []gardencorev1beta1.ControllerResource{
-								{Kind: requiredExtensionKind, Type: requiredExtensionType},
+								{Kind: "BackupBucket", Type: "local-infrastructure"},
 							},
 						},
 					}
 
-					testExtension2 = &operatorv1alpha1.Extension{
+					dnsExtension = &operatorv1alpha1.Extension{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-extension-2",
+							Name: "local-dns",
 						},
 						Spec: operatorv1alpha1.ExtensionSpec{
 							Resources: []gardencorev1beta1.ControllerResource{
-								{Kind: "DNSRecord", Type: requiredExtensionType},
+								{Kind: "DNSRecord", Type: "local-dns"},
 							},
 						},
 					}
 
-					Expect(fakeClient.Create(ctx, testExtension1)).To(Succeed())
-					Expect(fakeClient.Create(ctx, testExtension2)).To(Succeed())
+					Expect(fakeClient.Create(ctx, infraExtension)).To(Succeed())
+					Expect(fakeClient.Create(ctx, dnsExtension)).To(Succeed())
 				})
 
-				It("should add the kind with an empty set to the map and return the extension", func() {
-					Expect(mapperFunc(ctx, nil)).To(ConsistOf(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: testExtension1.Name, Namespace: testExtension1.Namespace}})))
-					Expect(kindToRequiredTypes).To(HaveKeyWithValue(requiredExtensionKind, sets.New[string]()))
-				})
-
-				It("should correctly calculate the kind-to-types map and return the expected extension in the requests", func() {
-					By("Invoke mapper the first time and expect requests")
-					backupBucket := &extensionsv1alpha1.BackupBucket{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-backup-bucket",
-						},
-						Spec: extensionsv1alpha1.BackupBucketSpec{
-							DefaultSpec: extensionsv1alpha1.DefaultSpec{
-								Type:  requiredExtensionType,
-								Class: ptr.To(extensionsv1alpha1.ExtensionClassGarden),
-							},
-						},
-					}
-
-					Expect(fakeClient.Create(ctx, backupBucket)).To(Succeed())
-
-					Expect(mapperFunc(ctx, nil)).To(ConsistOf(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: testExtension1.Name, Namespace: testExtension1.Namespace}})))
-					Expect(kindToRequiredTypes).To(HaveKeyWithValue(requiredExtensionKind, sets.New[string](requiredExtensionType)))
-
-					By("Invoke mapper again w/o changes and expect no requests")
-					Expect(kindToRequiredTypes).To(HaveKeyWithValue(requiredExtensionKind, sets.New[string](requiredExtensionType)))
-					Expect(mapperFunc(ctx, nil)).To(BeEmpty())
-
-					By("Delete BackupBucket and expect the extension in the requests")
-					Expect(fakeClient.Delete(ctx, backupBucket)).To(Succeed())
-					Expect(mapperFunc(ctx, nil)).To(ConsistOf(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: testExtension1.Name, Namespace: testExtension1.Namespace}})))
-					Expect(kindToRequiredTypes).To(HaveKeyWithValue(requiredExtensionKind, sets.New[string]()))
+				It("should return the expected extensions", func() {
+					Expect(mapperFunc(ctx, garden)).To(ConsistOf(
+						Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: infraExtension.Name}}),
+						Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: dnsExtension.Name}}),
+					))
 				})
 			})
 		})

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -135,15 +135,17 @@ func (r *Reconciler) ensureAtMostOneGardenExists(ctx context.Context) error {
 	return fmt.Errorf("there can be at most one operator.gardener.cloud/v1alpha1.Garden resource in the system at a time")
 }
 
-func (r *Reconciler) reportProgress(log logr.Logger, garden *operatorv1alpha1.Garden) flow.ProgressReporter {
+func (r *Reconciler) reportProgress(log logr.Logger, garden *operatorv1alpha1.Garden, reportProgress bool) flow.ProgressReporter {
 	return flow.NewDelayingProgressReporter(clock.RealClock{}, func(ctx context.Context, stats *flow.Stats) {
 		patch := client.MergeFrom(garden.DeepCopy())
 
 		if garden.Status.LastOperation == nil {
 			garden.Status.LastOperation = &gardencorev1beta1.LastOperation{}
 		}
+		if reportProgress {
+			garden.Status.LastOperation.Progress = stats.ProgressPercent()
+		}
 		garden.Status.LastOperation.Description = flow.MakeDescription(stats)
-		garden.Status.LastOperation.Progress = stats.ProgressPercent()
 		garden.Status.LastOperation.LastUpdateTime = metav1.NewTime(r.Clock.Now().UTC())
 
 		if err := r.RuntimeClientSet.Client().Status().Patch(ctx, garden, patch); err != nil {

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -396,7 +396,7 @@ func (r *Reconciler) delete(
 	gardenCopy := garden.DeepCopy()
 	if err := g.Compile().Run(ctx, flow.Opts{
 		Log:              log,
-		ProgressReporter: r.reportProgress(log, gardenCopy),
+		ProgressReporter: r.reportProgress(log, gardenCopy, true),
 	}); err != nil {
 		return reconcilerutils.ReconcileErr(flow.Errors(err))
 	}

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -543,6 +543,7 @@ func (r *Reconciler) reconcile(
 				c.alertManager.SetIngressAuthSecret(credentialsSecret)
 				return c.alertManager.Deploy(ctx)
 			},
+			Dependencies: flow.NewTaskIDs(generateObservabilityIngressPassword),
 		})
 		deployPrometheusGarden = g.Add(flow.Task{
 			Name: "Deploying Garden Prometheus",

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -371,7 +371,7 @@ func IsServedByKubeAPIServer(resource string) bool {
 
 // ComputeRequiredExtensionsForGarden computes the extension kind/type combinations that are required for the
 // garden reconciliation flow.
-func ComputeRequiredExtensionsForGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) sets.Set[string] {
+func ComputeRequiredExtensionsForGarden(garden *operatorv1alpha1.Garden) sets.Set[string] {
 	requiredExtensions := sets.New[string]()
 
 	if helper.GetETCDMainBackup(garden) != nil {

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -23,13 +23,18 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/operations"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/operator/v1alpha1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	"github.com/gardener/gardener/pkg/apis/settings"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 )
 
@@ -362,4 +367,87 @@ func IsServedByGardenerAPIServer(resource string) bool {
 // IsServedByKubeAPIServer returns true if the passed resources is served by the Kube API Server.
 func IsServedByKubeAPIServer(resource string) bool {
 	return !IsServedByGardenerAPIServer(resource)
+}
+
+// ComputeRequiredExtensionsForGarden computes the extension kind/type combinations that are required for the
+// garden reconciliation flow.
+func ComputeRequiredExtensionsForGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) sets.Set[string] {
+	requiredExtensions := sets.New[string]()
+
+	if helper.GetETCDMainBackup(garden) != nil {
+		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.BackupBucketResource, garden.Spec.VirtualCluster.ETCD.Main.Backup.Provider))
+	}
+
+	for _, provider := range helper.GetDNSProviders(garden) {
+		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.DNSRecordResource, provider.Type))
+	}
+
+	for _, extension := range garden.Spec.Extensions {
+		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.ExtensionResource, extension.Type))
+	}
+
+	return requiredExtensions
+}
+
+// CheckRuntimeExtensionInstallation checks if an Extension has been marked as "successfully" in the Garden runtime cluster.
+func CheckRuntimeExtensionInstallation(ctx context.Context, c client.Client, gardenNamespace, extensionName string) error {
+	managedResource := &resourcesv1alpha1.ManagedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helper.ExtensionRuntimeManagedResourceName(extensionName),
+			Namespace: gardenNamespace,
+		},
+	}
+
+	if err := c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource); err != nil {
+		return err
+	}
+
+	if err := health.CheckManagedResource(managedResource); err != nil {
+		return err
+	}
+
+	return health.CheckManagedResourceProgressing(managedResource)
+}
+
+// RequiredGardenExtensionsReady checks if all required extensions for a garden exist and are ready.
+func RequiredGardenExtensionsReady(ctx context.Context, log logr.Logger, c client.Client, gardenNamespace string, requiredExtensions sets.Set[string]) error {
+	extensionList := &operatorv1alpha1.ExtensionList{}
+	if err := c.List(ctx, extensionList); err != nil {
+		return err
+	}
+
+	for _, extension := range extensionList.Items {
+		var (
+			extensionChecked  bool
+			extensionCheckErr error
+		)
+		for _, kindType := range requiredExtensions.UnsortedList() {
+			extensionKind, extensionType, err := ExtensionKindAndTypeForID(kindType)
+			if err != nil {
+				return err
+			}
+
+			if !v1beta1helper.IsResourceSupported(extension.Spec.Resources, extensionKind, extensionType) {
+				continue
+			}
+
+			if !extensionChecked {
+				extensionCheckErr = CheckRuntimeExtensionInstallation(ctx, c, gardenNamespace, extension.Name)
+				extensionChecked = true
+			}
+
+			if extensionCheckErr != nil {
+				log.Error(err, "Extension installation not successful", "kind", kindType)
+				continue
+			}
+
+			requiredExtensions.Delete(kindType)
+		}
+	}
+
+	if len(requiredExtensions) > 0 {
+		return fmt.Errorf("extension controllers missing or unready: %+v", requiredExtensions)
+	}
+
+	return nil
 }

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -448,7 +448,7 @@ var _ = Describe("Garden", func() {
 		})
 	})
 
-	Describe("#CheckRuntimeExtensionInstallation", func() {
+	Describe("#IsRuntimeExtensionInstallationSuccessful", func() {
 		var (
 			ctx        context.Context
 			fakeClient client.Client
@@ -475,7 +475,7 @@ var _ = Describe("Garden", func() {
 		})
 
 		It("should return an error if no managed resource status is available", func() {
-			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesApplied for managed resource test-namespace/extension-test-garden has not been reported yet"))
+			Expect(IsRuntimeExtensionInstallationSuccessful(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesApplied for managed resource test-namespace/extension-test-garden has not been reported yet"))
 		})
 
 		It("should return an error if managed resource applied condition is false", func() {
@@ -484,7 +484,7 @@ var _ = Describe("Garden", func() {
 			}
 			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
 
-			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesApplied of managed resource test-namespace/extension-test-garden is False: "))
+			Expect(IsRuntimeExtensionInstallationSuccessful(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesApplied of managed resource test-namespace/extension-test-garden is False: "))
 		})
 
 		It("should return an error if managed resource healthy condition is false", func() {
@@ -494,7 +494,7 @@ var _ = Describe("Garden", func() {
 			}
 			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
 
-			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesHealthy of managed resource test-namespace/extension-test-garden is False: "))
+			Expect(IsRuntimeExtensionInstallationSuccessful(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesHealthy of managed resource test-namespace/extension-test-garden is False: "))
 		})
 
 		It("should return an error if managed resource is progressing", func() {
@@ -505,7 +505,7 @@ var _ = Describe("Garden", func() {
 			}
 			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
 
-			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesProgressing of managed resource test-namespace/extension-test-garden is True: "))
+			Expect(IsRuntimeExtensionInstallationSuccessful(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesProgressing of managed resource test-namespace/extension-test-garden is True: "))
 		})
 
 		It("should succeed if managed resource is healthy", func() {
@@ -516,7 +516,7 @@ var _ = Describe("Garden", func() {
 			}
 			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
 
-			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(Succeed())
+			Expect(IsRuntimeExtensionInstallationSuccessful(ctx, fakeClient, gardenNamespace, extensionName)).To(Succeed())
 		})
 	})
 

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -5,8 +5,10 @@
 package gardener_test
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -14,14 +16,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	settingsv1alpha1 "github.com/gardener/gardener/pkg/apis/settings/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -361,4 +369,218 @@ var _ = Describe("Garden", func() {
 		Entry("seedmanagement resource", seedmanagementv1alpha1.Resource("managedseeds").String(), false),
 		Entry("any other resource", "foo", true),
 	)
+
+	Describe("#ComputeRequiredExtensionsForGarden", func() {
+		var garden *operatorv1alpha1.Garden
+
+		BeforeEach(func() {
+			garden = &operatorv1alpha1.Garden{}
+		})
+
+		It("should return no extension types", func() {
+			Expect(ComputeRequiredExtensionsForGarden(garden).UnsortedList()).To(BeEmpty())
+		})
+
+		It("should return required BackupBucket extension type", func() {
+			garden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
+				Main: &operatorv1alpha1.ETCDMain{
+					Backup: &operatorv1alpha1.Backup{
+						Provider: "local-infrastructure",
+					},
+				},
+			}
+
+			Expect(ComputeRequiredExtensionsForGarden(garden).UnsortedList()).To(ConsistOf(
+				"BackupBucket/local-infrastructure",
+			))
+		})
+
+		It("should return required DNSRecord extension types", func() {
+			garden.Spec.DNS = &operatorv1alpha1.DNSManagement{
+				Providers: []operatorv1alpha1.DNSProvider{
+					{Type: "local-dns-1"},
+					{Type: "local-dns-2"},
+				},
+			}
+
+			Expect(ComputeRequiredExtensionsForGarden(garden).UnsortedList()).To(ConsistOf(
+				"DNSRecord/local-dns-1",
+				"DNSRecord/local-dns-2",
+			))
+		})
+
+		It("should return required Extension extension types", func() {
+			garden.Spec.Extensions = []operatorv1alpha1.GardenExtension{
+				{Type: "local-extension-1"},
+				{Type: "local-extension-2"},
+			}
+
+			Expect(ComputeRequiredExtensionsForGarden(garden).UnsortedList()).To(ConsistOf(
+				"Extension/local-extension-1",
+				"Extension/local-extension-2",
+			))
+		})
+
+		It("should return all required extensions", func() {
+			garden.Spec.DNS = &operatorv1alpha1.DNSManagement{
+				Providers: []operatorv1alpha1.DNSProvider{
+					{Type: "local-dns"},
+				},
+			}
+			garden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
+				Main: &operatorv1alpha1.ETCDMain{
+					Backup: &operatorv1alpha1.Backup{
+						Provider: "local-infrastructure",
+					},
+				},
+			}
+			garden.Spec.Extensions = []operatorv1alpha1.GardenExtension{
+				{Type: "local-extension-1"},
+				{Type: "local-extension-2"},
+			}
+
+			Expect(ComputeRequiredExtensionsForGarden(garden).UnsortedList()).To(ConsistOf(
+				"BackupBucket/local-infrastructure",
+				"DNSRecord/local-dns",
+				"Extension/local-extension-1",
+				"Extension/local-extension-2",
+			))
+		})
+	})
+
+	Describe("#CheckRuntimeExtensionInstallation", func() {
+		var (
+			ctx        context.Context
+			fakeClient client.Client
+
+			extensionName   string
+			gardenNamespace string
+			managedResource *resourcesv1alpha1.ManagedResource
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+			extensionName = "test"
+			gardenNamespace = "test-namespace"
+			managedResource = &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "extension-test-garden",
+					Namespace: gardenNamespace,
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
+		})
+
+		It("should return an error if no managed resource status is available", func() {
+			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesApplied for managed resource test-namespace/extension-test-garden has not been reported yet"))
+		})
+
+		It("should return an error if managed resource applied condition is false", func() {
+			managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+				{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionFalse, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+			}
+			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
+
+			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesApplied of managed resource test-namespace/extension-test-garden is False: "))
+		})
+
+		It("should return an error if managed resource healthy condition is false", func() {
+			managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+				{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionFalse, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+			}
+			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
+
+			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesHealthy of managed resource test-namespace/extension-test-garden is False: "))
+		})
+
+		It("should return an error if managed resource is progressing", func() {
+			managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+				{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				{Type: resourcesv1alpha1.ResourcesProgressing, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+			}
+			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
+
+			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(MatchError("condition ResourcesProgressing of managed resource test-namespace/extension-test-garden is True: "))
+		})
+
+		It("should succeed if managed resource is healthy", func() {
+			managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+				{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				{Type: resourcesv1alpha1.ResourcesProgressing, Status: gardencorev1beta1.ConditionFalse, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+			}
+			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
+
+			Expect(CheckRuntimeExtensionInstallation(ctx, fakeClient, gardenNamespace, extensionName)).To(Succeed())
+		})
+	})
+
+	Describe("#RequiredGardenExtensionsReady", func() {
+		var (
+			ctx        context.Context
+			log        logr.Logger
+			fakeClient client.Client
+
+			extensionName   string
+			gardenNamespace string
+
+			extension       *operatorv1alpha1.Extension
+			managedResource *resourcesv1alpha1.ManagedResource
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			log = logr.Discard()
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+			extensionName = "test"
+			gardenNamespace = "test-namespace"
+
+			extension = &operatorv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: extensionName,
+				},
+				Spec: operatorv1alpha1.ExtensionSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "BackupBucket", Type: "local-infrastructure"},
+						{Kind: "DNSRecord", Type: "local-dns"},
+						{Kind: "Extension", Type: "local-ext"},
+					},
+				},
+			}
+			managedResource = &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "extension-test-garden",
+					Namespace: gardenNamespace,
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, extension)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
+		})
+
+		It("should return an error if required extension does not exist", func() {
+			Expect(RequiredGardenExtensionsReady(ctx, log, fakeClient, gardenNamespace, sets.New("BackupBucket/foo"))).To(MatchError("extension controllers missing or unready: map[BackupBucket/foo:{}]"))
+		})
+
+		It("should return an error if required extension is not ready", func() {
+			Expect(RequiredGardenExtensionsReady(ctx, log, fakeClient, gardenNamespace, sets.New("BackupBucket/local-infrastructure"))).To(MatchError("extension controllers missing or unready: map[BackupBucket/local-infrastructure:{}]"))
+		})
+
+		It("should succeed if required extension is ready", func() {
+			managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+				{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				{Type: resourcesv1alpha1.ResourcesProgressing, Status: gardencorev1beta1.ConditionFalse, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+			}
+			Expect(fakeClient.Update(ctx, managedResource)).To(Succeed())
+
+			Expect(RequiredGardenExtensionsReady(ctx, log, fakeClient, gardenNamespace, sets.New("BackupBucket/local-infrastructure", "DNSRecord/local-dns"))).To(Succeed())
+		})
+	})
 })

--- a/pkg/utils/gardener/seed.go
+++ b/pkg/utils/gardener/seed.go
@@ -153,6 +153,16 @@ func ComputeRequiredExtensionsForSeed(seed *gardencorev1beta1.Seed) sets.Set[str
 	return wantedKindTypeCombinations
 }
 
+// ExtensionKindAndTypeForID returns the extension's type and kind based on the given ID.
+func ExtensionKindAndTypeForID(extensionID string) (extensionKind string, extensionType string, err error) {
+	split := strings.Split(extensionID, "/")
+	if len(split) != 2 {
+		return "", "", fmt.Errorf("unexpected required extension: %q", extensionID)
+	}
+	extensionKind, extensionType = split[0], split[1]
+	return
+}
+
 // RequiredExtensionsReady checks if all required extensions for a seed exist and are ready.
 func RequiredExtensionsReady(ctx context.Context, gardenClient client.Client, seedName string, requiredExtensions sets.Set[string]) error {
 	controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
@@ -169,11 +179,10 @@ func RequiredExtensionsReady(ctx context.Context, gardenClient client.Client, se
 		}
 
 		for _, kindType := range requiredExtensions.UnsortedList() {
-			split := strings.Split(kindType, "/")
-			if len(split) != 2 {
-				return fmt.Errorf("unexpected required extension: %q", kindType)
+			extensionKind, extensionType, err := ExtensionKindAndTypeForID(kindType)
+			if err != nil {
+				return err
 			}
-			extensionKind, extensionType := split[0], split[1]
 
 			if helper.IsResourceSupported(controllerRegistration.Spec.Resources, extensionKind, extensionType) && helper.IsControllerInstallationSuccessful(controllerInstallation) {
 				requiredExtensions.Delete(kindType)

--- a/pkg/utils/gardener/seed_test.go
+++ b/pkg/utils/gardener/seed_test.go
@@ -188,6 +188,29 @@ var _ = Describe("utils", func() {
 		})
 	})
 
+	Describe("#ExtensionKindAndTypeForID", func() {
+		It("should return the expected kind and type", func() {
+			extKind, extType, err := ExtensionKindAndTypeForID("extension/test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(extKind).To(Equal("extension"))
+			Expect(extType).To(Equal("test"))
+		})
+
+		It("should return an error when separator is invalid", func() {
+			extKind, extType, err := ExtensionKindAndTypeForID("extension-test")
+			Expect(err).To(MatchError(ContainSubstring("unexpected required extension")))
+			Expect(extKind).To(BeEmpty())
+			Expect(extType).To(BeEmpty())
+		})
+
+		It("should return an error when format is invalid", func() {
+			extKind, extType, err := ExtensionKindAndTypeForID("extension/backupbucket/test")
+			Expect(err).To(MatchError(ContainSubstring("unexpected required extension")))
+			Expect(extKind).To(BeEmpty())
+			Expect(extType).To(BeEmpty())
+		})
+	})
+
 	Describe("#RequiredExtensionsReady", func() {
 		var (
 			ctx        context.Context

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -29,6 +29,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -381,6 +381,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -15,7 +15,6 @@ build:
             - cmd/utils/initrun
             - extensions/pkg/apis/config/v1alpha1
             - extensions/pkg/controller
-            - extensions/pkg/predicate
             - extensions/pkg/util
             - extensions/pkg/webhook
             - extensions/pkg/webhook/certificates
@@ -331,6 +330,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/resources/v1alpha1/helper
@@ -450,6 +450,7 @@ build:
             - pkg/apis/operations/validation
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -660,6 +661,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -774,6 +776,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -862,6 +865,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -1025,6 +1029,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -1176,6 +1181,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -52,6 +52,7 @@ build:
             - pkg/apis/operations/validation
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -262,6 +263,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -376,6 +378,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -464,6 +467,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -673,6 +677,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -974,6 +979,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -1333,6 +1339,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/resources/v1alpha1/helper
@@ -1447,6 +1454,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security

--- a/test/integration/operator/extension/required/runtime/runtime_suite_test.go
+++ b/test/integration/operator/extension/required/runtime/runtime_suite_test.go
@@ -72,9 +72,8 @@ var _ = BeforeSuite(func() {
 			CRDInstallOptions: envtest.CRDInstallOptions{
 				Paths: []string{
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_extensions.yaml"),
+					filepath.Join("..", "..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_backupbuckets.yaml"),
-					filepath.Join("..", "..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_dnsrecords.yaml"),
-					filepath.Join("..", "..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_extensions.yaml"),
 				},
 			},
 			ErrorIfCRDPathMissing: true,
@@ -125,6 +124,9 @@ var _ = BeforeSuite(func() {
 				&operatorv1alpha1.Extension{}: {
 					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
 				},
+				&operatorv1alpha1.Garden{}: {
+					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+				},
 			},
 		},
 	})
@@ -133,7 +135,7 @@ var _ = BeforeSuite(func() {
 	mgrClient = mgr.GetClient()
 
 	By("Register controller")
-	DeferCleanup(test.WithVar(&requiredruntime.RequeueExtensionKindNotCalculated, 10*time.Millisecond))
+	DeferCleanup(test.WithVar(&requiredruntime.RequeueDurationWhenGardenIsBeingDeleted, 10*time.Millisecond))
 
 	Expect((&requiredruntime.Reconciler{
 		Config: operatorconfigv1alpha1.ExtensionRequiredRuntimeControllerConfiguration{ConcurrentSyncs: ptr.To(5)},

--- a/test/integration/operator/garden/garden/garden_suite_test.go
+++ b/test/integration/operator/garden/garden/garden_suite_test.go
@@ -61,6 +61,7 @@ var _ = BeforeSuite(func() {
 				filepath.Join("..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
 				filepath.Join("..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_extensions.yaml"),
 				filepath.Join("..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-autoscaling.k8s.io_verticalpodautoscalers.yaml"),
+				filepath.Join("..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-resources.gardener.cloud_managedresources.yaml"),
 				filepath.Join("testdata", "crd-seeds.yaml"),
 				filepath.Join("testdata", "crd-gardenlets.yaml"),
 			},

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -17,6 +17,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -412,57 +413,57 @@ spec:
 		Expect(garden.Status.Gardener).NotTo(BeNil())
 
 		By("Verify that the custom resource definitions have been created")
-		Eventually(func(g Gomega) []apiextensionsv1.CustomResourceDefinition {
+		Eventually(func(g Gomega) []string {
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-			return crdList.Items
+			return objectNames(crdList)
 		}).WithTimeout(kubernetesutils.WaitTimeout).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("authorizationpolicies.security.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("destinationrules.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("envoyfilters.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gateways.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("peerauthentications.security.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("proxyconfigs.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("requestauthentications.security.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("serviceentries.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("sidecars.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("telemetries.telemetry.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtualservices.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("wasmplugins.extensions.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadentries.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadgroups.networking.istio.io")})}),
+			"etcds.druid.gardener.cloud",
+			"etcdcopybackupstasks.druid.gardener.cloud",
+			"managedresources.resources.gardener.cloud",
+			"verticalpodautoscalers.autoscaling.k8s.io",
+			"verticalpodautoscalercheckpoints.autoscaling.k8s.io",
+			"authorizationpolicies.security.istio.io",
+			"destinationrules.networking.istio.io",
+			"envoyfilters.networking.istio.io",
+			"gateways.networking.istio.io",
+			"peerauthentications.security.istio.io",
+			"proxyconfigs.networking.istio.io",
+			"requestauthentications.security.istio.io",
+			"serviceentries.networking.istio.io",
+			"sidecars.networking.istio.io",
+			"telemetries.telemetry.istio.io",
+			"virtualservices.networking.istio.io",
+			"wasmplugins.extensions.istio.io",
+			"workloadentries.networking.istio.io",
+			"workloadgroups.networking.istio.io",
 			// fluent-operator
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfilters.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfluentbitconfigs.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterinputs.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusteroutputs.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterparsers.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbits.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("collectors.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbitconfigs.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("filters.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("parsers.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("outputs.fluentbit.fluent.io")})}),
+			"clusterfilters.fluentbit.fluent.io",
+			"clusterfluentbitconfigs.fluentbit.fluent.io",
+			"clusterinputs.fluentbit.fluent.io",
+			"clusteroutputs.fluentbit.fluent.io",
+			"clusterparsers.fluentbit.fluent.io",
+			"fluentbits.fluentbit.fluent.io",
+			"collectors.fluentbit.fluent.io",
+			"fluentbitconfigs.fluentbit.fluent.io",
+			"filters.fluentbit.fluent.io",
+			"parsers.fluentbit.fluent.io",
+			"outputs.fluentbit.fluent.io",
 			// prometheus-operator
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanagerconfigs.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanagers.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("podmonitors.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("probes.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheusagents.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheuses.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheusrules.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("scrapeconfigs.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("servicemonitors.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("thanosrulers.monitoring.coreos.com")})}),
+			"alertmanagerconfigs.monitoring.coreos.com",
+			"alertmanagers.monitoring.coreos.com",
+			"podmonitors.monitoring.coreos.com",
+			"probes.monitoring.coreos.com",
+			"prometheusagents.monitoring.coreos.com",
+			"prometheuses.monitoring.coreos.com",
+			"prometheusrules.monitoring.coreos.com",
+			"scrapeconfigs.monitoring.coreos.com",
+			"servicemonitors.monitoring.coreos.com",
+			"thanosrulers.monitoring.coreos.com",
 			// extensions
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("backupbuckets.extensions.gardener.cloud")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dnsrecords.extensions.gardener.cloud")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("extensions.extensions.gardener.cloud")})}),
+			"backupbuckets.extensions.gardener.cloud",
+			"dnsrecords.extensions.gardener.cloud",
+			"extensions.extensions.gardener.cloud",
 		))
 
 		// The garden controller waits for the gardener-resource-manager Deployment to be healthy, so let's fake this here.
@@ -522,22 +523,22 @@ spec:
 		}).Should(Succeed())
 
 		By("Verify that the ManagedResources related to runtime components have been deployed")
-		Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
+		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return managedResourceList.Items
+			return objectNames(managedResourceList)
 		}).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden-system")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vpa")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-druid")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("nginx-ingress")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-bit")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator-custom-resources-garden")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vali")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("plutono")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-operator")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanager-garden")})}),
+			"garden-system",
+			"vpa",
+			"etcd-druid",
+			"nginx-ingress",
+			"fluent-operator",
+			"fluent-bit",
+			"fluent-operator-custom-resources-garden",
+			"vali",
+			"plutono",
+			"prometheus-operator",
+			"alertmanager-garden",
 		))
 
 		// The garden controller waits for the Istio ManagedResources to be healthy, but Istio is not really running in
@@ -553,13 +554,13 @@ spec:
 		Eventually(makeManagedResourceHealthy("etcd-druid", testNamespace.Name)).Should(Succeed())
 
 		By("Verify that the virtual garden control plane components have been deployed")
-		Eventually(func(g Gomega) []druidv1alpha1.Etcd {
+		Eventually(func(g Gomega) []string {
 			etcdList := &druidv1alpha1.EtcdList{}
 			g.Expect(testClient.List(ctx, etcdList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return etcdList.Items
+			return objectNames(etcdList)
 		}).Should(ConsistOf(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-etcd-main")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-etcd-events")})}),
+			"virtual-garden-etcd-main",
+			"virtual-garden-etcd-events",
 		))
 
 		Eventually(func(g Gomega) map[string]string {
@@ -617,12 +618,12 @@ spec:
 		// The garden controller waits for the virtual-garden-kube-apiserver Deployment to be healthy, so let's fake
 		// this here.
 		By("Patch virtual-garden-kube-apiserver deployment to report healthiness")
-		Eventually(func(g Gomega) []appsv1.Deployment {
+		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return deploymentList.Items
+			return objectNames(deploymentList)
 		}).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-kube-apiserver")})}),
+			"virtual-garden-kube-apiserver",
 		))
 
 		Eventually(func(g Gomega) {
@@ -656,21 +657,21 @@ spec:
 		}).Should(Succeed())
 
 		By("Bootstrapping virtual-garden-gardener-resource-manager")
-		Eventually(func(g Gomega) []appsv1.Deployment {
+		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return deploymentList.Items
+			return objectNames(deploymentList)
 		}).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-gardener-resource-manager")})}),
+			"virtual-garden-gardener-resource-manager",
 		))
 
 		// The secret with the bootstrap certificate indicates that the bootstrapping of virtual-garden-gardener-resource-manager started.
-		Eventually(func(g Gomega) []corev1.Secret {
+		Eventually(func(g Gomega) []string {
 			secretList := &corev1.SecretList{}
 			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return secretList.Items
+			return objectNames(secretList)
 		}).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-")})}),
+			ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-"),
 		))
 
 		// virtual-garden-gardener-resource manager usually sets the token-renew-timestamp when it reconciled the secret.
@@ -684,12 +685,12 @@ spec:
 			g.Expect(testClient.Patch(ctx, secret, patch)).To(Succeed())
 		}).Should(Succeed())
 
-		Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
+		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return managedResourceList.Items
+			return objectNames(managedResourceList)
 		}).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("shoot-core-gardener-resource-manager")})}),
+			"shoot-core-gardener-resource-manager",
 		))
 
 		// The garden controller waits for the shoot-core-gardener-resource-manager ManagedResource to be healthy, but virtual-garden-gardener-resource-manager is not really running in
@@ -698,12 +699,12 @@ spec:
 		Eventually(makeManagedResourceHealthy("shoot-core-gardener-resource-manager", testNamespace.Name)).Should(Succeed())
 
 		// The secret with the bootstrap certificate should be gone when virtual-garden-gardener-resource-manager was bootstrapped.
-		Eventually(func(g Gomega) []corev1.Secret {
+		Eventually(func(g Gomega) []string {
 			secretList := &corev1.SecretList{}
 			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return secretList.Items
+			return objectNames(secretList)
 		}).ShouldNot(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-")})}),
+			ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-"),
 		))
 
 		// The garden controller waits for the virtual-garden-gardener-resource-manager Deployment to be healthy, so let's fake this here.
@@ -772,12 +773,12 @@ spec:
 		}).Should(Succeed())
 
 		By("Ensure virtual-garden-kube-controller-manager was deployed")
-		Eventually(func(g Gomega) []appsv1.Deployment {
+		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return deploymentList.Items
+			return objectNames(deploymentList)
 		}).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-kube-controller-manager")})}),
+			"virtual-garden-kube-controller-manager",
 		))
 
 		// The garden controller waits for the virtual-garden-kube-controller-manager Deployment to be healthy, so let's fake this here.
@@ -834,13 +835,13 @@ spec:
 
 		for _, name := range []string{"apiserver", "admission-controller", "controller-manager", "scheduler", "dashboard"} {
 			By("Verify that the ManagedResources related to gardener-" + name + " have been deployed")
-			Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
+			Eventually(func(g Gomega) []string {
 				managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 				g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-				return managedResourceList.Items
+				return objectNames(managedResourceList)
 			}).Should(ContainElements(
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-" + name + "-runtime")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-" + name + "-virtual")})}),
+				"gardener-"+name+"-runtime",
+				"gardener-"+name+"-virtual",
 			), "for gardener-"+name)
 
 			// The garden controller waits for the Gardener-related ManagedResources to be healthy, but no
@@ -851,20 +852,20 @@ spec:
 		}
 
 		By("Verify that the ManagedResources related to other components have been deployed")
-		Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
+		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return managedResourceList.Items
+			return objectNames(managedResourceList)
 		}).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("terminal-runtime")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("terminal-virtual")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden-system-virtual")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics-runtime")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-runtime")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-virtual")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-garden")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-longterm")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("blackbox-exporter")})}),
+			"terminal-runtime",
+			"terminal-virtual",
+			"garden-system-virtual",
+			"kube-state-metrics-runtime",
+			"gardener-metrics-exporter-runtime",
+			"gardener-metrics-exporter-virtual",
+			"prometheus-garden",
+			"prometheus-longterm",
+			"blackbox-exporter",
 		))
 
 		By("Verify and patch extensions")
@@ -900,23 +901,23 @@ spec:
 		Expect(testClient.Delete(ctx, extensionManagedResource)).To(Succeed())
 
 		By("Verify that the virtual garden control plane components have been deleted")
-		Eventually(func(g Gomega) []appsv1.Deployment {
+		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return deploymentList.Items
+			return objectNames(deploymentList)
 		}).ShouldNot(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-kube-apiserver")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-kube-controller-manager")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-gardener-resource-manager")})}),
+			"virtual-garden-kube-apiserver",
+			"virtual-garden-kube-controller-manager",
+			"virtual-garden-gardener-resource-manager",
 		))
 
-		Eventually(func(g Gomega) []druidv1alpha1.Etcd {
+		Eventually(func(g Gomega) []string {
 			etcdList := &druidv1alpha1.EtcdList{}
 			g.Expect(testClient.List(ctx, etcdList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return etcdList.Items
+			return objectNames(etcdList)
 		}).ShouldNot(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-etcd-main")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtual-garden-etcd-events")})}),
+			"virtual-garden-etcd-main",
+			"virtual-garden-etcd-events",
 		))
 
 		By("Verify that the garden system components have been deleted")
@@ -927,53 +928,53 @@ spec:
 		}).Should(BeNotFoundError())
 
 		By("Verify that the custom resource definitions have been deleted")
-		Eventually(func(g Gomega) []apiextensionsv1.CustomResourceDefinition {
+		Eventually(func(g Gomega) []string {
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-			return crdList.Items
+			return objectNames(crdList)
 		}).ShouldNot(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("authorizationpolicies.security.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("destinationrules.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("envoyfilters.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gateways.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("peerauthentications.security.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("proxyconfigs.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("requestauthentications.security.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("serviceentries.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("sidecars.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("telemetries.telemetry.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtualservices.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("wasmplugins.extensions.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadentries.networking.istio.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadgroups.networking.istio.io")})}),
+			"etcds.druid.gardener.cloud",
+			"etcdcopybackupstasks.druid.gardener.cloud",
+			"managedresources.resources.gardener.cloud",
+			"verticalpodautoscalers.autoscaling.k8s.io",
+			"verticalpodautoscalercheckpoints.autoscaling.k8s.io",
+			"authorizationpolicies.security.istio.io",
+			"destinationrules.networking.istio.io",
+			"envoyfilters.networking.istio.io",
+			"gateways.networking.istio.io",
+			"peerauthentications.security.istio.io",
+			"proxyconfigs.networking.istio.io",
+			"requestauthentications.security.istio.io",
+			"serviceentries.networking.istio.io",
+			"sidecars.networking.istio.io",
+			"telemetries.telemetry.istio.io",
+			"virtualservices.networking.istio.io",
+			"wasmplugins.extensions.istio.io",
+			"workloadentries.networking.istio.io",
+			"workloadgroups.networking.istio.io",
 			// fluent-operator
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfilters.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfluentbitconfigs.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterinputs.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusteroutputs.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterparsers.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbits.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("collectors.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbitconfigs.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("filters.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("parsers.fluentbit.fluent.io")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("outputs.fluentbit.fluent.io")})}),
+			"clusterfilters.fluentbit.fluent.io",
+			"clusterfluentbitconfigs.fluentbit.fluent.io",
+			"clusterinputs.fluentbit.fluent.io",
+			"clusteroutputs.fluentbit.fluent.io",
+			"clusterparsers.fluentbit.fluent.io",
+			"fluentbits.fluentbit.fluent.io",
+			"collectors.fluentbit.fluent.io",
+			"fluentbitconfigs.fluentbit.fluent.io",
+			"filters.fluentbit.fluent.io",
+			"parsers.fluentbit.fluent.io",
+			"outputs.fluentbit.fluent.io",
 			// prometheus-operator
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanagerconfigs.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanagers.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("podmonitors.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("probes.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheusagents.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheuses.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheusrules.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("scrapeconfigs.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("servicemonitors.monitoring.coreos.com")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("thanosrulers.monitoring.coreos.com")})}),
+			"alertmanagerconfigs.monitoring.coreos.com",
+			"alertmanagers.monitoring.coreos.com",
+			"podmonitors.monitoring.coreos.com",
+			"probes.monitoring.coreos.com",
+			"prometheusagents.monitoring.coreos.com",
+			"prometheuses.monitoring.coreos.com",
+			"prometheusrules.monitoring.coreos.com",
+			"scrapeconfigs.monitoring.coreos.com",
+			"servicemonitors.monitoring.coreos.com",
+			"thanosrulers.monitoring.coreos.com",
 		))
 
 		By("Verify that gardener-resource-manager has been deleted")
@@ -1090,4 +1091,17 @@ func patchExtensionStatus(cl client.Client, name, namespace string, lastOp garde
 		},
 	}
 	ExpectWithOffset(1, cl.Status().Patch(ctx, ext, patch)).To(Succeed())
+}
+
+func objectNames(list client.ObjectList) []string {
+	GinkgoHelper()
+
+	names := make([]string, 0, meta.LenList(list))
+	err := meta.EachListItem(list, func(o runtime.Object) error {
+		names = append(names, o.(client.Object).GetName())
+		return nil
+	})
+
+	Expect(err).NotTo(HaveOccurred())
+	return names
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the `gardener-operator` to wait for required `Extension`s to be ready during the `Garden` reconcile flow. It addresses use-cases where extensions run mutating webhooks in the garden runtime cluster that must be present when `Garden` components are deployed.

Earlier, required `Extension`s were only deployed when the involved object was created, e.g. `BackupBucket`.

**Which issue(s) this PR fixes**:
Part of #9635

**Special notes for your reviewer**:
/cc @afritzler

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` now waits for required `Extension`s to get ready early in the reconcile flow. It addresses use-cases where extensions run mutating webhooks in the garden runtime cluster that must be present when `Garden` components are deployed.
```
