### PR TITLE
🧹 Cleanup Integration Tests

### DIFF
--- a/test/integration/gardenlet/seed/care/care_test.go
+++ b/test/integration/gardenlet/seed/care/care_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -55,7 +54,6 @@ var _ = Describe("Seed Care controller tests", func() {
 			Controller: controllerconfig.Controller{
 				SkipNameValidation: ptr.To(true),
 			},
-			MapperProvider: apiutil.NewDynamicRESTMapper,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		mgrClient = mgr.GetClient()

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -19,11 +19,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -81,16 +79,10 @@ var _ = Describe("Seed controller tests", func() {
 		})
 
 		By("Setup manager")
-		httpClient, err := rest.HTTPClientFor(restConfig)
-		Expect(err).NotTo(HaveOccurred())
-		mapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
-		Expect(err).NotTo(HaveOccurred())
-
 		mgr, err := manager.New(restConfig, manager.Options{
 			Scheme:  testScheme,
 			Metrics: metricsserver.Options{BindAddress: "0"},
 			Cache: cache.Options{
-				Mapper: mapper,
 				ByObject: map[client.Object]cache.ByObject{
 					&gardencorev1beta1.Seed{}: {
 						Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),

--- a/test/integration/operator/controllerregistrar/controllerregistrar_suite_test.go
+++ b/test/integration/operator/controllerregistrar/controllerregistrar_suite_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -99,16 +98,10 @@ var _ = BeforeSuite(func() {
 	})
 
 	By("Setup manager")
-	httpClient, err := rest.HTTPClientFor(restConfig)
-	Expect(err).NotTo(HaveOccurred())
-	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
-	Expect(err).NotTo(HaveOccurred())
-
 	mgr, err = manager.New(restConfig, manager.Options{
 		Scheme:  operatorclient.RuntimeScheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
 		Cache: cache.Options{
-			Mapper: mapper,
 			ByObject: map[client.Object]cache.ByObject{
 				&operatorv1alpha1.Garden{}: {
 					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),

--- a/test/integration/operator/garden/care/care_suite_test.go
+++ b/test/integration/operator/garden/care/care_suite_test.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -120,16 +119,10 @@ var _ = BeforeSuite(func() {
 	})
 
 	By("Setup manager")
-	httpClient, err := rest.HTTPClientFor(restConfig)
-	Expect(err).NotTo(HaveOccurred())
-	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
-	Expect(err).NotTo(HaveOccurred())
-
 	mgr, err := manager.New(restConfig, manager.Options{
 		Scheme:  operatorclient.RuntimeScheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
 		Cache: cache.Options{
-			Mapper: mapper,
 			ByObject: map[client.Object]cache.ByObject{
 				&operatorv1alpha1.Garden{}: {
 					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -22,13 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/client-go/rest"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -126,16 +124,10 @@ var _ = Describe("Garden controller tests", func() {
 		})
 
 		By("Setup manager")
-		httpClient, err := rest.HTTPClientFor(restConfig)
-		Expect(err).NotTo(HaveOccurred())
-		mapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
-		Expect(err).NotTo(HaveOccurred())
-
 		mgr, err := manager.New(restConfig, manager.Options{
 			Scheme:  scheme,
 			Metrics: metricsserver.Options{BindAddress: "0"},
 			Cache: cache.Options{
-				Mapper: mapper,
 				ByObject: map[client.Object]cache.ByObject{
 					&operatorv1alpha1.Garden{}: {
 						Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),

--- a/test/integration/resourcemanager/health/health_suite_test.go
+++ b/test/integration/resourcemanager/health/health_suite_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -109,7 +108,6 @@ var _ = BeforeSuite(func() {
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{testNamespace.Name: {}},
 		},
-		MapperProvider: apiutil.NewDynamicRESTMapper,
 		Controller: controllerconfig.Controller{
 			SkipNameValidation: ptr.To(true),
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
Cleanup integration tests by removing the explicit `RESTMapper` configuration. A `DynamicRESTMapper` is the standard mapper in Controller-Runtime ([ref1](https://github.com/kubernetes-sigs/controller-runtime/blob/6eb011f4f89e47364617b6d9f0af1e682c8adbf2/pkg/cluster/cluster.go#L266), [ref2](https://github.com/kubernetes-sigs/controller-runtime/blob/6eb011f4f89e47364617b6d9f0af1e682c8adbf2/pkg/cluster/cluster.go#L168)).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
