### PR TITLE
Set `revisionHistoryLimit=2` also for `DaemonSet`s

### DIFF
--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -190,9 +190,10 @@ This document provides a checklist for them that you can walk through.
    This should be done inside a dedicated `logging.go` file.
    Extensions should follow the guidelines described in [Fluent-bit log parsers and filters](../extensions/logging-and-monitoring.md#fluent-bit-log-parsers-and-filters).
 
-3. **Set the `revisionHistoryLimit` to `2` for `Deployment`s** ([example](https://github.com/gardener/gardener/blob/b0de7db96ad436fe32c25daae5e8cb552dac351f/pkg/component/metricsserver/metrics_server.go#L272))
+3. **Set the `revisionHistoryLimit` to `2` for `Deployment`s and `DaemonSet`s** ([example](https://github.com/gardener/gardener/blob/b0de7db96ad436fe32c25daae5e8cb552dac351f/pkg/component/metricsserver/metrics_server.go#L272))
 
-   In order to allow easy inspection of two `ReplicaSet`s to quickly find the changes that lead to a rolling update, the [revision history limit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit) should be set to `2`.
+   In order to allow easy inspection of two `ReplicaSet`s / `ControllerRevision`s to quickly find the changes that lead to a rolling update, the [revision history limit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit) should be set to `2`.
+   This also helps to not flood the API server with too many revisions.
 
 4. **Define health checks** ([example 1](https://github.com/gardener/gardener/blob/180951eac9b8183175d4dcadc305c7722ce8122d/pkg/gardenlet/controller/shoot/care/health.go#L763-L795))
 

--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -556,6 +556,7 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 						},
 					},
 					Spec: appsv1.DaemonSetSpec{
+						RevisionHistoryLimit: ptr.To[int32](2),
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"app":     "kubernetes",

--- a/pkg/component/kubernetes/proxy/resources.go
+++ b/pkg/component/kubernetes/proxy/resources.go
@@ -218,6 +218,7 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 				Selector: &metav1.LabelSelector{
 					MatchLabels: getPoolLabels(pool),
 				},
+				RevisionHistoryLimit: ptr.To[int32](2),
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: utils.MergeStringMaps(

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy.go
@@ -275,6 +275,7 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 					Type: appsv1.RollingUpdateDaemonSetStrategyType,
 				},
+				RevisionHistoryLimit: ptr.To[int32](2),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: getSelector(),
 				},

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -604,6 +604,7 @@ func getDaemonSet(hash string, advertiseIPAddress string) *appsv1.DaemonSet {
 					"role": "apiserver-proxy",
 				},
 			},
+			RevisionHistoryLimit: ptr.To[int32](2),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -320,6 +320,7 @@ ip6.arpa:53 {
 						MaxUnavailable: &maxUnavailable,
 					},
 				},
+				RevisionHistoryLimit: ptr.To[int32](2),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						labelKey: nodelocaldnsconstants.LabelValue,

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -368,6 +368,7 @@ status:
 								MaxUnavailable: &maxUnavailable,
 							},
 						},
+						RevisionHistoryLimit: ptr.To[int32](2),
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								labelKey: labelValue,

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -707,7 +707,7 @@ func (v *vpnSeedServer) deployDeployment(ctx context.Context, labels map[string]
 		})
 		deployment.Spec = appsv1.DeploymentSpec{
 			Replicas:             ptr.To(v.values.Replicas),
-			RevisionHistoryLimit: ptr.To[int32](1),
+			RevisionHistoryLimit: ptr.To[int32](2),
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
 				v1beta1constants.LabelApp: deploymentName,
 			}},

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -454,7 +454,7 @@ var _ = Describe("VpnSeedServer", func() {
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas:             ptr.To(values.Replicas),
-					RevisionHistoryLimit: ptr.To[int32](1),
+					RevisionHistoryLimit: ptr.To[int32](2),
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						v1beta1constants.LabelApp: "vpn-seed-server",
 					}},

--- a/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
@@ -176,6 +176,7 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 						v1beta1constants.LabelApp: labelValue,
 					}),
 				},
+				RevisionHistoryLimit: ptr.To[int32](2),
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: utils.MergeStringMaps(getLabels(), map[string]string{

--- a/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector_test.go
@@ -172,6 +172,7 @@ metadata:
   name: node-problem-detector
   namespace: kube-system
 spec:
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: node-problem-detector

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -330,6 +330,7 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 				Selector: &metav1.LabelSelector{
 					MatchLabels: getLabels(),
 				},
+				RevisionHistoryLimit: ptr.To[int32](2),
 				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 					Type: appsv1.RollingUpdateDaemonSetStrategyType,
 				},

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -308,6 +308,7 @@ metadata:
   name: node-exporter
   namespace: kube-system
 spec:
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       component: node-exporter


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Set `revisionHistoryLimit=2` also for `DaemonSet`s to prevent creating too many `ControllerRevision`s.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The [component checklist](https://github.com/gardener/gardener/blob/v1.115.0/docs/development/component-checklist.md) now recommends setting `revisionHistoryLimit=2` for `DaemonSet`s as well.
```
