### PR TITLE
Enable the `VerticalPodAutoscalerCappedRecommendation` alerts

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -329,6 +329,9 @@ spec:
           count(
             count by (seed) (ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="seed", alertstate="firing"})
           )
+      labels:
+          severity: warning
+          topology: garden
       annotations:
         summary: >-
           A VPA recommendation in a seed is capped.

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/shoot.yaml
@@ -117,6 +117,9 @@ spec:
           count(
             count by (cluster) (ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="shoot", alertstate="firing"})
           )
+      labels:
+        severity: warning
+        topology: garden
       annotations:
         summary: >-
           A VPA recommendation in a shoot is capped.

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
@@ -231,6 +231,7 @@ func gardenPrometheusRule(isGardenerDiscoveryServerEnabled bool) *monitoringv1.P
   )
 ==
   5`),
+			Labels: getLabels("warning"),
 			Annotations: map[string]string{
 				"summary": "A VPA recommendation in the garden cluster is capped.",
 				"description": "The following VPA in the garden cluster shows a " +

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -201,6 +201,8 @@ tests:
       eval_time: 0m # test the alert fires immediately
       exp_alerts:
         - exp_labels:
+            severity: warning
+            topology: garden
           exp_annotations:
             summary: >-
               A VPA recommendation in a seed is capped.

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/shoot.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/shoot.prometheusrule.test.yaml
@@ -53,6 +53,8 @@ tests:
       eval_time: 0m # test the alert fires immediately
       exp_alerts:
         - exp_labels:
+            severity: warning
+            topology: garden
           exp_annotations:
             summary: >-
               A VPA recommendation in a shoot is capped.


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

https://github.com/gardener/gardener/pull/11136 introduces a new `VerticalPodAutoscalerCappedRecommendation` alert when a VPA uncapped target recommendation is larger than the regular target. https://github.com/gardener/gardener/pull/11325 revisits this to address a few caveats with the original alert that went undetected in development environments. In both cases, however, the alert was never enabled. Initially, we wanted to introduce the alert without enabling it to develop an understanding of its behaviour, such as how often it would fire. Now, in this PR, we proceed to enable it.

**Special notes for your reviewer**:

/cc @istvanballok @rickardsjp @chrkl 

**Release note**:

```other operator
Enable the `VerticalPodAutoscalerCappedRecommendation` alerts
```
