### PR TITLE
chore: Remove Renovate package rule for the NewVPN feature gate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -449,18 +449,6 @@
       enabled: false,
     },
     {
-      // TODO(marc1404): Remove when the NewVPN feature gate is removed.
-      // Ignore dependency updates of gardener/vpn2@0.26.0 which is used when the NewVPN feature gate is disabled.
-      matchFileNames: [
-        'imagevector/containers.yaml',
-      ],
-      matchPackageNames: [
-        'gardener/vpn2',
-      ],
-      matchCurrentVersion: '0.26.0',
-      enabled: false,
-    },
-    {
       // TODO(marc1404): Remove when support for Kubernetes v1.27 is dropped.
       // Restrict updates of ingress-nginx/controller-chroot@v1.11.x for Kubernetes v1.27 to stay below v1.12.0.
       matchFileNames: [


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

#11578 introduced a Renovate package rule that disables unwanted updates related to the `NewVPN` feature gate.
The feature gate has been promoted to GA and removed:

* https://github.com/gardener/gardener/pull/11714

Therefore, the package rule can be removed as well 🧹 ✨ 

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

_n.a._

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
