### PR TITLE
Remove cloud provider specific logic from the guestbook TM test

### DIFF
--- a/pkg/apis/core/v1beta1/helper/seed.go
+++ b/pkg/apis/core/v1beta1/helper/seed.go
@@ -7,6 +7,7 @@ package helper
 import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -116,4 +117,19 @@ func CalculateSeedUsage(shootList []*gardencorev1beta1.Shoot) map[string]int {
 	}
 
 	return m
+}
+
+// GetValidVolumeSize is to get a valid volume size.
+// If the given size is smaller than the minimum volume size permitted by cloud provider on which seed cluster is running, it will return the minimum size.
+func GetValidVolumeSize(seed *gardencorev1beta1.Seed, size string) string {
+	if seed.Spec.Volume == nil || seed.Spec.Volume.MinimumSize == nil {
+		return size
+	}
+
+	qs, err := resource.ParseQuantity(size)
+	if err == nil && qs.Cmp(*seed.Spec.Volume.MinimumSize) < 0 {
+		return seed.Spec.Volume.MinimumSize.String()
+	}
+
+	return size
 }

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -563,7 +563,7 @@ func (r *Reconciler) newCachePrometheus(log logr.Logger, seed *seedpkg.Seed, isM
 	return sharedcomponent.NewPrometheus(log, r.SeedClientSet.Client(), r.GardenNamespace, prometheus.Values{
 		Name:              "cache",
 		PriorityClassName: v1beta1constants.PriorityClassNameSeedSystem600,
-		StorageCapacity:   resource.MustParse(seed.GetValidVolumeSize("10Gi")),
+		StorageCapacity:   resource.MustParse(v1beta1helper.GetValidVolumeSize(seed.GetInfo(), "10Gi")),
 		Replicas:          1,
 		Retention:         ptr.To(monitoringv1.Duration("1d")),
 		RetentionSize:     "5GB",
@@ -586,7 +586,7 @@ func (r *Reconciler) newSeedPrometheus(log logr.Logger, seed *seedpkg.Seed) (com
 	return sharedcomponent.NewPrometheus(log, r.SeedClientSet.Client(), r.GardenNamespace, prometheus.Values{
 		Name:              "seed",
 		PriorityClassName: v1beta1constants.PriorityClassNameSeedSystem600,
-		StorageCapacity:   resource.MustParse(seed.GetValidVolumeSize("100Gi")),
+		StorageCapacity:   resource.MustParse(v1beta1helper.GetValidVolumeSize(seed.GetInfo(), "100Gi")),
 		Replicas:          1,
 		RetentionSize:     "85GB",
 		VPAMinAllowed:     &corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("400Mi")},
@@ -610,7 +610,7 @@ func (r *Reconciler) newAggregatePrometheus(log logr.Logger, seed *seedpkg.Seed,
 	values := prometheus.Values{
 		Name:              "aggregate",
 		PriorityClassName: v1beta1constants.PriorityClassNameSeedSystem600,
-		StorageCapacity:   resource.MustParse(seed.GetValidVolumeSize("20Gi")),
+		StorageCapacity:   resource.MustParse(v1beta1helper.GetValidVolumeSize(seed.GetInfo(), "20Gi")),
 		Replicas:          1,
 		Retention:         ptr.To(monitoringv1.Duration("30d")),
 		RetentionSize:     "15GB",
@@ -654,7 +654,7 @@ func (r *Reconciler) newAlertmanager(log logr.Logger, seed *seedpkg.Seed, alerti
 		Name:               "seed",
 		ClusterType:        component.ClusterTypeSeed,
 		PriorityClassName:  v1beta1constants.PriorityClassNameSeedSystem600,
-		StorageCapacity:    resource.MustParse(seed.GetValidVolumeSize("1Gi")),
+		StorageCapacity:    resource.MustParse(v1beta1helper.GetValidVolumeSize(seed.GetInfo(), "1Gi")),
 		Replicas:           1,
 		AlertingSMTPSecret: alertingSMTPSecret,
 	})

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -69,7 +69,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 			Class:                       class,
 			Replicas:                    replicas,
 			Autoscaling:                 etcd.AutoscalingConfig{MinAllowed: minAllowed},
-			StorageCapacity:             b.Seed.GetValidVolumeSize(storageCapacity),
+			StorageCapacity:             v1beta1helper.GetValidVolumeSize(b.Seed.GetInfo(), storageCapacity),
 			DefragmentationSchedule:     &defragmentationSchedule,
 			CARotationPhase:             v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials),
 			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/alertmanager"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
@@ -36,7 +37,7 @@ func (b *Botanist) DefaultAlertmanager() (alertmanager.Interface, error) {
 		Name:               "shoot",
 		ClusterType:        component.ClusterTypeShoot,
 		PriorityClassName:  v1beta1constants.PriorityClassNameShootControlPlane100,
-		StorageCapacity:    resource.MustParse(b.Seed.GetValidVolumeSize("1Gi")),
+		StorageCapacity:    resource.MustParse(v1beta1helper.GetValidVolumeSize(b.Seed.GetInfo(), "1Gi")),
 		Replicas:           b.Shoot.GetReplicas(1),
 		AlertingSMTPSecret: b.LoadSecret(v1beta1constants.GardenRoleAlerting),
 		EmailReceivers:     emailReceivers,
@@ -86,7 +87,7 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 	values := prometheus.Values{
 		Name:                "shoot",
 		PriorityClassName:   v1beta1constants.PriorityClassNameShootControlPlane100,
-		StorageCapacity:     resource.MustParse(b.Seed.GetValidVolumeSize("20Gi")),
+		StorageCapacity:     resource.MustParse(v1beta1helper.GetValidVolumeSize(b.Seed.GetInfo(), "20Gi")),
 		ClusterType:         component.ClusterTypeShoot,
 		Replicas:            b.Shoot.GetReplicas(1),
 		Retention:           ptr.To(monitoringv1.Duration("30d")),

--- a/pkg/gardenlet/operation/seed/seed.go
+++ b/pkg/gardenlet/operation/seed/seed.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -140,22 +139,6 @@ func (s *Seed) IngressDomain() string {
 		return seed.Spec.Ingress.Domain
 	}
 	return ""
-}
-
-// GetValidVolumeSize is to get a valid volume size.
-// If the given size is smaller than the minimum volume size permitted by cloud provider on which seed cluster is running, it will return the minimum size.
-func (s *Seed) GetValidVolumeSize(size string) string {
-	seed := s.GetInfo()
-	if seed.Spec.Volume == nil || seed.Spec.Volume.MinimumSize == nil {
-		return size
-	}
-
-	qs, err := resource.ParseQuantity(size)
-	if err == nil && qs.Cmp(*seed.Spec.Volume.MinimumSize) < 0 {
-		return seed.Spec.Volume.MinimumSize.String()
-	}
-
-	return size
 }
 
 // GetLoadBalancerServiceAnnotations returns the load balancer annotations set for the seed if any.

--- a/pkg/gardenlet/operation/seed/seed_test.go
+++ b/pkg/gardenlet/operation/seed/seed_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
@@ -16,58 +15,6 @@ import (
 )
 
 var _ = Describe("seed", func() {
-	Describe("#GetValidVolumeSize", func() {
-		It("should return the size because no minimum size was set", func() {
-			var (
-				size = "20Gi"
-				seed = &Seed{}
-			)
-			seed.SetInfo(&gardencorev1beta1.Seed{
-				Spec: gardencorev1beta1.SeedSpec{
-					Volume: nil,
-				},
-			})
-
-			Expect(seed.GetValidVolumeSize(size)).To(Equal(size))
-		})
-
-		It("should return the minimum size because the given value is smaller", func() {
-			var (
-				size                = "20Gi"
-				minimumSize         = "25Gi"
-				minimumSizeQuantity = resource.MustParse(minimumSize)
-				seed                = &Seed{}
-			)
-			seed.SetInfo(&gardencorev1beta1.Seed{
-				Spec: gardencorev1beta1.SeedSpec{
-					Volume: &gardencorev1beta1.SeedVolume{
-						MinimumSize: &minimumSizeQuantity,
-					},
-				},
-			})
-
-			Expect(seed.GetValidVolumeSize(size)).To(Equal(minimumSize))
-		})
-
-		It("should return the given value size because the minimum size is smaller", func() {
-			var (
-				size                = "30Gi"
-				minimumSize         = "25Gi"
-				minimumSizeQuantity = resource.MustParse(minimumSize)
-				seed                = &Seed{}
-			)
-			seed.SetInfo(&gardencorev1beta1.Seed{
-				Spec: gardencorev1beta1.SeedSpec{
-					Volume: &gardencorev1beta1.SeedVolume{
-						MinimumSize: &minimumSizeQuantity,
-					},
-				},
-			})
-
-			Expect(seed.GetValidVolumeSize(size)).To(Equal(size))
-		})
-	})
-
 	Describe("#GetLoadBalancerServiceAnnotations", func() {
 		It("should return the annotations", func() {
 			var (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Currently, we have a special cloud provider specific logic in the guestbook test. 
See https://github.com/gardener/gardener/blob/906f0866aa4ba5cbe06508604119743b09cfbb39/test/framework/applications/guestbooktest.go#L138-L143

In the registry-cache extension, we have the same check duplicated many times.

This PR moves the `GetValidVolumeSize` func from a botanist pkg to a helper pkg. In this way, the func will be reusable by TM tests (in gardener/gardener and in extensions repos) which create volumes.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`github.com/gardener/gardener/pkg/apis/core/v1beta1/helper.GetValidVolumeSize` func is now available as a helper func. It can be used by TM tests in extension repositories which create volumes and need to respect with the minimum volume size restriction of the Seed cluster.
```
