### PR TITLE
Add /run/udev/data to the node exporter configuration

### DIFF
--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -377,6 +377,7 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 									"--path.procfs=/host/proc",
 									"--path.sysfs=/host/sys",
 									"--path.rootfs=/host",
+									"--path.udev.data=/host/run/udev/data",
 									"--log.level=error",
 									"--collector.disable-defaults",
 									"--collector.conntrack",

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -330,6 +330,7 @@ spec:
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
         - --path.rootfs=/host
+        - --path.udev.data=/host/run/udev/data
         - --log.level=error
         - --collector.disable-defaults
         - --collector.conntrack


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR addresses an error message during the startup of the node exporter. Despite the error, the node exporters have been running successfully. This PR simply adjusts the node exporter configuration to resolve the error message. We have not identified any other issues resulting from this error.

```
level=ERROR source=diskstats_linux.go:264 msg="Failed to open directory, disabling udev device properties" collector=diskstats path=/run/udev/data
```

**Special notes for your reviewer**:

/cc @plkokanov @rickardsjp @chrkl @istvanballok 

**Release note**:

```other operator
Fix an error message during the startup of the node exporter
```
