### PR TITLE
Fix flake in nscpfl integration test.

### DIFF
--- a/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
+++ b/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
@@ -418,13 +418,15 @@ var _ = Describe("NamespacedCloudProfile controller tests", func() {
 				}).Should(Succeed())
 
 				By("Patch the NamespacedCloudProfile with an increased limit")
-				namespacedCloudProfilePatch := client.StrategicMergeFrom(namespacedCloudProfile.DeepCopy())
-				namespacedCloudProfile.Spec.Limits = &gardencorev1beta1.Limits{
-					MaxNodesTotal: ptr.To(int32(24)),
-				}
-				Eventually(func() error {
-					return testClient.Patch(ctx, namespacedCloudProfile, namespacedCloudProfilePatch)
-				}).Should(MatchError(ContainSubstring("spec.limits.maxNodesTotal: Invalid value: 24: overriding value must be less than or equal to value set in parent CloudProfile")))
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
+					namespacedCloudProfilePatch := client.StrategicMergeFrom(namespacedCloudProfile.DeepCopy())
+					namespacedCloudProfile.Spec.Limits = &gardencorev1beta1.Limits{
+						MaxNodesTotal: ptr.To(int32(24)),
+					}
+					g.Expect(testClient.Patch(ctx, namespacedCloudProfile, namespacedCloudProfilePatch)).To(MatchError(ContainSubstring(
+						"spec.limits.maxNodesTotal: Invalid value: 24: overriding value must be less than or equal to value set in parent CloudProfile")))
+				}).Should(Succeed())
 			})
 
 			It("should update the NamespacedCloudProfile status if a limit from the parent CloudProfile is increased again", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Get updated state of NamespacedCloudProfile to apply patch on, if result has not been as expected.

**Which issue(s) this PR fixes**:
Fixes #11761

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
