### PR TITLE
chore: Restrict Renovate kindest/node updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -305,11 +305,11 @@
       matchDatasources: [
         'docker',
       ],
-      matchUpdateTypes: [
-        'major',
-        'minor',
-        'patch', // TODO(marc1404): Remove this line once kindest/node ships with runc >= v1.2.4 and containerd >= v2.0.3
-      ],
+      // TODO(marc1404): Enable the code below once kindest/node ships with runc >= v1.2.4 and containerd >= v2.0.3
+//      matchUpdateTypes: [
+//        'major',
+//        'minor',
+//      ],
       dependencyDashboardApproval: true,
       matchPackageNames: [
         '/kindest/node/',


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

We would like to restrict Renovate updates of `kindest/node` until there are stable versions that we can use again (no `runc` and `containerd` issues).

In the meantime, PRs such as the one below should not be opened automatically:
https://github.com/gardener/gardener/pull/11563

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
