### PR TITLE
Fix the `should get container logs from logging-pod` VPN tunnel TM test

### DIFF
--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -21,19 +21,12 @@ spec:
         # A custom agnhost image (europe-docker.pkg.dev/gardener-project/releases/3rd/agnhost) is used instead of the upstream one (registry.k8s.io/e2e-test-images/agnhost)
         # because this Deployment is created in a Seed cluster and the image needs to be signed with particular keys.
         image: europe-docker.pkg.dev/gardener-project/releases/3rd/agnhost:2.40
-        command: ["/bin/sh"]
+        command: ["/bin/sh", "-c"]
         args:
-          - -c
-          - |-
 {{ if .DeltaLogsCount }}
-            /agnhost logs-generator --log-lines-total={{ .DeltaLogsCount }} --run-duration={{ .DeltaLogsDuration }}
+        - /agnhost logs-generator --log-lines-total={{ .DeltaLogsCount }} --run-duration={{ .DeltaLogsDuration }} && /agnhost pause
 {{- end }}
-            /agnhost logs-generator --log-lines-total={{ .LogsCount }} --run-duration={{ .LogsDuration }}
-
-            # Sleep forever to prevent restarts
-            while true; do
-              sleep 3600;
-            done
+        - /agnhost logs-generator --log-lines-total={{ .LogsCount }} --run-duration={{ .LogsDuration }} && /agnhost pause
         resources:
           limits:
             cpu: 8m

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -23,11 +23,9 @@ spec:
         - pause
       - name: logger
         image: registry.k8s.io/e2e-test-images/agnhost:2.40
+        command: ["/bin/sh", "-c"]
         args:
-        - logs-generator
-        - --logtostderr
-        - --log-lines-total={{ .LogsCount }}
-        - --run-duration={{ .LogsDuration }}
+        - /agnhost logs-generator --logtostderr --log-lines-total={{ .LogsCount }} --run-duration={{ .LogsDuration }} && /agnhost pause
       securityContext:
         fsGroup: 65532
         runAsUser: 65532

--- a/test/testmachinery/shoots/vpntunnel/vpntunnel.go
+++ b/test/testmachinery/shoots/vpntunnel/vpntunnel.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("Shoot vpn tunnel testing", func() {
 					pod.Namespace,
 					pod.Name,
 					"pause",
-					fmt.Sprintf("curl -k -v -XGET  -H \"Accept: application/json, */*\" -H \"Authorization: Bearer %s\" \"%s/api/v1/namespaces/%s/pods/%s/log?container=logger\"", token, f.Shoot.Status.AdvertisedAddresses[0].URL, pod.Namespace, pod.Name),
+					"curl", "-k", "-v", "-H", "Accept: application/json, */*", "-H", "Authorization: Bearer "+token, fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/log?container=logger", f.Shoot.Status.AdvertisedAddresses[0].URL, pod.Namespace, pod.Name),
 				)
 				if apierrors.IsNotFound(err) {
 					log.Error(err, "Aborting as pod was not found anymore")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
An adaptation is needed to https://github.com/gardener/gardener/blob/00afe0f706006dc6e6c3d4e6e1965fd634a63601/test/testmachinery/shoots/vpntunnel/vpntunnel.go#L96 after the breaking changes to the PodExecutor in https://github.com/gardener/gardener/pull/10977.
The PodExecutor now accept varargs for command and not a single line.

The VPN Shoot test is currently failing due to this.
```
exec failed: unable to start container process: exec: \"curl -k -v -XGET <omitted>\": no such file or directory: unknown
```

With this PR:
```
% go test -timeout=0 ./test/testmachinery/suites/shoot \
      ... \
      -project-namespace=garden-foo \
      -shoot-name=bar \
      -ginkgo.focus="should get container logs from logging-pod"

Ran 1 of 19 Specs in 17.860 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 18 Skipped
--- PASS: TestGardenerSuite (17.86s)
PASS
ok  	github.com/gardener/gardener/test/testmachinery/suites/shoot	18.514s
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
An issue causing the VPN tunnel test-machinery integration test to fail is now fixed.
```
