### PR TITLE
`CreateShoot` testdefinition exposes `minAllowed` options for control plane

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -37,6 +37,10 @@ spec:
     -start-hibernated=$START_HIBERNATED
     -annotations=$SHOOT_ANNOTATIONS
     -control-plane-failure-tolerance=$CONTROL_PLANE_FAILURE_TOLERANCE
+    -kube-apiserver-min-allowed-cpu=$KUBE_APISERVER_MIN_ALLOWED_CPU
+    -kube-apiserver-min-allowed-memory=$KUBE_APISERVER_MIN_ALLOWED_MEMORY
+    -etcd-min-allowed-cpu=$ETCD_MIN_ALLOWED_CPU
+    -etcd-min-allowed-memory=$ETCD_MIN_ALLOWED_MEMORY
 #    -machine-image-name=$MACHINE_IMAGE
 #    -machine-image-version=$MACHINE_IMAGE_VERSION
 #    -machine-type=$MACHINE_TYPE

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -27,35 +27,39 @@ var shootCreationCfg *ShootCreationConfig
 type ShootCreationConfig struct {
 	GardenerConfig *GardenerConfig
 
-	shootKubeconfigPath          string
-	testShootName                string
-	testShootPrefix              string
-	shootMachineImageName        string
-	shootMachineType             string
-	shootMachineImageVersion     string
-	cloudProfileName             string
-	cloudProfileKind             string
-	seedName                     string
-	shootRegion                  string
-	secretBinding                string
-	shootProviderType            string
-	shootK8sVersion              string
-	externalDomain               string
-	workerZone                   string
-	ipFamilies                   string
-	networkingType               string
-	networkingPods               string
-	networkingServices           string
-	networkingNodes              string
-	startHibernatedFlag          string
-	startHibernated              bool
-	infrastructureProviderConfig string
-	controlPlaneProviderConfig   string
-	networkingProviderConfig     string
-	workersConfig                string
-	shootYamlPath                string
-	shootAnnotations             string
-	controlPlaneFailureTolerance string
+	shootKubeconfigPath           string
+	testShootName                 string
+	testShootPrefix               string
+	shootMachineImageName         string
+	shootMachineType              string
+	shootMachineImageVersion      string
+	cloudProfileName              string
+	cloudProfileKind              string
+	seedName                      string
+	shootRegion                   string
+	secretBinding                 string
+	shootProviderType             string
+	shootK8sVersion               string
+	externalDomain                string
+	workerZone                    string
+	ipFamilies                    string
+	networkingType                string
+	networkingPods                string
+	networkingServices            string
+	networkingNodes               string
+	startHibernatedFlag           string
+	startHibernated               bool
+	infrastructureProviderConfig  string
+	controlPlaneProviderConfig    string
+	networkingProviderConfig      string
+	workersConfig                 string
+	shootYamlPath                 string
+	shootAnnotations              string
+	controlPlaneFailureTolerance  string
+	kubeApiserverMinAllowedCPU    string
+	kubeApiserverMinAllowedMemory string
+	etcdMinAllowedCPU             string
+	etcdMinAllowedMemory          string
 }
 
 // ShootCreationFramework represents the shoot test framework that includes
@@ -291,6 +295,22 @@ func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreati
 		base.controlPlaneFailureTolerance = overwrite.controlPlaneFailureTolerance
 	}
 
+	if StringSet(overwrite.kubeApiserverMinAllowedCPU) {
+		base.kubeApiserverMinAllowedCPU = overwrite.kubeApiserverMinAllowedCPU
+	}
+
+	if StringSet(overwrite.kubeApiserverMinAllowedMemory) {
+		base.kubeApiserverMinAllowedMemory = overwrite.kubeApiserverMinAllowedMemory
+	}
+
+	if StringSet(overwrite.etcdMinAllowedCPU) {
+		base.etcdMinAllowedCPU = overwrite.etcdMinAllowedCPU
+	}
+
+	if StringSet(overwrite.etcdMinAllowedMemory) {
+		base.etcdMinAllowedMemory = overwrite.etcdMinAllowedMemory
+	}
+
 	if StringSet(overwrite.shootYamlPath) {
 		base.shootYamlPath = overwrite.shootYamlPath
 	}
@@ -327,6 +347,10 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	flag.StringVar(&newCfg.networkingNodes, "networking-nodes", "", "the spec.networking.nodes to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.startHibernatedFlag, "start-hibernated", "", "the spec.hibernation.enabled to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.controlPlaneFailureTolerance, "control-plane-failure-tolerance", "", "the .spec.controlPlane.HighAvailability.FailureTolerance.FailureToleranceType to use for this shoot. Optional, defaults to no failure tolerance")
+	flag.StringVar(&newCfg.kubeApiserverMinAllowedCPU, "kube-apiserver-min-allowed-cpu", "", "the .spec.kubernetes.kubeAPIServer.autoscaling.cpu to use for this shoot. Optional.")
+	flag.StringVar(&newCfg.kubeApiserverMinAllowedMemory, "kube-apiserver-min-allowed-memory", "", "the .spec.kubernetes.kubeAPIServer.autoscaling.memory to use for this shoot. Optional.")
+	flag.StringVar(&newCfg.etcdMinAllowedCPU, "etcd-min-allowed-cpu", "", "the .spec.kubernetes.etcd.{main|events}.autoscaling.cpu to use for this shoot. Optional.")
+	flag.StringVar(&newCfg.etcdMinAllowedMemory, "etcd-min-allowed-memory", "", "the .spec.kubernetes.etcd.{main|events}.autoscaling.memory to use for this shoot. Optional.")
 
 	if newCfg.networkingType == "" {
 		newCfg.networkingType = "calico"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

https://github.com/gardener/gardener/pull/11252 added a `minAllowed` configuration option to set initial VPA values for a shoot's control plane. 

To make use of this feature in testmachinery tests, the flag needs to be exposed by the test definition.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @dguendisch @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`CreateShoot` testdefinition exposes `minAllowed` options for control plane
```
