### PR TITLE
Promote `NodeAgentAuthorizer` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,7 +26,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
-| NodeAgentAuthorizer                      | `false` | `Alpha` | `1.109` |         |
+| NodeAgentAuthorizer                      | `false` | `Alpha` | `1.109` | `1.115` |
+| NodeAgentAuthorizer                      | `true`  | `Beta`  | `1.116` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
 | RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` | `1.115` |

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -38,7 +38,6 @@ config:
   featureGates:
     DefaultSeccompProfile: true
     NewWorkerPoolHash: true
-    NodeAgentAuthorizer: true
     IstioTLSTermination: true
   etcdConfig:
     featureGates:

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer"
 	"github.com/gardener/gardener/pkg/extensions"
+	"github.com/gardener/gardener/pkg/features"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -453,7 +454,8 @@ var _ = Describe("OperatingSystemConfig", func() {
 		})
 
 		Describe("#Deploy", func() {
-			It("should successfully deploy the shoot access secret for the gardener-node-agent", func() {
+			It("should successfully deploy the shoot access secret for the gardener-node-agent when NodeAgentAuthorizer feature gate is disabled", func() {
+				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, false))
 				DeferCleanup(test.WithVars(
 					&OriginalConfigFn, originalConfigFn,
 				))
@@ -808,7 +810,8 @@ var _ = Describe("OperatingSystemConfig", func() {
 				}
 			})
 
-			It("should properly restore the extensions state if it exists", func() {
+			It("should properly restore the extensions state if it exists when NodeAgentAuthorizer feature gate is disabled", func() {
+				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, false))
 				defer test.WithVars(
 					&InitConfigFn, initConfigFn,
 					&OriginalConfigFn, originalConfigFn,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -109,7 +109,8 @@ WantedBy=multi-user.target`))
 	})
 
 	Describe("#ComponentConfig", func() {
-		It("should return the expected result", func() {
+		It("should return the expected result when NodeAgentAuthorizer feature gate is disabled", func() {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, false))
 			Expect(ComponentConfig(oscSecretName, kubernetesVersion, apiServerURL, caBundle, additionalTokenSyncConfigs)).To(Equal(&nodeagentconfigv1alpha1.NodeAgentConfiguration{
 				APIServer: nodeagentconfigv1alpha1.APIServer{
 					Server:   apiServerURL,
@@ -138,8 +139,7 @@ WantedBy=multi-user.target`))
 			}))
 		})
 
-		It("should return the expected result when NodeAgentAuthorizer feature gate is enabled", func() {
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, true))
+		It("should return the expected result", func() {
 			Expect(ComponentConfig(oscSecretName, kubernetesVersion, apiServerURL, caBundle, additionalTokenSyncConfigs)).To(Equal(&nodeagentconfigv1alpha1.NodeAgentConfiguration{
 				APIServer: nodeagentconfigv1alpha1.APIServer{
 					Server:   apiServerURL,
@@ -166,7 +166,8 @@ WantedBy=multi-user.target`))
 	})
 
 	Describe("#Files", func() {
-		It("should return the expected files", func() {
+		It("should return the expected files when NodeAgentAuthorizer feature gate is disabled ", func() {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, false))
 			config := ComponentConfig(oscSecretName, nil, apiServerURL, caBundle, additionalTokenSyncConfigs)
 
 			Expect(Files(config)).To(ConsistOf(extensionsv1alpha1.File{
@@ -203,8 +204,7 @@ server: {}
 			}))
 		})
 
-		It("should return the expected files when NodeAgentAuthorizer feature gate is enabled", func() {
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, true))
+		It("should return the expected files", func() {
 			config := ComponentConfig(oscSecretName, nil, apiServerURL, caBundle, additionalTokenSyncConfigs)
 
 			Expect(Files(config)).To(ConsistOf(extensionsv1alpha1.File{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac_test.go
@@ -27,8 +27,11 @@ var _ = Describe("RBAC", func() {
 			clusterRoleBindingSelfNodeClientYAML   string
 		)
 
-		BeforeEach(func() {
-			clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
+		When("NodeAgentAuthorizer feature gate is disabled", func() {
+			BeforeEach(func() {
+				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, false))
+
+				clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
@@ -58,7 +61,7 @@ rules:
   - update
 `
 
-			clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+				clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
@@ -76,7 +79,7 @@ subjects:
   name: gardener.cloud:node-agents
 `
 
-			roleYAML = `apiVersion: rbac.authorization.k8s.io/v1
+				roleYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
@@ -108,7 +111,7 @@ rules:
   - update
 `
 
-			roleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+				roleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
@@ -129,7 +132,7 @@ subjects:
   name: gardener.cloud:node-agents
 `
 
-			clusterRoleBindingNodeBootstrapperYAML = `apiVersion: rbac.authorization.k8s.io/v1
+				clusterRoleBindingNodeBootstrapperYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
@@ -144,7 +147,7 @@ subjects:
   name: system:bootstrappers
 `
 
-			clusterRoleBindingNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
+				clusterRoleBindingNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
@@ -158,7 +161,7 @@ subjects:
   kind: Group
   name: system:bootstrappers
 `
-			clusterRoleBindingSelfNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
+				clusterRoleBindingSelfNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
@@ -172,33 +175,32 @@ subjects:
   kind: Group
   name: system:nodes
 `
-		})
+			})
 
-		It("should generate the expected RBAC resources", func() {
-			dataMap, err := RBACResourcesData([]string{"osc-secret1", "osc-secret2"})
-			Expect(err).NotTo(HaveOccurred())
+			It("should generate the expected RBAC resources", func() {
+				dataMap, err := RBACResourcesData([]string{"osc-secret1", "osc-secret2"})
+				Expect(err).NotTo(HaveOccurred())
 
-			Expect(dataMap).To(HaveKey("data.yaml.br"))
-			compressedData := dataMap["data.yaml.br"]
-			data, err := test.BrotliDecompression(compressedData)
-			Expect(err).NotTo(HaveOccurred())
+				Expect(dataMap).To(HaveKey("data.yaml.br"))
+				compressedData := dataMap["data.yaml.br"]
+				data, err := test.BrotliDecompression(compressedData)
+				Expect(err).NotTo(HaveOccurred())
 
-			manifests := strings.Split(string(data), "---\n")
-			Expect(manifests).To(ConsistOf(
-				clusterRoleYAML,
-				clusterRoleBindingYAML,
-				roleYAML,
-				roleBindingYAML,
-				clusterRoleBindingNodeBootstrapperYAML,
-				clusterRoleBindingNodeClientYAML,
-				clusterRoleBindingSelfNodeClientYAML,
-			))
+				manifests := strings.Split(string(data), "---\n")
+				Expect(manifests).To(ConsistOf(
+					clusterRoleYAML,
+					clusterRoleBindingYAML,
+					roleYAML,
+					roleBindingYAML,
+					clusterRoleBindingNodeBootstrapperYAML,
+					clusterRoleBindingNodeClientYAML,
+					clusterRoleBindingSelfNodeClientYAML,
+				))
+			})
 		})
 
 		When("NodeAgentAuthorizer feature gate is enabled", func() {
 			BeforeEach(func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, true))
-
 				clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -62,6 +62,7 @@ const (
 	// Enabling this feature gate restricts the permissions of each gardener-node-agent instance to the objects belonging to its own node only.
 	// owner: @oliver-goetz
 	// alpha: v1.109.0
+	// beta: v1.116.0
 	NodeAgentAuthorizer featuregate.Feature = "NodeAgentAuthorizer"
 
 	// CredentialsRotationWithoutWorkersRollout enables starting the credentials rotation without immediately causing
@@ -127,7 +128,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ShootCredentialsBinding:                  {Default: true, PreRelease: featuregate.Beta},
 	NewWorkerPoolHash:                        {Default: false, PreRelease: featuregate.Alpha},
 	NewVPN:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	NodeAgentAuthorizer:                      {Default: false, PreRelease: featuregate.Alpha},
+	NodeAgentAuthorizer:                      {Default: true, PreRelease: featuregate.Beta},
 	CredentialsRotationWithoutWorkersRollout: {Default: false, PreRelease: featuregate.Alpha},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},
 	RemoveAPIServerProxyLegacyPort:           {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Promote `NodeAgentAuthorizer` feature gate to beta and enable it by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`NodeAgentAuthorizer` feature gate has been promoted to beta and is now enabled by default.
```
