### PR TITLE
[release-v1.113] Automated cherry pick of #11732: Update registry.k8s.io/ingress-nginx/controller-chroot Docker tag to v1.12.1

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -76,7 +76,7 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.12.0"
+  tag: "v1.12.1"
   targetVersion: ">= 1.28"
   labels:
   - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
/kind enhancement

Cherry pick of #11732 on release-v1.113.

#11732: Update registry.k8s.io/ingress-nginx/controller-chroot Docker tag to v1.12.1

**Release Notes:**
```other dependency
The following dependencies have been updated:
- `registry.k8s.io/ingress-nginx/controller-chroot` from `v1.12.0` to `v1.12.1`. 
```