### PR TITLE
e2e: Refactor `Create Delete Garden` test to ordered containers

### DIFF
--- a/test/e2e/gardener/context.go
+++ b/test/e2e/gardener/context.go
@@ -10,12 +10,17 @@ import (
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
 )
@@ -56,8 +61,13 @@ func NewTestContext() *TestContext {
 		Log: logger.MustNewZapLogger(logger.DebugLevel, logger.FormatText, logzap.WriteTo(GinkgoWriter)),
 	}
 
+	gardenScheme := kubernetes.GardenScheme
+	utilruntime.Must(operatorv1alpha1.AddToScheme(gardenScheme))
+	utilruntime.Must(resourcesv1alpha1.AddToScheme(gardenScheme))
+	utilruntime.Must(apiextensionsscheme.AddToScheme(gardenScheme))
+
 	gardenClientSet, err := kubernetes.NewClientFromFile("", os.Getenv("KUBECONFIG"),
-		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
+		kubernetes.WithClientOptions(client.Options{Scheme: gardenScheme}),
 		kubernetes.WithClientConnectionOptions(componentbaseconfigv1alpha1.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
 		kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
 		kubernetes.WithDisabledCachedClient(),
@@ -136,5 +146,53 @@ func (s *ShootContext) WithSeedClientSet(clientSet kubernetes.Interface) *ShootC
 	s.SeedClientSet = clientSet
 	s.SeedClient = clientSet.Client()
 	s.SeedKomega = komega.New(s.SeedClient)
+	return s
+}
+
+// GardenContext is a test case-specific TestContext that carries test state and helpers through multiple steps of the
+// same test case, i.e., within the same ordered container.
+// Accordingly, GardenContext values must not be reused across multiple test cases (ordered containers). Make sure to
+// declare GardenContext variables within the ordered container and initialize them during ginkgo tree construction,
+// e.g., in a BeforeTestSetup node or when invoking a shared `test` func.
+//
+// A GardenContext can be initialized using TestContext.ForGarden.
+type GardenContext struct {
+	TestContext
+
+	// Garden object the test is working with
+	Garden *operatorv1alpha1.Garden
+
+	// BackupSecret contains the backup secret the test is working with
+	BackupSecret *corev1.Secret
+
+	// VirtualClusterClientSet is a client for the virtual cluster. It must be initialized via WithVirtualClusterClientSet.
+	VirtualClusterClientSet kubernetes.Interface
+	// VirtualClusterClient is the controller-runtime client of the VirtualClusterClientSet. This is a more convenient equivalent of
+	// VirtualClusterClientSet.Client().
+	VirtualClusterClient client.Client
+	// VirtualClusterKomega is a Komega instance for writing assertions on objects in the virtual cluster. E.g.,
+	//  Eventually(ctx, s.VirtualClusterKomega.ObjectList(&corev1.NodeList{})).Should(
+	//    HaveField("Items", HaveLen(1)),
+	//  )
+	VirtualClusterKomega komega.Komega
+}
+
+// ForGarden copies the receiver TestContext for deriving a GardenContext.
+func (t *TestContext) ForGarden(garden *operatorv1alpha1.Garden, backupSecret *corev1.Secret) *GardenContext {
+	s := &GardenContext{
+		TestContext:  *t,
+		Garden:       garden,
+		BackupSecret: backupSecret,
+	}
+	s.Log = s.Log.WithValues("garden", client.ObjectKeyFromObject(garden))
+
+	return s
+}
+
+// WithVirtualClusterClientSet initializes the virtual cluster clients of this GardenContext from the given client set.
+func (s *GardenContext) WithVirtualClusterClientSet(clientSet kubernetes.Interface) *GardenContext {
+	s.VirtualClusterClientSet = clientSet
+	s.VirtualClusterClient = clientSet.Client()
+	s.VirtualClusterKomega = komega.New(s.VirtualClusterClient)
 	return s
 }

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -31,91 +31,86 @@ import (
 )
 
 var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
-	Describe("Create, Delete Garden", Label("simple"), func() {
-		test := func(s *GardenContext) {
-			ItShouldCreateGarden(s)
-			ItShouldWaitForGardenToBeReconciledAndHealthy(s)
-			ItShouldVerifyGardenManagedResourcesAndAwaitHealthiness(s)
-			ItShouldVerifyIstioManagedResourcesAndAwaitHealthiness(s)
-			ItShouldInitializeVirtualClusterClient(s)
-
-			It("Verify Gardener APIs availability", func(ctx SpecContext) {
-				Eventually(ctx, s.VirtualClusterKomega.List(&gardencorev1beta1.ShootList{})).Should(Succeed())
-				Eventually(ctx, s.VirtualClusterKomega.List(&seedmanagementv1alpha1.ManagedSeedList{})).Should(Succeed())
-				Eventually(ctx, s.VirtualClusterKomega.List(&settingsv1alpha1.ClusterOpenIDConnectPresetList{})).Should(Succeed())
-				Eventually(ctx, s.VirtualClusterKomega.List(&operationsv1alpha1.BastionList{})).Should(Succeed())
-			}, SpecTimeout(time.Minute))
-
-			It("Verify virtual cluster extension installations", func(ctx SpecContext) {
-				controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
-				Eventually(ctx, s.VirtualClusterKomega.List(controllerRegistrationList)).Should(Succeed())
-				Expect(controllerRegistrationList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})))
-
-				controllerDeploymentList := &gardencorev1.ControllerDeploymentList{}
-				Eventually(ctx, s.VirtualClusterKomega.List(controllerDeploymentList)).Should(Succeed())
-				Expect(controllerDeploymentList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})))
-			}, SpecTimeout(time.Minute))
-
-			It("Verify 'gardener-system-public' namespace and 'gardener-info' configmap exist", func(ctx SpecContext) {
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: gardencorev1beta1.GardenerSystemPublicNamespace,
-					},
-				}
-				Eventually(ctx, s.VirtualClusterKomega.Get(namespace)).Should(Succeed())
-
-				configMap := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "gardener-info",
-						Namespace: gardencorev1beta1.GardenerSystemPublicNamespace,
-					},
-				}
-				Eventually(ctx, s.VirtualClusterKomega.Get(configMap)).Should(Succeed())
-				Expect(configMap.Data).To(HaveKey("gardenerAPIServer"))
-			}, SpecTimeout(time.Minute))
-
-			ItShouldDeleteGarden(s)
-			ItShouldWaitForGardenToBeDeleted(s)
-			ItShouldCleanUp(s)
-
-			It("Verify no leftover secrets", func(ctx SpecContext) {
-				secretList := &corev1.SecretList{}
-				Eventually(ctx, s.GardenKomega.List(secretList, client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{
-					secretsmanager.LabelKeyManagedBy:       secretsmanager.LabelValueSecretsManager,
-					secretsmanager.LabelKeyManagerIdentity: operatorv1alpha1.SecretManagerIdentityOperator,
-				})).Should(Succeed())
-
-				Expect(secretList.Items).To(BeEmpty())
-			}, SpecTimeout(time.Minute))
-
-			It("Verify CRD still present", func(ctx SpecContext) {
-				crdList := &apiextensionsv1.CustomResourceDefinitionList{}
-				Eventually(ctx, s.GardenKomega.List(crdList)).Should(Succeed())
-				Expect(crdList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardens.operator.gardener.cloud")})})))
-			}, SpecTimeout(time.Minute))
-
-			It("Verify gardener-resource-manager was deleted", func(ctx SpecContext) {
-				deployment := &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      v1beta1constants.DeploymentNameGardenerResourceManager,
-						Namespace: v1beta1constants.GardenNamespace,
-					},
-				}
-
-				Eventually(ctx, s.GardenKomega.Get(deployment)).Should(BeNotFoundError())
-			}, SpecTimeout(time.Minute))
-
-			ItShouldWaitForExtensionToReportDeletion(s, "provider-local")
-		}
-
-		Context("Garden", Ordered, func() {
-			var s *GardenContext
-			BeforeTestSetup(func() {
-				backupSecret := defaultBackupSecret()
-				s = NewTestContext().ForGarden(defaultGarden(backupSecret, true), backupSecret)
-			})
-
-			test(s)
+	Describe("Create, Delete Garden", Label("simple"), Ordered, func() {
+		var s *GardenContext
+		BeforeTestSetup(func() {
+			backupSecret := defaultBackupSecret()
+			s = NewTestContext().ForGarden(defaultGarden(backupSecret, true), backupSecret)
 		})
+
+		ItShouldCreateGarden(s)
+		ItShouldWaitForGardenToBeReconciledAndHealthy(s)
+		ItShouldVerifyGardenManagedResourcesAndAwaitHealthiness(s)
+		ItShouldVerifyIstioManagedResourcesAndAwaitHealthiness(s)
+		ItShouldInitializeVirtualClusterClient(s)
+
+		It("Verify Gardener APIs availability", func(ctx SpecContext) {
+			Eventually(ctx, s.VirtualClusterKomega.List(&gardencorev1beta1.ShootList{})).Should(Succeed())
+			Eventually(ctx, s.VirtualClusterKomega.List(&seedmanagementv1alpha1.ManagedSeedList{})).Should(Succeed())
+			Eventually(ctx, s.VirtualClusterKomega.List(&settingsv1alpha1.ClusterOpenIDConnectPresetList{})).Should(Succeed())
+			Eventually(ctx, s.VirtualClusterKomega.List(&operationsv1alpha1.BastionList{})).Should(Succeed())
+		}, SpecTimeout(time.Minute))
+
+		It("Verify virtual cluster extension installations", func(ctx SpecContext) {
+			controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
+			Eventually(ctx, s.VirtualClusterKomega.List(controllerRegistrationList)).Should(Succeed())
+			Expect(controllerRegistrationList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})))
+
+			controllerDeploymentList := &gardencorev1.ControllerDeploymentList{}
+			Eventually(ctx, s.VirtualClusterKomega.List(controllerDeploymentList)).Should(Succeed())
+			Expect(controllerDeploymentList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})))
+		}, SpecTimeout(time.Minute))
+
+		It("Verify 'gardener-system-public' namespace and 'gardener-info' configmap exist", func(ctx SpecContext) {
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: gardencorev1beta1.GardenerSystemPublicNamespace,
+				},
+			}
+			Eventually(ctx, s.VirtualClusterKomega.Get(namespace)).Should(Succeed())
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gardener-info",
+					Namespace: gardencorev1beta1.GardenerSystemPublicNamespace,
+				},
+			}
+			Eventually(ctx, s.VirtualClusterKomega.Get(configMap)).Should(Succeed())
+			Expect(configMap.Data).To(HaveKey("gardenerAPIServer"))
+		}, SpecTimeout(time.Minute))
+
+		ItShouldDeleteGarden(s)
+		ItShouldWaitForGardenToBeDeleted(s)
+		ItShouldCleanUp(s)
+
+		It("Verify no leftover secrets", func(ctx SpecContext) {
+			secretList := &corev1.SecretList{}
+			Eventually(ctx, s.GardenKomega.List(secretList, client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{
+				secretsmanager.LabelKeyManagedBy:       secretsmanager.LabelValueSecretsManager,
+				secretsmanager.LabelKeyManagerIdentity: operatorv1alpha1.SecretManagerIdentityOperator,
+			})).Should(Succeed())
+
+			Expect(secretList.Items).To(BeEmpty())
+		}, SpecTimeout(time.Minute))
+
+		It("Verify CRD still present", func(ctx SpecContext) {
+			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+			Eventually(ctx, s.GardenKomega.List(crdList)).Should(Succeed())
+			Expect(crdList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardens.operator.gardener.cloud")})})))
+		}, SpecTimeout(time.Minute))
+
+		It("Verify gardener-resource-manager was deleted", func(ctx SpecContext) {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta1constants.DeploymentNameGardenerResourceManager,
+					Namespace: v1beta1constants.GardenNamespace,
+				},
+			}
+
+			Eventually(ctx, s.GardenKomega.Get(deployment)).Should(BeNotFoundError())
+		}, SpecTimeout(time.Minute))
+
+		ItShouldWaitForExtensionToReportDeletion(s, "provider-local")
+
 	})
 })

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -5,16 +5,15 @@
 package garden
 
 import (
-	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	gomegatypes "github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
@@ -22,168 +21,101 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	settingsv1alpha1 "github.com/gardener/gardener/pkg/apis/settings/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	operatorclient "github.com/gardener/gardener/pkg/operator/client"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
-	. "github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/test/e2e"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+	. "github.com/gardener/gardener/test/e2e/operator/garden/internal"
 )
 
 var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
-	var (
-		backupSecret = defaultBackupSecret()
-		garden       = defaultGarden(backupSecret, true)
-	)
+	Describe("Create, Delete Garden", Label("simple"), func() {
+		test := func(s *GardenContext) {
+			ItShouldCreateGarden(s)
+			ItShouldWaitForGardenToBeReconciledAndHealthy(s)
+			ItShouldVerifyGardenManagedResourcesAndAwaitHealthiness(s)
+			ItShouldVerifyIstioManagedResourcesAndAwaitHealthiness(s)
+			ItShouldInitializeVirtualClusterClient(s)
 
-	It("Create, Delete", Label("simple"), func() {
-		By("Create Garden")
-		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
-		defer cancel()
+			It("Verify Gardener APIs availability", func(ctx SpecContext) {
+				Eventually(ctx, s.VirtualClusterKomega.List(&gardencorev1beta1.ShootList{})).Should(Succeed())
+				Eventually(ctx, s.VirtualClusterKomega.List(&seedmanagementv1alpha1.ManagedSeedList{})).Should(Succeed())
+				Eventually(ctx, s.VirtualClusterKomega.List(&settingsv1alpha1.ClusterOpenIDConnectPresetList{})).Should(Succeed())
+				Eventually(ctx, s.VirtualClusterKomega.List(&operationsv1alpha1.BastionList{})).Should(Succeed())
+			}, SpecTimeout(time.Minute))
 
-		Expect(runtimeClient.Create(ctx, backupSecret)).To(Succeed())
-		Expect(runtimeClient.Create(ctx, garden)).To(Succeed())
+			It("Verify virtual cluster extension installations", func(ctx SpecContext) {
+				controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
+				Eventually(ctx, s.VirtualClusterKomega.List(controllerRegistrationList)).Should(Succeed())
+				Expect(controllerRegistrationList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})))
 
-		waitForGardenToBeReconciledAndHealthy(ctx, garden)
+				controllerDeploymentList := &gardencorev1.ControllerDeploymentList{}
+				Eventually(ctx, s.VirtualClusterKomega.List(controllerDeploymentList)).Should(Succeed())
+				Expect(controllerDeploymentList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})))
+			}, SpecTimeout(time.Minute))
 
-		DeferCleanup(func() {
-			ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
-			defer cancel()
+			It("Verify 'gardener-system-public' namespace and 'gardener-info' configmap exist", func(ctx SpecContext) {
+				namespace := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: gardencorev1beta1.GardenerSystemPublicNamespace,
+					},
+				}
+				Eventually(ctx, s.VirtualClusterKomega.Get(namespace)).Should(Succeed())
 
-			By("Delete Garden")
-			Expect(gardenerutils.ConfirmDeletion(ctx, runtimeClient, garden)).To(Succeed())
-			Expect(runtimeClient.Delete(ctx, garden)).To(Succeed())
-			Expect(runtimeClient.Delete(ctx, backupSecret)).To(Succeed())
-			waitForGardenToBeDeleted(ctx, garden)
-			cleanupVolumes(ctx)
-			Expect(runtimeClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(namespace), client.MatchingLabels{"role": "kube-apiserver-etcd-encryption-configuration"})).To(Succeed())
-			Expect(runtimeClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(namespace), client.MatchingLabels{"role": "gardener-apiserver-etcd-encryption-configuration"})).To(Succeed())
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gardener-info",
+						Namespace: gardencorev1beta1.GardenerSystemPublicNamespace,
+					},
+				}
+				Eventually(ctx, s.VirtualClusterKomega.Get(configMap)).Should(Succeed())
+				Expect(configMap.Data).To(HaveKey("gardenerAPIServer"))
+			}, SpecTimeout(time.Minute))
 
-			By("Verify deletion")
-			secretList := &corev1.SecretList{}
-			Expect(runtimeClient.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabels{
-				secretsmanager.LabelKeyManagedBy:       secretsmanager.LabelValueSecretsManager,
-				secretsmanager.LabelKeyManagerIdentity: operatorv1alpha1.SecretManagerIdentityOperator,
-			})).To(Succeed())
-			Expect(secretList.Items).To(BeEmpty())
+			ItShouldDeleteGarden(s)
+			ItShouldWaitForGardenToBeDeleted(s)
+			ItShouldCleanUp(s)
 
-			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
-			Expect(runtimeClient.List(ctx, crdList)).To(Succeed())
-			Expect(crdList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardens.operator.gardener.cloud")})})))
+			It("Verify no leftover secrets", func(ctx SpecContext) {
+				secretList := &corev1.SecretList{}
+				Eventually(ctx, s.GardenKomega.List(secretList, client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{
+					secretsmanager.LabelKeyManagedBy:       secretsmanager.LabelValueSecretsManager,
+					secretsmanager.LabelKeyManagerIdentity: operatorv1alpha1.SecretManagerIdentityOperator,
+				})).Should(Succeed())
 
-			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: v1beta1constants.DeploymentNameGardenerResourceManager, Namespace: namespace}, &appsv1.Deployment{})).To(BeNotFoundError())
+				Expect(secretList.Items).To(BeEmpty())
+			}, SpecTimeout(time.Minute))
 
-			By("Wait until extension reports a successful uninstallation")
-			waitForExtensionToReportDeletion(ctx, "provider-local")
+			It("Verify CRD still present", func(ctx SpecContext) {
+				crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+				Eventually(ctx, s.GardenKomega.List(crdList)).Should(Succeed())
+				Expect(crdList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardens.operator.gardener.cloud")})})))
+			}, SpecTimeout(time.Minute))
+
+			It("Verify gardener-resource-manager was deleted", func(ctx SpecContext) {
+				deployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      v1beta1constants.DeploymentNameGardenerResourceManager,
+						Namespace: v1beta1constants.GardenNamespace,
+					},
+				}
+
+				Eventually(ctx, s.GardenKomega.Get(deployment)).Should(BeNotFoundError())
+			}, SpecTimeout(time.Minute))
+
+			ItShouldWaitForExtensionToReportDeletion(s, "provider-local")
+		}
+
+		Context("Garden", Ordered, func() {
+			var s *GardenContext
+			BeforeTestSetup(func() {
+				backupSecret := defaultBackupSecret()
+				s = NewTestContext().ForGarden(defaultGarden(backupSecret, true), backupSecret)
+			})
+
+			test(s)
 		})
-
-		By("Verify creation")
-		CEventually(ctx, func(g Gomega) {
-			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
-			g.Expect(runtimeClient.List(ctx, managedResourceList, client.InNamespace(namespace))).To(Succeed())
-			g.Expect(managedResourceList.Items).To(ConsistOf(
-				healthyManagedResource("vpa"),
-				healthyManagedResource("etcd-druid"),
-				healthyManagedResource("kube-state-metrics-runtime"),
-				healthyManagedResource("kube-apiserver-sni"),
-				healthyManagedResource("istio-tls-secrets"),
-				healthyManagedResource("shoot-core-kube-controller-manager"),
-				healthyManagedResource("shoot-core-gardener-resource-manager"),
-				healthyManagedResource("shoot-core-gardeneraccess"),
-				healthyManagedResource("nginx-ingress"),
-				healthyManagedResource("fluent-bit"),
-				healthyManagedResource("fluent-operator"),
-				healthyManagedResource("fluent-operator-custom-resources-garden"),
-				healthyManagedResource("vali"),
-				healthyManagedResource("plutono"),
-				healthyManagedResource("prometheus-operator"),
-				healthyManagedResource("alertmanager-garden"),
-				healthyManagedResource("prometheus-garden"),
-				healthyManagedResource("prometheus-garden-target"),
-				healthyManagedResource("prometheus-longterm"),
-				healthyManagedResource("blackbox-exporter"),
-				healthyManagedResource("garden-system"),
-				healthyManagedResource("garden-system-virtual"),
-				healthyManagedResource("gardener-apiserver-runtime"),
-				healthyManagedResource("gardener-apiserver-virtual"),
-				healthyManagedResource("gardener-admission-controller-runtime"),
-				healthyManagedResource("gardener-admission-controller-virtual"),
-				healthyManagedResource("gardener-controller-manager-runtime"),
-				healthyManagedResource("gardener-controller-manager-virtual"),
-				healthyManagedResource("gardener-scheduler-runtime"),
-				healthyManagedResource("gardener-scheduler-virtual"),
-				healthyManagedResource("gardener-dashboard-runtime"),
-				healthyManagedResource("gardener-dashboard-virtual"),
-				healthyManagedResource("terminal-runtime"),
-				healthyManagedResource("terminal-virtual"),
-				healthyManagedResource("gardener-metrics-exporter-runtime"),
-				healthyManagedResource("gardener-metrics-exporter-virtual"),
-				healthyManagedResource("extension-admission-runtime-provider-local"),
-				healthyManagedResource("extension-admission-virtual-provider-local"),
-				healthyManagedResource("extension-registration-provider-local"),
-				healthyManagedResource("extension-provider-local-garden"),
-				healthyManagedResource("local-ext-shoot"),
-			))
-
-			g.Expect(runtimeClient.List(ctx, managedResourceList, client.InNamespace("istio-system"))).To(Succeed())
-			g.Expect(managedResourceList.Items).To(ConsistOf(
-				healthyManagedResource("istio-system"),
-				healthyManagedResource("virtual-garden-istio"),
-			))
-		}).WithPolling(2 * time.Second).Should(Succeed())
-
-		var virtualClusterClient kubernetes.Interface
-		By("Verify virtual cluster access using token-request kubeconfig")
-		Eventually(func(g Gomega) {
-			var err error
-			virtualClusterClient, err = kubernetes.NewClientFromSecret(ctx, runtimeClient, namespace, "gardener",
-				kubernetes.WithDisabledCachedClient(),
-				kubernetes.WithClientOptions(client.Options{Scheme: operatorclient.VirtualScheme}),
-			)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(virtualClusterClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
-		}).Should(Succeed())
-
-		By("Verify Gardener APIs availability")
-		Eventually(func(g Gomega) {
-			g.Expect(virtualClusterClient.Client().List(ctx, &gardencorev1beta1.ShootList{})).To(Succeed())
-			g.Expect(virtualClusterClient.Client().List(ctx, &seedmanagementv1alpha1.ManagedSeedList{})).To(Succeed())
-			g.Expect(virtualClusterClient.Client().List(ctx, &settingsv1alpha1.ClusterOpenIDConnectPresetList{})).To(Succeed())
-			g.Expect(virtualClusterClient.Client().List(ctx, &operationsv1alpha1.BastionList{})).To(Succeed())
-		}).Should(Succeed())
-
-		By("Verify virtual cluster extension installations")
-		Eventually(func(g Gomega) {
-			controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
-			g.Expect(virtualClusterClient.Client().List(ctx, controllerRegistrationList)).To(Succeed())
-			g.Expect(controllerRegistrationList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})))
-			controllerDeploymentList := &gardencorev1.ControllerDeploymentList{}
-			g.Expect(virtualClusterClient.Client().List(ctx, controllerDeploymentList)).To(Succeed())
-			g.Expect(controllerDeploymentList.Items).To(ContainElement(MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})))
-		}).Should(Succeed())
-
-		By("Verify 'gardener-system-public' namespace and 'gardener-info' configmap exist")
-		Eventually(func(g Gomega) {
-			namespace := &corev1.Namespace{}
-			g.Expect(virtualClusterClient.Client().Get(ctx, client.ObjectKey{Name: gardencorev1beta1.GardenerSystemPublicNamespace}, namespace)).To(Succeed())
-
-			configMap := &corev1.ConfigMap{}
-			g.Expect(virtualClusterClient.Client().Get(ctx, client.ObjectKey{Namespace: gardencorev1beta1.GardenerSystemPublicNamespace, Name: "gardener-info"}, configMap)).To(Succeed())
-			g.Expect(configMap.Data).To(HaveKey("gardenerAPIServer"))
-		}).Should(Succeed())
 	})
 })
-
-func healthyManagedResource(name string) gomegatypes.GomegaMatcher {
-	return MatchFields(IgnoreExtras, Fields{
-		"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal(name)}),
-		"Status": MatchFields(IgnoreExtras, Fields{"Conditions": And(
-			ContainCondition(OfType(resourcesv1alpha1.ResourcesApplied), WithStatus(gardencorev1beta1.ConditionTrue)),
-			ContainCondition(OfType(resourcesv1alpha1.ResourcesHealthy), WithStatus(gardencorev1beta1.ConditionTrue)),
-			ContainCondition(OfType(resourcesv1alpha1.ResourcesProgressing), WithStatus(gardencorev1beta1.ConditionFalse)),
-		)}),
-	})
-}

--- a/test/e2e/operator/garden/internal/garden.go
+++ b/test/e2e/operator/garden/internal/garden.go
@@ -159,15 +159,15 @@ func itShouldVerifyManagedResourcesAndAwaitHealthiness(s *GardenContext, namespa
 		})
 	}
 
-	equalsManagedResourcesInNamespace(s, namespace, managedResourceList)
+	equalsManagedResourcesInNamespace(s, namespace, managedResourceList...)
 	waitForManagedResourcesToBeHealthy(s, managedResourceList)
 }
 
-func equalsManagedResourcesInNamespace(s *GardenContext, namespace string, managedResourceList []resourcesv1alpha1.ManagedResource) {
+func equalsManagedResourcesInNamespace(s *GardenContext, namespace string, expectedManagedResources ...resourcesv1alpha1.ManagedResource) {
 	It(fmt.Sprintf("Verify ManagedResources in namespace %s equal expected resources", namespace), func(ctx SpecContext) {
-		managedResourcesInNamespace := &resourcesv1alpha1.ManagedResourceList{}
-		Eventually(ctx, s.GardenKomega.List(managedResourcesInNamespace, client.InNamespace(namespace))).Should(Succeed())
-		Expect(managedResourcesInNamespace.Items).To(ConsistOf(managedResourceNames(managedResourceList)))
+		managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
+		Eventually(ctx, s.GardenKomega.List(managedResourceList, client.InNamespace(namespace))).Should(Succeed())
+		Expect(managedResourceList.Items).To(ConsistOf(managedResourceNames(expectedManagedResources)))
 	}, SpecTimeout(time.Minute))
 }
 

--- a/test/e2e/operator/garden/internal/garden.go
+++ b/test/e2e/operator/garden/internal/garden.go
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+)
+
+var gardenManagedResourceList = []string{
+	"vpa",
+	"etcd-druid",
+	"kube-state-metrics-runtime",
+	"kube-apiserver-sni",
+	"istio-tls-secrets",
+	"shoot-core-kube-controller-manager",
+	"shoot-core-gardener-resource-manager",
+	"shoot-core-gardeneraccess",
+	"nginx-ingress",
+	"fluent-bit",
+	"fluent-operator",
+	"fluent-operator-custom-resources-garden",
+	"vali",
+	"plutono",
+	"prometheus-operator",
+	"alertmanager-garden",
+	"prometheus-garden",
+	"prometheus-garden-target",
+	"prometheus-longterm",
+	"blackbox-exporter",
+	"garden-system",
+	"garden-system-virtual",
+	"gardener-apiserver-runtime",
+	"gardener-apiserver-virtual",
+	"gardener-admission-controller-runtime",
+	"gardener-admission-controller-virtual",
+	"gardener-controller-manager-runtime",
+	"gardener-controller-manager-virtual",
+	"gardener-scheduler-runtime",
+	"gardener-scheduler-virtual",
+	"gardener-dashboard-runtime",
+	"gardener-dashboard-virtual",
+	"terminal-runtime",
+	"terminal-virtual",
+	"gardener-metrics-exporter-runtime",
+	"gardener-metrics-exporter-virtual",
+	"extension-admission-runtime-provider-local",
+	"extension-admission-virtual-provider-local",
+	"extension-registration-provider-local",
+	"extension-provider-local-garden",
+	"local-ext-shoot",
+}
+
+var istioManagedResourceList = []string{
+	"istio-system",
+	"virtual-garden-istio",
+}
+
+// ItShouldCreateGarden creates the garden object
+func ItShouldCreateGarden(s *GardenContext) {
+	GinkgoHelper()
+
+	It("Create Garden", func(ctx SpecContext) {
+		s.Log.Info("Creating Backup Secret")
+		Eventually(ctx, func() error {
+			if err := s.GardenClient.Create(ctx, s.BackupSecret); !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			return StopTrying("backup secret already exists")
+		}).Should(Succeed())
+
+		s.Log.Info("Creating Garden")
+
+		Eventually(ctx, func() error {
+			if err := s.GardenClient.Create(ctx, s.Garden); !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			return StopTrying("garden already exists")
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+}
+
+// ItShouldWaitForGardenToBeReconciledAndHealthy waits for the garden to be reconciled successfully and healthy
+func ItShouldWaitForGardenToBeReconciledAndHealthy(s *GardenContext) {
+	GinkgoHelper()
+
+	It("Wait for Garden to be reconciled", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) bool {
+			g.Expect(s.GardenKomega.Get(s.Garden)()).To(Succeed())
+
+			completed, reason := gardenReconciliationSuccessful(s.Garden)
+			if !completed {
+				s.Log.Info("Waiting for reconciliation and healthiness", "lastOperation", s.Garden.Status.LastOperation, "reason", reason)
+			}
+			return completed
+		}).WithPolling(30 * time.Second).Should(BeTrue())
+
+		s.Log.Info("Garden has been reconciled and is healthy")
+	}, SpecTimeout(15*time.Minute))
+}
+
+// ItShouldInitializeVirtualClusterClient initialized the contexts virtual cluster client from the "gardener" secret in the garden namespace
+func ItShouldInitializeVirtualClusterClient(s *GardenContext) {
+	GinkgoHelper()
+
+	It("Initialize virtual cluster client", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			virtualClusterClient, err := kubernetes.NewClientFromSecret(ctx, s.GardenClient, v1beta1constants.GardenNamespace, "gardener",
+				kubernetes.WithDisabledCachedClient(),
+				kubernetes.WithClientOptions(client.Options{Scheme: operatorclient.VirtualScheme}),
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+			s.WithVirtualClusterClientSet(virtualClusterClient)
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+}
+
+// ItShouldVerifyGardenManagedResourcesAndAwaitHealthiness verifies that the managed resources in the "garden" namespace are the ones we expect and waits for their healthiness
+func ItShouldVerifyGardenManagedResourcesAndAwaitHealthiness(s *GardenContext) {
+	GinkgoHelper()
+	itShouldVerifyManagedResourcesAndAwaitHealthiness(s, v1beta1constants.GardenNamespace, gardenManagedResourceList)
+}
+
+// ItShouldVerifyIstioManagedResourcesAndAwaitHealthiness verifies that the managed resources in the "istio-system" namespace are the ones we expect and waits for their healthiness
+func ItShouldVerifyIstioManagedResourcesAndAwaitHealthiness(s *GardenContext) {
+	GinkgoHelper()
+	itShouldVerifyManagedResourcesAndAwaitHealthiness(s, v1beta1constants.IstioSystemNamespace, istioManagedResourceList)
+}
+
+func itShouldVerifyManagedResourcesAndAwaitHealthiness(s *GardenContext, namespace string, managedResourceNames []string) {
+	managedResourceList := []resourcesv1alpha1.ManagedResource{}
+	for _, managedResource := range managedResourceNames {
+		managedResourceList = append(managedResourceList, resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResource,
+				Namespace: namespace,
+			},
+		})
+	}
+
+	equalsManagedResourcesInNamespace(s, namespace, managedResourceList)
+	waitForManagedResourcesToBeHealthy(s, managedResourceList)
+}
+
+func equalsManagedResourcesInNamespace(s *GardenContext, namespace string, managedResourceList []resourcesv1alpha1.ManagedResource) {
+	It(fmt.Sprintf("Verify ManagedResources in namespace %s equal expected resources", namespace), func(ctx SpecContext) {
+		managedResourcesInNamespace := &resourcesv1alpha1.ManagedResourceList{}
+		Eventually(ctx, s.GardenKomega.List(managedResourcesInNamespace, client.InNamespace(namespace))).Should(Succeed())
+		Expect(managedResourcesInNamespace.Items).To(ConsistOf(managedResourceNames(managedResourceList)))
+	}, SpecTimeout(time.Minute))
+}
+
+func waitForManagedResourcesToBeHealthy(s *GardenContext, managedResourceList []resourcesv1alpha1.ManagedResource) {
+	for _, managedResource := range managedResourceList {
+		It(fmt.Sprintf("Wait for ManagedResource %s/%s to be healthy", managedResource.Namespace, managedResource.Name), func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) {
+				g.Expect(s.GardenClient.Get(ctx, client.ObjectKeyFromObject(&managedResource), &managedResource)).To(Succeed())
+				g.Expect(managedResource).To(beHealthyManagedResource())
+			}).WithPolling(15 * time.Second).Should(Succeed())
+		}, SpecTimeout(5*time.Minute))
+	}
+}
+
+// ItShouldDeleteGarden deletes the garden object
+func ItShouldDeleteGarden(s *GardenContext) {
+	GinkgoHelper()
+
+	It("Delete Garden", func(ctx SpecContext) {
+		s.Log.Info("Deleting Garden")
+
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(gardenerutils.ConfirmDeletion(ctx, s.GardenClient, s.Garden)).To(Succeed())
+			g.Expect(s.GardenClient.Delete(ctx, s.Garden)).To(Succeed())
+		}).Should(Succeed())
+
+		s.Log.Info("Deleting Backup Secret")
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(s.GardenClient.Delete(ctx, s.BackupSecret)).To(Succeed())
+		}).Should(Succeed())
+	})
+}
+
+// ItShouldWaitForGardenToBeDeleted waits for the garden object to be gone
+func ItShouldWaitForGardenToBeDeleted(s *GardenContext) {
+	GinkgoHelper()
+
+	It("Wait for Garden to be deleted", func(ctx SpecContext) {
+		Eventually(ctx, func() error {
+			err := s.GardenKomega.Get(s.Garden)()
+			if err == nil {
+				s.Log.Info("Waiting for deletion", "lastOperation", s.Garden.Status.LastOperation)
+			}
+			return err
+		}).WithPolling(30 * time.Second).Should(BeNotFoundError())
+
+		s.Log.Info("Garden has been deleted")
+	}, SpecTimeout(15*time.Minute))
+}
+
+// ItShouldCleanUp cleans up any remaining volumes and etcd encryption configs
+func ItShouldCleanUp(s *GardenContext) {
+	itShouldCleanupVolumes(s)
+	itShouldCleanupEtcdEncryptionConfig(s)
+}
+
+func itShouldCleanupVolumes(s *GardenContext) {
+	GinkgoHelper()
+
+	It("Delete all persistent volume claims in garden namespace", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(s.GardenClient.DeleteAllOf(ctx, &corev1.PersistentVolumeClaim{}, client.InNamespace(v1beta1constants.GardenNamespace))).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+
+	It("Wait for PersistentVolumes to be cleaned up", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) bool {
+			pvList := &corev1.PersistentVolumeList{}
+			g.Expect(s.GardenClient.List(ctx, pvList)).To(Succeed())
+
+			for _, pv := range pvList.Items {
+				if pv.Spec.ClaimRef != nil &&
+					pv.Spec.ClaimRef.APIVersion == "v1" &&
+					pv.Spec.ClaimRef.Kind == "PersistentVolumeClaim" &&
+					pv.Spec.ClaimRef.Namespace == v1beta1constants.GardenNamespace {
+					return false
+				}
+			}
+
+			return true
+		}).WithPolling(2 * time.Second).Should(BeTrue())
+	}, SpecTimeout(time.Minute))
+}
+
+func itShouldCleanupEtcdEncryptionConfig(s *GardenContext) {
+	GinkgoHelper()
+
+	It("Delete etcd-encryption-configurations", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(s.GardenClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{"role": "kube-apiserver-etcd-encryption-configuration"})).To(Succeed())
+			g.Expect(s.GardenClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{"role": "gardener-apiserver-etcd-encryption-configuration"})).To(Succeed())
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+}
+
+// ItShouldWaitForExtensionToReportDeletion waits for the specified extension to report DeleteSuccessful
+func ItShouldWaitForExtensionToReportDeletion(s *GardenContext, extensionName string) {
+	extension := &operatorv1alpha1.Extension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: extensionName,
+		},
+	}
+
+	It(fmt.Sprintf("Wait for extension %s to report deletion", extensionName), func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(s.GardenClient.Get(ctx, client.ObjectKeyFromObject(extension), extension)).To(Succeed())
+			g.Expect(extension.Status.Conditions).Should(ContainCondition(
+				OfType(operatorv1alpha1.ExtensionInstalled),
+				WithStatus(gardencorev1beta1.ConditionFalse),
+				WithReason("DeleteSuccessful"),
+			))
+		}).WithPolling(2 * time.Second).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+}
+
+func gardenReconciliationSuccessful(garden *operatorv1alpha1.Garden) (bool, string) {
+	if garden.Generation != garden.Status.ObservedGeneration {
+		return false, "garden generation did not equal observed generation"
+	}
+	if len(garden.Status.Conditions) == 0 && garden.Status.LastOperation == nil {
+		return false, "no conditions and last operation present yet"
+	}
+
+	for _, condition := range garden.Status.Conditions {
+		if condition.Status != gardencorev1beta1.ConditionTrue {
+			return false, fmt.Sprintf("condition type %s is not true yet, had message %s with reason %s", condition.Type, condition.Message, condition.Reason)
+		}
+	}
+
+	if garden.Status.LastOperation != nil {
+		if garden.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
+			return false, "last operation state is not succeeded"
+		}
+	}
+
+	return true, ""
+}
+
+func managedResourceNames(managedResourceList []resourcesv1alpha1.ManagedResource) []gomegatypes.GomegaMatcher {
+	out := []gomegatypes.GomegaMatcher{}
+
+	for _, managedResource := range managedResourceList {
+		out = append(out, MatchFields(IgnoreExtras, Fields{
+			"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal(managedResource.Name)}),
+		}))
+	}
+
+	return out
+}
+
+func beHealthyManagedResource() gomegatypes.GomegaMatcher {
+	return MatchFields(IgnoreExtras, Fields{
+		"Status": MatchFields(IgnoreExtras, Fields{"Conditions": And(
+			ContainCondition(OfType(resourcesv1alpha1.ResourcesApplied), WithStatus(gardencorev1beta1.ConditionTrue)),
+			ContainCondition(OfType(resourcesv1alpha1.ResourcesHealthy), WithStatus(gardencorev1beta1.ConditionTrue)),
+			ContainCondition(OfType(resourcesv1alpha1.ResourcesProgressing), WithStatus(gardencorev1beta1.ConditionFalse)),
+		)}),
+	})
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the mentioned test to the ordered containers approach.
See https://github.com/gardener/gardener/issues/11379

It also introduces the `GardenContext` to simplify `Garden` related tests.
This will temporarily lead to code duplication until we refactor the `Create Rotate Delete Garden` test as well.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
