### PR TITLE
Revert "Promote feature gate RemoveAPIServerProxyLegacyPort to beta (#11734)"

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -30,8 +30,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | NodeAgentAuthorizer                      | `true`  | `Beta`  | `1.116` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
-| RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` | `1.115` |
-| RemoveAPIServerProxyLegacyPort           | `true`  | `Beta`  | `1.116` |         |
+| RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` |         |
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
 
 ## Feature Gates for Graduated or Deprecated Features

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -39,6 +39,7 @@ config:
     DefaultSeccompProfile: true
     NewWorkerPoolHash: true
     IstioTLSTermination: true
+    RemoveAPIServerProxyLegacyPort: true
   logging:
     enabled: true
     vali:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -87,7 +87,6 @@ const (
 	// proxy protocol headers of untrusted clients on the apiserver-proxy port.
 	// owner: @Wieneo @timebertt
 	// alpha: v1.113.0
-	// beta: v1.116.0
 	RemoveAPIServerProxyLegacyPort featuregate.Feature = "RemoveAPIServerProxyLegacyPort"
 
 	// IstioTLSTermination enables TLS termination for the Istio Ingress Gateway instead of TLS termination at the kube-apiserver.
@@ -131,7 +130,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	NodeAgentAuthorizer:                      {Default: true, PreRelease: featuregate.Beta},
 	CredentialsRotationWithoutWorkersRollout: {Default: false, PreRelease: featuregate.Alpha},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},
-	RemoveAPIServerProxyLegacyPort:           {Default: true, PreRelease: featuregate.Beta},
+	RemoveAPIServerProxyLegacyPort:           {Default: false, PreRelease: featuregate.Alpha},
 	IstioTLSTermination:                      {Default: false, PreRelease: featuregate.Alpha},
 }
 


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This reverts commit 0484ec199a4dd6799cca648d497581a6246d9f04.

Unfortunately, from SAP side  we are not ready yet to enable the `RemoveAPIServerProxyLegacyPort` feature gate by default.
On our side, we have many Shoots that still miss the `APIServerProxyUsesHTTPProxy` constraint. Hence, when the feature gate is enabled by default, gardenlet is panic'ing with: 
```
panic: the `proxy` port on the istio ingress gateway cannot be removed until all api server proxies in all shoots on this seed have been reconfigured to use the `tls-tunnel` port instead, i.e., the `RemoveAPIServerProxyLegacyPort` feature gate can only be enabled once all shoots have the `APIServerProxyUsesHTTPProxy` constraint with status `true`
```

We also considered other alternatives like disabling the feature gate but the safest one is to revert the promotion PR.

We will follow up on the issue and check if some of the conditions in https://github.com/gardener/gardener/blob/ac54a8d9e1136f71ba02f05f866eb7d8b5e27624/cmd/gardenlet/app/migration.go#L104-L126 have to be updated. So far, we discovered several different cases where the constraint was not present in a Shoot:
- Shoots failing to be reconciled due to invalid credentials since longtime
- Shoots failing to be deleted due to invalid credentials or infrastructure dependencies.


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
