### PR TITLE
Start using shared renovate config presets

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   extends: [
     'config:recommended',
     ':semanticCommitsDisabled',
+    'github>gardener/ci-infra//config/renovate/makefile-versions.json5',
   ],
   labels: [
     'kind/enhancement',
@@ -13,19 +14,6 @@
   // Add PR footer with empty release note by default.
   prFooter: '**Release note**:\n```other dependency\nNONE\n```',
   customManagers: [
-    {
-      // Update `_VERSION` and `_version` variables in Makefiles and scripts.
-      // Inspired by `regexManagers:dockerfileVersions` preset.
-      customType: 'regex',
-      fileMatch: [
-        'Makefile$',
-        '\\.mk$',
-        '\\.sh$',
-      ],
-      matchStrings: [
-        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_(VERSION|version) *[?:]?= *"?(?<currentValue>.+?)"?\\s',
-      ],
-    },
     {
       // Generic detection for pod-like image specifications.
       customType: 'regex',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     'config:recommended',
     ':semanticCommitsDisabled',
     'github>gardener/ci-infra//config/renovate/makefile-versions.json5',
+    'github>gardener/ci-infra//config/renovate/imagevector.json5(^imagevector/containers.yaml$)',
   ],
   labels: [
     'kind/enhancement',
@@ -50,28 +51,6 @@
         '--image[=| ]["|\']?(?<depName>.*?):(?<currentValue>.*?)["|\']?\\s',
       ],
       datasourceTemplate: 'docker',
-    },
-    {
-      // Generic detection of container images in containers.yaml via container registry.
-      customType: 'regex',
-      fileMatch: [
-        '^imagevector/containers.yaml$',
-      ],
-      matchStrings: [
-        '\\s+repository:\\s+(?<depName>.*?)\\n\\s+tag:\\s+["]?(?<currentValue>.*?)["]?\\n',
-      ],
-      datasourceTemplate: 'docker',
-    },
-    {
-      // Generic detection of container images in containers.yaml via github releases.
-      customType: 'regex',
-      fileMatch: [
-        '^imagevector/containers.yaml$',
-      ],
-      matchStrings: [
-        '\\s+sourceRepository:\\s+github.com/(?<depName>.*?)\\n\\s+repository:\\s+.*\\n\\s+tag:\\s+["]?(?<currentValue>.*?)["]?\\n',
-      ],
-      datasourceTemplate: 'github-releases',
     },
     {
       // Detection for images with prow like tags (e.g. v20240213-749005b2).

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    ':semanticCommitsDisabled',
   ],
   labels: [
     'kind/enhancement',


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Start using shared renovate config presets from https://github.com/gardener/ci-infra/tree/master/config/renovate.

Also, this repository doesn't use or require semantic commits, so disable them in renovate as well to reduce confusion and shorten the PR titles.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
