### PR TITLE
Fix `check-generate` script for extensions

### DIFF
--- a/hack/check-generate.sh
+++ b/hack/check-generate.sh
@@ -77,7 +77,7 @@ if which git &>/dev/null; then
   git commit -q --allow-empty -m 'checkpoint'
 
   old_status="$(git status -s)"
-  if ! out=$(make -f "$makefile" tools-for-generate 2>&1); then
+  if $(make -f "$makefile" -n tools-for-generate  &> /dev/null) && ! out=$(make -f "$makefile" tools-for-generate 2>&1); then
     echo "Error during calling make tools-for-generate: $out"
     exit 1
   fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Only execute `tools-for-generate` in the `check-generate` script if the make target exists. Gardener extensions use this script as a convenience but fail if they don't define a `tools-for-generate` target in their Makefile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @dimityrmirchev @dimitar-kostadinov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
The `hack/check-generate.sh` script was fixed to only execute the `check-generate` target if it exists in the corresponding Makefile.
```
