### PR TITLE
[Flaky Test] Wrap create calls in Eventually blocks.

### DIFF
--- a/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
+++ b/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
@@ -206,14 +206,18 @@ var _ = Describe("NamespacedCloudProfile controller tests", func() {
 
 		JustBeforeEach(func() {
 			By("Create parent CloudProfile")
-			Expect(testClient.Create(ctx, parentCloudProfile)).To(Succeed())
+			Eventually(func() error {
+				return testClient.Create(ctx, parentCloudProfile)
+			}).Should(Succeed())
 
 			By("Create NamespacedCloudProfile")
 			namespacedCloudProfile.Spec.Parent = gardencorev1beta1.CloudProfileReference{
 				Kind: "CloudProfile",
 				Name: parentCloudProfile.Name,
 			}
-			Expect(testClient.Create(ctx, namespacedCloudProfile)).To(Succeed())
+			Eventually(func() error {
+				return testClient.Create(ctx, namespacedCloudProfile)
+			}).Should(Succeed())
 			waitForNamespacedCloudProfileToBeReconciled(ctx, namespacedCloudProfile)
 
 			if shoot != nil {
@@ -222,7 +226,9 @@ var _ = Describe("NamespacedCloudProfile controller tests", func() {
 					Kind: "NamespacedCloudProfile",
 					Name: namespacedCloudProfile.Name,
 				}
-				Expect(testClient.Create(ctx, shoot)).To(Succeed())
+				Eventually(func() error {
+					return testClient.Create(ctx, shoot)
+				}).Should(Succeed())
 				log.Info("Created shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
 
 				By("Wait until manager has observed Shoot")
@@ -299,14 +305,18 @@ var _ = Describe("NamespacedCloudProfile controller tests", func() {
 	Context("merging the CloudProfiles", func() {
 		JustBeforeEach(func() {
 			By("Create parent CloudProfile")
-			Expect(testClient.Create(ctx, parentCloudProfile)).To(Succeed())
+			Eventually(func() error {
+				return testClient.Create(ctx, parentCloudProfile)
+			}).Should(Succeed())
 
 			By("Create NamespacedCloudProfile")
 			namespacedCloudProfile.Spec.Parent = gardencorev1beta1.CloudProfileReference{
 				Kind: "CloudProfile",
 				Name: parentCloudProfile.Name,
 			}
-			Expect(testClient.Create(ctx, namespacedCloudProfile)).To(Succeed())
+			Eventually(func() error {
+				return testClient.Create(ctx, namespacedCloudProfile)
+			}).Should(Succeed())
 			waitForNamespacedCloudProfileToBeReconciled(ctx, namespacedCloudProfile)
 
 			DeferCleanup(func() {
@@ -475,7 +485,9 @@ var _ = Describe("NamespacedCloudProfile controller tests", func() {
 
 		JustBeforeEach(func() {
 			By("Create parent CloudProfile")
-			Expect(testClient.Create(ctx, parentCloudProfile)).To(Succeed())
+			Eventually(func() error {
+				return testClient.Create(ctx, parentCloudProfile)
+			}).Should(Succeed())
 			log.Info("Created parent CloudProfile for test", "parentCloudProfile", client.ObjectKeyFromObject(parentCloudProfile))
 
 			namespacedCloudProfile.Spec.Parent = gardencorev1beta1.CloudProfileReference{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Fix flake in `NamespacedCloudProfile` integration test.

**Which issue(s) this PR fixes**:
Flake introduced with https://github.com/gardener/gardener/pull/11647/files#diff-19b7feb25274925851b2106b3a357de9cfc578ad4237efb2f2e780bec7244b09R309.

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
