### PR TITLE
[GEP-28] Make extension ports configurable via helm values

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/name: 'provider-local'
         # default metrics endpoint in controller-runtime
-        prometheus.io/port: "{{ .Values.metricsPort }}"
+        prometheus.io/port: "{{ tpl .Values.metricsPort . }}"
         {{- end }}
       labels:
         networking.gardener.cloud/to-runtime-apiserver: allowed
@@ -75,7 +75,7 @@ spec:
         {{- else }}
         - --webhook-config-namespace={{ .Release.Namespace }}
         - --webhook-config-service-port={{ .Values.webhookConfig.servicePort }}
-        - --webhook-config-server-port={{ .Values.webhookConfig.serverPort }}
+        - --webhook-config-server-port={{ tpl .Values.webhookConfig.serverPort . }}
         {{- range .Values.webhooks.prometheus.remoteWriteURLs }}
         - --prometheus-remote-write-url={{ . }}
         {{- end }}
@@ -85,12 +85,8 @@ spec:
         - --disable-controllers={{ .Values.disableControllers | join "," }}
         - --disable-webhooks={{ .Values.disableWebhooks | join "," }}
         {{- end }}
-        {{- if .Values.metricsPort }}
-        - --metrics-bind-address=:{{ .Values.metricsPort }}
-        {{- end }}
-        {{- if .Values.healthPort }}
-        - --health-bind-address=:{{ .Values.healthPort }}
-        {{- end }}
+        - --metrics-bind-address=:{{ tpl .Values.metricsPort . }}
+        - --health-bind-address=:{{ tpl .Values.healthPort . }}
         {{- if .Values.gardener.version }}
         - --gardener-version={{ .Values.gardener.version }}
         {{- end }}
@@ -108,18 +104,18 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.healthPort }}
+            port: {{ tpl .Values.healthPort . }}
             scheme: HTTP
           initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /readyz
-            port: {{ .Values.healthPort }}
+            port: {{ tpl .Values.healthPort . }}
             scheme: HTTP
           initialDelaySeconds: 5
         ports:
         - name: webhook-server
-          containerPort: {{ .Values.webhookConfig.serverPort }}
+          containerPort: {{ tpl .Values.webhookConfig.serverPort . }}
           protocol: TCP
 {{- if .Values.resources }}
         resources:

--- a/charts/gardener/provider-local/templates/service.yaml
+++ b/charts/gardener/provider-local/templates/service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
-    networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":{{ .Values.metricsPort }},"protocol":"TCP"}]'
-    networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
+    networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":{{ tpl .Values.webhookConfig.serverPort . }}}]'
+    networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":{{ tpl .Values.metricsPort . }},"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ tpl .Values.webhookConfig.serverPort . }}}]'
     networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}},{"matchLabels":{"gardener.cloud/role":"shoot"}}]'
     networking.resources.gardener.cloud/pod-label-selector-namespace-alias: extensions
 {{-  if .Values.ignoreResources }}
@@ -21,4 +21,4 @@ spec:
   ports:
   - port: {{ .Values.webhookConfig.servicePort }}
     protocol: TCP
-    targetPort: {{ .Values.webhookConfig.serverPort }}
+    targetPort: {{ tpl .Values.webhookConfig.serverPort . }}

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -70,10 +70,10 @@ imageVectorOverwrite: {}
 
 webhookConfig:
   servicePort: 443
-  serverPort: 10250
+  serverPort: "{{ index .Values.usablePorts 1 }}"
 
-metricsPort: 8080
-healthPort: 8081
+metricsPort: "{{ index .Values.usablePorts 0 }}"
+healthPort: "{{ index .Values.usablePorts 2 }}"
 
 ## settings for metrics, e.g. scraping by seed-prometheus
 ##
@@ -96,3 +96,8 @@ gardener:
     provider: local
   runtimeCluster:
     enabled: false
+
+usablePorts:
+- 8080  # metrics
+- 10250 # webhook server
+- 8081  # healthcheck


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Make extension ports configurable via helm values.

In certain scenarios, e.g. in the autonomous cluster use case, multiple extensions may run side-by-side in the host network. In this case, they cannot use the same ports. Therefore, it should be possible to inject the usable ports from outside via helm values.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

Analogous to https://github.com/gardener/gardener-extension-provider-aws/pull/1229.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The ports used by provider-local can now be specified via helm values.
```
