### PR TITLE
[GEP-28] Add bootstrap etcd component for deploying etcd to bootstrap a control plane node in the autonomous shoot cluster scenario.

### DIFF
--- a/pkg/component/etcd/bootstrap/etcd.go
+++ b/pkg/component/etcd/bootstrap/etcd.go
@@ -6,11 +6,38 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
+	"net"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/etcd/etcd"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+const (
+	metricsPort = 2381
+
+	volumeNameData          = "main-etcd"
+	volumeNameETCDCA        = "etcd-ca"
+	volumeNameServerTLS     = "etcd-server-tls"
+	volumeNameClientTLS     = "etcd-client-tls"
+	volumeNamePeerCA        = "etcd-peer-ca"
+	volumeNamePeerServerTLS = "etcd-peer-server-tls"
+
+	volumeMountPathData          = "/var/etcd/data"
+	volumeMountPathETCDCA        = "/var/etcd/ssl/ca"
+	volumeMountPathServerTLS     = "/var/etcd/ssl/server"
+	volumeMountPathPeerCA        = "/var/etcd/ssl/peer/ca"
+	volumeMountPathPeerServerTLS = "/var/etcd/ssl/peer/server"
 )
 
 // Values is a set of configuration values for the Etcd component.
@@ -41,10 +68,193 @@ type etcdDeployer struct {
 	values         Values
 }
 
-func (e *etcdDeployer) Deploy(_ context.Context) error {
-	return nil
+func (e *etcdDeployer) Deploy(ctx context.Context) error {
+	etcdCASecret, serverSecret, clientSecret, err := etcd.GenerateClientServerCertificates(
+		ctx,
+		e.secretsManager,
+		"main",
+		[]string{"localhost"},
+		[]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to generate etcd client/server certificates: %w", err)
+	}
+
+	etcdPeerCASecretName, peerServerSecretName, err := etcd.GeneratePeerCertificates(
+		ctx,
+		e.secretsManager,
+		"main",
+		[]string{"localhost"},
+		[]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to generate etcd peer certificates: %w", err)
+	}
+
+	pod := e.emptyPod()
+
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, e.client, pod, func() error {
+		pod.Labels = map[string]string{
+			v1beta1constants.LabelApp:   "etcd",
+			v1beta1constants.LabelRole:  "main",
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+		}
+		pod.Spec = corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Command: []string{
+					"etcd",
+					"--advertise-client-urls=https://127.0.0.1:2379,https://[::1]:2379",
+					"--cert-file=" + volumeMountPathServerTLS + "/tls.crt",
+					"--client-cert-auth=true",
+					"--data-dir=" + volumeMountPathData,
+					"--experimental-initial-corrupt-check=true",
+					"--experimental-watch-progress-notify-interval=5s",
+					"--initial-advertise-peer-urls=https://127.0.0.1:2380,https://[::1]:2380",
+					"--initial-cluster=etcd-main=https://127.0.0.1:2380",
+					"--key-file=" + volumeNamePeerServerTLS + "/tls.key",
+					"--listen-client-urls=https://127.0.0.1:2379,https://[::1]:2379",
+					"--listen-metrics-urls=http://127.0.0.1:2381,http://[::1]:2381",
+					"--listen-peer-urls=https://127.0.0.1:2380,https://[::1]:2380",
+					"--name=etcd-main",
+					"--peer-cert-file=" + volumeNamePeerServerTLS + "/tls.crt",
+					"--peer-client-cert-auth=true",
+					"--peer-key-file=" + volumeNamePeerServerTLS + "/tls.key",
+					"--peer-trusted-ca-file=" + volumeMountPathPeerCA + "/bundle.crt",
+					"--snapshot-count=10000",
+					"--trusted-ca-file=" + volumeNameETCDCA + "/bundle.crt",
+				},
+				Image:           e.values.Image,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/livez",
+							Scheme: corev1.URISchemeHTTP,
+							Port:   intstr.FromInt32(metricsPort),
+						},
+					},
+					SuccessThreshold:    1,
+					FailureThreshold:    8,
+					InitialDelaySeconds: 10,
+					PeriodSeconds:       10,
+					TimeoutSeconds:      15,
+				},
+				Name: "etcd",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				StartupProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/health",
+							Scheme: corev1.URISchemeHTTP,
+							Port:   intstr.FromInt32(metricsPort),
+						},
+					},
+					SuccessThreshold:    1,
+					FailureThreshold:    24,
+					InitialDelaySeconds: 10,
+					PeriodSeconds:       10,
+					TimeoutSeconds:      15,
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						MountPath: volumeMountPathData,
+						Name:      volumeNameData,
+					},
+					{
+						MountPath: volumeMountPathETCDCA,
+						Name:      volumeNameETCDCA,
+					},
+					{
+						MountPath: volumeMountPathServerTLS,
+						Name:      volumeNameServerTLS,
+					},
+					{
+						MountPath: "/var/etcd/ssl/client",
+						Name:      volumeNameClientTLS,
+					},
+					{
+						MountPath: volumeMountPathPeerCA,
+						Name:      volumeNamePeerCA,
+					},
+					{
+						MountPath: volumeMountPathPeerServerTLS,
+						Name:      volumeNamePeerServerTLS,
+					},
+				},
+			}},
+			SecurityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: volumeNameData,
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/lib/etcd",
+							Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+						},
+					},
+				},
+				{
+					Name: volumeNameETCDCA,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: etcdCASecret.Name,
+						},
+					},
+				},
+				{
+					Name: volumeNamePeerCA,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: etcdPeerCASecretName,
+						},
+					},
+				},
+				{
+					Name: volumeNameServerTLS,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: serverSecret.Name,
+						},
+					},
+				},
+				{
+					Name: volumeNameClientTLS,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: clientSecret.Name,
+						},
+					},
+				},
+				{
+					Name: volumeNamePeerServerTLS,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: peerServerSecretName,
+						},
+					},
+				},
+			},
+		}
+
+		return nil
+	})
+
+	return err
 }
 
 func (e *etcdDeployer) Destroy(_ context.Context) error {
 	return nil
+}
+
+func (e *etcdDeployer) emptyPod() *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "etcd-main", Namespace: e.namespace}}
 }

--- a/pkg/component/etcd/bootstrap/etcd.go
+++ b/pkg/component/etcd/bootstrap/etcd.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrap
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/component"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+// Values is a set of configuration values for the Etcd component.
+type Values struct {
+	// Image is the container image used for Etcd.
+	Image string
+}
+
+// New creates a new instance of DeployWaiter for the Etcd.
+func New(
+	client client.Client,
+	namespace string,
+	secretsManager secretsmanager.Interface,
+	values Values,
+) component.Deployer {
+	return &etcdDeployer{
+		client:         client,
+		namespace:      namespace,
+		secretsManager: secretsManager,
+		values:         values,
+	}
+}
+
+type etcdDeployer struct {
+	client         client.Client
+	namespace      string
+	secretsManager secretsmanager.Interface
+	values         Values
+}
+
+func (e *etcdDeployer) Deploy(_ context.Context) error {
+	return nil
+}
+
+func (e *etcdDeployer) Destroy(_ context.Context) error {
+	return nil
+}

--- a/pkg/component/etcd/bootstrap/etcd_suite_test.go
+++ b/pkg/component/etcd/bootstrap/etcd_suite_test.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrap_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+func TestBootstrap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Etcd Bootstrap Suite")
+}
+
+var _ = BeforeSuite(func() {
+	DeferCleanup(test.WithVar(&secretsutils.GenerateKey, secretsutils.FakeGenerateKey))
+})

--- a/pkg/component/etcd/bootstrap/etcd_test.go
+++ b/pkg/component/etcd/bootstrap/etcd_test.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrap_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("Etcd", func() {
+	var (
+		c         client.Client
+		sm        secretsmanager.Interface
+		etcd      component.Deployer
+		ctx       = context.Background()
+		namespace = "shoot--foo--bar"
+		image     = "some.registry.io/etcd:v3.5.10"
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		sm = fakesecretsmanager.New(c, namespace)
+		etcd = New(c, namespace, sm, Values{Image: image})
+	})
+
+	Describe("#Deploy", func() {
+		It("should successfully deploy bootstrap etcd", func() {
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should return nil as it's not implemented as of now", func() {
+			Expect(etcd.Destroy(ctx)).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Add bootstrap etcd component for deploying etcd to bootstrap a control plane node in the autonomous shoot cluster scenario.

The `etcd` pod will be transformed into a static pod. Later, its maintenance should be taken over by etcd-druid.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
