### PR TITLE
Keep extension.operator as `RequiredRuntime` until extension.extension deleted

### DIFF
--- a/pkg/operator/controller/extension/required/runtime/add.go
+++ b/pkg/operator/controller/extension/required/runtime/add.go
@@ -16,12 +16,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -34,10 +39,13 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
+	if r.GardenNamespace == "" {
+		r.GardenNamespace = v1beta1constants.GardenNamespace
+	}
 
 	r.clock = clock.RealClock{}
 
-	return builder.
+	c, err := builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(
@@ -52,7 +60,34 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: ptr.Deref(r.Config.ConcurrentSyncs, 0),
 		}).
-		Complete(r)
+		Build(r)
+	if err != nil {
+		return err
+	}
+
+	r.registerManagedResourceWatchFunc = func() error {
+		return c.Watch(source.Kind[client.Object](
+			mgr.GetCache(),
+			&extensionsv1alpha1.Extension{},
+			handler.EnqueueRequestsFromMapFunc(r.MapExtensionToExtensions(mgr.GetLogger().WithValues("controller", ControllerName))),
+			predicate.Funcs{
+				CreateFunc: func(_ event.CreateEvent) bool {
+					return false
+				},
+				UpdateFunc: func(_ event.UpdateEvent) bool {
+					return false
+				},
+				GenericFunc: func(_ event.GenericEvent) bool {
+					return false
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return e.Object.GetNamespace() == r.GardenNamespace
+				},
+			},
+		))
+	}
+
+	return nil
 }
 
 // MapGardenToExtensions returns a mapping function that maps a given garden resource to all related extensions.
@@ -79,6 +114,35 @@ func (r *Reconciler) MapGardenToExtensions(log logr.Logger) handler.MapFunc {
 			if slices.ContainsFunc(extension.Spec.Resources, func(resource gardencorev1beta1.ControllerResource) bool {
 				return requiredExtensions.Has(gardenerutils.ExtensionsID(resource.Kind, resource.Type))
 			}) {
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: extension.Name, Namespace: extension.Namespace}})
+			}
+		}
+
+		return requests
+	}
+}
+
+// MapExtensionToExtensions returns a mapping function that maps a given extension.extension resource to the related extension.operator.
+func (r *Reconciler) MapExtensionToExtensions(log logr.Logger) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		ext, ok := obj.(*extensionsv1alpha1.Extension)
+		if !ok {
+			log.Error(fmt.Errorf("expected Extension but got %#v", obj), "Unable to convert to Extension")
+			return nil
+		}
+
+		extensionList := &operatorv1alpha1.ExtensionList{}
+		if err := r.Client.List(ctx, extensionList); err != nil {
+			log.Error(err, "Failed to list extensions")
+			return nil
+		}
+
+		var (
+			requests []reconcile.Request
+		)
+
+		for _, extension := range extensionList.Items {
+			if v1beta1helper.IsResourceSupported(extension.Spec.Resources, extensionsv1alpha1.ExtensionResource, ext.Spec.Type) {
 				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: extension.Name, Namespace: extension.Namespace}})
 			}
 		}

--- a/pkg/operator/controller/extension/required/runtime/add.go
+++ b/pkg/operator/controller/extension/required/runtime/add.go
@@ -8,39 +8,59 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sync"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
+	apiextensions "github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/extensions"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ControllerName is the name of this controller.
 const ControllerName = "extension-required-runtime"
 
+type extension struct {
+	objectKind        string
+	object            client.Object
+	newObjectListFunc func() client.ObjectList
+}
+
+var runtimeClusterExtensions = []extension{
+	{objectKind: extensionsv1alpha1.BackupBucketResource, object: &extensionsv1alpha1.BackupBucket{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.BackupBucketList{} }},
+	{objectKind: extensionsv1alpha1.DNSRecordResource, object: &extensionsv1alpha1.DNSRecord{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.DNSRecordList{} }},
+	{objectKind: extensionsv1alpha1.ExtensionResource, object: &extensionsv1alpha1.Extension{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.ExtensionList{} }},
+}
+
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
-	if r.GardenNamespace == "" {
-		r.GardenNamespace = v1beta1constants.GardenNamespace
+	if r.KindToRequiredTypes == nil {
+		r.KindToRequiredTypes = map[string]sets.Set[string]{}
+	}
+	if r.Lock == nil {
+		r.Lock = &sync.RWMutex{}
 	}
 
 	r.clock = clock.RealClock{}
@@ -65,26 +85,26 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		return err
 	}
 
-	r.registerManagedResourceWatchFunc = func() error {
-		return c.Watch(source.Kind[client.Object](
-			mgr.GetCache(),
-			&extensionsv1alpha1.Extension{},
-			handler.EnqueueRequestsFromMapFunc(r.MapExtensionToExtensions(mgr.GetLogger().WithValues("controller", ControllerName))),
-			predicate.Funcs{
-				CreateFunc: func(_ event.CreateEvent) bool {
-					return false
-				},
-				UpdateFunc: func(_ event.UpdateEvent) bool {
-					return false
-				},
-				GenericFunc: func(_ event.GenericEvent) bool {
-					return false
-				},
-				DeleteFunc: func(e event.DeleteEvent) bool {
-					return e.Object.GetNamespace() == r.GardenNamespace
-				},
-			},
+	for _, extension := range runtimeClusterExtensions {
+		eventHandler := handler.EnqueueRequestsFromMapFunc(r.MapObjectKindToExtensions(
+			mgr.GetLogger().WithValues("controller", ControllerName),
+			extension.objectKind,
+			extension.newObjectListFunc,
 		))
+
+		// Execute the mapper function at least once to initialize the `KindToRequiredTypes` map.
+		// This is necessary for extension kinds which are registered but for which no extension objects exist in the
+		// garden runtime cluster (e.g. when backups are disabled).
+		// In such cases, no regular watch event is triggered, and the mapping function will not be executed.
+		// Thus, the extension kind would never be part of the `KindToRequiredTypes` map
+		// and the reconciler would not be able to decide whether the  Extension is required.
+		if err = c.Watch(&controllerutils.HandleOnce[client.Object, reconcile.Request]{Handler: eventHandler}); err != nil {
+			return err
+		}
+
+		if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), extension.object, eventHandler, extensions.ObjectPredicate(), extensionspredicate.HasClass(extensionsv1alpha1.ExtensionClassGarden))); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -122,28 +142,67 @@ func (r *Reconciler) MapGardenToExtensions(log logr.Logger) handler.MapFunc {
 	}
 }
 
-// MapExtensionToExtensions returns a mapping function that maps a given extension.extension resource to the related extension.operator.
-func (r *Reconciler) MapExtensionToExtensions(log logr.Logger) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		ext, ok := obj.(*extensionsv1alpha1.Extension)
-		if !ok {
-			log.Error(fmt.Errorf("expected Extension but got %#v", obj), "Unable to convert to Extension")
+// MapObjectKindToExtensions returns a mapper function for the given 'extensions.gardener.cloud' extension kind
+// that lists all existing resources of the given kind and stores the respective types in the `KindToRequiredTypes` map.
+// Afterwards, it returns all 'operator.gardener.cloud' Extensions that responsible for the given kind.
+func (r *Reconciler) MapObjectKindToExtensions(log logr.Logger, objectKind string, newObjectListFunc func() client.ObjectList) handler.MapFunc {
+	return func(ctx context.Context, _ client.Object) []reconcile.Request {
+		log = log.WithValues("extensionKind", objectKind)
+
+		listObj := newObjectListFunc()
+		if err := r.Client.List(ctx, listObj); err != nil && !meta.IsNoMatchError(err) {
+			// Let's ignore bootstrap situations where extension CRDs were not yet applied. They will be deployed
+			// eventually by the garden controller.
+			log.Error(err, "Failed to list extension objects")
 			return nil
 		}
 
+		r.Lock.RLock()
+		oldRequiredTypes, kindCalculated := r.KindToRequiredTypes[objectKind]
+		r.Lock.RUnlock()
+		newRequiredTypes := sets.New[string]()
+
+		if err := meta.EachListItem(listObj, func(o runtime.Object) error {
+			obj, err := apiextensions.Accessor(o)
+			if err != nil {
+				return err
+			}
+
+			if ptr.Deref(obj.GetExtensionSpec().GetExtensionClass(), extensionsv1alpha1.ExtensionClassShoot) != extensionsv1alpha1.ExtensionClassGarden {
+				return nil
+			}
+
+			newRequiredTypes.Insert(obj.GetExtensionSpec().GetExtensionType())
+			return nil
+		}); err != nil {
+			log.Error(err, "Failed while iterating over extension objects")
+			return nil
+		}
+
+		// if there is no difference compared to before then exit early
+		if kindCalculated && oldRequiredTypes.Equal(newRequiredTypes) {
+			return nil
+		}
+
+		r.Lock.Lock()
+		r.KindToRequiredTypes[objectKind] = newRequiredTypes
+		r.Lock.Unlock()
+
+		// List all extensions and queue those that are supporting resources for the
+		// extension kind this particular reconciler is responsible for.
 		extensionList := &operatorv1alpha1.ExtensionList{}
 		if err := r.Client.List(ctx, extensionList); err != nil {
 			log.Error(err, "Failed to list extensions")
 			return nil
 		}
 
-		var (
-			requests []reconcile.Request
-		)
-
+		var requests []reconcile.Request
 		for _, extension := range extensionList.Items {
-			if v1beta1helper.IsResourceSupported(extension.Spec.Resources, extensionsv1alpha1.ExtensionResource, ext.Spec.Type) {
-				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: extension.Name, Namespace: extension.Namespace}})
+			for _, resource := range extension.Spec.Resources {
+				if resource.Kind == objectKind {
+					requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: extension.Name}})
+					break
+				}
 			}
 		}
 

--- a/pkg/operator/controller/extension/required/runtime/reconciler.go
+++ b/pkg/operator/controller/extension/required/runtime/reconciler.go
@@ -98,9 +98,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	requiredExtensionKinds.Insert(requiredExtensionKindsBySpec.UnsortedList()...)
 
-	if err := r.updateCondition(ctx, log, extension, requiredExtensionKinds); err != nil {
+	if err := r.updateCondition(ctx, log, extension, requiredExtensionKinds.Union(requiredExtensionKindsBySpec)); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update extension status: %w", err)
 	}
 

--- a/pkg/operator/controller/extension/required/runtime/reconciler.go
+++ b/pkg/operator/controller/extension/required/runtime/reconciler.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,33 +21,23 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
-var extensionKindToObjectList = map[string]client.ObjectList{
-	extensionsv1alpha1.BackupBucketResource: &extensionsv1alpha1.BackupBucketList{},
-	extensionsv1alpha1.DNSRecordResource:    &extensionsv1alpha1.DNSRecordList{},
-	extensionsv1alpha1.ExtensionResource:    &extensionsv1alpha1.ExtensionList{},
-}
-
-// RequeueDurationWhenGardenIsBeingDeleted is the duration after the request will be requeued when the Garden is being deleted.
-// Exposed for testing.
-var RequeueDurationWhenGardenIsBeingDeleted = 2 * time.Second
+// RequeueExtensionKindNotCalculated is the time after which an extension will be requeued if the extension kind has not been processed yet. Exposed for testing.
+var RequeueExtensionKindNotCalculated = 2 * time.Second
 
 // Reconciler reconciles Extensions to determine their required state.
 type Reconciler struct {
-	Client          client.Client
-	Config          operatorconfigv1alpha1.ExtensionRequiredRuntimeControllerConfiguration
-	GardenNamespace string
+	Client              client.Client
+	Config              operatorconfigv1alpha1.ExtensionRequiredRuntimeControllerConfiguration
+	Lock                *sync.RWMutex
+	KindToRequiredTypes map[string]sets.Set[string]
 
-	clock                            clock.Clock
-	registerManagedResourceWatchFunc func() error
-	managedResourceWatchRegistered   bool
+	clock clock.Clock
 }
 
 // Reconcile performs the main reconciliation logic.
@@ -57,6 +47,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
+	for _, ext := range runtimeClusterExtensions {
+		r.Lock.RLock()
+		_, kindProcessed := r.KindToRequiredTypes[ext.objectKind]
+		r.Lock.RUnlock()
+		if !kindProcessed {
+			// The object kind in question has not yet been processed.
+			// Hence, it's not possible to determine if the extension is required or not.
+			log.Info("Kind is not yet calculated. Request is re-queued", "kind", ext.objectKind)
+			return reconcile.Result{RequeueAfter: RequeueExtensionKindNotCalculated}, nil
+		}
+	}
+
 	extension := &operatorv1alpha1.Extension{}
 	if err := r.Client.Get(ctx, request.NamespacedName, extension); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -64,6 +66,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
+	}
+
+	requiredExtensionKinds := sets.New[string]()
+	for _, resource := range extension.Spec.Resources {
+		r.Lock.RLock()
+		requiredTypes, ok := r.KindToRequiredTypes[resource.Kind]
+		r.Lock.RUnlock()
+		if !ok {
+			continue
+		}
+
+		if requiredTypes.Has(resource.Type) {
+			requiredExtensionKinds.Insert(resource.Kind)
+		}
 	}
 
 	gardenList := &operatorv1alpha1.GardenList{}
@@ -78,47 +94,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		log.Info("No Garden found")
 	}
 
-	if garden != nil && !r.managedResourceWatchRegistered && r.registerManagedResourceWatchFunc != nil {
-		if err := r.registerManagedResourceWatchFunc(); err != nil {
-			log.Error(err, "Failed registering watch for extensions.extension.gardener.cloud/v1alpha1.Extension now that a operator.gardener.cloud/v1alpha1.Garden object has been created")
-		} else {
-			r.managedResourceWatchRegistered = true
-		}
-	}
-
-	requiredExtensionKinds, err := r.calculateRequiredResourceKinds(ctx, log, r.Client, garden, extension)
+	requiredExtensionKindsBySpec, err := r.calculateRequiredResourceKindsBySpec(garden, extension)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	requiredExtensionKinds.Insert(requiredExtensionKindsBySpec.UnsortedList()...)
 
 	if err := r.updateCondition(ctx, log, extension, requiredExtensionKinds); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update extension status: %w", err)
 	}
 
-	if len(requiredExtensionKinds) > 0 && garden.DeletionTimestamp != nil {
-		return reconcile.Result{RequeueAfter: RequeueDurationWhenGardenIsBeingDeleted}, nil
-	}
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) calculateRequiredResourceKinds(ctx context.Context, log logr.Logger, c client.Client, garden *operatorv1alpha1.Garden, extension *operatorv1alpha1.Extension) (sets.Set[string], error) {
+func (r *Reconciler) calculateRequiredResourceKindsBySpec(garden *operatorv1alpha1.Garden, extension *operatorv1alpha1.Extension) (sets.Set[string], error) {
+	// Extensions are not required anymore if the Garden is in deletion.
+	if garden.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
 	var (
 		requiredExtensionKinds = sets.New[string]()
 		requiredExtensions     = gardenerutils.ComputeRequiredExtensionsForGarden(garden)
 	)
-
-	if r.managedResourceWatchRegistered {
-		// If an extension.extension resource is existing in the garden namespace, the extension.operator is still required for the garden runtime cluster.
-		extensionList := &extensionsv1alpha1.ExtensionList{}
-		if err := r.Client.List(ctx, extensionList, client.InNamespace(r.GardenNamespace)); err != nil {
-			return nil, fmt.Errorf("could not list extensions: %w", err)
-		}
-		for _, ext := range extensionList.Items {
-			if v1beta1helper.IsResourceSupported(extension.Spec.Resources, extensionsv1alpha1.ExtensionResource, ext.Spec.Type) {
-				requiredExtensions.Insert(gardenerutils.ExtensionsID(extensionsv1alpha1.ExtensionResource, ext.Spec.Type))
-			}
-		}
-	}
 
 	for _, kindType := range requiredExtensions.UnsortedList() {
 		extensionKind, extensionType, err := gardenerutils.ExtensionKindAndTypeForID(kindType)
@@ -127,26 +125,6 @@ func (r *Reconciler) calculateRequiredResourceKinds(ctx context.Context, log log
 		}
 
 		if v1beta1helper.IsResourceSupported(extension.Spec.Resources, extensionKind, extensionType) {
-			// The extension is not required anymore if the Garden is in deletion and resources are gone.
-			if garden.DeletionTimestamp != nil {
-				objList, ok := extensionKindToObjectList[extensionKind].DeepCopyObject().(client.ObjectList)
-				if !ok {
-					return nil, fmt.Errorf("extension kind %s unknown", extensionKind)
-				}
-
-				resourcesExist, err := kubernetesutils.ResourcesExist(ctx, c, objList, c.Scheme())
-				if meta.IsNoMatchError(err) {
-					continue
-				} else if err != nil {
-					return nil, err
-				}
-
-				if !resourcesExist {
-					continue
-				} else {
-					log.Info("At least one extension is still present", "kind", extensionKind)
-				}
-			}
 			requiredExtensionKinds.Insert(extensionKind)
 		}
 	}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -15,6 +15,7 @@ build:
             - cmd/utils/initrun
             - extensions/pkg/apis/config/v1alpha1
             - extensions/pkg/controller
+            - extensions/pkg/predicate
             - extensions/pkg/util
             - extensions/pkg/webhook
             - extensions/pkg/webhook/certificates

--- a/test/integration/operator/extension/required/runtime/runtime_suite_test.go
+++ b/test/integration/operator/extension/required/runtime/runtime_suite_test.go
@@ -53,7 +53,6 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
-	mgrClient  client.Client
 
 	testRunID       string
 	testNamespace   *corev1.Namespace
@@ -74,6 +73,8 @@ var _ = BeforeSuite(func() {
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_extensions.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_backupbuckets.yaml"),
+					filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_backupbuckets.yaml"),
+					filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_dnsrecords.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_extensions.yaml"),
 				},
 			},
@@ -133,14 +134,12 @@ var _ = BeforeSuite(func() {
 	})
 
 	Expect(err).NotTo(HaveOccurred())
-	mgrClient = mgr.GetClient()
 
 	By("Register controller")
-	DeferCleanup(test.WithVar(&requiredruntime.RequeueDurationWhenGardenIsBeingDeleted, 10*time.Millisecond))
+	DeferCleanup(test.WithVar(&requiredruntime.RequeueExtensionKindNotCalculated, 10*time.Millisecond))
 
 	Expect((&requiredruntime.Reconciler{
-		Config:          operatorconfigv1alpha1.ExtensionRequiredRuntimeControllerConfiguration{ConcurrentSyncs: ptr.To(5)},
-		GardenNamespace: testNamespace.Name,
+		Config: operatorconfigv1alpha1.ExtensionRequiredRuntimeControllerConfiguration{ConcurrentSyncs: ptr.To(5)},
 	}).AddToManager(mgr)).Should(Succeed())
 
 	By("Start manager")

--- a/test/integration/operator/extension/required/runtime/runtime_suite_test.go
+++ b/test/integration/operator/extension/required/runtime/runtime_suite_test.go
@@ -74,6 +74,7 @@ var _ = BeforeSuite(func() {
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_extensions.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_backupbuckets.yaml"),
+					filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_extensions.yaml"),
 				},
 			},
 			ErrorIfCRDPathMissing: true,
@@ -138,7 +139,8 @@ var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&requiredruntime.RequeueDurationWhenGardenIsBeingDeleted, 10*time.Millisecond))
 
 	Expect((&requiredruntime.Reconciler{
-		Config: operatorconfigv1alpha1.ExtensionRequiredRuntimeControllerConfiguration{ConcurrentSyncs: ptr.To(5)},
+		Config:          operatorconfigv1alpha1.ExtensionRequiredRuntimeControllerConfiguration{ConcurrentSyncs: ptr.To(5)},
+		GardenNamespace: testNamespace.Name,
 	}).AddToManager(mgr)).Should(Succeed())
 
 	By("Start manager")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Cleaning up the `extension.extension.gardener.cloud` in the garden namespace of the runtime cluster may take some time. The `RequiredRuntime` controller of the operator should wait until the object has been deleted before it changes the condition `RequiredRuntime` to `false` and the runtime extension is removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Keep `operator.gardener.cloud.Extension` condition `RequiredRuntime` = `true` until deletion of `extensions.gardener.cloud.Extension`s has completed.
```
