### PR TITLE
Fix the Shoot logging TM test

### DIFF
--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -23,10 +23,13 @@ spec:
         image: europe-docker.pkg.dev/gardener-project/releases/3rd/agnhost:2.40
         command: ["/bin/sh", "-c"]
         args:
-{{ if .DeltaLogsCount }}
-        - /agnhost logs-generator --log-lines-total={{ .DeltaLogsCount }} --run-duration={{ .DeltaLogsDuration }} && /agnhost pause
+        - |-
+{{- if .DeltaLogsCount }}
+          /agnhost logs-generator --log-lines-total={{ .DeltaLogsCount }} --run-duration={{ .DeltaLogsDuration }}
 {{- end }}
-        - /agnhost logs-generator --log-lines-total={{ .LogsCount }} --run-duration={{ .LogsDuration }} && /agnhost pause
+          /agnhost logs-generator --log-lines-total={{ .LogsCount }} --run-duration={{ .LogsDuration }}
+
+          sleep infinity
         resources:
           limits:
             cpu: 8m

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -25,7 +25,7 @@ spec:
         image: registry.k8s.io/e2e-test-images/agnhost:2.40
         command: ["/bin/sh", "-c"]
         args:
-        - /agnhost logs-generator --logtostderr --log-lines-total={{ .LogsCount }} --run-duration={{ .LogsDuration }} && /agnhost pause
+        - /agnhost logs-generator --logtostderr --log-lines-total={{ .LogsCount }} --run-duration={{ .LogsDuration }} && sleep infinity
       securityContext:
         fsGroup: 65532
         runAsUser: 65532


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind regression

**What this PR does / why we need it**:
#11708 regressed the the following tests:
- `Seed logging testing  [It] [BETA] [SHOOT] should get container logs from the shoot cluster`
- `Seed logging testing  [It] [BETA] [SERIAL] [SHOOT] should get container logs from vali for all namespaces`

The failure reason for the 1st test:
`/agnhost pause` logs `Paused`: https://github.com/kubernetes/kubernetes/blob/ef7d51e5ba77004cb95dc2127ed90f8bbfdabc72/test/images/agnhost/pause/pause.go#L38
This breaks the assertion in the tests. It now gets 101 logs instead of 100 logs.

The failure reason for the 2nd test is that we now sleep after the first command and block the execution of the 2nd command: 
```yaml
      spec:
        containers:
        - args:
          - /agnhost logs-generator --log-lines-total=1 --run-duration=180s && /agnhost
            pause
          - /agnhost logs-generator --log-lines-total=2000 --run-duration=90s && /agnhost
            pause
          command:
          - /bin/sh
          - -c
```

Kudos to @nickytd for investigating the failure.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11791

**Special notes for your reviewer**:
```
% go test -timeout=0 ./test/testmachinery/suites/shoot \
      ... \
      -project-namespace=garden-foo \
      -shoot-name=bar \
      -ginkgo.focus="should get container logs from the shoot cluster"

Ran 1 of 19 Specs in 113.418 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 18 Skipped
--- PASS: TestGardenerSuite (113.43s)
PASS
ok  	github.com/gardener/gardener/test/testmachinery/suites/shoot	114.095s
```

```
% go test -timeout=0 ./test/testmachinery/suites/shoot \
      ... \
      -project-namespace=garden-foo \
      -shoot-name=bar \
      -ginkgo.focus="should get container logs from vali for all namespaces"

Ran 1 of 19 Specs in 537.059 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 18 Skipped
--- PASS: TestGardenerSuite (537.08s)
PASS
ok  	github.com/gardener/gardener/test/testmachinery/suites/shoot	537.741s
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing the Shoot logging test-machinery integration tests to fail is now fixed.
```
