### PR TITLE
Graduate feature gate `NewVPN` to `Beta`

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -27,7 +27,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
 | NewVPN                                   | `false` | `Alpha` | `1.104` | `1.114` |
-| NewVPN                                   | `false` | `Beta`  | `1.115` |         |
+| NewVPN                                   | `true`  | `Beta`  | `1.115` |         |
 | NodeAgentAuthorizer                      | `false` | `Alpha` | `1.109` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,7 +26,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
-| NewVPN                                   | `false` | `Alpha` | `1.104` |         |
+| NewVPN                                   | `false` | `Alpha` | `1.104` | `1.114` |
+| NewVPN                                   | `false` | `Beta`  | `1.115` |         |
 | NodeAgentAuthorizer                      | `false` | `Alpha` | `1.109` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -38,7 +38,6 @@ config:
   featureGates:
     DefaultSeccompProfile: true
     NewWorkerPoolHash: true
-    NewVPN: true
     NodeAgentAuthorizer: true
     IstioTLSTermination: true
     RemoveAPIServerProxyLegacyPort: true

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -54,6 +54,7 @@ const (
 	// NewVPN enables the new implementation of the VPN (go rewrite) using an IPv6 transfer network.
 	// owner: @MartinWeindel @ScheererJ @axel7born @DockToFuture
 	// alpha: v1.104.0
+	// beta: v1.115.0
 	NewVPN featuregate.Feature = "NewVPN"
 
 	// NodeAgentAuthorizer enables authorization of requests from gardener-node-agents to shoot kube-apiservers using an authorization webhook.
@@ -123,7 +124,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	UseNamespacedCloudProfile:                {Default: true, PreRelease: featuregate.Beta},
 	ShootCredentialsBinding:                  {Default: true, PreRelease: featuregate.Beta},
 	NewWorkerPoolHash:                        {Default: false, PreRelease: featuregate.Alpha},
-	NewVPN:                                   {Default: false, PreRelease: featuregate.Alpha},
+	NewVPN:                                   {Default: true, PreRelease: featuregate.Beta},
 	NodeAgentAuthorizer:                      {Default: false, PreRelease: featuregate.Alpha},
 	CredentialsRotationWithoutWorkersRollout: {Default: false, PreRelease: featuregate.Alpha},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Graduate feature gate `NewVPN` to `Beta`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The feature gate `NewVPN` has been graduated to `Beta` and is now enabled by default.
```
