### PR TITLE
Document how to federate metrics from the shoot Prometheus

### DIFF
--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -55,27 +55,65 @@ Deployed in the shoot control plane namespace. Important scrape targets:
 
 **Purpose**: Monitor all relevant components belonging to a shoot cluster managed by Gardener. Shoot owners can view the metrics in Plutono dashboards and receive alerts based on these metrics. For alerting internals refer to [this](alerting.md) document.
 
-#### Federate from the shoot Prometheus
+#### Federate from the Shoot Prometheus to an External Prometheus
 
-Shoot owners that are interested in collecting metrics for their shoot's kube API servers can deploy their own Prometheus and federate metrics from the shoot Prometheus. Scraping the shoot's kube API server directly from within the shoot, while technically possible, will only result in meaningless metrics because the shoot's API server pods are behind a Load Balancer, and it is impossible to control which API server pod is targeted.
+Shoot owners that are interested in collecting metrics for their shoot's control-planes can do so by federating from their shoot Prometheus instances. This allows shoot owners to selectively pull metrics from the shoot Prometheus into their own Prometheus instance. Collecting shoot's control-plane metrics by directly scraping control-plane resources will not work because such resources are managed by Gardener and are either not accessible to shoot owners or are behind a load balancer.
 
-The following snippet is a configuration example to federate shoot's kube API server metrics from the shoot Prometheus. The federated metrics will have a `pod` label to distinguish between the different API server pods. The credentials and endpoint for the shoot Prometheus are exposed via the dashboard, or programmatically in the shoot's project namespace in the garden virtual cluster as a secret:<br/>`<shoot-name>.monitoring`.
+Note Gardener is working on an OpenTelemetry-based approach for observability, but there is no official timeline for its release yet.
 
-```yaml
-scrape_configs:
-- job_name: "prometheus"
-  scheme: https
-  basic_auth:
-    username: admin
-    password: <password>
-  metrics_path: /federate
-  params:
-    match[]:
-    - '{job="kube-apiserver"}'
-  static_configs:
-  - targets:
-    - p-<project-name>--<shoot-name>.ingress.<domain>
-```
+##### Step 1: Retrieve Prometheus Credentials and URL
+
+Gardener provides access to the shoot control plane Prometheus instance through a monitoring secret stored in the virtual garden cluster. The necessary credentials can be found in the dashboard or by following these steps:
+
+1. Target the shoot's project using `gardenctl`:
+
+   ```sh
+   gardenctl target --garden <garden-name> --project <project-name>
+   ```
+
+2. Retrieve the shoot's monitoring secret:
+
+   ```sh
+   kubectl get secret <shoot-name>.monitoring -o yaml
+   ```
+
+3. Extract the Prometheus URL from the secret’s annotations:
+
+   ```sh
+   metadata.annotations.prometheus-url
+   ```
+
+4. Extract the credentials from the secret’s data fields:
+
+   ```sh
+   echo "$(kubectl get secret <shoot-name>.monitoring -o jsonpath='{.data.username}' | base64 --decode)"
+   echo "$(kubectl get secret <shoot-name>.monitoring -o jsonpath='{.data.password}' | base64 --decode)"
+
+##### Step 2: Configure Federation in Your Prometheus
+
+Once the Prometheus URL, username, and password are obtained, federation can be configured in the external Prometheus instance.
+
+1. Edit the external Prometheus configuration to add a federation job:
+
+   ```yaml
+   scrape_configs:
+     - job_name: 'gardener-federation'
+       honor_labels: true
+       metrics_path: '/federate'
+       params:
+         'match[]':
+           - '{job="kube-apiserver"}'
+       scheme: https
+       basic_auth:
+         username: '<prometheus-username>'
+         password: '<prometheus-password>'
+       static_configs:
+         - targets:
+           - '<prometheus-url>'
+   ```
+   Replace `<prometheus-username>`, `<prometheus-password>`, and `<prometheus-url>` with the values obtained earlier. In this example, the federation job is configured to federate metrics scraped by the `kube-apiserver` job, but `match[]` entry should be adjusted to the specific use-case.
+
+2. Restart Prometheus to apply the configuration.
 
 ## Collect all shoot Prometheus with remote write
 


### PR DESCRIPTION
**How to categorize this PR?**

/area documentation
/kind enhancement

**What this PR does / why we need it**:

This motivates the federation from the shoot Prometheus as the proper way for shoot owners to collect control-plane metrics and includes a configuration example.

**Special notes for your reviewer**:

/cc @rickardsjp @chrkl @vpnachev 

**Release note**:

```doc user
Add documentation on how to federate metrics from the shoot Prometheus into an external Prometheus instance
```
