### PR TITLE
Fix `kube-proxy` race condition

### DIFF
--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -618,8 +618,8 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 											{MountPath: "/var/lib/kube-proxy-kubeconfig", Name: "kubeconfig"},
 											{MountPath: "/var/lib/kube-proxy-config", Name: "kube-proxy-config"},
 											{MountPath: "/etc/ssl/certs", Name: "ssl-certs-hosts", ReadOnly: true},
-											{MountPath: "/var/run/dbus/system_bus_socket", Name: "systembussocket"},
 											{MountPath: "/lib/modules", Name: "kernel-modules"},
+											{MountPath: "/run/xtables.lock", Name: "xtables-lock"},
 										},
 									},
 									{
@@ -704,14 +704,6 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 										},
 									},
 									{
-										Name: "systembussocket",
-										VolumeSource: corev1.VolumeSource{
-											HostPath: &corev1.HostPathVolumeSource{
-												Path: "/var/run/dbus/system_bus_socket",
-											},
-										},
-									},
-									{
 										Name: "kernel-modules",
 										VolumeSource: corev1.VolumeSource{
 											HostPath: &corev1.HostPathVolumeSource{
@@ -758,6 +750,15 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 											},
 										},
 									},
+									{
+										Name: "xtables-lock",
+										VolumeSource: corev1.VolumeSource{
+											HostPath: &corev1.HostPathVolumeSource{
+												Path: "/run/xtables.lock",
+												Type: ptr.To(corev1.HostPathFileOrCreate),
+											},
+										},
+									},
 								},
 							},
 						},
@@ -791,8 +792,8 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 							{MountPath: "/var/lib/kube-proxy-kubeconfig", Name: "kubeconfig"},
 							{MountPath: "/var/lib/kube-proxy-config", Name: "kube-proxy-config"},
 							{MountPath: "/etc/ssl/certs", Name: "ssl-certs-hosts", ReadOnly: true},
-							{MountPath: "/var/run/dbus/system_bus_socket", Name: "systembussocket"},
 							{MountPath: "/lib/modules", Name: "kernel-modules"},
+							{MountPath: "/run/xtables.lock", Name: "xtables-lock"},
 						},
 					})
 

--- a/pkg/component/kubernetes/proxy/resources.go
+++ b/pkg/component/kubernetes/proxy/resources.go
@@ -58,7 +58,7 @@ const (
 	volumeMountPathConntrackFixScript = "/script"
 	volumeMountPathKernelModules      = "/lib/modules"
 	volumeMountPathSSLCertsHosts      = "/etc/ssl/certs"
-	volumeMountPathSystemBusSocket    = "/var/run/dbus/system_bus_socket"
+	volumeMountPathXtablesLock        = "/run/xtables.lock"
 
 	volumeNameKubeconfig         = "kubeconfig"
 	volumeNameConfig             = "kube-proxy-config"
@@ -68,12 +68,12 @@ const (
 	volumeNameConntrackFixScript = "conntrack-fix-script"
 	volumeNameKernelModules      = "kernel-modules"
 	volumeNameSSLCertsHosts      = "ssl-certs-hosts"
-	volumeNameSystemBusSocket    = "systembussocket"
+	volumeNameXtablesLock        = "xtables-lock"
 
-	hostPathSSLCertsHosts   = "/usr/share/ca-certificates"
-	hostPathSystemBusSocket = "/var/run/dbus/system_bus_socket"
-	hostPathKernelModules   = "/lib/modules"
-	hostPathDir             = "/var/lib/kube-proxy"
+	hostPathSSLCertsHosts = "/usr/share/ca-certificates"
+	hostPathKernelModules = "/lib/modules"
+	hostPathDir           = "/var/lib/kube-proxy"
+	hostPathXtablesLock   = "/run/xtables.lock"
 )
 
 var (
@@ -303,14 +303,6 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 								},
 							},
 							{
-								Name: volumeNameSystemBusSocket,
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: hostPathSystemBusSocket,
-									},
-								},
-							},
-							{
 								Name: volumeNameKernelModules,
 								VolumeSource: corev1.VolumeSource{
 									HostPath: &corev1.HostPathVolumeSource{
@@ -354,6 +346,15 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 										LocalObjectReference: corev1.LocalObjectReference{
 											Name: k.configMapConntrackFixScript.Name,
 										},
+									},
+								},
+							},
+							{
+								Name: volumeNameXtablesLock,
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										Path: hostPathXtablesLock,
+										Type: &fileOrCreate,
 									},
 								},
 							},
@@ -573,12 +574,12 @@ func (k *kubeProxy) getKubeProxyContainer(k8sGreaterEqual129 bool, image string,
 				ReadOnly:  true,
 			},
 			{
-				Name:      volumeNameSystemBusSocket,
-				MountPath: volumeMountPathSystemBusSocket,
-			},
-			{
 				Name:      volumeNameKernelModules,
 				MountPath: volumeMountPathKernelModules,
+			},
+			{
+				Name:      volumeNameXtablesLock,
+				MountPath: volumeMountPathXtablesLock,
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/kind bug

**What this PR does / why we need it**:
This PR adds the `/run/xtables.lock` file for the `kube-proxy` pod to prevent concurrent modifications of iptables rules. This PR also removes the unused `hostPath` `/var/run/dbus/system_bus_socket`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing race condition in the `kube-proxy` pod related to concurrent modifications of iptables rules was fixed.
```
