### PR TITLE
Remove label `topology-spread-constraints.resources.gardener.cloud/skip` under `Remove this label in gardener v1.116.0`

### DIFF
--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -63,8 +63,6 @@ spec:
 {{ include "gardenlet.deployment.labels" . | indent 8 }}
         projected-token-mount.resources.gardener.cloud/skip: "true"
         seccompprofile.resources.gardener.cloud/skip: "true"
-        # TODO(shafeeqes): Remove this label in gardener v1.116.0
-        topology-spread-constraints.resources.gardener.cloud/skip: "true"
         networking.resources.gardener.cloud/to-all-shoots-etcd-main-client-tcp-8080: allowed
         networking.resources.gardener.cloud/to-all-shoots-kube-apiserver-tcp-443: allowed
         {{- if .Values.podLabels }}

--- a/charts/gardener/gardenlet/test/chart_test.go
+++ b/charts/gardener/gardenlet/test/chart_test.go
@@ -55,7 +55,6 @@ var (
 	expectedLabelsWithSkippedWebhooks = utils.MergeStringMaps(expectedLabels, map[string]string{
 		"projected-token-mount.resources.gardener.cloud/skip":                         "true",
 		"seccompprofile.resources.gardener.cloud/skip":                                "true",
-		"topology-spread-constraints.resources.gardener.cloud/skip":                   "true",
 		"networking.resources.gardener.cloud/to-all-shoots-etcd-main-client-tcp-8080": "allowed",
 		"networking.resources.gardener.cloud/to-all-shoots-kube-apiserver-tcp-443":    "allowed",
 	})

--- a/charts/gardener/operator/templates/deployment.yaml
+++ b/charts/gardener/operator/templates/deployment.yaml
@@ -54,8 +54,6 @@ spec:
 {{ include "operator.deployment.labels" . | indent 8 }}
         projected-token-mount.resources.gardener.cloud/skip: "true"
         seccompprofile.resources.gardener.cloud/skip: "true"
-        # TODO(shafeeqes): Remove this label in gardener v1.116.0
-        topology-spread-constraints.resources.gardener.cloud/skip: "true"
         networking.resources.gardener.cloud/to-virtual-garden-etcd-main-client-tcp-8080: allowed
         networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
         networking.resources.gardener.cloud/to-gardener-apiserver-tcp-8443: allowed

--- a/example/provider-extensions/kyverno/kyverno-deployment.yaml
+++ b/example/provider-extensions/kyverno/kyverno-deployment.yaml
@@ -10,8 +10,6 @@ spec:
       labels:
         projected-token-mount.resources.gardener.cloud/skip: "true"
         seccompprofile.resources.gardener.cloud/skip: "true"
-        # TODO(shafeeqes): Remove this label in gardener v1.116.0
-        topology-spread-constraints.resources.gardener.cloud/skip: "true"
     spec:
       # Kyverno should not be evicted for gardener pods because it needs to add the imagePullSecrets to these pods
       priorityClassName: system-cluster-critical

--- a/example/provider-extensions/registry-seed/registry/registry.yaml
+++ b/example/provider-extensions/registry-seed/registry/registry.yaml
@@ -17,8 +17,6 @@ spec:
         app: registry
         projected-token-mount.resources.gardener.cloud/skip: "true"
         seccompprofile.resources.gardener.cloud/skip: "true"
-        # TODO(shafeeqes): Remove this label in gardener v1.116.0
-        topology-spread-constraints.resources.gardener.cloud/skip: "true"
     spec:
       # Registry should not be evicted for gardener pods because these rely on Registry to pull their images
       priorityClassName: system-cluster-critical

--- a/example/provider-extensions/ssh-reverse-tunnel/base/sshd/sshd_deployment.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/sshd/sshd_deployment.yaml
@@ -16,8 +16,6 @@ spec:
         app: gardener-apiserver-tunnel-sshd
         projected-token-mount.resources.gardener.cloud/skip: "true"
         seccompprofile.resources.gardener.cloud/skip: "true"
-        # TODO(shafeeqes): Remove this label in gardener v1.116.0
-        topology-spread-constraints.resources.gardener.cloud/skip: "true"
     spec:
       # Relay should not be evicted for gardener pods because gardenlet does not work when it cannot reach the gardener-apiserver
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
This PR removes labels added in https://github.com/gardener/gardener/pull/11497/commits/6b8d4e49ab7a068f448b175eddab46a4d5b40aa4 and tagged with `# TODO(shafeeqes): Remove this label in gardener v1.116.0`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
