### PR TITLE
Only set static pod path in `kubelet` config for control plane worker pools

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -695,6 +695,9 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 		kubeletConfigParameters = components.KubeletConfigParametersFromCoreV1beta1KubeletConfig(worker.Kubernetes.Kubelet)
 		kubeletCLIFlags = components.KubeletCLIFlagsFromCoreV1beta1KubeletConfig(worker.Kubernetes.Kubelet)
 	}
+	if worker.ControlPlane != nil {
+		kubeletConfigParameters.WithStaticPodPath = true
+	}
 	setDefaultEvictionMemoryAvailable(kubeletConfigParameters.EvictionHard, kubeletConfigParameters.EvictionSoft, o.values.MachineTypes, worker.Machine.Type)
 
 	kubernetesVersion, err := v1beta1helper.CalculateEffectiveKubernetesVersion(o.values.KubernetesVersion, worker.Kubernetes)

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet.go
@@ -48,6 +48,7 @@ type ConfigurableKubeletConfigParameters struct {
 	PodPidsLimit                     *int64
 	ProtectKernelDefaults            *bool
 	SystemReserved                   map[string]string
+	WithStaticPodPath                bool
 }
 
 const (

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -124,7 +124,6 @@ serializeImagePulls: true
 serverTLSBootstrap: true
 shutdownGracePeriod: 0s
 shutdownGracePeriodCriticalPods: 0s
-staticPodPath: /etc/kubernetes/manifests
 streamingConnectionIdleTimeout: 5m0s
 syncFrequency: 1m0s
 volumePluginDir: /var/lib/kubelet/volumeplugins

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -96,7 +96,6 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddresses []string, clu
 		SeccompDefault:                   params.SeccompDefault,
 		SerializeImagePulls:              params.SerializeImagePulls,
 		ServerTLSBootstrap:               true,
-		StaticPodPath:                    FilePathKubernetesManifests,
 		StreamingConnectionIdleTimeout:   *params.StreamingConnectionIdleTimeout,
 		RegisterWithTaints:               nodeTaints,
 		RegistryPullQPS:                  params.RegistryPullQPS,
@@ -109,6 +108,10 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddresses []string, clu
 
 	if params.MemorySwap != nil {
 		config.MemorySwap = *params.MemorySwap
+	}
+
+	if params.WithStaticPodPath {
+		config.StaticPodPath = FilePathKubernetesManifests
 	}
 
 	return config

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Config", func() {
 			PodPidsLimit:                     ptr.To[int64](101),
 			SystemReserved:                   map[string]string{"memory": "321"},
 			StreamingConnectionIdleTimeout:   &metav1.Duration{Duration: time.Minute * 12},
+			WithStaticPodPath:                true,
 		}
 
 		taints = []corev1.Taint{{
@@ -282,6 +283,7 @@ var _ = Describe("Config", func() {
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 				cfg.ProtectKernelDefaults = true
 				cfg.StreamingConnectionIdleTimeout = metav1.Duration{Duration: time.Minute * 5}
+				cfg.StaticPodPath = ""
 			},
 		),
 		Entry(
@@ -309,6 +311,7 @@ var _ = Describe("Config", func() {
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 				cfg.ProtectKernelDefaults = true
 				cfg.StreamingConnectionIdleTimeout = metav1.Duration{Duration: time.Minute * 5}
+				cfg.StaticPodPath = ""
 			},
 		),
 		Entry(
@@ -337,6 +340,7 @@ var _ = Describe("Config", func() {
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 				cfg.ProtectKernelDefaults = true
 				cfg.StreamingConnectionIdleTimeout = metav1.Duration{Duration: time.Minute * 5}
+				cfg.StaticPodPath = ""
 			},
 		),
 		Entry(

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -150,7 +150,6 @@ var _ = Describe("Config", func() {
 			RuntimeRequestTimeout:          metav1.Duration{Duration: 2 * time.Minute},
 			SerializeImagePulls:            ptr.To(true),
 			ServerTLSBootstrap:             true,
-			StaticPodPath:                  "/etc/kubernetes/manifests",
 			StreamingConnectionIdleTimeout: metav1.Duration{Duration: time.Hour * 4},
 			SyncFrequency:                  metav1.Duration{Duration: time.Minute},
 			VolumeStatsAggPeriod:           metav1.Duration{Duration: time.Minute},
@@ -283,7 +282,6 @@ var _ = Describe("Config", func() {
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 				cfg.ProtectKernelDefaults = true
 				cfg.StreamingConnectionIdleTimeout = metav1.Duration{Duration: time.Minute * 5}
-				cfg.StaticPodPath = ""
 			},
 		),
 		Entry(
@@ -311,7 +309,6 @@ var _ = Describe("Config", func() {
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 				cfg.ProtectKernelDefaults = true
 				cfg.StreamingConnectionIdleTimeout = metav1.Duration{Duration: time.Minute * 5}
-				cfg.StaticPodPath = ""
 			},
 		),
 		Entry(
@@ -340,7 +337,6 @@ var _ = Describe("Config", func() {
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 				cfg.ProtectKernelDefaults = true
 				cfg.StreamingConnectionIdleTimeout = metav1.Duration{Duration: time.Minute * 5}
-				cfg.StaticPodPath = ""
 			},
 		),
 		Entry(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Previously, they were set unconditionally (even for regular shoots/worker pools w/o static pods), however, since the configured path does not exist here, this leads to the following errors in the `kubelet` logs:

```
Apr 01 19:02:30 my-node kubelet[2909]: E0401 19:02:30.625168    2909 file_linux.go:61] "Unable to read config path" err="path does not exist, ignoring" path="/etc/kubernetes/manifests"
Apr 01 19:02:31 my-node kubelet[2909]: E0401 19:02:31.625987    2909 file_linux.go:61] "Unable to read config path" err="path does not exist, ignoring" path="/etc/kubernetes/manifests"
Apr 01 19:02:32 my-node kubelet[2909]: E0401 19:02:32.252776    2909 file.go:104] "Unable to read config path" err="path does not exist, ignoring" path="/etc/kubernetes/manifests"
Apr 01 19:02:32 my-node kubelet[2909]: E0401 19:02:32.626646    2909 file_linux.go:61] "Unable to read config path" err="path does not exist, ignoring" path="/etc/kubernetes/manifests"
Apr 01 19:02:33 my-node kubelet[2909]: E0401 19:02:33.627135    2909 file_linux.go:61] "Unable to read config path" err="path does not exist, ignoring" path="/etc/kubernetes/manifests"
```

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/11701/commits/4c24082f3efe81d6c06b412a6b4a868adf46fdb0 in #11701

**Special notes for your reviewer**:
Thanks for reporting @plkokanov !

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
