### PR TITLE
Fix wildcard certificate endpoints of shoots and virtual-garden

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -88,12 +88,11 @@ func init() {
 
 // SNIValues configure the kube-apiserver service SNI.
 type SNIValues struct {
-	Hosts               []string
-	APIServerProxy      *APIServerProxy
-	IstioIngressGateway IstioIngressGateway
-	IstioTLSTermination bool
-	WildcardHosts       []string
-	WildcardTLSSecret   *corev1.Secret
+	Hosts                 []string
+	APIServerProxy        *APIServerProxy
+	IstioIngressGateway   IstioIngressGateway
+	IstioTLSTermination   bool
+	WildcardConfiguration *WildcardConfiguration
 }
 
 // APIServerProxy contains values for the APIServer proxy protocol configuration.
@@ -105,6 +104,13 @@ type APIServerProxy struct {
 type IstioIngressGateway struct {
 	Namespace string
 	Labels    map[string]string
+}
+
+// WildcardConfiguration contains the values for the wildcard certificate configuration.
+type WildcardConfiguration struct {
+	Hosts               []string
+	TLSSecret           corev1.Secret
+	IstioIngressGateway *IstioIngressGateway
 }
 
 // NewSNI creates a new instance of DeployWaiter which deploys Istio resources for
@@ -168,24 +174,29 @@ type envoyFilterIstioTLSTerminationTemplateValues struct {
 	WildcardRouteConfigurationName   string
 }
 
+type istioGatewayConfiguration struct {
+	istioIngressGateway   IstioIngressGateway
+	hosts                 []string
+	gateway               *istionetworkingv1beta1.Gateway
+	virtualService        *istionetworkingv1beta1.VirtualService
+	wildcardConfiguration *WildcardConfiguration
+}
+
 func (s *sni) Deploy(ctx context.Context) error {
 	var (
 		values = s.valuesFunc()
 
 		destinationRule     = s.emptyDestinationRule()
 		mTLSDestinationRule = s.emptyMTLSDestinationRule()
-		gateway             = s.emptyGateway()
-		virtualService      = s.emptyVirtualService()
 
-		hostName                       = fmt.Sprintf("%s.%s.svc.%s", s.name, s.namespace, gardencorev1beta1.DefaultDomain)
-		mTLSHostName                   = fmt.Sprintf("%s%s.%s.svc.%s", s.name, MutualTLSServiceNameSuffix, s.namespace, gardencorev1beta1.DefaultDomain)
-		routeConfigurationName         = fmt.Sprintf("https.%d.%s.%s.%s", kubeapiserverconstants.Port, portNameTLS, s.name, s.namespace)
-		wildcardRouteConfigurationName = fmt.Sprintf("https.%d.%s.%s.%s", kubeapiserverconstants.Port, portNameWildcardTLS, s.name, s.namespace)
-		envoyFilterAPIServerProxy      bytes.Buffer
-		envoyFilterIstioTLSTermination bytes.Buffer
+		hostName     = fmt.Sprintf("%s.%s.svc.%s", s.name, s.namespace, gardencorev1beta1.DefaultDomain)
+		mTLSHostName = fmt.Sprintf("%s%s.%s.svc.%s", s.name, MutualTLSServiceNameSuffix, s.namespace, gardencorev1beta1.DefaultDomain)
 	)
 
-	allHosts := append(values.Hosts, values.WildcardHosts...)
+	istioGatewayConfigurations, err := s.getIstioGatewayConfigurations()
+	if err != nil {
+		return fmt.Errorf("failed to get istio gateway configuration: %w", err)
+	}
 
 	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
@@ -193,8 +204,8 @@ func (s *sni) Deploy(ctx context.Context) error {
 		envoyFilter := s.emptyEnvoyFilterAPIServerProxy()
 
 		var (
-			apiServerClusterIPPrefixLen int
 			err                         error
+			apiServerClusterIPPrefixLen int
 		)
 
 		if values.APIServerProxy != nil {
@@ -207,6 +218,8 @@ func (s *sni) Deploy(ctx context.Context) error {
 		if values.IstioTLSTermination {
 			targetClusterProxyProtocol = GetAPIServerProxyTargetClusterName(s.namespace)
 		}
+
+		var envoyFilterAPIServerProxy bytes.Buffer
 
 		if err := envoyFilterAPIServerProxyTemplate.Execute(&envoyFilterAPIServerProxy, envoyFilterAPIServerProxyTemplateValues{
 			APIServerProxy:                 values.APIServerProxy,
@@ -237,25 +250,39 @@ func (s *sni) Deploy(ctx context.Context) error {
 	}
 
 	if values.IstioTLSTermination {
-		envoyFilter := s.emptyEnvoyFilterIstioTLSTermination()
+		for _, configuration := range istioGatewayConfigurations {
+			var (
+				routeConfigurationName         = fmt.Sprintf("https.%d.%s.%s.%s", kubeapiserverconstants.Port, portNameTLS, configuration.gateway.Name, configuration.gateway.Namespace)
+				wildcardRouteConfigurationName = fmt.Sprintf("https.%d.%s.%s.%s", kubeapiserverconstants.Port, portNameWildcardTLS, configuration.gateway.Name, configuration.gateway.Namespace)
 
-		if err := envoyFilterIstioTLSTerminationTemplate.Execute(&envoyFilterIstioTLSTermination, envoyFilterIstioTLSTerminationTemplateValues{
-			AuthenticationDynamicMetadataKey: AuthenticationDynamicMetadataKey,
-			Hosts:                            values.Hosts,
-			WildcardHosts:                    values.WildcardHosts,
-			IngressGatewayLabels:             values.IstioIngressGateway.Labels,
-			Name:                             envoyFilter.Name,
-			Namespace:                        envoyFilter.Namespace,
-			Port:                             kubeapiserverconstants.Port,
-			MutualTLSHost:                    mTLSHostName,
-			RouteConfigurationName:           routeConfigurationName,
-			WildcardRouteConfigurationName:   wildcardRouteConfigurationName,
-		}); err != nil {
-			return err
+				envoyFilterIstioTLSTermination bytes.Buffer
+			)
+
+			envoyFilter := s.emptyEnvoyFilterIstioTLSTermination(configuration.istioIngressGateway.Namespace)
+
+			var wildcardHosts []string
+			if configuration.wildcardConfiguration != nil {
+				wildcardHosts = configuration.wildcardConfiguration.Hosts
+			}
+
+			if err := envoyFilterIstioTLSTerminationTemplate.Execute(&envoyFilterIstioTLSTermination, envoyFilterIstioTLSTerminationTemplateValues{
+				AuthenticationDynamicMetadataKey: AuthenticationDynamicMetadataKey,
+				Hosts:                            configuration.hosts,
+				WildcardHosts:                    wildcardHosts,
+				IngressGatewayLabels:             configuration.istioIngressGateway.Labels,
+				Name:                             envoyFilter.Name,
+				Namespace:                        envoyFilter.Namespace,
+				Port:                             kubeapiserverconstants.Port,
+				MutualTLSHost:                    mTLSHostName,
+				RouteConfigurationName:           routeConfigurationName,
+				WildcardRouteConfigurationName:   wildcardRouteConfigurationName,
+			}); err != nil {
+				return err
+			}
+
+			filename := fmt.Sprintf("envoyfilter__%s__%s.yaml", envoyFilter.Namespace, envoyFilter.Name)
+			registry.AddSerialized(filename, envoyFilterIstioTLSTermination.Bytes())
 		}
-
-		filename := fmt.Sprintf("envoyfilter__%s__%s.yaml", envoyFilter.Namespace, envoyFilter.Name)
-		registry.AddSerialized(filename, envoyFilterIstioTLSTermination.Bytes())
 	}
 
 	if values.APIServerProxy != nil || values.IstioTLSTermination {
@@ -293,26 +320,42 @@ func (s *sni) Deploy(ctx context.Context) error {
 		}
 	}
 
-	gatewayMutateFn := istio.GatewayWithTLSPassthrough(gateway, getLabels(), s.valuesFunc().IstioIngressGateway.Labels, allHosts, kubeapiserverconstants.Port)
-	if values.IstioTLSTermination {
-		serverConfigs := []istio.ServerConfig{{Hosts: values.Hosts, Port: kubeapiserverconstants.Port, PortName: portNameTLS, TLSSecret: s.namespace + istioTLSSecretSuffix}}
-		if len(values.WildcardHosts) > 0 && values.WildcardTLSSecret != nil {
-			serverConfigs = append(serverConfigs, istio.ServerConfig{Hosts: values.WildcardHosts, Port: kubeapiserverconstants.Port, PortName: portNameWildcardTLS, TLSSecret: s.emptyIstioWildcardTLSSecret().Name})
+	for _, configuration := range istioGatewayConfigurations {
+		allHosts := configuration.hosts
+		if configuration.wildcardConfiguration != nil {
+			allHosts = append(allHosts, configuration.wildcardConfiguration.Hosts...)
 		}
-		gatewayMutateFn = istio.GatewayWithMutualTLS(gateway, getLabels(), s.valuesFunc().IstioIngressGateway.Labels, serverConfigs)
+
+		gatewayMutateFn := istio.GatewayWithTLSPassthrough(configuration.gateway, getLabels(), configuration.istioIngressGateway.Labels, allHosts, kubeapiserverconstants.Port)
+		if values.IstioTLSTermination {
+			var serverConfigs []istio.ServerConfig
+			if len(configuration.hosts) > 0 {
+				serverConfigs = append(serverConfigs, istio.ServerConfig{Hosts: configuration.hosts, Port: kubeapiserverconstants.Port, PortName: portNameTLS, TLSSecret: s.namespace + istioTLSSecretSuffix})
+			}
+			if configuration.wildcardConfiguration != nil {
+				serverConfigs = append(serverConfigs, istio.ServerConfig{Hosts: configuration.wildcardConfiguration.Hosts, Port: kubeapiserverconstants.Port, PortName: portNameWildcardTLS, TLSSecret: s.emptyIstioWildcardTLSSecret().Name})
+			}
+			gatewayMutateFn = istio.GatewayWithMutualTLS(configuration.gateway, getLabels(), configuration.istioIngressGateway.Labels, serverConfigs)
+		}
+
+		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, s.client, configuration.gateway, gatewayMutateFn); err != nil {
+			return err
+		}
+
+		virtualServiceMutateFn := istio.VirtualServiceWithSNIMatch(configuration.virtualService, getLabels(), allHosts, configuration.gateway.Name, kubeapiserverconstants.Port, hostName)
+		if values.IstioTLSTermination {
+			virtualServiceMutateFn = istio.VirtualServiceForTLSTermination(configuration.virtualService, getLabels(), allHosts, configuration.gateway.Name, kubeapiserverconstants.Port, hostName)
+		}
+
+		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, s.client, configuration.virtualService, virtualServiceMutateFn); err != nil {
+			return err
+		}
 	}
 
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, s.client, gateway, gatewayMutateFn); err != nil {
-		return err
-	}
-
-	virtualServiceMutateFn := istio.VirtualServiceWithSNIMatch(virtualService, getLabels(), allHosts, gateway.Name, kubeapiserverconstants.Port, hostName)
-	if values.IstioTLSTermination {
-		virtualServiceMutateFn = istio.VirtualServiceForTLSTermination(virtualService, getLabels(), allHosts, gateway.Name, kubeapiserverconstants.Port, hostName)
-	}
-
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, s.client, virtualService, virtualServiceMutateFn); err != nil {
-		return err
+	if len(istioGatewayConfigurations) < 2 {
+		if err := kubernetesutils.DeleteObjects(ctx, s.client, s.emptyWildcardGateway(), s.emptyWildcardVirtualService()); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -333,7 +376,9 @@ func (s *sni) Destroy(ctx context.Context) error {
 		s.emptyDestinationRule(),
 		s.emptyMTLSDestinationRule(),
 		s.emptyGateway(),
+		s.emptyWildcardGateway(),
 		s.emptyVirtualService(),
+		s.emptyWildcardVirtualService(),
 	)
 }
 
@@ -352,16 +397,24 @@ func (s *sni) emptyEnvoyFilterAPIServerProxy() *istionetworkingv1alpha3.EnvoyFil
 	return &istionetworkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Name: s.namespace + "-apiserver-proxy", Namespace: s.valuesFunc().IstioIngressGateway.Namespace}}
 }
 
-func (s *sni) emptyEnvoyFilterIstioTLSTermination() *istionetworkingv1alpha3.EnvoyFilter {
-	return &istionetworkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Name: s.namespace + IstioTLSTerminationEnvoyFilterSuffix, Namespace: s.valuesFunc().IstioIngressGateway.Namespace}}
+func (s *sni) emptyEnvoyFilterIstioTLSTermination(namespace string) *istionetworkingv1alpha3.EnvoyFilter {
+	return &istionetworkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Name: s.namespace + IstioTLSTerminationEnvoyFilterSuffix, Namespace: namespace}}
 }
 
 func (s *sni) emptyGateway() *istionetworkingv1beta1.Gateway {
 	return &istionetworkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: s.name, Namespace: s.namespace}}
 }
 
+func (s *sni) emptyWildcardGateway() *istionetworkingv1beta1.Gateway {
+	return &istionetworkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: s.name + "-wildcard", Namespace: s.namespace}}
+}
+
 func (s *sni) emptyVirtualService() *istionetworkingv1beta1.VirtualService {
 	return &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: s.name, Namespace: s.namespace}}
+}
+
+func (s *sni) emptyWildcardVirtualService() *istionetworkingv1beta1.VirtualService {
+	return &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: s.name + "-wildcard", Namespace: s.namespace}}
 }
 
 func (s *sni) emptyIstioMTLSSecret() *corev1.Secret {
@@ -383,10 +436,15 @@ func (s *sni) emptyIstioTLSSecret() *corev1.Secret {
 }
 
 func (s *sni) emptyIstioWildcardTLSSecret() *corev1.Secret {
+	namespace := s.valuesFunc().IstioIngressGateway.Namespace
+	if s.valuesFunc().WildcardConfiguration != nil && s.valuesFunc().WildcardConfiguration.IstioIngressGateway != nil {
+		namespace = s.valuesFunc().WildcardConfiguration.IstioIngressGateway.Namespace
+	}
+
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.namespace + istioWildcardTLSSecretSuffix,
-			Namespace: s.valuesFunc().IstioIngressGateway.Namespace,
+			Namespace: namespace,
 		},
 	}
 }
@@ -440,12 +498,18 @@ func (s *sni) reconcileIstioTLSSecrets(ctx context.Context) error {
 	}
 	serializeObjects = append(serializeObjects, istioMTLSSecret)
 
-	if s.valuesFunc().WildcardTLSSecret != nil {
+	if s.valuesFunc().WildcardConfiguration != nil && s.valuesFunc().WildcardConfiguration.IstioIngressGateway != nil {
+		istioWildcardMTLSSecret := istioMTLSSecret.DeepCopy()
+		istioWildcardMTLSSecret.Namespace = s.valuesFunc().WildcardConfiguration.IstioIngressGateway.Namespace
+		serializeObjects = append(serializeObjects, istioWildcardMTLSSecret)
+	}
+
+	if s.valuesFunc().WildcardConfiguration != nil {
 		istioWildcardTLSSecret := s.emptyIstioWildcardTLSSecret()
 		istioWildcardTLSSecret.Data = map[string][]byte{
 			"cacert": secretCAClient.Data[secretsutils.DataKeyCertificateBundle],
-			"key":    s.valuesFunc().WildcardTLSSecret.Data[secretsutils.DataKeyPrivateKey],
-			"cert":   s.valuesFunc().WildcardTLSSecret.Data[secretsutils.DataKeyCertificate],
+			"key":    s.valuesFunc().WildcardConfiguration.TLSSecret.Data[secretsutils.DataKeyPrivateKey],
+			"cert":   s.valuesFunc().WildcardConfiguration.TLSSecret.Data[secretsutils.DataKeyCertificate],
 		}
 		serializeObjects = append(serializeObjects, istioWildcardTLSSecret)
 	}
@@ -460,6 +524,42 @@ func (s *sni) reconcileIstioTLSSecrets(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (s *sni) getIstioGatewayConfigurations() ([]istioGatewayConfiguration, error) {
+	var configurations []istioGatewayConfiguration
+
+	values := s.valuesFunc()
+
+	if values.WildcardConfiguration != nil && values.WildcardConfiguration.IstioIngressGateway != nil {
+		if values.IstioIngressGateway.Namespace == values.WildcardConfiguration.IstioIngressGateway.Namespace {
+			return nil, fmt.Errorf("wildcard istio ingress gateway must be nil or in different namespace than istio ingress gateway")
+		}
+
+		configurations = append(configurations,
+			istioGatewayConfiguration{
+				istioIngressGateway: values.IstioIngressGateway,
+				hosts:               values.Hosts,
+				gateway:             s.emptyGateway(),
+				virtualService:      s.emptyVirtualService(),
+			},
+			istioGatewayConfiguration{
+				istioIngressGateway:   *values.WildcardConfiguration.IstioIngressGateway,
+				gateway:               s.emptyWildcardGateway(),
+				virtualService:        s.emptyWildcardVirtualService(),
+				wildcardConfiguration: values.WildcardConfiguration,
+			})
+	} else {
+		configurations = append(configurations, istioGatewayConfiguration{
+			istioIngressGateway:   values.IstioIngressGateway,
+			hosts:                 values.Hosts,
+			gateway:               s.emptyGateway(),
+			virtualService:        s.emptyVirtualService(),
+			wildcardConfiguration: values.WildcardConfiguration,
+		})
+	}
+
+	return configurations, nil
 }
 
 // GetAPIServerProxyTargetClusterName returns the name of the target cluster for apiserver-proxy for the given control-plane namespace.

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"net"
 
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -77,10 +76,10 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 		b.Shoot.ControlPlaneNamespace,
 		b.SecretsManager,
 		func() *kubeapiserverexposure.SNIValues {
-			var wildcardHost *string
+			var wildcardHosts []string
 
 			if b.ControlPlaneWildcardCert != nil {
-				wildcardHost = ptr.To(b.ComputeKubeAPIServerHost())
+				wildcardHosts = []string{b.ComputeKubeAPIServerHost()}
 			}
 
 			return &kubeapiserverexposure.SNIValues{
@@ -89,7 +88,7 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 					Labels:    b.IstioLabels(),
 				},
 				IstioTLSTermination: features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
-				WildcardHost:        wildcardHost,
+				WildcardHosts:       wildcardHosts,
 				WildcardTLSSecret:   b.ControlPlaneWildcardCert,
 			}
 		},
@@ -127,10 +126,10 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 		b.Shoot.ControlPlaneNamespace,
 		b.SecretsManager,
 		func() *kubeapiserverexposure.SNIValues {
-			var wildcardHost *string
+			var wildcardHosts []string
 
 			if b.ControlPlaneWildcardCert != nil {
-				wildcardHost = ptr.To(b.ComputeKubeAPIServerHost())
+				wildcardHosts = []string{b.ComputeKubeAPIServerHost()}
 			}
 
 			values := &kubeapiserverexposure.SNIValues{
@@ -146,7 +145,7 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 					Labels:    b.IstioLabels(),
 				},
 				IstioTLSTermination: features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
-				WildcardHost:        wildcardHost,
+				WildcardHosts:       wildcardHosts,
 				WildcardTLSSecret:   b.ControlPlaneWildcardCert,
 			}
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -899,17 +899,22 @@ func GetAPIServerSNIDomains(domains []string, sni operatorv1alpha1.SNI) []string
 	var sniDomains []string
 
 	for _, domainPattern := range sni.DomainPatterns {
+		// Handle wildcard domains
 		if strings.HasPrefix(domainPattern, "*.") {
 			patternWithoutWildcard := domainPattern[1:]
 			for _, domain := range domains {
-				domainWithoutSuffix := strings.TrimSuffix(domain, patternWithoutWildcard)
-				if strings.HasSuffix(domain, patternWithoutWildcard) && len(domainWithoutSuffix) > 0 && !strings.Contains(domainWithoutSuffix, ".") {
-					sniDomains = append(sniDomains, domain)
+				if strings.HasSuffix(domain, patternWithoutWildcard) {
+					subDomain := strings.TrimSuffix(domain, patternWithoutWildcard)
+					// The wildcard is for one subdomain level only, so the subdomain should not contain any dots.
+					if len(subDomain) > 0 && !strings.Contains(subDomain, ".") {
+						sniDomains = append(sniDomains, domain)
+					}
 				}
 			}
 			continue
 		}
 
+		// Handle exact domains
 		if slices.Contains(domains, domainPattern) {
 			sniDomains = append(sniDomains, domainPattern)
 		}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -214,7 +215,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.kubeAPIServerSNI, err = r.newSNI(garden, secretsManager, c.istio.GetValues().IngressGateway)
+	c.kubeAPIServerSNI, err = r.newSNI(ctx, garden, secretsManager, c.istio.GetValues().IngressGateway)
 	if err != nil {
 		return
 	}
@@ -804,12 +805,37 @@ func (r *Reconciler) newIstio(ctx context.Context, garden *operatorv1alpha1.Gard
 	)
 }
 
-func (r *Reconciler) newSNI(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressGatewayValues []istio.IngressGatewayValues) (component.Deployer, error) {
+func (r *Reconciler) newSNI(ctx context.Context, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressGatewayValues []istio.IngressGatewayValues) (component.Deployer, error) {
+	var wildcardConfiguration *kubeapiserverexposure.WildcardConfiguration
+
 	if len(ingressGatewayValues) != 1 {
 		return nil, fmt.Errorf("exactly one Istio Ingress Gateway is required for the SNI config")
 	}
 
 	domains := toDomainNames(getAPIServerDomains(garden.Spec.VirtualCluster.DNS.Domains))
+
+	if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI != nil {
+		sni := garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI
+		sniDomains := GetAPIServerSNIDomains(domains, *sni)
+
+		if len(sniDomains) > 0 {
+			var tlsSecret corev1.Secret
+
+			if err := r.RuntimeClientSet.Client().Get(ctx, client.ObjectKey{Name: sni.SecretName, Namespace: r.GardenNamespace}, &tlsSecret); err != nil {
+				return nil, fmt.Errorf("failed to get SNI TLS secret %q: %w", sni.SecretName, err)
+			}
+
+			wildcardConfiguration = &kubeapiserverexposure.WildcardConfiguration{
+				Hosts:     sniDomains,
+				TLSSecret: tlsSecret,
+			}
+
+			domains = slices.DeleteFunc(domains, func(domain string) bool {
+				return slices.Contains(sniDomains, domain)
+			})
+		}
+	}
+
 	return kubeapiserverexposure.NewSNI(
 		r.RuntimeClientSet.Client(),
 		namePrefix+v1beta1constants.DeploymentNameKubeAPIServer,
@@ -822,7 +848,8 @@ func (r *Reconciler) newSNI(garden *operatorv1alpha1.Garden, secretsManager secr
 					Namespace: ingressGatewayValues[0].Namespace,
 					Labels:    ingressGatewayValues[0].Labels,
 				},
-				IstioTLSTermination: isIstioTLSTerminationEnabled(garden),
+				IstioTLSTermination:   isIstioTLSTerminationEnabled(garden),
+				WildcardConfiguration: wildcardConfiguration,
 			}
 		},
 	), nil
@@ -865,6 +892,30 @@ func getAPIServerDomains(domains []operatorv1alpha1.DNSDomain) []operatorv1alpha
 			})
 	}
 	return apiServerDomains
+}
+
+// GetAPIServerSNIDomains returns the domains which match a SNI domain pattern.
+func GetAPIServerSNIDomains(domains []string, sni operatorv1alpha1.SNI) []string {
+	var sniDomains []string
+
+	for _, domainPattern := range sni.DomainPatterns {
+		if strings.HasPrefix(domainPattern, "*.") {
+			patternWithoutWildcard := domainPattern[1:]
+			for _, domain := range domains {
+				domainWithoutSuffix := strings.TrimSuffix(domain, patternWithoutWildcard)
+				if strings.HasSuffix(domain, patternWithoutWildcard) && len(domainWithoutSuffix) > 0 && !strings.Contains(domainWithoutSuffix, ".") {
+					sniDomains = append(sniDomains, domain)
+				}
+			}
+			continue
+		}
+
+		if slices.Contains(domains, domainPattern) {
+			sniDomains = append(sniDomains, domainPattern)
+		}
+	}
+
+	return sniDomains
 }
 
 func getIngressWildcardDomains(domains []operatorv1alpha1.DNSDomain) []operatorv1alpha1.DNSDomain {

--- a/pkg/operator/controller/garden/garden/components_test.go
+++ b/pkg/operator/controller/garden/garden/components_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package garden_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	. "github.com/gardener/gardener/pkg/operator/controller/garden/garden"
+)
+
+var _ = Describe("Components", func() {
+	Describe("GetAPIServerSNIDomains", func() {
+		It("should return the correct SNI domains", func() {
+			domains := []string{"foo.bar", "bar.foo.bar", "foo.foo.bar", "foo.bar.foo.bar", "api.bar"}
+			sni := operatorv1alpha1.SNI{
+				DomainPatterns: []string{"api.bar", "*.foo.bar"},
+			}
+
+			Expect(GetAPIServerSNIDomains(domains, sni)).To(Equal([]string{"api.bar", "bar.foo.bar", "foo.foo.bar"}))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes issues with wildcard certificate endpoints introduced by PR #11085.
- The shoot kube-apiserver endpoint which uses the wildcard TLS certificate of the seed was not reachable for shoots which are not HA-multizone
  - This happened because this endpoint was configured on an Istio Gateway to which DNS does not resolve its address.  
- The endpoint of virtual-garden which should use the wildcard certificate served the self-signed certificate instead when IstioTLSTermination feature gate is active

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug which made the wildcard TLS certificate endpoint of non-HA-multizone shoot kube-apiservers inaccessible has been fixed.
```
```bugfix user
A bug in gardener-operator which made the virtual-kube-apiserver serve the self-signed certificate on the wildcard TLS certificate endpoint when IstioTLSTermination feature gate is active has been fixed.
```