### PR TITLE
Enable Gardener Node Agent to properly configure containerd 2.0 which introduced v3 of its config file

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
@@ -43,21 +43,18 @@ var (
 	containerdConfigPaths = containerdConfigPathMapVersions{
 		1: {
 			registryConfigPath: {"plugins", "io.containerd.grpc.v1.cri", "registry", "config_path"},
-			importsPath:        {"imports"},
 			sandboxImagePath:   {"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"},
 			cgroupDriverPath:   {"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
 			cniPluginPath:      {"plugins", "io.containerd.grpc.v1.cri", "cni", "bin_dir"},
 		},
 		2: {
 			registryConfigPath: {"plugins", "io.containerd.grpc.v1.cri", "registry", "config_path"},
-			importsPath:        {"imports"},
 			sandboxImagePath:   {"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"},
 			cgroupDriverPath:   {"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
 			cniPluginPath:      {"plugins", "io.containerd.grpc.v1.cri", "cni", "bin_dir"},
 		},
 		3: {
 			registryConfigPath: {"plugins", "io.containerd.cri.v1.images", "registry", "config_path"},
-			importsPath:        {"imports"},
 			sandboxImagePath:   {"plugins", "io.containerd.cri.v1.runtime", "sandbox_image"},
 			cgroupDriverPath:   {"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
 			cniPluginPath:      {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
@@ -144,7 +141,7 @@ func (r *Reconciler) ensureContainerdConfiguration(log logr.Logger, criConfig *e
 		},
 		{
 			name: "imports paths",
-			path: containerdConfigPaths[configFileVersion][importsPath],
+			path: structuredmap.Path{"imports"},
 			setFn: func(value any) (any, error) {
 				importPath := path.Join(configDir, "*.toml")
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package operatingsystemconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"slices"
+
+	"github.com/go-logr/logr"
+	"github.com/pelletier/go-toml"
+	"k8s.io/utils/ptr"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/structuredmap"
+)
+
+type (
+	containerdConfigFileVersion int
+	containerdConfigPathName    int
+
+	containerdConfigPathMap         map[containerdConfigPathName]structuredmap.Path
+	containerdConfigPathMapVersions map[containerdConfigFileVersion]containerdConfigPathMap
+
+	replacementMap map[*structuredmap.Path]structuredmap.Path
+)
+
+const (
+	registryConfigPath containerdConfigPathName = iota
+	importsPath
+	sandboxImagePath
+	cgroupDriverPath
+	cniPluginPath
+)
+
+var (
+	// containerdConfigPaths is a nested map that contains the paths/keys for certain configuration options that change across different config file versions
+	containerdConfigPaths = containerdConfigPathMapVersions{
+		1: {
+			registryConfigPath: {"plugins", "io.containerd.grpc.v1.cri", "registry", "config_path"},
+			importsPath:        {"imports"},
+			sandboxImagePath:   {"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"},
+			cgroupDriverPath:   {"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
+			cniPluginPath:      {"plugins", "io.containerd.grpc.v1.cri", "cni", "bin_dir"},
+		},
+		2: {
+			registryConfigPath: {"plugins", "io.containerd.grpc.v1.cri", "registry", "config_path"},
+			importsPath:        {"imports"},
+			sandboxImagePath:   {"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"},
+			cgroupDriverPath:   {"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
+			cniPluginPath:      {"plugins", "io.containerd.grpc.v1.cri", "cni", "bin_dir"},
+		},
+		3: {
+			registryConfigPath: {"plugins", "io.containerd.cri.v1.images", "registry", "config_path"},
+			importsPath:        {"imports"},
+			sandboxImagePath:   {"plugins", "io.containerd.cri.v1.runtime", "sandbox_image"},
+			cgroupDriverPath:   {"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
+			cniPluginPath:      {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
+		},
+	}
+
+	// pluginPathReplacements is a map that contains replacements for paths brought in through an osc plugin config
+	pluginPathReplacements = replacementMap{
+		{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes"}: {"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes"},
+	}
+)
+
+// getContainerdConfigFileVersion obtains the containerd configuration file version from the configuration file
+func getContainerdConfigFileVersion(config map[string]any) (containerdConfigFileVersion, error) {
+	version, ok := config["version"]
+	if !ok {
+		// config file versions 2 and 3 must contain a version header
+		// if it cannot be found, it therefore must be version 1
+		return 1, nil
+	}
+
+	i, ok := version.(int64)
+	if !ok {
+		return 0, fmt.Errorf("cannot assert containerd config file version as an int64")
+	}
+
+	if i > 3 {
+		return 0, fmt.Errorf("unsupported containerd config file version %d", i)
+	}
+
+	return containerdConfigFileVersion(i), nil
+}
+
+// ensureContainerdDefaultConfig invokes the 'containerd' and saves the resulting default configuration.
+func (r *Reconciler) ensureContainerdDefaultConfig(ctx context.Context) error {
+	exists, err := r.FS.Exists(configFile)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		return nil
+	}
+
+	output, err := Exec(ctx, "containerd", "config", "default")
+	if err != nil {
+		return err
+	}
+
+	return r.FS.WriteFile(configFile, output, 0644)
+}
+
+// ensureContainerdConfiguration sets the configuration for containerd.
+func (r *Reconciler) ensureContainerdConfiguration(log logr.Logger, criConfig *extensionsv1alpha1.CRIConfig) error {
+	config, err := r.FS.ReadFile(configFile)
+	if err != nil {
+		return fmt.Errorf("unable to read containerd config.toml: %w", err)
+	}
+
+	content := map[string]any{}
+
+	if err = toml.Unmarshal(config, &content); err != nil {
+		return fmt.Errorf("unable to decode containerd default config: %w", err)
+	}
+
+	containerdConfigFileVersion, err := getContainerdConfigFileVersion(content)
+	if err != nil {
+		return err
+	}
+
+	type (
+		patch struct {
+			name  string
+			path  structuredmap.Path
+			setFn structuredmap.SetFn
+		}
+	)
+
+	patches := []patch{
+		{
+			name: "registry config path",
+			path: containerdConfigPaths[containerdConfigFileVersion][registryConfigPath],
+			setFn: func(_ any) (any, error) {
+				return certsDir, nil
+			},
+		},
+		{
+			name: "imports paths",
+			path: containerdConfigPaths[containerdConfigFileVersion][importsPath],
+			setFn: func(value any) (any, error) {
+				importPath := path.Join(configDir, "*.toml")
+
+				imports, ok := value.([]any)
+				if !ok {
+					return []string{importPath}, nil
+				}
+
+				for _, imp := range imports {
+					path, ok := imp.(string)
+					if !ok {
+						continue
+					}
+
+					if path == importPath {
+						return value, nil
+					}
+				}
+
+				return append(imports, importPath), nil
+			},
+		},
+		{
+			name: "sandbox image",
+			path: containerdConfigPaths[containerdConfigFileVersion][sandboxImagePath],
+			setFn: func(value any) (any, error) {
+				if criConfig.Containerd == nil {
+					return value, nil
+				}
+
+				return criConfig.Containerd.SandboxImage, nil
+			},
+		},
+		{
+			name: "CNI plugin dir",
+			path: containerdConfigPaths[containerdConfigFileVersion][cniPluginPath],
+			setFn: func(_ any) (any, error) {
+				return cniPluginDir, nil
+			},
+		},
+	}
+
+	if criConfig.CgroupDriver != nil {
+		patches = append(patches, patch{
+			name: "cgroup driver",
+			path: containerdConfigPaths[containerdConfigFileVersion][cgroupDriverPath],
+			setFn: func(_ any) (any, error) {
+				return *criConfig.CgroupDriver == extensionsv1alpha1.CgroupDriverSystemd, nil
+			},
+		})
+	}
+
+	if criConfig.Containerd != nil {
+		for _, pluginConfig := range criConfig.Containerd.Plugins {
+			patches = append(patches, patch{
+				name: "plugin configuration",
+				path: replacePluginPath(append(structuredmap.Path{"plugins"}, pluginConfig.Path...), pluginPathReplacements, containerdConfigFileVersion),
+				setFn: func(val any) (any, error) {
+					switch op := ptr.Deref(pluginConfig.Op, extensionsv1alpha1.AddPluginPathOperation); op {
+					case extensionsv1alpha1.AddPluginPathOperation:
+						values, ok := val.(map[string]any)
+						if !ok || values == nil {
+							values = map[string]any{}
+						}
+
+						pluginValues := pluginConfig.Values
+						// Return unchanged values if plugin values is not set, i.e. only create table.
+						if pluginValues == nil {
+							return values, nil
+						}
+
+						if err := json.Unmarshal(pluginValues.Raw, &values); err != nil {
+							return nil, err
+						}
+
+						return values, nil
+					case extensionsv1alpha1.RemovePluginPathOperation:
+						// Return nil if operation is remove, to delete the entire sub-tree.
+						return nil, nil
+					default:
+						return nil, fmt.Errorf("operation %q is not supported", op)
+					}
+				},
+			})
+		}
+	}
+
+	for _, p := range patches {
+		if err := structuredmap.SetMapEntry(content, p.path, p.setFn); err != nil {
+			return fmt.Errorf("unable setting %q in containerd config.toml: %w", p.name, err)
+		}
+	}
+
+	f, err := r.FS.OpenFile(configFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("unable to open containerd config.toml: %w", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Error(err, "Failed closing file", "file", f.Name())
+		}
+	}()
+
+	return toml.NewEncoder(f).Encode(content)
+}
+
+func isConfigPathPrefix(path, prefix structuredmap.Path) bool {
+	if len(prefix) > len(path) {
+		return false
+	}
+
+	return slices.Equal(prefix, path[:len(prefix)])
+}
+
+func replaceConfigPathPrefix(path, prefix, replace structuredmap.Path) structuredmap.Path {
+	if slices.Equal(replace, prefix) {
+		return path
+	}
+
+	if !isConfigPathPrefix(path, prefix) {
+		return path
+	}
+
+	pathStripped := path[len(prefix):]
+
+	return slices.Concat(replace, pathStripped)
+}
+
+func replacePluginPath(path structuredmap.Path, replacementMap replacementMap, version containerdConfigFileVersion) structuredmap.Path {
+	if version != 3 {
+		return path
+	}
+
+	for find, replace := range replacementMap {
+		if isConfigPathPrefix(path, *find) {
+			return replaceConfigPathPrefix(path, *find, replace)
+		}
+	}
+	return path
+}

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package operatingsystemconfig_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pelletier/go-toml"
+	"github.com/spf13/afero"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/ptr"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
+	"github.com/gardener/gardener/pkg/utils/structuredmap"
+)
+
+var (
+	r   operatingsystemconfig.Reconciler
+	osc *extensionsv1alpha1.OperatingSystemConfig
+
+	ctx context.Context
+	log logr.Logger
+)
+
+const (
+	containerdConfigFilePath = "/etc/containerd/config.toml"
+
+	certdsDirValue    = "/etc/containerd/certs.d"
+	importsValue      = "/etc/containerd/conf.d/*.toml"
+	sandBoxImageValue = "foo:1.23"
+	cniBinDirValue    = "/opt/cni/bin"
+)
+
+func init() {
+	ctx = context.Background()
+	log = logr.Discard()
+
+	r = operatingsystemconfig.Reconciler{}
+
+	osc = &extensionsv1alpha1.OperatingSystemConfig{
+		Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+			CRIConfig: &extensionsv1alpha1.CRIConfig{
+				Name:         extensionsv1alpha1.CRINameContainerD,
+				CgroupDriver: ptr.To(extensionsv1alpha1.CgroupDriverSystemd),
+				Containerd: &extensionsv1alpha1.ContainerdConfig{
+					SandboxImage: sandBoxImageValue,
+				},
+			},
+			Units: []extensionsv1alpha1.Unit{},
+		},
+	}
+}
+
+func getMapEntry(m map[string]any, path structuredmap.Path) (any, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	key := path[0]
+
+	if len(path) == 1 {
+		return m[key], nil
+	}
+
+	entry, ok := m[key]
+	if !ok {
+		return nil, fmt.Errorf("unable to traverse into data structure because key %q does not exist", key)
+	}
+
+	childMap, ok := entry.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unable to traverse into data structure because value at %q is not a map", key)
+	}
+
+	r, err := getMapEntry(childMap, path[1:])
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func getContainerdConfigValue(fs afero.Afero, path structuredmap.Path) (any, error) {
+	containerdConfigfile, err := fs.ReadFile(containerdConfigFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	containerdConfigContent := map[string]any{}
+
+	if err = toml.Unmarshal(containerdConfigfile, &containerdConfigContent); err != nil {
+		return nil, err
+	}
+
+	return getMapEntry(containerdConfigContent, path)
+}
+
+func loadContainerdConfig(source string, fs afero.Afero) error {
+	containerdConfig, err := os.ReadFile(source)
+	if err != nil {
+		return err
+	}
+
+	err = fs.WriteFile("/etc/containerd/config.toml", containerdConfig, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ = Describe("containerd configuration file tests", func() {
+
+	BeforeEach(func() {
+		r.FS = afero.Afero{Fs: afero.NewMemMapFs()}
+		Expect(r.FS.MkdirAll("/etc/containerd", 0755)).To(Succeed())
+	})
+
+	Describe("static containerd configuration paths set by gardener-node-agent", func() {
+
+		When("containerd configuration file version is v2", func() {
+			BeforeEach(func() {
+				Expect(loadContainerdConfig("testfiles/containerd-config.toml-v2", r.FS)).To(Succeed())
+				Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
+			})
+
+			It("should set the imports", func() {
+				path := structuredmap.Path{"imports"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				rawImports, ok := configValue.([]any)
+				Expect(ok).To(BeTrue())
+				Expect(rawImports).To(HaveLen(1))
+
+				v, ok := rawImports[0].(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal(importsValue))
+			})
+
+			It("should set the sandbox image", func() {
+				path := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal(sandBoxImageValue))
+			})
+
+			It("should set the registry config path", func() {
+				path := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "registry", "config_path"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal(certdsDirValue))
+			})
+
+			It("should set the cgroup driver", func() {
+				path := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "options", "SystemdCgroup"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(bool)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(BeTrue())
+			})
+
+			It("should set the CNI plugin dir", func() {
+				path := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "cni", "bin_dir"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal(cniBinDirValue))
+			})
+		})
+
+		When("containerd configuration file version is v3", func() {
+			BeforeEach(func() {
+				Expect(loadContainerdConfig("testfiles/containerd-config.toml-v3", r.FS)).To(Succeed())
+				Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
+			})
+
+			It("should set the imports", func() {
+				path := structuredmap.Path{"imports"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				rawImports, ok := configValue.([]any)
+				Expect(ok).To(BeTrue())
+				Expect(rawImports).To(HaveLen(1))
+
+				v, ok := rawImports[0].(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal(importsValue))
+			})
+
+			It("should set the sandbox image", func() {
+				path := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "sandbox_image"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal(sandBoxImageValue))
+			})
+
+			It("should set the registry config path", func() {
+				path := structuredmap.Path{"plugins", "io.containerd.cri.v1.images", "registry", "config_path"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal(certdsDirValue))
+			})
+
+			It("should set the cgroup driver", func() {
+				path := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(bool)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(BeTrue())
+			})
+
+			It("should set the CNI plugin dir", func() {
+				path := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"}
+				configValue, err := getContainerdConfigValue(r.FS, path)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal(cniBinDirValue))
+			})
+		})
+	})
+
+	Describe("plugin configuration paths inserted by osc plugin config", func() {
+
+		When("containerd configuration file version is v2", func() {
+			BeforeEach(func() {
+				Expect(loadContainerdConfig("testfiles/containerd-config.toml-v2", r.FS)).To(Succeed())
+			})
+
+			It("should not translate anything", func() {
+				osc.Spec.CRIConfig.Containerd.Plugins = []extensionsv1alpha1.PluginConfig{
+					{
+						Op:   ptr.To(extensionsv1alpha1.AddPluginPathOperation),
+						Path: []string{"io.containerd.grpc.v1.cri", "containerd", "runtimes", "foo"},
+						Values: &apiextensionsv1.JSON{
+							Raw: []byte("{\"runtime_type\": \"bar.123\"}"),
+						},
+					},
+				}
+
+				Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
+
+				wrongPath := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "foo", "runtime_type"}
+				_, err := getContainerdConfigValue(r.FS, wrongPath)
+				Expect(err).To(HaveOccurred())
+
+				goodPath := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "foo", "runtime_type"}
+				configValue, err := getContainerdConfigValue(r.FS, goodPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal("bar.123"))
+			})
+		})
+
+		When("containerd configuration file version is v3", func() {
+			BeforeEach(func() {
+				Expect(loadContainerdConfig("testfiles/containerd-config.toml-v3", r.FS)).To(Succeed())
+			})
+
+			It("should translate a v2 compliant runtime path to its v3 equivalent", func() {
+				osc.Spec.CRIConfig.Containerd.Plugins = []extensionsv1alpha1.PluginConfig{
+					{
+						Op:   ptr.To(extensionsv1alpha1.AddPluginPathOperation),
+						Path: []string{"io.containerd.grpc.v1.cri", "containerd", "runtimes", "foo"},
+						Values: &apiextensionsv1.JSON{
+							Raw: []byte("{\"runtime_type\": \"bar.123\"}"),
+						},
+					},
+				}
+
+				Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
+
+				wrongPath := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "foo", "runtime_type"}
+				_, err := getContainerdConfigValue(r.FS, wrongPath)
+				Expect(err).To(HaveOccurred())
+
+				goodPath := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "foo", "runtime_type"}
+				configValue, err := getContainerdConfigValue(r.FS, goodPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal("bar.123"))
+			})
+
+			It("should not translate a path that is not in the translation map", func() {
+				osc.Spec.CRIConfig.Containerd.Plugins = []extensionsv1alpha1.PluginConfig{
+					{
+						Op:   ptr.To(extensionsv1alpha1.AddPluginPathOperation),
+						Path: []string{"io.containerd.grpc.v1.cri", "containerd", "foobar", "foo"},
+						Values: &apiextensionsv1.JSON{
+							Raw: []byte("{\"runtime_type\": \"bar.123\"}"),
+						},
+					},
+				}
+
+				Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
+
+				wrongPath := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "containerd", "foobar", "foo", "runtime_type"}
+				_, err := getContainerdConfigValue(r.FS, wrongPath)
+				Expect(err).To(HaveOccurred())
+
+				goodPath := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "containerd", "foobar", "foo", "runtime_type"}
+				configValue, err := getContainerdConfigValue(r.FS, goodPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal("bar.123"))
+			})
+		})
+	})
+})

--- a/pkg/nodeagent/controller/operatingsystemconfig/testfiles/containerd-config.toml-v2
+++ b/pkg/nodeagent/controller/operatingsystemconfig/testfiles/containerd-config.toml-v2
@@ -1,0 +1,293 @@
+# obtained through containerd config default on containerd 1.7.23
+
+disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
+root = "/var/lib/containerd"
+state = "/run/containerd"
+temp = ""
+version = 2
+
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+  gid = 0
+  level = ""
+  uid = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_ca = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 0
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+    pause_threshold = 0.02
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+    device_ownership_from_security_context = false
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = true
+    disable_proc_mount = false
+    disable_tcp_service = true
+    drain_exec_sync_io_timeout = "0s"
+    enable_cdi = false
+    enable_selinux = false
+    enable_tls_streaming = false
+    enable_unprivileged_icmp = false
+    enable_unprivileged_ports = false
+    ignore_deprecation_warnings = []
+    ignore_image_defined_volumes = false
+    image_pull_progress_timeout = "5m0s"
+    image_pull_with_sync_fs = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "registry.k8s.io/pause:3.8"
+    selinux_category_range = 1024
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = true
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+      ip_pref = ""
+      max_conf_num = 1
+      setup_serially = false
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runc"
+      disable_snapshot_annotations = true
+      discard_unpacked_layers = false
+      ignore_blockio_not_enabled_errors = false
+      ignore_rdt_not_enabled_errors = false
+      no_pivot = false
+      snapshotter = "overlayfs"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        privileged_without_host_devices_all_devices_allowed = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+        sandbox_mode = ""
+        snapshotter = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+          sandbox_mode = "podsandbox"
+          snapshotter = ""
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = ""
+            CriuImagePath = ""
+            CriuPath = ""
+            CriuWorkPath = ""
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            NoPivotRoot = false
+            Root = ""
+            ShimCgroup = ""
+            SystemdCgroup = false
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        privileged_without_host_devices_all_devices_allowed = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+        sandbox_mode = ""
+        snapshotter = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+    [plugins."io.containerd.grpc.v1.cri".image_decryption]
+      key_model = "node"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.internal.v1.tracing"]
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+
+  [plugins."io.containerd.nri.v1.nri"]
+    disable = true
+    disable_connections = false
+    plugin_config_path = "/etc/nri/conf.d"
+    plugin_path = "/opt/nri/plugins"
+    plugin_registration_timeout = "5s"
+    plugin_request_timeout = "2s"
+    socket_path = "/var/run/nri/nri.sock"
+
+  [plugins."io.containerd.runtime.v1.linux"]
+    no_shim = false
+    runtime = "runc"
+    runtime_root = ""
+    shim = "containerd-shim"
+    shim_debug = false
+
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["linux/amd64"]
+    sched_core = false
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+
+  [plugins."io.containerd.service.v1.tasks-service"]
+    blockio_config_file = ""
+    rdt_config_file = ""
+
+  [plugins."io.containerd.snapshotter.v1.aufs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.blockfile"]
+    fs_type = ""
+    mount_options = []
+    root_path = ""
+    scratch_file = ""
+
+  [plugins."io.containerd.snapshotter.v1.btrfs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    async_remove = false
+    base_image_size = ""
+    discard_blocks = false
+    fs_options = ""
+    fs_type = ""
+    pool_name = ""
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.native"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    mount_options = []
+    root_path = ""
+    sync_remove = false
+    upperdir_label = false
+
+  [plugins."io.containerd.snapshotter.v1.zfs"]
+    root_path = ""
+
+  [plugins."io.containerd.tracing.processor.v1.otlp"]
+
+  [plugins."io.containerd.transfer.v1.local"]
+    config_path = ""
+    max_concurrent_downloads = 3
+    max_concurrent_uploaded_layers = 3
+
+    [[plugins."io.containerd.transfer.v1.local".unpack_config]]
+      differ = ""
+      platform = "linux/amd64"
+      snapshotter = "overlayfs"
+
+[proxy_plugins]
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.bolt.open" = "0s"
+  "io.containerd.timeout.metrics.shimstats" = "2s"
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0

--- a/pkg/nodeagent/controller/operatingsystemconfig/testfiles/containerd-config.toml-v3
+++ b/pkg/nodeagent/controller/operatingsystemconfig/testfiles/containerd-config.toml-v3
@@ -1,0 +1,241 @@
+# obtained through containerd config default on containerd 2.0.2 (w/ Debian patches)
+
+version = 3
+root = '/var/lib/containerd'
+state = '/run/containerd'
+temp = ''
+plugin_dir = ''
+disabled_plugins = []
+required_plugins = []
+oom_score = 0
+imports = []
+
+[grpc]
+  address = '/run/containerd/containerd.sock'
+  tcp_address = ''
+  tcp_tls_ca = ''
+  tcp_tls_cert = ''
+  tcp_tls_key = ''
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[ttrpc]
+  address = ''
+  uid = 0
+  gid = 0
+
+[debug]
+  address = ''
+  uid = 0
+  gid = 0
+  level = ''
+  format = ''
+
+[metrics]
+  address = ''
+  grpc_histogram = false
+
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    snapshotter = 'overlayfs'
+    disable_snapshot_annotations = true
+    discard_unpacked_layers = false
+    max_concurrent_downloads = 3
+    image_pull_progress_timeout = '5m0s'
+    image_pull_with_sync_fs = false
+    stats_collect_period = 10
+
+    [plugins.'io.containerd.cri.v1.images'.pinned_images]
+      sandbox = 'registry.k8s.io/pause:3.10'
+
+    [plugins.'io.containerd.cri.v1.images'.registry]
+      config_path = ''
+
+    [plugins.'io.containerd.cri.v1.images'.image_decryption]
+      key_model = 'node'
+
+  [plugins.'io.containerd.cri.v1.runtime']
+    enable_selinux = false
+    selinux_category_range = 1024
+    max_container_log_line_size = 16384
+    disable_apparmor = false
+    restrict_oom_score_adj = false
+    disable_proc_mount = false
+    unset_seccomp_profile = ''
+    tolerate_missing_hugetlb_controller = true
+    disable_hugetlb_controller = true
+    device_ownership_from_security_context = false
+    ignore_image_defined_volumes = false
+    netns_mounts_under_state_dir = false
+    enable_unprivileged_ports = true
+    enable_unprivileged_icmp = true
+    enable_cdi = true
+    cdi_spec_dirs = ['/etc/cdi', '/var/run/cdi']
+    drain_exec_sync_io_timeout = '0s'
+    ignore_deprecation_warnings = []
+
+    [plugins.'io.containerd.cri.v1.runtime'.containerd]
+      default_runtime_name = 'runc'
+      ignore_blockio_not_enabled_errors = false
+      ignore_rdt_not_enabled_errors = false
+
+      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]
+        [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+          runtime_type = 'io.containerd.runc.v2'
+          runtime_path = ''
+          pod_annotations = []
+          container_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          base_runtime_spec = ''
+          cni_conf_dir = ''
+          cni_max_conf_num = 0
+          snapshotter = ''
+          sandboxer = 'podsandbox'
+          io_type = ''
+
+          [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
+            BinaryName = ''
+            CriuImagePath = ''
+            CriuWorkPath = ''
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            Root = ''
+            ShimCgroup = ''
+
+    [plugins.'io.containerd.cri.v1.runtime'.cni]
+      bin_dir = '/usr/lib/cni'
+      conf_dir = '/etc/cni/net.d'
+      max_conf_num = 1
+      setup_serially = false
+      conf_template = ''
+      ip_pref = ''
+      use_internal_loopback = false
+
+  [plugins.'io.containerd.gc.v1.scheduler']
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = '0s'
+    startup_delay = '100ms'
+
+  [plugins.'io.containerd.grpc.v1.cri']
+    disable_tcp_service = true
+    stream_server_address = '127.0.0.1'
+    stream_server_port = '0'
+    stream_idle_timeout = '4h0m0s'
+    enable_tls_streaming = false
+
+    [plugins.'io.containerd.grpc.v1.cri'.x509_key_pair_streaming]
+      tls_cert_file = ''
+      tls_key_file = ''
+
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+    max_verifiers = 10
+    per_verifier_timeout = '10s'
+
+  [plugins.'io.containerd.internal.v1.opt']
+    path = '/opt/containerd'
+
+  [plugins.'io.containerd.internal.v1.tracing']
+
+  [plugins.'io.containerd.metadata.v1.bolt']
+    content_sharing_policy = 'shared'
+
+  [plugins.'io.containerd.monitor.container.v1.restart']
+    interval = '10s'
+
+  [plugins.'io.containerd.monitor.task.v1.cgroups']
+    no_prometheus = false
+
+  [plugins.'io.containerd.nri.v1.nri']
+    disable = false
+    socket_path = '/var/run/nri/nri.sock'
+    plugin_path = '/opt/nri/plugins'
+    plugin_config_path = '/etc/nri/conf.d'
+    plugin_registration_timeout = '5s'
+    plugin_request_timeout = '2s'
+    disable_connections = false
+
+  [plugins.'io.containerd.runtime.v2.task']
+    platforms = ['linux/amd64']
+
+  [plugins.'io.containerd.service.v1.diff-service']
+    default = ['walking']
+    sync_fs = false
+
+  [plugins.'io.containerd.service.v1.tasks-service']
+    blockio_config_file = ''
+    rdt_config_file = ''
+
+  [plugins.'io.containerd.shim.v1.manager']
+    env = []
+
+  [plugins.'io.containerd.snapshotter.v1.blockfile']
+    root_path = ''
+    scratch_file = ''
+    fs_type = ''
+    mount_options = []
+    recreate_scratch = false
+
+  [plugins.'io.containerd.snapshotter.v1.btrfs']
+    root_path = ''
+
+  [plugins.'io.containerd.snapshotter.v1.devmapper']
+    root_path = ''
+    pool_name = ''
+    base_image_size = ''
+    async_remove = false
+    discard_blocks = false
+    fs_type = ''
+    fs_options = ''
+
+  [plugins.'io.containerd.snapshotter.v1.native']
+    root_path = ''
+
+  [plugins.'io.containerd.snapshotter.v1.overlayfs']
+    root_path = ''
+    upperdir_label = false
+    sync_remove = false
+    slow_chown = false
+    mount_options = []
+
+  [plugins.'io.containerd.snapshotter.v1.zfs']
+    root_path = ''
+
+  [plugins.'io.containerd.tracing.processor.v1.otlp']
+
+  [plugins.'io.containerd.transfer.v1.local']
+    max_concurrent_downloads = 3
+    max_concurrent_uploaded_layers = 3
+    config_path = ''
+
+[cgroup]
+  path = ''
+
+[timeouts]
+  'io.containerd.timeout.bolt.open' = '0s'
+  'io.containerd.timeout.metrics.shimstats' = '2s'
+  'io.containerd.timeout.shim.cleanup' = '5s'
+  'io.containerd.timeout.shim.load' = '5s'
+  'io.containerd.timeout.shim.shutdown' = '3s'
+  'io.containerd.timeout.task.state' = '2s'
+
+[stream_processors]
+  [stream_processors.'io.containerd.ocicrypt.decoder.v1.tar']
+    accepts = ['application/vnd.oci.image.layer.v1.tar+encrypted']
+    returns = 'application/vnd.oci.image.layer.v1.tar'
+    path = 'ctd-decoder'
+    args = ['--decryption-keys-path', '/etc/containerd/ocicrypt/keys']
+    env = ['OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf']
+
+  [stream_processors.'io.containerd.ocicrypt.decoder.v1.tar.gzip']
+    accepts = ['application/vnd.oci.image.layer.v1.tar+gzip+encrypted']
+    returns = 'application/vnd.oci.image.layer.v1.tar+gzip'
+    path = 'ctd-decoder'
+    args = ['--decryption-keys-path', '/etc/containerd/ocicrypt/keys']
+    env = ['OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf']

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -118,6 +118,9 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "registry.k8s.io/pause:latest"
 
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+
     [plugins."io.containerd.grpc.v1.cri".containerd]
 
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
@@ -714,7 +717,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that containerd config was updated properly")
-		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", "imports = [\"/etc/containerd/conf.d/*.toml\"]\n\n[plugins]\n\n  [plugins.bar]\n\n  [plugins.\"io.containerd.grpc.v1.cri\"]\n    sandbox_image = \"registry.k8s.io/pause:latest\"\n\n    [plugins.\"io.containerd.grpc.v1.cri\".containerd]\n\n      [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes]\n\n        [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc]\n\n          [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]\n            SystemdCgroup = true\n\n    [plugins.\"io.containerd.grpc.v1.cri\".registry]\n      config_path = \"/etc/containerd/certs.d\"\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/containerd/config.toml", "imports = [\"/etc/containerd/conf.d/*.toml\"]\n\n[plugins]\n\n  [plugins.bar]\n\n  [plugins.\"io.containerd.grpc.v1.cri\"]\n    sandbox_image = \"registry.k8s.io/pause:latest\"\n\n    [plugins.\"io.containerd.grpc.v1.cri\".cni]\n      bin_dir = \"/opt/cni/bin\"\n\n    [plugins.\"io.containerd.grpc.v1.cri\".containerd]\n\n      [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes]\n\n        [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc]\n\n          [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]\n            SystemdCgroup = true\n\n    [plugins.\"io.containerd.grpc.v1.cri\".registry]\n      config_path = \"/etc/containerd/certs.d\"\n", 0644)
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area os

**What this PR does / why we need it**:

With containerd 2.0, a new config file version v3 was introduced. With that, a number of configuration options in
`/etc/containerd/config.toml` moved to different paths - see issue #11611 for more details.

With this PR, when GNA makes changes to `/etc/containerd/config.toml` in its `ensureContainerdConfiguration()`, it will first read the version header of the config file and then use a lookup-table to determine at which path the configuration needs to be set.
Furthermore, when config file version 3 is detected, it will translate any path that is inserted through an OSC `PluginConfiguration` and that matches a typical v2 compliant path prefix to the equivalent v3 compliant path prefix.
Finally, this PR makes GNA always configure the CNI plugin directory to `/opt/cni/bin` as this is the upstream containerd default that all network plugins we use in Gardener get installed into.

I took the liberty to move all containerd config related functions into the separate file `containerd_config.go` for better test coverage of these changes.

**Which issue(s) this PR fixes**:
Fixes #11611

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The gardener-node-agent is now able to deal with the new version v3 of containerd's configuration file `/etc/containerd/config.toml`. As this new version of the configuration file comes with a new structure of certain configuration options, gardener-node-agent must be able to write configuration changes to different locations within the file based on its version. If it detects this config file to be version 3, it will write all relevant configuration changes to the new config keys. In addition, for any plugins inserted through an OSC `PluginConfiguration`, it will check if its path matches a typical v2 compliant path prefix and will translate it to the equivalent v3 compliant path prefix.
```
