### PR TITLE
[release-v1.113] Automated cherry pick of #11628: Update quay.io/kiwigrid/k8s-sidecar Docker tag to v1.30.2

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -346,7 +346,7 @@ images:
 - name: plutono-dashboard-refresher
   sourceRepository: github.com/kiwigrid/k8s-sidecar
   repository: quay.io/kiwigrid/k8s-sidecar
-  tag: "1.30.0"
+  tag: "1.30.2"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind enhancement

Cherry pick of #11628 on release-v1.113.

#11628: Update quay.io/kiwigrid/k8s-sidecar Docker tag to v1.30.2

**Release Notes:**
```other dependency
The following dependencies have been updated:
- `quay.io/kiwigrid/k8s-sidecar` from `1.30.0` to `1.30.2`. 
```