### PR TITLE
Default `injectGardenKubeconfig` to `true` for `Worker` extensions in `operator.gardener.cloud/v1alpha1.Extension` API

### DIFF
--- a/pkg/operator/webhook/add.go
+++ b/pkg/operator/webhook/add.go
@@ -16,6 +16,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/operator/webhook/defaulting"
+	extensiondefaulting "github.com/gardener/gardener/pkg/operator/webhook/defaulting/extension"
 	gardendefaulting "github.com/gardener/gardener/pkg/operator/webhook/defaulting/garden"
 	"github.com/gardener/gardener/pkg/operator/webhook/validation"
 	extensionvalidation "github.com/gardener/gardener/pkg/operator/webhook/validation/extension"
@@ -119,6 +120,26 @@ func GetMutatingWebhookConfiguration(mode, url string) *admissionregistrationv1.
 						admissionregistrationv1.Create,
 						admissionregistrationv1.Update,
 						admissionregistrationv1.Delete,
+					},
+				}},
+				SideEffects:    &sideEffects,
+				FailurePolicy:  &failurePolicy,
+				MatchPolicy:    &matchPolicy,
+				TimeoutSeconds: ptr.To[int32](10),
+			},
+			{
+				Name:                    "extension-defaulting.operator.gardener.cloud",
+				ClientConfig:            getClientConfig(extensiondefaulting.WebhookPath, mode, url),
+				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{operatorv1alpha1.SchemeGroupVersion.Group},
+						APIVersions: []string{operatorv1alpha1.SchemeGroupVersion.Version},
+						Resources:   []string{"extensions"},
+					},
+					Operations: []admissionregistrationv1.OperationType{
+						admissionregistrationv1.Create,
+						admissionregistrationv1.Update,
 					},
 				}},
 				SideEffects:    &sideEffects,

--- a/pkg/operator/webhook/defaulting/add.go
+++ b/pkg/operator/webhook/defaulting/add.go
@@ -9,6 +9,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/gardener/gardener/pkg/operator/webhook/defaulting/extension"
 	"github.com/gardener/gardener/pkg/operator/webhook/defaulting/garden"
 )
 
@@ -16,6 +17,10 @@ import (
 func AddToManager(mgr manager.Manager) error {
 	if err := (&garden.Handler{}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding %s webhook handler: %w", garden.HandlerName, err)
+	}
+
+	if err := (&extension.Handler{}).AddToManager(mgr); err != nil {
+		return fmt.Errorf("failed adding %s webhook handler: %w", extension.HandlerName, err)
 	}
 
 	return nil

--- a/pkg/operator/webhook/defaulting/extension/add.go
+++ b/pkg/operator/webhook/defaulting/extension/add.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package extension
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+)
+
+const (
+	// HandlerName is the name of this admission webhook handler.
+	HandlerName = "extension-defaulter"
+	// WebhookPath is the HTTP handler path for this admission webhook handler.
+	WebhookPath = "/webhooks/default-operator-gardener-cloud-v1alpha1-extension"
+)
+
+// AddToManager adds Handler to the given manager.
+func (h *Handler) AddToManager(mgr manager.Manager) error {
+	webhook := admission.
+		WithCustomDefaulter(mgr.GetScheme(), &operatorv1alpha1.Extension{}, h).
+		WithRecoverPanic(true)
+
+	mgr.GetWebhookServer().Register(WebhookPath, webhook)
+	return nil
+}

--- a/pkg/operator/webhook/defaulting/extension/extension_suite_test.go
+++ b/pkg/operator/webhook/defaulting/extension/extension_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package extension_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestExtension(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Webhook Defaulting Extension Suite")
+}

--- a/pkg/operator/webhook/defaulting/extension/handler.go
+++ b/pkg/operator/webhook/defaulting/extension/handler.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package extension
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+)
+
+// Handler performs defaulting.
+type Handler struct{}
+
+// Default performs the defaulting.
+func (h *Handler) Default(_ context.Context, obj runtime.Object) error {
+	extension, ok := obj.(*operatorv1alpha1.Extension)
+	if !ok {
+		return fmt.Errorf("expected *operatorv1alpha1.Extension but got %T", obj)
+	}
+
+	if slices.ContainsFunc(extension.Spec.Resources, func(resource gardencorev1beta1.ControllerResource) bool {
+		return resource.Kind == extensionsv1alpha1.WorkerResource
+	}) && extension.Spec.Deployment != nil && extension.Spec.Deployment.ExtensionDeployment != nil && extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig == nil {
+		extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig = ptr.To(true)
+	}
+
+	return nil
+}

--- a/pkg/operator/webhook/defaulting/extension/handler_test.go
+++ b/pkg/operator/webhook/defaulting/extension/handler_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package extension_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"k8s.io/utils/ptr"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	. "github.com/gardener/gardener/pkg/operator/webhook/defaulting/extension"
+)
+
+var _ = Describe("Handler", func() {
+	var (
+		ctx       context.Context
+		handler   *Handler
+		extension *operatorv1alpha1.Extension
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		handler = &Handler{}
+		extension = &operatorv1alpha1.Extension{
+			Spec: operatorv1alpha1.ExtensionSpec{
+				Resources: []gardencorev1beta1.ControllerResource{
+					{Kind: "Worker", Type: "test"},
+				},
+				Deployment: &operatorv1alpha1.Deployment{
+					ExtensionDeployment: &operatorv1alpha1.ExtensionDeploymentSpec{
+						InjectGardenKubeconfig: ptr.To(true),
+					},
+				},
+			},
+		}
+	})
+
+	Describe("#Default", func() {
+		Context("injectGardenKubeconfig defaulting", func() {
+			It("should do nothing if the extension does not handle Worker resources", func() {
+				extension.Spec.Resources = nil
+				extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig = nil
+
+				Expect(handler.Default(ctx, extension)).To(Succeed())
+				Expect(extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig).To(BeNil())
+			})
+
+			It("should do nothing if the deployment section is not set", func() {
+				extension.Spec.Deployment = nil
+
+				Expect(handler.Default(ctx, extension)).To(Succeed())
+				Expect(extension.Spec.Deployment).To(BeNil())
+			})
+
+			It("should do nothing if the extension deployment section is not set", func() {
+				extension.Spec.Deployment.ExtensionDeployment = nil
+
+				Expect(handler.Default(ctx, extension)).To(Succeed())
+				Expect(extension.Spec.Deployment.ExtensionDeployment).To(BeNil())
+			})
+
+			It("should do nothing if injectGardenKubeconfig is already set", func() {
+				extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig = ptr.To(false)
+
+				Expect(handler.Default(ctx, extension)).To(Succeed())
+				Expect(extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig).To(PointTo(BeFalse()))
+			})
+
+			It("should do default the injectGardenKubeconfig to true", func() {
+				extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig = nil
+
+				Expect(handler.Default(ctx, extension)).To(Succeed())
+				Expect(extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig).To(PointTo(BeTrue()))
+			})
+		})
+	})
+})

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -252,6 +252,7 @@ build:
             - pkg/operator/predicate
             - pkg/operator/webhook
             - pkg/operator/webhook/defaulting
+            - pkg/operator/webhook/defaulting/extension
             - pkg/operator/webhook/defaulting/garden
             - pkg/operator/webhook/validation
             - pkg/operator/webhook/validation/extension


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Follow-up of https://github.com/gardener/gardener/pull/11593. As `Worker` extensions usually use the generic `Actuator` which requires passing a `cluster.Cluster` for the garden, we default the `injectGardenKubeconfig` setting to `true` for extensions reconciling `Worker` resources. https://github.com/gardener/gardener/blob/20d3fadb1ebf2dd618c8db49e94575228c960028/extensions/pkg/controller/worker/genericactuator/actuator.go#L44

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `injectGardenKubeconfig` field is defaulted to `true` for extensions responsible for `Worker` resources when registered via the `operator.gardener.cloud/v1alpha1.Extension` API.
```
