### PR TITLE
[GEP-28] Add support for `kubelet` bootstrap kubeconfig handling

### DIFF
--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -30,6 +30,7 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
 
 // NewAuthorizer returns a new authorizer for requests from gardenlets. It never has an opinion on the request.
@@ -308,7 +309,7 @@ func (a *authorizer) authorizeSecret(log logr.Logger, seedName string, attrs aut
 	if (attrs.GetVerb() == "delete" &&
 		attrs.GetNamespace() == metav1.NamespaceSystem &&
 		strings.HasPrefix(attrs.GetName(), bootstraptokenapi.BootstrapTokenSecretPrefix)) &&
-		(attrs.GetName() == bootstraptokenapi.BootstrapTokenSecretPrefix+gardenletbootstraputil.TokenID(metav1.ObjectMeta{Name: seedName, Namespace: v1beta1constants.GardenNamespace})) {
+		(attrs.GetName() == bootstraptokenapi.BootstrapTokenSecretPrefix+bootstraptoken.TokenID(metav1.ObjectMeta{Name: seedName, Namespace: v1beta1constants.GardenNamespace})) {
 		return auth.DecisionAllow, "", nil
 	}
 

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -31,9 +31,9 @@ import (
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/logger"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
 
 var _ = Describe("Seed", func() {
@@ -2000,7 +2000,7 @@ var _ = Describe("Seed", func() {
 				It("should allow to delete the gardenlet's bootstrap tokens without consulting the graph", func() {
 					attrs.Verb = "delete"
 					attrs.Namespace = "kube-system"
-					attrs.Name = "bootstrap-token-" + gardenletbootstraputil.TokenID(metav1.ObjectMeta{Name: seedName, Namespace: v1beta1constants.GardenNamespace})
+					attrs.Name = "bootstrap-token-" + bootstraptoken.TokenID(metav1.ObjectMeta{Name: seedName, Namespace: v1beta1constants.GardenNamespace})
 
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_gardenlet.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_gardenlet.go
@@ -19,7 +19,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	seedmanagementv1alpha1helper "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
-	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
 
 func (g *graph) setupGardenletWatch(ctx context.Context, informer cache.Informer) error {
@@ -95,7 +95,7 @@ func (g *graph) handleGardenletCreateOrUpdate(ctx context.Context, gardenlet *se
 	}
 
 	if allowBootstrap {
-		secretVertex := g.getOrCreateVertex(VertexTypeSecret, metav1.NamespaceSystem, bootstraptokenapi.BootstrapTokenSecretPrefix+gardenletbootstraputil.TokenID(gardenlet.ObjectMeta))
+		secretVertex := g.getOrCreateVertex(VertexTypeSecret, metav1.NamespaceSystem, bootstraptokenapi.BootstrapTokenSecretPrefix+bootstraptoken.TokenID(gardenlet.ObjectMeta))
 		g.addEdge(secretVertex, gardenletVertex)
 	}
 }

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
@@ -20,6 +20,7 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	seedmanagementv1alpha1helper "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
 
 func (g *graph) setupManagedSeedWatch(ctx context.Context, informer cache.Informer) error {
@@ -113,7 +114,7 @@ func (g *graph) handleManagedSeedCreateOrUpdate(ctx context.Context, managedSeed
 	if allowBootstrap {
 		switch *managedSeed.Spec.Gardenlet.Bootstrap {
 		case seedmanagementv1alpha1.BootstrapToken:
-			secretVertex := g.getOrCreateVertex(VertexTypeSecret, metav1.NamespaceSystem, bootstraptokenapi.BootstrapTokenSecretPrefix+gardenletbootstraputil.TokenID(managedSeed.ObjectMeta))
+			secretVertex := g.getOrCreateVertex(VertexTypeSecret, metav1.NamespaceSystem, bootstraptokenapi.BootstrapTokenSecretPrefix+bootstraptoken.TokenID(managedSeed.ObjectMeta))
 			g.addEdge(secretVertex, managedSeedVertex)
 
 		case seedmanagementv1alpha1.BootstrapServiceAccount:

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/graph_test.go
@@ -114,11 +114,11 @@ var _ = Describe("graph", func() {
 		managedSeed1                  *seedmanagementv1alpha1.ManagedSeed
 		managedSeedBootstrapMode      = seedmanagementv1alpha1.BootstrapToken
 		bootstrapTokenNamespace       = "kube-system"
-		managedSeedBootstrapTokenName = "bootstrap-token-2d9418"
+		managedSeedBootstrapTokenName = "bootstrap-token-78f9fc"
 		backupSecretRef               = corev1.SecretReference{Namespace: "backupsecret1ns", Name: "backupsecret1name"}
 
 		gardenlet1                  *seedmanagementv1alpha1.Gardenlet
-		gardenletBootstrapTokenName = "bootstrap-token-34d1a7"
+		gardenletBootstrapTokenName = "bootstrap-token-2a9d62"
 
 		seedNameInCSR = "myseed"
 		csr1          *certificatesv1.CertificateSigningRequest

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
 
 const (
@@ -790,7 +791,7 @@ func createBootstrapKubeconfig(
 		}
 
 		var (
-			tokenID          = gardenletbootstraputil.TokenID(metav1.ObjectMeta{Name: obj.GetName(), Namespace: obj.GetNamespace()})
+			tokenID          = bootstraptoken.TokenID(metav1.ObjectMeta{Name: obj.GetName(), Namespace: obj.GetNamespace()})
 			tokenDescription = gardenletbootstraputil.Description(kind, obj.GetNamespace(), obj.GetName())
 			tokenValidity    = 24 * time.Hour
 		)

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -414,17 +414,17 @@ var _ = Describe("Interface", func() {
 			}
 
 			// Create bootstrap token secret
-			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "bootstrap-token-a82f8a"}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "bootstrap-token-295eab"}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, _ *corev1.Secret, _ ...client.GetOption) error {
-					return apierrors.NewNotFound(corev1.Resource("secret"), "bootstrap-token-a82f8a")
+					return apierrors.NewNotFound(corev1.Resource("secret"), "bootstrap-token-295eab")
 				},
 			).Times(3)
 			gardenClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 				func(_ context.Context, s *corev1.Secret, _ ...client.CreateOption) error {
-					Expect(s.Name).To(Equal("bootstrap-token-a82f8a"))
+					Expect(s.Name).To(Equal("bootstrap-token-295eab"))
 					Expect(s.Namespace).To(Equal(metav1.NamespaceSystem))
 					Expect(s.Type).To(Equal(corev1.SecretTypeBootstrapToken))
-					Expect(s.Data).To(HaveKeyWithValue("token-id", []byte("a82f8a")))
+					Expect(s.Data).To(HaveKeyWithValue("token-id", []byte("295eab")))
 					Expect(s.Data).To(HaveKey("token-secret"))
 					Expect(s.Data).To(HaveKeyWithValue("usage-bootstrap-signing", []byte("true")))
 					Expect(s.Data).To(HaveKeyWithValue("usage-bootstrap-authentication", []byte("true")))

--- a/pkg/gardenadm/cmd/init/kubelet.go
+++ b/pkg/gardenadm/cmd/init/kubelet.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package init
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+
+	"github.com/gardener/gardener/cmd/gardener-node-agent/app/bootstrappers"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
+)
+
+const (
+	kubeletBootstrapKubeconfigPath = "/var/lib/kubelet/kubeconfig-real"
+	kubeletTokenDescription        = "kubelet"
+	kubeletTokenFilePermission     = 0o600
+)
+
+// CreateBootstrapToken creates a bootstrap token for the kubelet and writes it to the file system.
+func CreateBootstrapToken(ctx context.Context, b *botanistpkg.Botanist, fs afero.Afero) error {
+	bootstrapTokenSecret, err := bootstraptoken.ComputeBootstrapToken(
+		ctx,
+		b.SeedClientSet.Client(),
+		tokenID(metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name, Namespace: b.Shoot.GetInfo().Namespace}),
+		kubeletTokenDescription,
+		10*time.Minute)
+	if err != nil {
+		return fmt.Errorf("failed to create bootstrap token: %w", err)
+	}
+
+	bootstrapToken := string(bootstrapTokenSecret.Data[bootstraptokenapi.BootstrapTokenIDKey]) +
+		"." + string(bootstrapTokenSecret.Data[bootstraptokenapi.BootstrapTokenSecretKey])
+	return fs.WriteFile(nodeagentv1alpha1.BootstrapTokenFilePath, []byte(bootstrapToken), kubeletTokenFilePermission)
+}
+
+// WriteKubeletBootstrapKubeconfig writes the kubelet bootstrap kubeconfig to the file system.
+func WriteKubeletBootstrapKubeconfig(
+	ctx context.Context,
+	b *botanistpkg.Botanist,
+	fs afero.Afero,
+	server string,
+	caBundle []byte,
+) error {
+	if err := fs.MkdirAll(nodeagentv1alpha1.TempDir, os.ModeDir); err != nil {
+		return fmt.Errorf("failed to create temporary directory ('%s'): %w", nodeagentv1alpha1.TempDir, err)
+	}
+	if err := fs.MkdirAll(nodeagentv1alpha1.CredentialsDir, os.ModeDir); err != nil {
+		return fmt.Errorf("failed to create credentials directory ('%s'): %w", nodeagentv1alpha1.CredentialsDir, err)
+	}
+
+	exists, err := fs.Exists(nodeagentv1alpha1.BootstrapTokenFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to check whether bootstrap token file exists ('%s'): %w", nodeagentv1alpha1.BootstrapTokenFilePath, err)
+	}
+	if !exists {
+		b.Logger.Info("Writing fake bootstrap token to file to make sure kubelet can start up", "path", nodeagentv1alpha1.BootstrapTokenFilePath)
+		// without this, kubelet will complain about an invalid kubeconfig
+		token := tokenID(metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name, Namespace: b.Shoot.GetInfo().Namespace})
+		if err := fs.WriteFile(nodeagentv1alpha1.BootstrapTokenFilePath, []byte(token), kubeletTokenFilePermission); err != nil {
+			return fmt.Errorf("failed to write fake bootstrap token to file ('%s'): %w", nodeagentv1alpha1.BootstrapTokenFilePath, err)
+		}
+	}
+
+	if err := fs.Remove(kubeletBootstrapKubeconfigPath); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
+		return fmt.Errorf("failed to remove kubelet bootstrap kubeconfig file ('%s'): %w", kubeletBootstrapKubeconfigPath, err)
+	}
+
+	kubeletBootstrapKubeconfigCreator := &bootstrappers.KubeletBootstrapKubeconfig{
+		Log: b.Logger,
+		FS:  fs,
+		APIServerConfig: nodeagentconfigv1alpha1.APIServer{
+			Server:   server,
+			CABundle: caBundle,
+		},
+	}
+
+	return kubeletBootstrapKubeconfigCreator.Start(ctx)
+}
+
+func tokenID(meta metav1.ObjectMeta) string {
+	value := meta.Name
+	if meta.Namespace != "" {
+		value = meta.Namespace + "--" + meta.Name
+	}
+
+	return utils.ComputeSHA256Hex([]byte(value))[:6]
+}

--- a/pkg/gardenadm/cmd/init/kubelet.go
+++ b/pkg/gardenadm/cmd/init/kubelet.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/gardener/gardener/cmd/gardener-node-agent/app/bootstrappers"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
-	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
@@ -33,7 +32,7 @@ func CreateBootstrapToken(ctx context.Context, b *botanistpkg.Botanist, fs afero
 	bootstrapTokenSecret, err := bootstraptoken.ComputeBootstrapToken(
 		ctx,
 		b.SeedClientSet.Client(),
-		gardenletbootstraputil.TokenID(metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name, Namespace: b.Shoot.GetInfo().Namespace}),
+		bootstraptoken.TokenID(metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name, Namespace: b.Shoot.GetInfo().Namespace}),
 		kubeletTokenDescription,
 		10*time.Minute,
 	)

--- a/pkg/gardenadm/cmd/init/kubelet_test.go
+++ b/pkg/gardenadm/cmd/init/kubelet_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package init_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	. "github.com/gardener/gardener/pkg/gardenadm/cmd/init"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	"github.com/gardener/gardener/pkg/logger"
+)
+
+var _ = Describe("Kubelet", func() {
+	var (
+		ctx context.Context
+		log logr.Logger
+		fs  afero.Afero
+		b   *botanistpkg.Botanist
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON)
+		fs = afero.Afero{Fs: afero.NewMemMapFs()}
+		b = &botanistpkg.Botanist{
+			Operation: &operation.Operation{
+				Logger: log,
+				Shoot:  &shoot.Shoot{},
+				SeedClientSet: fakekubernetes.
+					NewClientSetBuilder().
+					WithClient(fakeclient.
+						NewClientBuilder().
+						WithScheme(kubernetes.SeedScheme).
+						Build(),
+					).
+					WithRESTConfig(&rest.Config{}).
+					Build(),
+			},
+		}
+		b.Shoot.SetInfo(&corev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: metav1.NamespaceSystem,
+			},
+		})
+	})
+
+	Describe("#CreateBootstrapToken", func() {
+		It("should create a bootstrap token", func() {
+			Expect(fs.Exists("/var/lib/gardener-node-agent/credentials/bootstrap-token")).To(BeFalse())
+			Expect(CreateBootstrapToken(ctx, b, fs)).To(Succeed())
+			Expect(fs.Exists("/var/lib/gardener-node-agent/credentials/bootstrap-token")).To(BeTrue())
+		})
+	})
+
+	Describe("#WriteKubeletBootstrapKubeconfig", func() {
+		It("should write the kubelet bootstrap kubeconfig", func() {
+			Expect(fs.WriteFile("/var/lib/kubelet/kubeconfig-real", []byte{}, 0o600)).To(Succeed())
+			Expect(fs.Exists("/var/lib/gardener-node-agent/tmp")).To(BeFalse())
+			Expect(fs.Exists("/var/lib/gardener-node-agent/credentials")).To(BeFalse())
+			Expect(fs.Exists("/var/lib/gardener-node-agent/credentials/bootstrap-token")).To(BeFalse())
+			Expect(fs.Exists("/var/lib/kubelet/kubeconfig-real")).To(BeTrue())
+			Expect(fs.Exists("/var/lib/kubelet/kubeconfig-bootstrap")).To(BeFalse())
+			Expect(WriteKubeletBootstrapKubeconfig(ctx, b, fs, "foo", []byte("bar"))).To(Succeed())
+			Expect(fs.Exists("/var/lib/gardener-node-agent/tmp")).To(BeTrue())
+			Expect(fs.Exists("/var/lib/gardener-node-agent/credentials")).To(BeTrue())
+			Expect(fs.Exists("/var/lib/gardener-node-agent/credentials/bootstrap-token")).To(BeTrue())
+			Expect(fs.Exists("/var/lib/kubelet/kubeconfig-real")).To(BeFalse())
+			Expect(fs.Exists("/var/lib/kubelet/kubeconfig-bootstrap")).To(BeTrue())
+		})
+	})
+})

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
-	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
@@ -252,16 +251,6 @@ func ComputeGardenletKubeconfigWithServiceAccountToken(ctx context.Context, gard
 
 	// Get bootstrap kubeconfig from service account secret
 	return CreateGardenletKubeconfigWithToken(gardenClientRestConfig, tokenRequest.Status.Token)
-}
-
-// TokenID returns the token id based on the given metadata.
-func TokenID(meta metav1.ObjectMeta) string {
-	value := meta.Name
-	if meta.Namespace != "" {
-		value = meta.Namespace + "--" + meta.Name
-	}
-
-	return utils.ComputeSHA256Hex([]byte(value))[:6]
 }
 
 // ClusterRoleBindingName concatenates the gardener seed bootstrapper group with the given name, separated by a colon.

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -258,7 +258,7 @@ func ComputeGardenletKubeconfigWithServiceAccountToken(ctx context.Context, gard
 func TokenID(meta metav1.ObjectMeta) string {
 	value := meta.Name
 	if meta.Namespace != "" {
-		value += meta.Namespace + "--" + meta.Name
+		value = meta.Namespace + "--" + meta.Name
 	}
 
 	return utils.ComputeSHA256Hex([]byte(value))[:6]

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -472,16 +472,6 @@ var _ = Describe("Util", func() {
 			})
 		})
 
-		Describe("#TokenID", func() {
-			It("should compute the expected id (w/o namespace", func() {
-				Expect(TokenID(metav1.ObjectMeta{Name: name})).To(Equal("baa5a0"))
-			})
-
-			It("should compute the expected id (w/ namespace", func() {
-				Expect(TokenID(metav1.ObjectMeta{Name: name, Namespace: namespace})).To(Equal("594384"))
-			})
-		})
-
 		Describe("#Description", func() {
 			It("should compute the expected description (w/o namespace)", func() {
 				Expect(Description(kind, "", name)).To(Equal(descriptionWithoutNamespace))

--- a/pkg/utils/kubernetes/bootstraptoken/bootstraptoken.go
+++ b/pkg/utils/kubernetes/bootstraptoken/bootstraptoken.go
@@ -70,3 +70,13 @@ func ComputeBootstrapToken(ctx context.Context, c client.Client, tokenID, descri
 func FromSecretData(data map[string][]byte) string {
 	return bootstraptokenutil.TokenFromIDAndSecret(string(data[bootstraptokenapi.BootstrapTokenIDKey]), string(data[bootstraptokenapi.BootstrapTokenSecretKey]))
 }
+
+// TokenID returns the token id based on the given metadata.
+func TokenID(meta metav1.ObjectMeta) string {
+	value := meta.Name
+	if meta.Namespace != "" {
+		value = meta.Namespace + "--" + meta.Name
+	}
+
+	return utils.ComputeSHA256Hex([]byte(value))[:6]
+}

--- a/pkg/utils/kubernetes/bootstraptoken/bootstraptoken_suite_test.go
+++ b/pkg/utils/kubernetes/bootstraptoken/bootstraptoken_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstraptoken_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Kubernetes Bootstraptoken Suite")
+}

--- a/pkg/utils/kubernetes/bootstraptoken/bootstraptoken_test.go
+++ b/pkg/utils/kubernetes/bootstraptoken/bootstraptoken_test.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstraptoken_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
+)
+
+var _ = Describe("#TokenID", func() {
+	const (
+		namespace = "bar"
+		name      = "baz"
+	)
+
+	It("should compute the expected id (w/o namespace", func() {
+		Expect(TokenID(metav1.ObjectMeta{Name: name})).To(Equal("baa5a0"))
+	})
+
+	It("should compute the expected id (w/ namespace", func() {
+		Expect(TokenID(metav1.ObjectMeta{Name: name, Namespace: namespace})).To(Equal("cc19de"))
+	})
+})

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -10,6 +10,7 @@ build:
           paths:
             - cmd/gardenadm
             - cmd/gardenadm/app
+            - cmd/gardener-node-agent/app/bootstrappers
             - cmd/utils
             - imagevector
             - imagevector/charts.yaml
@@ -260,6 +261,7 @@ build:
             - pkg/utils/imagevector
             - pkg/utils/istio
             - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/bootstraptoken
             - pkg/utils/kubernetes/client
             - pkg/utils/kubernetes/health
             - pkg/utils/kubernetes/unstructured


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Add support for `kubelet` bootstrap kubeconfig handling.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```

/cc @rfranzke 