### PR TITLE
Enhance Etcd Compaction Job Monitoring with Detailed Failure Reasons

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -62,7 +62,7 @@ func CentralPrometheusRules(seedIsGarden bool) []*monitoringv1.PrometheusRule {
 		},
 		{
 			Alert: "TooManyEtcdSnapshotCompactionJobsFailing",
-			Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
+			Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false", failureReason=~"processFailure|unknown"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
 			Labels: map[string]string{
 				"severity":   "warning",
 				"type":       "seed",

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -50,7 +50,7 @@ var _ = Describe("PrometheusRules", func() {
 			},
 			{
 				Alert: "TooManyEtcdSnapshotCompactionJobsFailing",
-				Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
+				Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false", failureReason=~"processFailure|unknown"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
 				Labels: map[string]string{
 					"severity":   "warning",
 					"type":       "seed",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-compaction-job-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-compaction-job-dashboard.json
@@ -131,7 +131,7 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "sum(floor(increase(etcddruid_compaction_jobs_total{succeeded=\"false\"}[${__range}])))",
+            "expr": "sum(floor(increase(etcddruid_compaction_jobs_total{succeeded=\"false\", failureReason=~\"processFailure|unknown\"}[${__range}])))",
             "instant": true,
             "interval": "",
             "legendFormat": "",
@@ -139,6 +139,128 @@
           }
         ],
         "title": "Failed Jobs",
+        "type": "stat"
+      },
+      {
+        "datasource": null,
+        "description": "Number of compaction jobs that have exceeded their deadline before finishing up.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 23763572001,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.5.22",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum(floor(increase(etcddruid_compaction_jobs_total{succeeded=\"false\", failureReason=\"deadlineExceeded\"}[${__range}])))",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Deadline Exceeded Jobs",
+        "type": "stat"
+      },
+      {
+        "datasource": null,
+        "description": "Number of compaction jobs initiated by compaction controller that have been disrupted in the form of either preemptions or evictions in the selected time range.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 23763571999,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.5.22",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum(floor(increase(etcddruid_compaction_jobs_total{succeeded=\"false\", failureReason=~\"preempted|evicted\"}[${__range}])))",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Disrupted Jobs",
         "type": "stat"
       },
       {
@@ -386,7 +508,7 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "sum(rate(etcddruid_compaction_job_duration_seconds_bucket{succeeded=\"true\"}[$__rate_interval])) by (le)",
+            "expr": "sum(rate(etcddruid_compaction_job_duration_seconds_bucket{succeeded=\"true\", failureReason=\"none\"}[$__rate_interval])) by (le)",
             "format": "heatmap",
             "interval": "",
             "legendFormat": "{{le}}",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR adds two new plutono dashboard panes for the Etcd Compaction Job monitoring. Those are titled `Deadline Exceeded Jobs` & `Disrupted Jobs`. These two, as the name suggests, tells us in more detail about the reason for the compaction job failure.

The [druid PR#1039](https://github.com/gardener/etcd-druid/pull/1039) introduced a new prometheus label alongside the existing `succeeded` label, named `failureReason` which can take values such as : 

* `preempted` indicates that the compaction pod has been preempted by the scheduler.
* `evicted` indicates that the compaction Pod has been evicted due to various eviction reasons outlined in [druid-issue#1037](https://github.com/gardener/etcd-druid/issues/1037)
* `deadlineExceeded` indicates that compaction could not finish before the `activeDeadlineSeconds` of the job.
* `processFailure` indicates that the compaction process has failed.
* `unknown` indicates that the failure reason is not known.
* `none` this is used when combined with the {label, value} pair `succeeded`:`true`.

This PR also consequently adapts the existing `Failed Jobs` board & the alert `TooManyEtcdSnapshotCompactionJobsFailing` that we have set for alerting when too many control-plane namespaces have compaction jobs failing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Earlier, the Job was considered `Failed` even when it was due to pod getting disrupted or deadline exceeding, and was queried using the label:value pair `{succeeded="false"}`. But now that we have introduced the extra label to identify the reason for failure, we now consider the Job as `Failed` only when it is because of process failure or un-identified reason. And for that reason, we now use `{succeeded="false", failureReason=~"processFailure|unknown"}` label:value pair to query the failed jobs. This is reflected in both the `Failed Jobs` board & `TooManyEtcdSnapshotCompactionJobsFailing` alert.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add new monitoring dashboard panes for Etcd Compaction Job with detailed failure reasons and updated existing alerts and boards.
```
