### PR TITLE
Update documentation for installing `hub`

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -239,7 +239,7 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
 - Have the `gardener/gardener` repository cloned as follows:
   - the `origin` remote should point to your fork (alternatively this can be overwritten by passing `FORK_REMOTE=<fork-remote>`).
   - the `upstream` remote should point to the Gardener GitHub org (alternatively this can be overwritten by passing `UPSTREAM_REMOTE=<upstream-remote>`).
-- Have `hub` installed, which is most easily installed via `brew install hub` for MacOS. For other OS follow https://github.com/mislav/hub?tab=readme-ov-file#installation
+- Have `hub` installed. On macOS, `hub` can be installed via homebrew using the [hub formula](https://formulae.brew.sh/formula/hub). For other OS, follow the [`hub` installation instructions](https://github.com/mislav/hub?tab=readme-ov-file#installation).
 - A GitHub token which has permissions to create a PR in an upstream branch.
 
 ### Initiate a Cherry Pick

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -239,9 +239,7 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
 - Have the `gardener/gardener` repository cloned as follows:
   - the `origin` remote should point to your fork (alternatively this can be overwritten by passing `FORK_REMOTE=<fork-remote>`).
   - the `upstream` remote should point to the Gardener GitHub org (alternatively this can be overwritten by passing `UPSTREAM_REMOTE=<upstream-remote>`).
-- Have `hub` installed, which is most easily installed via
-  `go get github.com/github/hub` assuming you have a standard golang
-  development environment.
+- Have `hub` installed, which is most easily installed via `brew install hub` for MacOS. For other OS follow https://github.com/mislav/hub?tab=readme-ov-file#installation
 - A GitHub token which has permissions to create a PR in an upstream branch.
 
 ### Initiate a Cherry Pick


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Tested with @RadaBDimitrova that `go get github.com/github/hub` does not work. According to https://github.com/mislav/hub?tab=readme-ov-file#installation for macOS `brew install hub` is the recommended way

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
