### PR TITLE
Remove code with no effect

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -672,10 +672,8 @@ func (h *Health) CheckClusterNodes(
 	registeredNodes = registeredNodes - nodeNotManagedByMCM
 
 	machineList := &machinev1alpha1.MachineList{}
-	if registeredNodes != desiredMachines || readyNodes != desiredMachines {
-		if err := h.seedClient.Client().List(ctx, machineList, client.InNamespace(h.shoot.ControlPlaneNamespace)); err != nil {
-			return nil, err
-		}
+	if err := h.seedClient.Client().List(ctx, machineList, client.InNamespace(h.shoot.ControlPlaneNamespace)); err != nil {
+		return nil, err
 	}
 
 	leaseList := &coordinationv1.LeaseList{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
The effect of the deleted code is when `registeredNodes == desiredMachines && readyNodes == desiredMachines` then `machineList` remains `&machinev1alpha1.MachineList{}`. If we remove it `machineList` will not remain `&machinev1alpha1.MachineList{}`. This will not change anything logically as `machineList` is only referenced and used in `CheckNodesScalingUp` and `CheckNodesScalingDown`.
 If `registeredNodes == desiredMachines && readyNodes == desiredMachines` then the two functions above will exit early
https://github.com/gardener/gardener/blob/5efb7f94739c6805682099b46fce141a22c6b00d/pkg/gardenlet/controller/shoot/care/health.go#L826-L828
https://github.com/gardener/gardener/blob/5efb7f94739c6805682099b46fce141a22c6b00d/pkg/gardenlet/controller/shoot/care/health.go#L791-L793
Therefore the functions will behave equivalently regardless of the value of `machineList`. So removing the code will not change anything
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
