### PR TITLE
remove istio loadbalancer annotations from kapi service

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/service_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/service_test.go
@@ -65,8 +65,7 @@ var _ = Describe("#Service", func() {
 		ingressIPFunc = func(c string) { ingressIP = c }
 
 		values = &ServiceValues{
-			AnnotationsFunc: func() map[string]string { return map[string]string{"foo": "bar"} },
-			NamePrefix:      namePrefix,
+			NamePrefix: namePrefix,
 		}
 		expected = &corev1.Service{
 			TypeMeta: metav1.TypeMeta{

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -49,7 +49,7 @@ func (b *Botanist) defaultKubeAPIServerServiceWithSuffix(suffix string, register
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		&kubeapiserverexposure.ServiceValues{
-			AnnotationsFunc:             func() map[string]string { return b.IstioLoadBalancerAnnotations() },
+			AnnotationsFunc:             func() map[string]string { return nil },
 			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
 			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,
 			NameSuffix:                  suffix,

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -49,7 +49,6 @@ func (b *Botanist) defaultKubeAPIServerServiceWithSuffix(suffix string, register
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		&kubeapiserverexposure.ServiceValues{
-			AnnotationsFunc:             func() map[string]string { return nil },
 			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
 			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,
 			NameSuffix:                  suffix,

--- a/pkg/gardenlet/operation/istio_config.go
+++ b/pkg/gardenlet/operation/istio_config.go
@@ -12,7 +12,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
-	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -29,21 +28,6 @@ func (o *Operation) IstioNamespace() string {
 // DefaultIstioNamespace is the default namespace of the istio ingress gateway disregarding zonal affinities of the shoot cluster.
 func (o *Operation) DefaultIstioNamespace() string {
 	return *o.sniConfig().Ingress.Namespace
-}
-
-// IstioLoadBalancerAnnotations contain the annotation to be used for the istio ingress service load balancer.
-func (o *Operation) IstioLoadBalancerAnnotations() map[string]string {
-	zone := o.singleZoneIfPinned()
-	if exposureClassHandler := o.exposureClassHandler(); exposureClassHandler != nil {
-		if zone != nil {
-			return utils.MergeStringMaps(exposureClassHandler.LoadBalancerService.Annotations, o.Seed.GetZonalLoadBalancerServiceAnnotations(*zone))
-		}
-		return utils.MergeStringMaps(o.Seed.GetLoadBalancerServiceAnnotations(), exposureClassHandler.LoadBalancerService.Annotations)
-	}
-	if zone != nil {
-		return o.Seed.GetZonalLoadBalancerServiceAnnotations(*zone)
-	}
-	return o.Seed.GetLoadBalancerServiceAnnotations()
 }
 
 // IstioLabels contain the labels to be used for the istio ingress gateway entities.

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -530,17 +530,12 @@ func (r *Reconciler) newKubeAPIServerService(log logr.Logger, garden *operatorv1
 }
 
 func (r *Reconciler) newKubeAPIServerServiceWithSuffix(log logr.Logger, garden *operatorv1alpha1.Garden, ingressGatewayValues []istio.IngressGatewayValues, suffix string) component.DeployWaiter {
-	var annotations map[string]string
-	if settings := garden.Spec.RuntimeCluster.Settings; settings != nil && settings.LoadBalancerServices != nil {
-		annotations = settings.LoadBalancerServices.Annotations
-	}
-
 	return kubeapiserverexposure.NewService(
 		log,
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
 		&kubeapiserverexposure.ServiceValues{
-			AnnotationsFunc:             func() map[string]string { return annotations },
+			AnnotationsFunc:             func() map[string]string { return nil },
 			NamePrefix:                  namePrefix,
 			NameSuffix:                  suffix,
 			TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -535,7 +535,6 @@ func (r *Reconciler) newKubeAPIServerServiceWithSuffix(log logr.Logger, garden *
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
 		&kubeapiserverexposure.ServiceValues{
-			AnnotationsFunc:             func() map[string]string { return nil },
 			NamePrefix:                  namePrefix,
 			NameSuffix:                  suffix,
 			TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -54,7 +54,6 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 	gardencontroller "github.com/gardener/gardener/pkg/operator/controller/garden/garden"
-	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -558,11 +557,11 @@ spec:
 			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "virtual-garden-kube-apiserver", Namespace: testNamespace.Name}}
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(service), service)).To(Succeed())
 			return service.Annotations
-		}).Should(Equal(utils.MergeStringMaps(loadBalancerServiceAnnotations, map[string]string{
+		}).Should(Equal(map[string]string{
 			"networking.istio.io/exportTo": "*",
 			"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
 			"networking.resources.gardener.cloud/namespace-selectors":                          `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
-		})))
+		}))
 
 		// The garden controller waits for the Etcd resources to be healthy, but etcd-druid is not really running in
 		// this test, so let's fake this here.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Currently the seed loadbalancer annotations as specified by `.spec.settings.loadbalancerServices.annotations` are added to the kube-apiserver service. Since this is now a ClusterIP and not a loadbalancer, the annotations should not be necessary. They may even cause issues or silent errors when controllers like the aws-loadbalancer-controller tries to reconcile the services containing the annotations but are not LB type services. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove unnecessary istio loadbalancer annotations from the ClusterIP kube-apiserver service.
```
