### PR TITLE
ssh reverse tunnel: Exit on error

### DIFF
--- a/example/provider-extensions/ssh-reverse-tunnel/base/sshd/files/entrypoint.sh
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/sshd/files/entrypoint.sh
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # Install openssh
 apk add --no-cache openssh


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
In @georgibaltiev's provider-extensions setup the ssh reverse tunnel was failing with:
```
fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.21/main: temporary error (try again later)
WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.21/community: temporary error (try again later)
ERROR: unable to select packages:
  openssh (no such package):
    required by: world[openssh]
Starting sshd
/gardener_apiserver_sshd/entrypoint.sh: exec: line 12: /usr/sbin/sshd: not found
```


We don't have `set -e` / `set -o errexit` and it was continuing the script despite failing the pull the required package.
At the end, it was failing with super confusing error:  `/usr/sbin/sshd: not found`. But it is because it failed to install the `openssh` package.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
