### PR TITLE
[renovate] Rebase PRs on conflicts only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,7 +16,7 @@
   // Add PR footer with empty release note by default.
   prFooter: '**Release note**:\n```other dependency\nNONE\n```',
   // Only rebase when there are conflicts. Prow tests against the latest state of master branch anyway before merging the PR.
-  rebaseWhen: "conflicted",
+  rebaseWhen: 'conflicted',
   customManagers: [
     {
       // Generic detection for pod-like image specifications.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,8 @@
   ],
   // Add PR footer with empty release note by default.
   prFooter: '**Release note**:\n```other dependency\nNONE\n```',
+  // Only rebase when there are conflicts. Prow tests against the latest state of master branch anyway before merging the PR.
+  rebaseWhen: "conflicted",
   customManagers: [
     {
       // Generic detection for pod-like image specifications.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
At the moment renovate rebases PRs every time the master branch changes. This starts needless tests (e.g. [here](https://github.com/gardener/gardener/pull/11599)). Before merging a PR, Prow is testing it against the latest state of master branch anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
