### PR TITLE
Add SPDY support for L7 load balancing

### DIFF
--- a/docs/operations/kube_apiserver_loadbalancing.md
+++ b/docs/operations/kube_apiserver_loadbalancing.md
@@ -14,14 +14,8 @@ traffic within the cluster remains encrypted.
 
 This document is focused on the second mode.
 
-The minimum version of Kube API server (for virtual garden and shoot) is v1.31.0. Starting with this version the Kube API
-server uses the WebSocket protocol instead of SPDY for streaming APIs ([ref](https://kubernetes.io/blog/2024/08/20/websockets-transition/)).
-Envoy cannot upgrade the connection from HTTP to SPDY ([ref](https://github.com/envoyproxy/envoy/issues/36469)).  
-Thus, for shoots and gardens using lower versions L7 load balancing remains deactivated even when the feature gate is enabled.  
-On eligible shoots L7 load balancing is activated by default. However, it can be deactivated by annotating the shoot with
-`shoot.gardener.cloud/disable-istio-tls-termination: "true"`.  
-The same logic applies to `kubectl` tool. Thus, please use `kubectl` v1.31.0 or higher if you want to access a Kube API
-server with L7 load balancing.
+On seeds where the feature gate is activated L7 load balancing can still be deactivated for single shoots by annotating
+them with `shoot.gardener.cloud/disable-istio-tls-termination: "true"`.
 
 ## How it works
 

--- a/pkg/apis/core/v1beta1/helper/shoot.go
+++ b/pkg/apis/core/v1beta1/helper/shoot.go
@@ -17,7 +17,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // HibernationIsEnabled checks if the given shoot's desired state is hibernated.
@@ -662,11 +661,6 @@ func IsUpdateStrategyInPlace(updateStrategy *gardencorev1beta1.MachineUpdateStra
 
 // IsShootIstioTLSTerminationEnabled returns true if the Istio TLS termination for the shoot kube-apiserver is enabled.
 func IsShootIstioTLSTerminationEnabled(shoot *gardencorev1beta1.Shoot) bool {
-	shootKubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
-	if err != nil || versionutils.ConstraintK8sLess131.Check(shootKubernetesVersion) {
-		return false
-	}
-
 	value, ok := shoot.Annotations[v1beta1constants.ShootDisableIstioTLSTermination]
 	if !ok {
 		return true

--- a/pkg/apis/core/v1beta1/helper/shoot_test.go
+++ b/pkg/apis/core/v1beta1/helper/shoot_test.go
@@ -1505,26 +1505,18 @@ var _ = Describe("Helper", func() {
 	)
 
 	DescribeTable("#IsShootIstioTLSTerminationEnabled",
-		func(shootKubernetesVersion string, shootAnnotations map[string]string, expected bool) {
+		func(shootAnnotations map[string]string, expected bool) {
 			shoot := &gardencorev1beta1.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: shootAnnotations,
-				},
-				Spec: gardencorev1beta1.ShootSpec{
-					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: shootKubernetesVersion,
-					},
 				},
 			}
 			Expect(IsShootIstioTLSTerminationEnabled(shoot)).To(Equal(expected))
 		},
 
-		Entry("shoot with Kubernetes v1.30.0 has no Istio TLS termination", "1.30.0", nil, false),
-		Entry("shoot with Kubernetes v1.31.0 has Istio TLS termination", "1.31.0", nil, true),
-		Entry("shoot with Kubernetes v1.31.0 has no Istio TLS termination if is disabled by annotation", "1.31.0", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "true"}, false),
-		Entry("shoot with Kubernetes v1.31.0 has no Istio TLS termination if is not disabled by annotation", "1.31.0", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "false"}, true),
-		Entry("shoot with Kubernetes v1.31.0 has no Istio TLS termination if it is annotated with a bogus value", "1.31.0", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "foobar"}, true),
-		Entry("shoot with Kubernetes v1.30.0 has no Istio TLS termination even if is not disabled by annotation", "1.30.0", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "false"}, false),
-		Entry("shoot with bogus Kubernetes version has no Istio TLS termination - this should not happen in reality anyway", "foobar", nil, false),
+		Entry("shoot has Istio TLS termination if it has no annotations", nil, true),
+		Entry("shoot has no Istio TLS termination if is disabled by annotation", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "true"}, false),
+		Entry("shoot has no Istio TLS termination if is not disabled by annotation", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "false"}, true),
+		Entry("shoot has no Istio TLS termination if it is annotated with a bogus value", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "foobar"}, true),
 	)
 })

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -490,7 +490,7 @@ var _ = Describe("#SNI", func() {
 				expectedDestinationRule.Spec.TrafficPolicy.Tls = &istioapinetworkingv1beta1.ClientTLSSettings{
 					Mode:           istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE,
 					CredentialName: namespace + "-kube-apiserver-istio-mtls",
-					Sni:            expectedDestinationRule.Spec.Host,
+					Sni:            "kubernetes.default.svc.cluster.local",
 				}
 
 				expectedGateway.Spec.Servers[0].Port.Protocol = "HTTPS"
@@ -536,7 +536,7 @@ var _ = Describe("#SNI", func() {
 				expectedDestinationRule.Spec.TrafficPolicy.Tls = &istioapinetworkingv1beta1.ClientTLSSettings{
 					Mode:           istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE,
 					CredentialName: namespace + "-kube-apiserver-istio-mtls",
-					Sni:            expectedDestinationRule.Spec.Host,
+					Sni:            "kubernetes.default.svc.cluster.local",
 				}
 
 				expectedGateway.Spec.Servers[0].Port.Protocol = "HTTPS"
@@ -598,7 +598,7 @@ var _ = Describe("#SNI", func() {
 				expectedDestinationRule.Spec.TrafficPolicy.Tls = &istioapinetworkingv1beta1.ClientTLSSettings{
 					Mode:           istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE,
 					CredentialName: namespace + "-kube-apiserver-istio-mtls",
-					Sni:            expectedDestinationRule.Spec.Host,
+					Sni:            "kubernetes.default.svc.cluster.local",
 				}
 
 				expectedGateway.Spec.Servers[0].Port.Protocol = "HTTPS"

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -53,7 +53,7 @@ var _ = Describe("#SNI", func() {
 		istioTLSTermination         bool
 		hosts                       []string
 		hostName                    string
-		upgradeHostName             string
+		connectionUpgradeHostName   string
 		wildcardConfiguration       *WildcardConfiguration
 		wildcardHosts               []string
 		wildcardTLSSecret           corev1.Secret
@@ -95,7 +95,7 @@ var _ = Describe("#SNI", func() {
 		istioTLSTermination = false
 		hosts = []string{"foo.bar"}
 		hostName = "kube-apiserver." + namespace + ".svc.cluster.local"
-		upgradeHostName = "kube-apiserver-upgrade." + namespace + ".svc.cluster.local"
+		connectionUpgradeHostName = "kube-apiserver-connection-upgrade." + namespace + ".svc.cluster.local"
 		wildcardConfiguration = nil
 		wildcardHosts = []string{"foo.wildcard", "bar.wildcard"}
 		wildcardTLSSecret = corev1.Secret{
@@ -516,7 +516,7 @@ var _ = Describe("#SNI", func() {
 						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
 							{
 								Destination: &istioapinetworkingv1beta1.Destination{
-									Host: upgradeHostName,
+									Host: connectionUpgradeHostName,
 									Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
 								},
 							},
@@ -594,7 +594,7 @@ var _ = Describe("#SNI", func() {
 						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
 							{
 								Destination: &istioapinetworkingv1beta1.Destination{
-									Host: upgradeHostName,
+									Host: connectionUpgradeHostName,
 									Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
 								},
 							},
@@ -669,7 +669,7 @@ var _ = Describe("#SNI", func() {
 						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
 							{
 								Destination: &istioapinetworkingv1beta1.Destination{
-									Host: upgradeHostName,
+									Host: connectionUpgradeHostName,
 									Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
 								},
 							},
@@ -702,7 +702,7 @@ var _ = Describe("#SNI", func() {
 						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
 							{
 								Destination: &istioapinetworkingv1beta1.Destination{
-									Host: upgradeHostName,
+									Host: connectionUpgradeHostName,
 									Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
 								},
 							},

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -53,6 +53,7 @@ var _ = Describe("#SNI", func() {
 		istioTLSTermination         bool
 		hosts                       []string
 		hostName                    string
+		upgradeHostName             string
 		wildcardConfiguration       *WildcardConfiguration
 		wildcardHosts               []string
 		wildcardTLSSecret           corev1.Secret
@@ -94,6 +95,7 @@ var _ = Describe("#SNI", func() {
 		istioTLSTermination = false
 		hosts = []string{"foo.bar"}
 		hostName = "kube-apiserver." + namespace + ".svc.cluster.local"
+		upgradeHostName = "kube-apiserver-upgrade." + namespace + ".svc.cluster.local"
 		wildcardConfiguration = nil
 		wildcardHosts = []string{"foo.wildcard", "bar.wildcard"}
 		wildcardTLSSecret = corev1.Secret{
@@ -502,6 +504,25 @@ var _ = Describe("#SNI", func() {
 				expectedVirtualService.Spec.Tls = nil
 				expectedVirtualService.Spec.Http = []*istioapinetworkingv1beta1.HTTPRoute{
 					{
+						Name: "connection-upgrade",
+						Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{
+							{
+								Headers: map[string]*istioapinetworkingv1beta1.StringMatch{
+									"Connection": {MatchType: &istioapinetworkingv1beta1.StringMatch_Exact{Exact: "Upgrade"}},
+									"Upgrade":    {},
+								},
+							},
+						},
+						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
+							{
+								Destination: &istioapinetworkingv1beta1.Destination{
+									Host: upgradeHostName,
+									Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
+								},
+							},
+						},
+					},
+					{
 						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
 							{
 								Destination: &istioapinetworkingv1beta1.Destination{
@@ -561,6 +582,25 @@ var _ = Describe("#SNI", func() {
 				expectedVirtualService.Spec.Tls = nil
 				expectedVirtualService.Spec.Http = []*istioapinetworkingv1beta1.HTTPRoute{
 					{
+						Name: "connection-upgrade",
+						Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{
+							{
+								Headers: map[string]*istioapinetworkingv1beta1.StringMatch{
+									"Connection": {MatchType: &istioapinetworkingv1beta1.StringMatch_Exact{Exact: "Upgrade"}},
+									"Upgrade":    {},
+								},
+							},
+						},
+						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
+							{
+								Destination: &istioapinetworkingv1beta1.Destination{
+									Host: upgradeHostName,
+									Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
+								},
+							},
+						},
+					},
+					{
 						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
 							{
 								Destination: &istioapinetworkingv1beta1.Destination{
@@ -617,6 +657,25 @@ var _ = Describe("#SNI", func() {
 				expectedVirtualService.Spec.Tls = nil
 				expectedVirtualService.Spec.Http = []*istioapinetworkingv1beta1.HTTPRoute{
 					{
+						Name: "connection-upgrade",
+						Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{
+							{
+								Headers: map[string]*istioapinetworkingv1beta1.StringMatch{
+									"Connection": {MatchType: &istioapinetworkingv1beta1.StringMatch_Exact{Exact: "Upgrade"}},
+									"Upgrade":    {},
+								},
+							},
+						},
+						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
+							{
+								Destination: &istioapinetworkingv1beta1.Destination{
+									Host: upgradeHostName,
+									Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
+								},
+							},
+						},
+					},
+					{
 						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
 							{
 								Destination: &istioapinetworkingv1beta1.Destination{
@@ -630,6 +689,25 @@ var _ = Describe("#SNI", func() {
 
 				expectedWildcardVirtualService.Spec.Tls = nil
 				expectedWildcardVirtualService.Spec.Http = []*istioapinetworkingv1beta1.HTTPRoute{
+					{
+						Name: "connection-upgrade",
+						Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{
+							{
+								Headers: map[string]*istioapinetworkingv1beta1.StringMatch{
+									"Connection": {MatchType: &istioapinetworkingv1beta1.StringMatch_Exact{Exact: "Upgrade"}},
+									"Upgrade":    {},
+								},
+							},
+						},
+						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
+							{
+								Destination: &istioapinetworkingv1beta1.Destination{
+									Host: upgradeHostName,
+									Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
+								},
+							},
+						},
+					},
 					{
 						Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
 							{

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -77,7 +77,20 @@ spec:
                           string_match:
                             exact: {{ .ControlPlaneNamespace }}
                     route:
-                      cluster: outbound|{{ .Port }}||{{ .MTLSHost }}
+                      cluster: outbound|{{ .Port }}||{{ .MutualTLSHost }}
+                  - match:
+                      prefix: "/"
+                      headers:
+                      - name: Connection
+                        string_match:
+                          exact: Upgrade
+                      - name: Upgrade
+                        present_match: true
+                    route:
+                      cluster: outbound|{{ .Port }}||{{ .UpgradeHost }}
+                      upgrade_configs:
+                      - upgrade_type: spdy/3.1
+                      - upgrade_type: websocket
                   - match:
                       prefix: "/"
                     route:

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -87,7 +87,7 @@ spec:
                       - name: Upgrade
                         present_match: true
                     route:
-                      cluster: outbound|{{ .Port }}||{{ .UpgradeHost }}
+                      cluster: outbound|{{ .Port }}||{{ .ConnectionUpgradeHost }}
                       upgrade_configs:
                       - upgrade_type: spdy/3.1
                       - upgrade_type: websocket

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-istio-tls-termination.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-istio-tls-termination.yaml
@@ -57,7 +57,7 @@ spec:
     match:
       context: ANY
       cluster:
-        name: outbound|{{ .Port }}||{{ .UpgradeHost }}
+        name: outbound|{{ .Port }}||{{ .ConnectionUpgradeHost }}
     patch:
       operation: MERGE
       value:

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-istio-tls-termination.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-istio-tls-termination.yaml
@@ -53,3 +53,33 @@ spec:
         route:
           cluster: outbound|{{ $.Port }}||{{ $.MutualTLSHost }}
 {{- end }}
+  - applyTo: CLUSTER
+    match:
+      context: ANY
+      cluster:
+        name: outbound|{{ .Port }}||{{ .UpgradeHost }}
+    patch:
+      operation: MERGE
+      value:
+        transportSocket:
+          name: envoy.transport_sockets.tls
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+            commonTlsContext:
+              alpnProtocols:
+              - "http/1.1"
+  - applyTo: HTTP_ROUTE
+    match:
+      context: GATEWAY
+      routeConfiguration:
+        name: "{{ .RouteConfigurationName }}"
+        vhost:
+          route:
+            name: "{{ .ConnectionUpgradeRouteName }}"
+    patch:
+      operation: MERGE
+      value:
+        route:
+          upgrade_configs:
+          - upgrade_type: spdy/3.1
+          - upgrade_type: websocket

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -25,8 +25,10 @@ func (b *Botanist) DefaultKubeAPIServerService() component.DeployWaiter {
 		b.defaultKubeAPIServerServiceWithSuffix("", true),
 	}
 	mutualTLSService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.MutualTLSServiceNameSuffix, false)
+	upgradeService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.UpgradeServiceNameSuffix, false)
 	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()) {
 		deployer = append(deployer, mutualTLSService)
+		deployer = append(deployer, upgradeService)
 	} else {
 		deployer = append(deployer, component.OpDestroy(mutualTLSService))
 	}

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -25,7 +25,7 @@ func (b *Botanist) DefaultKubeAPIServerService() component.DeployWaiter {
 		b.defaultKubeAPIServerServiceWithSuffix("", true),
 	}
 	mutualTLSService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.MutualTLSServiceNameSuffix, false)
-	upgradeService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.UpgradeServiceNameSuffix, false)
+	upgradeService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.ConnectionUpgradeServiceNameSuffix, false)
 	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()) {
 		deployer = append(deployer, mutualTLSService)
 		deployer = append(deployer, upgradeService)

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -523,7 +523,7 @@ func (r *Reconciler) newKubeAPIServerService(log logr.Logger, garden *operatorv1
 	deployer := []component.Deployer{r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, "")}
 
 	mutualTLSService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.MutualTLSServiceNameSuffix)
-	if isIstioTLSTerminationEnabled(garden) {
+	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
 		deployer = append(deployer, mutualTLSService)
 	} else {
 		deployer = append(deployer, component.OpDestroy(mutualTLSService))
@@ -863,7 +863,7 @@ func (r *Reconciler) newSNI(ctx context.Context, garden *operatorv1alpha1.Garden
 					Namespace: ingressGatewayValues[0].Namespace,
 					Labels:    ingressGatewayValues[0].Labels,
 				},
-				IstioTLSTermination:   isIstioTLSTerminationEnabled(garden),
+				IstioTLSTermination:   features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
 				WildcardConfiguration: wildcardConfiguration,
 			}
 		},

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -523,7 +523,7 @@ func (r *Reconciler) newKubeAPIServerService(log logr.Logger, garden *operatorv1
 	deployer := []component.Deployer{r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, "")}
 
 	mutualTLSService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.MutualTLSServiceNameSuffix)
-	upgradeService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.UpgradeServiceNameSuffix)
+	upgradeService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.ConnectionUpgradeServiceNameSuffix)
 	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
 		deployer = append(deployer, mutualTLSService)
 		deployer = append(deployer, upgradeService)

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -523,8 +523,10 @@ func (r *Reconciler) newKubeAPIServerService(log logr.Logger, garden *operatorv1
 	deployer := []component.Deployer{r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, "")}
 
 	mutualTLSService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.MutualTLSServiceNameSuffix)
+	upgradeService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.UpgradeServiceNameSuffix)
 	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
 		deployer = append(deployer, mutualTLSService)
+		deployer = append(deployer, upgradeService)
 	} else {
 		deployer = append(deployer, component.OpDestroy(mutualTLSService))
 	}

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -29,14 +29,12 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
-	"github.com/gardener/gardener/pkg/features"
 	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 const (
@@ -538,17 +536,4 @@ func getValidVolumeSize(volume *operatorv1alpha1.Volume, size string) string {
 	}
 
 	return size
-}
-
-func isIstioTLSTerminationEnabled(garden *operatorv1alpha1.Garden) bool {
-	if !features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
-		return false
-	}
-
-	kubernetesVersion, err := semver.NewVersion(garden.Spec.VirtualCluster.Kubernetes.Version)
-	if err != nil {
-		return false
-	}
-
-	return versionutils.ConstraintK8sGreaterEqual131.Check(kubernetesVersion)
 }

--- a/pkg/utils/istio/destinationrule.go
+++ b/pkg/utils/istio/destinationrule.go
@@ -33,7 +33,10 @@ func DestinationRuleWithTLSTermination(destinationRule *istionetworkingv1beta1.D
 		&istioapinetworkingv1beta1.ClientTLSSettings{
 			Mode:           mode,
 			CredentialName: caSecret,
-			Sni:            destinationHost,
+			// SNI needs to be set for the wildcard certificate case. The wildcard cert is not signed by the cluster CA
+			// so it would cause a certificate error otherwise.
+			// `kubernetes.default.svc.cluster.local` is part of any kube-apiserver certificate, so we select this one.
+			Sni: "kubernetes.default.svc.cluster.local",
 		},
 	)
 }

--- a/pkg/utils/istio/destinationrule.go
+++ b/pkg/utils/istio/destinationrule.go
@@ -18,7 +18,7 @@ func DestinationRuleWithLocalityPreference(destinationRule *istionetworkingv1bet
 }
 
 // DestinationRuleWithTLSTermination returns a function setting the given attributes to a destination rule object.
-func DestinationRuleWithTLSTermination(destinationRule *istionetworkingv1beta1.DestinationRule, labels map[string]string, destinationHost, caSecret string, mode istioapinetworkingv1beta1.ClientTLSSettings_TLSmode) func() error {
+func DestinationRuleWithTLSTermination(destinationRule *istionetworkingv1beta1.DestinationRule, labels map[string]string, destinationHost, sniHost, caSecret string, mode istioapinetworkingv1beta1.ClientTLSSettings_TLSmode) func() error {
 	return destinationRuleWithTrafficPolicy(
 		destinationRule,
 		labels,
@@ -33,10 +33,7 @@ func DestinationRuleWithTLSTermination(destinationRule *istionetworkingv1beta1.D
 		&istioapinetworkingv1beta1.ClientTLSSettings{
 			Mode:           mode,
 			CredentialName: caSecret,
-			// SNI needs to be set for the wildcard certificate case. The wildcard cert is not signed by the cluster CA
-			// so it would cause a certificate error otherwise.
-			// `kubernetes.default.svc.cluster.local` is part of any kube-apiserver certificate, so we select this one.
-			Sni: "kubernetes.default.svc.cluster.local",
+			Sni:            sniHost,
 		},
 	)
 }

--- a/pkg/utils/istio/virtualservice_test.go
+++ b/pkg/utils/istio/virtualservice_test.go
@@ -7,6 +7,7 @@ package istio_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 
 	. "github.com/gardener/gardener/pkg/utils/istio"
@@ -40,10 +41,10 @@ var _ = Describe("VirtualService", func() {
 		Entry("Some values", map[string]string{"foo": "bar", "key": "value"}, []string{"host-1", "host-2"}, "my-gateway", uint32(123456), "destination.namespace.svc.cluster.local"),
 	)
 
-	DescribeTable("#VirtualServiceForTLSTermination", func(labels map[string]string, hosts []string, gatewayName string, port uint32, destinationHost string) {
+	DescribeTable("#VirtualServiceForTLSTermination", func(labels map[string]string, hosts []string, gatewayName string, port uint32, destinationHost, upgradeDestinationHost, connectionUpgradeRouteName string) {
 		virtualService := &istionetworkingv1beta1.VirtualService{}
 
-		function := VirtualServiceForTLSTermination(virtualService, labels, hosts, gatewayName, port, destinationHost)
+		function := VirtualServiceForTLSTermination(virtualService, labels, hosts, gatewayName, port, destinationHost, upgradeDestinationHost, connectionUpgradeRouteName)
 
 		Expect(function).NotTo(BeNil())
 
@@ -54,14 +55,22 @@ var _ = Describe("VirtualService", func() {
 		Expect(virtualService.Spec.Hosts).To(Equal(hosts))
 		Expect(virtualService.Spec.Gateways).To(HaveLen(1))
 		Expect(virtualService.Spec.Gateways[0]).To(Equal(gatewayName))
-		Expect(virtualService.Spec.Http).To(HaveLen(1))
-		Expect(virtualService.Spec.Http[0].Match).To(BeEmpty())
+		Expect(virtualService.Spec.Http).To(HaveLen(2))
+		Expect(virtualService.Spec.Http[0].Match).To(HaveLen(1))
+		Expect(virtualService.Spec.Http[0].Match[0].Headers).To(HaveLen(2))
+		Expect(virtualService.Spec.Http[0].Match[0].Headers["Connection"]).To(Equal(&istioapinetworkingv1beta1.StringMatch{MatchType: &istioapinetworkingv1beta1.StringMatch_Exact{Exact: "Upgrade"}}))
+		Expect(virtualService.Spec.Http[0].Match[0].Headers["Upgrade"]).To(Equal(&istioapinetworkingv1beta1.StringMatch{}))
 		Expect(virtualService.Spec.Http[0].Route).To(HaveLen(1))
-		Expect(virtualService.Spec.Http[0].Route[0].Destination.Host).To(Equal(destinationHost))
+		Expect(virtualService.Spec.Http[0].Name).To(Equal(connectionUpgradeRouteName))
+		Expect(virtualService.Spec.Http[0].Route[0].Destination.Host).To(Equal(upgradeDestinationHost))
 		Expect(virtualService.Spec.Http[0].Route[0].Destination.Port.Number).To(Equal(port))
+		Expect(virtualService.Spec.Http[1].Match).To(BeEmpty())
+		Expect(virtualService.Spec.Http[1].Route).To(HaveLen(1))
+		Expect(virtualService.Spec.Http[1].Route[0].Destination.Host).To(Equal(destinationHost))
+		Expect(virtualService.Spec.Http[1].Route[0].Destination.Port.Number).To(Equal(port))
 	},
 
-		Entry("Nil values", nil, nil, "", uint32(0), ""),
-		Entry("Some values", map[string]string{"foo": "bar", "key": "value"}, []string{"host-1", "host-2"}, "my-gateway", uint32(123456), "destination.namespace.svc.cluster.local"),
+		Entry("Nil values", nil, nil, "", uint32(0), "", "", ""),
+		Entry("Some values", map[string]string{"foo": "bar", "key": "value"}, []string{"host-1", "host-2"}, "my-gateway", uint32(123456), "destination.namespace.svc.cluster.local", "destination-upgrade.namespace.svc.cluster.local", "connection-upgrade"),
 	)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
When L7 was introduced with PR #11085 it did not include support for SPDY which is the old streaming protocol in Kubernetes. Websocket is the future protocol which is enabled by default since Kubernetes v1.31.0 (see [this blog](https://kubernetes.io/blog/2024/08/20/websockets-transition/) entry for more information). Thus, L7 load balancing could be enabled for Kubernetes >=v1.31.0 only.

Later, we found out that the Kubernetes Conformance tests require SPDY support until Kubernetes v1.33.0. Additionally, some of our own implementation using streaming APIs had to be adapted (see https://github.com/gardener/gardener/issues/8810#issuecomment-2757563585). 
We decided to add SPDY support to allow users a smooth transition to websockets and pass the Conformance test when the feature is active.

This PR implements SPDY support and is following [this suggestion](https://github.com/envoyproxy/envoy/issues/11190#issuecomment-658918760) to create a custom route configuration and a custom (envoy) cluster with no HTTP2 support in order to support upgrading the connection to SPDY.

Given the circumstances that we are using istio, there are two different options.
- Create the configuration entirely with `EnvoyFilter`s
- Use Istio objects and add the missing parts via `EnvoyFilter`s

This PR follows the latter approach.
It uses `EnvoyFilter` to disable HTTP2 and to set the correct upgrade configs. Both cannot be done via Istio objects. Apart from that, the existing Istio configuration is used in a slightly adapted way. 


**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:
/cc @ScheererJ @DockToFuture @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
L7 load balancing is supporting the SPDY protocol for streaming APIs too.
```
```feature user
L7 load balancing can now be enabled independently from the Kubernetes version of the shoot when `IstioTLSTermination` feature gate is enabled on the seed.
```
