### PR TITLE
[renovate] Disable major updates of jsonpatch/v2

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -444,7 +444,7 @@
         'gomodules.xyz/jsonpatch/v2',
       ],
       matchUpdateTypes: [
-        'major'
+        'major',
       ],
       enabled: false,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -434,6 +434,18 @@
       ],
     },
     {
+      // Limit updates of jsonpatch/v2 to stay below v3.0.0.
+      // The major version of this dependency should be kept in sync with controller-runtime:
+      // https://github.com/kubernetes-sigs/controller-runtime/blob/main/go.mod
+      matchDatasources: [
+        'go',
+      ],
+      matchPackageNames: [
+        'gomodules.xyz/jsonpatch/v2',
+      ],
+      allowedVersions: '<v3.0.0', // Should be updated when controller-runtime uses a new major version.
+    },
+    {
       // TODO(marc1404): Remove when the NewVPN feature gate is removed.
       // Ignore dependency updates of gardener/vpn2@0.26.0 which is used when the NewVPN feature gate is disabled.
       matchFileNames: [
@@ -449,10 +461,10 @@
       // TODO(marc1404): Remove when support for Kubernetes v1.27 is dropped.
       // Restrict updates of ingress-nginx/controller-chroot@v1.11.x for Kubernetes v1.27 to stay below v1.12.0.
       matchFileNames: [
-        'imagevector/containers.yaml'
+        'imagevector/containers.yaml',
       ],
       matchPackageNames: [
-        'registry.k8s.io/ingress-nginx/controller-chroot'
+        'registry.k8s.io/ingress-nginx/controller-chroot',
       ],
       matchCurrentValue: 'v1.11.*',
       allowedVersions: '<v1.12.0',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -434,7 +434,7 @@
       ],
     },
     {
-      // Limit updates of jsonpatch/v2 to stay below v3.0.0.
+      // Disable major updates of jsonpatch/v2.
       // The major version of this dependency should be kept in sync with controller-runtime:
       // https://github.com/kubernetes-sigs/controller-runtime/blob/main/go.mod
       matchDatasources: [
@@ -443,7 +443,10 @@
       matchPackageNames: [
         'gomodules.xyz/jsonpatch/v2',
       ],
-      allowedVersions: '<v3.0.0', // Should be updated when controller-runtime uses a new major version.
+      matchUpdateTypes: [
+        'major'
+      ],
+      enabled: false,
     },
     {
       // TODO(marc1404): Remove when the NewVPN feature gate is removed.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR configures Renovate to disable major updates of `gomodules.xyz/jsonpatch/v2`.
The major version of `jsonpatch/v2` that we use should stay in sync with the major version that is used by the `controller-runtime` internally ([ref](https://github.com/kubernetes-sigs/controller-runtime/blob/f80bc5dbf8f7d60b565179724bc1a77d2db7b342/go.mod#L23)).

See also the history of [closed v3 update PRs](https://github.com/gardener/gardener/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aclosed+%22Update+module+gomodules.xyz%2Fjsonpatch%2Fv2%22).

The [Kubernetes release responsibles](https://github.com/gardener/gardener/blob/master/docs/development/new-kubernetes-version.md#kubernetes-release-responsible-plan) should check the major versions when updating the `controller-runtime`.

**Which issue(s) this PR fixes**:

Follow-up to: https://github.com/gardener/gardener/pull/11627

**Special notes for your reviewer**:

/cc @timebertt @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
