### PR TITLE
Fixes restoration of multi-node etcds during control plane migration of HA `Shoot`s

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -293,7 +293,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilEtcdReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd report readiness",
 			Fn:           botanist.WaitUntilEtcdsReady,
-			SkipIf:       !isRestoringHAControlPlane && o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       (!isRestoringHAControlPlane && o.Shoot.HibernationEnabled) || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -103,6 +103,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		kubeProxyEnabled               = v1beta1helper.KubeProxyEnabled(o.Shoot.GetInfo().Spec.Kubernetes.KubeProxy)
 		deployKubeAPIServerTaskTimeout = defaultTimeout
 		shootSSHAccessEnabled          = v1beta1helper.ShootEnablesSSHAccess(o.Shoot.GetInfo())
+		isRestoringHAControlPlane      = botanist.IsRestorePhase() && v1beta1helper.IsHAControlPlaneConfigured(o.Shoot.GetInfo())
 	)
 
 	// During the 'Preparing' phase of different rotation operations, components are deployed twice. Also, the
@@ -292,7 +293,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilEtcdReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd report readiness",
 			Fn:           botanist.WaitUntilEtcdsReady,
-			SkipIf:       o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       !isRestoringHAControlPlane && o.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
@@ -334,13 +335,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		scaleEtcdAfterRestore = g.Add(flow.Task{
 			Name:         "Scaling main and events etcd after kube-apiserver is ready",
 			Fn:           flow.TaskFn(botanist.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
-			SkipIf:       !v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo()) || !botanist.IsRestorePhase() || o.Shoot.HibernationEnabled || skipReadiness,
-			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
+			SkipIf:       !isRestoringHAControlPlane,
+			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady, waitUntilKubeAPIServerIsReady),
 		})
-		_ = g.Add(flow.Task{
+		waitUntilEtcdScaledAfterRestore = g.Add(flow.Task{
 			Name:         "Waiting until main and events etcd scaled up after kube-apiserver is ready",
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsReady),
-			SkipIf:       !v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo()) || !botanist.IsRestorePhase() || o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       !isRestoringHAControlPlane || skipReadiness,
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{
@@ -897,7 +898,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Name:         "Hibernating control plane",
 			Fn:           flow.TaskFn(botanist.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			SkipIf:       !o.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(initializeShootClients, deployPrometheus, deployAlertmanager, deploySeedLogging, deployClusterAutoscaler, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady),
+			Dependencies: flow.NewTaskIDs(initializeShootClients, deployPrometheus, deployAlertmanager, deploySeedLogging, deployClusterAutoscaler, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady, waitUntilEtcdScaledAfterRestore),
 		})
 
 		// logic is inverted here


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/7626 support for migrating hibernated shoots with HA control planes was added. The special handling is necessary because to restore a clustered etcd the following steps have to be done:
1. Scale etcd from 0 to 1 replica to restore from backup
2. Scale etcd from 1 to 3 replicas to restore the etcd cluster
3. Scale etcd from 3 replicas back to 0 in https://github.com/gardener/gardener/blob/0f728f88f1fe3fe623437bfc545f0c221ee62387/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go#L896-L901
4. Future scaling from 0 to 3 replicas (e.g. when cluster is woken up or deleted) work as expected

However, with https://github.com/gardener/gardener/pull/9462 the flow was changed slightly to speed up control plane migration by only scaling etcd to 3 replicas after the kube-apiserver is deployed. This scale-up was only done for non hibernated clusters. For control plane migration of hibernated clusters the flow was ended up like this:
1. Scale etcd from 0 to 1 replica to restore from backup
2. Scale etcd from 1 to 0 replicas in https://github.com/gardener/gardener/blob/0f728f88f1fe3fe623437bfc545f0c221ee62387/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go#L896-L901
3. Future scaling from 0 to 3 replicas (e.g. when cluster is woken up or deleted) do not work as the etcd cluster was never restored and scale from 0 is not supported.

This PR modifies the restoration flow to ensure that steps occur in the same order as from https://github.com/gardener/gardener/pull/7626:
1. Scale etcd from 0 to 1 replica to restore from backup
2. Scale etcd from 1 to 3 replicas to restore the etcd cluster
3. Scale etcd from 3 replicas back to 0

This should also fix the flakiness of the `e2e-kind-migration-ha-single-zone` e2e test.

**Which issue(s) this PR fixes**:
Fixes #11525

**Special notes for your reviewer**:
Cheers to @rfranzke @LucaBernstein @shreyas-s-rao @unmarshall @ishan16696 for discovering and investigating this bug as part of the effort to deflake our e2e tests.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug that caused multi-node etcd clusters to not be properly restored when performing control plane migration for hibernated HA `Shoot`s.
```
