### PR TITLE
[GEP-28] Allow to configure `hostNetwork`, `replicas` and `tolerations` for controller installations.

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -62,7 +62,7 @@ const usablePortsRangeSize = 5
 // the process of being deleted when deleting a ControllerInstallation.
 var RequeueDurationWhenResourceDeletionStillPresent = 5 * time.Second
 
-// Reconciler reconciles ControllerInstallations and deploys them into the seed cluster.
+// Reconciler reconciles ControllerInstallations and deploys them into the seed cluster or the autonomous shoot cluster.
 type Reconciler struct {
 	GardenClient          client.Client
 	GardenConfig          *rest.Config
@@ -79,7 +79,7 @@ type Reconciler struct {
 	BootstrapControlPlaneNode bool
 }
 
-// Reconcile reconciles ControllerInstallations and deploys them into the seed cluster.
+// Reconcile reconciles ControllerInstallations and deploys them into the seed cluster or the autonomous shoot cluster.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -49,7 +49,7 @@ import (
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
-	utilsnet "github.com/gardener/gardener/pkg/utils/net"
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 	"github.com/gardener/gardener/pkg/utils/oci"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
@@ -596,7 +596,7 @@ func (r *Reconciler) BootstrapControlPlaneNodeFunc(obj runtime.Object) error {
 func (r *Reconciler) CalculateNextUsablePorts() ([]int, error) {
 	var ports []int
 	for i := 0; i < usablePortsRangeSize; i++ {
-		p, _, err := utilsnet.SuggestPort("")
+		p, _, err := netutils.SuggestPort("")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -214,8 +214,8 @@ func (r *Reconciler) reconcile(
 
 	var (
 		gardenAccessSecret = gardenerutils.NewGardenAccessSecret("extension", namespace.Name).
-			WithServiceAccountName(v1beta1constants.ExtensionGardenServiceAccountPrefix + controllerInstallation.Name).
-			WithServiceAccountLabels(map[string]string{v1beta1constants.LabelControllerRegistrationName: controllerRegistration.Name})
+					WithServiceAccountName(v1beta1constants.ExtensionGardenServiceAccountPrefix + controllerInstallation.Name).
+					WithServiceAccountLabels(map[string]string{v1beta1constants.LabelControllerRegistrationName: controllerRegistration.Name})
 
 		volumeProvider  string
 		volumeProviders []gardencorev1beta1.SeedVolumeProvider

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Reconciler", func() {
 		reconciler = &Reconciler{}
 	})
 
-	Describe("#BootstrapControlPlaneNodeFunc", func() {
+	Describe("#MutateSpecForControlPlaneNodeBootstrapping", func() {
 		var (
 			pod         *corev1.Pod
 			deployment  *appsv1.Deployment
@@ -50,27 +50,27 @@ var _ = Describe("Reconciler", func() {
 			reconciler.BootstrapControlPlaneNode = false
 
 			p := pod.DeepCopy()
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(p)).To(Succeed())
+			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(p)).To(Succeed())
 			Expect(p).To(Equal(pod))
 
 			d := deployment.DeepCopy()
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(d)).To(Succeed())
+			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(d)).To(Succeed())
 			Expect(d).To(Equal(deployment))
 
 			s := statefulSet.DeepCopy()
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(s)).To(Succeed())
+			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(s)).To(Succeed())
 			Expect(s).To(Equal(statefulSet))
 
 			ds := daemonSet.DeepCopy()
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(ds)).To(Succeed())
+			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(ds)).To(Succeed())
 			Expect(ds).To(Equal(daemonSet))
 
 			j := job.DeepCopy()
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(j)).To(Succeed())
+			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(j)).To(Succeed())
 			Expect(j).To(Equal(job))
 
 			c := cronJob.DeepCopy()
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(c)).To(Succeed())
+			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(c)).To(Succeed())
 			Expect(c).To(Equal(cronJob))
 		})
 
@@ -110,15 +110,15 @@ var _ = Describe("Reconciler", func() {
 					checkHostNetworkAndTolerations(&cronJob.Spec.JobTemplate.Spec.Template.Spec)
 				}},
 			} {
-				Expect(reconciler.BootstrapControlPlaneNodeFunc(obj.object)).To(Succeed(), "for %T", obj.object)
+				Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(obj.object)).To(Succeed(), "for %T", obj.object)
 				obj.checkFunc()
 			}
 		})
 	})
 
-	Describe("#CalculateNextUsablePorts", func() {
+	Describe("#CalculateUsablePorts", func() {
 		It("should calculate usable ports range", func() {
-			ports, err := reconciler.CalculateNextUsablePorts()
+			ports, err := reconciler.CalculateUsablePorts()
 			Expect(err).To(Succeed())
 			Expect(ports).To(HaveLen(5))
 			allocatedPorts := map[int]struct{}{}
@@ -131,14 +131,14 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should not have any overlap between two calls", func() {
-			ports, err := reconciler.CalculateNextUsablePorts()
+			ports, err := reconciler.CalculateUsablePorts()
 			Expect(err).To(Succeed())
 			allocatedPorts := map[int]struct{}{}
 			for _, p := range ports {
 				Expect(allocatedPorts).NotTo(HaveKey(p))
 				allocatedPorts[p] = struct{}{}
 			}
-			ports, err = reconciler.CalculateNextUsablePorts()
+			ports, err = reconciler.CalculateUsablePorts()
 			Expect(err).To(Succeed())
 			for _, p := range ports {
 				Expect(allocatedPorts).NotTo(HaveKey(p))

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -78,6 +78,7 @@ var _ = Describe("Reconciler", func() {
 			reconciler.BootstrapControlPlaneNode = true
 
 			checkHostNetworkAndTolerations := func(podSpec *corev1.PodSpec) {
+				GinkgoHelper()
 				Expect(podSpec.HostNetwork).To(BeTrue())
 				Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{
 					{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
@@ -109,7 +110,7 @@ var _ = Describe("Reconciler", func() {
 					checkHostNetworkAndTolerations(&cronJob.Spec.JobTemplate.Spec.Template.Spec)
 				}},
 			} {
-				Expect(reconciler.BootstrapControlPlaneNodeFunc(obj.object)).To(Succeed())
+				Expect(reconciler.BootstrapControlPlaneNodeFunc(obj.object)).To(Succeed(), "for %T", obj.object)
 				obj.checkFunc()
 			}
 		})
@@ -121,10 +122,10 @@ var _ = Describe("Reconciler", func() {
 			Expect(err).To(Succeed())
 			Expect(ports).To(HaveLen(5))
 			allocatedPorts := map[int]struct{}{}
-			for i, p := range ports {
-				ExpectWithOffset(i, p).To(BeNumerically(">", 0))
-				ExpectWithOffset(i, p).To(BeNumerically("<", math.MaxUint16+1))
-				ExpectWithOffset(i, allocatedPorts).NotTo(HaveKey(p))
+			for _, p := range ports {
+				Expect(p).To(BeNumerically(">", 0))
+				Expect(p).To(BeNumerically("<", math.MaxUint16+1))
+				Expect(allocatedPorts).NotTo(HaveKey(p))
 				allocatedPorts[p] = struct{}{}
 			}
 		})
@@ -133,14 +134,14 @@ var _ = Describe("Reconciler", func() {
 			ports, err := reconciler.CalculateNextUsablePorts()
 			Expect(err).To(Succeed())
 			allocatedPorts := map[int]struct{}{}
-			for i, p := range ports {
-				ExpectWithOffset(i, allocatedPorts).NotTo(HaveKey(p))
+			for _, p := range ports {
+				Expect(allocatedPorts).NotTo(HaveKey(p))
 				allocatedPorts[p] = struct{}{}
 			}
 			ports, err = reconciler.CalculateNextUsablePorts()
 			Expect(err).To(Succeed())
-			for i, p := range ports {
-				ExpectWithOffset(i, allocatedPorts).NotTo(HaveKey(p))
+			for _, p := range ports {
+				Expect(allocatedPorts).NotTo(HaveKey(p))
 			}
 		})
 	})

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerinstallation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
+)
+
+var _ = Describe("Reconciler", func() {
+	var (
+		reconciler *Reconciler
+	)
+
+	BeforeEach(func() {
+		reconciler = &Reconciler{}
+	})
+
+	Describe("#BootstrapControlPlaneNodeFunc", func() {
+		var (
+			pod         *corev1.Pod
+			deployment  *appsv1.Deployment
+			statefulSet *appsv1.StatefulSet
+			daemonSet   *appsv1.DaemonSet
+			job         *batchv1.Job
+			cronJob     *batchv1.CronJob
+		)
+
+		BeforeEach(func() {
+			pod = &corev1.Pod{}
+			deployment = &appsv1.Deployment{}
+			statefulSet = &appsv1.StatefulSet{}
+			daemonSet = &appsv1.DaemonSet{}
+			job = &batchv1.Job{}
+			cronJob = &batchv1.CronJob{}
+		})
+
+		It("should not change objects if not bootstrapping control plane node", func() {
+			reconciler.BootstrapControlPlaneNode = false
+
+			p := pod.DeepCopy()
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(p)).To(Succeed())
+			Expect(p).To(Equal(pod))
+
+			d := deployment.DeepCopy()
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(d)).To(Succeed())
+			Expect(d).To(Equal(deployment))
+
+			s := statefulSet.DeepCopy()
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(s)).To(Succeed())
+			Expect(s).To(Equal(statefulSet))
+
+			ds := daemonSet.DeepCopy()
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(ds)).To(Succeed())
+			Expect(ds).To(Equal(daemonSet))
+
+			j := job.DeepCopy()
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(j)).To(Succeed())
+			Expect(j).To(Equal(job))
+
+			c := cronJob.DeepCopy()
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(c)).To(Succeed())
+			Expect(c).To(Equal(cronJob))
+		})
+
+		It("should adapt objects if bootstrapping control plane node", func() {
+			reconciler.BootstrapControlPlaneNode = true
+
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(pod)).To(Succeed())
+			Expect(pod.Spec.HostNetwork).To(BeTrue())
+			Expect(pod.Spec.Tolerations).To(Equal([]corev1.Toleration{
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+			}))
+
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(deployment)).To(Succeed())
+			Expect(deployment.Spec.Replicas).To(Equal(ptr.To(int32(1))))
+			Expect(deployment.Spec.Template.Spec.HostNetwork).To(BeTrue())
+			Expect(deployment.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+			}))
+
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(statefulSet)).To(Succeed())
+			Expect(statefulSet.Spec.Template.Spec.HostNetwork).To(BeTrue())
+			Expect(statefulSet.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+			}))
+
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(daemonSet)).To(Succeed())
+			Expect(daemonSet.Spec.Template.Spec.HostNetwork).To(BeTrue())
+			Expect(daemonSet.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+			}))
+
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(job)).To(Succeed())
+			Expect(job.Spec.Template.Spec.HostNetwork).To(BeTrue())
+			Expect(job.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+			}))
+
+			Expect(reconciler.BootstrapControlPlaneNodeFunc(cronJob)).To(Succeed())
+			Expect(cronJob.Spec.JobTemplate.Spec.Template.Spec.HostNetwork).To(BeTrue())
+			Expect(cronJob.Spec.JobTemplate.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+			}))
+		})
+	})
+
+	Describe("#CalculateNextUsablePorts", func() {
+		It("should calculate the first usable ports range", func() {
+			ports := reconciler.CalculateNextUsablePorts()
+			Expect(ports).To(Equal([]int{10101, 10102, 10103, 10104, 10105}))
+		})
+
+		It("should calculate the second usable ports range", func() {
+			_ = reconciler.CalculateNextUsablePorts()
+			ports := reconciler.CalculateNextUsablePorts()
+			Expect(ports).To(Equal([]int{10106, 10107, 10108, 10109, 10110}))
+		})
+	})
+})

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -5,11 +5,14 @@
 package controllerinstallation_test
 
 import (
+	"math"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
@@ -74,61 +77,71 @@ var _ = Describe("Reconciler", func() {
 		It("should adapt objects if bootstrapping control plane node", func() {
 			reconciler.BootstrapControlPlaneNode = true
 
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(pod)).To(Succeed())
-			Expect(pod.Spec.HostNetwork).To(BeTrue())
-			Expect(pod.Spec.Tolerations).To(Equal([]corev1.Toleration{
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-			}))
+			checkHostNetworkAndTolerations := func(podSpec *corev1.PodSpec) {
+				Expect(podSpec.HostNetwork).To(BeTrue())
+				Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{
+					{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+					{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+				}))
+			}
 
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(deployment)).To(Succeed())
-			Expect(deployment.Spec.Replicas).To(Equal(ptr.To(int32(1))))
-			Expect(deployment.Spec.Template.Spec.HostNetwork).To(BeTrue())
-			Expect(deployment.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-			}))
-
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(statefulSet)).To(Succeed())
-			Expect(statefulSet.Spec.Template.Spec.HostNetwork).To(BeTrue())
-			Expect(statefulSet.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-			}))
-
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(daemonSet)).To(Succeed())
-			Expect(daemonSet.Spec.Template.Spec.HostNetwork).To(BeTrue())
-			Expect(daemonSet.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-			}))
-
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(job)).To(Succeed())
-			Expect(job.Spec.Template.Spec.HostNetwork).To(BeTrue())
-			Expect(job.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-			}))
-
-			Expect(reconciler.BootstrapControlPlaneNodeFunc(cronJob)).To(Succeed())
-			Expect(cronJob.Spec.JobTemplate.Spec.Template.Spec.HostNetwork).To(BeTrue())
-			Expect(cronJob.Spec.JobTemplate.Spec.Template.Spec.Tolerations).To(Equal([]corev1.Toleration{
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-				{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-			}))
+			for _, obj := range []struct {
+				object    runtime.Object
+				checkFunc func()
+			}{
+				{pod, func() {
+					checkHostNetworkAndTolerations(&pod.Spec)
+				}},
+				{deployment, func() {
+					Expect(deployment.Spec.Replicas).To(Equal(ptr.To(int32(1))))
+					checkHostNetworkAndTolerations(&deployment.Spec.Template.Spec)
+				}},
+				{statefulSet, func() {
+					checkHostNetworkAndTolerations(&statefulSet.Spec.Template.Spec)
+				}},
+				{daemonSet, func() {
+					checkHostNetworkAndTolerations(&daemonSet.Spec.Template.Spec)
+				}},
+				{job, func() {
+					checkHostNetworkAndTolerations(&job.Spec.Template.Spec)
+				}},
+				{cronJob, func() {
+					checkHostNetworkAndTolerations(&cronJob.Spec.JobTemplate.Spec.Template.Spec)
+				}},
+			} {
+				Expect(reconciler.BootstrapControlPlaneNodeFunc(obj.object)).To(Succeed())
+				obj.checkFunc()
+			}
 		})
 	})
 
 	Describe("#CalculateNextUsablePorts", func() {
-		It("should calculate the first usable ports range", func() {
-			ports := reconciler.CalculateNextUsablePorts()
-			Expect(ports).To(Equal([]int{10101, 10102, 10103, 10104, 10105}))
+		It("should calculate usable ports range", func() {
+			ports, err := reconciler.CalculateNextUsablePorts()
+			Expect(err).To(Succeed())
+			Expect(ports).To(HaveLen(5))
+			allocatedPorts := map[int]struct{}{}
+			for i, p := range ports {
+				ExpectWithOffset(i, p).To(BeNumerically(">", 0))
+				ExpectWithOffset(i, p).To(BeNumerically("<", math.MaxUint16+1))
+				ExpectWithOffset(i, allocatedPorts).NotTo(HaveKey(p))
+				allocatedPorts[p] = struct{}{}
+			}
 		})
 
-		It("should calculate the second usable ports range", func() {
-			_ = reconciler.CalculateNextUsablePorts()
-			ports := reconciler.CalculateNextUsablePorts()
-			Expect(ports).To(Equal([]int{10106, 10107, 10108, 10109, 10110}))
+		It("should not have any overlap between two calls", func() {
+			ports, err := reconciler.CalculateNextUsablePorts()
+			Expect(err).To(Succeed())
+			allocatedPorts := map[int]struct{}{}
+			for i, p := range ports {
+				ExpectWithOffset(i, allocatedPorts).NotTo(HaveKey(p))
+				allocatedPorts[p] = struct{}{}
+			}
+			ports, err = reconciler.CalculateNextUsablePorts()
+			Expect(err).To(Succeed())
+			for i, p := range ports {
+				ExpectWithOffset(i, allocatedPorts).NotTo(HaveKey(p))
+			}
 		})
 	})
 })

--- a/pkg/utils/net/port.go
+++ b/pkg/utils/net/port.go
@@ -17,7 +17,7 @@
 //
 // Modifications Copyright 2024 SAP SE or an SAP affiliate company and Gardener contributors
 
-package port
+package net
 
 import (
 	"fmt"

--- a/pkg/utils/oci/oci_suite_test.go
+++ b/pkg/utils/oci/oci_suite_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	helmregistry "helm.sh/helm/v3/pkg/registry"
 
-	utilsnet "github.com/gardener/gardener/pkg/utils/net"
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 )
 
 func TestOCI(t *testing.T) {
@@ -52,7 +52,7 @@ func startTestRegistry(ctx context.Context) (string, error) {
 	config := &configuration.Configuration{}
 	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 
-	port, host, err := utilsnet.SuggestPort("")
+	port, host, err := netutils.SuggestPort("")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/utils/oci/oci_suite_test.go
+++ b/pkg/utils/oci/oci_suite_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	helmregistry "helm.sh/helm/v3/pkg/registry"
 
-	"github.com/gardener/gardener/pkg/utils/test/port"
+	utilsnet "github.com/gardener/gardener/pkg/utils/net"
 )
 
 func TestOCI(t *testing.T) {
@@ -52,7 +52,7 @@ func startTestRegistry(ctx context.Context) (string, error) {
 	config := &configuration.Configuration{}
 	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 
-	port, host, err := port.SuggestPort("")
+	port, host, err := utilsnet.SuggestPort("")
 	if err != nil {
 		return "", err
 	}

--- a/test/envtest/apiserver.go
+++ b/test/envtest/apiserver.go
@@ -44,9 +44,9 @@ import (
 	"github.com/gardener/gardener/pkg/apiserver/features"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	utilsnet "github.com/gardener/gardener/pkg/utils/net"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-	"github.com/gardener/gardener/pkg/utils/test/port"
 )
 
 const (
@@ -230,7 +230,7 @@ func (g *GardenerAPIServer) defaultSettings() error {
 	}
 
 	if g.SecurePort == 0 {
-		g.SecurePort, _, err = port.SuggestPort("")
+		g.SecurePort, _, err = utilsnet.SuggestPort("")
 		if err != nil {
 			return err
 		}

--- a/test/envtest/apiserver.go
+++ b/test/envtest/apiserver.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gardener/gardener/pkg/apiserver/features"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	utilsnet "github.com/gardener/gardener/pkg/utils/net"
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 )
@@ -230,7 +230,7 @@ func (g *GardenerAPIServer) defaultSettings() error {
 	}
 
 	if g.SecurePort == 0 {
-		g.SecurePort, _, err = utilsnet.SuggestPort("")
+		g.SecurePort, _, err = netutils.SuggestPort("")
 		if err != nil {
 			return err
 		}

--- a/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_suite_test.go
+++ b/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_suite_test.go
@@ -44,8 +44,8 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/nodeagentauthorizer"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	utilsnet "github.com/gardener/gardener/pkg/utils/net"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	"github.com/gardener/gardener/pkg/utils/test/port"
 	"github.com/gardener/gardener/test/framework"
 )
 
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 	By("Create kubeconfig file for the authorization webhook")
 	webhookAddress, err := net.ResolveTCPAddr("tcp", net.JoinHostPort("localhost", "0"))
 	Expect(err).NotTo(HaveOccurred())
-	webhookPort, _, err := port.SuggestPort("")
+	webhookPort, _, err := utilsnet.SuggestPort("")
 	Expect(err).ToNot(HaveOccurred())
 	kubeconfigFileName, err := createKubeconfigFileForAuthorizationWebhook(webhookAddress.IP.String(), webhookPort)
 	Expect(err).ToNot(HaveOccurred())

--- a/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_suite_test.go
+++ b/test/integration/resourcemanager/nodeagentauthorizer/nodeagentauthorizer_suite_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/nodeagentauthorizer"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	utilsnet "github.com/gardener/gardener/pkg/utils/net"
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	"github.com/gardener/gardener/test/framework"
 )
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 	By("Create kubeconfig file for the authorization webhook")
 	webhookAddress, err := net.ResolveTCPAddr("tcp", net.JoinHostPort("localhost", "0"))
 	Expect(err).NotTo(HaveOccurred())
-	webhookPort, _, err := utilsnet.SuggestPort("")
+	webhookPort, _, err := netutils.SuggestPort("")
 	Expect(err).ToNot(HaveOccurred())
 	kubeconfigFileName, err := createKubeconfigFileForAuthorizationWebhook(webhookAddress.IP.String(), webhookPort)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Allow to configure `hostNetwork`, `replicas`, `tolerations` and usable ports for controller installations.

In the autonomous shoot cluster scenario, some controller installations may need to run in the host network. They may also need to be scaled down in a single node scenario or may need to tolerate additional taints during bootstrap. Running multiple controller installations in the host network also requires managing the usable ports so that two controllers
do not clash in their port usage.
This change adds the one flag to the controller installation reconciler that will trigger the corresponding changes.
Notably, the handling of the usable ports is focussed on the `gardenadm` scenario and is explicitly not supposed to be run as a controller.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Allow to configure bootstrapping control plane nodes with controller installations by setting `hostNetwork`, `replicas`, `tolerations` and usable ports.
```
