### PR TITLE
Fix `Gardenlet` Reconciliation

### DIFF
--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -55,7 +55,6 @@ type Interface interface {
 // Actuator is a concrete implementation of Interface.
 type Actuator struct {
 	GardenConfig            *rest.Config
-	GardenAPIReader         client.Reader
 	GardenClient            client.Client
 	GetTargetClientFunc     func(ctx context.Context) (kubernetes.Interface, error)
 	CheckIfVPAAlreadyExists func(ctx context.Context) (bool, error)

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -53,7 +53,6 @@ var _ = Describe("Interface", func() {
 		ctrl *gomock.Controller
 
 		gardenClient      *mockclient.MockClient
-		gardenAPIReader   *mockclient.MockReader
 		seedClient        *mockclient.MockClient
 		shootClientSet    *kubernetesmock.MockInterface
 		vh                *mockgardenletdepoyer.MockValuesHelper
@@ -87,7 +86,6 @@ var _ = Describe("Interface", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		gardenClient = mockclient.NewMockClient(ctrl)
-		gardenAPIReader = mockclient.NewMockReader(ctrl)
 		seedClient = mockclient.NewMockClient(ctrl)
 		shootClient = mockclient.NewMockClient(ctrl)
 		shootClientSet = kubernetesmock.NewMockInterface(ctrl)
@@ -100,9 +98,8 @@ var _ = Describe("Interface", func() {
 
 		log = logr.Discard()
 		actuator = &Actuator{
-			GardenConfig:    &rest.Config{},
-			GardenAPIReader: gardenAPIReader,
-			GardenClient:    gardenClient,
+			GardenConfig: &rest.Config{},
+			GardenClient: gardenClient,
 			GetTargetClientFunc: func(_ context.Context) (kubernetes.Interface, error) {
 				return shootClientSet, nil
 			},

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -91,9 +91,8 @@ func (r *Reconciler) newActuator(shoot *gardencorev1beta1.Shoot) gardenletdeploy
 	}
 
 	return &gardenletdeployer.Actuator{
-		GardenConfig:    r.GardenConfig,
-		GardenAPIReader: r.GardenAPIReader,
-		GardenClient:    r.GardenClient,
+		GardenConfig: r.GardenConfig,
+		GardenClient: r.GardenClient,
 		GetTargetClientFunc: func(ctx context.Context) (kubernetes.Interface, error) {
 			return r.ShootClientMap.GetClient(ctx, keys.ForShoot(shoot))
 		},

--- a/pkg/operator/controller/gardenlet/add.go
+++ b/pkg/operator/controller/gardenlet/add.go
@@ -35,14 +35,8 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, virt
 	if r.RuntimeCluster == nil {
 		r.RuntimeCluster = mgr
 	}
-	if r.RuntimeClient == nil {
-		r.RuntimeClient = mgr.GetClient()
-	}
 	if r.VirtualConfig == nil {
 		r.VirtualConfig = virtualCluster.GetConfig()
-	}
-	if r.VirtualAPIReader == nil {
-		r.VirtualAPIReader = virtualCluster.GetAPIReader()
 	}
 	if r.VirtualClient == nil {
 		r.VirtualClient = virtualCluster.GetClient()

--- a/pkg/operator/controller/gardenlet/reconciler.go
+++ b/pkg/operator/controller/gardenlet/reconciler.go
@@ -89,7 +89,7 @@ func (r *Reconciler) newActuator(gardenlet *seedmanagementv1alpha1.Gardenlet) ga
 			}
 			return kubernetes.NewClientFromSecret(
 				ctx,
-				r.RuntimeClient,
+				r.VirtualClient,
 				gardenlet.Namespace,
 				gardenlet.Spec.KubeconfigSecretRef.Name,
 				kubernetes.WithDisabledCachedClient(),

--- a/pkg/operator/controller/gardenlet/reconciler.go
+++ b/pkg/operator/controller/gardenlet/reconciler.go
@@ -40,9 +40,7 @@ var RequeueDurationSeedIsNotYetRegistered = 30 * time.Second
 // Reconciler reconciles the Gardenlet.
 type Reconciler struct {
 	RuntimeCluster        cluster.Cluster
-	RuntimeClient         client.Client
 	VirtualConfig         *rest.Config
-	VirtualAPIReader      client.Reader
 	VirtualClient         client.Client
 	Config                operatorconfigv1alpha1.GardenletDeployerControllerConfig
 	Clock                 clock.Clock
@@ -74,9 +72,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) newActuator(gardenlet *seedmanagementv1alpha1.Gardenlet) gardenletdeployer.Interface {
 	return &gardenletdeployer.Actuator{
-		GardenConfig:    r.VirtualConfig,
-		GardenAPIReader: r.VirtualAPIReader,
-		GardenClient:    r.VirtualClient,
+		GardenConfig: r.VirtualConfig,
+		GardenClient: r.VirtualClient,
 		GetTargetClientFunc: func(ctx context.Context) (kubernetes.Interface, error) {
 			if gardenlet.Spec.KubeconfigSecretRef == nil {
 				return kubernetes.NewWithConfig(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
This PR fixes a deployment issue when `Gardenlet` refers to a remote cluster (`spec.kubeconfigSecretRef` defined).

**Which issue(s) this PR fixes**:
Fixes #11530

**Special notes for your reviewer**:
Thanks @matthias-horne for reporting the issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue was fixed that caused a deployment error when a `Gardenlet` resource referred to a remote cluster (`spec.kubeconfigSecretRef` defined).
```
