### PR TITLE
fix: SSH tunnel livenessProbe no longer fails with slow DNS

### DIFF
--- a/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
@@ -24,7 +24,7 @@ spec:
             command:
             - sh
             - "-c"
-            - "netstat | grep gardener-apiserver-tunnel-ssh"
+            - "netstat -n -p | grep ssh"
         volumeMounts:
         - name: gardener-apiserver-ssh
           mountPath: /gardener_apiserver_ssh


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity robustness
/kind impediment

**What this PR does / why we need it**:

The netstat command in the livenessProbe of the SSH tunnel for local development sometimes failed when the DNS resolution takes more than 1 second. The `-n` parameter skips name resolution. `grep` can then no longer look for the local hostname, so adding the `-p` parameter adds info about the process name, which we can grep for instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
SSH tunnel for local development with remote seed no longer fails with slow DNS.
```
