### PR TITLE
Fix the `should copy data to pod` VPN tunnel TM test

### DIFF
--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -523,7 +523,7 @@ func DeployRootPod(ctx context.Context, c client.Client, namespace string, noden
 			Containers: []corev1.Container{
 				{
 					Name:  "root-container",
-					Image: "registry.k8s.io/e2e-test-images/busybox:1.29-4",
+					Image: "registry.k8s.io/e2e-test-images/busybox:1.36.1-1",
 					Command: []string{
 						"sleep",
 						"10000000",

--- a/test/framework/resources/templates/simple-load-deployment.yaml.tpl
+++ b/test/framework/resources/templates/simple-load-deployment.yaml.tpl
@@ -14,7 +14,7 @@ spec:
         app: load
     spec:
       containers:
-      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
+      - image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
         name: load
         command: ["sh", "-c"]
         args:

--- a/test/framework/resources/templates/vpntunnel-copy.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel-copy.yaml.tpl
@@ -17,8 +17,8 @@ spec:
         app: {{ .AppLabel }}
     spec:
       initContainers:
-      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
-        name: data-generator
+      - name: data-generator
+        image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
         command:
         - dd
         - if=/dev/urandom
@@ -28,22 +28,20 @@ spec:
         volumeMounts:
         - name: source-data
           mountPath: /data
-      # TODO(ialidzhikov): There is a kubectl image (registry.k8s.io/kubectl), available in K8s 1.28+.
-      # In future, use the kubectl image, instead of downloading kubectl via init container.
-      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
-        name: install-kubectl
+      - name: install-kubectl
+        image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
         command:
         - /bin/sh
         - -c
         - |-
-          wget https://storage.googleapis.com/kubernetes-release/release/v{{ .KubeVersion }}/bin/linux/{{ .Architecture }}/kubectl -O /data/kubectl;
+          wget https://dl.k8s.io/release/v{{ .KubeVersion }}/bin/linux/{{ .Architecture }}/kubectl -O /data/kubectl;
           chmod +x /data/kubectl;
         volumeMounts:
         - name: source-data
           mountPath: /data
       containers:
-      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
-        name: source-container
+      - name: source-container
+        image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
         command:
         - sleep
         - "3600"
@@ -55,8 +53,8 @@ spec:
           mountPath: /data
         - name: kubecfg
           mountPath: /secret
-      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
-        name: target-container
+      - name: target-container
+        image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
         command:
         - sleep
         - "3600"

--- a/test/testmachinery/shoots/vpntunnel/vpntunnel.go
+++ b/test/testmachinery/shoots/vpntunnel/vpntunnel.go
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("Shoot vpn tunnel testing", func() {
 
 			ginkgo.By("Copy data to target-container in pod " + pod.Name)
 			stdout, _, err := f.ShootClient.PodExecutor().Execute(ctx, pod.Namespace, pod.Name, "source-container",
-				"/data/kubectl", "cp", "/data/data", pod.Namespace+"/"+pod.Name, "/data/data", "-c", "target-container",
+				"/data/kubectl", "cp", "/data/data", pod.Namespace+"/"+pod.Name+":/data/data", "-c", "target-container",
 			)
 			if apierrors.IsNotFound(err) {
 				log.Error(err, "Aborting as pod was not found anymore")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind regression

**What this PR does / why we need it**:
Right now, there are 2 issues with the `should copy data to pod` VPN tunnel TM test:
- The URL to download kubectl got changed from `https://storage.googleapis.com/kubernetes-release` to `https://dl.k8s.io`. For more details, see https://github.com/kubernetes/k8s.io/issues/2396.
- https://github.com/gardener/gardener/pull/10977 regressed how the command: https://github.com/gardener/gardener/commit/c0486a3187b5e2e0697f9e373c008c588689960a#diff-7a2e700a3e2f673a6abf5d3d6ea5856e42b8154e5283ca6c961d125ea6e92ba0L179-R178

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
```
% go test -timeout=0 ./test/testmachinery/suites/shoot \
      ... \
      -project-namespace=garden-foo \
      -shoot-name=bar \
      -ginkgo.focus="should copy data to pod"

Ran 1 of 19 Specs in 33.782 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 18 Skipped
--- PASS: TestGardenerSuite (33.79s)
PASS
ok  	github.com/gardener/gardener/test/testmachinery/suites/shoot	34.445s
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
An issue causing the `should copy data to pod` VPN tunnel test-machinery integration test to fail is now fixed.
```
