### PR TITLE
Issue 11505: CoreDNS not truly configurable / import *.override not working as intended

### DIFF
--- a/docs/usage/networking/custom-dns-config.md
+++ b/docs/usage/networking/custom-dns-config.md
@@ -52,7 +52,7 @@ Be careful when overriding plugins `log`, `forward` or `cache`.
 - Playing with the cache settings can impact the timeframe how long it takes for changes to become visible.
 
 `*.override` and `*.server` data points from `coredns-custom` `ConfigMap` are imported into Corefile as follows.
-Consult plugin specifications from https://coredns.io/plugins/ for potential side-effects.
+Please consult `coredns` [plugin documentation](https://coredns.io/plugins/) for potential side-effects.
 ```yaml
 .:8053 {
   health {

--- a/docs/usage/networking/custom-dns-config.md
+++ b/docs/usage/networking/custom-dns-config.md
@@ -46,7 +46,7 @@ It is important to have the `ConfigMap` keys ending with `*.server` (if you woul
 if you want to customize the current server configuration (it is optional setting both).
 
 ## Warning
-Be careful when overriding plugins log, forward or cache. 
+Be careful when overriding plugins `log`, `forward` or `cache`.
 - Increasing log level can lead to increased load/reduced throughput. 
 - Changing the forward target may lead to unexpected results. 
 - Playing with the cache settings can impact the timeframe how long it takes for changes to become visible.

--- a/docs/usage/networking/custom-dns-config.md
+++ b/docs/usage/networking/custom-dns-config.md
@@ -51,7 +51,7 @@ Be careful when overriding plugins log, forward or cache.
 - Changing the forward target may lead to unexpected results. 
 - Playing with the cache settings can impact the timeframe how long it takes for changes to become visible.
 
-*.override and *.server data points from coredns-custom are imported into Corefile as follows.
+`*.override` and `*.server` data points from `coredns-custom` `ConfigMap` are imported into Corefile as follows.
 Consult plugin specifications from https://coredns.io/plugins/ for potential side-effects.
 ```yaml
 .:8053 {

--- a/docs/usage/networking/custom-dns-config.md
+++ b/docs/usage/networking/custom-dns-config.md
@@ -45,6 +45,41 @@ In order for the destination DNS server to be reachable, it must listen on port 
 It is important to have the `ConfigMap` keys ending with `*.server` (if you would like to add a new server) or `*.override`
 if you want to customize the current server configuration (it is optional setting both).
 
+## Warning
+Be careful when overriding plugins log, forward or cache. 
+- Increasing log level can lead to increased load/reduced throughput. 
+- Changing the forward target may lead to unexpected results. 
+- Playing with the cache settings can impact the timeframe how long it takes for changes to become visible.
+
+*.override and *.server data points from coredns-custom are imported into Corefile as follows.
+Consult plugin specifications from https://coredns.io/plugins/ for potential side-effects.
+```yaml
+.:8053 {
+  health {
+      lameduck 15s
+  }
+  ready
+  [search-rewrites]
+  kubernetes[clusterDomain]in-addr.arpa ip6.arpa {
+      pods insecure
+      fallthrough in-addr.arpa ip6.arpa
+      ttl 30
+  }
+  prometheus :9153
+  loop
+  import custom/*.override
+  errors
+  log . {
+      class error
+  }
+  forward . /etc/resolv.conf
+  cache 30
+  reload
+  loadbalance round_robin
+}
+import custom/*.server
+```
+
 ## [Optional] Reload CoreDNS
 
 As Gardener is configuring the `reload` [plugin](https://coredns.io/plugins/reload/) of CoreDNS a restart of the CoreDNS components is typically not necessary to propagate `ConfigMap` changes. However, if you don't want to wait for the default (30s) to kick in, you can roll-out your CoreDNS deployment using:

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -289,11 +289,7 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
 				Namespace: metav1.NamespaceSystem,
 			},
 			Data: map[string]string{
-				configDataKey: `.:` + strconv.Itoa(corednsconstants.PortServer) + ` {
-  errors
-  log . {
-      class error
-  }
+				configDataKey: `.:` + strconv.Itoa(corednsconstants.PortServer) + ` {  
   health {
       lameduck 15s
   }
@@ -304,12 +300,18 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
       ttl 30
   }
   prometheus :` + strconv.Itoa(portMetrics) + `
+
+  import custom/*.override
+
+  errors
+  log . {
+      class error
+  }
   forward . /etc/resolv.conf
-  cache 30
   loop
   reload
   loadbalance round_robin
-  import custom/*.override
+  cache 30
 }
 import custom/*.server
 `,

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -289,7 +289,7 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
 				Namespace: metav1.NamespaceSystem,
 			},
 			Data: map[string]string{
-				configDataKey: `.:` + strconv.Itoa(corednsconstants.PortServer) + ` {  
+				configDataKey: `.:` + strconv.Itoa(corednsconstants.PortServer) + ` {
   health {
       lameduck 15s
   }

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -300,18 +300,16 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
       ttl 30
   }
   prometheus :` + strconv.Itoa(portMetrics) + `
-
+  loop
   import custom/*.override
-
   errors
   log . {
       class error
   }
   forward . /etc/resolv.conf
-  loop
+  cache 30
   reload
   loadbalance round_robin
-  cache 30
 }
 import custom/*.server
 `,

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -121,10 +121,6 @@ subjects:
 data:
   Corefile: |
     .:8053 {
-      errors
-      log . {
-          class error
-      }
       health {
           lameduck 15s
       }

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -149,12 +149,16 @@ data:
           ttl 30
       }
       prometheus :9153
+      loop
+      import custom/*.override
+      errors
+      log . {
+          class error
+      }
       forward . /etc/resolv.conf
       cache 30
-      loop
       reload
       loadbalance round_robin
-      import custom/*.override
     }
     import custom/*.server
 kind: ConfigMap


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/area bug

**What this PR does / why we need it**:
ConfigMap coredns-custom is imported into CoreDNS Corefile. However, the import is late in the Corefile and ultimately does not meet the expectations raised by:
- https://gardener.cloud/docs/gardener/networking/custom-dns-config/
- https://github.com/gardener/gardener/blob/master/docs/usage/networking/custom-dns-config.md

This fix is an attempt to be consistent with the expectations raised by existing documentation.

**Which issue(s) this PR fixes**:
Fixes #11505  

**Special notes for your reviewer**:
Hello @plkokanov and @ScheererJ. How are things in Walldorf? Allow me to send regards from us guys at plusserver.com. We are using Gardener in our product PSKE (plusserver kubernetes engine) and we would like to extend a big thanks to you for open sourcing the great work you have put in. I am really just starting out with golang and gardener but would like to get my hands dirty. I made a proposition here: https://github.com/gardener/gardener-extension-networking-cilium/issues/495
Feel free to ask me about implementing other things. Cheers guys.

**Release note**:
<!--
bugfix user
-->
```
Make ConfigMap coredns-custom behave the way existing documentation suggests.
```
