### PR TITLE
Fix func IsServedByGardenerAPIServer to check all served groups

### DIFF
--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -402,7 +402,7 @@ func validateGardenerAPIServerConfig(config *operatorv1alpha1.GardenerAPIServerC
 			}
 
 			if !gardenerutils.IsServedByGardenerAPIServer(resource) {
-				allErrs = append(allErrs, field.Invalid(idxPath, resource, "should be a resource served by gardener-apiserver. ie; should have any of the suffixes {core,operations,settings,seedmanagement}.gardener.cloud"))
+				allErrs = append(allErrs, field.Invalid(idxPath, resource, "should be a resource served by gardener-apiserver. ie; should have any of the suffixes {authentication,core,operations,security,settings,seedmanagement}.gardener.cloud"))
 			}
 
 			if strings.HasPrefix(resource, "*") {

--- a/pkg/apis/operator/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation_test.go
@@ -1544,19 +1544,19 @@ var _ = Describe("Validation Tests", func() {
 									"Type":     Equal(field.ErrorTypeInvalid),
 									"Field":    Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[2]"),
 									"BadValue": Equal("ingresses.networking.io"),
-									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {core,operations,settings,seedmanagement}.gardener.cloud"),
+									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {authentication,core,operations,security,settings,seedmanagement}.gardener.cloud"),
 								})),
 								PointTo(MatchFields(IgnoreExtras, Fields{
 									"Type":     Equal(field.ErrorTypeInvalid),
 									"Field":    Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[3]"),
 									"BadValue": Equal("foo.gardener.cloud"),
-									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {core,operations,settings,seedmanagement}.gardener.cloud"),
+									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {authentication,core,operations,security,settings,seedmanagement}.gardener.cloud"),
 								})),
 								PointTo(MatchFields(IgnoreExtras, Fields{
 									"Type":     Equal(field.ErrorTypeInvalid),
 									"Field":    Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[4]"),
 									"BadValue": Equal("configmaps"),
-									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {core,operations,settings,seedmanagement}.gardener.cloud"),
+									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {authentication,core,operations,security,settings,seedmanagement}.gardener.cloud"),
 								})),
 							))
 						})

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/apis/authentication"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -29,6 +30,7 @@ import (
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/operator/v1alpha1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/security"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	"github.com/gardener/gardener/pkg/apis/settings"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -351,8 +353,10 @@ func DefaultGardenerResourcesForEncryption() sets.Set[string] {
 // IsServedByGardenerAPIServer returns true if the passed resources is served by the Gardener API Server.
 func IsServedByGardenerAPIServer(resource string) bool {
 	for _, groupName := range []string{
+		authentication.GroupName,
 		gardencore.GroupName,
 		operations.GroupName,
+		security.GroupName,
 		settings.GroupName,
 		seedmanagement.GroupName,
 	} {

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -22,11 +22,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	authenticationv1alpha1 "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	settingsv1alpha1 "github.com/gardener/gardener/pkg/apis/settings/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -355,6 +357,8 @@ var _ = Describe("Garden", func() {
 		Entry("operations resource", operationsv1alpha1.Resource("bastions").String(), true),
 		Entry("settings resource", settingsv1alpha1.Resource("openidconnectpresets").String(), true),
 		Entry("seedmanagement resource", seedmanagementv1alpha1.Resource("managedseeds").String(), true),
+		Entry("authentication resource", authenticationv1alpha1.Resource("adminkubeconfigrequests").String(), true),
+		Entry("security resource", securityv1alpha1.Resource("workloadidentities").String(), true),
 		Entry("any other resource", "foo", false),
 	)
 
@@ -367,6 +371,8 @@ var _ = Describe("Garden", func() {
 		Entry("operations resource", operationsv1alpha1.Resource("bastions").String(), false),
 		Entry("settings resource", settingsv1alpha1.Resource("openidconnectpresets").String(), false),
 		Entry("seedmanagement resource", seedmanagementv1alpha1.Resource("managedseeds").String(), false),
+		Entry("authentication resource", authenticationv1alpha1.Resource("adminkubeconfigrequests").String(), false),
+		Entry("security resource", securityv1alpha1.Resource("workloadidentities").String(), false),
 		Entry("any other resource", "foo", true),
 	)
 

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -15,6 +15,7 @@ build:
             - imagevector
             - imagevector/charts.yaml
             - imagevector/containers.yaml
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -370,6 +371,7 @@ build:
             - imagevector/charts.yaml
             - imagevector/containers.yaml
             - pkg/api/extensions
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -26,6 +26,7 @@ build:
             - pkg/admissioncontroller/apis/config/v1alpha1/validation
             - pkg/api/extensions
             - pkg/api/indexer
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/helper
             - pkg/apis/core/install
@@ -319,6 +320,7 @@ build:
             - cmd/utils/initrun
             - pkg/api/extensions
             - pkg/api/indexer
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -650,6 +652,7 @@ build:
             - cmd/utils/initrun
             - pkg/api/extensions
             - pkg/api/indexer
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -765,6 +768,7 @@ build:
             - cmd/utils
             - cmd/utils/initrun
             - pkg/api/extensions
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -853,6 +857,7 @@ build:
             - pkg/admissioncontroller/webhook/admission/updaterestriction
             - pkg/admissioncontroller/webhook/auth/seed
             - pkg/admissioncontroller/webhook/auth/seed/graph
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/helper
             - pkg/apis/core/install
@@ -1018,6 +1023,7 @@ build:
             - imagevector/charts.yaml
             - imagevector/containers.yaml
             - pkg/api/extensions
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -1172,6 +1178,7 @@ build:
             - extensions/pkg/webhook/cmd
             - extensions/pkg/webhook/shoot
             - pkg/api/extensions
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -250,6 +250,7 @@ build:
             - cmd/utils/initrun
             - pkg/api/extensions
             - pkg/api/indexer
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -365,6 +366,7 @@ build:
             - cmd/utils
             - cmd/utils/initrun
             - pkg/api/extensions
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -453,6 +455,7 @@ build:
             - pkg/admissioncontroller/webhook/admission/updaterestriction
             - pkg/admissioncontroller/webhook/auth/seed
             - pkg/admissioncontroller/webhook/auth/seed/graph
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/helper
             - pkg/apis/core/install
@@ -676,6 +679,7 @@ build:
             - imagevector/charts.yaml
             - imagevector/containers.yaml
             - pkg/api/extensions
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -976,6 +980,7 @@ build:
             - imagevector/containers.yaml
             - pkg/api/extensions
             - pkg/api/indexer
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/helper
             - pkg/apis/core/install
@@ -1338,6 +1343,7 @@ build:
             - cmd/utils/initrun
             - pkg/api/extensions
             - pkg/api/indexer
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -1452,6 +1458,7 @@ build:
             - imagevector/charts.yaml
             - imagevector/containers.yaml
             - pkg/api/extensions
+            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
Fix func IsServedByGardenerAPIServer to check all served groups

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`authentication.gardener.cloud` is actually not served, but used for the shoot subresources like `/adminkubeconfig`, thus I am not sure if it should be included or not. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
