### PR TITLE
Use explicit verbs for role(bindings) permissions in gardener.cloud:admin role

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -46,7 +46,14 @@ rules:
   - roles
   - rolebindings
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - watch
+  - patch
+  - update
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -177,7 +177,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				{
 					APIGroups: []string{rbacv1.GroupName},
 					Resources: []string{"clusterroles", "clusterrolebindings", "roles", "rolebindings"},
-					Verbs:     []string{"*"},
+					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
 					APIGroups: []string{admissionregistrationv1.GroupName},

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Virtual", func() {
 				{
 					APIGroups: []string{"rbac.authorization.k8s.io"},
 					Resources: []string{"clusterroles", "clusterrolebindings", "roles", "rolebindings"},
-					Verbs:     []string{"*"},
+					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
 					APIGroups: []string{"admissionregistration.k8s.io"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR explicitly states the verbs that gardener admins have over (cluster)role(binding)s.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @vpnachev @petersutter 

cc @AleksandarSavchev for diki rule

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
