### PR TITLE
[release-v1.113] Automated cherry pick of #11733: Update registry.k8s.io/ingress-nginx/controller-chroot Docker tag to v1.11.5

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -90,7 +90,7 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.11.4"
+  tag: "v1.11.5"
   targetVersion: ">= 1.26 < 1.28"
   labels:
   - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
/kind enhancement

Cherry pick of #11733 on release-v1.113.

#11733: Update registry.k8s.io/ingress-nginx/controller-chroot Docker tag to v1.11.5

**Release Notes:**
```other dependency
The following dependencies have been updated:
- `registry.k8s.io/ingress-nginx/controller-chroot` from `v1.11.4` to `v1.11.5`. 
```