### PR TITLE
Support configuring GOAWAY chance for `gardener-apiserver` via `Garden` API

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -625,6 +625,17 @@ spec:
                             description: FeatureGates contains information about enabled
                               feature gates.
                             type: object
+                          goAwayChance:
+                            description: |-
+                              GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
+                              connection (GOAWAY). The client's other in-flight requests won't be affected, and the client will reconnect,
+                              likely landing on a different apiserver after going through the load balancer again. This field sets the fraction
+                              of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer,
+                              should NOT enable this. Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting
+                              point.
+                            maximum: 0.02
+                            minimum: 0
+                            type: number
                           logging:
                             description: Logging contains configuration for the log
                               level and HTTP access logs.

--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -630,9 +630,8 @@ spec:
                               GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
                               connection (GOAWAY). The client's other in-flight requests won't be affected, and the client will reconnect,
                               likely landing on a different apiserver after going through the load balancer again. This field sets the fraction
-                              of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer,
-                              should NOT enable this. Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting
-                              point.
+                              of requests that will be sent a GOAWAY. Min is 0 (off), Max is 0.02 (1/50 requests); 0.001 (1/1000) is a
+                              recommended starting point.
                             maximum: 0.02
                             minimum: 0
                             type: number

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -1975,9 +1975,8 @@ float64
 <p>GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
 connection (GOAWAY). The client&rsquo;s other in-flight requests won&rsquo;t be affected, and the client will reconnect,
 likely landing on a different apiserver after going through the load balancer again. This field sets the fraction
-of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don&rsquo;t use a load balancer,
-should NOT enable this. Min is 0 (off), Max is .02 (<sup>1</sup>&frasl;<sub>50</sub> requests); .001 (<sup>1</sup>&frasl;<sub>1000</sub>) is a recommended starting
-point.</p>
+of requests that will be sent a GOAWAY. Min is 0 (off), Max is 0.02 (<sup>1</sup>&frasl;<sub>50</sub> requests); 0.001 (<sup>1</sup>&frasl;<sub>1000</sub>) is a
+recommended starting point.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -1963,6 +1963,23 @@ github.com/gardener/gardener/pkg/apis/core/v1beta1.EncryptionConfig
 <p>EncryptionConfig contains customizable encryption configuration of the Gardener API server.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>goAwayChance</code></br>
+<em>
+float64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
+connection (GOAWAY). The client&rsquo;s other in-flight requests won&rsquo;t be affected, and the client will reconnect,
+likely landing on a different apiserver after going through the load balancer again. This field sets the fraction
+of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don&rsquo;t use a load balancer,
+should NOT enable this. Min is 0 (off), Max is .02 (<sup>1</sup>&frasl;<sub>50</sub> requests); .001 (<sup>1</sup>&frasl;<sub>1000</sub>) is a recommended starting
+point.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="operator.gardener.cloud/v1alpha1.GardenerAdmissionControllerConfig">GardenerAdmissionControllerConfig

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -625,6 +625,17 @@ spec:
                             description: FeatureGates contains information about enabled
                               feature gates.
                             type: object
+                          goAwayChance:
+                            description: |-
+                              GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
+                              connection (GOAWAY). The client's other in-flight requests won't be affected, and the client will reconnect,
+                              likely landing on a different apiserver after going through the load balancer again. This field sets the fraction
+                              of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer,
+                              should NOT enable this. Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting
+                              point.
+                            maximum: 0.02
+                            minimum: 0
+                            type: number
                           logging:
                             description: Logging contains configuration for the log
                               level and HTTP access logs.

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -630,9 +630,8 @@ spec:
                               GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
                               connection (GOAWAY). The client's other in-flight requests won't be affected, and the client will reconnect,
                               likely landing on a different apiserver after going through the load balancer again. This field sets the fraction
-                              of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer,
-                              should NOT enable this. Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting
-                              point.
+                              of requests that will be sent a GOAWAY. Min is 0 (off), Max is 0.02 (1/50 requests); 0.001 (1/1000) is a
+                              recommended starting point.
                             maximum: 0.02
                             minimum: 0
                             type: number

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -215,6 +215,7 @@ spec:
     #     version: audit.k8s.io/v1
     #   featureGates:
     #     SomeGardenerFeature: true
+    #   goAwayChance: 0.001
     #   logging:
     #     verbosity: 2
     #     httpAccessVerbosity: 3

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -491,9 +491,8 @@ type GardenerAPIServerConfig struct {
 	// GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
 	// connection (GOAWAY). The client's other in-flight requests won't be affected, and the client will reconnect,
 	// likely landing on a different apiserver after going through the load balancer again. This field sets the fraction
-	// of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer,
-	// should NOT enable this. Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting
-	// point.
+	// of requests that will be sent a GOAWAY. Min is 0 (off), Max is 0.02 (1/50 requests); 0.001 (1/1000) is a
+	// recommended starting point.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=0.02
 	// +optional

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -488,6 +488,16 @@ type GardenerAPIServerConfig struct {
 	// EncryptionConfig contains customizable encryption configuration of the Gardener API server.
 	// +optional
 	EncryptionConfig *gardencorev1beta1.EncryptionConfig `json:"encryptionConfig,omitempty"`
+	// GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
+	// connection (GOAWAY). The client's other in-flight requests won't be affected, and the client will reconnect,
+	// likely landing on a different apiserver after going through the load balancer again. This field sets the fraction
+	// of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer,
+	// should NOT enable this. Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting
+	// point.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=0.02
+	// +optional
+	GoAwayChance *float64 `json:"goAwayChance,omitempty"`
 }
 
 // GardenerAdmissionControllerConfig contains configuration settings for the gardener-admission-controller.

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -971,6 +971,11 @@ func (in *GardenerAPIServerConfig) DeepCopyInto(out *GardenerAPIServerConfig) {
 		*out = new(v1beta1.EncryptionConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.GoAwayChance != nil {
+		in, out := &in.GoAwayChance, &out.GoAwayChance
+		*out = new(float64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -62,6 +62,9 @@ type Values struct {
 	LogLevel string
 	// LogFormat is the output format for the logs. Must be one of [text,json].
 	LogFormat string
+	// GoAwayChance can be used to prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a
+	// connection (GOAWAY).
+	GoAwayChance *float64
 	// TopologyAwareRoutingEnabled specifies where the topology-aware feature is enabled.
 	TopologyAwareRoutingEnabled bool
 	// WorkloadIdentityTokenIssuer is the issuer identifier of the workload identity tokens set in the 'iss' claim.

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -134,6 +134,7 @@ var _ = Describe("GardenerAPIServer", func() {
 			Image:                       image,
 			LogFormat:                   logFormat,
 			LogLevel:                    logLevel,
+			GoAwayChance:                ptr.To(0.0015),
 			TopologyAwareRoutingEnabled: true,
 			WorkloadIdentityTokenIssuer: workloadIdentityIssuer,
 		}
@@ -402,6 +403,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								"--log-level=" + logLevel,
 								"--log-format=" + logFormat,
 								"--secure-port=8443",
+								"--goaway-chance=0.001500",
 								"--workload-identity-token-issuer=" + workloadIdentityIssuer,
 								"--workload-identity-signing-key-file=/etc/gardener-apiserver/workload-identity/signing/key.pem",
 								"--http2-max-streams-per-connection=1000",

--- a/pkg/component/shared/gardenerapiserver.go
+++ b/pkg/component/shared/gardenerapiserver.go
@@ -38,6 +38,7 @@ func NewGardenerAPIServer(
 	topologyAwareRoutingEnabled bool,
 	clusterIdentity,
 	workloadIdentityTokenIssuer string,
+	goAwayChance *float64,
 ) (
 	gardenerapiserver.Interface,
 	error,
@@ -102,6 +103,7 @@ func NewGardenerAPIServer(
 			Image:                       image.String(),
 			LogLevel:                    logLevel,
 			LogFormat:                   logger.FormatJSON,
+			GoAwayChance:                goAwayChance,
 			TopologyAwareRoutingEnabled: topologyAwareRoutingEnabled,
 			WorkloadIdentityTokenIssuer: workloadIdentityTokenIssuer,
 		},

--- a/pkg/component/shared/gardenerapiserver_test.go
+++ b/pkg/component/shared/gardenerapiserver_test.go
@@ -41,6 +41,7 @@ var _ = Describe("GardenerAPIServer", func() {
 		clusterIdentity             = "cluster-id"
 		workloadIdentityTokenIssuer = "https://issuer.gardener.cloud.local"
 		topologyAwareRoutingEnabled = false
+		goAwayChance                = 0.001337
 		apiServerConfig             *operatorv1alpha1.GardenerAPIServerConfig
 	)
 
@@ -88,7 +89,7 @@ var _ = Describe("GardenerAPIServer", func() {
 				func(configuredPlugins []gardencorev1beta1.AdmissionPlugin, expectedPlugins []apiserver.AdmissionPluginConfig) {
 					apiServerConfig.AdmissionPlugins = configuredPlugins
 
-					gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+					gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(gardenerAPIServer.GetValues().EnabledAdmissionPlugins).To(Equal(expectedPlugins))
 				},
@@ -125,7 +126,7 @@ var _ = Describe("GardenerAPIServer", func() {
 				var expectedDisabledPlugins []gardencorev1beta1.AdmissionPlugin
 
 				AfterEach(func() {
-					gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+					gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(gardenerAPIServer.GetValues().DisabledAdmissionPlugins).To(Equal(expectedDisabledPlugins))
 				})
@@ -192,7 +193,7 @@ var _ = Describe("GardenerAPIServer", func() {
 						prepTest()
 					}
 
-					gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+					gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 					Expect(err).To(errMatcher)
 					if gardenerAPIServer != nil {
 						Expect(gardenerAPIServer.GetValues().Audit).To(Equal(expectedConfig))
@@ -325,7 +326,7 @@ var _ = Describe("GardenerAPIServer", func() {
 
 		Describe("FeatureGates", func() {
 			It("should set the field to nil by default", func() {
-				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(gardenerAPIServer.GetValues().FeatureGates).To(BeNil())
 			})
@@ -339,7 +340,7 @@ var _ = Describe("GardenerAPIServer", func() {
 					},
 				}
 
-				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(gardenerAPIServer.GetValues().FeatureGates).To(Equal(featureGates))
 			})
@@ -347,7 +348,7 @@ var _ = Describe("GardenerAPIServer", func() {
 
 		Describe("Requests", func() {
 			It("should set the field to nil by default", func() {
-				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(gardenerAPIServer.GetValues().Requests).To(BeNil())
 			})
@@ -359,7 +360,7 @@ var _ = Describe("GardenerAPIServer", func() {
 				}
 				apiServerConfig = &operatorv1alpha1.GardenerAPIServerConfig{Requests: requests}
 
-				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(gardenerAPIServer.GetValues().Requests).To(Equal(requests))
 			})
@@ -367,7 +368,7 @@ var _ = Describe("GardenerAPIServer", func() {
 
 		Describe("WatchCacheSizes", func() {
 			It("should set the field to nil by default", func() {
-				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(gardenerAPIServer.GetValues().WatchCacheSizes).To(BeNil())
 			})
@@ -379,7 +380,7 @@ var _ = Describe("GardenerAPIServer", func() {
 				}
 				apiServerConfig = &operatorv1alpha1.GardenerAPIServerConfig{WatchCacheSizes: watchCacheSizes}
 
-				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer)
+				gardenerAPIServer, err := NewGardenerAPIServer(ctx, runtimeClient, namespace, objectMeta, runtimeVersion, sm, apiServerConfig, autoscalingConfig, auditWebhookConfig, topologyAwareRoutingEnabled, clusterIdentity, workloadIdentityTokenIssuer, &goAwayChance)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(gardenerAPIServer.GetValues().WatchCacheSizes).To(Equal(watchCacheSizes))
 			})

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -978,6 +978,7 @@ func (r *Reconciler) newGardenerAPIServer(ctx context.Context, garden *operatorv
 		err                error
 		apiServerConfig    *operatorv1alpha1.GardenerAPIServerConfig
 		auditWebhookConfig *apiserver.AuditWebhook
+		goAwayChance       *float64
 	)
 
 	if apiServer := garden.Spec.VirtualCluster.Gardener.APIServer; apiServer != nil {
@@ -987,6 +988,7 @@ func (r *Reconciler) newGardenerAPIServer(ctx context.Context, garden *operatorv
 		if err != nil {
 			return nil, err
 		}
+		goAwayChance = apiServer.GoAwayChance
 	}
 
 	return sharedcomponent.NewGardenerAPIServer(
@@ -1002,6 +1004,7 @@ func (r *Reconciler) newGardenerAPIServer(ctx context.Context, garden *operatorv
 		helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
 		garden.Spec.VirtualCluster.Gardener.ClusterIdentity,
 		workloadIdentityTokenIssuer,
+		goAwayChance,
 	)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
This PR exposes the `--goaway-chance` flag of `gardener-apiserver` via the `Garden` API. The flag can help to resolve imbalanced API requests.

**Special notes for your reviewer**:
FYI @hendrikKahl @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
You can use `.spec.virtualCluster.gardener.gardenerAPIServer.goAwayChance` in the `Garden` API to specify the probability for randomly closing a connection (GOAWAY) in order to prevent HTTP/2 clients from getting stuck on a single `gardener-apiserver`.
```
