### PR TITLE
Add optional virtualCapacity field to extensions/NodeTemplate on WorkerConfig

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4031,6 +4031,20 @@ Kubernetes core/v1.ResourceList
 <p>Capacity represents the expected Node capacity.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>virtualCapacity</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcelist-v1-core">
+Kubernetes core/v1.ResourceList
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VirtualCapacity represents the expected Node &lsquo;virtual&rsquo; capacity ie comprising virtual extended resources.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="extensions.gardener.cloud/v1alpha1.OSUpdate">OSUpdate

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -5011,7 +5011,7 @@ NodeTemplate
 </td>
 <td>
 <em>(Optional)</em>
-<p>NodeTemplate contains resource information of the machine which is used by Cluster Autoscaler to generate nodeTemplate during scaling a nodeGroup from zero</p>
+<p>NodeTemplate contains resource information of the machine which is used by Cluster Autoscaler to generate nodeTemplate during scaling a nodeGroup</p>
 </td>
 </tr>
 <tr>

--- a/docs/extensions/resources/worker.md
+++ b/docs/extensions/resources/worker.md
@@ -76,6 +76,8 @@ spec:
         cpu: 2
         gpu: 0
         memory: 8Gi
+      virtualCapacity: 
+        hc.hana.com/memory: 1234567
     labels:
       node.kubernetes.io/role: node
       worker.gardener.cloud/cri-name: containerd
@@ -121,6 +123,8 @@ Nevertheless, this is only effective when bootstrapping new nodes.
 The provider extension (respectively, machine-controller-manager) is still responsible for updating the labels of existing `Nodes` when the worker specification changes.
 
 The `spec.pools[].nodeTemplate.capacity` field contains the resource information of the machine like `cpu`, `gpu`, and `memory`. This info is used by Cluster Autoscaler to generate `nodeTemplate` during scaling the `nodeGroup` from zero.
+
+The `spec.pools[].nodeTemplate.virtualCapacity` field contains the _virtual_ resource information associated with the machine and used to specify extended resources that are _virtual_ in nature (For specifying real, provisionable resources `nodeTemplate.capacity` should be used). This will be applied to the machine class `nodeTemplate` without triggering a rollout of the cluster and will be  used by Cluster Autoscaler for scaling the `nodeGroup` from zero.
 
 The `spec.pools[].machineControllerManager` field allows to configure the settings for machine-controller-manager component. Providers must populate these settings on worker-pool to the related [fields](https://github.com/gardener/machine-controller-manager/blob/master/kubernetes/machine_objects/machine-deployment.yaml#L30-L34) in MachineDeployment.
 

--- a/docs/extensions/resources/worker.md
+++ b/docs/extensions/resources/worker.md
@@ -77,7 +77,7 @@ spec:
         gpu: 0
         memory: 8Gi
       virtualCapacity: 
-        hc.hana.com/memory: 1234567
+        subdomain.domain.com/resource-name: 1234567
     labels:
       node.kubernetes.io/role: node
       worker.gardener.cloud/cri-name: containerd
@@ -124,7 +124,7 @@ The provider extension (respectively, machine-controller-manager) is still respo
 
 The `spec.pools[].nodeTemplate.capacity` field contains the resource information of the machine like `cpu`, `gpu`, and `memory`. This info is used by Cluster Autoscaler to generate `nodeTemplate` during scaling the `nodeGroup` from zero.
 
-The `spec.pools[].nodeTemplate.virtualCapacity` field contains the _virtual_ resource information associated with the machine and used to specify extended resources that are _virtual_ in nature (for specifying real, provisionable resources, `nodeTemplate.capacity` should be used). This will be applied to the machine class `nodeTemplate` without triggering a rollout of the cluster and will be  used by Cluster Autoscaler for scaling the `nodeGroup` from zero.
+The `spec.pools[].nodeTemplate.virtualCapacity` field contains the _virtual_ resource information associated with the machine and used to specify extended resources that are _virtual_ in nature (for specifying real, provisionable resources, `nodeTemplate.capacity` should be used). This will be applied to the machine class `nodeTemplate` without triggering a rollout of the cluster and will be  used by Cluster Autoscaler for scaling the `nodeGroup`.
 
 The `spec.pools[].machineControllerManager` field allows to configure the settings for machine-controller-manager component. Providers must populate these settings on worker-pool to the related [fields](https://github.com/gardener/machine-controller-manager/blob/master/kubernetes/machine_objects/machine-deployment.yaml#L30-L34) in MachineDeployment.
 

--- a/docs/extensions/resources/worker.md
+++ b/docs/extensions/resources/worker.md
@@ -124,7 +124,7 @@ The provider extension (respectively, machine-controller-manager) is still respo
 
 The `spec.pools[].nodeTemplate.capacity` field contains the resource information of the machine like `cpu`, `gpu`, and `memory`. This info is used by Cluster Autoscaler to generate `nodeTemplate` during scaling the `nodeGroup` from zero.
 
-The `spec.pools[].nodeTemplate.virtualCapacity` field contains the _virtual_ resource information associated with the machine and used to specify extended resources that are _virtual_ in nature (For specifying real, provisionable resources `nodeTemplate.capacity` should be used). This will be applied to the machine class `nodeTemplate` without triggering a rollout of the cluster and will be  used by Cluster Autoscaler for scaling the `nodeGroup` from zero.
+The `spec.pools[].nodeTemplate.virtualCapacity` field contains the _virtual_ resource information associated with the machine and used to specify extended resources that are _virtual_ in nature (for specifying real, provisionable resources, `nodeTemplate.capacity` should be used). This will be applied to the machine class `nodeTemplate` without triggering a rollout of the cluster and will be  used by Cluster Autoscaler for scaling the `nodeGroup` from zero.
 
 The `spec.pools[].machineControllerManager` field allows to configure the settings for machine-controller-manager component. Providers must populate these settings on worker-pool to the related [fields](https://github.com/gardener/machine-controller-manager/blob/master/kubernetes/machine_objects/machine-deployment.yaml#L30-L34) in MachineDeployment.
 

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -588,6 +588,16 @@ spec:
                             x-kubernetes-int-or-string: true
                           description: Capacity represents the expected Node capacity.
                           type: object
+                        virtualCapacity:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: VirtualCapacity represents the expected Node
+                            'virtual' capacity ie comprising virtual extended resources.
+                          type: object
                       required:
                       - capacity
                       type: object

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -577,7 +577,7 @@ spec:
                     nodeTemplate:
                       description: NodeTemplate contains resource information of the
                         machine which is used by Cluster Autoscaler to generate nodeTemplate
-                        during scaling a nodeGroup from zero
+                        during scaling a nodeGroup
                       properties:
                         capacity:
                           additionalProperties:

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -158,7 +158,7 @@ type WorkerPool struct {
 	// KubeletConfig contains the kubelet configuration for the worker pool.
 	// +optional
 	KubeletConfig *gardencorev1beta1.KubeletConfig `json:"kubeletConfig,omitempty"`
-	// NodeTemplate contains resource information of the machine which is used by Cluster Autoscaler to generate nodeTemplate during scaling a nodeGroup from zero
+	// NodeTemplate contains resource information of the machine which is used by Cluster Autoscaler to generate nodeTemplate during scaling a nodeGroup
 	// +optional
 	NodeTemplate *NodeTemplate `json:"nodeTemplate,omitempty"`
 	// Architecture is the CPU architecture of the worker pool machines and machine image.

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -198,6 +198,9 @@ type ClusterAutoscalerOptions struct {
 type NodeTemplate struct {
 	// Capacity represents the expected Node capacity.
 	Capacity corev1.ResourceList `json:"capacity"`
+	// VirtualCapacity represents the expected Node 'virtual' capacity ie comprising virtual extended resources.
+	// +optional
+	VirtualCapacity corev1.ResourceList `json:"virtualCapacity,omitempty"`
 }
 
 // MachineImage contains logical information about the name and the version of the machie image that

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1580,6 +1580,13 @@ func (in *NodeTemplate) DeepCopyInto(out *NodeTemplate) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
+	if in.VirtualCapacity != nil {
+		in, out := &in.VirtualCapacity, &out.VirtualCapacity
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
 	return
 }
 

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -579,7 +579,7 @@ spec:
                     nodeTemplate:
                       description: NodeTemplate contains resource information of the
                         machine which is used by Cluster Autoscaler to generate nodeTemplate
-                        during scaling a nodeGroup from zero
+                        during scaling a nodeGroup
                       properties:
                         capacity:
                           additionalProperties:

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -590,6 +590,16 @@ spec:
                             x-kubernetes-int-or-string: true
                           description: Capacity represents the expected Node capacity.
                           type: object
+                        virtualCapacity:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: VirtualCapacity represents the expected Node
+                            'virtual' capacity ie comprising virtual extended resources.
+                          type: object
                       required:
                       - capacity
                       type: object


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:

In order to support an extension requirement. See https://github.com/gardener/gardener-extension-provider-aws/issues/1238 we would like `NodeTemplate` in `pkg/apis/extensions/v1alpha1/types_worker.go` to have an additional map used to specify *virtual* resources of a Node that don't require rollout as opposed to *real* provisionable resources

```yaml
providerConfig:
    nodeTemplate:
        capacity:
            cpu: 123
        virtualCapacity: #PROPOSED API CHANGE
             hc.hana.com/memory: 1234567
```
This is to disambiguate *real* capacity attributes that indicate provision-able resources that necessitate rollout versus *virtual* capacity attributes that are applied on existing Nodes to affect workload scheduling and scaling.

**Which issue(s) this PR fixes**:
Fixes #11691

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Virtual extended resources can now be set on the NodeTemplate without triggering rollout
```
