### PR TITLE
e2e: Refactor `Create Rotate Delete Shoot` test to ordered containers

### DIFF
--- a/test/e2e/gardener/shoot/common.go
+++ b/test/e2e/gardener/shoot/common.go
@@ -5,31 +5,18 @@
 package shoot
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/logger"
-	e2e "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal"
-	"github.com/gardener/gardener/test/framework"
 )
 
 // TODO(timebertt): delete this file when finishing https://github.com/gardener/gardener/issues/11379
 
-var parentCtx context.Context
-
 var _ = BeforeEach(func() {
-	parentCtx = context.Background()
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("shoot-test"))
 
 	internal.LoadLegacyFlags()
 })
-
-func defaultShootCreationFramework() *framework.ShootCreationFramework {
-	return framework.NewShootCreationFramework(&framework.ShootCreationConfig{
-		GardenerConfig: e2e.DefaultGardenConfig("garden-local"),
-	})
-}

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -24,6 +24,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/test/e2e"
 	. "github.com/gardener/gardener/test/e2e/gardener"
 	. "github.com/gardener/gardener/test/e2e/gardener/shoot/internal"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
@@ -358,14 +359,19 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			test(NewTestContext().ForShoot(DefaultShoot("e2e-rotate")), false)
 
 			Context("without workers rollout", Label("without-workers-rollout"), Ordered, func() {
-				shoot := DefaultShoot("e2e-rotate")
-				shoot.Name = "e2e-rot-noroll"
-				// Add a second worker pool when worker rollout should not be performed such that we can make proper
-				// assertions of the shoot status
-				shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers[0])
-				shoot.Spec.Provider.Workers[len(shoot.Spec.Provider.Workers)-1].Name += "2"
+				var s *ShootContext
+				BeforeTestSetup(func() {
+					shoot := DefaultShoot("e2e-rotate")
+					shoot.Name = "e2e-rot-noroll"
+					// Add a second worker pool when worker rollout should not be performed such that we can make proper
+					// assertions of the shoot status
+					shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers[0])
+					shoot.Spec.Provider.Workers[len(shoot.Spec.Provider.Workers)-1].Name += "2"
 
-				test(NewTestContext().ForShoot(shoot), true)
+					s = NewTestContext().ForShoot(shoot)
+				})
+
+				test(s, true)
 			})
 
 		})

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -6,6 +6,8 @@ package shoot
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -22,242 +24,300 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+	. "github.com/gardener/gardener/test/e2e/gardener/shoot/internal"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/rotation"
-	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/access"
 	rotationutils "github.com/gardener/gardener/test/utils/rotation"
 )
 
-func testCredentialRotation(parentCtx context.Context, v rotationutils.Verifiers, f *framework.ShootCreationFramework, startRotationAnnotation, completeRotationAnnotation string) {
-	ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
-	defer cancel()
+func testCredentialRotation(s *ShootContext, shootVerifiers rotationutils.Verifiers, utilsverifiers rotationutils.Verifiers, startRotationAnnotation, completeRotationAnnotation string) {
+	// the verifier interface requires that we pass a context to some of the verifier functions
+	// this is not needed anymore for refactored tests as these use the SpecContext supplied by the "It" statement
+	// Also we cannot pass a nil as the context argument as this makes the linter unhappy :(
+	// TODO(Wieneo): Remove context argument from verifier functions / interface once all verifiers got refactored
 
-	By("Before credential rotation")
-	v.Before(ctx)
+	// shoot verifiers are dedicated verifiers for this test and were already refactored to separate "It" statements
+	// we can just execute the verifier function
+	shootVerifiers.Before(context.TODO())
+
+	// utils verifiers are shared verifiers which still use separate "By" statements for structuring tests and expect to be executed within an "It" statement
+	// This is a problem as we removed the "top-level" "It" statements during the refactoring of this test
+	// Until all verifiers are refactored, we need to instantiate separate "It" statements for all shared verifiers to allow for assertions
+	for _, k := range utilsverifiers {
+		It(fmt.Sprintf("Verify before for %s", reflect.TypeOf(k).String()), func(ctx SpecContext) {
+			k.Before(ctx)
+		}, SpecTimeout(5*time.Minute))
+	}
 
 	if startRotationAnnotation != "" {
-		By("Start credentials rotation")
-		patch := client.MergeFrom(f.Shoot.DeepCopy())
-		metav1.SetMetaDataAnnotation(&f.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, startRotationAnnotation)
-		EventuallyWithOffset(1, func() error {
-			return f.GardenClient.Client().Patch(ctx, f.Shoot, patch)
-		}).Should(Succeed())
+		ItShouldAnnotateShoot(s, map[string]string{
+			v1beta1constants.GardenerOperation: startRotationAnnotation,
+		})
 
-		EventuallyWithOffset(1, func(g Gomega) {
-			g.ExpectWithOffset(1, f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)).To(Succeed())
-			g.ExpectWithOffset(1, f.Shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
-			v.ExpectPreparingStatus(g)
-		}).Should(Succeed())
+		itShouldEventuallyNotHaveOperationAnnotation(s)
 
-		ExpectWithOffset(1, f.WaitForShootToBeReconciled(ctx, f.Shoot)).To(Succeed())
-		EventuallyWithOffset(1, func() error { return f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot) }).Should(Succeed())
+		It("Rotation in preparing status", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) {
+				g.Expect(s.GardenClient.Get(ctx, client.ObjectKeyFromObject(s.Shoot), s.Shoot)).To(Succeed())
+				shootVerifiers.ExpectPreparingStatus(g)
+				utilsverifiers.ExpectPreparingStatus(g)
+			}).Should(Succeed())
+		}, SpecTimeout(time.Minute))
 
-		v.AfterPrepared(ctx)
+		ItShouldWaitForShootToBeReconciledAndHealthy(s)
+		shootVerifiers.AfterPrepared(context.TODO())
+		for _, k := range utilsverifiers {
+			It(fmt.Sprintf("Verify after prepared for %s", reflect.TypeOf(k).String()), func(ctx SpecContext) {
+				k.AfterPrepared(ctx)
+			})
+		}
 	}
 
-	testCredentialRotationComplete(parentCtx, v, f, completeRotationAnnotation)
+	testCredentialRotationComplete(s, shootVerifiers, utilsverifiers, completeRotationAnnotation)
 }
 
-func testCredentialRotationComplete(parentCtx context.Context, v rotationutils.Verifiers, f *framework.ShootCreationFramework, completeRotationAnnotation string) {
+func testCredentialRotationComplete(s *ShootContext, shootVerifiers rotationutils.Verifiers, utilsverifiers rotationutils.Verifiers, completeRotationAnnotation string) {
 	if completeRotationAnnotation != "" {
-		By("Complete credentials rotation")
-		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
-		defer cancel()
+		ItShouldAnnotateShoot(s, map[string]string{
+			v1beta1constants.GardenerOperation: completeRotationAnnotation,
+		})
 
-		patch := client.MergeFrom(f.Shoot.DeepCopy())
-		metav1.SetMetaDataAnnotation(&f.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, completeRotationAnnotation)
-		EventuallyWithOffset(1, func() error {
-			return f.GardenClient.Client().Patch(ctx, f.Shoot, patch)
-		}).Should(Succeed())
+		itShouldEventuallyNotHaveOperationAnnotation(s)
 
-		EventuallyWithOffset(1, func(g Gomega) {
-			g.ExpectWithOffset(1, f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)).To(Succeed())
-			g.ExpectWithOffset(1, f.Shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
-			v.ExpectCompletingStatus(g)
-		}).Should(Succeed())
+		It("Rotation in completing status", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) {
+				g.Expect(s.GardenClient.Get(ctx, client.ObjectKeyFromObject(s.Shoot), s.Shoot)).To(Succeed())
+				shootVerifiers.ExpectCompletingStatus(g)
+				utilsverifiers.ExpectCompletingStatus(g)
+			}).Should(Succeed())
+		}, SpecTimeout(time.Minute))
 
-		ExpectWithOffset(1, f.WaitForShootToBeReconciled(ctx, f.Shoot)).To(Succeed())
+		ItShouldWaitForShootToBeReconciledAndHealthy(s)
 
-		EventuallyWithOffset(1, func() error {
-			return f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)
-		}).Should(Succeed())
-
-		v.AfterCompleted(ctx)
+		shootVerifiers.AfterCompleted(context.TODO())
+		for _, k := range utilsverifiers {
+			It(fmt.Sprintf("Verify after completed for %s", reflect.TypeOf(k).String()), func(ctx SpecContext) {
+				k.AfterCompleted(ctx)
+			})
+		}
 	}
 
-	By("Cleanup")
-	cleanupCtx, cleanupCancel := context.WithTimeout(parentCtx, 2*time.Minute)
-	defer cleanupCancel()
-
-	v.Cleanup(cleanupCtx)
+	shootVerifiers.Cleanup(context.TODO())
+	for _, k := range utilsverifiers {
+		if cleanup, ok := k.(rotationutils.CleanupVerifier); ok {
+			It(fmt.Sprintf("Cleanup for %s", reflect.TypeOf(k).String()), func(ctx SpecContext) {
+				cleanup.Cleanup(ctx)
+			})
+		}
+	}
 }
 
-func testCredentialRotationWithoutWorkersRollout(parentCtx context.Context, v rotationutils.Verifiers, f *framework.ShootCreationFramework) {
-	ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
-	defer cancel()
-
-	By("Before credential rotation")
-	v.Before(ctx)
-
-	By("Find all machine pods to ensure later that they weren't rolled out")
-	beforeStartMachinePodList := &corev1.PodList{}
-	ExpectWithOffset(1, f.ShootFramework.SeedClient.Client().List(ctx, beforeStartMachinePodList, client.InNamespace(f.Shoot.Status.TechnicalID), client.MatchingLabels{
-		"app":              "machine",
-		"machine-provider": "local",
-	})).To(Succeed())
+func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers rotationutils.Verifiers, utilsverifiers rotationutils.Verifiers) {
+	shootVerifiers.Before(context.TODO())
+	for _, k := range utilsverifiers {
+		It(fmt.Sprintf("Verify before for %s", reflect.TypeOf(k).String()), func(ctx SpecContext) {
+			k.Before(ctx)
+		}, SpecTimeout(5*time.Minute))
+	}
 
 	beforeStartMachinePodNames := sets.New[string]()
-	for _, item := range beforeStartMachinePodList.Items {
-		beforeStartMachinePodNames.Insert(item.Name)
-	}
 
-	By("Start credentials rotation without workers rollout")
-	patch := client.MergeFrom(f.Shoot.DeepCopy())
-	metav1.SetMetaDataAnnotation(&f.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout)
-	EventuallyWithOffset(1, func() error {
-		return f.GardenClient.Client().Patch(ctx, f.Shoot, patch)
-	}).Should(Succeed())
+	It("Find all machine pods to ensure later that they weren't rolled out", func(ctx SpecContext) {
+		beforeStartMachinePodList := &corev1.PodList{}
+		Eventually(ctx, s.SeedKomega.List(beforeStartMachinePodList, client.InNamespace(s.Shoot.Status.TechnicalID), client.MatchingLabels{
+			"app":              "machine",
+			"machine-provider": "local",
+		})).Should(Succeed())
 
-	EventuallyWithOffset(1, func(g Gomega) {
-		g.ExpectWithOffset(1, f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot)).To(Succeed())
-		g.ExpectWithOffset(1, f.Shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
-		v.ExpectPreparingWithoutWorkersRolloutStatus(g)
-	}).Should(Succeed())
+		for _, item := range beforeStartMachinePodList.Items {
+			beforeStartMachinePodNames.Insert(item.Name)
+		}
+	}, SpecTimeout(time.Minute))
 
-	ExpectWithOffset(1, f.WaitForShootToBeReconciled(ctx, f.Shoot)).To(Succeed())
-	EventuallyWithOffset(1, func() error { return f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot) }).Should(Succeed())
-
-	By("Ensure workers were not rolled out")
-	EventuallyWithOffset(1, func(g Gomega) {
-		v.ExpectWaitingForWorkersRolloutStatus(g)
-	}).Should(Succeed())
-
-	afterStartMachinePodList := &corev1.PodList{}
-	ExpectWithOffset(1, f.ShootFramework.SeedClient.Client().List(ctx, afterStartMachinePodList, client.InNamespace(f.Shoot.Status.TechnicalID), client.MatchingLabels{
-		"app":              "machine",
-		"machine-provider": "local",
-	})).To(Succeed())
-
-	afterStartMachinePodNames := sets.New[string]()
-	for _, item := range afterStartMachinePodList.Items {
-		afterStartMachinePodNames.Insert(item.Name)
-	}
-
-	ExpectWithOffset(1, beforeStartMachinePodNames.Equal(afterStartMachinePodNames)).To(BeTrue())
-
-	By("Ensure all worker pools are marked as 'pending for roll out'")
-	for _, worker := range f.Shoot.Spec.Provider.Workers {
-		ExpectWithOffset(1, slices.ContainsFunc(f.Shoot.Status.Credentials.Rotation.CertificateAuthorities.PendingWorkersRollouts, func(rollout gardencorev1beta1.PendingWorkersRollout) bool {
-			return rollout.Name == worker.Name
-		})).To(BeTrue(), "worker pool "+worker.Name+" should be pending for roll out in CA rotation status")
-
-		ExpectWithOffset(1, slices.ContainsFunc(f.Shoot.Status.Credentials.Rotation.ServiceAccountKey.PendingWorkersRollouts, func(rollout gardencorev1beta1.PendingWorkersRollout) bool {
-			return rollout.Name == worker.Name
-		})).To(BeTrue(), "worker pool "+worker.Name+" should be pending for roll out in service account key rotation status")
-	}
-
-	By("Remove last worker pool from spec and check that it is no longer pending for roll out")
-	patch = client.MergeFrom(f.Shoot.DeepCopy())
-	lastWorkerPoolName := f.Shoot.Spec.Provider.Workers[len(f.Shoot.Spec.Provider.Workers)-1].Name
-	f.Shoot.Spec.Provider.Workers = slices.DeleteFunc(f.Shoot.Spec.Provider.Workers, func(worker gardencorev1beta1.Worker) bool {
-		return worker.Name == lastWorkerPoolName
+	ItShouldAnnotateShoot(s, map[string]string{
+		v1beta1constants.GardenerOperation: v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout,
 	})
-	EventuallyWithOffset(1, func() error { return f.GardenClient.Client().Patch(ctx, f.Shoot, patch) }).Should(Succeed())
 
-	ExpectWithOffset(1, f.WaitForShootToBeReconciled(ctx, f.Shoot)).To(Succeed())
-	EventuallyWithOffset(1, func() error { return f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot) }).Should(Succeed())
+	itShouldEventuallyNotHaveOperationAnnotation(s)
 
-	ExpectWithOffset(1, slices.ContainsFunc(f.Shoot.Status.Credentials.Rotation.CertificateAuthorities.PendingWorkersRollouts, func(rollout gardencorev1beta1.PendingWorkersRollout) bool {
-		return rollout.Name == lastWorkerPoolName
-	})).To(BeFalse())
-	ExpectWithOffset(1, slices.ContainsFunc(f.Shoot.Status.Credentials.Rotation.ServiceAccountKey.PendingWorkersRollouts, func(rollout gardencorev1beta1.PendingWorkersRollout) bool {
-		return rollout.Name == lastWorkerPoolName
-	})).To(BeFalse())
+	It("Rotation in preparing without workers rollout status", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootVerifiers.ExpectPreparingWithoutWorkersRolloutStatus(g)
+			utilsverifiers.ExpectPreparingWithoutWorkersRolloutStatus(g)
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Trigger rollout of pending worker pools")
-	workerNames := sets.New[string]()
-	for _, rollout := range f.Shoot.Status.Credentials.Rotation.CertificateAuthorities.PendingWorkersRollouts {
-		workerNames.Insert(rollout.Name)
+	ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+	It("Ensure workers were not rolled out", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootVerifiers.ExpectWaitingForWorkersRolloutStatus(g)
+			utilsverifiers.ExpectWaitingForWorkersRolloutStatus(g)
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+
+	It("Compare machine pod names", func(ctx SpecContext) {
+		afterStartMachinePodList := &corev1.PodList{}
+		Eventually(ctx, s.SeedKomega.List(afterStartMachinePodList, client.InNamespace(s.Shoot.Status.TechnicalID), client.MatchingLabels{
+			"app":              "machine",
+			"machine-provider": "local",
+		})).Should(Succeed())
+
+		afterStartMachinePodNames := sets.New[string]()
+		for _, item := range afterStartMachinePodList.Items {
+			afterStartMachinePodNames.Insert(item.Name)
+		}
+
+		Expect(beforeStartMachinePodNames.Equal(afterStartMachinePodNames)).To(BeTrue())
+	}, SpecTimeout(time.Minute))
+
+	It("Ensure all worker pools are marked as 'pending for roll out'", func() {
+		for _, worker := range s.Shoot.Spec.Provider.Workers {
+			Expect(slices.ContainsFunc(s.Shoot.Status.Credentials.Rotation.CertificateAuthorities.PendingWorkersRollouts, func(rollout gardencorev1beta1.PendingWorkersRollout) bool {
+				return rollout.Name == worker.Name
+			})).To(BeTrue(), "worker pool "+worker.Name+" should be pending for roll out in CA rotation status")
+
+			Expect(slices.ContainsFunc(s.Shoot.Status.Credentials.Rotation.ServiceAccountKey.PendingWorkersRollouts, func(rollout gardencorev1beta1.PendingWorkersRollout) bool {
+				return rollout.Name == worker.Name
+			})).To(BeTrue(), "worker pool "+worker.Name+" should be pending for roll out in service account key rotation status")
+		}
+	})
+
+	var lastWorkerPoolName string
+	It("Remove last worker pool from spec", func(ctx SpecContext) {
+		Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+			lastWorkerPoolName = s.Shoot.Spec.Provider.Workers[len(s.Shoot.Spec.Provider.Workers)-1].Name
+			s.Shoot.Spec.Provider.Workers = slices.DeleteFunc(s.Shoot.Spec.Provider.Workers, func(worker gardencorev1beta1.Worker) bool {
+				return worker.Name == lastWorkerPoolName
+			})
+		})).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+
+	ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+	It("Last worker pool no longer pending rollout", func() {
+		Expect(slices.ContainsFunc(s.Shoot.Status.Credentials.Rotation.CertificateAuthorities.PendingWorkersRollouts, func(rollout gardencorev1beta1.PendingWorkersRollout) bool {
+			return rollout.Name == lastWorkerPoolName
+		})).To(BeFalse())
+		Expect(slices.ContainsFunc(s.Shoot.Status.Credentials.Rotation.ServiceAccountKey.PendingWorkersRollouts, func(rollout gardencorev1beta1.PendingWorkersRollout) bool {
+			return rollout.Name == lastWorkerPoolName
+		})).To(BeFalse())
+	})
+
+	It("Trigger rollout of pending worker pools", func(ctx SpecContext) {
+		workerNames := sets.New[string]()
+		for _, rollout := range s.Shoot.Status.Credentials.Rotation.CertificateAuthorities.PendingWorkersRollouts {
+			workerNames.Insert(rollout.Name)
+		}
+		for _, rollout := range s.Shoot.Status.Credentials.Rotation.ServiceAccountKey.PendingWorkersRollouts {
+			workerNames.Insert(rollout.Name)
+		}
+
+		// as this annotation is computed dynamically, we can't use the "ItShouldAnnotateShoot" function
+		// this is because the ginkgo tree construction would just pass the empty output string to the annotate function
+		rolloutWorkersAnnotation := v1beta1constants.OperationRotateRolloutWorkers + "=" + strings.Join(workerNames.UnsortedList(), ",")
+		Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+			metav1.SetMetaDataAnnotation(&s.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, rolloutWorkersAnnotation)
+		})).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+
+	ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+	It("Credential rotation in status prepared", func() {
+		Expect(s.Shoot.Status.Credentials.Rotation.CertificateAuthorities.Phase).To(Equal(gardencorev1beta1.RotationPrepared))
+		Expect(s.Shoot.Status.Credentials.Rotation.ServiceAccountKey.Phase).To(Equal(gardencorev1beta1.RotationPrepared))
+	})
+
+	shootVerifiers.AfterPrepared(context.TODO())
+	for _, k := range utilsverifiers {
+		It(fmt.Sprintf("Verify after prepared for %s", reflect.TypeOf(k).String()), func(ctx SpecContext) {
+			k.AfterPrepared(ctx)
+		}, SpecTimeout(5*time.Minute))
 	}
-	for _, rollout := range f.Shoot.Status.Credentials.Rotation.ServiceAccountKey.PendingWorkersRollouts {
-		workerNames.Insert(rollout.Name)
-	}
 
-	patch = client.MergeFrom(f.Shoot.DeepCopy())
-	metav1.SetMetaDataAnnotation(&f.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.OperationRotateRolloutWorkers+"="+strings.Join(workerNames.UnsortedList(), ","))
-	EventuallyWithOffset(1, func() error { return f.GardenClient.Client().Patch(ctx, f.Shoot, patch) }).Should(Succeed())
+	testCredentialRotationComplete(s, shootVerifiers, utilsverifiers, v1beta1constants.OperationRotateCredentialsComplete)
+}
 
-	ExpectWithOffset(1, f.WaitForShootToBeReconciled(ctx, f.Shoot)).To(Succeed())
-	EventuallyWithOffset(1, func() error { return f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(f.Shoot), f.Shoot) }).Should(Succeed())
-
-	ExpectWithOffset(1, f.Shoot.Status.Credentials.Rotation.CertificateAuthorities.Phase).To(Equal(gardencorev1beta1.RotationPrepared))
-	v.AfterPrepared(ctx)
-
-	testCredentialRotationComplete(parentCtx, v, f, v1beta1constants.OperationRotateCredentialsComplete)
+func itShouldEventuallyNotHaveOperationAnnotation(s *ShootContext) {
+	It("Should not have operation annotation", func(ctx SpecContext) {
+		Eventually(ctx, s.GardenKomega.Object(s.Shoot)).WithPolling(2 * time.Second).Should(
+			HaveField("ObjectMeta.Annotations", Not(HaveKey(v1beta1constants.GardenerOperation))))
+	}, SpecTimeout(time.Minute))
 }
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	test := func(shoot *gardencorev1beta1.Shoot, withoutWorkersRollout bool) {
-		f := defaultShootCreationFramework()
-		f.Shoot = shoot
-
-		It("Create Shoot, Rotate Credentials and Delete Shoot", Offset(1), Label("credentials-rotation"), func() {
-			ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
-			defer cancel()
-
-			By("Create Shoot")
-			Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
-			f.Verify()
-
-			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
-			// if !v1beta1helper.IsWorkerless(s.Shoot) {
-			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
-			// }
+	Describe("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
+		test := func(s *ShootContext, withoutWorkersRollout bool) {
+			ItShouldCreateShoot(s)
+			ItShouldWaitForShootToBeReconciledAndHealthy(s)
+			ItShouldInitializeShootClient(s)
+			ItShouldGetResponsibleSeed(s)
+			ItShouldInitializeSeedClient(s)
 
 			// isolated test for ssh key rotation (does not trigger node rolling update)
-			if !v1beta1helper.IsWorkerless(f.Shoot) && !withoutWorkersRollout {
-				testCredentialRotation(parentCtx, rotationutils.Verifiers{&rotation.SSHKeypairVerifier{ShootCreationFramework: f}}, f, v1beta1constants.ShootOperationRotateSSHKeypair, "")
+			if !v1beta1helper.IsWorkerless(s.Shoot) && !withoutWorkersRollout {
+				testCredentialRotation(s, rotationutils.Verifiers{&rotation.SSHKeypairVerifier{ShootContext: s}}, nil, v1beta1constants.ShootOperationRotateSSHKeypair, "")
 			}
 
-			v := rotationutils.Verifiers{
+			// because of the ongoing refactoring efforts, we currently have two sorts of verifiers
+			// - refactored verifiers / verifiers dedicated to this test scenario, which use separate It's for structuring the tests
+			// - unrefactored verifiers / shared verifiers, which use "By" statements to structure tests
+			//
+			// until all tests and thereby verifiers are refactored, we need to distinguish how we execute the verifier functions
+			// TODO(Wieneo): Consolidate verifiers once operator e2e tests are refactored
+
+			shootVerifiers := rotationutils.Verifiers{
 				// basic verifiers checking secrets
-				&rotation.CAVerifier{ShootCreationFramework: f},
+				&rotation.CAVerifier{ShootContext: s},
+				&rotation.ShootAccessVerifier{ShootContext: s},
+			}
+			utilsVerifiers := rotationutils.Verifiers{
 				&rotationutils.ObservabilityVerifier{
 					GetObservabilitySecretFunc: func(ctx context.Context) (*corev1.Secret, error) {
 						secret := &corev1.Secret{}
-						return secret, f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(f.Shoot.Name, "monitoring")}, secret)
+						return secret, s.GardenClient.Get(ctx, client.ObjectKey{Namespace: s.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(s.Shoot.Name, "monitoring")}, secret)
 					},
 					GetObservabilityEndpoint: func(secret *corev1.Secret) string {
 						return secret.Annotations["plutono-url"]
 					},
 					GetObservabilityRotation: func() *gardencorev1beta1.ObservabilityRotation {
-						return f.Shoot.Status.Credentials.Rotation.Observability
+						return s.Shoot.Status.Credentials.Rotation.Observability
 					},
 				},
 				&rotationutils.ETCDEncryptionKeyVerifier{
-					RuntimeClient:               f.ShootFramework.SeedClient.Client(),
-					Namespace:                   f.Shoot.Status.TechnicalID,
+					GetETCDSecretNamespace: func() string {
+						return s.Shoot.Status.TechnicalID
+					},
+					ListETCDEncryptionSecretsFunc: func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error) {
+						secretList := &corev1.SecretList{}
+						return secretList, s.SeedClient.List(ctx, secretList, namespace, matchLabels)
+					},
 					SecretsManagerLabelSelector: rotation.ManagedByGardenletSecretsManager,
 					GetETCDEncryptionKeyRotation: func() *gardencorev1beta1.ETCDEncryptionKeyRotation {
-						return f.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey
+						return s.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey
 					},
 					EncryptionKey:  v1beta1constants.SecretNameETCDEncryptionKey,
 					RoleLabelValue: v1beta1constants.SecretNamePrefixETCDEncryptionConfiguration,
 				},
 				&rotationutils.ServiceAccountKeyVerifier{
-					RuntimeClient:               f.ShootFramework.SeedClient.Client(),
-					Namespace:                   f.Shoot.Status.TechnicalID,
+					GetServiceAccountKeySecretNamespace: func() string {
+						return s.Shoot.Status.TechnicalID
+					},
+					ListServiceAccountKeySecretsFunc: func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error) {
+						secretList := &corev1.SecretList{}
+						return secretList, s.SeedClient.List(ctx, secretList, namespace, matchLabels)
+					},
 					SecretsManagerLabelSelector: rotation.ManagedByGardenletSecretsManager,
 					GetServiceAccountKeyRotation: func() *gardencorev1beta1.ServiceAccountKeyRotation {
-						return f.Shoot.Status.Credentials.Rotation.ServiceAccountKey
+						return s.Shoot.Status.Credentials.Rotation.ServiceAccountKey
 					},
 				},
-
 				// advanced verifiers testing things from the user's perspective
 				&rotationutils.EncryptedDataVerifier{
 					NewTargetClientFunc: func(ctx context.Context) (kubernetes.Interface, error) {
-						return access.CreateShootClientFromAdminKubeconfig(ctx, f.GardenClient, f.Shoot)
+						return access.CreateShootClientFromAdminKubeconfig(ctx, s.GardenClientSet, s.Shoot)
 					},
 					Resources: []rotationutils.EncryptedResource{
 						{
@@ -271,51 +331,47 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 						},
 					},
 				},
-				&rotation.ShootAccessVerifier{ShootCreationFramework: f},
 			}
 
-			if !v1beta1helper.IsWorkerless(f.Shoot) && !withoutWorkersRollout {
-				v = append(v, &rotation.SSHKeypairVerifier{ShootCreationFramework: f})
+			if !v1beta1helper.IsWorkerless(s.Shoot) && !withoutWorkersRollout {
+				shootVerifiers = append(shootVerifiers, &rotation.SSHKeypairVerifier{ShootContext: s})
 			}
 
 			if !withoutWorkersRollout {
 				// test rotation for every rotation type
-				testCredentialRotation(parentCtx, v, f, v1beta1constants.OperationRotateCredentialsStart, v1beta1constants.OperationRotateCredentialsComplete)
+				testCredentialRotation(s, shootVerifiers, utilsVerifiers, v1beta1constants.OperationRotateCredentialsStart, v1beta1constants.OperationRotateCredentialsComplete)
 			} else {
-				testCredentialRotationWithoutWorkersRollout(parentCtx, v, f)
+				testCredentialRotationWithoutWorkersRollout(s, shootVerifiers, utilsVerifiers)
 			}
 
-			By("Renew shoot client after credentials rotation")
-			Expect(f.ShootFramework.AddShoot(parentCtx, f.Shoot.Name, f.Shoot.Namespace)).To(Succeed())
+			if !v1beta1helper.IsWorkerless(s.Shoot) {
+				// renew shoot clients after rotation
+				ItShouldInitializeShootClient(s)
+				inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			}
 
-			// TODO: add back VerifyInClusterAccessToAPIServer once this test has been refactored to ordered containers
-			// if !v1beta1helper.IsWorkerless(s.Shoot) {
-			// 	inclusterclient.VerifyInClusterAccessToAPIServer(s)
-			// }
+			ItShouldDeleteShoot(s)
+			ItShouldWaitForShootToBeDeleted(s)
+		}
 
-			By("Delete Shoot")
-			ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
-			defer cancel()
-			Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
+		Context("Shoot with workers", Label("basic"), Ordered, func() {
+			test(NewTestContext().ForShoot(DefaultShoot("e2e-rotate")), false)
+
+			Context("without workers rollout", Label("without-workers-rollout"), Ordered, func() {
+				shoot := DefaultShoot("e2e-rotate")
+				shoot.Name = "e2e-rot-noroll"
+				// Add a second worker pool when worker rollout should not be performed such that we can make proper
+				// assertions of the shoot status
+				shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers[0])
+				shoot.Spec.Provider.Workers[len(shoot.Spec.Provider.Workers)-1].Name += "2"
+
+				test(NewTestContext().ForShoot(shoot), true)
+			})
+
 		})
-	}
 
-	Context("Shoot with workers", Label("basic"), func() {
-		test(e2e.DefaultShoot("e2e-rotate"), false)
-
-		Context("without workers rollout", Label("without-workers-rollout"), func() {
-			shoot := e2e.DefaultShoot("e2e-rotate")
-			shoot.Name = "e2e-rot-noroll"
-			// Add a second worker pool when worker rollout should not be performed such that we can make proper
-			// assertions of the shoot status
-			shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers[0])
-			shoot.Spec.Provider.Workers[len(shoot.Spec.Provider.Workers)-1].Name += "2"
-
-			test(shoot, true)
+		Context("Workerless Shoot", Label("workerless"), Ordered, func() {
+			test(NewTestContext().ForShoot(DefaultWorkerlessShoot("e2e-rotate")), false)
 		})
-	})
-
-	Context("Workerless Shoot", Label("workerless"), func() {
-		test(e2e.DefaultWorkerlessShoot("e2e-rotate"), false)
 	})
 })

--- a/test/e2e/gardener/shoot/internal/rotation/certificate_authorities.go
+++ b/test/e2e/gardener/shoot/internal/rotation/certificate_authorities.go
@@ -17,13 +17,13 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	"github.com/gardener/gardener/test/framework"
+	. "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/utils/rotation"
 )
 
 // CAVerifier verifies the certificate authorities rotation.
 type CAVerifier struct {
-	*framework.ShootCreationFramework
+	*ShootContext
 
 	oldCACert []byte
 	caBundle  []byte
@@ -59,61 +59,63 @@ const (
 )
 
 // Before is called before the rotation is started.
-func (v *CAVerifier) Before(ctx context.Context) {
-	seedClient := v.ShootFramework.SeedClient.Client()
+func (v *CAVerifier) Before(_ context.Context) {
+	It("Verify CA secrets of gardenlet before rotation", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			secretList := &corev1.SecretList{}
+			g.Expect(v.SeedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), ManagedByGardenletSecretsManager)).To(Succeed())
 
-	By("Verify CA secrets of gardenlet before rotation")
-	Eventually(func(g Gomega) {
-		secretList := &corev1.SecretList{}
-		g.Expect(seedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), ManagedByGardenletSecretsManager)).To(Succeed())
+			allGardenletCAs := getAllGardenletCAs(v1beta1helper.IsWorkerless(v.Shoot))
+			grouped := rotation.GroupByName(secretList.Items)
+			for _, ca := range allGardenletCAs {
+				bundle := ca + "-bundle"
+				g.Expect(grouped[ca]).To(HaveLen(1), ca+" secret should get created, but not rotated yet")
+				g.Expect(grouped[bundle]).To(HaveLen(1), ca+" bundle secret should get created, but not rotated yet")
+			}
+			v.gardenletSecretsBefore = grouped
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-		allGardenletCAs := getAllGardenletCAs(v1beta1helper.IsWorkerless(v.Shoot))
-		grouped := rotation.GroupByName(secretList.Items)
-		for _, ca := range allGardenletCAs {
-			bundle := ca + "-bundle"
-			g.Expect(grouped[ca]).To(HaveLen(1), ca+" secret should get created, but not rotated yet")
-			g.Expect(grouped[bundle]).To(HaveLen(1), ca+" bundle secret should get created, but not rotated yet")
-		}
-		v.gardenletSecretsBefore = grouped
-	}).Should(Succeed())
+	It("Verify old CA config map in garden cluster", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			configMap := &corev1.ConfigMap{}
+			g.Expect(v.GardenClient.Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, configMap)).To(Succeed())
+			g.Expect([]byte(configMap.Data["ca.crt"])).To(And(
+				Not(BeEmpty()),
+				Equal(v.gardenletSecretsBefore[caCluster+"-bundle"][0].Data["bundle.crt"]),
+			), "ca-cluster config map in garden should contain the same bundle as ca-bundle secret on seed")
+			v.oldCACert = []byte(configMap.Data["ca.crt"])
+		}).Should(Succeed(), "old CA cert should be synced to garden")
+	}, SpecTimeout(time.Minute))
 
-	By("Verify old CA config map in garden cluster")
-	Eventually(func(g Gomega) {
-		configMap := &corev1.ConfigMap{}
-		g.Expect(v.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, configMap)).To(Succeed())
-		g.Expect([]byte(configMap.Data["ca.crt"])).To(And(
-			Not(BeEmpty()),
-			Equal(v.gardenletSecretsBefore[caCluster+"-bundle"][0].Data["bundle.crt"]),
-		), "ca-cluster config map in garden should contain the same bundle as ca-bundle secret on seed")
-		v.oldCACert = []byte(configMap.Data["ca.crt"])
-	}).Should(Succeed(), "old CA cert should be synced to garden")
-
-	By("Verify old CA secret in garden cluster")
-	Eventually(func(g Gomega) {
-		secret := &corev1.Secret{}
-		g.Expect(v.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, secret)).To(Succeed())
-		g.Expect(secret.Data["ca.crt"]).To(And(
-			Not(BeEmpty()),
-			Equal(v.gardenletSecretsBefore[caCluster+"-bundle"][0].Data["bundle.crt"]),
-		), "ca-cluster secret in garden should contain the same bundle as ca-bundle secret on seed")
-		oldCACert := secret.Data["ca.crt"]
-		Expect(oldCACert).To(Equal(v.oldCACert), "ca-cluster secret in garden should contain the same bundle as ca-cluster config map in garden")
-	}).Should(Succeed(), "old CA cert should be synced to garden")
+	It("Verify old CA secret in garden cluster", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			secret := &corev1.Secret{}
+			g.Expect(v.GardenClient.Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, secret)).To(Succeed())
+			g.Expect(secret.Data["ca.crt"]).To(And(
+				Not(BeEmpty()),
+				Equal(v.gardenletSecretsBefore[caCluster+"-bundle"][0].Data["bundle.crt"]),
+			), "ca-cluster secret in garden should contain the same bundle as ca-bundle secret on seed")
+			oldCACert := secret.Data["ca.crt"]
+			Expect(oldCACert).To(Equal(v.oldCACert), "ca-cluster secret in garden should contain the same bundle as ca-cluster config map in garden")
+		}).Should(Succeed(), "old CA cert should be synced to garden")
+	}, SpecTimeout(time.Minute))
 
 	if !v1beta1helper.IsWorkerless(v.Shoot) {
-		By("Verify secrets of provider-local before rotation")
-		Eventually(func(g Gomega) {
-			secretList := &corev1.SecretList{}
-			g.Expect(seedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), managedByProviderLocalSecretsManager)).To(Succeed())
+		It("Verify secrets of provider-local before rotation", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) {
+				secretList := &corev1.SecretList{}
+				g.Expect(v.SeedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), managedByProviderLocalSecretsManager)).To(Succeed())
 
-			grouped := rotation.GroupByName(secretList.Items)
-			g.Expect(grouped[caProviderLocalControlPlane]).To(HaveLen(1), "CA secret should get created, but not rotated yet")
-			g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(HaveLen(1), "CA bundle secret should get created, but not rotated yet")
-			g.Expect(grouped[providerLocalDummyServer]).To(HaveLen(1))
-			g.Expect(grouped[providerLocalDummyClient]).To(HaveLen(1))
-			g.Expect(grouped[providerLocalDummyAuth]).To(HaveLen(1))
-			v.providerLocalSecretsBefore = grouped
-		}).Should(Succeed())
+				grouped := rotation.GroupByName(secretList.Items)
+				g.Expect(grouped[caProviderLocalControlPlane]).To(HaveLen(1), "CA secret should get created, but not rotated yet")
+				g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(HaveLen(1), "CA bundle secret should get created, but not rotated yet")
+				g.Expect(grouped[providerLocalDummyServer]).To(HaveLen(1))
+				g.Expect(grouped[providerLocalDummyClient]).To(HaveLen(1))
+				g.Expect(grouped[providerLocalDummyAuth]).To(HaveLen(1))
+				v.providerLocalSecretsBefore = grouped
+			}).Should(Succeed())
+		}, SpecTimeout(time.Minute))
 	}
 }
 
@@ -142,157 +144,166 @@ func (v *CAVerifier) ExpectWaitingForWorkersRolloutStatus(g Gomega) {
 }
 
 // AfterPrepared is called when the Shoot is in Prepared status.
-func (v *CAVerifier) AfterPrepared(ctx context.Context) {
-	seedClient := v.ShootFramework.SeedClient.Client()
-	Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.Phase).To(Equal(gardencorev1beta1.RotationPrepared), "ca rotation phase should be 'Prepared'")
-	Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime).NotTo(BeNil())
-	Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.After(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time)).To(BeTrue())
+func (v *CAVerifier) AfterPrepared(_ context.Context) {
+	It("ca rotation phase should be 'Prepared'", func() {
+		Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.Phase).To(Equal(gardencorev1beta1.RotationPrepared))
+		Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime).NotTo(BeNil())
+		Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.After(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time)).To(BeTrue())
+	})
 
-	By("Verify CA secrets of gardenlet after preparation")
-	Eventually(func(g Gomega) {
-		secretList := &corev1.SecretList{}
-		g.Expect(seedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), ManagedByGardenletSecretsManager)).To(Succeed())
+	It("Verify CA secrets of gardenlet after preparation", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			secretList := &corev1.SecretList{}
+			g.Expect(v.SeedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), ManagedByGardenletSecretsManager)).To(Succeed())
 
-		allGardenletCAs := getAllGardenletCAs(v1beta1helper.IsWorkerless(v.Shoot))
-		grouped := rotation.GroupByName(secretList.Items)
-		for _, ca := range allGardenletCAs {
-			bundle := ca + "-bundle"
-			g.Expect(grouped[ca]).To(HaveLen(2), ca+" secret should get rotated, but old CA is kept")
-			g.Expect(grouped[bundle]).To(HaveLen(1), ca+" bundle secret should have changed")
-			g.Expect(grouped[ca]).To(ContainElement(v.gardenletSecretsBefore[ca][0]), "old "+ca+" secret should be kept")
-			g.Expect(grouped[bundle]).To(Not(ContainElement(v.gardenletSecretsBefore[bundle][0])), "old "+ca+" bundle should get cleaned up")
-		}
-		v.gardenletSecretsPrepared = grouped
-	}).Should(Succeed())
+			allGardenletCAs := getAllGardenletCAs(v1beta1helper.IsWorkerless(v.Shoot))
+			grouped := rotation.GroupByName(secretList.Items)
+			for _, ca := range allGardenletCAs {
+				bundle := ca + "-bundle"
+				g.Expect(grouped[ca]).To(HaveLen(2), ca+" secret should get rotated, but old CA is kept")
+				g.Expect(grouped[bundle]).To(HaveLen(1), ca+" bundle secret should have changed")
+				g.Expect(grouped[ca]).To(ContainElement(v.gardenletSecretsBefore[ca][0]), "old "+ca+" secret should be kept")
+				g.Expect(grouped[bundle]).To(Not(ContainElement(v.gardenletSecretsBefore[bundle][0])), "old "+ca+" bundle should get cleaned up")
+			}
+			v.gardenletSecretsPrepared = grouped
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Verify CA bundle config map in garden cluster")
-	Eventually(func(g Gomega) {
-		configMap := &corev1.ConfigMap{}
-		g.Expect(v.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, configMap)).To(Succeed())
-		g.Expect([]byte(configMap.Data["ca.crt"])).To(And(
-			Not(BeEmpty()),
-			Equal(v.gardenletSecretsPrepared[caCluster+"-bundle"][0].Data["bundle.crt"]),
-		), "ca-cluster config map in garden should contain the same bundle as ca-bundle secret on seed")
-		g.Expect(configMap.Data["ca.crt"]).To(ContainSubstring(string(v.oldCACert)), "CA bundle should contain the old CA cert")
-		v.caBundle = []byte(configMap.Data["ca.crt"])
+	It("Verify CA bundle config map in garden cluster", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			configMap := &corev1.ConfigMap{}
+			g.Expect(v.GardenClient.Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, configMap)).To(Succeed())
+			g.Expect([]byte(configMap.Data["ca.crt"])).To(And(
+				Not(BeEmpty()),
+				Equal(v.gardenletSecretsPrepared[caCluster+"-bundle"][0].Data["bundle.crt"]),
+			), "ca-cluster config map in garden should contain the same bundle as ca-bundle secret on seed")
+			g.Expect(configMap.Data["ca.crt"]).To(ContainSubstring(string(v.oldCACert)), "CA bundle should contain the old CA cert")
+			v.caBundle = []byte(configMap.Data["ca.crt"])
 
-		v.newCACert = []byte(strings.ReplaceAll(string(v.caBundle), string(v.oldCACert), ""))
-		Expect(v.newCACert).NotTo(BeEmpty())
-	}).Should(Succeed(), "CA bundle should be synced to garden")
+			v.newCACert = []byte(strings.ReplaceAll(string(v.caBundle), string(v.oldCACert), ""))
+			Expect(v.newCACert).NotTo(BeEmpty())
+		}).Should(Succeed(), "CA bundle should be synced to garden")
+	}, SpecTimeout(time.Minute))
 
-	By("Verify CA bundle secret in garden cluster")
-	Eventually(func(g Gomega) {
-		secret := &corev1.Secret{}
-		g.Expect(v.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, secret)).To(Succeed())
-		g.Expect(secret.Data["ca.crt"]).To(And(
-			Not(BeEmpty()),
-			Equal(v.gardenletSecretsPrepared[caCluster+"-bundle"][0].Data["bundle.crt"]),
-		), "ca-cluster secret in garden should contain the same bundle as ca-bundle secret on seed")
-		g.Expect(string(secret.Data["ca.crt"])).To(ContainSubstring(string(v.oldCACert)), "CA bundle should contain the old CA cert")
-		caBundle := secret.Data["ca.crt"]
-		Expect(caBundle).To(Equal(v.caBundle), "ca-cluster secret in garden should contain the same bundle as ca-cluster config map in garden")
+	It("Verify CA bundle secret in garden cluster", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			secret := &corev1.Secret{}
+			g.Expect(v.GardenClient.Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, secret)).To(Succeed())
+			g.Expect(secret.Data["ca.crt"]).To(And(
+				Not(BeEmpty()),
+				Equal(v.gardenletSecretsPrepared[caCluster+"-bundle"][0].Data["bundle.crt"]),
+			), "ca-cluster secret in garden should contain the same bundle as ca-bundle secret on seed")
+			g.Expect(string(secret.Data["ca.crt"])).To(ContainSubstring(string(v.oldCACert)), "CA bundle should contain the old CA cert")
+			caBundle := secret.Data["ca.crt"]
+			Expect(caBundle).To(Equal(v.caBundle), "ca-cluster secret in garden should contain the same bundle as ca-cluster config map in garden")
 
-		newCACert := []byte(strings.ReplaceAll(string(caBundle), string(v.oldCACert), ""))
-		Expect(newCACert).To(Equal(v.newCACert), "new CA bundle from secret in garden should match new CA bundle from config map in garden")
-	}).Should(Succeed(), "CA bundle should be synced to garden")
+			newCACert := []byte(strings.ReplaceAll(string(caBundle), string(v.oldCACert), ""))
+			Expect(newCACert).To(Equal(v.newCACert), "new CA bundle from secret in garden should match new CA bundle from config map in garden")
+		}).Should(Succeed(), "CA bundle should be synced to garden")
+	}, SpecTimeout(time.Minute))
 
 	if !v1beta1helper.IsWorkerless(v.Shoot) {
-		By("Verify secrets of provider-local after preparation")
-		Eventually(func(g Gomega) {
-			secretList := &corev1.SecretList{}
-			g.Expect(seedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), managedByProviderLocalSecretsManager)).To(Succeed())
+		It("Verify secrets of provider-local after preparation", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) {
+				secretList := &corev1.SecretList{}
+				g.Expect(v.SeedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), managedByProviderLocalSecretsManager)).To(Succeed())
 
-			grouped := rotation.GroupByName(secretList.Items)
-			g.Expect(grouped[caProviderLocalControlPlane]).To(HaveLen(2), "CA secret should get rotated, but old CA is kept")
-			g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(HaveLen(1), "CA bundle secret should have changed")
-			g.Expect(grouped[providerLocalDummyServer]).To(HaveLen(1))
-			g.Expect(grouped[providerLocalDummyClient]).To(HaveLen(1))
-			g.Expect(grouped[providerLocalDummyAuth]).To(HaveLen(1))
+				grouped := rotation.GroupByName(secretList.Items)
+				g.Expect(grouped[caProviderLocalControlPlane]).To(HaveLen(2), "CA secret should get rotated, but old CA is kept")
+				g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(HaveLen(1), "CA bundle secret should have changed")
+				g.Expect(grouped[providerLocalDummyServer]).To(HaveLen(1))
+				g.Expect(grouped[providerLocalDummyClient]).To(HaveLen(1))
+				g.Expect(grouped[providerLocalDummyAuth]).To(HaveLen(1))
 
-			g.Expect(grouped[caProviderLocalControlPlane]).To(ContainElement(v.providerLocalSecretsBefore[caProviderLocalControlPlane][0]), "old CA secret should be kept")
-			g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(Not(ContainElement(v.providerLocalSecretsBefore[caProviderLocalControlPlaneBundle][0])), "old CA bundle should get cleaned up")
-			g.Expect(grouped[providerLocalDummyServer]).To(ContainElement(v.providerLocalSecretsBefore[providerLocalDummyServer][0]), "server cert should be kept (signed with old CA)")
-			g.Expect(grouped[providerLocalDummyClient]).To(Not(ContainElement(v.providerLocalSecretsBefore[providerLocalDummyServer][0])), "client cert should have changed (signed with new CA)")
-			v.providerLocalSecretsPrepared = grouped
-		}).Should(Succeed())
+				g.Expect(grouped[caProviderLocalControlPlane]).To(ContainElement(v.providerLocalSecretsBefore[caProviderLocalControlPlane][0]), "old CA secret should be kept")
+				g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(Not(ContainElement(v.providerLocalSecretsBefore[caProviderLocalControlPlaneBundle][0])), "old CA bundle should get cleaned up")
+				g.Expect(grouped[providerLocalDummyServer]).To(ContainElement(v.providerLocalSecretsBefore[providerLocalDummyServer][0]), "server cert should be kept (signed with old CA)")
+				g.Expect(grouped[providerLocalDummyClient]).To(Not(ContainElement(v.providerLocalSecretsBefore[providerLocalDummyServer][0])), "client cert should have changed (signed with new CA)")
+				v.providerLocalSecretsPrepared = grouped
+			}).Should(Succeed())
+		}, SpecTimeout(time.Minute))
 	}
 }
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
 func (v *CAVerifier) ExpectCompletingStatus(g Gomega) {
 	g.Expect(v1beta1helper.GetShootCARotationPhase(v.Shoot.Status.Credentials)).To(Equal(gardencorev1beta1.RotationCompleting))
-	Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime).NotTo(BeNil())
-	Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.Time.Equal(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time) ||
+	g.Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime).NotTo(BeNil())
+	g.Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.Time.Equal(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time) ||
 		v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.After(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time)).To(BeTrue())
 }
 
 // AfterCompleted is called when the Shoot is in Completed status.
-func (v *CAVerifier) AfterCompleted(ctx context.Context) {
-	seedClient := v.ShootFramework.SeedClient.Client()
+func (v *CAVerifier) AfterCompleted(_ context.Context) {
+	It("ca rotation phase should be 'Completed'", func() {
+		caRotation := v.Shoot.Status.Credentials.Rotation.CertificateAuthorities
+		Expect(v1beta1helper.GetShootCARotationPhase(v.Shoot.Status.Credentials)).To(Equal(gardencorev1beta1.RotationCompleted))
+		Expect(caRotation.LastCompletionTime.Time.UTC().After(caRotation.LastInitiationTime.Time.UTC())).To(BeTrue())
+		Expect(caRotation.LastInitiationFinishedTime).To(BeNil())
+		Expect(caRotation.LastCompletionTriggeredTime).To(BeNil())
+	})
 
-	caRotation := v.Shoot.Status.Credentials.Rotation.CertificateAuthorities
-	Expect(v1beta1helper.GetShootCARotationPhase(v.Shoot.Status.Credentials)).To(Equal(gardencorev1beta1.RotationCompleted))
-	Expect(caRotation.LastCompletionTime.Time.UTC().After(caRotation.LastInitiationTime.Time.UTC())).To(BeTrue())
-	Expect(caRotation.LastInitiationFinishedTime).To(BeNil())
-	Expect(caRotation.LastCompletionTriggeredTime).To(BeNil())
+	It("Verify CA secrets of gardenlet after completion", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			secretList := &corev1.SecretList{}
+			g.Expect(v.SeedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), ManagedByGardenletSecretsManager)).To(Succeed())
 
-	By("Verify CA secrets of gardenlet after completion")
-	Eventually(func(g Gomega) {
-		secretList := &corev1.SecretList{}
-		g.Expect(seedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), ManagedByGardenletSecretsManager)).To(Succeed())
+			allGardenletCAs := getAllGardenletCAs(v1beta1helper.IsWorkerless(v.Shoot))
+			grouped := rotation.GroupByName(secretList.Items)
+			for _, ca := range allGardenletCAs {
+				bundle := ca + "-bundle"
+				g.Expect(grouped[ca]).To(HaveLen(1), "old "+ca+" secret should get cleaned up")
+				g.Expect(grouped[bundle]).To(HaveLen(1), ca+" bundle secret should have changed")
+				g.Expect(grouped[ca]).To(ContainElement(v.gardenletSecretsPrepared[ca][1]), "new "+ca+" secret should be kept")
+				g.Expect(grouped[bundle]).To(Not(ContainElement(v.gardenletSecretsPrepared[bundle][0])), "combined "+ca+" bundle should get cleaned up")
+			}
+			v.gardenletSecretsCompleted = grouped
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-		allGardenletCAs := getAllGardenletCAs(v1beta1helper.IsWorkerless(v.Shoot))
-		grouped := rotation.GroupByName(secretList.Items)
-		for _, ca := range allGardenletCAs {
-			bundle := ca + "-bundle"
-			g.Expect(grouped[ca]).To(HaveLen(1), "old "+ca+" secret should get cleaned up")
-			g.Expect(grouped[bundle]).To(HaveLen(1), ca+" bundle secret should have changed")
-			g.Expect(grouped[ca]).To(ContainElement(v.gardenletSecretsPrepared[ca][1]), "new "+ca+" secret should be kept")
-			g.Expect(grouped[bundle]).To(Not(ContainElement(v.gardenletSecretsPrepared[bundle][0])), "combined "+ca+" bundle should get cleaned up")
-		}
-		v.gardenletSecretsCompleted = grouped
-	}).Should(Succeed())
+	It("Verify new CA config map in garden cluster", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			configMap := &corev1.ConfigMap{}
+			g.Expect(v.GardenClient.Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, configMap)).To(Succeed())
+			g.Expect([]byte(configMap.Data["ca.crt"])).To(And(
+				Not(BeEmpty()),
+				Equal(v.gardenletSecretsCompleted[caCluster+"-bundle"][0].Data["bundle.crt"]),
+			), "ca-cluster config map in garden should contain the same bundle as ca-bundle secret on seed")
+			g.Expect([]byte(configMap.Data["ca.crt"])).To(Equal(v.newCACert), "new CA bundle should only contain new CA cert")
+		}).Should(Succeed(), "new CA cert should be synced to garden")
+	}, SpecTimeout(time.Minute))
 
-	By("Verify new CA config map in garden cluster")
-	Eventually(func(g Gomega) {
-		configMap := &corev1.ConfigMap{}
-		g.Expect(v.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, configMap)).To(Succeed())
-		g.Expect([]byte(configMap.Data["ca.crt"])).To(And(
-			Not(BeEmpty()),
-			Equal(v.gardenletSecretsCompleted[caCluster+"-bundle"][0].Data["bundle.crt"]),
-		), "ca-cluster config map in garden should contain the same bundle as ca-bundle secret on seed")
-		g.Expect([]byte(configMap.Data["ca.crt"])).To(Equal(v.newCACert), "new CA bundle should only contain new CA cert")
-	}).Should(Succeed(), "new CA cert should be synced to garden")
-
-	By("Verify new CA secret in garden cluster")
-	Eventually(func(g Gomega) {
-		secret := &corev1.Secret{}
-		g.Expect(v.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, secret)).To(Succeed())
-		g.Expect(secret.Data["ca.crt"]).To(And(
-			Not(BeEmpty()),
-			Equal(v.gardenletSecretsCompleted[caCluster+"-bundle"][0].Data["bundle.crt"]),
-		), "ca-cluster secret in garden should contain the same bundle as ca-bundle secret on seed")
-		g.Expect(secret.Data["ca.crt"]).To(Equal(v.newCACert), "new CA bundle should only contain new CA cert")
-	}).Should(Succeed(), "new CA cert should be synced to garden")
+	It("Verify new CA secret in garden cluster", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			secret := &corev1.Secret{}
+			g.Expect(v.GardenClient.Get(ctx, client.ObjectKey{Namespace: v.Shoot.Namespace, Name: gardenerutils.ComputeShootProjectResourceName(v.Shoot.Name, "ca-cluster")}, secret)).To(Succeed())
+			g.Expect(secret.Data["ca.crt"]).To(And(
+				Not(BeEmpty()),
+				Equal(v.gardenletSecretsCompleted[caCluster+"-bundle"][0].Data["bundle.crt"]),
+			), "ca-cluster secret in garden should contain the same bundle as ca-bundle secret on seed")
+			g.Expect(secret.Data["ca.crt"]).To(Equal(v.newCACert), "new CA bundle should only contain new CA cert")
+		}).Should(Succeed(), "new CA cert should be synced to garden")
+	}, SpecTimeout(time.Minute))
 
 	if !v1beta1helper.IsWorkerless(v.Shoot) {
-		By("Verify secrets of provider-local after completion")
-		Eventually(func(g Gomega) {
-			secretList := &corev1.SecretList{}
-			g.Expect(seedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), managedByProviderLocalSecretsManager)).To(Succeed())
+		It("Verify secrets of provider-local after completion", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) {
+				secretList := &corev1.SecretList{}
+				g.Expect(v.SeedClient.List(ctx, secretList, client.InNamespace(v.Shoot.Status.TechnicalID), managedByProviderLocalSecretsManager)).To(Succeed())
 
-			grouped := rotation.GroupByName(secretList.Items)
-			g.Expect(grouped[caProviderLocalControlPlane]).To(HaveLen(1), "old CA secret should get cleaned up")
-			g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(HaveLen(1), "CA bundle secret should have changed")
-			g.Expect(grouped[providerLocalDummyServer]).To(HaveLen(1))
-			g.Expect(grouped[providerLocalDummyClient]).To(HaveLen(1))
-			g.Expect(grouped[providerLocalDummyAuth]).To(HaveLen(1))
+				grouped := rotation.GroupByName(secretList.Items)
+				g.Expect(grouped[caProviderLocalControlPlane]).To(HaveLen(1), "old CA secret should get cleaned up")
+				g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(HaveLen(1), "CA bundle secret should have changed")
+				g.Expect(grouped[providerLocalDummyServer]).To(HaveLen(1))
+				g.Expect(grouped[providerLocalDummyClient]).To(HaveLen(1))
+				g.Expect(grouped[providerLocalDummyAuth]).To(HaveLen(1))
 
-			g.Expect(grouped[caProviderLocalControlPlane]).To(ContainElement(v.providerLocalSecretsPrepared[caProviderLocalControlPlane][1]), "new CA secret should be kept")
-			g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(Not(ContainElement(v.providerLocalSecretsPrepared[caProviderLocalControlPlaneBundle][0])), "combined CA bundle should get cleaned up")
-			g.Expect(grouped[providerLocalDummyServer]).To(Not(ContainElement(v.providerLocalSecretsPrepared[providerLocalDummyServer][0])), "server cert should have changed (signed with new CA)")
-			g.Expect(grouped[providerLocalDummyClient]).To(ContainElement(v.providerLocalSecretsPrepared[providerLocalDummyClient][0]), "client cert should be kept (already signed with new CA)")
-		}).Should(Succeed())
+				g.Expect(grouped[caProviderLocalControlPlane]).To(ContainElement(v.providerLocalSecretsPrepared[caProviderLocalControlPlane][1]), "new CA secret should be kept")
+				g.Expect(grouped[caProviderLocalControlPlaneBundle]).To(Not(ContainElement(v.providerLocalSecretsPrepared[caProviderLocalControlPlaneBundle][0])), "combined CA bundle should get cleaned up")
+				g.Expect(grouped[providerLocalDummyServer]).To(Not(ContainElement(v.providerLocalSecretsPrepared[providerLocalDummyServer][0])), "server cert should have changed (signed with new CA)")
+				g.Expect(grouped[providerLocalDummyClient]).To(ContainElement(v.providerLocalSecretsPrepared[providerLocalDummyClient][0]), "client cert should be kept (already signed with new CA)")
+			}).Should(Succeed())
+		}, SpecTimeout(time.Minute))
 	}
 }
 

--- a/test/e2e/gardener/shoot/internal/rotation/shoot_access.go
+++ b/test/e2e/gardener/shoot/internal/rotation/shoot_access.go
@@ -256,6 +256,8 @@ func (v *ShootAccessVerifier) AfterCompleted(_ context.Context) {
 
 // Cleanup is passed to ginkgo.DeferCleanup.
 func (v *ShootAccessVerifier) Cleanup() {
+	// TODO(Wieneo): drop this lookup and use the new flags from the e2e package once the test/e2e/gardener package no longer uses
+	// the test framework (when finishing https://github.com/gardener/gardener/issues/11379)
 	if flag.Lookup("existing-shoot-name").Value.String() == "" {
 		// we only have to clean up if we are using an existing shoot, otherwise the shoot will be deleted
 		return

--- a/test/e2e/gardener/shoot/internal/rotation/shoot_access.go
+++ b/test/e2e/gardener/shoot/internal/rotation/shoot_access.go
@@ -6,13 +6,15 @@ package rotation
 
 import (
 	"context"
+	"flag"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/test/framework"
+	. "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/utils/access"
 )
 
@@ -22,52 +24,56 @@ type clients struct {
 
 // ShootAccessVerifier uses the various access methods to access the Shoot.
 type ShootAccessVerifier struct {
-	*framework.ShootCreationFramework
+	*ShootContext
 
 	clientsBefore, clientsPrepared, clientsAfter clients
 }
 
 // Before is called before the rotation is started.
-func (v *ShootAccessVerifier) Before(ctx context.Context) {
-	By("Use admin kubeconfig with old CA to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClient, v.Shoot)
-		g.Expect(err).NotTo(HaveOccurred())
+func (v *ShootAccessVerifier) Before(_ context.Context) {
+	It("Use admin kubeconfig with old CA to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClientSet, v.Shoot)
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsBefore.adminKubeconfig = shootClient
-	}).Should(Succeed())
+			v.clientsBefore.adminKubeconfig = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new client certificate and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateTargetClientFromCSR(ctx, v.clientsBefore.adminKubeconfig, "e2e-rotate-csr-before")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new client certificate and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateTargetClientFromCSR(ctx, v.clientsBefore.adminKubeconfig, "e2e-rotate-csr-before")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsBefore.clientCert = shootClient
-	}).Should(Succeed())
+			v.clientsBefore.clientCert = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new dynamic token for a ServiceAccount and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateTargetClientFromDynamicServiceAccountToken(ctx, v.clientsBefore.adminKubeconfig, "e2e-rotate-sa-dynamic-before")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new dynamic token for a ServiceAccount and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateTargetClientFromDynamicServiceAccountToken(ctx, v.clientsBefore.adminKubeconfig, "e2e-rotate-sa-dynamic-before")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsBefore.serviceAccountDynamic = shootClient
-	}).Should(Succeed())
+			v.clientsBefore.serviceAccountDynamic = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new static token for a ServiceAccount and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateShootClientFromStaticServiceAccountToken(ctx, v.clientsBefore.adminKubeconfig, "e2e-rotate-sa-static-before")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new static token for a ServiceAccount and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateShootClientFromStaticServiceAccountToken(ctx, v.clientsBefore.adminKubeconfig, "e2e-rotate-sa-static-before")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsBefore.serviceAccountStatic = shootClient
-	}).Should(Succeed())
+			v.clientsBefore.serviceAccountStatic = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 }
 
 // ExpectPreparingStatus is called while waiting for the Preparing status.
@@ -80,157 +86,177 @@ func (v *ShootAccessVerifier) ExpectPreparingWithoutWorkersRolloutStatus(_ Gomeg
 func (v *ShootAccessVerifier) ExpectWaitingForWorkersRolloutStatus(_ Gomega) {}
 
 // AfterPrepared is called when the Shoot is in Prepared status.
-func (v *ShootAccessVerifier) AfterPrepared(ctx context.Context) {
-	By("Use admin kubeconfig with old CA to access shoot")
-	Eventually(func(g Gomega) {
-		g.Expect(v.clientsBefore.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-	}).Should(Succeed())
+func (v *ShootAccessVerifier) AfterPrepared(_ context.Context) {
+	It("Use admin kubeconfig with old CA to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(v.clientsBefore.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use client certificate from before rotation to access shoot")
-	Eventually(func(g Gomega) {
-		g.Expect(v.clientsBefore.clientCert.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-	}).Should(Succeed())
+	It("Use client certificate from before rotation to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(v.clientsBefore.clientCert.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use dynamic ServiceAccount token from before rotation to access shoot")
-	Eventually(func(g Gomega) {
-		g.Expect(v.clientsBefore.serviceAccountDynamic.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-	}).Should(Succeed())
+	It("Use dynamic ServiceAccount token from before rotation to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(v.clientsBefore.serviceAccountDynamic.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use static ServiceAccount token from before rotation to access shoot")
-	Eventually(func(g Gomega) {
-		g.Expect(v.clientsBefore.serviceAccountStatic.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-	}).Should(Succeed())
+	It("Use static ServiceAccount token from before rotation to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(v.clientsBefore.serviceAccountStatic.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use admin kubeconfig with CA bundle to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClient, v.Shoot)
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Use admin kubeconfig with CA bundle to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClientSet, v.Shoot)
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsPrepared.adminKubeconfig = shootClient
-	}).Should(Succeed())
+			v.clientsPrepared.adminKubeconfig = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new client certificate and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateTargetClientFromCSR(ctx, v.clientsPrepared.adminKubeconfig, "e2e-rotate-csr-prepared")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new client certificate and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateTargetClientFromCSR(ctx, v.clientsPrepared.adminKubeconfig, "e2e-rotate-csr-prepared")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsPrepared.clientCert = shootClient
-	}).Should(Succeed())
+			v.clientsPrepared.clientCert = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new dynamic token for a ServiceAccount and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateTargetClientFromDynamicServiceAccountToken(ctx, v.clientsPrepared.adminKubeconfig, "e2e-rotate-sa-dynamic-prepared")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new dynamic token for a ServiceAccount and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateTargetClientFromDynamicServiceAccountToken(ctx, v.clientsPrepared.adminKubeconfig, "e2e-rotate-sa-dynamic-prepared")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsPrepared.serviceAccountDynamic = shootClient
-	}).Should(Succeed())
+			v.clientsPrepared.serviceAccountDynamic = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new static token for a ServiceAccount and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateShootClientFromStaticServiceAccountToken(ctx, v.clientsPrepared.adminKubeconfig, "e2e-rotate-sa-static-prepared")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new static token for a ServiceAccount and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateShootClientFromStaticServiceAccountToken(ctx, v.clientsPrepared.adminKubeconfig, "e2e-rotate-sa-static-prepared")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsPrepared.serviceAccountStatic = shootClient
-	}).Should(Succeed())
+			v.clientsPrepared.serviceAccountStatic = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 }
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
 func (v *ShootAccessVerifier) ExpectCompletingStatus(_ Gomega) {}
 
 // AfterCompleted is called when the Shoot is in Completed status.
-func (v *ShootAccessVerifier) AfterCompleted(ctx context.Context) {
-	By("Use admin kubeconfig with old CA to access shoot")
-	Consistently(func(g Gomega) {
-		g.Expect(v.clientsBefore.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
-	}).Should(Succeed())
+func (v *ShootAccessVerifier) AfterCompleted(_ context.Context) {
+	It("Use admin kubeconfig with old CA to access shoot", func(ctx SpecContext) {
+		Consistently(func(g Gomega) {
+			g.Expect(v.clientsBefore.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use client certificate from before rotation to access shoot")
-	Consistently(func(g Gomega) {
-		g.Expect(v.clientsBefore.clientCert.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
-	}).Should(Succeed())
+	It("Use client certificate from before rotation to access shoot", func(ctx SpecContext) {
+		Consistently(func(g Gomega) {
+			g.Expect(v.clientsBefore.clientCert.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use dynamic ServiceAccount token from before rotation to access shoot")
-	Consistently(func(g Gomega) {
-		g.Expect(v.clientsBefore.serviceAccountDynamic.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
-	}).Should(Succeed())
+	It("Use dynamic ServiceAccount token from before rotation to access shoot", func(ctx SpecContext) {
+		Consistently(func(g Gomega) {
+			g.Expect(v.clientsBefore.serviceAccountDynamic.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use static ServiceAccount token from before rotation to access shoot")
-	Consistently(func(g Gomega) {
-		g.Expect(v.clientsBefore.serviceAccountStatic.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
-	}).Should(Succeed())
+	It("Use static ServiceAccount token from before rotation to access shoot", func(ctx SpecContext) {
+		Consistently(func(g Gomega) {
+			g.Expect(v.clientsBefore.serviceAccountStatic.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use admin kubeconfig with CA bundle to access shoot")
-	Eventually(func(g Gomega) {
-		g.Expect(v.clientsPrepared.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-	}).Should(Succeed())
+	It("Use admin kubeconfig with CA bundle to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(v.clientsPrepared.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+	})
 
-	By("Use client certificate from after preparation to access shoot")
-	Eventually(func(g Gomega) {
-		g.Expect(v.clientsPrepared.clientCert.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-	}).Should(Succeed())
+	It("Use client certificate from after preparation to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(v.clientsPrepared.clientCert.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use dynamic ServiceAccount token from after preparation to access shoot")
-	Eventually(func(g Gomega) {
-		g.Expect(v.clientsPrepared.serviceAccountDynamic.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-	}).Should(Succeed())
+	It("Use dynamic ServiceAccount token from after preparation to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(v.clientsPrepared.serviceAccountDynamic.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use static ServiceAccount token from after preparation to access shoot")
-	Eventually(func(g Gomega) {
-		g.Expect(v.clientsPrepared.serviceAccountStatic.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-	}).Should(Succeed())
+	It("Use static ServiceAccount token from after preparation to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(v.clientsPrepared.serviceAccountStatic.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Use admin kubeconfig with new CA to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClient, v.Shoot)
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Use admin kubeconfig with new CA to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClientSet, v.Shoot)
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsAfter.adminKubeconfig = shootClient
-	}).Should(Succeed())
+			v.clientsAfter.adminKubeconfig = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new client certificate and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateTargetClientFromCSR(ctx, v.clientsAfter.adminKubeconfig, "e2e-rotate-csr-after")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new client certificate and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateTargetClientFromCSR(ctx, v.clientsAfter.adminKubeconfig, "e2e-rotate-csr-after")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsAfter.clientCert = shootClient
-	}).Should(Succeed())
+			v.clientsAfter.clientCert = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new dynamic token for a ServiceAccount and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateTargetClientFromDynamicServiceAccountToken(ctx, v.clientsAfter.adminKubeconfig, "e2e-rotate-sa-dynamic-after")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new dynamic token for a ServiceAccount and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateTargetClientFromDynamicServiceAccountToken(ctx, v.clientsAfter.adminKubeconfig, "e2e-rotate-sa-dynamic-after")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsAfter.serviceAccountDynamic = shootClient
-	}).Should(Succeed())
+			v.clientsAfter.serviceAccountDynamic = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Request new static token for a ServiceAccount and using it to access shoot")
-	Eventually(func(g Gomega) {
-		shootClient, err := access.CreateShootClientFromStaticServiceAccountToken(ctx, v.clientsAfter.adminKubeconfig, "e2e-rotate-sa-static-after")
-		g.Expect(err).NotTo(HaveOccurred())
+	It("Request new static token for a ServiceAccount and using it to access shoot", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			shootClient, err := access.CreateShootClientFromStaticServiceAccountToken(ctx, v.clientsAfter.adminKubeconfig, "e2e-rotate-sa-static-after")
+			g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 
-		v.clientsAfter.serviceAccountStatic = shootClient
-	}).Should(Succeed())
+			v.clientsAfter.serviceAccountStatic = shootClient
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 }
 
 // Cleanup is passed to ginkgo.DeferCleanup.
-func (v *ShootAccessVerifier) Cleanup(ctx context.Context) {
-	if v.Config.GardenerConfig.ExistingShootName == "" {
+func (v *ShootAccessVerifier) Cleanup() {
+	if flag.Lookup("existing-shoot-name").Value.String() == "" {
 		// we only have to clean up if we are using an existing shoot, otherwise the shoot will be deleted
 		return
 	}
@@ -248,18 +274,21 @@ func (v *ShootAccessVerifier) Cleanup(ctx context.Context) {
 		shootClient = v.clientsAfter.adminKubeconfig
 	}
 
-	By("Clean up objects in shoot from client certificate access")
-	Eventually(func(g Gomega) {
-		g.Expect(access.CleanupObjectsFromCSRAccess(ctx, shootClient)).To(Succeed())
-	}).Should(Succeed())
+	It("Clean up objects in shoot from client certificate access", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(access.CleanupObjectsFromCSRAccess(ctx, shootClient)).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Clean up objects in shoot from dynamic ServiceAccount token access")
-	Eventually(func(g Gomega) {
-		g.Expect(access.CleanupObjectsFromDynamicServiceAccountTokenAccess(ctx, shootClient)).To(Succeed())
-	}).Should(Succeed())
+	It("Clean up objects in shoot from dynamic ServiceAccount token access", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(access.CleanupObjectsFromDynamicServiceAccountTokenAccess(ctx, shootClient)).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 
-	By("Clean up objects in shoot from static ServiceAccount token access")
-	Eventually(func(g Gomega) {
-		g.Expect(access.CleanupObjectsFromStaticServiceAccountTokenAccess(ctx, shootClient)).To(Succeed())
-	}).Should(Succeed())
+	It("Clean up objects in shoot from static ServiceAccount token access", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(access.CleanupObjectsFromStaticServiceAccountTokenAccess(ctx, shootClient)).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
 }

--- a/test/e2e/operation.go
+++ b/test/e2e/operation.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
+// ItShouldEventuallyNotHaveOperationAnnotation checks if the given object does not have the gardener operation annotation set
+func ItShouldEventuallyNotHaveOperationAnnotation(komega komega.Komega, obj client.Object) {
+	GinkgoHelper()
+	It("Should not have operation annotation", func(ctx SpecContext) {
+		Eventually(ctx, komega.Object(obj)).WithPolling(2 * time.Second).Should(
+			HaveField("ObjectMeta.Annotations", Not(HaveKey(v1beta1constants.GardenerOperation))))
+	}, SpecTimeout(time.Minute))
+}

--- a/test/e2e/operator/garden/create_rotate_delete.go
+++ b/test/e2e/operator/garden/create_rotate_delete.go
@@ -89,13 +89,8 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				GetETCDSecretNamespace: func() string {
 					return namespace
 				},
-				ListETCDEncryptionSecretsFunc: func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error) {
-					secretList := &corev1.SecretList{}
-					if err := runtimeClient.List(ctx, secretList, namespace, matchLabels); err != nil {
-						return nil, err
-					}
-
-					return secretList, nil
+				GetRuntimeClient: func() client.Client {
+					return runtimeClient
 				},
 				SecretsManagerLabelSelector: rotation.ManagedByGardenerOperatorSecretsManager,
 				GetETCDEncryptionKeyRotation: func() *gardencorev1beta1.ETCDEncryptionKeyRotation {
@@ -108,9 +103,8 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				GetETCDSecretNamespace: func() string {
 					return namespace
 				},
-				ListETCDEncryptionSecretsFunc: func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error) {
-					secretList := &corev1.SecretList{}
-					return secretList, runtimeClient.List(ctx, secretList, namespace, matchLabels)
+				GetRuntimeClient: func() client.Client {
+					return runtimeClient
 				},
 				SecretsManagerLabelSelector: rotation.ManagedByGardenerOperatorSecretsManager,
 				GetETCDEncryptionKeyRotation: func() *gardencorev1beta1.ETCDEncryptionKeyRotation {
@@ -123,9 +117,8 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				GetServiceAccountKeySecretNamespace: func() string {
 					return namespace
 				},
-				ListServiceAccountKeySecretsFunc: func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error) {
-					secretList := &corev1.SecretList{}
-					return secretList, runtimeClient.List(ctx, secretList, namespace, matchLabels)
+				GetRuntimeClient: func() client.Client {
+					return runtimeClient
 				},
 				SecretsManagerLabelSelector: rotation.ManagedByGardenerOperatorSecretsManager,
 				GetServiceAccountKeyRotation: func() *gardencorev1beta1.ServiceAccountKeyRotation {

--- a/test/e2e/operator/garden/create_rotate_delete.go
+++ b/test/e2e/operator/garden/create_rotate_delete.go
@@ -86,8 +86,17 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				},
 			},
 			&rotationutils.ETCDEncryptionKeyVerifier{
-				RuntimeClient:               runtimeClient,
-				Namespace:                   namespace,
+				GetETCDSecretNamespace: func() string {
+					return namespace
+				},
+				ListETCDEncryptionSecretsFunc: func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error) {
+					secretList := &corev1.SecretList{}
+					if err := runtimeClient.List(ctx, secretList, namespace, matchLabels); err != nil {
+						return nil, err
+					}
+
+					return secretList, nil
+				},
 				SecretsManagerLabelSelector: rotation.ManagedByGardenerOperatorSecretsManager,
 				GetETCDEncryptionKeyRotation: func() *gardencorev1beta1.ETCDEncryptionKeyRotation {
 					return garden.Status.Credentials.Rotation.ETCDEncryptionKey
@@ -96,8 +105,13 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				RoleLabelValue: v1beta1constants.SecretNamePrefixETCDEncryptionConfiguration,
 			},
 			&rotationutils.ETCDEncryptionKeyVerifier{
-				RuntimeClient:               runtimeClient,
-				Namespace:                   namespace,
+				GetETCDSecretNamespace: func() string {
+					return namespace
+				},
+				ListETCDEncryptionSecretsFunc: func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error) {
+					secretList := &corev1.SecretList{}
+					return secretList, runtimeClient.List(ctx, secretList, namespace, matchLabels)
+				},
 				SecretsManagerLabelSelector: rotation.ManagedByGardenerOperatorSecretsManager,
 				GetETCDEncryptionKeyRotation: func() *gardencorev1beta1.ETCDEncryptionKeyRotation {
 					return garden.Status.Credentials.Rotation.ETCDEncryptionKey
@@ -106,8 +120,13 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				RoleLabelValue: v1beta1constants.SecretNamePrefixGardenerETCDEncryptionConfiguration,
 			},
 			&rotationutils.ServiceAccountKeyVerifier{
-				RuntimeClient:               runtimeClient,
-				Namespace:                   namespace,
+				GetServiceAccountKeySecretNamespace: func() string {
+					return namespace
+				},
+				ListServiceAccountKeySecretsFunc: func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error) {
+					secretList := &corev1.SecretList{}
+					return secretList, runtimeClient.List(ctx, secretList, namespace, matchLabels)
+				},
 				SecretsManagerLabelSelector: rotation.ManagedByGardenerOperatorSecretsManager,
 				GetServiceAccountKeyRotation: func() *gardencorev1beta1.ServiceAccountKeyRotation {
 					return garden.Status.Credentials.Rotation.ServiceAccountKey

--- a/test/utils/rotation/etcd_encryption_key.go
+++ b/test/utils/rotation/etcd_encryption_key.go
@@ -26,10 +26,10 @@ import (
 
 // ETCDEncryptionKeyVerifier verifies the etcd encryption key rotation.
 type ETCDEncryptionKeyVerifier struct {
-	SecretsManagerLabelSelector   client.MatchingLabels
-	GetETCDEncryptionKeyRotation  func() *gardencorev1beta1.ETCDEncryptionKeyRotation
-	ListETCDEncryptionSecretsFunc func(ctx context.Context, namespace client.InNamespace, matchLabels client.MatchingLabels) (*corev1.SecretList, error)
-	GetETCDSecretNamespace        func() string
+	SecretsManagerLabelSelector  client.MatchingLabels
+	GetETCDEncryptionKeyRotation func() *gardencorev1beta1.ETCDEncryptionKeyRotation
+	GetRuntimeClient             func() client.Client
+	GetETCDSecretNamespace       func() string
 
 	EncryptionKey  string
 	RoleLabelValue string
@@ -48,10 +48,11 @@ func init() {
 
 // Before is called before the rotation is started.
 func (v *ETCDEncryptionKeyVerifier) Before(ctx context.Context) {
+	runtimeClient := v.GetRuntimeClient()
 	By("Verify old etcd encryption key secret")
 	Eventually(func(g Gomega) {
-		secretList, err := v.ListETCDEncryptionSecretsFunc(ctx, client.InNamespace(v.GetETCDSecretNamespace()), v.SecretsManagerLabelSelector)
-		g.Expect(err).NotTo(HaveOccurred())
+		secretList := &corev1.SecretList{}
+		g.Expect(runtimeClient.List(ctx, secretList, client.InNamespace(v.GetETCDSecretNamespace()), v.SecretsManagerLabelSelector)).To(Succeed())
 
 		grouped := GroupByName(secretList.Items)
 		g.Expect(grouped[v.EncryptionKey]).To(HaveLen(1), "etcd encryption key should get created, but not rotated yet")
@@ -60,8 +61,8 @@ func (v *ETCDEncryptionKeyVerifier) Before(ctx context.Context) {
 
 	By("Verify old etcd encryption config secret")
 	Eventually(func(g Gomega) {
-		secretList, err := v.ListETCDEncryptionSecretsFunc(ctx, client.InNamespace(v.GetETCDSecretNamespace()), client.MatchingLabels{v1beta1constants.LabelRole: v.RoleLabelValue})
-		g.Expect(err).NotTo(HaveOccurred())
+		secretList := &corev1.SecretList{}
+		g.Expect(runtimeClient.List(ctx, secretList, client.InNamespace(v.GetETCDSecretNamespace()), client.MatchingLabels{v1beta1constants.LabelRole: v.RoleLabelValue})).To(Succeed())
 		g.Expect(secretList.Items).NotTo(BeEmpty())
 		sort.Sort(sort.Reverse(AgeSorter(secretList.Items)))
 
@@ -110,10 +111,11 @@ func (v *ETCDEncryptionKeyVerifier) AfterPrepared(ctx context.Context) {
 	Expect(etcdEncryptionKeyRotation.LastInitiationFinishedTime).NotTo(BeNil())
 	Expect(etcdEncryptionKeyRotation.LastInitiationFinishedTime.After(etcdEncryptionKeyRotation.LastInitiationTime.Time)).To(BeTrue())
 
+	runtimeClient := v.GetRuntimeClient()
 	By("Verify etcd encryption key secrets")
 	Eventually(func(g Gomega) {
-		secretList, err := v.ListETCDEncryptionSecretsFunc(ctx, client.InNamespace(v.GetETCDSecretNamespace()), v.SecretsManagerLabelSelector)
-		g.Expect(err).NotTo(HaveOccurred())
+		secretList := &corev1.SecretList{}
+		g.Expect(runtimeClient.List(ctx, secretList, client.InNamespace(v.GetETCDSecretNamespace()))).To(Succeed())
 
 		grouped := GroupByName(secretList.Items)
 		g.Expect(grouped[v.EncryptionKey]).To(HaveLen(2), "etcd encryption key should get rotated")
@@ -123,14 +125,13 @@ func (v *ETCDEncryptionKeyVerifier) AfterPrepared(ctx context.Context) {
 
 	By("Verify combined etcd encryption config secret")
 	Eventually(func(g Gomega) {
-		secretList, err := v.ListETCDEncryptionSecretsFunc(ctx, client.InNamespace(v.GetETCDSecretNamespace()), client.MatchingLabels{v1beta1constants.LabelRole: v.RoleLabelValue})
-		g.Expect(err).NotTo(HaveOccurred())
+		secretList := &corev1.SecretList{}
+		g.Expect(runtimeClient.List(ctx, secretList, client.InNamespace(v.GetETCDSecretNamespace()), client.MatchingLabels{v1beta1constants.LabelRole: v.RoleLabelValue})).To(Succeed())
 		g.Expect(secretList.Items).NotTo(BeEmpty())
 		sort.Sort(sort.Reverse(AgeSorter(secretList.Items)))
 
 		encryptionConfiguration := &apiserverconfigv1.EncryptionConfiguration{}
-		err = runtime.DecodeInto(decoder, secretList.Items[0].Data["encryption-configuration.yaml"], encryptionConfiguration)
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(runtime.DecodeInto(decoder, secretList.Items[0].Data["encryption-configuration.yaml"], encryptionConfiguration)).To(Succeed())
 
 		g.Expect(encryptionConfiguration.Resources).To(HaveLen(1))
 		g.Expect(encryptionConfiguration.Resources[0].Providers).To(DeepEqual([]apiserverconfigv1.ProviderConfiguration{
@@ -171,11 +172,11 @@ func (v *ETCDEncryptionKeyVerifier) AfterCompleted(ctx context.Context) {
 	Expect(etcdEncryptionKeyRotation.LastInitiationFinishedTime).To(BeNil())
 	Expect(etcdEncryptionKeyRotation.LastCompletionTriggeredTime).To(BeNil())
 
+	runtimeClient := v.GetRuntimeClient()
 	By("Verify new etcd encryption key secret")
 	Eventually(func(g Gomega) {
-		secretList, err := v.ListETCDEncryptionSecretsFunc(ctx, client.InNamespace(v.GetETCDSecretNamespace()), v.SecretsManagerLabelSelector)
-		g.Expect(err).NotTo(HaveOccurred())
-
+		secretList := &corev1.SecretList{}
+		Expect(runtimeClient.List(ctx, secretList, client.InNamespace(v.GetETCDSecretNamespace()), v.SecretsManagerLabelSelector)).To(Succeed())
 		grouped := GroupByName(secretList.Items)
 		g.Expect(grouped[v.EncryptionKey]).To(HaveLen(1), "old etcd encryption key should get cleaned up")
 		g.Expect(grouped[v.EncryptionKey]).To(ContainElement(v.secretsPrepared[v.EncryptionKey][1]), "new etcd encryption key secret should be kept")
@@ -183,14 +184,13 @@ func (v *ETCDEncryptionKeyVerifier) AfterCompleted(ctx context.Context) {
 
 	By("Verify new etcd encryption config secret")
 	Eventually(func(g Gomega) {
-		secretList, err := v.ListETCDEncryptionSecretsFunc(ctx, client.InNamespace(v.GetETCDSecretNamespace()), client.MatchingLabels{v1beta1constants.LabelRole: v.RoleLabelValue})
-		g.Expect(err).NotTo(HaveOccurred())
+		secretList := &corev1.SecretList{}
+		g.Expect(runtimeClient.List(ctx, secretList, client.InNamespace(v.GetETCDSecretNamespace()), client.MatchingLabels{v1beta1constants.LabelRole: v.RoleLabelValue})).To(Succeed())
 		g.Expect(secretList.Items).NotTo(BeEmpty())
 		sort.Sort(sort.Reverse(AgeSorter(secretList.Items)))
 
 		encryptionConfiguration := &apiserverconfigv1.EncryptionConfiguration{}
-		err = runtime.DecodeInto(decoder, secretList.Items[0].Data["encryption-configuration.yaml"], encryptionConfiguration)
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(runtime.DecodeInto(decoder, secretList.Items[0].Data["encryption-configuration.yaml"], encryptionConfiguration)).To(Succeed())
 
 		g.Expect(encryptionConfiguration.Resources).To(HaveLen(1))
 		g.Expect(encryptionConfiguration.Resources[0].Providers).To(DeepEqual([]apiserverconfigv1.ProviderConfiguration{

--- a/test/utils/rotation/verifier.go
+++ b/test/utils/rotation/verifier.go
@@ -32,7 +32,7 @@ type Verifier interface {
 type Verifiers []Verifier
 
 var _ Verifier = Verifiers{}
-var _ cleanupVerifier = Verifiers{}
+var _ CleanupVerifier = Verifiers{}
 
 // Before is called before the rotation is started.
 func (v Verifiers) Before(ctx context.Context) {
@@ -83,8 +83,8 @@ func (v Verifiers) AfterCompleted(ctx context.Context) {
 	}
 }
 
-// cleanupVerifier can be implemented optionally to run cleanup code.
-type cleanupVerifier interface {
+// CleanupVerifier can be implemented optionally to run cleanup code.
+type CleanupVerifier interface {
 	// Cleanup is passed to ginkgo.DeferCleanup.
 	Cleanup(ctx context.Context)
 }
@@ -92,7 +92,7 @@ type cleanupVerifier interface {
 // Cleanup is passed to ginkgo.DeferCleanup.
 func (v Verifiers) Cleanup(ctx context.Context) {
 	for _, vv := range v {
-		if cleanup, ok := vv.(cleanupVerifier); ok {
+		if cleanup, ok := vv.(CleanupVerifier); ok {
 			cleanup.Cleanup(ctx)
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the mentioned test to the ordered containers approach.
See https://github.com/gardener/gardener/issues/11379

It also refactors some of the credential rotation verifiers to separate "It" statements.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
