### PR TITLE
Override machine image `updateStrategy` from `NamespacedCloudProfile`

### DIFF
--- a/docs/usage/project/namespaced-cloud-profiles.md
+++ b/docs/usage/project/namespaced-cloud-profiles.md
@@ -16,9 +16,9 @@ When creating or updating a `Shoot`, the cloud profile reference can be set to p
 The modification of a `Shoot`'s cloud profile reference is restricted to switching within the same profile hierarchy, i.e. from a `CloudProfile` to a descendant `NamespacedCloudProfile`, from a `NamespacedCloudProfile` to its parent `CloudProfile` and between `NamespacedCloudProfile`s having the same `CloudProfile` parent.
 Changing the reference from one `CloudProfile` or descendant `NamespacedCloudProfile` to another `CloudProfile` or descendant `NamespacedCloudProfile` is not allowed.
 
-The usage of `NamespacedCloudProfile`s is currently subject to an alpha feature gate and is not enabled by default.
+The usage of `NamespacedCloudProfile`s is currently subject to a beta feature gate and is enabled by default.
 It requires the enabled provider extensions to support the feature as well.
-The feature gate can be enabled by passing the `--feature-gates=NamespacedCloudProfiles=true` flag to the Gardener API server.
+The feature gate can be disabled by passing the `--feature-gates=NamespacedCloudProfiles=false` flag to the Gardener API server.
 
 Please see [this](../../../example/35-namespacedcloudprofile.yaml) example manifest and [GEP-25](../../proposals/25-namespaced-cloud-profiles.md) for additional information.
 

--- a/example/35-namespacedcloudprofile.yaml
+++ b/example/35-namespacedcloudprofile.yaml
@@ -21,7 +21,7 @@ spec:
     usable: true
   machineImages:
   - name: local
-    # updateStrategy: minor
+  # updateStrategy: minor
     versions:
     - version: 1.0.1-dev
       architectures:

--- a/example/35-namespacedcloudprofile.yaml
+++ b/example/35-namespacedcloudprofile.yaml
@@ -21,6 +21,7 @@ spec:
     usable: true
   machineImages:
   - name: local
+    # updateStrategy: minor
     versions:
     - version: 1.0.1-dev
       architectures:

--- a/pkg/apis/core/helper/cloudprofile.go
+++ b/pkg/apis/core/helper/cloudprofile.go
@@ -32,10 +32,13 @@ func FindMachineImageVersion(machineImages []core.MachineImage, name, version st
 }
 
 // DetermineLatestMachineImageVersions determines the latest versions (semVer) of the given machine images from a slice of machine images
-func DetermineLatestMachineImageVersions(images []core.MachineImage) (map[string]core.MachineImageVersion, error) {
+func DetermineLatestMachineImageVersions(images []core.MachineImage, allowEmptyVersions bool) (map[string]core.MachineImageVersion, error) {
 	resultMapVersions := make(map[string]core.MachineImageVersion)
 
 	for _, image := range images {
+		if len(image.Versions) == 0 && allowEmptyVersions {
+			continue
+		}
 		latestMachineImageVersion, err := DetermineLatestMachineImageVersion(image.Versions, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to determine latest machine image version for image '%s': %w", image.Name, err)

--- a/pkg/apis/core/helper/cloudprofile.go
+++ b/pkg/apis/core/helper/cloudprofile.go
@@ -32,11 +32,11 @@ func FindMachineImageVersion(machineImages []core.MachineImage, name, version st
 }
 
 // DetermineLatestMachineImageVersions determines the latest versions (semVer) of the given machine images from a slice of machine images
-func DetermineLatestMachineImageVersions(images []core.MachineImage, allowEmptyVersions bool) (map[string]core.MachineImageVersion, error) {
+func DetermineLatestMachineImageVersions(images []core.MachineImage) (map[string]core.MachineImageVersion, error) {
 	resultMapVersions := make(map[string]core.MachineImageVersion)
 
 	for _, image := range images {
-		if len(image.Versions) == 0 && allowEmptyVersions {
+		if len(image.Versions) == 0 {
 			continue
 		}
 		latestMachineImageVersion, err := DetermineLatestMachineImageVersion(image.Versions, false)

--- a/pkg/apis/core/helper/cloudprofile_test.go
+++ b/pkg/apis/core/helper/cloudprofile_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Helper", func() {
 
 	DescribeTable("#DetermineLatestMachineImageVersions",
 		func(versions []core.MachineImage, expectation map[string]core.MachineImageVersion, expectError bool) {
-			result, err := DetermineLatestMachineImageVersions(versions)
+			result, err := DetermineLatestMachineImageVersions(versions, false)
 			if expectError {
 				Expect(err).To(HaveOccurred())
 				return

--- a/pkg/apis/core/helper/cloudprofile_test.go
+++ b/pkg/apis/core/helper/cloudprofile_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Helper", func() {
 
 	DescribeTable("#DetermineLatestMachineImageVersions",
 		func(versions []core.MachineImage, expectation map[string]core.MachineImageVersion, expectError bool) {
-			result, err := DetermineLatestMachineImageVersions(versions, false)
+			result, err := DetermineLatestMachineImageVersions(versions)
 			if expectError {
 				Expect(err).To(HaveOccurred())
 				return

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -154,7 +154,7 @@ func ValidateCloudProfileMachineImages(machineImages []core.MachineImage, fldPat
 		allErrs = append(allErrs, field.Required(fldPath, "must provide at least one machine image"))
 	}
 
-	allErrs = append(allErrs, ValidateMachineImages(machineImages, fldPath)...)
+	allErrs = append(allErrs, ValidateMachineImages(machineImages, fldPath, false)...)
 
 	for i, image := range machineImages {
 		idxPath := fldPath.Index(i)

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -445,14 +445,13 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					errorList := ValidateCloudProfile(cloudProfile)
 
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.machineImages[0].versions"),
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.machineImages[0].versions"),
+						"Detail": ContainSubstring("must provide at least one version for the machine image 'some-machine-image'"),
 					})), PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.machineImages"),
-					})), PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.machineImages[0].updateStrategy"),
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.machineImages[0].updateStrategy"),
+						"Detail": ContainSubstring("must provide an update strategy"),
 					}))))
 				})
 

--- a/pkg/apis/core/validation/namespacedcloudprofile.go
+++ b/pkg/apis/core/validation/namespacedcloudprofile.go
@@ -20,7 +20,7 @@ func ValidateNamespacedCloudProfile(namespacedCloudProfile *core.NamespacedCloud
 	allErrs = append(allErrs, validateNamespacedCloudProfileParent(namespacedCloudProfile.Spec.Parent, field.NewPath("spec.parent"))...)
 
 	allErrs = append(allErrs, validateNamespacedCloudProfileKubernetesVersions(namespacedCloudProfile.Spec.Kubernetes, field.NewPath("spec.kubernetes"))...)
-	allErrs = append(allErrs, ValidateMachineImages(namespacedCloudProfile.Spec.MachineImages, field.NewPath("spec.machineImages"))...)
+	allErrs = append(allErrs, ValidateMachineImages(namespacedCloudProfile.Spec.MachineImages, field.NewPath("spec.machineImages"), true)...)
 	allErrs = append(allErrs, validateVolumeTypes(namespacedCloudProfile.Spec.VolumeTypes, field.NewPath("spec.volumeTypes"))...)
 	allErrs = append(allErrs, validateMachineTypes(namespacedCloudProfile.Spec.MachineTypes, field.NewPath("spec.machineTypes"))...)
 

--- a/pkg/apis/core/validation/namespacedcloudprofile_test.go
+++ b/pkg/apis/core/validation/namespacedcloudprofile_test.go
@@ -296,20 +296,12 @@ var _ = Describe("NamespacedCloudProfile Validation Tests ", func() {
 					}))))
 				})
 
-				It("should forbid machine images with no version", func() {
+				It("should allow machine images that only override the update strategy", func() {
 					namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
-						{Name: machineImageName},
+						{Name: machineImageName, UpdateStrategy: ptr.To(core.UpdateStrategyMajor)},
 					}
 
-					errorList := ValidateNamespacedCloudProfile(namespacedCloudProfile)
-
-					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.machineImages[0].versions"),
-					})), PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.machineImages"),
-					}))))
+					Expect(ValidateNamespacedCloudProfile(namespacedCloudProfile)).To(BeEmpty())
 				})
 
 				It("should allow providing new machine image versions with all fields filled out", func() {

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -204,7 +204,7 @@ func ValidateMachineImages(machineImages []core.MachineImage, fldPath *field.Pat
 		return allErrs
 	}
 
-	latestMachineImages, err := helper.DetermineLatestMachineImageVersions(machineImages, allowEmptyVersions)
+	latestMachineImages, err := helper.DetermineLatestMachineImageVersions(machineImages)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, latestMachineImages, err.Error()))
 	}

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -197,14 +197,14 @@ func validateKubernetesVersions(versions []core.ExpirableVersion, fldPath *field
 }
 
 // ValidateMachineImages validates the given list of machine images for valid values and combinations.
-func ValidateMachineImages(machineImages []core.MachineImage, fldPath *field.Path) field.ErrorList {
+func ValidateMachineImages(machineImages []core.MachineImage, fldPath *field.Path, allowEmptyVersions bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(machineImages) == 0 {
 		return allErrs
 	}
 
-	latestMachineImages, err := helper.DetermineLatestMachineImageVersions(machineImages)
+	latestMachineImages, err := helper.DetermineLatestMachineImageVersions(machineImages, allowEmptyVersions)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, latestMachineImages, err.Error()))
 	}
@@ -222,7 +222,7 @@ func ValidateMachineImages(machineImages []core.MachineImage, fldPath *field.Pat
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "machine image name must not be empty"))
 		}
 
-		if len(image.Versions) == 0 {
+		if len(image.Versions) == 0 && !allowEmptyVersions {
 			allErrs = append(allErrs, field.Required(idxPath.Child("versions"), fmt.Sprintf("must provide at least one version for the machine image '%s'", image.Name)))
 		}
 

--- a/pkg/apiserver/registry/core/namespacedcloudprofile/strategy.go
+++ b/pkg/apiserver/registry/core/namespacedcloudprofile/strategy.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/extensions/pkg/util"
 	"github.com/gardener/gardener/pkg/api"
@@ -131,7 +132,7 @@ func dropExpiredMachineImageVersions(newProfile, oldProfile *core.NamespacedClou
 		existingMachineImages = oldProfile.Spec.MachineImages
 	}
 	existingMachineImageVersions := util.NewCoreImagesContext(existingMachineImages)
-	validMachineImages := []core.MachineImage{}
+	var validMachineImages []core.MachineImage
 	for i, machineImage := range newProfile.Spec.MachineImages {
 		var validMachineImageVersions []core.MachineImageVersion
 
@@ -142,7 +143,7 @@ func dropExpiredMachineImageVersions(newProfile, oldProfile *core.NamespacedClou
 			}
 			validMachineImageVersions = append(validMachineImageVersions, version)
 		}
-		if len(validMachineImageVersions) > 0 {
+		if len(validMachineImageVersions) > 0 || ptr.Deref(machineImage.UpdateStrategy, "") != "" {
 			newProfile.Spec.MachineImages[i].Versions = validMachineImageVersions
 			validMachineImages = append(validMachineImages, newProfile.Spec.MachineImages[i])
 		}

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -141,19 +141,11 @@ func mergeExpirationDates(base, override gardencorev1beta1.ExpirableVersion) gar
 }
 
 func mergeMachineImages(base, override gardencorev1beta1.MachineImage) gardencorev1beta1.MachineImage {
-	if override.UpdateStrategy == nil {
-		// The NamespacedCloudProfile only extends parent CloudProfile machine image versions by the expiration date.
-		base.Versions = mergeDeep(base.Versions, override.Versions, machineImageVersionKeyFunc, mergeMachineImageVersions, true)
-		return base
+	if ptr.Deref(override.UpdateStrategy, "") != "" {
+		base.UpdateStrategy = override.UpdateStrategy
 	}
-
-	// A formerly new machine image in the NamespacedCloudProfile has been added to the parent CloudProfile by now.
-	// If NamespacedCloudProfile and parent CloudProfile UpdateStrategies conflict, only use NamespacedCloudProfile machine images.
-	if override.UpdateStrategy == base.UpdateStrategy {
-		// Add additional CloudProfile machine image versions to the NamespacedCloudProfile versions without overriding explicitly set expiration dates.
-		override.Versions = mergeDeep(override.Versions, base.Versions, machineImageVersionKeyFunc, nil, true)
-	}
-	return override
+	base.Versions = mergeDeep(base.Versions, override.Versions, machineImageVersionKeyFunc, mergeMachineImageVersions, true)
+	return base
 }
 
 func mergeMachineImageVersions(base, override gardencorev1beta1.MachineImageVersion) gardencorev1beta1.MachineImageVersion {

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -251,10 +251,6 @@ func (c *validationContext) validateMachineImageOverrides(attr admission.Attribu
 				}
 			}
 
-			if len(ptr.Deref(image.UpdateStrategy, "")) > 0 && !imageAlreadyExistsInNamespacedCloudProfile {
-				allErrs = append(allErrs, field.Forbidden(imageIndexPath.Child("updateStrategy"), "must not provide an updateStrategy to an extended machine image in NamespacedCloudProfile"))
-			}
-
 			for imageVersionIndex, imageVersion := range image.Versions {
 				if _, isExistingVersion := parentImages.GetImageVersion(image.Name, imageVersion.Version); isExistingVersion {
 					// An image with the specified version is already present in the parent CloudProfile.
@@ -298,7 +294,7 @@ func (c *validationContext) validateMachineImageOverrides(attr admission.Attribu
 			}
 		} else {
 			// There is no entry for this image in the parent CloudProfile yet.
-			allErrs = append(allErrs, validation.ValidateMachineImages([]gardencore.MachineImage{image}, imageIndexPath)...)
+			allErrs = append(allErrs, validation.ValidateMachineImages([]gardencore.MachineImage{image}, imageIndexPath, false)...)
 			allErrs = append(allErrs, validation.ValidateCloudProfileMachineImages([]gardencore.MachineImage{image}, imageIndexPath)...)
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity os usability
/kind enhancement

**What this PR does / why we need it**:
Enable the `updateStrategy` of existing machine images to be overridden in a `NamespacedCloudProfile`.

**Which issue(s) this PR fixes**:
Part of #11520.

**Special notes for your reviewer**:
/cc @timuthy @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The `updateStrategy` of existing machine images in a `CloudProfile` can now be overridden in a `NamespacedCloudProfile`.
```
