### PR TITLE
Add ability to increase `maxNodesTotal` limit in `NamespacedCloudProfile`

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1136,7 +1136,7 @@ Limits
 <td>
 <em>(Optional)</em>
 <p>Limits configures operational limits for Shoot clusters using this NamespacedCloudProfile.
-If a limit is already set in the parent CloudProfile, it can only be more restrictive in the NamespacedCloudProfile.
+Any limits specified here override those set in the parent CloudProfile.
 See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md</a>.</p>
 </td>
 </tr>
@@ -8824,7 +8824,7 @@ Limits
 <td>
 <em>(Optional)</em>
 <p>Limits configures operational limits for Shoot clusters using this NamespacedCloudProfile.
-If a limit is already set in the parent CloudProfile, it can only be more restrictive in the NamespacedCloudProfile.
+Any limits specified here override those set in the parent CloudProfile.
 See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md</a>.</p>
 </td>
 </tr>

--- a/docs/usage/project/namespaced-cloud-profiles.md
+++ b/docs/usage/project/namespaced-cloud-profiles.md
@@ -32,6 +32,7 @@ Changing the following fields require the corresponding custom verbs:
 * For changing the `.spec.kubernetes` field, the custom verb `modify-spec-kubernetes` is required.
 * For changing the `.spec.machineImages` field, the custom verb `modify-spec-machineimages` is required.
 * For changing the `.spec.providerConfig` field, the custom verb `modify-spec-providerconfig` is required.
+* For raising limits in `.spec.limits` field above values in the parent CloudProfile `.spec.limits`, the custom verb `raise-spec-limits` is required.
 
 The assignment of these custom verbs can be achieved by creating a `ClusterRole` and a `RoleBinding` like in the following example:
 

--- a/docs/usage/shoot/shoot_limits.md
+++ b/docs/usage/shoot/shoot_limits.md
@@ -8,7 +8,10 @@ Gardener operators can configure limits for shoot clusters in the `CloudProfile.
 The limits are enforced on all shoot clusters using the respective `CloudProfile`.
 If a certain limit is not configured, no limit is enforced.
 
-The configured limits of a `CloudProfile` can be overridden by setting a more restrictive value in a `NamespacedCloudProfile`.
+The configured limits of a `CloudProfile` can be overridden by configuring limits in a `NamespacedCloudProfile`.
+To increase a `CloudProfile` limit, a user must have permission by the appropriate custom verbs.
+For more information, see the [NamespacedCloudProfile documentation](../project/namespaced-cloud-profiles.md#field-modification-restrictions).
+Setting a more restrictive limit does not require any special permission.
 
 This document explains the limits that can be configured in the `CloudProfile`.
 

--- a/docs/usage/shoot/shoot_limits.md
+++ b/docs/usage/shoot/shoot_limits.md
@@ -10,8 +10,8 @@ If a certain limit is not configured, no limit is enforced.
 
 The configured limits of a `CloudProfile` can be overridden by configuring limits in a `NamespacedCloudProfile`.
 To increase a `CloudProfile` limit, a user must have permission by the appropriate custom verbs.
+Setting a stricter limit is always allowed without requiring special permissions.
 For more information, see the [NamespacedCloudProfile documentation](../project/namespaced-cloud-profiles.md#field-modification-restrictions).
-Setting a more restrictive limit does not require any special permission.
 
 This document explains the limits that can be configured in the `CloudProfile`.
 

--- a/pkg/apis/core/types_namespacedcloudprofile.go
+++ b/pkg/apis/core/types_namespacedcloudprofile.go
@@ -51,7 +51,7 @@ type NamespacedCloudProfileSpec struct {
 	// ProviderConfig contains provider-specific configuration for the profile.
 	ProviderConfig *runtime.RawExtension
 	// Limits configures operational limits for Shoot clusters using this NamespacedCloudProfile.
-	// If a limit is already set in the parent CloudProfile, it can only be more restrictive in the NamespacedCloudProfile.
+	// Any limits specified here override those set in the parent CloudProfile.
 	// See https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md.
 	Limits *Limits
 }

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2011,7 +2011,7 @@ message NamespacedCloudProfileSpec {
   optional .k8s.io.apimachinery.pkg.runtime.RawExtension providerConfig = 8;
 
   // Limits configures operational limits for Shoot clusters using this NamespacedCloudProfile.
-  // If a limit is already set in the parent CloudProfile, it can only be more restrictive in the NamespacedCloudProfile.
+  // Any limits specified here override those set in the parent CloudProfile.
   // See https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md.
   // +optional
   optional Limits limits = 9;

--- a/pkg/apis/core/v1beta1/types_namespacedcloudprofile.go
+++ b/pkg/apis/core/v1beta1/types_namespacedcloudprofile.go
@@ -64,7 +64,7 @@ type NamespacedCloudProfileSpec struct {
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty" protobuf:"bytes,8,opt,name=providerConfig"`
 	// Limits configures operational limits for Shoot clusters using this NamespacedCloudProfile.
-	// If a limit is already set in the parent CloudProfile, it can only be more restrictive in the NamespacedCloudProfile.
+	// Any limits specified here override those set in the parent CloudProfile.
 	// See https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md.
 	// +optional
 	Limits *Limits `json:"limits,omitempty" protobuf:"bytes,9,opt,name=limits"`

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -6102,7 +6102,7 @@ func schema_pkg_apis_core_v1beta1_NamespacedCloudProfileSpec(ref common.Referenc
 					},
 					"limits": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Limits configures operational limits for Shoot clusters using this NamespacedCloudProfile. If a limit is already set in the parent CloudProfile, it can only be more restrictive in the NamespacedCloudProfile. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md.",
+							Description: "Limits configures operational limits for Shoot clusters using this NamespacedCloudProfile. Any limits specified here override those set in the parent CloudProfile. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_limits.md.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.Limits"),
 						},
 					},

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -129,14 +129,8 @@ func MergeCloudProfiles(namespacedCloudProfile *gardencorev1beta1.NamespacedClou
 		if namespacedCloudProfile.Status.CloudProfileSpec.Limits == nil {
 			namespacedCloudProfile.Status.CloudProfileSpec.Limits = &gardencorev1beta1.Limits{}
 		}
-
-		maxNodesTotalOverride := ptr.Deref(namespacedCloudProfile.Spec.Limits.MaxNodesTotal, 0)
-		var maxNodesTotalParent int32
-		if cloudProfile.Spec.Limits != nil {
-			maxNodesTotalParent = ptr.Deref(cloudProfile.Spec.Limits.MaxNodesTotal, 0)
-		}
-		if maxNodesTotal := utils.MinGreaterThanZero(maxNodesTotalOverride, maxNodesTotalParent); maxNodesTotal > 0 {
-			namespacedCloudProfile.Status.CloudProfileSpec.Limits.MaxNodesTotal = ptr.To(maxNodesTotal)
+		if ptr.Deref(namespacedCloudProfile.Spec.Limits.MaxNodesTotal, 0) > 0 {
+			namespacedCloudProfile.Status.CloudProfileSpec.Limits.MaxNodesTotal = namespacedCloudProfile.Spec.Limits.MaxNodesTotal
 		}
 	}
 }

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -844,13 +844,13 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 					Expect(namespacedCloudProfile.Status.CloudProfileSpec.Limits.MaxNodesTotal).To(Equal(ptr.To(int32(10))))
 				})
 
-				It("should ignore a higher value from the NamespacedCloudProfile", func() {
+				It("should apply the higher overridden value from the NamespacedCloudProfile", func() {
 					cloudProfile.Spec.Limits = &gardencorev1beta1.Limits{MaxNodesTotal: ptr.To(int32(10))}
 					namespacedCloudProfile.Spec.Limits = &gardencorev1beta1.Limits{MaxNodesTotal: ptr.To(int32(99))}
 
 					namespacedcloudprofilecontroller.MergeCloudProfiles(namespacedCloudProfile, cloudProfile)
 
-					Expect(namespacedCloudProfile.Status.CloudProfileSpec.Limits.MaxNodesTotal).To(Equal(ptr.To(int32(10))))
+					Expect(namespacedCloudProfile.Status.CloudProfileSpec.Limits.MaxNodesTotal).To(Equal(ptr.To(int32(99))))
 				})
 
 				It("should apply a lower value from the NamespacedCloudProfile", func() {

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -42,6 +42,9 @@ const (
 	// CustomVerbNamespacedCloudProfileModifyProviderConfig is a constant for the custom verb that allows modifying the
 	// `.spec.providerConfig` field in `NamespacedCloudProfile` resources.
 	CustomVerbNamespacedCloudProfileModifyProviderConfig = "modify-spec-providerconfig"
+	// CustomVerbNamespacedCloudProfileRaiseLimits is a constant for the custom verb that allows raising the
+	// `.spec.limits` limits in `NamespacedCloudProfile` resources above values defined in the parent `CloudProfile`.
+	CustomVerbNamespacedCloudProfileRaiseLimits = "raise-spec-limits"
 )
 
 // Register registers a plugin.
@@ -158,6 +161,13 @@ func (c *CustomVerbAuthorizer) admitNamespacedCloudProfiles(ctx context.Context,
 
 	if mustCheckProviderConfig(oldObj.Spec.ProviderConfig, obj.Spec.ProviderConfig) {
 		err := c.authorize(ctx, a, CustomVerbNamespacedCloudProfileModifyProviderConfig, "modify .spec.providerConfig")
+		if err != nil {
+			return err
+		}
+	}
+
+	if mustCheckLimits(oldObj.Spec.Limits, obj.Spec.Limits) {
+		err := c.authorize(ctx, a, CustomVerbNamespacedCloudProfileRaiseLimits, "modify .spec.limits")
 		if err != nil {
 			return err
 		}
@@ -280,4 +290,8 @@ func mustCheckMachineImages(oldMachineImages, machineImages []core.MachineImage)
 
 func mustCheckProviderConfig(oldProviderConfig, providerConfig *runtime.RawExtension) bool {
 	return !apiequality.Semantic.DeepEqual(oldProviderConfig, providerConfig)
+}
+
+func mustCheckLimits(oldLimits, limits *core.Limits) bool {
+	return !apiequality.Semantic.DeepEqual(oldLimits, limits)
 }

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -216,7 +216,7 @@ func (c *CustomVerbAuthorizer) admitNamespacedCloudProfiles(ctx context.Context,
 	}
 
 	if mustCheckLimits(oldObj.Spec.Limits, obj.Spec.Limits, parentCloudProfile) {
-		err := c.authorize(ctx, a, CustomVerbNamespacedCloudProfileRaiseLimits, "modify .spec.limits")
+		err := c.authorize(ctx, a, CustomVerbNamespacedCloudProfileRaiseLimits, "increase .spec.limits above parent CloudProfile limits")
 		if err != nil {
 			return err
 		}

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -6,6 +6,7 @@ package customverbauthorizer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -19,9 +20,13 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	plugin "github.com/gardener/gardener/plugin/pkg"
 )
 
@@ -60,16 +65,36 @@ func NewFactory(_ io.Reader) (admission.Interface, error) {
 // CustomVerbAuthorizer contains an admission handler and listers.
 type CustomVerbAuthorizer struct {
 	*admission.Handler
-	authorizer authorizer.Authorizer
+	cloudProfileLister gardencorev1beta1listers.CloudProfileLister
+	authorizer         authorizer.Authorizer
+	readyFunc          admission.ReadyFunc
 }
 
-var _ = admissioninitializer.WantsAuthorizer(&CustomVerbAuthorizer{})
+var (
+	_          = admissioninitializer.WantsAuthorizer(&CustomVerbAuthorizer{})
+	_          = admissioninitializer.WantsCoreInformerFactory(&CustomVerbAuthorizer{})
+	readyFuncs []admission.ReadyFunc
+)
 
 // New creates a new CustomVerbAuthorizer admission plugin.
 func New() (*CustomVerbAuthorizer, error) {
 	return &CustomVerbAuthorizer{
 		Handler: admission.NewHandler(admission.Create, admission.Update),
 	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (c *CustomVerbAuthorizer) AssignReadyFunc(f admission.ReadyFunc) {
+	c.readyFunc = f
+	c.SetReadyFunc(f)
+}
+
+// SetCoreInformerFactory gets Lister from SharedInformerFactory.
+func (c *CustomVerbAuthorizer) SetCoreInformerFactory(f gardencoreinformers.SharedInformerFactory) {
+	cloudProfileInformer := f.Core().V1beta1().CloudProfiles()
+	c.cloudProfileLister = cloudProfileInformer.Lister()
+
+	readyFuncs = append(readyFuncs, cloudProfileInformer.Informer().HasSynced)
 }
 
 // SetAuthorizer gets the authorizer.
@@ -79,6 +104,9 @@ func (c *CustomVerbAuthorizer) SetAuthorizer(authorizer authorizer.Authorizer) {
 
 // ValidateInitialization checks whether the plugin was correctly initialized.
 func (c *CustomVerbAuthorizer) ValidateInitialization() error {
+	if c.cloudProfileLister == nil {
+		return errors.New("missing cloudProfile lister")
+	}
 	return nil
 }
 
@@ -86,6 +114,21 @@ var _ admission.ValidationInterface = &CustomVerbAuthorizer{}
 
 // Validate makes admissions decisions based on custom verbs.
 func (c *CustomVerbAuthorizer) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	// Wait until the caches have been synced
+	if c.readyFunc == nil {
+		c.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+	if !c.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
 	switch a.GetKind().GroupKind() {
 	case core.Kind("Project"):
 		return c.admitProjects(ctx, a)
@@ -138,6 +181,12 @@ func (c *CustomVerbAuthorizer) admitNamespacedCloudProfiles(ctx context.Context,
 		return apierrors.NewBadRequest("could not convert resource into NamespacedCloudProfile object")
 	}
 
+	parentCloudProfileName := obj.Spec.Parent.Name
+	parentCloudProfile, err := c.cloudProfileLister.Get(parentCloudProfileName)
+	if err != nil {
+		return apierrors.NewBadRequest("parent CloudProfile could not be found")
+	}
+
 	if a.GetOperation() == admission.Update {
 		oldObj, ok = a.GetOldObject().(*core.NamespacedCloudProfile)
 		if !ok {
@@ -166,7 +215,7 @@ func (c *CustomVerbAuthorizer) admitNamespacedCloudProfiles(ctx context.Context,
 		}
 	}
 
-	if mustCheckLimits(oldObj.Spec.Limits, obj.Spec.Limits) {
+	if mustCheckLimits(oldObj.Spec.Limits, obj.Spec.Limits, parentCloudProfile) {
 		err := c.authorize(ctx, a, CustomVerbNamespacedCloudProfileRaiseLimits, "modify .spec.limits")
 		if err != nil {
 			return err
@@ -292,6 +341,10 @@ func mustCheckProviderConfig(oldProviderConfig, providerConfig *runtime.RawExten
 	return !apiequality.Semantic.DeepEqual(oldProviderConfig, providerConfig)
 }
 
-func mustCheckLimits(oldLimits, limits *core.Limits) bool {
-	return !apiequality.Semantic.DeepEqual(oldLimits, limits)
+func mustCheckLimits(oldLimits, limits *core.Limits, parentCloudProfile *v1beta1.CloudProfile) bool {
+	return limits != nil &&
+		!apiequality.Semantic.DeepEqual(oldLimits, limits) &&
+		parentCloudProfile.Spec.Limits != nil &&
+		parentCloudProfile.Spec.Limits.MaxNodesTotal != nil &&
+		ptr.Deref(limits.MaxNodesTotal, 0) > ptr.Deref(parentCloudProfile.Spec.Limits.MaxNodesTotal, 0)
 }

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -342,9 +342,7 @@ func mustCheckProviderConfig(oldProviderConfig, providerConfig *runtime.RawExten
 }
 
 func mustCheckLimits(oldLimits, limits *core.Limits, parentCloudProfile *v1beta1.CloudProfile) bool {
-	return limits != nil &&
-		!apiequality.Semantic.DeepEqual(oldLimits, limits) &&
+	return !apiequality.Semantic.DeepEqual(oldLimits, limits) &&
 		parentCloudProfile.Spec.Limits != nil &&
-		parentCloudProfile.Spec.Limits.MaxNodesTotal != nil &&
 		ptr.Deref(limits.MaxNodesTotal, 0) > ptr.Deref(parentCloudProfile.Spec.Limits.MaxNodesTotal, 0)
 }

--- a/plugin/pkg/global/customverbauthorizer/admission_test.go
+++ b/plugin/pkg/global/customverbauthorizer/admission_test.go
@@ -35,7 +35,7 @@ var _ = Describe("customverbauthorizer", func() {
 
 	Describe("#Validate", func() {
 		var (
-			ctx = context.TODO()
+			ctx = context.Background()
 
 			attrs            admission.Attributes
 			admissionHandler *CustomVerbAuthorizer
@@ -74,7 +74,7 @@ var _ = Describe("customverbauthorizer", func() {
 
 			It("should do nothing because the resource is not Project", func() {
 				attrs = admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), project.Namespace, project.Name, core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(ctx, attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -85,7 +85,7 @@ var _ = Describe("customverbauthorizer", func() {
 
 				It("should always allow creating a project without whitelist tolerations", func() {
 					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
 				Describe("permissions granted", func() {
@@ -97,7 +97,7 @@ var _ = Describe("customverbauthorizer", func() {
 						project.Spec.Tolerations = &core.ProjectTolerations{Whitelist: []core.Toleration{{Key: "foo"}}}
 
 						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow updating a project's whitelist tolerations", func() {
@@ -106,7 +106,7 @@ var _ = Describe("customverbauthorizer", func() {
 						project.Spec.Tolerations.Whitelist = append(project.Spec.Tolerations.Whitelist, core.Toleration{Key: "bar"})
 
 						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow removing a project's whitelist tolerations", func() {
@@ -115,7 +115,7 @@ var _ = Describe("customverbauthorizer", func() {
 						project.Spec.Tolerations.Whitelist = nil
 
 						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 				})
 
@@ -128,7 +128,7 @@ var _ = Describe("customverbauthorizer", func() {
 						project.Spec.Tolerations = &core.ProjectTolerations{Whitelist: []core.Toleration{{Key: "foo"}}}
 
 						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
 					It("should forbid updating a project's whitelist tolerations", func() {
@@ -137,7 +137,7 @@ var _ = Describe("customverbauthorizer", func() {
 						project.Spec.Tolerations.Whitelist = append(project.Spec.Tolerations.Whitelist, core.Toleration{Key: "bar"})
 
 						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
 					It("should forbid removing a project's whitelist tolerations", func() {
@@ -146,7 +146,7 @@ var _ = Describe("customverbauthorizer", func() {
 						project.Spec.Tolerations.Whitelist = nil
 
 						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 				})
 			})
@@ -200,14 +200,14 @@ var _ = Describe("customverbauthorizer", func() {
 
 				It("should always allow creating a project without members", func() {
 					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
 				It("should always allow creating a project with only owner as member", func() {
 					project.Spec.Owner = &owner
 					project.Spec.Members = []core.ProjectMember{{Subject: owner}}
 					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
 				It("should always allow adding non-human members to project", func() {
@@ -216,7 +216,7 @@ var _ = Describe("customverbauthorizer", func() {
 					project.Spec.Members = append(projectMembersWithHumans, projectMembersWithoutHumans...)
 
 					attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
 				Describe("permissions granted", func() {
@@ -229,21 +229,21 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Members = projectMembersWithHumans
 							project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
 							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow creating a project without human members if creator=owner", func() {
 							project.Spec.Members = projectMembersWithoutHumans
 							project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
 							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow creating a project with owner plus additional human members", func() {
 							project.Spec.Owner = &owner
 							project.Spec.Members = append([]core.ProjectMember{{Subject: owner}}, projectMembersWithHumans...)
 							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 					})
 
@@ -254,7 +254,7 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Members = append(projectMembersWithoutHumans, projectMembersWithHumans...)
 
 							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow to remove human users", func() {
@@ -263,7 +263,7 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Members = projectMembersWithoutHumans
 
 							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 					})
 				})
@@ -278,35 +278,35 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Owner = nil
 							project.Spec.Members = projectMembersWithoutHumans
 							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow creating a project with owner plus additional human members if creator=owner", func() {
 							project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
 							project.Spec.Members = append([]core.ProjectMember{{Subject: owner}}, projectMembersWithHumans...)
 							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow creating a project with human members if owner=nil (meaning creator=owner)", func() {
 							project.Spec.Owner = nil
 							project.Spec.Members = projectMembersWithHumans
 							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should forbid creating a project with human members if creator!=owner", func() {
 							project.Spec.Owner = &owner
 							project.Spec.Members = projectMembersWithHumans
 							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 
 						It("should forbid creating a project with owner plus additional human members if creator!=owner", func() {
 							project.Spec.Owner = &owner
 							project.Spec.Members = append([]core.ProjectMember{{Subject: owner}}, projectMembersWithHumans...)
 							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 					})
 
@@ -318,7 +318,7 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Members = append(projectMembersWithoutHumans, projectMembersWithHumans...)
 
 							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow to remove human users (user=owner)", func() {
@@ -328,7 +328,7 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Members = projectMembersWithoutHumans
 
 							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should forbid to add human users (user!=owner)", func() {
@@ -338,7 +338,7 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Members = append(projectMembersWithoutHumans, projectMembersWithHumans...)
 
 							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 
 						It("should forbid to remove human users (user!=owner)", func() {
@@ -348,7 +348,7 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Members = projectMembersWithoutHumans
 
 							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-							Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 					})
 				})
@@ -381,7 +381,7 @@ var _ = Describe("customverbauthorizer", func() {
 
 			It("should do nothing because the resource is not NamespacedCloudProfile", func() {
 				attrs = admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(ctx, attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -392,7 +392,7 @@ var _ = Describe("customverbauthorizer", func() {
 
 				It("should always allow creating a NamespacedCloudProfile without kubernetes settings", func() {
 					attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
 				Describe("permissions granted", func() {
@@ -406,7 +406,7 @@ var _ = Describe("customverbauthorizer", func() {
 						}}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow updating a NamespacedCloudProfile's kubernetes section", func() {
@@ -419,7 +419,7 @@ var _ = Describe("customverbauthorizer", func() {
 						}}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow removing a NamespacedCloudProfile's kubernetes section", func() {
@@ -430,7 +430,7 @@ var _ = Describe("customverbauthorizer", func() {
 						namespacedCloudProfile.Spec.Kubernetes = nil
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 				})
 
@@ -445,7 +445,7 @@ var _ = Describe("customverbauthorizer", func() {
 						}}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
 					It("should forbid updating a NamespacedCloudProfile's kubernetes section", func() {
@@ -458,7 +458,7 @@ var _ = Describe("customverbauthorizer", func() {
 						}}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
 					It("should forbid removing a NamespacedCloudProfile's kubernetes section", func() {
@@ -469,7 +469,7 @@ var _ = Describe("customverbauthorizer", func() {
 						namespacedCloudProfile.Spec.Kubernetes = nil
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 				})
 			})
@@ -481,7 +481,7 @@ var _ = Describe("customverbauthorizer", func() {
 
 				It("should always allow creating a NamespacedCloudProfile without machineImages settings", func() {
 					attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
 				Describe("permissions granted", func() {
@@ -497,7 +497,7 @@ var _ = Describe("customverbauthorizer", func() {
 						}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow updating a NamespacedCloudProfile's machineImages section", func() {
@@ -514,7 +514,7 @@ var _ = Describe("customverbauthorizer", func() {
 						}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow removing a NamespacedCloudProfile's machineImages section", func() {
@@ -527,7 +527,7 @@ var _ = Describe("customverbauthorizer", func() {
 						namespacedCloudProfile.Spec.MachineImages = nil
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 				})
 
@@ -544,7 +544,7 @@ var _ = Describe("customverbauthorizer", func() {
 						}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
 					It("should forbid updating a NamespacedCloudProfile's machineImages section", func() {
@@ -561,7 +561,7 @@ var _ = Describe("customverbauthorizer", func() {
 						}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
 					It("should forbid removing a NamespacedCloudProfile's machineImages section", func() {
@@ -574,7 +574,7 @@ var _ = Describe("customverbauthorizer", func() {
 						namespacedCloudProfile.Spec.MachineImages = nil
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 				})
 			})
@@ -586,7 +586,7 @@ var _ = Describe("customverbauthorizer", func() {
 
 				It("should always allow creating a NamespacedCloudProfile without providerConfig settings", func() {
 					attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
 				Describe("permissions granted", func() {
@@ -598,7 +598,7 @@ var _ = Describe("customverbauthorizer", func() {
 						namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte{}}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow removing a NamespacedCloudProfile's providerConfig section", func() {
@@ -607,7 +607,7 @@ var _ = Describe("customverbauthorizer", func() {
 						namespacedCloudProfile.Spec.ProviderConfig = nil
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 				})
 
@@ -620,7 +620,7 @@ var _ = Describe("customverbauthorizer", func() {
 						namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte{}}
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, nil, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
 					It("should forbid removing a NamespacedCloudProfile's providerConfig section", func() {
@@ -629,7 +629,7 @@ var _ = Describe("customverbauthorizer", func() {
 						namespacedCloudProfile.Spec.ProviderConfig = nil
 
 						attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("namespacedcloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
-						Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).NotTo(Succeed())
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 				})
 			})

--- a/plugin/pkg/global/customverbauthorizer/admission_test.go
+++ b/plugin/pkg/global/customverbauthorizer/admission_test.go
@@ -699,7 +699,7 @@ var _ = Describe("customverbauthorizer", func() {
 					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
-				Describe("permissions granted", func() {
+				When("permission is granted", func() {
 					BeforeEach(func() {
 						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionAllow, "", nil)
 
@@ -715,7 +715,7 @@ var _ = Describe("customverbauthorizer", func() {
 					})
 				})
 
-				Describe("permissions not granted", func() {
+				When("permission is not granted", func() {
 					BeforeEach(func() {
 						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
 

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -549,17 +549,12 @@ var _ = Describe("Admission", func() {
 				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
 
-			It("should fail creating a NamespacedCloudProfile with a higher limit than in the CloudProfile", func() {
+			It("should allow creating a NamespacedCloudProfile with a higher limit than in the CloudProfile", func() {
 				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
 				namespacedCloudProfile.Spec.Limits.MaxNodesTotal = ptr.To(int32(6))
 				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("spec.limits.maxNodesTotal"),
-					"BadValue": BeEquivalentTo(6),
-					"Detail":   ContainSubstring("overriding value must be less than or equal to value set in parent CloudProfile"),
-				}))))
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
 
 			It("should allow updating a NamespacedCloudProfile without changing the already higher value compared to the CloudProfile", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Open the restriction of `limits.maxNodesTotal` overrides in a NamespacedCloudProfile so that the limit can also be increased, if the user is assigned the appropriate custom verb `raise-spec-limits`.

**Which issue(s) this PR fixes**:
Fixes #11760.
Follow-up to https://github.com/gardener/gardener/pull/11647.

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`NamespacedCloudProfile.spec.limits.maxNodesTotal` can now also be used to override the limit defined in the parent `CloudProfile` with an increased value. Increasing requires additional permissions granted by the custom verb `raise-spec-limits`.
```
