### PR TITLE
Write seed-specific `Shoot` endpoint served with the control plane wildcard certificate into `.status.advertisedAddresses`

### DIFF
--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -108,6 +108,12 @@ kubectl create \
 
 The examples for other programming languages are similar to [the above](#shootsadminkubeconfig-subresource) and can be adapted accordingly.
 
+> [!TIP]
+> If the Gardener operator has configured a ["control plane wildcard certificate"](../../operations/trusted-tls-for-control-planes.md#register-a-trusted-wildcard-certificate), the issued kubeconfigs have a dedicated `Cluster` entry containing an endpoint that is served with this wildcard certificate.
+> Typically, this is a [Let's Encrypt](https://letsencrypt.org) certificate, i.e., it does not require you to specify the certificate authority bundle.
+>
+> ⚠️ This endpoint is specific to the seed cluster your `Shoot` is scheduled to, i.e., if the seed cluster changes (`.spec.seedName`, for example because of a [control plane migration](../../operations/control_plane_migration.md)), the endpoint changes as well. Have this in mind in case you consider using it!
+
 ## OpenID Connect
 
 > **Note:** OpenID Connect is deprecated in favor of [Structured Authentication configuration](#structured-authentication). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -110,7 +110,7 @@ The examples for other programming languages are similar to [the above](#shootsa
 
 > [!TIP]
 > If the Gardener operator has configured a ["control plane wildcard certificate"](../../operations/trusted-tls-for-control-planes.md#register-a-trusted-wildcard-certificate), the issued kubeconfigs have a dedicated `Cluster` entry containing an endpoint that is served with this wildcard certificate.
-> Typically, this is a [Let's Encrypt](https://letsencrypt.org) certificate, i.e., it does not require you to specify the certificate authority bundle.
+> This could be a generally trusted certificate, e.g. from [Let's Encrypt](https://letsencrypt.org) or a similar certificate authority, i.e., it does not require you to specify the certificate authority bundle.
 >
 > ⚠️ This endpoint is specific to the seed cluster your `Shoot` is scheduled to, i.e., if the seed cluster changes (`.spec.seedName`, for example because of a [control plane migration](../../operations/control_plane_migration.md)), the endpoint changes as well. Have this in mind in case you consider using it!
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -857,9 +857,12 @@ const (
 	AdvertisedAddressInternal = "internal"
 	// AdvertisedAddressUnmanaged is a constant that represents the name of the unmanaged kube-apiserver address.
 	AdvertisedAddressUnmanaged = "unmanaged"
-	// AdvertisedAddressServiceAccountIssuer is a constant that represents the name of the address
-	// that is used as a service account issuer for the kube-apiserver.
+	// AdvertisedAddressServiceAccountIssuer is a constant that represents the name of the address that is used as a
+	// service account issuer for the kube-apiserver.
 	AdvertisedAddressServiceAccountIssuer = "service-account-issuer"
+	// AdvertisedAddressWildcardTLSSeedBound is a constant that represents the name of the address that is
+	// seed-specific (i.e., changes when the Seed changes) and backed by a central wildcard TLS certificate.
+	AdvertisedAddressWildcardTLSSeedBound = "wildcard-tls-seed-bound"
 
 	// CloudProfileReferenceKindCloudProfile is a constant for the CloudProfile kind reference.
 	CloudProfileReferenceKindCloudProfile = "CloudProfile"

--- a/pkg/apiserver/registry/core/shoot/storage/kubeconfig_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/kubeconfig_test.go
@@ -149,6 +149,10 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 						URL:  "https://foo.bar.external:9443",
 					},
 					{
+						Name: "wildcard-tls-seed-bound",
+						URL:  "https://foo.bar.seed.specific.but.with.wildcard.tls:9443",
+					},
+					{
 						Name: "internal",
 						URL:  "https://foo.bar.internal:9443",
 					},
@@ -274,6 +278,12 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 					},
 				},
 				clientcmdv1.NamedCluster{
+					Name: "baz--test-wildcard-tls-seed-bound",
+					Cluster: clientcmdv1.Cluster{
+						Server: "https://foo.bar.seed.specific.but.with.wildcard.tls:9443",
+					},
+				},
+				clientcmdv1.NamedCluster{
 					Name: "baz--test-internal",
 					Cluster: clientcmdv1.Cluster{
 						Server:                   "https://foo.bar.internal:9443",
@@ -287,6 +297,13 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 					Name: "baz--test-external",
 					Context: clientcmdv1.Context{
 						Cluster:  "baz--test-external",
+						AuthInfo: "baz--test-external",
+					},
+				},
+				clientcmdv1.NamedContext{
+					Name: "baz--test-wildcard-tls-seed-bound",
+					Context: clientcmdv1.Context{
+						Cluster:  "baz--test-wildcard-tls-seed-bound",
 						AuthInfo: "baz--test-external",
 					},
 				},

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -41,6 +41,13 @@ func (b *Botanist) ToAdvertisedAddresses() ([]gardencorev1beta1.ShootAdvertisedA
 		})
 	}
 
+	if b.ControlPlaneWildcardCert != nil {
+		addresses = append(addresses, gardencorev1beta1.ShootAdvertisedAddress{
+			Name: v1beta1constants.AdvertisedAddressWildcardTLSSeedBound,
+			URL:  "https://" + b.ComputeKubeAPIServerHost(),
+		})
+	}
+
 	if len(b.Shoot.InternalClusterDomain) > 0 {
 		addresses = append(addresses, gardencorev1beta1.ShootAdvertisedAddress{
 			Name: v1beta1constants.AdvertisedAddressInternal,

--- a/pkg/utils/secrets/control_plane.go
+++ b/pkg/utils/secrets/control_plane.go
@@ -177,15 +177,10 @@ func generateKubeconfig(secret *ControlPlaneSecretConfig, certificate *Certifica
 	}
 
 	for _, req := range secret.KubeConfigRequests {
-		caData := req.CAData
-		if caData == nil && certificate != nil && certificate.CA != nil {
-			caData = certificate.CA.CertificatePEM
-		}
-
 		config.Clusters = append(config.Clusters, clientcmdv1.NamedCluster{
 			Name: req.ClusterName,
 			Cluster: clientcmdv1.Cluster{
-				CertificateAuthorityData: caData,
+				CertificateAuthorityData: req.CAData,
 				Server:                   fmt.Sprintf("https://%s", req.APIServerHost),
 			},
 		})

--- a/pkg/utils/secrets/control_plane_test.go
+++ b/pkg/utils/secrets/control_plane_test.go
@@ -39,6 +39,7 @@ var _ = Describe("utils", func() {
 					KubeConfigRequests: []KubeConfigRequest{{
 						ClusterName:   clusterName,
 						APIServerHost: apiServerURL,
+						CAData:        []byte(caCert),
 					}},
 				}
 
@@ -101,8 +102,7 @@ var _ = Describe("utils", func() {
 							{
 								Name: "foo",
 								Cluster: clientcmdv1.Cluster{
-									Server:                   "https://foo.bar",
-									CertificateAuthorityData: []byte(caCert),
+									Server: "https://foo.bar",
 								},
 							},
 						},
@@ -181,8 +181,7 @@ var _ = Describe("utils", func() {
 						{
 							Name: "foo",
 							Cluster: clientcmdv1.Cluster{
-								Server:                   "https://foo.bar",
-								CertificateAuthorityData: []byte(caCert),
+								Server: "https://foo.bar",
 							},
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR write the seed-specific `Shoot` endpoint served with the control plane wildcard certificate into `.status.advertisedAddresses`. This only works when such a control plane wildcard certificate is configure by the Gardener operator, i.e., when there is a `Secret` in the `garden` namespace of the seed cluster labeled with `gardener.cloud/role=controlplane-cert`.

Before:

```yaml
  status:
    advertisedAddresses:
    - name: external
      url: https://api.local.local.external.local.gardener.cloud
    - name: internal
      url: https://api.local.local.internal.local.gardener.cloud
    - name: service-account-issuer
      url: https://discovery.local.gardener.cloud/projects/local/shoots/59f7d506-f3c9-44ef-8b09-8e6fc6dd692f/issuer
```

Now:

```yaml
  status:
    advertisedAddresses:
    - name: external
      url: https://api.local.local.external.local.gardener.cloud
    - name: wildcard-tls-seed-bound
      url: https://api-local--local.ingress.local.seed.local.gardener.cloud
    - name: internal
      url: https://api.local.local.internal.local.gardener.cloud
    - name: service-account-issuer
      url: https://discovery.local.gardener.cloud/projects/local/shoots/59f7d506-f3c9-44ef-8b09-8e6fc6dd692f/issuer
```

Generated kubeconfigs also get this endpoint via a new `Cluster` entry:

```yaml
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: base64(cluster-ca-cert)
    server: https://api.local.local.external.local.gardener.cloud
  name: garden-local--local-external
- cluster:
    server: https://api-local--local.ingress.local.seed.local.gardener.cloud
  name: garden-local--local-wildcard-tls-seed-bound
- cluster:
    certificate-authority-data: base64(cluster-ca-cert)
    server: https://api.local.local.internal.local.gardener.cloud
  name: garden-local--local-internal
contexts:
- context:
    cluster: garden-local--local-external
    user: garden-local--local-external
  name: garden-local--local-external
- context:
    cluster: garden-local--local-wildcard-tls-seed-bound
    user: garden-local--local-external
  name: garden-local--local-wildcard-tls-seed-bound
- context:
    cluster: garden-local--local-internal
    user: garden-local--local-external
  name: garden-local--local-internal
current-context: garden-local--local-external
kind: Config
preferences: {}
users:
- name: garden-local--local-external
  user:
    client-certificate-data: base64(client-cert)
    client-key-data: base64(client-key)
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
If the Gardener operator has defined a control plane wildcard certificate, the `.status.advertisedAddresses` of the `Shoot` contain an entry with an endpoint secured by this certificate. Note that this endpoint is specific to the seed cluster the `Shoot` is scheduled to. Read all about it in [this document](https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md).
```
