### PR TITLE
Refactor `seed` integration test not to use `gstruct` Matcher

### DIFF
--- a/pkg/utils/test/objectnames.go
+++ b/pkg/utils/test/objectnames.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package matchers
+package test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ObjectNames takes an ObjectList and returns a list of the objects within this list.
+// ObjectNames takes an ObjectList and returns the corresponding names of the objects.
 func ObjectNames(list client.ObjectList) []string {
 	GinkgoHelper()
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -6,7 +6,6 @@ package seed_test
 
 import (
 	"context"
-	"github.com/gardener/gardener/test/utils/matchers"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -47,6 +46,7 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/test/utils/matchers"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 )
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -6,13 +6,12 @@ package seed_test
 
 import (
 	"context"
+	"github.com/gardener/gardener/test/utils/matchers"
 	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
-	gomegatypes "github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -491,80 +490,80 @@ var _ = Describe("Seed controller tests", func() {
 					}).Should(Succeed())
 
 					var (
-						crdsOnlyForSeedClusters = []gomegatypes.GomegaMatcher{
+						crdsOnlyForSeedClusters = []string{
 							// machine-controller-manager
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("machineclasses.machine.sapcloud.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("machinedeployments.machine.sapcloud.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("machines.machine.sapcloud.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("machinesets.machine.sapcloud.io")})}),
+							"machineclasses.machine.sapcloud.io",
+							"machinedeployments.machine.sapcloud.io",
+							"machines.machine.sapcloud.io",
+							"machinesets.machine.sapcloud.io",
 							// extensions
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("backupentries.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("bastions.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusters.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("containerruntimes.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("controlplanes.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("infrastructures.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("networks.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("operatingsystemconfigs.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workers.extensions.gardener.cloud")})}),
+							"backupentries.extensions.gardener.cloud",
+							"bastions.extensions.gardener.cloud",
+							"clusters.extensions.gardener.cloud",
+							"containerruntimes.extensions.gardener.cloud",
+							"controlplanes.extensions.gardener.cloud",
+							"infrastructures.extensions.gardener.cloud",
+							"networks.extensions.gardener.cloud",
+							"operatingsystemconfigs.extensions.gardener.cloud",
+							"workers.extensions.gardener.cloud",
 						}
-						crdsSharedWithGardenCluster = []gomegatypes.GomegaMatcher{
+						crdsSharedWithGardenCluster = []string{
 							// extensions
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("backupbuckets.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dnsrecords.extensions.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("extensions.extensions.gardener.cloud")})}),
+							"backupbuckets.extensions.gardener.cloud",
+							"dnsrecords.extensions.gardener.cloud",
+							"extensions.extensions.gardener.cloud",
 							// etcd-druid
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
+							"etcds.druid.gardener.cloud",
+							"etcdcopybackupstasks.druid.gardener.cloud",
+							"managedresources.resources.gardener.cloud",
 							// istio
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("destinationrules.networking.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("envoyfilters.networking.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gateways.networking.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("serviceentries.networking.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("sidecars.networking.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("virtualservices.networking.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("authorizationpolicies.security.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("peerauthentications.security.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("requestauthentications.security.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadentries.networking.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadgroups.networking.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("telemetries.telemetry.istio.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("wasmplugins.extensions.istio.io")})}),
+							"destinationrules.networking.istio.io",
+							"envoyfilters.networking.istio.io",
+							"gateways.networking.istio.io",
+							"serviceentries.networking.istio.io",
+							"sidecars.networking.istio.io",
+							"virtualservices.networking.istio.io",
+							"authorizationpolicies.security.istio.io",
+							"peerauthentications.security.istio.io",
+							"requestauthentications.security.istio.io",
+							"workloadentries.networking.istio.io",
+							"workloadgroups.networking.istio.io",
+							"telemetries.telemetry.istio.io",
+							"wasmplugins.extensions.istio.io",
 							// vertical-pod-autoscaler
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),
+							"verticalpodautoscalers.autoscaling.k8s.io",
+							"verticalpodautoscalercheckpoints.autoscaling.k8s.io",
 							// fluent-operator
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfilters.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfluentbitconfigs.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterinputs.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusteroutputs.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterparsers.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbits.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("collectors.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbitconfigs.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("filters.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("parsers.fluentbit.fluent.io")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("outputs.fluentbit.fluent.io")})}),
+							"clusterfilters.fluentbit.fluent.io",
+							"clusterfluentbitconfigs.fluentbit.fluent.io",
+							"clusterinputs.fluentbit.fluent.io",
+							"clusteroutputs.fluentbit.fluent.io",
+							"clusterparsers.fluentbit.fluent.io",
+							"fluentbits.fluentbit.fluent.io",
+							"collectors.fluentbit.fluent.io",
+							"fluentbitconfigs.fluentbit.fluent.io",
+							"filters.fluentbit.fluent.io",
+							"parsers.fluentbit.fluent.io",
+							"outputs.fluentbit.fluent.io",
 							// prometheus-operator
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanagerconfigs.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanagers.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("podmonitors.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("probes.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheusagents.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheuses.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheusrules.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("scrapeconfigs.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("servicemonitors.monitoring.coreos.com")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("thanosrulers.monitoring.coreos.com")})}),
+							"alertmanagerconfigs.monitoring.coreos.com",
+							"alertmanagers.monitoring.coreos.com",
+							"podmonitors.monitoring.coreos.com",
+							"probes.monitoring.coreos.com",
+							"prometheusagents.monitoring.coreos.com",
+							"prometheuses.monitoring.coreos.com",
+							"prometheusrules.monitoring.coreos.com",
+							"scrapeconfigs.monitoring.coreos.com",
+							"servicemonitors.monitoring.coreos.com",
+							"thanosrulers.monitoring.coreos.com",
 						}
 					)
 
 					By("Verify that the seed-specific CRDs have been deployed")
-					Eventually(func(g Gomega) []apiextensionsv1.CustomResourceDefinition {
+					Eventually(func(g Gomega) []string {
 						crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 						g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-						return crdList.Items
+						return matchers.ObjectNames(crdList)
 					}).WithTimeout(kubernetesutils.WaitTimeout).Should(ContainElements(crdsOnlyForSeedClusters))
 
 					By("Verify that VPA was created for gardenlet")
@@ -574,10 +573,10 @@ var _ = Describe("Seed controller tests", func() {
 
 					if !seedIsGarden {
 						By("Verify that the CRDs shared with the garden cluster have been deployed")
-						Eventually(func(g Gomega) []apiextensionsv1.CustomResourceDefinition {
+						Eventually(func(g Gomega) []string {
 							crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 							g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-							return crdList.Items
+							return matchers.ObjectNames(crdList)
 						}).Should(ContainElements(crdsSharedWithGardenCluster))
 
 						// The seed controller waits for the gardener-resource-manager Deployment to be healthy, so
@@ -594,10 +593,10 @@ var _ = Describe("Seed controller tests", func() {
 						}).Should(Succeed())
 					} else {
 						By("Verify that the CRDs shared with the garden cluster have not been deployed (gardener-operator deploys them)")
-						Eventually(func(g Gomega) []apiextensionsv1.CustomResourceDefinition {
+						Eventually(func(g Gomega) []string {
 							crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 							g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-							return crdList.Items
+							return matchers.ObjectNames(crdList)
 						}).ShouldNot(ContainElements(crdsSharedWithGardenCluster))
 
 						// Usually, the gardener-operator deploys and manages the following resources.
@@ -639,49 +638,49 @@ var _ = Describe("Seed controller tests", func() {
 					}
 
 					By("Verify that the seed system components have been deployed")
-					expectedManagedResources := []gomegatypes.GomegaMatcher{
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-autoscaler")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-weeder")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-prober")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("machine-controller-manager")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("system")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-cache")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-seed")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-aggregate")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics-seed")})}),
+					expectedManagedResources := []string{
+						"cluster-autoscaler",
+						"dependency-watchdog-weeder",
+						"dependency-watchdog-prober",
+						"machine-controller-manager",
+						"system",
+						"prometheus-cache",
+						"prometheus-seed",
+						"prometheus-aggregate",
+						"kube-state-metrics-seed",
 					}
 
 					if !seedIsGarden {
 						expectedManagedResources = append(expectedManagedResources,
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vpa")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-druid")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("nginx-ingress")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("plutono")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vali")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-bit")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator-custom-resources")})}),
-							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheus-operator")})}),
+							"vpa",
+							"etcd-druid",
+							"nginx-ingress",
+							"plutono",
+							"vali",
+							"fluent-bit",
+							"fluent-operator",
+							"fluent-operator-custom-resources",
+							"prometheus-operator",
 						)
 					}
 
-					Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
+					Eventually(func(g Gomega) []string {
 						managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 						g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-						return managedResourceList.Items
+						return matchers.ObjectNames(managedResourceList)
 					}).Should(ConsistOf(expectedManagedResources))
 
-					expectedIstioManagedResources := []gomegatypes.GomegaMatcher{
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("istio")})}),
+					expectedIstioManagedResources := []string{
+						"istio",
 					}
 					if !seedIsGarden {
-						expectedIstioManagedResources = append(expectedIstioManagedResources, MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("istio-system")})}))
+						expectedIstioManagedResources = append(expectedIstioManagedResources, "istio-system")
 					}
 
-					Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
+					Eventually(func(g Gomega) []string {
 						managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 						g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace("istio-system"))).To(Succeed())
-						return managedResourceList.Items
+						return matchers.ObjectNames(managedResourceList)
 					}).Should(ConsistOf(expectedIstioManagedResources))
 
 					By("Wait for 'last operation' state to be set to Succeeded")

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -46,7 +46,6 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	"github.com/gardener/gardener/test/utils/matchers"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 )
 
@@ -563,7 +562,7 @@ var _ = Describe("Seed controller tests", func() {
 					Eventually(func(g Gomega) []string {
 						crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 						g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-						return matchers.ObjectNames(crdList)
+						return test.ObjectNames(crdList)
 					}).WithTimeout(kubernetesutils.WaitTimeout).Should(ContainElements(crdsOnlyForSeedClusters))
 
 					By("Verify that VPA was created for gardenlet")
@@ -576,7 +575,7 @@ var _ = Describe("Seed controller tests", func() {
 						Eventually(func(g Gomega) []string {
 							crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 							g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-							return matchers.ObjectNames(crdList)
+							return test.ObjectNames(crdList)
 						}).Should(ContainElements(crdsSharedWithGardenCluster))
 
 						// The seed controller waits for the gardener-resource-manager Deployment to be healthy, so
@@ -596,7 +595,7 @@ var _ = Describe("Seed controller tests", func() {
 						Eventually(func(g Gomega) []string {
 							crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 							g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-							return matchers.ObjectNames(crdList)
+							return test.ObjectNames(crdList)
 						}).ShouldNot(ContainElements(crdsSharedWithGardenCluster))
 
 						// Usually, the gardener-operator deploys and manages the following resources.
@@ -667,7 +666,7 @@ var _ = Describe("Seed controller tests", func() {
 					Eventually(func(g Gomega) []string {
 						managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 						g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-						return matchers.ObjectNames(managedResourceList)
+						return test.ObjectNames(managedResourceList)
 					}).Should(ConsistOf(expectedManagedResources))
 
 					expectedIstioManagedResources := []string{
@@ -680,7 +679,7 @@ var _ = Describe("Seed controller tests", func() {
 					Eventually(func(g Gomega) []string {
 						managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 						g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace("istio-system"))).To(Succeed())
-						return matchers.ObjectNames(managedResourceList)
+						return test.ObjectNames(managedResourceList)
 					}).Should(ConsistOf(expectedIstioManagedResources))
 
 					By("Wait for 'last operation' state to be set to Succeeded")

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -7,7 +7,6 @@ package garden_test
 import (
 	"context"
 	"fmt"
-	"github.com/gardener/gardener/test/utils/matchers"
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -62,6 +61,7 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/test/utils/matchers"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 	"github.com/gardener/gardener/test/utils/operationannotation"
 )

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -7,6 +7,7 @@ package garden_test
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/gardener/test/utils/matchers"
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -17,7 +18,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -408,7 +408,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-			return objectNames(crdList)
+			return matchers.ObjectNames(crdList)
 		}).WithTimeout(kubernetesutils.WaitTimeout).Should(ContainElements(
 			"etcds.druid.gardener.cloud",
 			"etcdcopybackupstasks.druid.gardener.cloud",
@@ -518,7 +518,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(managedResourceList)
+			return matchers.ObjectNames(managedResourceList)
 		}).Should(ContainElements(
 			"garden-system",
 			"vpa",
@@ -549,7 +549,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			etcdList := &druidv1alpha1.EtcdList{}
 			g.Expect(testClient.List(ctx, etcdList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(etcdList)
+			return matchers.ObjectNames(etcdList)
 		}).Should(ConsistOf(
 			"virtual-garden-etcd-main",
 			"virtual-garden-etcd-events",
@@ -613,7 +613,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(deploymentList)
+			return matchers.ObjectNames(deploymentList)
 		}).Should(ContainElements(
 			"virtual-garden-kube-apiserver",
 		))
@@ -652,7 +652,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(deploymentList)
+			return matchers.ObjectNames(deploymentList)
 		}).Should(ContainElements(
 			"virtual-garden-gardener-resource-manager",
 		))
@@ -661,7 +661,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			secretList := &corev1.SecretList{}
 			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(secretList)
+			return matchers.ObjectNames(secretList)
 		}).Should(ContainElements(
 			ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-"),
 		))
@@ -680,7 +680,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(managedResourceList)
+			return matchers.ObjectNames(managedResourceList)
 		}).Should(ContainElements(
 			"shoot-core-gardener-resource-manager",
 		))
@@ -694,7 +694,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			secretList := &corev1.SecretList{}
 			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(secretList)
+			return matchers.ObjectNames(secretList)
 		}).ShouldNot(ContainElements(
 			ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-"),
 		))
@@ -768,7 +768,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(deploymentList)
+			return matchers.ObjectNames(deploymentList)
 		}).Should(ContainElements(
 			"virtual-garden-kube-controller-manager",
 		))
@@ -830,7 +830,7 @@ spec:
 			Eventually(func(g Gomega) []string {
 				managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 				g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-				return objectNames(managedResourceList)
+				return matchers.ObjectNames(managedResourceList)
 			}).Should(ContainElements(
 				"gardener-"+name+"-runtime",
 				"gardener-"+name+"-virtual",
@@ -847,7 +847,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(managedResourceList)
+			return matchers.ObjectNames(managedResourceList)
 		}).Should(ContainElements(
 			"terminal-runtime",
 			"terminal-virtual",
@@ -896,7 +896,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(deploymentList)
+			return matchers.ObjectNames(deploymentList)
 		}).ShouldNot(ContainElements(
 			"virtual-garden-kube-apiserver",
 			"virtual-garden-kube-controller-manager",
@@ -906,7 +906,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			etcdList := &druidv1alpha1.EtcdList{}
 			g.Expect(testClient.List(ctx, etcdList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return objectNames(etcdList)
+			return matchers.ObjectNames(etcdList)
 		}).ShouldNot(ContainElements(
 			"virtual-garden-etcd-main",
 			"virtual-garden-etcd-events",
@@ -923,7 +923,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-			return objectNames(crdList)
+			return matchers.ObjectNames(crdList)
 		}).ShouldNot(ContainElements(
 			"etcds.druid.gardener.cloud",
 			"etcdcopybackupstasks.druid.gardener.cloud",
@@ -1083,17 +1083,4 @@ func patchExtensionStatus(cl client.Client, name, namespace string, lastOp garde
 		},
 	}
 	ExpectWithOffset(1, cl.Status().Patch(ctx, ext, patch)).To(Succeed())
-}
-
-func objectNames(list client.ObjectList) []string {
-	GinkgoHelper()
-
-	names := make([]string, 0, meta.LenList(list))
-	err := meta.EachListItem(list, func(o runtime.Object) error {
-		names = append(names, o.(client.Object).GetName())
-		return nil
-	})
-
-	Expect(err).NotTo(HaveOccurred())
-	return names
 }

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -61,7 +61,6 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	"github.com/gardener/gardener/test/utils/matchers"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 	"github.com/gardener/gardener/test/utils/operationannotation"
 )
@@ -408,7 +407,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-			return matchers.ObjectNames(crdList)
+			return test.ObjectNames(crdList)
 		}).WithTimeout(kubernetesutils.WaitTimeout).Should(ContainElements(
 			"etcds.druid.gardener.cloud",
 			"etcdcopybackupstasks.druid.gardener.cloud",
@@ -518,7 +517,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(managedResourceList)
+			return test.ObjectNames(managedResourceList)
 		}).Should(ContainElements(
 			"garden-system",
 			"vpa",
@@ -549,7 +548,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			etcdList := &druidv1alpha1.EtcdList{}
 			g.Expect(testClient.List(ctx, etcdList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(etcdList)
+			return test.ObjectNames(etcdList)
 		}).Should(ConsistOf(
 			"virtual-garden-etcd-main",
 			"virtual-garden-etcd-events",
@@ -613,7 +612,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(deploymentList)
+			return test.ObjectNames(deploymentList)
 		}).Should(ContainElements(
 			"virtual-garden-kube-apiserver",
 		))
@@ -652,7 +651,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(deploymentList)
+			return test.ObjectNames(deploymentList)
 		}).Should(ContainElements(
 			"virtual-garden-gardener-resource-manager",
 		))
@@ -661,7 +660,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			secretList := &corev1.SecretList{}
 			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(secretList)
+			return test.ObjectNames(secretList)
 		}).Should(ContainElements(
 			ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-"),
 		))
@@ -680,7 +679,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(managedResourceList)
+			return test.ObjectNames(managedResourceList)
 		}).Should(ContainElements(
 			"shoot-core-gardener-resource-manager",
 		))
@@ -694,7 +693,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			secretList := &corev1.SecretList{}
 			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(secretList)
+			return test.ObjectNames(secretList)
 		}).ShouldNot(ContainElements(
 			ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-"),
 		))
@@ -768,7 +767,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(deploymentList)
+			return test.ObjectNames(deploymentList)
 		}).Should(ContainElements(
 			"virtual-garden-kube-controller-manager",
 		))
@@ -830,7 +829,7 @@ spec:
 			Eventually(func(g Gomega) []string {
 				managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 				g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-				return matchers.ObjectNames(managedResourceList)
+				return test.ObjectNames(managedResourceList)
 			}).Should(ContainElements(
 				"gardener-"+name+"-runtime",
 				"gardener-"+name+"-virtual",
@@ -847,7 +846,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(managedResourceList)
+			return test.ObjectNames(managedResourceList)
 		}).Should(ContainElements(
 			"terminal-runtime",
 			"terminal-virtual",
@@ -896,7 +895,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			deploymentList := &appsv1.DeploymentList{}
 			g.Expect(testClient.List(ctx, deploymentList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(deploymentList)
+			return test.ObjectNames(deploymentList)
 		}).ShouldNot(ContainElements(
 			"virtual-garden-kube-apiserver",
 			"virtual-garden-kube-controller-manager",
@@ -906,7 +905,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			etcdList := &druidv1alpha1.EtcdList{}
 			g.Expect(testClient.List(ctx, etcdList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return matchers.ObjectNames(etcdList)
+			return test.ObjectNames(etcdList)
 		}).ShouldNot(ContainElements(
 			"virtual-garden-etcd-main",
 			"virtual-garden-etcd-events",
@@ -923,7 +922,7 @@ spec:
 		Eventually(func(g Gomega) []string {
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
-			return matchers.ObjectNames(crdList)
+			return test.ObjectNames(crdList)
 		}).ShouldNot(ContainElements(
 			"etcds.druid.gardener.cloud",
 			"etcdcopybackupstasks.druid.gardener.cloud",

--- a/test/utils/matchers/matchers.go
+++ b/test/utils/matchers/matchers.go
@@ -1,0 +1,22 @@
+package matchers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ObjectNames(list client.ObjectList) []string {
+	GinkgoHelper()
+
+	names := make([]string, 0, meta.LenList(list))
+	err := meta.EachListItem(list, func(o runtime.Object) error {
+		names = append(names, o.(client.Object).GetName())
+		return nil
+	})
+
+	Expect(err).NotTo(HaveOccurred())
+	return names
+}

--- a/test/utils/matchers/matchers.go
+++ b/test/utils/matchers/matchers.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package matchers
 
 import (
@@ -8,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ObjectNames takes an ObjectList and returns a list of the objects within this list.
 func ObjectNames(list client.ObjectList) []string {
 	GinkgoHelper()
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
As mentioned in https://github.com/gardener/gardener/issues/11386#issuecomment-2688056177, this change aligns the output to this change, improving test output in error cases.

Before, we just used the `gstruct` matcher in this case to see if names of Objects align. In an error case, `ginkgo` prints out the entire struct (which are lists in this case), leading to truncated output.

With this change, this test also just matches for the name, shortening the output and making it more readable

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I was not sure where to extract the `objectNames()` function to, for me this place felt the most fitting, because I could not find a better place in `test/utils`. I am not satisfied with the name of the package, but could not find a better one.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `ObjectNames()` function of `github.com/gardener/gardener/test/utils/matchers` can be used to modify `object.Object` lists to a `[]string` with their name. This is useful in tests to avoid using `gstruct` matchers that bloat the test output.
```
