### PR TITLE
Automerge patch and `k8s.io/utils` updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,7 @@
     ':semanticCommitsDisabled',
     'github>gardener/ci-infra//config/renovate/makefile-versions.json5',
     'github>gardener/ci-infra//config/renovate/imagevector.json5(^imagevector/containers.yaml$)',
+    'github>gardener/ci-infra//config/renovate/automerge-with-tide.json5',
   ],
   labels: [
     'kind/enhancement',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,18 @@
   separateMinorPatch: true,
   packageRules: [
     {
+      // automerge patch updates
+      matchUpdateTypes: ['patch'],
+      automerge: true,
+    },
+    {
+      // automerge k8s.io/utils updates
+      matchDatasources: ['go'],
+      matchPackageNames: ['k8s.io/utils'],
+      matchUpdateTypes: ['digest'],
+      automerge: true,
+    },
+    {
       // Run make generate when Go API packages have been changed because CRDs might have changed.
       matchDatasources: [
         'go',


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR configures automerging for some no-brainer dependency updates: patch updates and `k8s.io/utils` updates.
There's nothing to actually review in such PRs and we usually just merge them as long as tests are passing. So, let's instruct the bots to do so themselves without our interaction 🤖 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Based on https://github.com/gardener/gardener/pull/11565 but in a dedicated PR because it might be controversial and I want to get explicit feedback on this aspect.

- [x] rebase once https://github.com/gardener/gardener/pull/11565 has been merged

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
