### PR TITLE
Make the deployment of the source `BackupEntry` dependant on the deployment of the  `Shoot`'s control plane namespace

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -233,9 +233,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
 		})
 		deploySourceBackupEntry = g.Add(flow.Task{
-			Name:   "Deploying source backup entry",
-			Fn:     botanist.DeploySourceBackupEntry,
-			SkipIf: !isCopyOfBackupsRequired,
+			Name:         "Deploying source backup entry",
+			Fn:           botanist.DeploySourceBackupEntry,
+			SkipIf:       !isCopyOfBackupsRequired,
+			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		waitUntilSourceBackupEntryInGardenReconciled = g.Add(flow.Task{
 			Name:         "Waiting until the source backup entry has been reconciled",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR makes the deployment of the source BackupEntry dependant on the deployment of the shoot's control plane namespace in the destination seed during the `restore` phase of control plane migration. This is similar to how the original BackupEntry also depends on the shoot's control plane namespace being deployed.

During the reconciliation of a BackupEntry, the creation of the `{source-}etcd-backup` Secret in the shoot's control plane namespace is skipped if the namespace does not exist, however, the reconciliation is treated as successful. The reconciliation is then not retried and if this happens for the source backup entry, the `source-etcd-backup` Secret does not get deployed. This causes the subsequent step which copies the etcd backups to time out. 

Note that when the `restore` operation is restarted, the `source-etcd-backup` Secret will be created successfully and the operation will continue. So this PR is needed to avoid the unnecessary timeout and restart of the `restore` operation.

Example provider local logs:
```
2025-04-03T14:53:36.470484056Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.470Z","msg":"Reconciling the BackupEntry","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"4142f45b-c575-4237-af47-bc95ef194171"}
2025-04-03T14:53:36.477875046Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.477Z","msg":"Adding finalizer to secret","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"4142f45b-c575-4237-af47-bc95ef194171","secret":{"name":"entry-source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","namespace":"garden"}}
2025-04-03T14:53:36.482400256Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.482Z","msg":"Starting the reconciliation of BackupEntry","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"4142f45b-c575-4237-af47-bc95ef194171"}
2025-04-03T14:53:36.482439406Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.482Z","msg":"SeedNamespace for shoot not found. Avoiding etcd backup secret deployment","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"4142f45b-c575-4237-af47-bc95ef194171"}
2025-04-03T14:53:36.482447416Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.482Z","msg":"Successfully reconciled BackupEntry","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"4142f45b-c575-4237-af47-bc95ef194171"}
2025-04-03T14:53:36.497932106Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.497Z","msg":"Reconciling the BackupEntry","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"18fad4a6-6f38-479f-83fe-2e2f07873e36"}
2025-04-03T14:53:36.504069856Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.503Z","msg":"Starting the reconciliation of BackupEntry","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"18fad4a6-6f38-479f-83fe-2e2f07873e36"}
2025-04-03T14:53:36.504197246Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.504Z","msg":"SeedNamespace for shoot not found. Avoiding etcd backup secret deployment","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"18fad4a6-6f38-479f-83fe-2e2f07873e36"}
2025-04-03T14:53:36.504213286Z stderr F {"level":"info","ts":"2025-04-03T14:53:36.504Z","msg":"Successfully reconciled BackupEntry","controller":"backupentry","namespace":"","name":"source-shoot--local--e2e-migrate--cc4305a3-616b-4bbd-b485-68dc38732b2a","reconcileID":"18fad4a6-6f38-479f-83fe-2e2f07873e36"}
```

Example gardenlet logs during shoot restoration:
```
2025-04-03T15:21:47.596Z	INFO	Waiting for reconciliation and healthiness	{"shoot": {"name":"e2e-migrate","namespace":"garden-local"}, "lastOperation": "&LastOperation{Description:Flow \"Shoot cluster restoration\" encountered task errors: [task \"Copying etcd backups to new seed's backup bucket\" failed: Secret \"source-etcd-backup\" not found] Operation will be retried.,LastUpdateTime:2025-04-03 15:19:39 +0000 UTC,Progress:21,State:Error,Type:Restore,}", "reason": "condition type APIServerAvailable is not true yet, had message Could not reach API server during client initialization. with reason APIServerDown"}
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/pull/11337#issuecomment-2776584567

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The step which deploys the source `BackupEntry` during the `restore` phase of control plane migration now depends on the successful deployment of the `Shoot`'s control plane namespace. This fixes a potential race condition which could cause the `source-etcd-backup` Secret to not be deployed in the `Shoot`'s control plane namespace and the subsequent step which copies etcd backups to time out.
```
