### PR TITLE
[GEP-28] Bootstrap `kubelet` and make `gardenadm init` idempotent

### DIFF
--- a/pkg/client/kubernetes/pods.go
+++ b/pkg/client/kubernetes/pods.go
@@ -130,7 +130,6 @@ func SetupPortForwarder(ctx context.Context, config *rest.Config, namespace, nam
 	var (
 		readyChan = make(chan struct{}, 1)
 		out       = io.Discard
-		localPort int
 	)
 
 	client, err := corev1client.NewForConfig(config)
@@ -147,13 +146,13 @@ func SetupPortForwarder(ctx context.Context, config *rest.Config, namespace, nam
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", u)
 
 	if local == 0 {
-		localPort, err = utils.FindFreePort()
+		local, err = utils.FindFreePort()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, remote)}, ctx.Done(), readyChan, out, out)
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", local, remote)}, ctx.Done(), readyChan, out, out)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/etcd/bootstrap/etcd.go
+++ b/pkg/component/etcd/bootstrap/etcd.go
@@ -135,6 +135,7 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 				LivenessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
+							Host:   "localhost",
 							Path:   "/livez",
 							Scheme: corev1.URISchemeHTTP,
 							Port:   intstr.FromInt32(e.values.PortMetrics),
@@ -156,6 +157,7 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 				StartupProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
+							Host:   "localhost",
 							Path:   "/health",
 							Scheme: corev1.URISchemeHTTP,
 							Port:   intstr.FromInt32(e.values.PortMetrics),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
@@ -116,8 +116,8 @@ func RBACResourcesData(secretNames []string) (map[string][]byte, error) {
 			Verbs:     []string{"create", "get"},
 		})
 	} else {
-		// For the case that NodeAgentAuthorizer feature gate is disabled again node-agents group have to be added to
-		// (cluster) role binding that node-agents which are already migrated do not lose access.
+		// For the case that NodeAgentAuthorizer feature gate is disabled again node-agents group has to be added to
+		// (cluster) role binding so that node-agents which are already migrated do not lose access.
 		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1.Subject{
 			APIGroup: rbacv1.SchemeGroupVersion.Group,
 			Kind:     rbacv1.GroupKind,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -104,54 +105,6 @@ func RBACResourcesData(secretNames []string) (map[string][]byte, error) {
 				},
 			},
 		}
-
-		clusterRoleBindingNodeBootstrapper = &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "system:node-bootstrapper",
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.SchemeGroupVersion.Group,
-				Kind:     "ClusterRole",
-				Name:     "system:node-bootstrapper",
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.SchemeGroupVersion.Group,
-				Kind:     rbacv1.GroupKind,
-				Name:     bootstraptokenapi.BootstrapDefaultGroup,
-			}},
-		}
-
-		clusterRoleBindingNodeClient = &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.SchemeGroupVersion.Group,
-				Kind:     "ClusterRole",
-				Name:     "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.SchemeGroupVersion.Group,
-				Kind:     rbacv1.GroupKind,
-				Name:     bootstraptokenapi.BootstrapDefaultGroup,
-			}},
-		}
-
-		clusterRoleBindingSelfNodeClient = &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.SchemeGroupVersion.Group,
-				Kind:     "ClusterRole",
-				Name:     "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.SchemeGroupVersion.Group,
-				Kind:     rbacv1.GroupKind,
-				Name:     user.NodesGroup,
-			}},
-		}
 	)
 
 	if features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer) {
@@ -179,13 +132,74 @@ func RBACResourcesData(secretNames []string) (map[string][]byte, error) {
 
 	return managedresources.
 		NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer).
-		AddAllAndSerialize(
+		AddAllAndSerialize(append([]client.Object{
 			clusterRole,
 			clusterRoleBinding,
 			role,
 			roleBinding,
-			clusterRoleBindingNodeBootstrapper,
-			clusterRoleBindingNodeClient,
-			clusterRoleBindingSelfNodeClient,
-		)
+		}, GetCertificateSigningRequestClusterRoleBindings()...)...)
+}
+
+// GetCertificateSigningRequestClusterRoleBindings returns the ClusterRoleBindings that allows bootstrap tokens to
+// create CertificateSigningRequests.
+func GetCertificateSigningRequestClusterRoleBindings() []client.Object {
+	return []client.Object{
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+				Kind:       "ClusterRoleBinding",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:node-bootstrapper",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     "system:node-bootstrapper",
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     rbacv1.GroupKind,
+				Name:     bootstraptokenapi.BootstrapDefaultGroup,
+			}},
+		},
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+				Kind:       "ClusterRoleBinding",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     rbacv1.GroupKind,
+				Name:     bootstraptokenapi.BootstrapDefaultGroup,
+			}},
+		},
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+				Kind:       "ClusterRoleBinding",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     rbacv1.GroupKind,
+				Name:     user.NodesGroup,
+			}},
+		},
+	}
 }

--- a/pkg/component/kubernetes/apiserver/secrets.go
+++ b/pkg/component/kubernetes/apiserver/secrets.go
@@ -148,7 +148,7 @@ func (k *kubeAPIServer) reconcileSecretETCDEncryptionConfiguration(ctx context.C
 
 func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secret, error) {
 	var (
-		ipAddresses    = append([]net.IP{}, k.values.ServerCertificate.ExtraIPAddresses...)
+		ipAddresses    []net.IP
 		deploymentName = k.values.NamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
 		dnsNames       = kubernetesutils.DNSNamesForService(deploymentName, k.namespace)
 	)

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -56,8 +56,10 @@ const (
 // Interface contains functions for a machine-controller-manager deployer.
 type Interface interface {
 	component.DeployWaiter
-	// SetNamespaceUID sets the UID of the namespace into which the cluster-autoscaler shall be deployed.
+	// SetNamespaceUID sets the UID of the namespace into which the machine-controller-manager shall be deployed.
 	SetNamespaceUID(types.UID)
+	// SetReplicas sets the replicas.
+	SetReplicas(int32)
 }
 
 // New creates a new instance of DeployWaiter for the machine-controller-manager.
@@ -485,6 +487,7 @@ func (m *machineControllerManager) WaitCleanup(ctx context.Context) error {
 }
 
 func (m *machineControllerManager) SetNamespaceUID(uid types.UID) { m.values.namespaceUID = uid }
+func (m *machineControllerManager) SetReplicas(replicas int32)    { m.values.Replicas = replicas }
 
 func (m *machineControllerManager) computeShootResourcesData(serviceAccountName string) (map[string][]byte, error) {
 	var (

--- a/pkg/component/nodemanagement/machinecontrollermanager/mock/mocks.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/mock/mocks.go
@@ -81,6 +81,18 @@ func (mr *MockInterfaceMockRecorder) SetNamespaceUID(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNamespaceUID", reflect.TypeOf((*MockInterface)(nil).SetNamespaceUID), arg0)
 }
 
+// SetReplicas mocks base method.
+func (m *MockInterface) SetReplicas(arg0 int32) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetReplicas", arg0)
+}
+
+// SetReplicas indicates an expected call of SetReplicas.
+func (mr *MockInterfaceMockRecorder) SetReplicas(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReplicas", reflect.TypeOf((*MockInterface)(nil).SetReplicas), arg0)
+}
+
 // Wait mocks base method.
 func (m *MockInterface) Wait(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/extensions/cluster.go
+++ b/pkg/extensions/cluster.go
@@ -29,10 +29,6 @@ func SyncClusterResourceToSeed(
 	cloudProfile *gardencorev1beta1.CloudProfile,
 	seed *gardencorev1beta1.Seed,
 ) error {
-	if shoot.Spec.SeedName == nil {
-		return nil
-	}
-
 	var (
 		cluster = &extensionsv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/extensions/cluster_test.go
+++ b/pkg/extensions/cluster_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -103,14 +102,7 @@ var _ = Describe("Cluster", func() {
 			}
 		})
 
-		It("should not sync cloudprofile, shoot and seed to cluster if seed is not assigned to shoot", func() {
-			Expect(SyncClusterResourceToSeed(ctx, fakeSeedClient, cluster.Name, expectedShoot, expectedCloudProfile, expectedSeed)).To(Succeed())
-			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(BeNotFoundError())
-		})
-
 		It("should sync cloudprofile, shoot and seed to cluster", func() {
-			expectedShoot.Spec.SeedName = ptr.To(expectedSeed.Name)
-
 			Expect(SyncClusterResourceToSeed(ctx, fakeSeedClient, cluster.Name, expectedShoot, expectedCloudProfile, expectedSeed)).To(Succeed())
 			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
 

--- a/pkg/gardenadm/botanist/customresourcedefinitions.go
+++ b/pkg/gardenadm/botanist/customresourcedefinitions.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/gardener/gardener/pkg/component/autoscaling/vpa"
+	extensioncrds "github.com/gardener/gardener/pkg/component/extensions/crds"
+	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+// ReconcileCustomResourceDefinitions reconciles the custom resource definitions.
+func (b *AutonomousBotanist) ReconcileCustomResourceDefinitions(ctx context.Context) error {
+	vpaCRDDeployer := vpa.NewCRD(b.SeedClientSet.Applier(), nil)
+
+	prometheusCRDDeployer, err := prometheusoperator.NewCRDs(b.SeedClientSet.Client(), b.SeedClientSet.Applier())
+	if err != nil {
+		return fmt.Errorf("failed creating Prometheus CRD deployer: %w", err)
+	}
+
+	fluentCRDDeployer, err := fluentoperator.NewCRDs(b.SeedClientSet.Client(), b.SeedClientSet.Applier())
+	if err != nil {
+		return fmt.Errorf("failed creating Prometheus CRD deployer: %w", err)
+	}
+
+	extensionCRDDeployer, err := extensioncrds.NewCRD(b.SeedClientSet.Client(), b.SeedClientSet.Applier(), true, true)
+	if err != nil {
+		return fmt.Errorf("failed creating Prometheus CRD deployer: %w", err)
+	}
+
+	for _, deploy := range []func(context.Context) error{
+		vpaCRDDeployer.Deploy,
+		prometheusCRDDeployer.Deploy,
+		fluentCRDDeployer.Deploy,
+		extensionCRDDeployer.Deploy,
+	} {
+		if err := deploy(ctx); err != nil {
+			return fmt.Errorf("failed to deploy CustomResourceDefinition: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// EnsureCustomResourceDefinitionsReady ensures that the custom resource definitions are ready.
+func (b *AutonomousBotanist) EnsureCustomResourceDefinitionsReady(ctx context.Context) error {
+	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+	if err := b.SeedClientSet.Client().List(ctx, crdList); err != nil {
+		return fmt.Errorf("failed to list CustomResourceDefinitions: %w", err)
+	}
+
+	for _, crd := range crdList.Items {
+		if err := health.CheckCustomResourceDefinition(&crd); err != nil {
+			return fmt.Errorf("CustomResourceDefinition %s is not ready yet: %w", crd.Name, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/gardenadm/botanist/customresourcedefinitions.go
+++ b/pkg/gardenadm/botanist/customresourcedefinitions.go
@@ -28,22 +28,22 @@ func (b *AutonomousBotanist) ReconcileCustomResourceDefinitions(ctx context.Cont
 
 	fluentCRDDeployer, err := fluentoperator.NewCRDs(b.SeedClientSet.Client(), b.SeedClientSet.Applier())
 	if err != nil {
-		return fmt.Errorf("failed creating Prometheus CRD deployer: %w", err)
+		return fmt.Errorf("failed creating fluent CRD deployer: %w", err)
 	}
 
 	extensionCRDDeployer, err := extensioncrds.NewCRD(b.SeedClientSet.Client(), b.SeedClientSet.Applier(), true, true)
 	if err != nil {
-		return fmt.Errorf("failed creating Prometheus CRD deployer: %w", err)
+		return fmt.Errorf("failed creating extension CRD deployer: %w", err)
 	}
 
-	for _, deploy := range []func(context.Context) error{
-		vpaCRDDeployer.Deploy,
-		prometheusCRDDeployer.Deploy,
-		fluentCRDDeployer.Deploy,
-		extensionCRDDeployer.Deploy,
+	for description, deploy := range map[string]func(context.Context) error{
+		"VPA":        vpaCRDDeployer.Deploy,
+		"Prometheus": prometheusCRDDeployer.Deploy,
+		"Fluent":     fluentCRDDeployer.Deploy,
+		"Extension":  extensionCRDDeployer.Deploy,
 	} {
 		if err := deploy(ctx); err != nil {
-			return fmt.Errorf("failed to deploy CustomResourceDefinition: %w", err)
+			return fmt.Errorf("failed to deploy CustomResourceDefinition related to %s: %w", description, err)
 		}
 	}
 

--- a/pkg/gardenadm/botanist/customresourcedefinitions_test.go
+++ b/pkg/gardenadm/botanist/customresourcedefinitions_test.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+)
+
+var _ = Describe("CustomResourceDefinitions", func() {
+	var (
+		ctx context.Context
+
+		fakeClient client.Client
+
+		b *AutonomousBotanist
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{apiextensionsv1.SchemeGroupVersion})
+		mapper.Add(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"), meta.RESTScopeRoot)
+		applier := kubernetes.NewApplier(fakeClient, mapper)
+
+		b = &AutonomousBotanist{
+			Botanist: &botanistpkg.Botanist{
+				Operation: &operation.Operation{
+					SeedClientSet: fakekubernetes.
+						NewClientSetBuilder().
+						WithClient(fakeClient).
+						WithApplier(applier).
+						WithRESTConfig(&rest.Config{}).
+						Build(),
+				},
+			},
+		}
+	})
+
+	Describe("#ReconcileCustomResourceDefinitions", func() {
+		It("should reconcile all expected CRDs", func() {
+			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+			Expect(fakeClient.List(ctx, crdList)).To(Succeed())
+
+			Expect(b.ReconcileCustomResourceDefinitions(ctx)).To(Succeed())
+
+			Expect(fakeClient.List(ctx, crdList)).To(Succeed())
+			Expect(crdList.Items).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanagerconfigs.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("alertmanagers.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("backupbuckets.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("backupentries.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("bastions.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfilters.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfluentbitconfigs.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterinputs.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clustermultilineparsers.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusteroutputs.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterparsers.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusters.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("collectors.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("containerruntimes.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("controlplanes.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dnsrecords.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("extensions.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("filters.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbitconfigs.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbits.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("infrastructures.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("multilineparsers.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("networks.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("operatingsystemconfigs.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("outputs.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("parsers.fluentbit.fluent.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("podmonitors.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("probes.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheusagents.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheuses.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("prometheusrules.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("scrapeconfigs.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("servicemonitors.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("thanosrulers.monitoring.coreos.com")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workers.extensions.gardener.cloud")})}),
+			))
+		})
+	})
+
+	Describe("#EnsureCustomResourceDefinitionsReady", func() {
+		var crd *apiextensionsv1.CustomResourceDefinition
+
+		BeforeEach(func() {
+			crd = &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "some.crd"}}
+			Expect(fakeClient.Create(ctx, crd)).To(Succeed())
+		})
+
+		It("should fail because some CRD is not ready", func() {
+			Expect(b.EnsureCustomResourceDefinitionsReady(ctx)).To(MatchError(ContainSubstring(crd.Name + " is not ready yet")))
+		})
+
+		It("should succeed because all CRDs are ready", func() {
+			crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{
+				{Type: apiextensionsv1.NamesAccepted, Status: apiextensionsv1.ConditionTrue},
+				{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+			}
+			Expect(fakeClient.Status().Update(ctx, crd)).To(Succeed())
+
+			Expect(b.EnsureCustomResourceDefinitionsReady(ctx)).To(Succeed())
+		})
+	})
+})

--- a/pkg/gardenadm/botanist/kubelet.go
+++ b/pkg/gardenadm/botanist/kubelet.go
@@ -11,12 +11,16 @@ import (
 	"time"
 
 	"github.com/spf13/afero"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/gardener/gardener/cmd/gardener-node-agent/app/bootstrappers"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
+	nodeagentcomponent "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
+	"github.com/gardener/gardener/pkg/nodeagent"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -24,8 +28,8 @@ import (
 
 const kubeletTokenFilePermission = 0o600
 
-// CreateBootstrapToken creates a bootstrap token for the kubelet and writes it to the file system.
-func (b *AutonomousBotanist) CreateBootstrapToken(ctx context.Context) error {
+// WriteBootstrapToken creates a bootstrap token for the kubelet and writes it to the file system.
+func (b *AutonomousBotanist) WriteBootstrapToken(ctx context.Context) error {
 	bootstrapTokenSecret, err := bootstraptoken.ComputeBootstrapToken(
 		ctx,
 		b.SeedClientSet.Client(),
@@ -79,4 +83,39 @@ func (b *AutonomousBotanist) WriteKubeletBootstrapKubeconfig(ctx context.Context
 	}
 
 	return kubeletBootstrapKubeconfigCreator.Start(ctx)
+}
+
+// BootstrapKubelet bootstraps the kubelet.
+func (b *AutonomousBotanist) BootstrapKubelet(ctx context.Context) error {
+	node, err := nodeagent.FetchNodeByHostName(ctx, b.SeedClientSet.Client(), b.HostName)
+	if err != nil {
+		return fmt.Errorf("failed fetching node object via hostname: %w", err)
+	}
+	if node != nil {
+		b.Logger.Info("Found node for hostname, skipping kubelet bootstrap", "hostName", b.HostName, "nodeName", node.Name)
+		return nil
+	}
+
+	b.Logger.Info("No node found for hostname, bootstrapping kubelet", "hostName", b.HostName)
+
+	for _, obj := range nodeagentcomponent.GetCertificateSigningRequestClusterRoleBindings() {
+		desired := obj.DeepCopyObject()
+		if _, err := controllerutil.CreateOrUpdate(ctx, b.SeedClientSet.Client(), obj, func() error {
+			obj.(*rbacv1.ClusterRoleBinding).Subjects = desired.(*rbacv1.ClusterRoleBinding).Subjects
+			obj.(*rbacv1.ClusterRoleBinding).RoleRef = desired.(*rbacv1.ClusterRoleBinding).RoleRef
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed reconciling ClusterRoleBinding %q: %w", obj.GetName(), err)
+		}
+	}
+
+	if err := b.WriteBootstrapToken(ctx); err != nil {
+		return fmt.Errorf("failed creating bootstrap token: %w", err)
+	}
+
+	if err := b.WriteKubeletBootstrapKubeconfig(ctx); err != nil {
+		return fmt.Errorf("failed writing kubelet bootstrap kubeconfig: %w", err)
+	}
+
+	return b.DBus.Restart(ctx, nil, nil, kubelet.UnitName)
 }

--- a/pkg/gardenadm/botanist/kubelet.go
+++ b/pkg/gardenadm/botanist/kubelet.go
@@ -8,9 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/spf13/afero"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
@@ -118,4 +122,41 @@ func (b *AutonomousBotanist) BootstrapKubelet(ctx context.Context) error {
 	}
 
 	return b.DBus.Restart(ctx, nil, nil, kubelet.UnitName)
+}
+
+// ApproveKubeletServerCertificateSigningRequest approves the kubelet server certificate signing request.
+func (b *AutonomousBotanist) ApproveKubeletServerCertificateSigningRequest(ctx context.Context) error {
+	serverCertificateExists, err := b.FS.Exists(filepath.Join(kubelet.PathKubeletDirectory, "pki", "kubelet-server-current.pem"))
+	if err != nil {
+		return fmt.Errorf("failed checking if kubelet server certificate exists: %w", err)
+	}
+	if serverCertificateExists {
+		return nil
+	}
+
+	csrList := &certificatesv1.CertificateSigningRequestList{}
+	if err := b.SeedClientSet.Client().List(ctx, csrList); err != nil {
+		return fmt.Errorf("failed listing certificate signing requests: %w", err)
+	}
+
+	for _, csr := range csrList.Items {
+		if csr.Spec.Username == "system:node:"+b.HostName {
+			if !slices.ContainsFunc(csr.Status.Conditions, func(condition certificatesv1.CertificateSigningRequestCondition) bool {
+				return condition.Type == certificatesv1.CertificateApproved && condition.Status == corev1.ConditionTrue
+			}) {
+				b.Logger.Info("Approving kubelet server certificate signing request")
+				csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+					Type:    certificatesv1.CertificateApproved,
+					Status:  corev1.ConditionTrue,
+					Reason:  "RequestApproved",
+					Message: "Approving kubelet server certificate signing request via gardenadm",
+				})
+				return b.SeedClientSet.Client().SubResource("approval").Update(ctx, &csr)
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no certificate signing request found for node %q", b.HostName)
 }

--- a/pkg/gardenadm/botanist/kubelet.go
+++ b/pkg/gardenadm/botanist/kubelet.go
@@ -114,7 +114,7 @@ func (b *AutonomousBotanist) BootstrapKubelet(ctx context.Context) error {
 	}
 
 	if err := b.WriteBootstrapToken(ctx); err != nil {
-		return fmt.Errorf("failed creating bootstrap token: %w", err)
+		return fmt.Errorf("failed writing bootstrap token: %w", err)
 	}
 
 	if err := b.WriteKubeletBootstrapKubeconfig(ctx); err != nil {
@@ -144,7 +144,7 @@ func (b *AutonomousBotanist) ApproveKubeletServerCertificateSigningRequest(ctx c
 			if !slices.ContainsFunc(csr.Status.Conditions, func(condition certificatesv1.CertificateSigningRequestCondition) bool {
 				return condition.Type == certificatesv1.CertificateApproved && condition.Status == corev1.ConditionTrue
 			}) {
-				b.Logger.Info("Approving kubelet server certificate signing request")
+				b.Logger.Info("Approving kubelet server certificate signing request", "csrName", csr.Name, "hostName", b.HostName)
 				csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
 					Type:    certificatesv1.CertificateApproved,
 					Status:  corev1.ConditionTrue,

--- a/pkg/gardenadm/botanist/kubelet_test.go
+++ b/pkg/gardenadm/botanist/kubelet_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,6 +128,38 @@ var _ = Describe("Kubelet", func() {
 
 			Expect(b.FS.Exists("/var/lib/gardener-node-agent/credentials/bootstrap-token")).To(BeTrue())
 			Expect(fakeDBus.Actions).To(HaveExactElements(fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"kubelet.service"}}))
+		})
+	})
+
+	Describe("#ApproveKubeletServerCertificateSigningRequest", func() {
+		It("should do nothing because the server certificate file already exists", func() {
+			file, err := b.FS.Create("/var/lib/kubelet/pki/kubelet-server-current.pem")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).NotTo(BeNil())
+
+			Expect(b.ApproveKubeletServerCertificateSigningRequest(ctx)).To(Succeed())
+		})
+
+		It("should return an error when no CSR was found for the node", func() {
+			Expect(b.ApproveKubeletServerCertificateSigningRequest(ctx)).To(MatchError(ContainSubstring("no certificate signing request found for node")))
+		})
+
+		It("should approve the CSR when not already approved", func() {
+			csr := &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr"},
+				Spec:       certificatesv1.CertificateSigningRequestSpec{Username: "system:node:" + hostName},
+			}
+			Expect(fakeSeedClient.Create(ctx, csr)).To(Succeed())
+
+			Expect(b.ApproveKubeletServerCertificateSigningRequest(ctx)).To(Succeed())
+
+			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
+			Expect(csr.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
+				Type:    certificatesv1.CertificateApproved,
+				Status:  corev1.ConditionTrue,
+				Reason:  "RequestApproved",
+				Message: "Approving kubelet server certificate signing request via gardenadm",
+			}))
 		})
 	})
 })

--- a/pkg/gardenadm/botanist/secrets.go
+++ b/pkg/gardenadm/botanist/secrets.go
@@ -6,6 +6,7 @@ package botanist
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +19,7 @@ import (
 func (b *AutonomousBotanist) MigrateSecrets(ctx context.Context, fakeClient, realClient client.Client) error {
 	secretList := &corev1.SecretList{}
 	if err := fakeClient.List(ctx, secretList, client.InNamespace(b.Shoot.ControlPlaneNamespace)); err != nil {
-		panic(err)
+		return fmt.Errorf("failed listing secrets with fake client: %w", err)
 	}
 
 	var taskFns []flow.TaskFn

--- a/pkg/gardenadm/botanist/secrets.go
+++ b/pkg/gardenadm/botanist/secrets.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+)
+
+// MigrateSecrets exports the secrets generated with the fake client and imports them with the real client.
+func (b *AutonomousBotanist) MigrateSecrets(ctx context.Context, fakeClient, realClient client.Client) error {
+	secretList := &corev1.SecretList{}
+	if err := fakeClient.List(ctx, secretList, client.InNamespace(b.Shoot.ControlPlaneNamespace)); err != nil {
+		panic(err)
+	}
+
+	var taskFns []flow.TaskFn
+
+	for _, secret := range secretList.Items {
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			return realClient.Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        secret.Name,
+					Namespace:   secret.Namespace,
+					Labels:      secret.Labels,
+					Annotations: secret.Annotations,
+				},
+				Type:      secret.Type,
+				Immutable: secret.Immutable,
+				Data:      secret.Data,
+			})
+		})
+	}
+
+	return flow.Parallel(taskFns...)(ctx)
+}

--- a/pkg/gardenadm/botanist/secrets_test.go
+++ b/pkg/gardenadm/botanist/secrets_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+)
+
+var _ = Describe("Secrets", func() {
+	var (
+		ctx context.Context
+
+		fakeClient1 client.Client
+		fakeClient2 client.Client
+
+		b *AutonomousBotanist
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		fakeClient1 = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		fakeClient2 = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+		b = &AutonomousBotanist{
+			Botanist: &botanistpkg.Botanist{
+				Operation: &operation.Operation{
+					SeedClientSet: fakekubernetes.
+						NewClientSetBuilder().
+						WithClient(fakeClient1).
+						WithRESTConfig(&rest.Config{}).
+						Build(),
+					Shoot: &shootpkg.Shoot{
+						ControlPlaneNamespace: "kube-system",
+					},
+				},
+			},
+		}
+	})
+
+	Describe("#MigrateSecrets", func() {
+		It("should copy all secrets from kube-system", func() {
+			var (
+				secret1 = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "kube-system", Finalizers: []string{"hugo"}},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"foo": []byte("bar")},
+				}
+				secret2 = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "default"},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"bar": []byte("foo")},
+				}
+				secret3 = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "s2", Namespace: "kube-system", OwnerReferences: []metav1.OwnerReference{{}}},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"baz": []byte("bar")},
+				}
+
+				secretList = &corev1.SecretList{}
+			)
+
+			Expect(fakeClient1.Create(ctx, secret1)).To(Succeed())
+			Expect(fakeClient1.Create(ctx, secret2)).To(Succeed())
+			Expect(fakeClient1.Create(ctx, secret3)).To(Succeed())
+
+			Expect(fakeClient2.List(ctx, secretList)).To(Succeed())
+			Expect(secretList.Items).To(BeEmpty())
+
+			Expect(b.MigrateSecrets(ctx, fakeClient1, fakeClient2)).To(Succeed())
+
+			Expect(fakeClient2.List(ctx, secretList)).To(Succeed())
+			Expect(secretList.Items).To(HaveExactElements(
+				corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "kube-system", ResourceVersion: "1"},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"foo": []byte("bar")},
+				},
+				corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "s2", Namespace: "kube-system", ResourceVersion: "1"},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"baz": []byte("bar")},
+				},
+			))
+		})
+	})
+})

--- a/pkg/gardenadm/staticpod/translator.go
+++ b/pkg/gardenadm/staticpod/translator.go
@@ -29,7 +29,7 @@ func Translate(ctx context.Context, c client.Client, o client.Object) ([]extensi
 	case *appsv1.Deployment:
 		return translatePodTemplate(ctx, c, obj.ObjectMeta, obj.Spec.Template)
 	case *corev1.Pod:
-		return translatePodTemplate(ctx, c, obj.ObjectMeta, corev1.PodTemplateSpec{ObjectMeta: obj.ObjectMeta, Spec: obj.Spec})
+		return translatePodTemplate(ctx, c, obj.ObjectMeta, corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: obj.Labels, Annotations: obj.Annotations}, Spec: obj.Spec})
 	// TODO(rfranzke): Consider adding support for StatefulSet in the future.
 	default:
 		return nil, fmt.Errorf("unsupported object type %T", o)

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -270,9 +270,12 @@ kind: Config
 			BeforeEach(func() {
 				pod = &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels:      map[string]string{"baz": "foo"},
-						Annotations: map[string]string{"bar": "baz"},
-						Name:        "foo",
+						Labels:          map[string]string{"baz": "foo"},
+						Annotations:     map[string]string{"bar": "baz"},
+						Name:            "foo",
+						ResourceVersion: "1",
+						Finalizers:      []string{"bar"},
+						OwnerReferences: []metav1.OwnerReference{{}},
 					},
 				}
 			})

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -137,7 +137,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		if err != nil {
 			return nil, err
 		}
-		o.Shoot.Components.ControlPlane.MachineControllerManager, err = b.DefaultMachineControllerManager(ctx)
+		o.Shoot.Components.ControlPlane.MachineControllerManager, err = b.DefaultMachineControllerManager()
 		if err != nil {
 			return nil, err
 		}

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -69,6 +69,19 @@ build:
             - pkg/component/etcd/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
             - pkg/component/extensions/containerruntime
             - pkg/component/extensions/controlplane
+            - pkg/component/extensions/crds
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_backupbuckets.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_backupentries.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_bastions.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_clusters.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_containerruntimes.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_controlplanes.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_dnsrecords.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_extensions.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_infrastructures.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_networks.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+            - pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
             - pkg/component/extensions/dnsrecord
             - pkg/component/extensions/extension
             - pkg/component/extensions/infrastructure

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -6,18 +6,25 @@ package hightouch
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
+	. "github.com/onsi/gomega/gstruct"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	. "github.com/gardener/gardener/test/e2e/gardenadm/common"
@@ -44,6 +51,17 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 	}, NodeTimeout(time.Minute))
 
 	Describe("Single-node control plane", Ordered, Label("single"), func() {
+		var (
+			portForwardCtx    context.Context
+			cancelPortForward context.CancelFunc
+			shootClientSet    kubernetes.Interface
+		)
+
+		BeforeAll(func() {
+			portForwardCtx, cancelPortForward = context.WithCancel(context.Background())
+			DeferCleanup(func() { cancelPortForward() })
+		})
+
 		It("should initialize as control plane node", func(ctx SpecContext) {
 			stdOut, _, err := execute(ctx, 0,
 				"gardenadm", "init", "-d", "/gardenadm/resources",
@@ -51,17 +69,65 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(ctx, stdOut).Should(gbytes.Say("Your Shoot cluster control-plane has initialized successfully!"))
-		}, SpecTimeout(time.Minute))
+		}, SpecTimeout(5*time.Minute))
 
-		It("should be able to communicate with the API server", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) *gbytes.Buffer {
-				_, stdErr, err := execute(ctx, 0,
-					"kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "get", "nodes",
-				)
+		It("copy admin kubeconfig and create client", func(ctx SpecContext) {
+			tempDir, err := os.MkdirTemp("", "tmp")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { Expect(os.RemoveAll(tempDir)).To(Succeed()) })
+			adminKubeconfigFile := filepath.Join(tempDir, "admin.conf")
+
+			By("Copy admin kubeconfig to local file")
+			localPort := 6443
+			Eventually(ctx, func(g Gomega) error {
+				stdOut, _, err := execute(ctx, 0, "cat", "/etc/kubernetes/admin.conf")
 				g.Expect(err).NotTo(HaveOccurred())
-				return stdErr
-			}).WithPolling(10 * time.Second).Should(gbytes.Say("No resources found"))
-		}, SpecTimeout(30*time.Second))
+
+				kubeconfig := strings.ReplaceAll(string(stdOut.Contents()), "localhost", fmt.Sprintf("localhost:%d", localPort))
+				return os.WriteFile(adminKubeconfigFile, []byte(kubeconfig), 0600)
+			}).Should(Succeed())
+
+			By("Forward port to control plane machine pod")
+			fw, err := kubernetes.SetupPortForwarder(portForwardCtx, RuntimeClient.RESTConfig(), namespace, machinePodName(0), localPort, 443)
+			Expect(err).NotTo(HaveOccurred())
+
+			go func() {
+				if err := fw.ForwardPorts(); err != nil {
+					Fail("Error forwarding ports: " + err.Error())
+				}
+			}()
+
+			Eventually(func() chan struct{} { return fw.Ready() }).Should(BeClosed())
+
+			By("Create client set")
+			Eventually(func() error {
+				shootClientSet, err = kubernetes.NewClientFromFile("", adminKubeconfigFile,
+					kubernetes.WithDisabledCachedClient(),
+					kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
+				)
+				return err
+			}).Should(Succeed())
+		})
+
+		It("should be able to communicate with the API server and see the node and the control plane pods", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) []corev1.Node {
+				nodeList := &corev1.NodeList{}
+				g.Expect(shootClientSet.Client().List(ctx, nodeList)).To(Succeed())
+				return nodeList.Items
+			}).Should(HaveLen(1))
+
+			Eventually(ctx, func(g Gomega) []corev1.Pod {
+				podList := &corev1.PodList{}
+				g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace("kube-system"))).To(Succeed())
+				return podList.Items
+			}).Should(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-events-0-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-main-0-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-apiserver-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-controller-manager-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-scheduler-machine-0")})}),
+			))
+		}, SpecTimeout(5*time.Second))
 
 		It("should join as worker node", func(ctx SpecContext) {
 			_, stdErr, err := execute(ctx, 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR is the next increment for `gardenadm init`. It bootstraps the `kubelet` and makes the `gardenadm init` invocations idempotent (under the assumption that the initial control plane deployment worked - otherwise, you have to start from scratch).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
~~Still in draft since it's based on #11701 which must be merged first.~~

/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
