### PR TITLE
Enable migration from single-stack IPv4 to dual-stack IPv4, IPv6. 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@
 * [`NodeLocalDNS` feature](usage/networking/node-local-dns.md)
 * [Shoot `KUBERNETES_SERVICE_HOST` Environment Variable Injection](usage/networking/shoot_kubernetes_service_host_injection.md)
 * [Shoot Networking](usage/networking/shoot_networking.md)
+* [Dual-Stack Network Migration](usage/networking/dual-stack-networking-migration.md)
 
 ### Autoscaling
 

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -1299,7 +1299,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+<p>IPFamilies specifies the IP protocol versions to use for shoot networking.
 See <a href="https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md">https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md</a></p>
 </td>
 </tr>
@@ -3492,7 +3492,8 @@ string
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#extensions.gardener.cloud/v1alpha1.NetworkSpec">NetworkSpec</a>)
+<a href="#extensions.gardener.cloud/v1alpha1.NetworkSpec">NetworkSpec</a>, 
+<a href="#extensions.gardener.cloud/v1alpha1.NetworkStatus">NetworkStatus</a>)
 </p>
 <p>
 <p>IPFamily is a type for specifying an IP protocol version to use in Gardener clusters.</p>
@@ -3960,7 +3961,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+<p>IPFamilies specifies the IP protocol versions to use for shoot networking.
 See <a href="https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md">https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md</a></p>
 </td>
 </tr>
@@ -3997,6 +3998,21 @@ DefaultStatus
 (Members of <code>DefaultStatus</code> are embedded into this type.)
 </p>
 <p>DefaultStatus is a structure containing common fields used by all extension resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ipFamilies</code></br>
+<em>
+<a href="#extensions.gardener.cloud/v1alpha1.IPFamily">
+[]IPFamily
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IPFamilies specifies the IP protocol versions that actually are used for shoot networking.
+During dual-stack migration, this field may differ from the spec.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/extensions/resources/network.md
+++ b/docs/extensions/resources/network.md
@@ -43,9 +43,12 @@ spec:
     ipam:
       cidr: usePodCIDR
       type: host-local
+status:
+  ipFamilies:
+  - IPv4
 ```
 
-The above resources is divided into two parts (more information can be found at [Using the Networking Calico Extension](https://github.com/gardener/gardener-extension-networking-calico/blob/master/docs/usage/usage.md)):
+The spec of above resources is divided into two parts (more information can be found at [Using the Networking Calico Extension](https://github.com/gardener/gardener-extension-networking-calico/blob/master/docs/usage/usage.md)):
 
 - global configuration (e.g., podCIDR, serviceCIDR, and type)
 - provider specific config (e.g., for calico we can choose to configure a `bird` backend)
@@ -91,6 +94,12 @@ The networking extensions need to handle this twofold:
 
 1. During the reconciliation of the networking resources, the extension needs to check whether `kube-proxy` takes care of the service routing or the networking extension itself should handle it. In case the networking extension should be responsible according to `.spec.kubernetes.kubeproxy.enabled` (but is unable to perform the service routing), it should raise an error during the reconciliation. If the networking extension should handle the service routing, it may reconfigure itself accordingly.
 1. (Optional) In case the networking extension does not support taking over the service routing (in some scenarios), it is recommended to also provide a validating admission webhook to reject corresponding changes early on. The validation may take the current operating mode of the networking extension into consideration.
+
+## Supporting Migration of `ipFamilies`
+
+To enable the migration from a shoot cluster with single-stack networking to a cluster with dual-stack networking, the `status` field of the `Network` resource includes the `ipFamilies` field. 
+
+This field reflects the currently deployed configuration and is used to verify whether the migration process has been completed successfully. To support the migration from single-stack to dual-stack networking, a network extension provider must ensure that this field is properly maintained and updated during the migration process.
 
 ## Related Links
 

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -1,0 +1,46 @@
+---
+title: Dual-stack network migration
+description: Migrate IPv4 shoots to dual-stack IPv,IPv6 network
+---
+
+# Dual-Stack Network Migration
+
+This document provides a guide for migrating IPv4-based or IPv6-based Gardener shoot clusters to dual-stack networking (IPv4 and IPv6).
+## Overview
+
+Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protocols. This configuration is controlled via the `shoot.Spec.Networking.IPFamilies` field, which accepts the following values:
+- `[IPv4]`
+- `[IPv6]`
+- `[IPv4, IPv6]`
+- `[IPv6, IPv4]`
+
+### Key Considerations
+- Adding a new protocol is only allowed as the second element in the array, ensuring the primary protocol remains unchanged.
+- Migration involves multiple reconciliation runs to ensure a smooth transition without disruptions.
+
+## Migration Process
+
+### Step 1: Update Networking Configuration
+Modify the `shoot.Spec.Networking.IPFamilies` field to include the desired dual-stack configuration. For example, change `[IPv4]` to `[IPv4, IPv6]`.
+
+### Step 2: Infrastructure Reconciliation
+Changing the `IPFamilies` field triggers an infrastructure reconciliation. This step applies necessary changes to the underlying infrastructure to support dual-stack networking.
+
+### Step 3: Control Plane Updates
+Depending on the infrastructure, control plane components will be updated or reconfigured to support dual-stack networking.
+
+### Step 4: Node Rollout
+Nodes must support the new network protocol. However, node rollout is not triggered automatically. It should be performed during a maintenance window to minimize disruptions. During shoot reconciliation, the system verifies if all nodes support dual-stack networking and updates the migration state accordingly.
+
+### Step 5: Final Reconciliation
+Once all nodes are migrated, the remaining control plane components and the Container Network Interface (CNI) are configured for dual-stack networking. The migration constraint is removed at the end of this step.
+
+## Post-Migration Behavior
+
+After completing the migration:
+- The shoot cluster supports dual-stack networking.
+- New pods will receive IP addresses from both protocols.
+- Existing pods will only receive a second IP address upon restart.
+
+
+

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -6,6 +6,7 @@ description: Migrate IPv4 shoots to dual-stack IPv4,IPv6 network
 # Dual-Stack Network Migration
 
 This document provides a guide for migrating IPv4-only or IPv6-only Gardener shoot clusters to dual-stack networking (IPv4 and IPv6).
+
 ## Overview
 
 Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protocols. This configuration is controlled via the `spec.networking.ipFamilies` field, which accepts the following values:
@@ -15,18 +16,22 @@ Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protoco
 - `[IPv6, IPv4]`
 
 ### Key Considerations
+
 - Adding a new protocol is only allowed as the second element in the array, ensuring the primary protocol remains unchanged.
 - Migration involves multiple reconciliation runs to ensure a smooth transition without disruptions.
 
 ## Migration Process
 
 ### Step 1: Update Networking Configuration
+
 Modify the `spec.networking.ipFamilies` field to include the desired dual-stack configuration. For example, change `[IPv4]` to `[IPv4, IPv6]`.
 
 ### Step 2: Infrastructure Reconciliation
+
 Changing the `ipFamilies` field triggers an infrastructure reconciliation. This step applies necessary changes to the underlying infrastructure to support dual-stack networking.
 
 ### Step 3: Control Plane Updates
+
 Depending on the infrastructure, control plane components will be updated or reconfigured to support dual-stack networking.
 
 ### Step 4: Node Rollout
@@ -36,15 +41,13 @@ Nodes must support the new network protocol. However, node rollout is a manual s
 Cluster owners can monitor the progress of this step by checking the `DualStackNodesMigrationReady` constraint in the shoot status. During shoot reconciliation, the system verifies if all nodes support dual-stack networking and updates the migration state accordingly.
 
 ### Step 5: Final Reconciliation
+
 Once all nodes are migrated, the remaining control plane components and the Container Network Interface (CNI) are configured for dual-stack networking. The migration constraint is removed at the end of this step.
 
 ## Post-Migration Behavior
 
 After completing the migration:
 - The shoot cluster supports dual-stack networking.
- New pods will receive IP addresses from both address families.
+- New pods will receive IP addresses from both address families.
 - Existing pods will only receive a second IP address upon recreation.
 - If full dual-stack networking is required all pods need to be rolled.
-
-
-

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -1,14 +1,14 @@
 ---
 title: Dual-stack network migration
-description: Migrate IPv4 shoots to dual-stack IPv,IPv6 network
+description: Migrate IPv4 shoots to dual-stack IPv4,IPv6 network
 ---
 
 # Dual-Stack Network Migration
 
-This document provides a guide for migrating IPv4-based or IPv6-based Gardener shoot clusters to dual-stack networking (IPv4 and IPv6).
+This document provides a guide for migrating IPv4-only or IPv6-only Gardener shoot clusters to dual-stack networking (IPv4 and IPv6).
 ## Overview
 
-Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protocols. This configuration is controlled via the `shoot.Spec.Networking.IPFamilies` field, which accepts the following values:
+Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protocols. This configuration is controlled via the `spec.networking.ipFamilies` field, which accepts the following values:
 - `[IPv4]`
 - `[IPv6]`
 - `[IPv4, IPv6]`
@@ -21,16 +21,19 @@ Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protoco
 ## Migration Process
 
 ### Step 1: Update Networking Configuration
-Modify the `shoot.Spec.Networking.IPFamilies` field to include the desired dual-stack configuration. For example, change `[IPv4]` to `[IPv4, IPv6]`.
+Modify the `spec.networking.ipFamilies` field to include the desired dual-stack configuration. For example, change `[IPv4]` to `[IPv4, IPv6]`.
 
 ### Step 2: Infrastructure Reconciliation
-Changing the `IPFamilies` field triggers an infrastructure reconciliation. This step applies necessary changes to the underlying infrastructure to support dual-stack networking.
+Changing the `ipFamilies` field triggers an infrastructure reconciliation. This step applies necessary changes to the underlying infrastructure to support dual-stack networking.
 
 ### Step 3: Control Plane Updates
 Depending on the infrastructure, control plane components will be updated or reconfigured to support dual-stack networking.
 
 ### Step 4: Node Rollout
-Nodes must support the new network protocol. However, node rollout is not triggered automatically. It should be performed during a maintenance window to minimize disruptions. During shoot reconciliation, the system verifies if all nodes support dual-stack networking and updates the migration state accordingly.
+
+Nodes must support the new network protocol. However, node rollout is a manual step and is not triggered automatically. It should be performed during a maintenance window to minimize disruptions. Over time, this step may occur automatically, for example, during Kubernetes minor version updates that involve node replacements.
+
+Cluster owners can monitor the progress of this step by checking the `DualStackNodesMigrationReady` constraint in the shoot status. During shoot reconciliation, the system verifies if all nodes support dual-stack networking and updates the migration state accordingly.
 
 ### Step 5: Final Reconciliation
 Once all nodes are migrated, the remaining control plane components and the Container Network Interface (CNI) are configured for dual-stack networking. The migration constraint is removed at the end of this step.
@@ -39,8 +42,9 @@ Once all nodes are migrated, the remaining control plane components and the Cont
 
 After completing the migration:
 - The shoot cluster supports dual-stack networking.
-- New pods will receive IP addresses from both protocols.
-- Existing pods will only receive a second IP address upon restart.
+ New pods will receive IP addresses from both address families.
+- Existing pods will only receive a second IP address upon recreation.
+- If full dual-stack networking is required all pods need to be rolled.
 
 
 

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
@@ -71,7 +71,7 @@ spec:
                   rule: self == oldSelf
               ipFamilies:
                 description: |-
-                  IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+                  IPFamilies specifies the IP protocol versions to use for shoot networking.
                   See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md
                 items:
                   description: IPFamily is a type for specifying an IP protocol version
@@ -145,6 +145,15 @@ spec:
                   - status
                   - type
                   type: object
+                type: array
+              ipFamilies:
+                description: |-
+                  IPFamilies specifies the IP protocol versions that actually are used for shoot networking.
+                  During dual-stack migration, this field may differ from the spec.
+                items:
+                  description: IPFamily is a type for specifying an IP protocol version
+                    to use in Gardener clusters.
+                  type: string
                 type: array
               lastError:
                 description: LastError holds information about the last occurred error

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1939,6 +1939,8 @@ const (
 	ShootAPIServerProxyUsesHTTPProxy ConditionType = "APIServerProxyUsesHTTPProxy"
 	// ShootReadyForMigration is a constant for a condition type indicating whether the Shoot can be migrated.
 	ShootReadyForMigration ConditionType = "ReadyForMigration"
+	// ShootDualStackNodesMigrationReady is a constant for a condition type indicating whether all nodes are migrated to dual-stack .
+	ShootDualStackNodesMigrationReady ConditionType = "DualStackNodesMigrationReady"
 )
 
 // ShootPurpose is a type alias for string.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -722,7 +722,6 @@ func validateNetworkingUpdate(newNetworking, oldNetworking *core.Networking, fld
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Type, oldNetworking.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.IPFamilies, oldNetworking.IPFamilies, fldPath.Child("ipFamilies"))...)
 	if oldNetworking.Pods != nil {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Pods, oldNetworking.Pods, fldPath.Child("pods"))...)
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3812,19 +3812,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})
 			})
 
-			It("should fail updating immutable fields", func() {
+			It("should allow updating ipfamilies", func() {
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4}
 
 				newShoot := prepareShootForUpdate(shoot)
-				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6}
+				newShoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 
 				errorList := ValidateShootUpdate(newShoot, shoot)
-
-				Expect(errorList).To(ConsistOfFields(Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.networking.ipFamilies"),
-					"Detail": ContainSubstring(`field is immutable`),
-				}))
+				Expect(errorList).To(BeEmpty())
 			})
 		})
 

--- a/pkg/apis/extensions/v1alpha1/types_network.go
+++ b/pkg/apis/extensions/v1alpha1/types_network.go
@@ -65,7 +65,7 @@ type NetworkSpec struct {
 	PodCIDR string `json:"podCIDR"`
 	// ServiceCIDR defines the CIDR that will be used for services. This field is immutable.
 	ServiceCIDR string `json:"serviceCIDR"`
-	// IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+	// IPFamilies specifies the IP protocol versions to use for shoot networking.
 	// See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md
 	// +optional
 	IPFamilies []IPFamily `json:"ipFamilies,omitempty"`
@@ -75,6 +75,10 @@ type NetworkSpec struct {
 type NetworkStatus struct {
 	// DefaultStatus is a structure containing common fields used by all extension resources.
 	DefaultStatus `json:",inline"`
+	// IPFamilies specifies the IP protocol versions that actually are used for shoot networking.
+	// During dual-stack migration, this field may differ from the spec.
+	// +optional
+	IPFamilies []IPFamily `json:"ipFamilies,omitempty"`
 }
 
 // GetExtensionType returns the type of this Network resource.

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1557,6 +1557,11 @@ func (in *NetworkSpec) DeepCopy() *NetworkSpec {
 func (in *NetworkStatus) DeepCopyInto(out *NetworkStatus) {
 	*out = *in
 	in.DefaultStatus.DeepCopyInto(&out.DefaultStatus)
+	if in.IPFamilies != nil {
+		in, out := &in.IPFamilies, &out.IPFamilies
+		*out = make([]IPFamily, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -141,19 +142,6 @@ func ValidateIPFamiliesUpdate(newIPFamilies, oldIPFamilies []extensionsv1alpha1.
 		}
 	}
 
-	if len(oldIPFamilies) == 2 && oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 && oldIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv6 {
-		if len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv4 {
-			// Allow transition from [IPv4, IPv6] to [IPv6, IPv4]
-			return allErrs
-		}
-	}
-
-	if len(oldIPFamilies) == 2 && oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 && oldIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv4 {
-		if len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv6 {
-			// Allow transition from [IPv6, IPv4] to [IPv4, IPv6]
-			return allErrs
-		}
-	}
 	if len(oldIPFamilies) == 1 && oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 {
 		if len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv6 {
 			// Allow transition from [IPv4] to [IPv4, IPv6]
@@ -162,7 +150,8 @@ func ValidateIPFamiliesUpdate(newIPFamilies, oldIPFamilies []extensionsv1alpha1.
 	}
 
 	if !apiequality.Semantic.DeepEqual(newIPFamilies, oldIPFamilies) {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "unsupported IP family update"))
+		allErrs = append(allErrs, field.Forbidden(fldPath,
+			fmt.Sprintf("unsupported IP family update: oldIPFamilies=%v, newIPFamilies=%v", oldIPFamilies, newIPFamilies)))
 	}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -135,18 +135,11 @@ func ValidateIPFamilies(ipFamilies []extensionsv1alpha1.IPFamily, fldPath *field
 func ValidateIPFamiliesUpdate(newIPFamilies, oldIPFamilies []extensionsv1alpha1.IPFamily, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(oldIPFamilies) == 1 && oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 {
-		if len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv4 {
-			// Allow transition from [IPv6] to [IPv6, IPv4]
-			return allErrs
-		}
-	}
-
-	if len(oldIPFamilies) == 1 && oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 {
-		if len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv6 {
-			// Allow transition from [IPv4] to [IPv4, IPv6]
-			return allErrs
-		}
+	if len(oldIPFamilies) == 1 &&
+		((oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 && len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv4) ||
+			(oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 && len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv6)) {
+		// Allow transition from [IPv6] to [IPv6, IPv4] or [IPv4] to [IPv4, IPv6]
+		return allErrs
 	}
 
 	if !apiequality.Semantic.DeepEqual(newIPFamilies, oldIPFamilies) {

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -225,26 +225,6 @@ var _ = Describe("Network validation tests", func() {
 			}))))
 		})
 
-		It("should prevent updating the ipFamilies", func() {
-			newNetwork := prepareNetworkForUpdate(network)
-			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6}
-
-			errorList := ValidateNetworkUpdate(newNetwork, network)
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.ipFamilies"),
-				"Detail": ContainSubstring("immutable"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.podCIDR"),
-				"Detail": Equal("must be a valid IPv6 address"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.serviceCIDR"),
-				"Detail": Equal("must be a valid IPv6 address"),
-			}))))
-		})
-
 		It("should allow updating the provider config", func() {
 			newNetwork := prepareNetworkForUpdate(network)
 			newNetwork.Spec.ProviderConfig = nil
@@ -252,6 +232,61 @@ var _ = Describe("Network validation tests", func() {
 			errorList := ValidateNetworkUpdate(newNetwork, network)
 
 			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should allow updating ipFamilies from IPv4 to dual-stack [IPv4, IPv6]", func() {
+			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4}
+			newNetwork := prepareNetworkForUpdate(network)
+			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6}
+
+			errorList := ValidateNetworkUpdate(newNetwork, network)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should allow updating ipFamilies from IPv6 to dual-stack [IPv6, IPv4]", func() {
+			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6}
+			newNetwork := prepareNetworkForUpdate(network)
+			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6, extensionsv1alpha1.IPFamilyIPv4}
+
+			errorList := ValidateNetworkUpdate(newNetwork, network)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should allow updating ipFamilies from dual-stack [IPv4, IPv6] to [IPv6, IPv4]", func() {
+			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6}
+			newNetwork := prepareNetworkForUpdate(network)
+			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6, extensionsv1alpha1.IPFamilyIPv4}
+
+			errorList := ValidateNetworkUpdate(newNetwork, network)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should prevent updating ipFamilies to an unsupported transition", func() {
+			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4}
+			newNetwork := prepareNetworkForUpdate(network)
+			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6}
+
+			errorList := ValidateNetworkUpdate(newNetwork, network)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.ipFamilies"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.podCIDR"),
+					"Detail": Equal("must be a valid IPv6 address"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.serviceCIDR"),
+					"Detail": Equal("must be a valid IPv6 address"),
+				})),
+			))
 		})
 	})
 

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_networks.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_networks.yaml
@@ -73,7 +73,7 @@ spec:
                   rule: self == oldSelf
               ipFamilies:
                 description: |-
-                  IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+                  IPFamilies specifies the IP protocol versions to use for shoot networking.
                   See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md
                 items:
                   description: IPFamily is a type for specifying an IP protocol version
@@ -147,6 +147,15 @@ spec:
                   - status
                   - type
                   type: object
+                type: array
+              ipFamilies:
+                description: |-
+                  IPFamilies specifies the IP protocol versions that actually are used for shoot networking.
+                  During dual-stack migration, this field may differ from the spec.
+                items:
+                  description: IPFamily is a type for specifying an IP protocol version
+                    to use in Gardener clusters.
+                  type: string
                 type: array
               lastError:
                 description: LastError holds information about the last occurred error

--- a/pkg/component/extensions/network/mock/mocks.go
+++ b/pkg/component/extensions/network/mock/mocks.go
@@ -15,6 +15,7 @@ import (
 	reflect "reflect"
 
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -68,6 +69,21 @@ func (m *MockInterface) Destroy(ctx context.Context) error {
 func (mr *MockInterfaceMockRecorder) Destroy(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), ctx)
+}
+
+// Get mocks base method.
+func (m *MockInterface) Get(ctx context.Context) (*v1alpha1.Network, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx)
+	ret0, _ := ret[0].(*v1alpha1.Network)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockInterfaceMockRecorder) Get(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInterface)(nil).Get), ctx)
 }
 
 // Migrate mocks base method.

--- a/pkg/component/extensions/network/network.go
+++ b/pkg/component/extensions/network/network.go
@@ -40,6 +40,7 @@ type Interface interface {
 	component.DeployMigrateWaiter
 	SetPodCIDRs([]net.IPNet)
 	SetServiceCIDRs([]net.IPNet)
+	Get(ctx context.Context) (*extensionsv1alpha1.Network, error)
 }
 
 // Values contains the values used to create a Network CRD
@@ -206,4 +207,12 @@ func (n *network) SetPodCIDRs(pods []net.IPNet) {
 
 func (n *network) SetServiceCIDRs(services []net.IPNet) {
 	n.values.ServiceCIDRs = services
+}
+
+// Get retrieves and returns the Network resources based on the configured values.
+func (n *network) Get(ctx context.Context) (*extensionsv1alpha1.Network, error) {
+	if err := n.client.Get(ctx, client.ObjectKeyFromObject(n.network), n.network); err != nil {
+		return nil, err
+	}
+	return n.network, nil
 }

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -124,6 +124,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	if hasNodesCIDR {
+		err := o.Shoot.CheckDualStackMigrateNetworks(ctx, botanist.GardenClient, botanist.Clock)
+		if err != nil {
+			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
+		}
 		networks, err := shoot.ToNetworks(o.Shoot.GetInfo(), o.Shoot.IsWorkerless)
 		if err != nil {
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
@@ -811,6 +815,12 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployWorker, waitUntilWorkerStatusUpdate, deployManagedResourceForGardenerNodeAgent),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Checking dual-stack migration of nodes",
+			Fn:           botanist.CheckPodCIDRsInNodes,
+			SkipIf:       o.Shoot.IsWorkerless,
+			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until extension resources handled after workers are ready",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -124,8 +124,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	if hasNodesCIDR {
-		err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx)
-		if err != nil {
+		if err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx); err != nil {
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 		}
 		networks, err := shoot.ToNetworks(o.Shoot.GetInfo(), o.Shoot.IsWorkerless)
@@ -817,7 +816,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(deployWorker, waitUntilWorkerStatusUpdate, deployManagedResourceForGardenerNodeAgent),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Checking dual-stack migration of nodes",
+			Name:         "Checking if we have dual-stack pod CIDRs in nodes",
 			Fn:           botanist.CheckPodCIDRsInNodes,
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -124,7 +124,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	if hasNodesCIDR {
-		err := o.Shoot.CheckDualStackMigrateNetworks(ctx, botanist.GardenClient, botanist.Clock)
+		err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx)
 		if err != nil {
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 		}

--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -6,7 +6,6 @@ package botanist
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,31 +14,37 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 )
 
-func (b *Botanist) checkInfraStatus(ctx context.Context) (bool, error) {
-	infra, err := b.Shoot.Components.Extensions.Infrastructure.Get(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to get infra resource: %w", err)
+// DetermineUpdateFunction determines the update function for the shoot's status based on dual-stack migration readiness.
+func (b *Botanist) DetermineUpdateFunction(
+	networkReadyForDualStackMigration bool,
+	nodeList *corev1.NodeList,
+) func(*gardencorev1beta1.Shoot) error {
+	if networkReadyForDualStackMigration {
+		return func(shoot *gardencorev1beta1.Shoot) error {
+			shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			return nil
+		}
 	}
-	result := len(infra.Status.Networking.Nodes) == 2
-	return result, nil
-}
 
-func (b *Botanist) checkNetworkStatusIPFamilies(ctx context.Context) (bool, error) {
-	network, err := b.Shoot.Components.Extensions.Network.Get(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to get network resource: %w", err)
+	allNodesDualStack := true
+	conditionStatus := gardencorev1beta1.ConditionFalse
+	conditionReason := "NodesNotMigrated"
+	conditionMessage := "Not all nodes were migrated to dual-stack networking."
+	for _, node := range nodeList.Items {
+		allNodesDualStack = allNodesDualStack && len(node.Spec.PodCIDRs) == 2
 	}
-	providerStatus := network.Status.GetProviderStatus()
-	if providerStatus.Raw == nil {
-		return false, fmt.Errorf("network providerStatus is nil")
+	if allNodesDualStack {
+		conditionStatus = gardencorev1beta1.ConditionTrue
+		conditionReason = "NodesMigrated"
+		conditionMessage = "All nodes were migrated to dual-stack networking."
 	}
-	var networkStatus map[string]any
-	if err := json.Unmarshal(providerStatus.Raw, &networkStatus); err != nil {
-		return false, fmt.Errorf("failed to unmarshal network providerStatus: %w", err)
-	}
-	ipFamilies, ok := networkStatus["ipFamilies"]
 
-	return ok && len(ipFamilies.([]any)) == 2, nil
+	return func(shoot *gardencorev1beta1.Shoot) error {
+		constraint := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+		constraint = v1beta1helper.UpdatedConditionWithClock(b.Clock, constraint, conditionStatus, conditionReason, conditionMessage)
+		shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, constraint)
+		return nil
+	}
 }
 
 // CheckPodCIDRsInNodes verifies the pod CIDRs in the nodes during dual-stack migration and updates the shoot's status accordingly.
@@ -48,52 +53,30 @@ func (b *Botanist) CheckPodCIDRsInNodes(ctx context.Context) error {
 		return nil
 	}
 
-	infraReady, err := b.checkInfraStatus(ctx)
+	infrastructure, err := b.Shoot.Components.Extensions.Infrastructure.Get(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed getting Infrastructure resource: %w", err)
 	}
-	if !infraReady {
+
+	infrastructureReadyForDualStackMigration := len(infrastructure.Status.Networking.Nodes) == 2
+	if !infrastructureReadyForDualStackMigration {
 		return nil
 	}
 
-	networkReady, err := b.checkNetworkStatusIPFamilies(ctx)
+	network, err := b.Shoot.Components.Extensions.Network.Get(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get network resource: %w", err)
 	}
-	if !networkReady {
-		if b.ShootClientSet != nil {
-			nodeList := &corev1.NodeList{}
-			if err := b.ShootClientSet.Client().List(ctx, nodeList); err != nil {
-				return fmt.Errorf("failed to list nodes during dual-stack migration: %w", err)
-			}
-			allNodesDualStack := true
-			conditionStatus := gardencorev1beta1.ConditionFalse
-			conditionReason := "NodesNotMigrated"
-			conditionMessage := "Nodes are not migrated to dual-stack networking."
-			for _, node := range nodeList.Items {
-				allNodesDualStack = allNodesDualStack && len(node.Spec.PodCIDRs) == 2
-			}
-			if allNodesDualStack {
-				conditionStatus = gardencorev1beta1.ConditionTrue
-				conditionReason = "NodesMigrated"
-				conditionMessage = "Nodes are migrated to dual-stack networking."
-			}
-			if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
-				condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-				condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, conditionStatus, conditionReason, conditionMessage)
-				shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
-				return nil
-			}); err != nil {
-				return fmt.Errorf("failed to update shoot info status during dual-stack migration: %w", err)
-			}
-		}
-	} else {
-		if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
-			shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-			return nil
-		}); err != nil {
-			return fmt.Errorf("failed to update shoot info status during dual-stack migration: %w", err)
-		}
+
+	nodeList := &corev1.NodeList{}
+	if err := b.ShootClientSet.Client().List(ctx, nodeList); err != nil {
+		return fmt.Errorf("failed to list nodes during dual-stack migration: %w", err)
+	}
+
+	networkReadyForDualStackMigration := len(network.Status.IPFamilies) == 2
+	updateFunction := b.DetermineUpdateFunction(networkReadyForDualStackMigration, nodeList)
+	if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, updateFunction); err != nil {
+		return fmt.Errorf("failed to update shoot info status during dual-stack migration: %w", err)
 	}
 	return nil
 }
@@ -102,16 +85,15 @@ func (b *Botanist) CheckPodCIDRsInNodes(ctx context.Context) error {
 func (b *Botanist) UpdateDualStackMigrationConditionIfNeeded(ctx context.Context) error {
 	shoot := b.Shoot.GetInfo()
 
-	condition := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-	if condition == nil && len(shoot.Spec.Networking.IPFamilies) == 2 && shoot.Status.Networking != nil && len(shoot.Status.Networking.Nodes) == 1 {
-		err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
-			condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-			condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, gardencorev1beta1.ConditionFalse, "DualStackMigration", "The shoot is migrating to dual-stack networking.")
-			shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
+	constraint := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+	if constraint == nil && len(shoot.Spec.Networking.IPFamilies) == 2 && shoot.Status.Networking != nil && len(shoot.Status.Networking.Nodes) == 1 {
+		if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+			constraint := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			constraint = v1beta1helper.UpdatedConditionWithClock(b.Clock, constraint, gardencorev1beta1.ConditionFalse, "DualStackMigration", "The shoot is migrating to dual-stack networking.")
+			shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, constraint)
 			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("error while updating shoot status in UpdateDualStackMigrationConditionIfNeeded: %w", err)
+		}); err != nil {
+			return fmt.Errorf("failed updating %s constraint in shoot status: %w", gardencorev1beta1.ShootDualStackNodesMigrationReady, err)
 		}
 	}
 	return nil

--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -52,45 +52,66 @@ func (b *Botanist) CheckPodCIDRsInNodes(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if !infraReady {
+		return nil
+	}
+
 	networkReady, err := b.checkNetworkStatusIPFamilies(ctx)
 	if err != nil {
 		return err
 	}
-	if infraReady {
-		if !networkReady {
-			if b.ShootClientSet != nil {
-				nodeList := &corev1.NodeList{}
-				if err := b.ShootClientSet.Client().List(ctx, nodeList); err != nil {
-					return err
-				}
-				allNodesIPv6 := true
-				conditionStatus := gardencorev1beta1.ConditionFalse
-				conditionReason := "NodesNotMigrated"
-				conditionMessage := "Nodes are not migrated to dual-stack networking."
-				for _, node := range nodeList.Items {
-					allNodesIPv6 = allNodesIPv6 && len(node.Spec.PodCIDRs) == 2
-				}
-				if allNodesIPv6 {
-					conditionStatus = gardencorev1beta1.ConditionTrue
-					conditionReason = "NodesMigrated"
-					conditionMessage = "Nodes are migrated to dual-stack networking."
-				}
-				if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
-					condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-					condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, conditionStatus, conditionReason, conditionMessage)
-					shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
-					return nil
-				}); err != nil {
-					return err
-				}
+	if !networkReady {
+		if b.ShootClientSet != nil {
+			nodeList := &corev1.NodeList{}
+			if err := b.ShootClientSet.Client().List(ctx, nodeList); err != nil {
+				return fmt.Errorf("failed to list nodes during dual-stack migration: %w", err)
 			}
-		} else {
+			allNodesDualStack := true
+			conditionStatus := gardencorev1beta1.ConditionFalse
+			conditionReason := "NodesNotMigrated"
+			conditionMessage := "Nodes are not migrated to dual-stack networking."
+			for _, node := range nodeList.Items {
+				allNodesDualStack = allNodesDualStack && len(node.Spec.PodCIDRs) == 2
+			}
+			if allNodesDualStack {
+				conditionStatus = gardencorev1beta1.ConditionTrue
+				conditionReason = "NodesMigrated"
+				conditionMessage = "Nodes are migrated to dual-stack networking."
+			}
 			if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
-				shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+				condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+				condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, conditionStatus, conditionReason, conditionMessage)
+				shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
 				return nil
 			}); err != nil {
-				return err
+				return fmt.Errorf("failed to update shoot info status during dual-stack migration: %w", err)
 			}
+		}
+	} else {
+		if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+			shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to update shoot info status during dual-stack migration: %w", err)
+		}
+	}
+	return nil
+}
+
+// UpdateDualStackMigrationConditionIfNeeded checks if the shoot should be migrated to dual-stack networking and sets the shoot status accordingly.
+func (b *Botanist) UpdateDualStackMigrationConditionIfNeeded(ctx context.Context) error {
+	shoot := b.Shoot.GetInfo()
+
+	condition := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+	if condition == nil && len(shoot.Spec.Networking.IPFamilies) == 2 && shoot.Status.Networking != nil && len(shoot.Status.Networking.Nodes) == 1 {
+		err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+			condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, gardencorev1beta1.ConditionFalse, "DualStackMigration", "The shoot is migrating to dual-stack networking.")
+			shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("error while updating shoot status in UpdateDualStackMigrationConditionIfNeeded: %w", err)
 		}
 	}
 	return nil

--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+)
+
+func (b *Botanist) checkInfraStatus(ctx context.Context) (bool, error) {
+	infra, err := b.Shoot.Components.Extensions.Infrastructure.Get(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get infra resource: %w", err)
+	}
+	result := len(infra.Status.Networking.Nodes) == 2
+	return result, nil
+}
+
+func (b *Botanist) checkNetworkStatusIPFamilies(ctx context.Context) (bool, error) {
+	network, err := b.Shoot.Components.Extensions.Network.Get(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get network resource: %w", err)
+	}
+	providerStatus := network.Status.GetProviderStatus()
+	if providerStatus.Raw == nil {
+		return false, fmt.Errorf("network providerStatus is nil")
+	}
+	var networkStatus map[string]any
+	if err := json.Unmarshal(providerStatus.Raw, &networkStatus); err != nil {
+		return false, fmt.Errorf("failed to unmarshal network providerStatus: %w", err)
+	}
+	ipFamilies, ok := networkStatus["ipFamilies"]
+
+	return ok && len(ipFamilies.([]any)) == 2, nil
+}
+
+// CheckPodCIDRsInNodes verifies the pod CIDRs in the nodes during dual-stack migration and updates the shoot's status accordingly.
+func (b *Botanist) CheckPodCIDRsInNodes(ctx context.Context) error {
+	if condition := v1beta1helper.GetCondition(b.Shoot.GetInfo().Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady); condition == nil {
+		return nil
+	}
+
+	infraReady, err := b.checkInfraStatus(ctx)
+	if err != nil {
+		return err
+	}
+	networkReady, err := b.checkNetworkStatusIPFamilies(ctx)
+	if err != nil {
+		return err
+	}
+	if infraReady {
+		if !networkReady {
+			if b.ShootClientSet != nil {
+				nodeList := &corev1.NodeList{}
+				if err := b.ShootClientSet.Client().List(ctx, nodeList); err != nil {
+					return err
+				}
+				allNodesIPv6 := true
+				conditionStatus := gardencorev1beta1.ConditionFalse
+				conditionReason := "NodesNotMigrated"
+				conditionMessage := "Nodes are not migrated to dual-stack networking."
+				for _, node := range nodeList.Items {
+					allNodesIPv6 = allNodesIPv6 && len(node.Spec.PodCIDRs) == 2
+				}
+				if allNodesIPv6 {
+					conditionStatus = gardencorev1beta1.ConditionTrue
+					conditionReason = "NodesMigrated"
+					conditionMessage = "Nodes are migrated to dual-stack networking."
+				}
+				if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+					condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+					condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, conditionStatus, conditionReason, conditionMessage)
+					shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
+					return nil
+				}); err != nil {
+					return err
+				}
+			}
+		} else {
+			if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+				shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/gardenlet/operation/botanist/dualstackmigration_test.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration_test.go
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
+	mockinfrastructure "github.com/gardener/gardener/pkg/component/extensions/infrastructure/mock"
+	mocknetwork "github.com/gardener/gardener/pkg/component/extensions/network/mock"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/test"
+	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+)
+
+var _ = Describe("DualStackMigration", func() {
+	var (
+		ctrl             *gomock.Controller
+		botanist         *Botanist
+		mockClock        *testing.FakeClock
+		infrastructure   *mockinfrastructure.MockInterface
+		network          *mocknetwork.MockInterface
+		shootInterface   *kubernetesmock.MockInterface
+		shootClient      *mockclient.MockClient
+		gardenClient     *mockclient.MockClient
+		mockStatusWriter *mockclient.MockStatusWriter
+		ctx              = context.TODO()
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		// Use a mock clock with a fixed time
+		mockClock = testing.NewFakeClock(time.Date(2025, 3, 30, 3, 33, 33, 33, time.UTC))
+
+		botanist = &Botanist{Operation: &operation.Operation{
+			Shoot: &shootpkg.Shoot{
+				Components: &shootpkg.Components{
+					Extensions: &shootpkg.Extensions{},
+				},
+			},
+		}}
+		shootInterface = kubernetesmock.NewMockInterface(ctrl)
+		shootClient = mockclient.NewMockClient(ctrl)
+		botanist.ShootClientSet = shootInterface
+		gardenClient = mockclient.NewMockClient(ctrl)
+		botanist.GardenClient = gardenClient
+		mockStatusWriter = mockclient.NewMockStatusWriter(ctrl)
+
+		infrastructure = mockinfrastructure.NewMockInterface(ctrl)
+		infrastructure.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Infrastructure{
+			Status: extensionsv1alpha1.InfrastructureStatus{
+				Networking: &extensionsv1alpha1.InfrastructureStatusNetworking{
+					Nodes: []string{"0.0.0.0", "2001:db8::1"},
+				},
+			},
+		}, nil).AnyTimes()
+
+		network = mocknetwork.NewMockInterface(ctrl)
+
+		botanist.Shoot = &shootpkg.Shoot{
+			Components: &shootpkg.Components{
+				Extensions: &shootpkg.Extensions{
+					Infrastructure: infrastructure,
+					Network:        network,
+				},
+			},
+		}
+		botanist.Clock = mockClock
+	})
+
+	Describe("#CheckDualStackMigration", func() {
+		It("Nodes are migrated to dual-stack networking", func() {
+			condition := v1beta1helper.InitConditionWithClock(mockClock, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			condition = v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "NodesNotMigrated", "Nodes are not migrated to dual-stack networking.")
+
+			shoot := &gardencorev1beta1.Shoot{
+				Status: gardencorev1beta1.ShootStatus{
+					Constraints: []gardencorev1beta1.Condition{condition},
+				},
+			}
+			botanist.Shoot.SetInfo(shoot)
+
+			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
+
+			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
+				*list = corev1.NodeList{Items: []corev1.Node{
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+				}}
+				return nil
+			}).AnyTimes()
+
+			network.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Network{
+				Status: extensionsv1alpha1.NetworkStatus{
+					DefaultStatus: extensionsv1alpha1.DefaultStatus{
+						ProviderStatus: &runtime.RawExtension{Raw: []byte(`{"ipFamilies": ["IPv4"]}`)},
+					},
+				},
+			}, nil).AnyTimes()
+
+			updatedShoot := shoot.DeepCopy()
+			updatedCondition := v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionTrue, "NodesMigrated", "Nodes are migrated to dual-stack networking.")
+			updatedShoot.Status.Constraints = v1beta1helper.MergeConditions(updatedShoot.Status.Constraints, updatedCondition)
+
+			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
+			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
+
+			err := botanist.CheckPodCIDRsInNodes(context.TODO())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Nodes are not migrated to dual-stack networking", func() {
+			condition := v1beta1helper.InitConditionWithClock(mockClock, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			condition = v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "NodesNotMigrated", "Nodes are not migrated to dual-stack networking.")
+
+			shoot := &gardencorev1beta1.Shoot{
+				Status: gardencorev1beta1.ShootStatus{
+					Constraints: []gardencorev1beta1.Condition{condition},
+				},
+			}
+			botanist.Shoot.SetInfo(shoot)
+
+			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
+
+			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
+				*list = corev1.NodeList{Items: []corev1.Node{
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24"}}},
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24"}}},
+				}}
+				return nil
+			}).AnyTimes()
+
+			network.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Network{
+				Status: extensionsv1alpha1.NetworkStatus{
+					DefaultStatus: extensionsv1alpha1.DefaultStatus{
+						ProviderStatus: &runtime.RawExtension{Raw: []byte(`{"ipFamilies": ["IPv4"]}`)},
+					},
+				},
+			}, nil).AnyTimes()
+
+			updatedShoot := shoot.DeepCopy()
+			updatedCondition := v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "NodesNotMigrated", "Nodes are not migrated to dual-stack networking.")
+			updatedShoot.Status.Constraints = v1beta1helper.MergeConditions(updatedShoot.Status.Constraints, updatedCondition)
+
+			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
+			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
+
+			err := botanist.CheckPodCIDRsInNodes(context.TODO())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Nodes and network config are migrated to dual-stack networking", func() {
+			condition := v1beta1helper.InitConditionWithClock(mockClock, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			condition = v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "NodesMigrated", "Nodes are migrated to dual-stack networking.")
+
+			shoot := &gardencorev1beta1.Shoot{
+				Status: gardencorev1beta1.ShootStatus{
+					Constraints: []gardencorev1beta1.Condition{condition},
+				},
+			}
+			botanist.Shoot.SetInfo(shoot)
+
+			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
+
+			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
+				*list = corev1.NodeList{Items: []corev1.Node{
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+				}}
+				return nil
+			}).AnyTimes()
+
+			network.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Network{
+				Status: extensionsv1alpha1.NetworkStatus{
+					DefaultStatus: extensionsv1alpha1.DefaultStatus{
+						ProviderStatus: &runtime.RawExtension{Raw: []byte(`{"ipFamilies": ["IPv4", "IPv6"]}`)},
+					},
+				},
+			}, nil).AnyTimes()
+
+			updatedShoot := shoot.DeepCopy()
+			updatedShoot.Status.Constraints = v1beta1helper.RemoveConditions(updatedShoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+
+			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
+			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
+
+			err := botanist.CheckPodCIDRsInNodes(context.TODO())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Doesn't add the constraint to a migrated shoot.", func() {
+
+			shoot := &gardencorev1beta1.Shoot{
+				Status: gardencorev1beta1.ShootStatus{},
+			}
+			botanist.Shoot.SetInfo(shoot)
+
+			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
+
+			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
+				*list = corev1.NodeList{Items: []corev1.Node{
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+				}}
+				return nil
+			}).AnyTimes()
+
+			network.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Network{
+				Status: extensionsv1alpha1.NetworkStatus{
+					DefaultStatus: extensionsv1alpha1.DefaultStatus{
+						ProviderStatus: &runtime.RawExtension{Raw: []byte(`{"ipFamilies": ["IPv4", "IPv6"]}`)},
+					},
+				},
+			}, nil).AnyTimes()
+
+			updatedShoot := shoot.DeepCopy()
+
+			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
+			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
+
+			err := botanist.CheckPodCIDRsInNodes(context.TODO())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
+})

--- a/pkg/gardenlet/operation/botanist/dualstackmigration_test.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration_test.go
@@ -5,49 +5,28 @@
 package botanist_test
 
 import (
-	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock/testing"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
-	mockinfrastructure "github.com/gardener/gardener/pkg/component/extensions/infrastructure/mock"
-	mocknetwork "github.com/gardener/gardener/pkg/component/extensions/network/mock"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("DualStackMigration", func() {
+
 	var (
-		ctrl             *gomock.Controller
-		botanist         *Botanist
-		mockClock        *testing.FakeClock
-		infrastructure   *mockinfrastructure.MockInterface
-		network          *mocknetwork.MockInterface
-		shootInterface   *kubernetesmock.MockInterface
-		shootClient      *mockclient.MockClient
-		gardenClient     *mockclient.MockClient
-		mockStatusWriter *mockclient.MockStatusWriter
-		ctx              = context.TODO()
+		botanist  *Botanist
+		mockClock *testing.FakeClock
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-
-		// Use a mock clock with a fixed time
 		mockClock = testing.NewFakeClock(time.Date(2025, 3, 30, 3, 33, 33, 33, time.UTC))
 
 		botanist = &Botanist{Operation: &operation.Operation{
@@ -56,284 +35,80 @@ var _ = Describe("DualStackMigration", func() {
 					Extensions: &shootpkg.Extensions{},
 				},
 			},
+			Clock: mockClock,
 		}}
-		shootInterface = kubernetesmock.NewMockInterface(ctrl)
-		shootClient = mockclient.NewMockClient(ctrl)
-		botanist.ShootClientSet = shootInterface
-		gardenClient = mockclient.NewMockClient(ctrl)
-		botanist.GardenClient = gardenClient
-		mockStatusWriter = mockclient.NewMockStatusWriter(ctrl)
-
-		infrastructure = mockinfrastructure.NewMockInterface(ctrl)
-		infrastructure.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Infrastructure{
-			Status: extensionsv1alpha1.InfrastructureStatus{
-				Networking: &extensionsv1alpha1.InfrastructureStatusNetworking{
-					Nodes: []string{"0.0.0.0", "2001:db8::1"},
-				},
-			},
-		}, nil).AnyTimes()
-
-		network = mocknetwork.NewMockInterface(ctrl)
-
-		botanist.Shoot = &shootpkg.Shoot{
-			Components: &shootpkg.Components{
-				Extensions: &shootpkg.Extensions{
-					Infrastructure: infrastructure,
-					Network:        network,
-				},
-			},
-		}
-		botanist.Clock = mockClock
 	})
 
-	Describe("#CheckDualStackMigration", func() {
-		It("Nodes are migrated to dual-stack networking", func() {
-			condition := v1beta1helper.InitConditionWithClock(mockClock, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-			condition = v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "NodesNotMigrated", "Nodes are not migrated to dual-stack networking.")
+	Describe("#DetermineUpdateFunction", func() {
+		It("Removes the constraint when network is ready for dual-stack migration", func() {
+			nodeList := &corev1.NodeList{
+				Items: []corev1.Node{
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+				},
+			}
 
 			shoot := &gardencorev1beta1.Shoot{
 				Status: gardencorev1beta1.ShootStatus{
-					Constraints: []gardencorev1beta1.Condition{condition},
-				},
-			}
-			botanist.Shoot.SetInfo(shoot)
-
-			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
-
-			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
-				*list = corev1.NodeList{Items: []corev1.Node{
-					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
-					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
-				}}
-				return nil
-			}).AnyTimes()
-
-			network.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Network{
-				Status: extensionsv1alpha1.NetworkStatus{
-					DefaultStatus: extensionsv1alpha1.DefaultStatus{
-						ProviderStatus: &runtime.RawExtension{Raw: []byte(`{"ipFamilies": ["IPv4"]}`)},
+					Constraints: []gardencorev1beta1.Condition{
+						v1beta1helper.InitConditionWithClock(mockClock, gardencorev1beta1.ShootDualStackNodesMigrationReady),
 					},
 				},
-			}, nil).AnyTimes()
+			}
 
-			updatedShoot := shoot.DeepCopy()
-			updatedCondition := v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionTrue, "NodesMigrated", "Nodes are migrated to dual-stack networking.")
-			updatedShoot.Status.Constraints = v1beta1helper.MergeConditions(updatedShoot.Status.Constraints, updatedCondition)
-
-			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
-			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
-
-			err := botanist.CheckPodCIDRsInNodes(context.TODO())
+			updateFunc := botanist.DetermineUpdateFunction(true, nodeList)
+			err := updateFunc(shoot)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(shoot.Status.Constraints).To(BeEmpty())
 		})
 
-		It("Nodes are not migrated to dual-stack networking", func() {
-			condition := v1beta1helper.InitConditionWithClock(mockClock, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-			condition = v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "NodesNotMigrated", "Nodes are not migrated to dual-stack networking.")
+		It("Updates the constraint to ConditionTrue when all nodes are dual-stack", func() {
+			nodeList := &corev1.NodeList{
+				Items: []corev1.Node{
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
+				},
+			}
 
 			shoot := &gardencorev1beta1.Shoot{
 				Status: gardencorev1beta1.ShootStatus{
-					Constraints: []gardencorev1beta1.Condition{condition},
+					Constraints: []gardencorev1beta1.Condition{},
 				},
 			}
-			botanist.Shoot.SetInfo(shoot)
 
-			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
+			updateFunc := botanist.DetermineUpdateFunction(false, nodeList)
+			err := updateFunc(shoot)
+			Expect(err).NotTo(HaveOccurred())
 
-			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
-				*list = corev1.NodeList{Items: []corev1.Node{
+			condition := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(gardencorev1beta1.ConditionTrue))
+			Expect(condition.Reason).To(Equal("NodesMigrated"))
+			Expect(condition.Message).To(Equal("All nodes were migrated to dual-stack networking."))
+		})
+
+		It("Updates the constraint to ConditionFalse when not all nodes are dual-stack", func() {
+			nodeList := &corev1.NodeList{
+				Items: []corev1.Node{
 					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24"}}},
-					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24"}}},
-				}}
-				return nil
-			}).AnyTimes()
-
-			network.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Network{
-				Status: extensionsv1alpha1.NetworkStatus{
-					DefaultStatus: extensionsv1alpha1.DefaultStatus{
-						ProviderStatus: &runtime.RawExtension{Raw: []byte(`{"ipFamilies": ["IPv4"]}`)},
-					},
-				},
-			}, nil).AnyTimes()
-
-			updatedShoot := shoot.DeepCopy()
-			updatedCondition := v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "NodesNotMigrated", "Nodes are not migrated to dual-stack networking.")
-			updatedShoot.Status.Constraints = v1beta1helper.MergeConditions(updatedShoot.Status.Constraints, updatedCondition)
-
-			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
-			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
-
-			err := botanist.CheckPodCIDRsInNodes(context.TODO())
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Nodes and network config are migrated to dual-stack networking", func() {
-			condition := v1beta1helper.InitConditionWithClock(mockClock, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-			condition = v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "NodesMigrated", "Nodes are migrated to dual-stack networking.")
-
-			shoot := &gardencorev1beta1.Shoot{
-				Status: gardencorev1beta1.ShootStatus{
-					Constraints: []gardencorev1beta1.Condition{condition},
-				},
-			}
-			botanist.Shoot.SetInfo(shoot)
-
-			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
-
-			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
-				*list = corev1.NodeList{Items: []corev1.Node{
 					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
-					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
-				}}
-				return nil
-			}).AnyTimes()
-
-			network.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Network{
-				Status: extensionsv1alpha1.NetworkStatus{
-					DefaultStatus: extensionsv1alpha1.DefaultStatus{
-						ProviderStatus: &runtime.RawExtension{Raw: []byte(`{"ipFamilies": ["IPv4", "IPv6"]}`)},
-					},
 				},
-			}, nil).AnyTimes()
-
-			updatedShoot := shoot.DeepCopy()
-			updatedShoot.Status.Constraints = v1beta1helper.RemoveConditions(updatedShoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-
-			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
-			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
-
-			err := botanist.CheckPodCIDRsInNodes(context.TODO())
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Doesn't add the constraint to a migrated shoot.", func() {
-
-			shoot := &gardencorev1beta1.Shoot{
-				Status: gardencorev1beta1.ShootStatus{},
 			}
-			botanist.Shoot.SetInfo(shoot)
 
-			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
-
-			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
-				*list = corev1.NodeList{Items: []corev1.Node{
-					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
-					{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.1.0.0/24", "fd01::/64"}}},
-				}}
-				return nil
-			}).AnyTimes()
-
-			network.EXPECT().Get(gomock.Any()).Return(&extensionsv1alpha1.Network{
-				Status: extensionsv1alpha1.NetworkStatus{
-					DefaultStatus: extensionsv1alpha1.DefaultStatus{
-						ProviderStatus: &runtime.RawExtension{Raw: []byte(`{"ipFamilies": ["IPv4", "IPv6"]}`)},
-					},
-				},
-			}, nil).AnyTimes()
-
-			updatedShoot := shoot.DeepCopy()
-
-			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
-			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
-
-			err := botanist.CheckPodCIDRsInNodes(context.TODO())
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-	})
-
-	Describe("#UpdateDualStackMigrationConditionIfNeeded", func() {
-		It("Adds the constraint when migration is required", func() {
 			shoot := &gardencorev1beta1.Shoot{
-				Spec: gardencorev1beta1.ShootSpec{
-					Networking: &gardencorev1beta1.Networking{
-						IPFamilies: []gardencorev1beta1.IPFamily{"IPv4", "IPv6"},
-					},
-				},
 				Status: gardencorev1beta1.ShootStatus{
-					Networking: &gardencorev1beta1.NetworkingStatus{
-						Nodes: []string{"0.0.0.0"},
-					},
+					Constraints: []gardencorev1beta1.Condition{},
 				},
 			}
-			botanist.Shoot.SetInfo(shoot)
 
-			updatedShoot := shoot.DeepCopy()
-			condition := v1beta1helper.GetOrInitConditionWithClock(mockClock, updatedShoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-			condition = v1beta1helper.UpdatedConditionWithClock(mockClock, condition, gardencorev1beta1.ConditionFalse, "DualStackMigration", "The shoot is migrating to dual-stack networking.")
-			updatedShoot.Status.Constraints = v1beta1helper.MergeConditions(updatedShoot.Status.Constraints, condition)
-
-			gardenClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
-			test.EXPECTStatusPatch(ctx, mockStatusWriter, updatedShoot, shoot, types.StrategicMergePatchType).AnyTimes()
-
-			err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Does not add the constraint when migration is not required", func() {
-			shoot := &gardencorev1beta1.Shoot{
-				Spec: gardencorev1beta1.ShootSpec{
-					Networking: &gardencorev1beta1.Networking{
-						IPFamilies: []gardencorev1beta1.IPFamily{"IPv4"},
-					},
-				},
-				Status: gardencorev1beta1.ShootStatus{
-					Networking: &gardencorev1beta1.NetworkingStatus{
-						Nodes: []string{"0.0.0.0"},
-					},
-				},
-			}
-			botanist.Shoot.SetInfo(shoot)
-
-			err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Does not add the constraint when already migrated", func() {
-			shoot := &gardencorev1beta1.Shoot{
-				Spec: gardencorev1beta1.ShootSpec{
-					Networking: &gardencorev1beta1.Networking{
-						IPFamilies: []gardencorev1beta1.IPFamily{"IPv4", "IPv6"},
-					},
-				},
-				Status: gardencorev1beta1.ShootStatus{
-					Networking: &gardencorev1beta1.NetworkingStatus{
-						Nodes: []string{"0.0.0.0", "2001:db8::1"},
-					},
-				},
-			}
-			botanist.Shoot.SetInfo(shoot)
-
-			err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Does not change the constraint when it is already set, even if the configuration requires an update", func() {
-			originalCondition := v1beta1helper.InitConditionWithClock(mockClock, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-			originalCondition = v1beta1helper.UpdatedConditionWithClock(mockClock, originalCondition, gardencorev1beta1.ConditionTrue, "DualStackMigration", "The shoot is migrating to dual-stack networking.")
-
-			shoot := &gardencorev1beta1.Shoot{
-				Spec: gardencorev1beta1.ShootSpec{
-					Networking: &gardencorev1beta1.Networking{
-						IPFamilies: []gardencorev1beta1.IPFamily{"IPv4", "IPv6"},
-					},
-				},
-				Status: gardencorev1beta1.ShootStatus{
-					Constraints: []gardencorev1beta1.Condition{originalCondition},
-					Networking: &gardencorev1beta1.NetworkingStatus{
-						Nodes: []string{"0.0.0.0"},
-					},
-				},
-			}
-			botanist.Shoot.SetInfo(shoot)
-
-			gardenClient.EXPECT().Status().Return(mockStatusWriter).Times(0)
-
-			err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx)
+			updateFunc := botanist.DetermineUpdateFunction(false, nodeList)
+			err := updateFunc(shoot)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(shoot.Status.Constraints).To(HaveLen(1))
-			Expect(shoot.Status.Constraints[0]).To(Equal(originalCondition))
+			condition := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(gardencorev1beta1.ConditionFalse))
+			Expect(condition.Reason).To(Equal("NodesNotMigrated"))
+			Expect(condition.Message).To(Equal("Not all nodes were migrated to dual-stack networking."))
 		})
 	})
 })

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -523,20 +523,20 @@ func (s *Shoot) IsShootControlPlaneLoggingEnabled(c *gardenletconfigv1alpha1.Gar
 	return s.Purpose != gardencorev1beta1.ShootPurposeTesting && gardenlethelper.IsLoggingEnabled(c)
 }
 
-func sortByIPFamilies(ipfamilies []gardencorev1beta1.IPFamily, cidr []net.IPNet) []net.IPNet {
+func sortByIPFamilies(ipfamilies []gardencorev1beta1.IPFamily, cidrs []net.IPNet) []net.IPNet {
 	var result []net.IPNet
 	for _, ipfamily := range ipfamilies {
 		switch ipfamily {
 		case gardencorev1beta1.IPFamilyIPv4:
-			for _, c := range cidr {
-				if c.IP.To4() != nil {
-					result = append(result, c)
+			for _, cidr := range cidrs {
+				if cidr.IP.To4() != nil {
+					result = append(result, cidr)
 				}
 			}
 		case gardencorev1beta1.IPFamilyIPv6:
-			for _, c := range cidr {
-				if c.IP.To4() == nil {
-					result = append(result, c)
+			for _, cidr := range cidrs {
+				if cidr.IP.To4() == nil {
+					result = append(result, cidr)
 				}
 			}
 		}
@@ -547,9 +547,9 @@ func sortByIPFamilies(ipfamilies []gardencorev1beta1.IPFamily, cidr []net.IPNet)
 func getPrimaryCIDRs(cidrs []net.IPNet, ipFamilies []gardencorev1beta1.IPFamily) []net.IPNet {
 	var result []net.IPNet
 	isIPv4 := ipFamilies[0] == gardencorev1beta1.IPFamilyIPv4
-	for _, c := range cidrs {
-		if (isIPv4 && c.IP.To4() != nil) || (!isIPv4 && c.IP.To4() == nil) {
-			result = append(result, c)
+	for _, cidr := range cidrs {
+		if (isIPv4 && cidr.IP.To4() != nil) || (!isIPv4 && cidr.IP.To4() == nil) {
+			result = append(result, cidr)
 		}
 	}
 	return result

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -554,25 +553,6 @@ func getPrimaryCIDRs(cidrs []net.IPNet, ipFamilies []gardencorev1beta1.IPFamily)
 		}
 	}
 	return result
-}
-
-// CheckDualStackMigrateNetworks checks if the shoot should be migrated to dual-stack networking and sets the shoot status accoridingly.
-func (s *Shoot) CheckDualStackMigrateNetworks(ctx context.Context, gardenClient client.Client, clock clock.Clock) error {
-	shoot := s.GetInfo()
-
-	condition := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-	if condition == nil && len(shoot.Spec.Networking.IPFamilies) == 2 && shoot.Status.Networking != nil && len(shoot.Status.Networking.Nodes) == 1 {
-		err := s.UpdateInfoStatus(ctx, gardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
-			condition := v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-			condition = v1beta1helper.UpdatedConditionWithClock(clock, condition, gardencorev1beta1.ConditionFalse, "DualStackMigration", "The shoot is migrating to dual-stack networking.")
-			shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // ToNetworks return a network with computed cidrs and ClusterIPs

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -782,7 +782,8 @@ func (c *validationContext) addMetadataAnnotations(a admission.Attributes) {
 		addDNSRecordDeploymentTasks(c.shoot)
 	}
 
-	if !reflect.DeepEqual(c.oldShoot.Spec.Provider.InfrastructureConfig, c.shoot.Spec.Provider.InfrastructureConfig) {
+	if !reflect.DeepEqual(c.oldShoot.Spec.Provider.InfrastructureConfig, c.shoot.Spec.Provider.InfrastructureConfig) ||
+		c.oldShoot.Spec.Networking != nil && c.oldShoot.Spec.Networking.IPFamilies != nil && !reflect.DeepEqual(c.oldShoot.Spec.Networking.IPFamilies, c.shoot.Spec.Networking.IPFamilies) {
 		addInfrastructureDeploymentTask(c.shoot)
 	}
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1498,6 +1498,20 @@ var _ = Describe("validator", func() {
 				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeTrue())
 			})
 
+			It("should add deploy infrastructure task because ipFamilies have changed", func() {
+				shoot.Spec.Networking = &core.Networking{
+					Nodes:      &nodesCIDR,
+					Pods:       &podsCIDR,
+					Services:   &servicesCIDR,
+					IPFamilies: []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6},
+				}
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
+
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeTrue())
+			})
+
 			It("should add deploy infrastructure task because SSHAccess in WorkersSettings config has changed", func() {
 				shoot.Spec.Provider.WorkersSettings = &core.WorkersSettings{
 					SSHAccess: &core.SSHAccess{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
It should be possible to migrate existing single-stack shoots to dual-stack shoots, with IPv4 and IPv6 network stack, without an interruption of ongoing network traffic. The current state of the migration is tracked via a constraint in the shoot state.

When the `IPFamily` of a shoot is changed from `[IPv4]` to `[IPv4, IPv6]`], the constraint `DualStackNodesMigrationReady` is added and set to status `False` and the infrastructure is reconciled to support the additional ip family.

With the next node roll-out, nodes will get IPv6 addresses and an IPv6 prefix for pods. 
When all nodes have IPv4 and IPv6 pod ranges, the status will be changed to `True`. 

The next reconcile will change all the remaining components to dual-stack and the constraint will be removed.

The migration requires additional changes in networking and provider extensions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related PR for networking-calico: https://github.com/gardener/gardener-extension-networking-calico/pull/615
Related PR for provider-aws: https://github.com/gardener/gardener-extension-provider-aws/pull/1252

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for single-stack to dual-stack networking migration.
```
