### PR TITLE
🧹 Cleanup a few `TODO`s

### DIFF
--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	goruntime "runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -19,11 +18,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"go.uber.org/automaxprocs/maxprocs"
-	"golang.org/x/exp/maps"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +33,6 @@ import (
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/api/indexer"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
@@ -45,7 +41,6 @@ import (
 	"github.com/gardener/gardener/pkg/features"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // Name is a const for the name of this component.
@@ -157,106 +152,62 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 		return fmt.Errorf("failed adding controllers to manager: %w", err)
 	}
 
-	// TODO(rfranzke): Remove this after Gardener v1.114 has been released and add code that cleans up all legacy
-	//  `seed.gardener.cloud/<name>=true` labels from these objects.
+	// TODO(rfranzke): Remove this runnable after Gardener v1.119 has been released.
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		var fns []flow.TaskFn
 
-		prepareEmptyPatchTasks := func(list client.ObjectList, seedNamesFromObject func(obj client.Object) ([]*string, error)) error {
+		seedList := &gardencorev1beta1.SeedList{}
+		if err := mgr.GetClient().List(ctx, seedList); err != nil {
+			return fmt.Errorf("failed listing seeds: %w", err)
+		}
+
+		seedNames := sets.New[string]()
+		for _, seed := range seedList.Items {
+			seedNames.Insert(seed.Name)
+		}
+
+		for _, list := range []client.ObjectList{
+			&gardencorev1beta1.BackupEntryList{},
+			&gardencorev1beta1.ShootList{},
+			&gardencorev1beta1.SeedList{},
+			&seedmanagementv1alpha1.ManagedSeedList{},
+		} {
 			if err := mgr.GetClient().List(ctx, list); err != nil {
 				return fmt.Errorf("failed listing objects: %w", err)
 			}
 
-			return meta.EachListItem(list, func(o runtime.Object) error {
+			if err := meta.EachListItem(list, func(o runtime.Object) error {
 				fns = append(fns, func(ctx context.Context) error {
 					obj := o.(client.Object)
-
-					if slices.ContainsFunc(maps.Keys(obj.GetLabels()), func(s string) bool {
-						return strings.HasPrefix(s, v1beta1constants.LabelPrefixSeedName)
-					}) {
-						return nil
-					}
 
 					gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
 					if err != nil {
 						return fmt.Errorf("could not get GroupVersionKind from object %v: %w", obj, err)
 					}
 
-					mgr.GetLogger().Info("Adding new seed name labels", "gvk", gvk, "objectKey", client.ObjectKeyFromObject(obj))
-
-					seedNames, err := seedNamesFromObject(obj)
-					if err != nil {
-						return err
-					}
+					mgr.GetLogger().Info("Removing legacy seed name labels", "gvk", gvk, "objectKey", client.ObjectKeyFromObject(obj))
 
 					patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
-					gardenerutils.MaintainSeedNameLabels(obj, seedNames...)
+
+					labels := obj.GetLabels()
+					for k, v := range labels {
+						if strings.HasPrefix(k, "seed.gardener.cloud/") && v == "true" && seedNames.Has(strings.TrimPrefix(k, "seed.gardener.cloud/")) {
+							delete(labels, k)
+						}
+					}
+					obj.SetLabels(labels)
+
 					return mgr.GetClient().Patch(ctx, obj, patch)
 				})
 				return nil
-			})
-		}
-
-		if err := prepareEmptyPatchTasks(&gardencorev1beta1.BackupEntryList{}, func(obj client.Object) ([]*string, error) {
-			backupEntry := obj.(*gardencorev1beta1.BackupEntry)
-			return []*string{backupEntry.Spec.SeedName, backupEntry.Status.SeedName}, nil
-		}); err != nil {
-			return fmt.Errorf("failed computing tasks for backup entries: %w", err)
-		}
-
-		if err := prepareEmptyPatchTasks(&gardencorev1beta1.ShootList{}, func(obj client.Object) ([]*string, error) {
-			shoot := obj.(*gardencorev1beta1.Shoot)
-			return []*string{shoot.Spec.SeedName, shoot.Status.SeedName}, nil
-		}); err != nil {
-			return fmt.Errorf("failed computing tasks for shoots: %w", err)
-		}
-
-		if err := prepareEmptyPatchTasks(&gardencorev1beta1.SeedList{}, func(obj client.Object) ([]*string, error) {
-			seed := obj.(*gardencorev1beta1.Seed)
-
-			seedNames := []*string{&seed.Name}
-
-			managedSeed := &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: seed.Name, Namespace: v1beta1constants.GardenNamespace}}
-			if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return nil, fmt.Errorf("failed to get managed seed %q: %v", seed.Name, err)
-				}
-			} else if managedSeed.Spec.Shoot != nil {
-				shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: managedSeed.Spec.Shoot.Name, Namespace: managedSeed.Namespace}}
-				if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
-					return nil, fmt.Errorf("failed to get shoot %s for managed seed %q: %v", managedSeed.Spec.Shoot.Name, managedSeed.Name, err)
-				}
-				seedNames = append(seedNames, shoot.Spec.SeedName)
+			}); err != nil {
+				return fmt.Errorf("failed preparing removal tasks for %T: %w", list, err)
 			}
-
-			return seedNames, nil
-		}); err != nil {
-			return fmt.Errorf("failed computing tasks for seeds: %w", err)
-		}
-
-		if err := prepareEmptyPatchTasks(&seedmanagementv1alpha1.ManagedSeedList{}, func(obj client.Object) ([]*string, error) {
-			managedSeed := obj.(*seedmanagementv1alpha1.ManagedSeed)
-
-			if managedSeed.Spec.Shoot == nil {
-				return nil, nil
-			}
-
-			shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: managedSeed.Spec.Shoot.Name, Namespace: managedSeed.Namespace}}
-			if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
-				if apierrors.IsNotFound(err) {
-					return nil, nil
-				}
-				return nil, err
-			}
-
-			return []*string{shoot.Spec.SeedName}, nil
-		}); err != nil {
-			return fmt.Errorf("failed computing tasks for managed seeds: %w", err)
 		}
 
 		return flow.Parallel(fns...)(ctx)
 	})); err != nil {
-		return fmt.Errorf("failed adding seed name label migration runnable to manager: %w", err)
+		return fmt.Errorf("failed adding seed name label removal runnable to manager: %w", err)
 	}
 
 	log.Info("Starting manager")

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -241,10 +241,9 @@ func (g *garden) Start(ctx context.Context) error {
 				&gardencorev1beta1.ControllerInstallation{}: {
 					Field: fields.SelectorFromSet(fields.Set{gardencore.SeedRefName: g.config.SeedConfig.Name}),
 				},
-				// TODO(rfranzke): Enable the label selector for Seeds after Gardener v1.114 has been released.
-				// &gardencorev1beta1.Seed{}: {
-				// 	Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.Name: "true"}),
-				// },
+				&gardencorev1beta1.Seed{}: {
+					Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.Name: "true"}),
+				},
 				&gardencorev1beta1.Shoot{}: {
 					Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.Name: "true"}),
 				},
@@ -258,10 +257,9 @@ func (g *garden) Start(ctx context.Context) error {
 				&corev1.ServiceAccount{}: {
 					Namespaces: map[string]cache.Config{seedNamespace: {}},
 				},
-				// TODO(rfranzke): Enable the label selector for Seeds after Gardener v1.113 has been released.
-				// &seedmanagementv1alpha1.ManagedSeed{}: {
-				// 	Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.Name: "true"}),
-				// },
+				&seedmanagementv1alpha1.ManagedSeed{}: {
+					Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.Name: "true"}),
+				},
 				&seedmanagementv1alpha1.Gardenlet{}: {
 					Field:      fields.SelectorFromSet(fields.Set{metav1.ObjectNameField: g.config.SeedConfig.Name}),
 					Namespaces: map[string]cache.Config{v1beta1constants.GardenNamespace: {}},

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -273,13 +273,9 @@ func (r *reconciler) migrate(
 }
 
 func (r *reconciler) reconcileOSCResultSecret(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, userData []byte) (*corev1.Secret, error) {
-	// For backwards-compatibility, we have to always create a secret since gardenlet expects to find it - even if the
-	// user data is nil/empty (which should always be the case when purpose=reconcile).
-	// https://github.com/gardener/gardener/blob/328e10d975c7b6caa5db139badcc42ac8f772d31/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go#L257-L259
-	// TODO(rfranzke): Activate the `if`-block after Gardener v1.112 has been released.
-	// if userData == nil {
-	// 	return nil, nil
-	// }
+	if userData == nil {
+		return nil, nil
+	}
 
 	secret := &corev1.Secret{ObjectMeta: SecretObjectMetaForConfig(osc)}
 	if _, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, r.client, secret, func() error {

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -104,7 +104,7 @@ func AddToManager(
 	if err := (&managedseed.Reconciler{
 		Config:         *cfg,
 		ShootClientMap: shootClientMap,
-	}).AddToManager(ctx, mgr, gardenCluster, seedCluster); err != nil {
+	}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 		return fmt.Errorf("failed adding ManagedSeed controller: %w", err)
 	}
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -579,19 +579,6 @@ deploy:
               - apply
               - -f
               - example/gardener-local/controlplane/service-account-issuer-secret.yaml
-        # This is to make the upgrade tests work after the API of `ControllerDeployment` was augmented as part of
-        # https://github.com/gardener/gardener/pull/11593#issuecomment-2701622011.
-        # See https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11593/pull-gardener-e2e-kind-upgrade/1897328254847553536#1:build-log.txt%3A1491.
-        # TODO(rfranzke): Remove this after Gardener v1.114 has been released.
-        - host:
-            command:
-              - bash
-              - -ec
-              - |
-                until kubectl explain controllerdeployments.core.gardener.cloud | grep -q "injectGardenKubeconfig"; do
-                  echo "Waiting for API server to serve upgraded API..."
-                  sleep 0.5
-                done
 profiles:
   - name: extensions
     patches:

--- a/test/integration/gardenlet/managedseed/managedseed_suite_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_suite_test.go
@@ -225,7 +225,7 @@ var _ = BeforeSuite(func() {
 		GardenNamespaceGarden: gardenNamespaceGarden.Name,
 		GardenNamespaceShoot:  gardenNamespaceShoot,
 		ShootClientMap:        shootClientMap,
-	}).AddToManager(ctx, mgr, mgr, mgr)).To(Succeed())
+	}).AddToManager(mgr, mgr, mgr)).To(Succeed())
 
 	By("Start manager")
 	mgrContext, mgrCancel := context.WithCancel(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
- Cleanup migration logic for e2e upgrade tests (from #11593, released with `v1.115.0`)
- Filter {Managed}Seeds in gardenlet on manager.Manager level (from #11479, released with `v1.114.0`)
- No longer generate empy Secret for reconcile OSC (from #11004, released with `v1.111.0`)

**Special notes for your reviewer**:
NONE

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
