### PR TITLE
local setup: Update registry image to 3.0.0

### DIFF
--- a/example/gardener-local/registry/base/registry.yaml
+++ b/example/gardener-local/registry/base/registry.yaml
@@ -12,7 +12,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.4
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: registry

--- a/example/gardener-local/registry/base/registry.yaml
+++ b/example/gardener-local/registry/base/registry.yaml
@@ -12,7 +12,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:2.8.3
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.4
         imagePullPolicy: IfNotPresent
         ports:
         - name: registry

--- a/example/gardener-local/registry/base/registry.yaml
+++ b/example/gardener-local/registry/base/registry.yaml
@@ -20,11 +20,15 @@ spec:
         env:
         - name: REGISTRY_HTTP_ADDR
           value: :5001
+        - name: OTEL_TRACES_EXPORTER
+          value: none
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
         - name: cache
           mountPath: /var/lib/registry
+        - name: config
+          mountPath: /etc/distribution
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
@@ -38,3 +42,6 @@ spec:
         hostPath:
           path: /etc/gardener/local-registry
           type: DirectoryOrCreate
+      - name: config
+        configMap:
+          name: registry-config

--- a/example/gardener-local/registry/configmap.yaml
+++ b/example/gardener-local/registry/configmap.yaml
@@ -4,6 +4,8 @@ metadata:
   name: registry-config
 data:
   config.yml: |
+    # Keep this config in sync with the default config (/etc/distribution/config.yml) from the registry image (europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0) with the following modifications:
+    # - Disable the debug endpoint (http.debug)
     version: 0.1
     log:
       fields:

--- a/example/gardener-local/registry/europe-docker-pkg-dev/kustomization.yaml
+++ b/example/gardener-local/registry/europe-docker-pkg-dev/kustomization.yaml
@@ -17,6 +17,8 @@ patches:
             value: https://europe-docker.pkg.dev
           - name: REGISTRY_HTTP_ADDR
             value: :5008
+          - name: OTEL_TRACES_EXPORTER
+            value: none
       - op: replace
         path: /spec/template/spec/containers/0/ports/0/containerPort
         value: 5008

--- a/example/gardener-local/registry/gcr/kustomization.yaml
+++ b/example/gardener-local/registry/gcr/kustomization.yaml
@@ -17,6 +17,8 @@ patches:
         value: https://gcr.io
       - name: REGISTRY_HTTP_ADDR
         value: :5003
+      - name: OTEL_TRACES_EXPORTER
+        value: none
     - op: replace
       path: /spec/template/spec/containers/0/ports/0/containerPort
       value: 5003

--- a/example/gardener-local/registry/k8s/kustomization.yaml
+++ b/example/gardener-local/registry/k8s/kustomization.yaml
@@ -17,6 +17,8 @@ patches:
         value: https://registry.k8s.io
       - name: REGISTRY_HTTP_ADDR
         value: :5006
+      - name: OTEL_TRACES_EXPORTER
+        value: none
     - op: replace
       path: /spec/template/spec/containers/0/ports/0/containerPort
       value: 5006

--- a/example/gardener-local/registry/kustomization.yaml
+++ b/example/gardener-local/registry/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: registry
 
 resources:
 - namespace.yaml
-- registry-cache-config.yaml
+- configmap.yaml
 - gcr
 - k8s
 - localhost

--- a/example/gardener-local/registry/kustomization.yaml
+++ b/example/gardener-local/registry/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: registry
 
 resources:
 - namespace.yaml
+- registry-cache-config.yaml
 - gcr
 - k8s
 - localhost

--- a/example/gardener-local/registry/quay/kustomization.yaml
+++ b/example/gardener-local/registry/quay/kustomization.yaml
@@ -17,6 +17,8 @@ patches:
         value: https://quay.io
       - name: REGISTRY_HTTP_ADDR
         value: :5007
+      - name: OTEL_TRACES_EXPORTER
+        value: none
     - op: replace
       path: /spec/template/spec/containers/0/ports/0/containerPort
       value: 5007

--- a/example/gardener-local/registry/registry-cache-config.yaml
+++ b/example/gardener-local/registry/registry-cache-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-config
+  namespace: registry
+data:
+  config.yml: |
+    version: 0.1
+    log:
+      fields:
+        service: registry
+    storage:
+      delete:
+        enabled: true
+      filesystem:
+        rootdirectory: /var/lib/registry
+      tag:
+        concurrencylimit: 5
+    http:
+      addr: :5000
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3

--- a/example/gardener-local/registry/registry-cache-config.yaml
+++ b/example/gardener-local/registry/registry-cache-config.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: registry-config
-  namespace: registry
 data:
   config.yml: |
     version: 0.1

--- a/example/provider-extensions/registry-seed/deploy-registry.sh
+++ b/example/provider-extensions/registry-seed/deploy-registry.sh
@@ -107,9 +107,9 @@ stringData:
       ctr snapshot rm seed-registry-cache
     fi
     echo "Pulling registry-cache image"
-    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.2
+    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.4
     echo "Starting registry-cache"
-    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.2 seed-registry-cache
+    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.4 seed-registry-cache
   stop-seed-registry-cache.sh: |
     #!/usr/bin/env bash
     echo "stopping seed-registry-cache"

--- a/example/provider-extensions/registry-seed/deploy-registry.sh
+++ b/example/provider-extensions/registry-seed/deploy-registry.sh
@@ -107,9 +107,9 @@ stringData:
       ctr snapshot rm seed-registry-cache
     fi
     echo "Pulling registry-cache image"
-    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.4
+    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0
     echo "Starting registry-cache"
-    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.4 seed-registry-cache
+    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0 seed-registry-cache
   stop-seed-registry-cache.sh: |
     #!/usr/bin/env bash
     echo "stopping seed-registry-cache"

--- a/example/provider-extensions/registry-seed/registry/registry.yaml
+++ b/example/provider-extensions/registry-seed/registry/registry.yaml
@@ -23,7 +23,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.2
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.4
         imagePullPolicy: IfNotPresent
         env:
         - name: REGISTRY_HTTP_TLS_CERTIFICATE

--- a/example/provider-extensions/registry-seed/registry/registry.yaml
+++ b/example/provider-extensions/registry-seed/registry/registry.yaml
@@ -23,7 +23,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0-rc.4
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0
         imagePullPolicy: IfNotPresent
         env:
         - name: REGISTRY_HTTP_TLS_CERTIFICATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Update to the new [distribution/distribution@v3.0.0](https://github.com/distribution/distribution/releases/tag/v3.0.0) release.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/386

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The images of the registry caches used in the local setups are now updated to [distribution/distribution@v3.0.0](https://github.com/distribution/distribution/releases/tag/v3.0.0).
```
