### PR TITLE
chore: Disable undesired Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -425,6 +425,34 @@
       ],
     },
     {
+      // TODO(marc1404): Remove when the NewVPN feature gate is removed.
+      // Ignore dependency updates of gardener/vpn2@0.26.0 which is used when the NewVPN feature gate is disabled.
+      matchFileNames: [
+        'imagevector/containers.yaml',
+      ],
+      matchPackageNames: [
+        'gardener/vpn2',
+      ],
+      matchCurrentVersion: [
+        '0.26.0'
+      ],
+      enabled: false
+    },
+    {
+      // TODO(marc1404): Remove when support for Kubernetes v1.27 is dropped.
+      // Ignore dependency updates of ingress-nginx/controller-chroot@v1.11.4 for Kubernetes v1.27.
+      matchFileNames: [
+        'imagevector/containers.yaml',
+      ],
+      matchPackageNames: [
+        'registry.k8s.io/ingress-nginx/controller-chroot',
+      ],
+      matchCurrentVersion: [
+        'v1.11.4'
+      ],
+      enabled: false
+    },
+    {
       // Ignore paths which most likely create false positives.
       matchFileNames: [
         'cmd/**',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -434,9 +434,9 @@
         'gardener/vpn2',
       ],
       matchCurrentVersion: [
-        '0.26.0'
+        '0.26.0',
       ],
-      enabled: false
+      enabled: false,
     },
     {
       // TODO(marc1404): Remove when support for Kubernetes v1.27 is dropped.
@@ -448,9 +448,9 @@
         'registry.k8s.io/ingress-nginx/controller-chroot',
       ],
       matchCurrentVersion: [
-        'v1.11.4'
+        'v1.11.4',
       ],
-      enabled: false
+      enabled: false,
     },
     {
       // Ignore paths which most likely create false positives.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -446,7 +446,7 @@
         'registry.k8s.io/ingress-nginx/controller-chroot'
       ],
       matchCurrentValue: 'v1.11.*',
-      allowedVersions: "<v1.12.0"
+      allowedVersions: '<v1.12.0',
     },
     {
       // Ignore paths which most likely create false positives.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -433,24 +433,20 @@
       matchPackageNames: [
         'gardener/vpn2',
       ],
-      matchCurrentVersion: [
-        '0.26.0',
-      ],
+      matchCurrentVersion: '0.26.0',
       enabled: false,
     },
     {
       // TODO(marc1404): Remove when support for Kubernetes v1.27 is dropped.
-      // Ignore dependency updates of ingress-nginx/controller-chroot@v1.11.4 for Kubernetes v1.27.
+      // Restrict updates of ingress-nginx/controller-chroot@v1.11.x for Kubernetes v1.27 to stay below v1.12.0.
       matchFileNames: [
-        'imagevector/containers.yaml',
+        'imagevector/containers.yaml'
       ],
       matchPackageNames: [
-        'registry.k8s.io/ingress-nginx/controller-chroot',
+        'registry.k8s.io/ingress-nginx/controller-chroot'
       ],
-      matchCurrentVersion: [
-        'v1.11.4',
-      ],
-      enabled: false,
+      matchCurrentValue: 'v1.11.*',
+      allowedVersions: "<v1.12.0"
     },
     {
       // Ignore paths which most likely create false positives.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR disables Renovate updates in [`imagevector/containers.yaml`](https://github.com/gardener/gardener/blob/master/imagevector/containers.yaml) for:
* `gardener/vpn2@0.26.0`
* `ingress-nginx/chroot-controller@v1.11.4`

These entries are pinned on purpose to a specific old version.
In the case of `vpn2` it's for the off state of the `NewVPN` feature gate.
For the nginx ingress controller, it's used for Kubernetes `v1.27`.

This configuration change would avoid the need for closing PRs such as these:
* https://github.com/gardener/gardener/pull/11568
* https://github.com/gardener/gardener/pull/11569

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @ScheererJ @shafeeqes @dimityrmirchev @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
