### PR TITLE
Improve printer columns for `operator.gardener.cloud/v1alpha1.Extension`

### DIFF
--- a/charts/gardener/operator/templates/crd-extensions.yaml
+++ b/charts/gardener/operator/templates/crd-extensions.yaml
@@ -17,6 +17,18 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - description: Indicates whether the extension has been reconciled successfully.
+      jsonPath: .status.conditions[?(@.type=="Installed")].status
+      name: Installed
+      type: string
+    - description: Indicates whether the extension is required in the runtime cluster.
+      jsonPath: .status.conditions[?(@.type=="RequiredRuntime")].status
+      name: Required Runtime
+      type: string
+    - description: Indicates whether the extension is required in the virtual cluster.
+      jsonPath: .status.conditions[?(@.type=="RequiredVirtual")].status
+      name: Required Virtual
+      type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/example/operator/10-crd-operator.gardener.cloud_extensions.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_extensions.yaml
@@ -17,6 +17,18 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - description: Indicates whether the extension has been reconciled successfully.
+      jsonPath: .status.conditions[?(@.type=="Installed")].status
+      name: Installed
+      type: string
+    - description: Indicates whether the extension is required in the runtime cluster.
+      jsonPath: .status.conditions[?(@.type=="RequiredRuntime")].status
+      name: Required Runtime
+      type: string
+    - description: Indicates whether the extension is required in the virtual cluster.
+      jsonPath: .status.conditions[?(@.type=="RequiredVirtual")].status
+      name: Required Virtual
+      type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/pkg/apis/operator/v1alpha1/types_extension.go
+++ b/pkg/apis/operator/v1alpha1/types_extension.go
@@ -16,6 +16,9 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster,shortName="extop"
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Installed",type=string,JSONPath=`.status.conditions[?(@.type=="Installed")].status`,description="Indicates whether the extension has been reconciled successfully."
+// +kubebuilder:printcolumn:name="Required Runtime",type=string,JSONPath=`.status.conditions[?(@.type=="RequiredRuntime")].status`,description="Indicates whether the extension is required in the runtime cluster."
+// +kubebuilder:printcolumn:name="Required Virtual",type=string,JSONPath=`.status.conditions[?(@.type=="RequiredVirtual")].status`,description="Indicates whether the extension is required in the virtual cluster."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="creation timestamp"
 
 // Extension describes a Gardener extension.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Before:

```
$ k get extop
NAME             AGE
provider-local   5m
```

Now:

```
$ k get extop
NAME             INSTALLED   REQUIRED RUNTIME   REQUIRED VIRTUAL   AGE
provider-local   False       True               False              5m
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
