### PR TITLE
Patch `ShootState` integration tests addressing flakes when managing resource finalizer 

### DIFF
--- a/test/integration/controllermanager/shootstate/shootstate_test.go
+++ b/test/integration/controllermanager/shootstate/shootstate_test.go
@@ -22,8 +22,6 @@ var _ = Describe("ShootState controller test", func() {
 		shoot          *gardencorev1beta1.Shoot
 		shootState     *gardencorev1beta1.ShootState
 		targetSeedName = "target-seed"
-
-		addFinalizer func(shootState *gardencorev1beta1.ShootState)
 	)
 
 	BeforeEach(func() {
@@ -61,14 +59,6 @@ var _ = Describe("ShootState controller test", func() {
 				},
 				SeedName: ptr.To("source-seed"),
 			},
-		}
-
-		addFinalizer = func(shootState *gardencorev1beta1.ShootState) {
-			By("Add ShootState finalizer")
-			EventuallyWithOffset(1, func(g Gomega) {
-				g.ExpectWithOffset(1, testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
-				g.ExpectWithOffset(1, controllerutils.AddFinalizers(ctx, testClient, shootState, shootstate.FinalizerName)).To(Succeed())
-			}).Should(Succeed())
 		}
 
 		By("Create Shoot")
@@ -229,3 +219,11 @@ var _ = Describe("ShootState controller test", func() {
 		})
 	})
 })
+
+func addFinalizer(shootState *gardencorev1beta1.ShootState) {
+	By("Add ShootState finalizer")
+	EventuallyWithOffset(1, func(g Gomega) {
+		g.ExpectWithOffset(1, testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
+		g.ExpectWithOffset(1, controllerutils.AddFinalizers(ctx, testClient, shootState, shootstate.FinalizerName)).To(Succeed())
+	}).Should(Succeed())
+}

--- a/test/integration/controllermanager/shootstate/shootstate_test.go
+++ b/test/integration/controllermanager/shootstate/shootstate_test.go
@@ -89,20 +89,20 @@ var _ = Describe("ShootState controller test", func() {
 		Expect(testClient.Create(ctx, shootState)).To(Succeed())
 
 		DeferCleanup(func() {
-			By("Delete Shoot")
-			Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot))).To(Succeed())
-
 			By("Delete ShootState")
+			Expect(client.IgnoreNotFound(testClient.Delete(ctx, shootState))).To(Succeed())
 			Eventually(func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Or(BeNotFoundError(), Succeed()))
 				g.Expect(controllerutils.RemoveFinalizers(ctx, testClient, shootState, shootstate.FinalizerName)).To(Succeed())
 			}).Should(Succeed())
-			Expect(client.IgnoreNotFound(testClient.Delete(ctx, shootState))).To(Succeed())
 
 			By("Ensure ShootState is gone")
 			Eventually(func() error {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)
 			}).Should(BeNotFoundError())
+
+			By("Delete Shoot")
+			Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot))).To(Succeed())
 
 			By("Ensure Shoot is gone")
 			Eventually(func() error {

--- a/test/integration/controllermanager/shootstate/shootstate_test.go
+++ b/test/integration/controllermanager/shootstate/shootstate_test.go
@@ -82,7 +82,7 @@ var _ = Describe("ShootState controller test", func() {
 			By("Delete ShootState")
 			Expect(client.IgnoreNotFound(testClient.Delete(ctx, shootState))).To(Succeed())
 			Eventually(func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Or(BeNotFoundError(), Succeed()))
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Or(Succeed(), BeNotFoundError()))
 				g.Expect(controllerutils.RemoveFinalizers(ctx, testClient, shootState, shootstate.FinalizerName)).To(Succeed())
 			}).Should(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

This PR fixes a flake within the `ShootState` finaliser controller integration tests. The following snippet shows an example error occurring when adding a finaliser with the `controllerutils.AddFinalizers` utility:

```sh
 [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0x14000951400>:
      Operation cannot be fulfilled on shootstates.core.gardener.cloud "test-rckqv": the object has been modified; please apply your changes to the latest version and try again
```

The following list of failed pipeline job executions showcase the issue:

* https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11774/pull-gardener-integration/1907352458116468736
* https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11788/pull-gardener-integration/1907328160328847360

The proposed resolution leverages the `Eventually` block in order to re-try the operation(s) for the default period of time (5s) and get the rest client cache updated with the latest `ResourceVersion` of the resource. The following snippet shows the `stress` logs after applying the change:

```sh
➜ gardener git:(chore/shootstate-finalizers-patch): ginkgo build ./test/integration/controllermanager/shootstate/
Compiled test/integration/controllermanager/shootstate/shootstate.test
➜ gardener git:(chore/shootstate-finalizers-patch): ~/go/bin/stress -ignore "unable to grab random port" -p 16 ./test/integration/controllermanager/shootstate/shootstate.test
5s: 0 runs so far, 0 failures, 16 active
10s: 0 runs so far, 0 failures, 16 active
15s: 0 runs so far, 0 failures, 16 active
20s: 16 runs so far, 0 failures, 16 active
25s: 16 runs so far, 0 failures, 16 active
30s: 16 runs so far, 0 failures, 16 active
35s: 16 runs so far, 0 failures, 16 active
40s: 32 runs so far, 0 failures, 16 active
45s: 32 runs so far, 0 failures, 16 active
50s: 32 runs so far, 0 failures, 16 active
55s: 48 runs so far, 0 failures, 16 active
1m0s: 48 runs so far, 0 failures, 16 active
1m5s: 48 runs so far, 0 failures, 16 active
1m10s: 61 runs so far, 0 failures, 16 active
1m15s: 64 runs so far, 0 failures, 16 active
1m20s: 64 runs so far, 0 failures, 16 active
1m25s: 67 runs so far, 0 failures, 16 active
1m30s: 80 runs so far, 0 failures, 16 active
1m35s: 80 runs so far, 0 failures, 16 active
1m40s: 80 runs so far, 0 failures, 16 active
1m45s: 96 runs so far, 0 failures, 16 active
1m50s: 96 runs so far, 0 failures, 16 active
1m55s: 96 runs so far, 0 failures, 16 active
2m0s: 109 runs so far, 0 failures, 16 active
2m5s: 112 runs so far, 0 failures, 16 active
2m10s: 112 runs so far, 0 failures, 16 active
2m15s: 115 runs so far, 0 failures, 16 active
2m20s: 128 runs so far, 0 failures, 16 active
2m25s: 128 runs so far, 0 failures, 16 active
2m30s: 129 runs so far, 0 failures, 16 active
2m35s: 144 runs so far, 0 failures, 16 active
2m40s: 144 runs so far, 0 failures, 16 active
2m45s: 144 runs so far, 0 failures, 16 active
2m50s: 154 runs so far, 0 failures, 16 active
2m55s: 160 runs so far, 0 failures, 16 active
3m0s: 160 runs so far, 0 failures, 16 active
3m5s: 166 runs so far, 0 failures, 16 active
3m10s: 176 runs so far, 0 failures, 16 active
3m15s: 176 runs so far, 0 failures, 16 active
3m20s: 178 runs so far, 0 failures, 16 active
3m25s: 192 runs so far, 0 failures, 16 active
3m30s: 192 runs so far, 0 failures, 16 active
3m35s: 192 runs so far, 0 failures, 16 active
3m40s: 204 runs so far, 0 failures, 16 active
3m45s: 208 runs so far, 0 failures, 16 active
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
