### PR TITLE
[resource-manager] Prevent infinite `NetworkPolicy` controller failures when the computed pod label selector has keys exceeding 63 characters

### DIFF
--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -38,6 +38,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 	if r.TargetClient == nil {
 		r.TargetClient = targetCluster.GetClient()
 	}
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor(ControllerName + "-controller")
+	}
 
 	for _, n := range r.Config.NamespaceSelectors {
 		namespaceSelector := n

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -354,7 +354,7 @@ func (r *Reconciler) reconcilePolicy(
 	}, controllerutils.SkipEmptyPatch{})
 
 	if mutated {
-		log.Info("Usual pod label selector contained at least one key exceeding 63 characters - it had to be mutated", "usualPodLabelSelector", podLabelSelector, "mutatedPodLabelSelector", effectivePodLabelSelector)
+		log.V(2).Info("Usual pod label selector contained at least one key exceeding 63 characters - it had to be mutated", "usualPodLabelSelector", podLabelSelector, "mutatedPodLabelSelector", effectivePodLabelSelector)
 		r.Recorder.Eventf(service, corev1.EventTypeWarning, "PodLabelSelectorKey(s)TooLong", "Usual pod label selector has at least one key exceeding 63 characters and had to be mutated - consider shortening the namespace name or the service name (%+v was mutated to %+v)", podLabelSelector, effectivePodLabelSelector)
 	}
 

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -11,12 +11,14 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -25,6 +27,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -35,6 +38,7 @@ var fromPolicyRegexp = regexp.MustCompile(resourcesv1alpha1.NetworkPolicyFromPol
 type Reconciler struct {
 	TargetClient client.Client
 	Config       resourcemanagerconfigv1alpha1.NetworkPolicyControllerConfig
+	Recorder     record.EventRecorder
 
 	selectors []labels.Selector
 }
@@ -81,7 +85,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	reconcileTaskFns, desiredObjectMetaKeys, err := r.reconcileDesiredPolicies(ctx, service, namespaceNames)
+	reconcileTaskFns, desiredObjectMetaKeys, err := r.reconcileDesiredPolicies(ctx, log, service, namespaceNames)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -153,7 +157,7 @@ func (r *Reconciler) fetchRelevantNamespaceNames(ctx context.Context, service *c
 	return namespaceNames, nil
 }
 
-func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, service *corev1.Service, namespaceNames sets.Set[string]) ([]flow.TaskFn, []string, error) {
+func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logger, service *corev1.Service, namespaceNames sets.Set[string]) ([]flow.TaskFn, []string, error) {
 	var (
 		taskFns               []flow.TaskFn
 		desiredObjectMetaKeys []string
@@ -168,7 +172,7 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, service *core
 		) {
 			for _, fns := range []struct {
 				objectMetaFunc func(string, string, string) metav1.ObjectMeta
-				reconcileFunc  func(context.Context, *corev1.Service, networkingv1.NetworkPolicyPort, metav1.ObjectMeta, string, metav1.LabelSelector) error
+				reconcileFunc  func(context.Context, logr.Logger, *corev1.Service, networkingv1.NetworkPolicyPort, metav1.ObjectMeta, string, metav1.LabelSelector) error
 			}{
 				{objectMetaFunc: ingressObjectMetaFunc, reconcileFunc: r.reconcileIngressPolicy},
 				{objectMetaFunc: egressObjectMetaFunc, reconcileFunc: r.reconcileEgressPolicy},
@@ -178,7 +182,7 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, service *core
 				desiredObjectMetaKeys = append(desiredObjectMetaKeys, key(objectMeta))
 
 				taskFns = append(taskFns, func(ctx context.Context) error {
-					return reconcileFn(ctx, service, port, objectMeta, namespaceName, podLabelSelector)
+					return reconcileFn(ctx, log, service, port, objectMeta, namespaceName, podLabelSelector)
 				})
 			}
 		}
@@ -277,13 +281,14 @@ func (r *Reconciler) deleteStalePolicies(networkPolicyList *metav1.PartialObject
 
 func (r *Reconciler) reconcileIngressPolicy(
 	ctx context.Context,
+	log logr.Logger,
 	service *corev1.Service,
 	port networkingv1.NetworkPolicyPort,
 	networkPolicyObjectMeta metav1.ObjectMeta,
 	namespaceName string,
 	podLabelSelector metav1.LabelSelector,
 ) error {
-	return r.reconcilePolicy(ctx, service, networkPolicyObjectMeta, podLabelSelector, func(networkPolicy *networkingv1.NetworkPolicy, podLabelSelector metav1.LabelSelector) {
+	return r.reconcilePolicy(ctx, log, service, networkPolicyObjectMeta, podLabelSelector, func(networkPolicy *networkingv1.NetworkPolicy, podLabelSelector metav1.LabelSelector) {
 		metav1.SetMetaDataAnnotation(&networkPolicy.ObjectMeta, v1beta1constants.GardenerDescription, fmt.Sprintf("Allows "+
 			"ingress %s traffic to port %s for pods selected by the %s service selector from pods running in namespace %s labeled "+
 			"with %s.", *port.Protocol, port.Port.String(), client.ObjectKeyFromObject(service), namespaceName, podLabelSelector))
@@ -303,13 +308,14 @@ func (r *Reconciler) reconcileIngressPolicy(
 
 func (r *Reconciler) reconcileEgressPolicy(
 	ctx context.Context,
+	log logr.Logger,
 	service *corev1.Service,
 	port networkingv1.NetworkPolicyPort,
 	networkPolicyObjectMeta metav1.ObjectMeta,
 	namespaceName string,
 	podLabelSelector metav1.LabelSelector,
 ) error {
-	return r.reconcilePolicy(ctx, service, networkPolicyObjectMeta, podLabelSelector, func(networkPolicy *networkingv1.NetworkPolicy, podLabelSelector metav1.LabelSelector) {
+	return r.reconcilePolicy(ctx, log, service, networkPolicyObjectMeta, podLabelSelector, func(networkPolicy *networkingv1.NetworkPolicy, podLabelSelector metav1.LabelSelector) {
 		metav1.SetMetaDataAnnotation(&networkPolicy.ObjectMeta, v1beta1constants.GardenerDescription, fmt.Sprintf("Allows "+
 			"egress %s traffic to port %s from pods running in namespace %s labeled with %s to pods selected by the %s service "+
 			"selector.", *port.Protocol, port.Port.String(), namespaceName, podLabelSelector, client.ObjectKeyFromObject(service)))
@@ -329,6 +335,7 @@ func (r *Reconciler) reconcileEgressPolicy(
 
 func (r *Reconciler) reconcilePolicy(
 	ctx context.Context,
+	log logr.Logger,
 	service *corev1.Service,
 	networkPolicyObjectMeta metav1.ObjectMeta,
 	podLabelSelector metav1.LabelSelector,
@@ -336,13 +343,20 @@ func (r *Reconciler) reconcilePolicy(
 ) error {
 	networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: networkPolicyObjectMeta}
 
+	effectivePodLabelSelector, mutated := shortenPodSelectorKeysIfTooLong(podLabelSelector)
+
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.TargetClient, networkPolicy, func() error {
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceName, service.Name)
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceNamespace, service.Namespace)
 
-		mutate(networkPolicy, podLabelSelector)
+		mutate(networkPolicy, effectivePodLabelSelector)
 		return nil
 	}, controllerutils.SkipEmptyPatch{})
+
+	if mutated {
+		log.Info("Usual pod label selector contained at least one key exceeding 63 characters - it had to be mutated", "usualPodLabelSelector", podLabelSelector, "mutatedPodLabelSelector", effectivePodLabelSelector)
+		r.Recorder.Eventf(service, corev1.EventTypeWarning, "PodLabelSelectorKey(s)TooLong", "Usual pod label selector has at least one key exceeding 63 characters and had to be mutated - consider shortening the namespace name or the service name (%+v was mutated to %+v)", podLabelSelector, effectivePodLabelSelector)
+	}
 
 	return err
 }
@@ -439,6 +453,8 @@ func policyIDFor(serviceName string, port networkingv1.NetworkPolicyPort) string
 	return fmt.Sprintf("%s-%s-%s", serviceName, strings.ToLower(string(*port.Protocol)), port.Port.String())
 }
 
+const labelSelectorKeyPrefix = "networking.resources.gardener.cloud/"
+
 func matchLabelsForServiceAndNamespace(podLabelSelector string, service *corev1.Service, namespaceName string) map[string]string {
 	var infix string
 
@@ -452,7 +468,28 @@ func matchLabelsForServiceAndNamespace(podLabelSelector string, service *corev1.
 		infix += "-"
 	}
 
-	return map[string]string{"networking.resources.gardener.cloud/to-" + infix + podLabelSelector: v1beta1constants.LabelNetworkPolicyAllowed}
+	return map[string]string{labelSelectorKeyPrefix + "to-" + infix + podLabelSelector: v1beta1constants.LabelNetworkPolicyAllowed}
+}
+
+func shortenPodSelectorKeysIfTooLong(podLabelSelector metav1.LabelSelector) (metav1.LabelSelector, bool) {
+	var (
+		maxLabelKeyLength       = 63
+		mutatedPodLabelSelector = podLabelSelector.DeepCopy()
+		mutated                 bool
+	)
+
+	// We only use matchLabels for the pod selector in this reconciler, so we can ignore match expressions.
+	for k, v := range podLabelSelector.MatchLabels {
+		// The values for the selectors are always "allowed", so we only need to check the keys.
+		if keyWithoutPrefix := strings.TrimPrefix(k, labelSelectorKeyPrefix); len(keyWithoutPrefix) > maxLabelKeyLength {
+			newKey := labelSelectorKeyPrefix + keyWithoutPrefix[:maxLabelKeyLength-6] + "-" + utils.ComputeSHA256Hex([]byte(keyWithoutPrefix))[:5]
+			mutatedPodLabelSelector.MatchLabels[newKey] = v
+			delete(mutatedPodLabelSelector.MatchLabels, k)
+			mutated = true
+		}
+	}
+
+	return *mutatedPodLabelSelector, mutated
 }
 
 func ingressPolicyObjectMetaFor(policyID, serviceNamespace, namespaceName string) metav1.ObjectMeta {

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -354,7 +354,7 @@ func (r *Reconciler) reconcilePolicy(
 	}, controllerutils.SkipEmptyPatch{})
 
 	if mutated {
-		log.V(2).Info("Usual pod label selector contained at least one key exceeding 63 characters - it had to be mutated", "usualPodLabelSelector", podLabelSelector, "mutatedPodLabelSelector", effectivePodLabelSelector)
+		log.V(1).Info("Usual pod label selector contained at least one key exceeding 63 characters - it had to be mutated", "usualPodLabelSelector", podLabelSelector, "mutatedPodLabelSelector", effectivePodLabelSelector)
 		r.Recorder.Eventf(service, corev1.EventTypeWarning, "PodLabelSelectorKey(s)TooLong", "Usual pod label selector has at least one key exceeding 63 characters and had to be mutated - consider shortening the namespace name or the service name (%+v was mutated to %+v)", podLabelSelector, effectivePodLabelSelector)
 	}
 

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -200,6 +200,13 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, service *core
 		}
 	)
 
+	// If the namespace of the Service is terminating, we don't want to create or maintain any policies. The Service
+	// itself is expected to disappear soon (namespace controller cleans up all resources on namespace deletion), so
+	// whatever we would do here will become obsolete very soon.
+	if !namespaceNames.Has(service.Namespace) {
+		return nil, nil, nil
+	}
+
 	for _, p := range service.Spec.Ports {
 		port := p
 		addTasksForRelevantNamespacesAndPort(networkingv1.NetworkPolicyPort{Protocol: &port.Protocol, Port: &port.TargetPort}, "")

--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
@@ -441,7 +441,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				}).Should(Succeed())
 
 				By("Ensure controller prints information about mutated pod label selector")
-				Eventually(func() string { return logBuffer.String() }).Should(ContainSubstring("Usual pod label selector contained at least one key exceeding 63 characters - it had to be mutated"))
+				Eventually(func() string { return logBuffer.String() }).Should(ContainSubstring("Usual pod label selector has at least one key exceeding 63 characters and had to be mutated"))
 			})
 		})
 	})

--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
@@ -441,7 +441,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				}).Should(Succeed())
 
 				By("Ensure controller prints information about mutated pod label selector")
-				Eventually(func() string { return logBuffer.String() }).Should(ContainSubstring("Usual pod label selector has at least one key exceeding 63 characters and had to be mutated"))
+				Eventually(func() string { return logBuffer.String() }).Should(ContainSubstring("Usual pod label selector contained at least one key exceeding 63 characters - it had to be mutated"))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Currently, there are two problems in the `NetworkPolicy` controller part of `gardener-resource-manager`:

1. In some situations, it tries to create `NetworkPolicy`s in terminating namespaces (addressed in first 3 commits).

   This leads to logs like this:
 
   ```
   {"level":"error","ts":"2025-03-31T15:56:47.462+0200","msg":"Reconciler error","controller":"networkpolicy","namespace":"test-ns-fdc05dc4ce36d8de","name":"service-whh6r","reconcileID":"24513f80-2491-4c43-ba2b-117f8c12c549","error":"3 errors occurred:\n\t* networkpolicies.networking.k8s.io \"ingress-to-service-whh6r-tcp-5678-from-other-ns-fdc05dc4ce36d8de\" is forbidden: unable to create new content in namespace test-ns-fdc05dc4ce36d8de because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-service-whh6r-tcp-6367-from-other-ns-fdc05dc4ce36d8de\" is forbidden: unable to create new content in namespace test-ns-fdc05dc4ce36d8de because it is being terminated\n\t* networkpolicies.networking.k8s.io \"ingress-to-service-whh6r-udp-testport-from-other-ns-fdc05dc4ce36d8de\" is forbidden: unable to create new content in namespace test-ns-fdc05dc4ce36d8de because it is being terminated\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}
   ```
 
   With #11605, this was partly addressed already, but I missed this case.

2. When the computed pod label selector key exceeds 63 characters, the controller fails trying to create them infinitely which can result in high CPU load in large clusters (addressed in last 3 commits).

   ```
   {"level":"error","ts":"2025-04-01T10:23:14.556+0200","msg":"Reconciler error","controller":"networkpolicy","namespace":"test-ns-fe0ab023ca410780","name":"this-is-a-very-long-port-name-which-will-exceed-max-length","reconcileID":"034aec52-5ffc-4a99-8ba9-6b0860265a78","error":"2 errors occurred:\n\t* NetworkPolicy.networking.k8s.io \"ingress-to-this-is-a-very-long-port-name-which-will-exceed-max-length-tcp-5678\" is invalid: spec.ingress[0].from[0].podSelector.matchLabels: Invalid value: \"networking.resources.gardener.cloud/to-this-is-a-very-long-port-name-which-will-exceed-max-length-tcp-5678\": name part must be no more than 63 characters\n\t* NetworkPolicy.networking.k8s.io \"egress-to-this-is-a-very-long-port-name-which-will-exceed-max-length-tcp-5678\" is invalid: spec.podSelector.matchLabels: Invalid value: \"networking.resources.gardener.cloud/to-this-is-a-very-long-port-name-which-will-exceed-max-length-tcp-5678\": name part must be no more than 63 characters\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}
   {"level":"error","ts":"2025-04-01T10:23:14.559+0200","msg":"Reconciler error","controller":"networkpolicy","namespace":"test-ns-fe0ab023ca410780","name":"this-is-a-very-long-port-name-which-will-exceed-max-length","reconcileID":"94d14fe2-e5eb-4a13-b893-0bf4b1bc259e","error":"2 errors occurred:\n\t* NetworkPolicy.networking.k8s.io \"ingress-to-this-is-a-very-long-port-name-which-will-exceed-max-length-tcp-5678\" is invalid: spec.ingress[0].from[0].podSelector.matchLabels: Invalid value: \"networking.resources.gardener.cloud/to-this-is-a-very-long-port-name-which-will-exceed-max-length-tcp-5678\": name part must be no more than 63 characters\n\t* NetworkPolicy.networking.k8s.io \"egress-to-this-is-a-very-long-port-name-which-will-exceed-max-length-tcp-5678\" is invalid: spec.podSelector.matchLabels: Invalid value: \"networking.resources.gardener.cloud/to-this-is-a-very-long-port-name-which-will-exceed-max-length-tcp-5678\": name part must be no more than 63 characters\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}
   ```
   Now, it computes a checksum out of the original key, and shortens it such that it can append the checksum. This results in a label selector key which deviates from the standard naming scheme.
   Users can check the events (`kubectl describe service`) or the logs of the controller to get information about this.

**Special notes for your reviewer**:
FYI @voelzmo

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `NetworkPolicy` controller part of `gardener-resource-manager` does no longer attempt to create resources in terminating namespaces.
```
```bugfix operator
If the computed pod label selector contains keys exceeding 63 characters, the `NetworkPolicy` controller part of `gardener-resource-manager` does now shorten them to make sure they can actually get created. Previously, it failed trying to create them infinitely, resulting in high CPU load in large clusters.
```
