### PR TITLE
Reintroduce an e2e test with a shoot using L4 load balancing

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -93,7 +93,7 @@ spec:
             echo {{p,g}-seed,{gu,p,v}-local--local}.ingress.local.seed.local.gardener.cloud \
                  api.{e2e-managedseed.garden,local.local}.{internal,external}.local.gardener.cloud \
                  api.e2e-{hib,upg-hib,wake-up,wake-up-ncp,migrate,rotate,default,upd-node,upgrade}{,-wl}.local.{internal,external}.local.gardener.cloud \
-                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib,e2e-auth-{one,two}}.local.{internal,external}.local.gardener.cloud \
+                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib,e2e-auth-{one,two},layer4-lb}.local.{internal,external}.local.gardener.cloud \
                  gu-local--e2e-rotate{,-wl}.ingress.local.seed.local.gardener.cloud
             " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort      >> /etc/hosts
           echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -107,6 +107,7 @@ case $TYPE in
       e2e-upg-hib-wl.local
       e2e-auth-one.local
       e2e-auth-two.local
+      e2e-layer4-lb.local
     )
 
     ingress_names=(

--- a/test/e2e/gardener/shoot/create_authenticate_delete.go
+++ b/test/e2e/gardener/shoot/create_authenticate_delete.go
@@ -67,7 +67,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			Eventually(func(g Gomega) {
 				g.Expect(validateShootAccess(ctx, shoot1Client.Client(), shoot1.Shoot, true)).To(Succeed())
 				g.Expect(validateShootAccess(ctx, shoot2Client.Client(), shoot2.Shoot, true)).To(Succeed())
-			}).WithTimeout(time.Minute).Should(Succeed())
+			}).WithTimeout(10 * time.Second).Should(Succeed())
 		})
 
 		It("should verify shoot access using service account token kubeconfig", func(ctx SpecContext) {
@@ -108,7 +108,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			Eventually(func(g Gomega) {
 				g.Expect(validateShootAccess(ctx, shoot1TokenClientAPIServerProxy, shoot1.Shoot, true)).To(Succeed())
 				g.Expect(validateShootAccess(ctx, shoot2TokenClientAPIServerProxy, shoot2.Shoot, true)).To(Succeed())
-			}).WithTimeout(time.Minute).Should(Succeed())
+			}).WithTimeout(10 * time.Second).Should(Succeed())
 		})
 
 		It("should verify a shoot cannot be accessed with a client certificate from another shoot", func(ctx SpecContext) {

--- a/test/e2e/gardener/shoot/create_authenticate_delete.go
+++ b/test/e2e/gardener/shoot/create_authenticate_delete.go
@@ -92,7 +92,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		Eventually(func(g Gomega) {
 			g.Expect(validateShootAccess(ctx, shoot1ClientAPIServerProxy, shoot1, true)).To(Succeed())
 			g.Expect(validateShootAccess(ctx, shoot2ClientAPIServerProxy, shoot2, true)).To(Succeed())
-		}).WithTimeout(time.Minute).Should(Succeed())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
 
 		By("Verify a shoot cannot be accessed with a client certificate from another shoot by manipulating the apiserver-proxy header")
 		shoot1NoAccessClientAPIServerProxy, err := getAPIServerProxyClient(shoot1NoAccessRestConfig, shoot1)
@@ -107,16 +107,16 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 
 		By("Verify shoot access using service account token kubeconfig")
-		shoot1TokenClient, err := access.CreateShootClientFromStaticServiceAccountToken(ctx, shoot1Client, "shoot-one")
+		shoot1TokenClient, err := access.CreateTargetClientFromDynamicServiceAccountToken(ctx, shoot1Client, "shoot-one")
 		Expect(err).NotTo(HaveOccurred())
 
-		shoot2TokenClient, err := access.CreateShootClientFromStaticServiceAccountToken(ctx, shoot2Client, "shoot-two")
+		shoot2TokenClient, err := access.CreateTargetClientFromDynamicServiceAccountToken(ctx, shoot2Client, "shoot-two")
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func(g Gomega) {
 			g.Expect(validateShootAccess(ctx, shoot1TokenClient.Client(), shoot1, true)).To(Succeed())
 			g.Expect(validateShootAccess(ctx, shoot2TokenClient.Client(), shoot2, true)).To(Succeed())
-		}).WithTimeout(time.Minute).Should(Succeed())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
 
 		By("Verify a shoot cannot be accessed with a service account token from another shoot")
 		shoot1NoAccessTokenRestConfig := copyRESTConfigAndInjectAuthorization(shoot1TokenClient.RESTConfig(), shoot2TokenClient.RESTConfig())

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/gardener"
@@ -237,6 +238,12 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 		Context("Shoot with workers", Label("basic"), Ordered, func() {
 			test(NewTestContext().ForShoot(DefaultShoot("e2e-default")))
+		})
+
+		Context("Shoot with workers and layer 4 load balancing", Ordered, Label("basic"), func() {
+			shoot := DefaultShoot("e2e-layer4-lb")
+			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.ShootDisableIstioTLSTermination, "true")
+			test(NewTestContext().ForShoot(shoot))
 		})
 
 		Context("Workerless Shoot", Label("workerless"), Ordered, func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Since PR #11085 has been merged we test shoots which are using L4 load balancing only implicitly (e.g. when they run Kubernetes < v1.31.0).
This PR adds a new shoot to `Create, Update, Delete` e2e test which disables L7 load balancing via `shoot.gardener.cloud/disable-istio-tls-termination: "true"` annotation on the shoot.

Additionally, `Create, Authenticate, Delete` uses a client with TokenRequest kubeconfig instead of a static token kubeconfig to prevent flakes like [this](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11085/pull-gardener-e2e-kind/1895476576062017536#1:build-log.txt%3A1400) where kube-controller-manager is not able to create the token in time.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
