### PR TITLE
Keep envoyfilters for L7 load-balancing unless no shoot is using this feature anymore

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -42,6 +42,8 @@ const (
 	MutualTLSServiceNameSuffix = "-mtls"
 	// AuthenticationDynamicMetadataKey is the key used to configure the istio envoy filter.
 	AuthenticationDynamicMetadataKey = "authenticated-kube-apiserver-host"
+	// IstioTLSTerminationEnvoyFilterSuffix is the suffix for the envoy filter used for TLS termination.
+	IstioTLSTerminationEnvoyFilterSuffix = "-istio-tls-termination"
 
 	// authenticationDynamicMetadataKeyAPIServerProxy is the key used to configure the istio envoy filter for the APIServer proxy.
 	authenticationDynamicMetadataKeyAPIServerProxy = "authenticated-shoot"
@@ -359,7 +361,7 @@ func (s *sni) emptyEnvoyFilterAPIServerProxy() *istionetworkingv1alpha3.EnvoyFil
 }
 
 func (s *sni) emptyEnvoyFilterIstioTLSTermination() *istionetworkingv1alpha3.EnvoyFilter {
-	return &istionetworkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Name: s.namespace + "-istio-tls-termination", Namespace: s.valuesFunc().IstioIngressGateway.Namespace}}
+	return &istionetworkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Name: s.namespace + IstioTLSTerminationEnvoyFilterSuffix, Namespace: s.valuesFunc().IstioIngressGateway.Namespace}}
 }
 
 func (s *sni) emptyGateway() *istionetworkingv1beta1.Gateway {

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -5,11 +5,15 @@
 package istio
 
 import (
+	"context"
 	"embed"
+	"fmt"
 	"path/filepath"
 	"strings"
 
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/chartrenderer"
@@ -51,10 +55,27 @@ type IngressGatewayValues struct {
 	Ports []corev1.ServicePort
 }
 
-func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChart, error) {
+func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartrenderer.RenderedChart, error) {
 	renderedChart := &chartrenderer.RenderedChart{}
 
 	for _, istioIngressGateway := range i.values.IngressGateway {
+		enableAPIServerTLSTermination := features.DefaultFeatureGate.Enabled(features.IstioTLSTermination)
+		// Keep the seed server components for istio tls termination until no shoot is using the feature to not break
+		// control plane communication when deactivating the feature gate.
+		if !enableAPIServerTLSTermination {
+			var envoyFilters networkingv1alpha3.EnvoyFilterList
+			if err := i.client.List(ctx, &envoyFilters, client.InNamespace(istioIngressGateway.Namespace)); err != nil {
+				return nil, fmt.Errorf("unable to list EnvoyFilters in namespace %s: %w", istioIngressGateway.Namespace, err)
+			}
+
+			for _, envoyFilter := range envoyFilters.Items {
+				if strings.HasSuffix(envoyFilter.Name, apiserverexposure.IstioTLSTerminationEnvoyFilterSuffix) {
+					enableAPIServerTLSTermination = true
+					break
+				}
+			}
+		}
+
 		values := map[string]any{
 			"trustDomain":                        istioIngressGateway.TrustDomain,
 			"labels":                             istioIngressGateway.Labels,
@@ -71,7 +92,7 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 			"serviceName":                        v1beta1constants.DefaultSNIIngressServiceName,
 			"proxyProtocolEnabled":               istioIngressGateway.ProxyProtocolEnabled,
 			"terminateLoadBalancerProxyProtocol": istioIngressGateway.TerminateLoadBalancerProxyProtocol,
-			"terminateAPIServerTLS":              features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
+			"terminateAPIServerTLS":              enableAPIServerTLSTermination,
 			"vpn": map[string]any{
 				"enabled": istioIngressGateway.VPNEnabled,
 			},

--- a/pkg/component/networking/istio/istiod.go
+++ b/pkg/component/networking/istio/istiod.go
@@ -245,7 +245,7 @@ func (i *istiod) Deploy(ctx context.Context) error {
 		}
 	}
 
-	renderedChart, err := i.generateIstioIngressGatewayChart()
+	renderedChart, err := i.generateIstioIngressGatewayChart(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
When you deactivate `IstioTLSTermination` feature gate on a seed with shoots where this feature is still active, control plane access using client certificates is broken for these shoots until their next reconciliation because some envoyfilters which are required get removed from istio ingress deployment.
With this PR the seed keeps these envoyfilters until no shoots are using L7 load-balancing anymore. This should happen during the next shoot reconciliation after the feature gate has been deactivated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which might break control-plane access to shoots until their next reconciliation when deactivating IstioTLSTermination feature gate on their seed has been fixed.
```
