### PR TITLE
Add missing `g.` to `Expect`s in `ControllerInstallation` integration test

### DIFF
--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -176,12 +176,12 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: managedResource.Namespace, Name: managedResource.Spec.SecretRefs[0].Name}, secret)).To(Succeed())
 
 				configMap := &corev1.ConfigMap{}
-				Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_config.yaml"], configMap)).To(Succeed())
-				Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
+				g.Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_config.yaml"], configMap)).To(Succeed())
+				g.Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
 
 				deployment := &appsv1.Deployment{}
-				Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_deployment.yaml"], deployment)).To(Succeed())
-				Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("test"))
+				g.Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_deployment.yaml"], deployment)).To(Succeed())
+				g.Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("test"))
 			}).Should(Succeed())
 
 			By("Ensure conditions are maintained correctly")
@@ -263,13 +263,13 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: managedResource.Namespace, Name: managedResource.Spec.SecretRefs[0].Name}, secret)).To(Succeed())
 
 				configMap := &corev1.ConfigMap{}
-				Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_config.yaml"], configMap)).To(Succeed())
-				Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
+				g.Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_config.yaml"], configMap)).To(Succeed())
+				g.Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
 
 				deployment := &appsv1.Deployment{}
-				Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_deployment.yaml"], deployment)).To(Succeed())
-				Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("test"))
-				Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(HaveExactElements(
+				g.Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_deployment.yaml"], deployment)).To(Succeed())
+				g.Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("test"))
+				g.Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(HaveExactElements(
 					corev1.EnvVar{Name: "GARDEN_KUBECONFIG", Value: "/var/run/secrets/gardener.cloud/garden/generic-kubeconfig/kubeconfig"},
 					corev1.EnvVar{Name: "SEED_NAME", Value: seed.Name},
 				))
@@ -474,9 +474,9 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: managedResource.Namespace, Name: managedResource.Spec.SecretRefs[0].Name}, secret)).To(Succeed())
 
 					deployment := &appsv1.Deployment{}
-					Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_deployment.yaml"], deployment)).To(Succeed())
-					Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("test"))
-					Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(HaveExactElements(
+					g.Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_deployment.yaml"], deployment)).To(Succeed())
+					g.Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("test"))
+					g.Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(HaveExactElements(
 						corev1.EnvVar{Name: "SEED_NAME", Value: seed.Name},
 					))
 				}).Should(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Add missing `g.` to `Expect`s in `ControllerInstallation` integration test: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11549/pull-gardener-integration/1897956753660710912

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
