### PR TITLE
Prevent reconciliation errors in `NetworkPolicy` controller when `Namespace` is terminating

### DIFF
--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -120,9 +120,8 @@ func (r *Reconciler) fetchRelevantNamespaceNames(ctx context.Context, service *c
 
 	namespaceNames := sets.New(service.Namespace)
 
-	for _, n := range namespaceSelectors {
-		namespaceSelector := n
 
+	for _, namespaceSelector := range namespaceSelectors {
 		selector, err := metav1.LabelSelectorAsSelector(&namespaceSelector)
 		if err != nil {
 			return nil, fmt.Errorf("failed parsing %s to labels.Selector: %w", namespaceSelector, err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
When the `Namespace` of a `Service` reconciled by `gardener-resource-manager`'s `NetworkPolicy` controller is terminating, we might see erroneous logs like this:

```
2025-03-05T09:15:07.503564228Z stderr F {"level":"error","ts":"2025-03-05T09:15:07.503Z","msg":"Reconciler error","controller":"networkpolicy","namespace":"shoot--local--e2e-migrate-wl","name":"kube-apiserver","reconcileID":"c660df31-7e25-440c-931b-59b15f63b154","error":"12 errors occurred:\n\t* networkpolicies.networking.k8s.io \"egress-to-kube-apiserver-tcp-443-via-all-scrape-targets\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-from-extension-provider-local-hc9lx\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-via-all-scrape-targets\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-from-garden\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-via-all-scrape-targets-from-istio-ingress\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-via-all-scrape-targets-from-garden\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"egress-to-kube-apiserver-tcp-443\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-via-all-scrape-targets-from-extension-networking-calico-r57vp\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-via-all-scrape-targets-from-extension-provider-local-hc9lx\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-from-extension-networking-calico-r57vp\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-kube-apiserver-tcp-443-from-istio-ingress\" is forbidden: unable to create new content in namespace shoot--local--e2e-migrate-wl because it is being terminated\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.20.2/pkg/internal/controller/controller.go:341\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.20.2/pkg/internal/controller/controller.go:288\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.20.2/pkg/internal/controller/controller.go:249"}
```

This PR prevents them by checking the `Namespace` upfront (just like the other namespaces).

Occurred in https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/11584/pull-gardener-e2e-kind-migration/1897208880002240512/artifacts/gardener-local/gardener-local-control-plane/pods/garden_gardener-resource-manager-5bf9dd4df7-jdpsx_a60543b4-3be7-45ea-9fc4-4e365f1c8ee4/gardener-resource-manager/0.log

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
