### PR TITLE
Fix `apiserver-proxy` connectivity when using feature gates `IstioTLSTermination` and `RemoveAPIServerProxyLegacyPort`

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -190,11 +190,19 @@ func (s *sni) Deploy(ctx context.Context) error {
 
 	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
-	if values.APIServerProxy != nil {
+	if values.APIServerProxy != nil || values.IstioTLSTermination {
 		envoyFilter := s.emptyEnvoyFilterAPIServerProxy()
-		apiServerClusterIPPrefixLen, err := netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
-		if err != nil {
-			return err
+
+		var (
+			apiServerClusterIPPrefixLen int
+			err                         error
+		)
+
+		if values.APIServerProxy != nil {
+			apiServerClusterIPPrefixLen, err = netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
+			if err != nil {
+				return err
+			}
 		}
 		targetClusterProxyProtocol := fmt.Sprintf("outbound|%d||%s", kubeapiserverconstants.Port, hostName)
 		if values.IstioTLSTermination {

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -11,6 +11,7 @@ spec:
       {{ $k }}: {{ $v }}
 {{- end }}
   configPatches:
+  {{- if .APIServerProxy }}
   - applyTo: FILTER_CHAIN
     match:
       context: ANY
@@ -41,6 +42,7 @@ spec:
           prefix_ranges:
           - address_prefix: {{ .APIServerClusterIP }}
             prefix_len: {{ .APIServerClusterIPPrefixLen }}
+  {{- end }}
   {{- if .IstioTLSTermination }}
   - applyTo: LISTENER
     match:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with the apiserver-proxy when running with the feature gates "IstioTLSTermination" and "RemoveAPIServerProxyLegacyPort" enabled.

The feature gate "IstioTLSTermination" introduced a new patch to the `${SHOOT_TECHNICAL_ID}-apiserver-proxy` EnvoyFilter, which is needed for the apiserver-proxy component to connect to the shoot control plane.
With the feature gate enabled, the apiserver-proxy `Reversed-VPN` header is also changed from `outbound|443||kube-apiserver.${SHOOT_TECHNICAL_ID}.svc.cluster.local` (envoy cluster format) to `${SHOOT_TECHNICAL_ID}--kube-apiserver-socket`

When we first implemented the "RemoveAPIServerProxyLegacyPort" feature gate, the EnvoyFilter `${SHOOT_TECHNICAL_ID}-apiserver-proxy` was only used for the proxy-protocol requests from the "apiserver-proxy" component.
Because of this, we destroyed the EnvoyFilter with the feature gate enabled as it would be unused.

With both feature gates enabled, we want to keep the `${SHOOT_TECHNICAL_ID}-apiserver-proxy` EnvoyFilter, as we need it to authenticate requests sent by the apiserver-proxy component, but remove the unused `FILTER_CHAIN` on port 8443 (old apiserver-proxy proxy protocol port).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:
No release note as the L7 load balancing was not yet released.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
