### PR TITLE
Upgrade Prometheus to v3.2

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -73,7 +73,7 @@ KUBECTL_VERSION ?= v1.32.2
 # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
 KUSTOMIZE_VERSION ?= v5.3.0
 # renovate: datasource=github-releases depName=prometheus/prometheus
-PROMTOOL_VERSION ?= 2.55.1
+PROMTOOL_VERSION ?= 3.2.1
 # renovate: datasource=github-releases depName=protocolbuffers/protobuf
 PROTOC_VERSION ?= v29.3
 # renovate: datasource=github-releases depName=GoogleContainerTools/skaffold

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -214,7 +214,7 @@ images:
 - name: prometheus
   sourceRepository: github.com/prometheus/prometheus
   repository: quay.io/prometheus/prometheus
-  tag: v2.55.1
+  tag: v3.2.1
   labels:
   - name: gardener.cloud/cve-categorisation
     value:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-important-multinode-with-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-important-multinode-with-backup.prometheusrule.test.yaml
@@ -45,7 +45,7 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 main is down, the cluster is unreachable.
         summary: Etcd3 main cluster down.
-  - eval_time: 15m
+  - eval_time: 10m
     alertname: KubeEtcd3MainNoLeader
     exp_alerts:
     - exp_labels:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-important-multinode-without-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-important-multinode-without-backup.prometheusrule.test.yaml
@@ -28,7 +28,7 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 main is down, the cluster is unreachable.
         summary: Etcd3 main cluster down.
-  - eval_time: 15m
+  - eval_time: 10m
     alertname: KubeEtcd3MainNoLeader
     exp_alerts:
     - exp_labels:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-important-singlenode-with-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-important-singlenode-with-backup.prometheusrule.test.yaml
@@ -45,7 +45,7 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 main is down, the cluster is unreachable.
         summary: Etcd3 main cluster down.
-  - eval_time: 15m
+  - eval_time: 10m
     alertname: KubeEtcd3MainNoLeader
     exp_alerts:
     - exp_labels:

--- a/pkg/component/etcd/etcd/testdata/shoot-etcd-important-singlenode-without-backup.prometheusrule.test.yaml
+++ b/pkg/component/etcd/etcd/testdata/shoot-etcd-important-singlenode-without-backup.prometheusrule.test.yaml
@@ -28,7 +28,7 @@ tests:
       exp_annotations:
         description: Etcd3 cluster main is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 main is down, the cluster is unreachable.
         summary: Etcd3 main cluster down.
-  - eval_time: 15m
+  - eval_time: 10m
     alertname: KubeEtcd3MainNoLeader
     exp_alerts:
     - exp_labels:

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
@@ -12,6 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
 )
 
@@ -65,12 +67,24 @@ func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
 						`{__name__="apiserver_request_total", job="virtual-garden-kube-apiserver"}`,
 					},
 				},
-				StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: []monitoringv1alpha1.Target{"prometheus-" + garden.Label}}},
-				RelabelConfigs: []monitoringv1.RelabelConfig{{
-					Action:      "replace",
-					Replacement: ptr.To("prometheus-" + garden.Label),
-					TargetLabel: "job",
+				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+					Role:       monitoringv1alpha1.KubernetesRoleService,
+					Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{v1beta1constants.GardenNamespace}},
 				}},
+				RelabelConfigs: []monitoringv1.RelabelConfig{
+					{
+						SourceLabels: []monitoringv1.LabelName{
+							"__meta_kubernetes_service_name",
+							"__meta_kubernetes_service_port_name",
+						},
+						Regex:  "prometheus-garden;" + prometheus.ServicePortName,
+						Action: "keep",
+					},
+					{
+						Action:      "replace",
+						Replacement: ptr.To("prometheus-" + garden.Label),
+						TargetLabel: "job",
+					}},
 			},
 		},
 	}

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
@@ -66,12 +66,24 @@ var _ = Describe("PrometheusRules", func() {
 								`{__name__="apiserver_request_total", job="virtual-garden-kube-apiserver"}`,
 							},
 						},
-						StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: []monitoringv1alpha1.Target{"prometheus-garden"}}},
-						RelabelConfigs: []monitoringv1.RelabelConfig{{
-							Action:      "replace",
-							Replacement: ptr.To("prometheus-garden"),
-							TargetLabel: "job",
+						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+							Role:       monitoringv1alpha1.KubernetesRoleService,
+							Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"garden"}},
 						}},
+						RelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{
+									"__meta_kubernetes_service_name",
+									"__meta_kubernetes_service_port_name",
+								},
+								Regex:  "prometheus-garden;web",
+								Action: "keep",
+							},
+							{
+								Action:      "replace",
+								Replacement: ptr.To("prometheus-garden"),
+								TargetLabel: "job",
+							}},
 					},
 				},
 			))

--- a/pkg/component/observability/monitoring/prometheus/seed/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/scrapeconfigs_test.go
@@ -50,14 +50,24 @@ var _ = Describe("ScrapeConfigs", func() {
 								`{job="cadvisor",namespace="kube-system"}`,
 							},
 						},
-						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
-							Targets: []monitoringv1alpha1.Target{"prometheus-cache.garden.svc"},
+						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+							Role:       monitoringv1alpha1.KubernetesRoleService,
+							Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"garden"}},
 						}},
-						RelabelConfigs: []monitoringv1.RelabelConfig{{
-							Action:      "replace",
-							Replacement: ptr.To("cadvisor"),
-							TargetLabel: "job",
-						}},
+						RelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{
+									"__meta_kubernetes_service_name",
+									"__meta_kubernetes_service_port_name",
+								},
+								Regex:  "prometheus-cache;web",
+								Action: "keep",
+							},
+							{
+								Action:      "replace",
+								Replacement: ptr.To("cadvisor"),
+								TargetLabel: "job",
+							}},
 						MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
 							SourceLabels: []monitoringv1.LabelName{"__name__"},
 							Action:       "keep",

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -17,6 +17,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 )
 
@@ -34,8 +35,9 @@ var _ = Describe("ScrapeConfigs", func() {
 					Spec: monitoringv1alpha1.ScrapeConfigSpec{
 						HonorTimestamps: ptr.To(false),
 						MetricsPath:     ptr.To("/federate"),
-						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
-							Targets: []monitoringv1alpha1.Target{"prometheus-cache.garden.svc"},
+						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+							Role:       monitoringv1alpha1.KubernetesRoleService,
+							Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{v1beta1constants.GardenNamespace}},
 						}},
 						Params: map[string][]string{
 							"match[]": {
@@ -45,11 +47,21 @@ var _ = Describe("ScrapeConfigs", func() {
 								`{job="etcd-druid",etcd_namespace="` + namespace + `"}`,
 							},
 						},
-						RelabelConfigs: []monitoringv1.RelabelConfig{{
-							Action:      "replace",
-							Replacement: ptr.To("kube-kubelet-seed"),
-							TargetLabel: "job",
-						}},
+						RelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{
+									"__meta_kubernetes_service_name",
+									"__meta_kubernetes_service_port_name",
+								},
+								Regex:  "prometheus-cache;" + prometheus.ServicePortName,
+								Action: "keep",
+							},
+							{
+								Action:      "replace",
+								Replacement: ptr.To("kube-kubelet-seed"),
+								TargetLabel: "job",
+							},
+						},
 						MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
 							Replacement: ptr.To("shoot-control-plane"),
 							TargetLabel: "namespace",


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

In order to test this major upgrade, we followed the [upgrade migration guide](https://prometheus.io/docs/prometheus/latest/migration/) provided by Prometheus. This guide outlines the major changes involved in upgrading to Prometheus v3.x. Based on our assessment, there is only one potential breaking change for Gardener when the scrape protocol from a scrape endpoint is invalid. 

The scrape protocol sets the data format that the endpoint uses to expose metrics. In short, when the scrape protocol is invalid, Prometheus v2.x falls back to using the default text protocol, while Prometheus v3.x will fail the scrape. Prometheus v3.x introduces a new `fallback_scrape_protocol` configuration property to restore the old behaviour from Prometheus v2.x, but this must be set for each scrape configuration, service monitor, or pod monitor. While we could use this property to avoid being affected by this breaking change, adding it to every scrape configuration feels a bit overwhelming for Gardener, where the scrape configurations are many. Therefore, we opted to validate during testing that none of the URLs scraped by the Prometheus instances managed by Gardener return an invalid scrape protocol.

<details><summary>Details on how we checked the scrape protocols are valid</summary>
<br/>

The scrape protocol information is available in the `Content-Type` field in the response headers from the scrape URL. The list of URLs a Prometheus instance scrapes can be retrieved from its API: `http://<prometheus-ip>:9090/api/v1/targets`. As a general example, the following snippet can be run on a debug pod to iterate over all scrape URLs for a certain Prometheus instance and show the `Content-Type` field in their responses, effectively listing the scrape protocols they use.

```bash
for url in $(curl -Ss http://<prometheus-ip>:9090/api/v1/targets | jq -r '.data.activeTargets[] | select(.health == "up").scrapeUrl | select(contains("/federate") | not)'); do
    curl -m 1 -i -Ss <additional-flags-for-certs-and-tokens> $url | grep -i content-type:
done
```

Running this in a debug pod requires it to have the same network policies and credentials as the Prometheus instance to reach and access the scrape URL. Note that these network policies and credentials differ for each Prometheus instance. By adjusting this snippet to each Prometheus instance and executing it, we observed all responses contained either `Content-Type: text/plain; version=0.0.4` or `Content-Type: text/plain`, both of which are [valid protocols](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md).

</details>

Additionally, we validated the following on a local deployment of Gardener with Prometheus v3.x, among other checks:

- There are no significant changes in the number of ingested samples.
- No scrape targets are down.
- We downloaded the existing series from every Prometheus instance on v2.x, upgraded to Prometheus v3.x, downloaded the series again and compared the old and the new series. None of the old were removed, and a few new series related Prometheus were added, as described in the Prometheus' [release notes](https://github.com/prometheus/prometheus/releases).

**Special notes for your reviewer**:

/cc @istvanballok @chrkl @rickardsjp 

**Release note**:

```other operator
Upgrade Prometheus to v3.2
```
