### PR TITLE
Refactor `create_update_delete` Shoot e2e test to ordered `It` containers

### DIFF
--- a/test/utils/shoots/update/update.go
+++ b/test/utils/shoots/update/update.go
@@ -76,14 +76,14 @@ func RunTest(
 	}
 
 	By("Verify the Kubernetes version for all existing nodes matches with the versions defined in the Shoot spec [before update]")
-	Expect(verifyKubernetesVersions(ctx, shootClient, f.Shoot)).To(Succeed())
+	Expect(VerifyKubernetesVersions(ctx, shootClient, f.Shoot)).To(Succeed())
 
 	By("Read CloudProfile")
 	cloudProfile, err := f.GetCloudProfile(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Compute new Kubernetes version for control plane and worker pools")
-	controlPlaneVersion, poolNameToKubernetesVersion, err := computeNewKubernetesVersions(cloudProfile, f.Shoot, newControlPlaneKubernetesVersion, newWorkerPoolKubernetesVersion)
+	controlPlaneVersion, poolNameToKubernetesVersion, err := ComputeNewKubernetesVersions(cloudProfile, f.Shoot, newControlPlaneKubernetesVersion, newWorkerPoolKubernetesVersion)
 	Expect(err).NotTo(HaveOccurred())
 
 	if len(controlPlaneVersion) == 0 && len(poolNameToKubernetesVersion) == 0 {
@@ -117,7 +117,7 @@ func RunTest(
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Verify the Kubernetes version for all existing nodes matches with the versions defined in the Shoot spec [after update]")
-	Expect(verifyKubernetesVersions(ctx, shootClient, f.Shoot)).To(Succeed())
+	Expect(VerifyKubernetesVersions(ctx, shootClient, f.Shoot)).To(Succeed())
 
 	if v1beta1helper.IsHAControlPlaneConfigured(f.Shoot) {
 		By("Ensure there was no downtime while upgrading shoot")
@@ -133,7 +133,9 @@ func RunTest(
 	}
 }
 
-func verifyKubernetesVersions(ctx context.Context, shootClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot) error {
+// VerifyKubernetesVersions verifies that the Kubernetes versions of the control plane and worker nodes
+// match the versions defined in the shoot spec.
+func VerifyKubernetesVersions(ctx context.Context, shootClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot) error {
 	controlPlaneKubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
 	if err != nil {
 		return err
@@ -172,7 +174,8 @@ func verifyKubernetesVersions(ctx context.Context, shootClient kubernetes.Interf
 	return nil
 }
 
-func computeNewKubernetesVersions(
+// ComputeNewKubernetesVersions computes the new Kubernetes versions for the control plane and worker pools of the given shoot.
+func ComputeNewKubernetesVersions(
 	cloudProfile *gardencorev1beta1.CloudProfile,
 	shoot *gardencorev1beta1.Shoot,
 	newControlPlaneKubernetesVersion *string,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR refactors the e2e test create_update_delete to ordered containers.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379.

**Special notes for your reviewer**:
/cc @rfranzke @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
