### PR TITLE
Improve error message when updating shoot while it's in deletion

### DIFF
--- a/pkg/apis/core/validation/controllerinstallation.go
+++ b/pkg/apis/core/validation/controllerinstallation.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -58,10 +59,8 @@ func ValidateControllerInstallationSpecUpdate(new, old *core.ControllerInstallat
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.RegistrationRef.Name, old.RegistrationRef.Name, fldPath.Child("registrationRef", "name"))...)

--- a/pkg/apis/core/validation/controllerinstallation.go
+++ b/pkg/apis/core/validation/controllerinstallation.go
@@ -60,7 +60,7 @@ func ValidateControllerInstallationSpecUpdate(new, old *core.ControllerInstallat
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update controller installation spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.RegistrationRef.Name, old.RegistrationRef.Name, fldPath.Child("registrationRef", "name"))...)

--- a/pkg/apis/core/validation/controllerinstallation_test.go
+++ b/pkg/apis/core/validation/controllerinstallation_test.go
@@ -114,7 +114,7 @@ var _ = Describe("validation", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("RegistrationRef.APIVersion: another-api-version != "),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: RegistrationRef.APIVersion: another-api-version != "),
 			}))))
 		})
 

--- a/pkg/apis/core/validation/controllerinstallation_test.go
+++ b/pkg/apis/core/validation/controllerinstallation_test.go
@@ -114,7 +114,7 @@ var _ = Describe("validation", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: RegistrationRef.APIVersion: another-api-version != "),
+				"Detail": Equal("cannot update controller installation spec if deletion timestamp is set. Requested changes: RegistrationRef.APIVersion: another-api-version != "),
 			}))))
 		})
 

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -151,7 +151,7 @@ func ValidateControllerRegistrationSpecUpdate(new, old *core.ControllerRegistrat
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update controller registration spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, ValidateControllerResourceUpdate(new.Resources, old.Resources, fldPath.Child("resources"))...)

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -150,10 +150,8 @@ func ValidateControllerRegistrationSpecUpdate(new, old *core.ControllerRegistrat
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, ValidateControllerResourceUpdate(new.Resources, old.Resources, fldPath.Child("resources"))...)

--- a/pkg/apis/core/validation/controllerregistration_test.go
+++ b/pkg/apis/core/validation/controllerregistration_test.go
@@ -399,7 +399,7 @@ var _ = Describe("validation", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("Resources.slice[0].Type: another-os != my-os"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: Resources.slice[0].Type: another-os != my-os"),
 			}))))
 		})
 

--- a/pkg/apis/core/validation/controllerregistration_test.go
+++ b/pkg/apis/core/validation/controllerregistration_test.go
@@ -399,7 +399,7 @@ var _ = Describe("validation", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: Resources.slice[0].Type: another-os != my-os"),
+				"Detail": Equal("cannot update controller registration spec if deletion timestamp is set. Requested changes: Resources.slice[0].Type: another-os != my-os"),
 			}))))
 		})
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -287,10 +287,8 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	allErrs := field.ErrorList{}
 
 	if newObjectMeta.DeletionTimestamp != nil && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
-		if diff := deep.Equal(newSpec, oldSpec); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("can't edit shoot while it's in deletion. Requested changes: %s", strings.Join(diff, ",")))}
-		}
-		return apivalidation.ValidateImmutableField(newSpec, oldSpec, fldPath)
+		diff := deep.Equal(newSpec, oldSpec)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Region, oldSpec.Region, fldPath.Child("region"))...)

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -288,7 +288,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 
 	if newObjectMeta.DeletionTimestamp != nil && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
 		if diff := deep.Equal(newSpec, oldSpec); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
+			return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("can't edit shoot while it's in deletion. Requested changes: %s", strings.Join(diff, ",")))}
 		}
 		return apivalidation.ValidateImmutableField(newSpec, oldSpec, fldPath)
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3909,7 +3909,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("can't edit shoot while it's in deletion. Requested changes: Maintenance.AutoUpdate.KubernetesVersion: false != true"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: Maintenance.AutoUpdate.KubernetesVersion: false != true"),
 			}))))
 		})
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3909,7 +3909,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("Maintenance.AutoUpdate.KubernetesVersion: false != true"),
+				"Detail": Equal("can't edit shoot while it's in deletion. Requested changes: Maintenance.AutoUpdate.KubernetesVersion: false != true"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/backupbucket.go
+++ b/pkg/apis/extensions/validation/backupbucket.go
@@ -61,7 +61,7 @@ func ValidateBackupBucketSpecUpdate(new, old *extensionsv1alpha1.BackupBucketSpe
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update backup bucket spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/backupbucket.go
+++ b/pkg/apis/extensions/validation/backupbucket.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -59,10 +60,8 @@ func ValidateBackupBucketSpecUpdate(new, old *extensionsv1alpha1.BackupBucketSpe
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/backupbucket_test.go
+++ b/pkg/apis/extensions/validation/backupbucket_test.go
@@ -76,7 +76,7 @@ var _ = Describe("BackupBucket validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update backup bucket spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/backupbucket_test.go
+++ b/pkg/apis/extensions/validation/backupbucket_test.go
@@ -76,7 +76,7 @@ var _ = Describe("BackupBucket validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/backupentry.go
+++ b/pkg/apis/extensions/validation/backupentry.go
@@ -65,7 +65,7 @@ func ValidateBackupEntrySpecUpdate(new, old *extensionsv1alpha1.BackupEntrySpec,
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update backup entry spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/backupentry.go
+++ b/pkg/apis/extensions/validation/backupentry.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -63,10 +64,8 @@ func ValidateBackupEntrySpecUpdate(new, old *extensionsv1alpha1.BackupEntrySpec,
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/backupentry_test.go
+++ b/pkg/apis/extensions/validation/backupentry_test.go
@@ -80,7 +80,7 @@ var _ = Describe("BackupEntry validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update backup entry spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/backupentry_test.go
+++ b/pkg/apis/extensions/validation/backupentry_test.go
@@ -80,7 +80,7 @@ var _ = Describe("BackupEntry validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/bastion.go
+++ b/pkg/apis/extensions/validation/bastion.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -59,10 +60,8 @@ func ValidateBastionSpecUpdate(new, old *extensionsv1alpha1.BastionSpec, deletio
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/bastion.go
+++ b/pkg/apis/extensions/validation/bastion.go
@@ -61,7 +61,7 @@ func ValidateBastionSpecUpdate(new, old *extensionsv1alpha1.BastionSpec, deletio
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update bastion spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/bastion_test.go
+++ b/pkg/apis/extensions/validation/bastion_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Bastion validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("Ingress.slice[0].IPBlock.CIDR: 8.8.8.8/8 != 1.2.3.4/8"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: Ingress.slice[0].IPBlock.CIDR: 8.8.8.8/8 != 1.2.3.4/8"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/bastion_test.go
+++ b/pkg/apis/extensions/validation/bastion_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Bastion validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: Ingress.slice[0].IPBlock.CIDR: 8.8.8.8/8 != 1.2.3.4/8"),
+				"Detail": Equal("cannot update bastion spec if deletion timestamp is set. Requested changes: Ingress.slice[0].IPBlock.CIDR: 8.8.8.8/8 != 1.2.3.4/8"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/containerruntime.go
+++ b/pkg/apis/extensions/validation/containerruntime.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -59,10 +60,8 @@ func ValidateContainerRuntimeSpecUpdate(new, old *extensionsv1alpha1.ContainerRu
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/containerruntime.go
+++ b/pkg/apis/extensions/validation/containerruntime.go
@@ -61,7 +61,7 @@ func ValidateContainerRuntimeSpecUpdate(new, old *extensionsv1alpha1.ContainerRu
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update container runtime spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/containerruntime_test.go
+++ b/pkg/apis/extensions/validation/containerruntime_test.go
@@ -77,7 +77,7 @@ var _ = Describe("ContainerRuntime validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: BinaryPath: changed-binaryPath != /test/path"),
+				"Detail": Equal("cannot update container runtime spec if deletion timestamp is set. Requested changes: BinaryPath: changed-binaryPath != /test/path"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/containerruntime_test.go
+++ b/pkg/apis/extensions/validation/containerruntime_test.go
@@ -77,7 +77,7 @@ var _ = Describe("ContainerRuntime validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("BinaryPath: changed-binaryPath != /test/path"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: BinaryPath: changed-binaryPath != /test/path"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/controlplane.go
+++ b/pkg/apis/extensions/validation/controlplane.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -65,10 +66,8 @@ func ValidateControlPlaneSpecUpdate(new, old *extensionsv1alpha1.ControlPlaneSpe
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/controlplane.go
+++ b/pkg/apis/extensions/validation/controlplane.go
@@ -67,7 +67,7 @@ func ValidateControlPlaneSpecUpdate(new, old *extensionsv1alpha1.ControlPlaneSpe
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update control plane spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/controlplane_test.go
+++ b/pkg/apis/extensions/validation/controlplane_test.go
@@ -97,7 +97,7 @@ var _ = Describe("ControlPlane validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/controlplane_test.go
+++ b/pkg/apis/extensions/validation/controlplane_test.go
@@ -97,7 +97,7 @@ var _ = Describe("ControlPlane validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update control plane spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -97,7 +97,7 @@ func ValidateDNSRecordSpecUpdate(new, old *extensionsv1alpha1.DNSRecordSpec, del
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update dns record spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -95,10 +96,8 @@ func ValidateDNSRecordSpecUpdate(new, old *extensionsv1alpha1.DNSRecordSpec, del
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/dnsrecord_test.go
+++ b/pkg/apis/extensions/validation/dnsrecord_test.go
@@ -224,7 +224,7 @@ var _ = Describe("DNSRecord validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update dns record spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/dnsrecord_test.go
+++ b/pkg/apis/extensions/validation/dnsrecord_test.go
@@ -224,7 +224,7 @@ var _ = Describe("DNSRecord validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/extension.go
+++ b/pkg/apis/extensions/validation/extension.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -51,10 +52,8 @@ func ValidateExtensionSpecUpdate(new, old *extensionsv1alpha1.ExtensionSpec, del
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/extension.go
+++ b/pkg/apis/extensions/validation/extension.go
@@ -53,7 +53,7 @@ func ValidateExtensionSpecUpdate(new, old *extensionsv1alpha1.ExtensionSpec, del
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update extension spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/extension_test.go
+++ b/pkg/apis/extensions/validation/extension_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Extension validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("DefaultSpec.ProviderConfig: <nil pointer> != runtime.RawExtension"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: DefaultSpec.ProviderConfig: <nil pointer> != runtime.RawExtension"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/extension_test.go
+++ b/pkg/apis/extensions/validation/extension_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Extension validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: DefaultSpec.ProviderConfig: <nil pointer> != runtime.RawExtension"),
+				"Detail": Equal("cannot update extension spec if deletion timestamp is set. Requested changes: DefaultSpec.ProviderConfig: <nil pointer> != runtime.RawExtension"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/infrastructure.go
+++ b/pkg/apis/extensions/validation/infrastructure.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -59,10 +60,8 @@ func ValidateInfrastructureSpecUpdate(new, old *extensionsv1alpha1.Infrastructur
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/infrastructure.go
+++ b/pkg/apis/extensions/validation/infrastructure.go
@@ -61,7 +61,7 @@ func ValidateInfrastructureSpecUpdate(new, old *extensionsv1alpha1.Infrastructur
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update infrastructure spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/infrastructure_test.go
+++ b/pkg/apis/extensions/validation/infrastructure_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Infrastructure validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/infrastructure_test.go
+++ b/pkg/apis/extensions/validation/infrastructure_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Infrastructure validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update infrastructure spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -87,7 +87,7 @@ func ValidateNetworkSpecUpdate(new, old *extensionsv1alpha1.NetworkSpec, deletio
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update network spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, ValidateIPFamiliesUpdate(new.IPFamilies, old.IPFamilies, fldPath.Child("ipFamilies"))...)

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -86,10 +86,8 @@ func ValidateNetworkSpecUpdate(new, old *extensionsv1alpha1.NetworkSpec, deletio
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, ValidateIPFamiliesUpdate(new.IPFamilies, old.IPFamilies, fldPath.Child("ipFamilies"))...)

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Network validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("DefaultSpec.ProviderConfig: <nil pointer> != runtime.RawExtension"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: DefaultSpec.ProviderConfig: <nil pointer> != runtime.RawExtension"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Network validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: DefaultSpec.ProviderConfig: <nil pointer> != runtime.RawExtension"),
+				"Detail": Equal("cannot update network spec if deletion timestamp is set. Requested changes: DefaultSpec.ProviderConfig: <nil pointer> != runtime.RawExtension"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -352,7 +352,7 @@ func ValidateOperatingSystemConfigSpecUpdate(new, old *extensionsv1alpha1.Operat
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update operatingsystemconfig spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -351,10 +351,8 @@ func ValidateOperatingSystemConfigSpecUpdate(new, old *extensionsv1alpha1.Operat
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -579,7 +579,7 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: DefaultSpec.Type: changed-type != provider"),
+				"Detail": Equal("cannot update operatingsystemconfig spec if deletion timestamp is set. Requested changes: DefaultSpec.Type: changed-type != provider"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -579,7 +579,7 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("DefaultSpec.Type: changed-type != provider"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: DefaultSpec.Type: changed-type != provider"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/worker.go
+++ b/pkg/apis/extensions/validation/worker.go
@@ -5,6 +5,7 @@
 package validation
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -108,10 +109,8 @@ func ValidateWorkerSpecUpdate(new, old *extensionsv1alpha1.WorkerSpec, deletionT
 	allErrs := field.ErrorList{}
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		if diff := deep.Equal(new, old); diff != nil {
-			return field.ErrorList{field.Forbidden(fldPath, strings.Join(diff, ","))}
-		}
-		return apivalidation.ValidateImmutableField(new, old, fldPath)
+		diff := deep.Equal(new, old)
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/worker.go
+++ b/pkg/apis/extensions/validation/worker.go
@@ -110,7 +110,7 @@ func ValidateWorkerSpecUpdate(new, old *extensionsv1alpha1.WorkerSpec, deletionT
 
 	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
 		diff := deep.Equal(new, old)
-		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update shoot spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update worker spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)

--- a/pkg/apis/extensions/validation/worker_test.go
+++ b/pkg/apis/extensions/validation/worker_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Worker validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update worker spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 

--- a/pkg/apis/extensions/validation/worker_test.go
+++ b/pkg/apis/extensions/validation/worker_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Worker validation tests", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec"),
-				"Detail": Equal("SecretRef.Name: changed-secretref-name != test"),
+				"Detail": Equal("cannot update shoot spec if deletion timestamp is set. Requested changes: SecretRef.Name: changed-secretref-name != test"),
 			}))))
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind cleanup

**What this PR does / why we need it**:
When trying to patch the shoot spec while it's in deletion, the resulting log message is confusing. This PR improves the error message. 

**Which issue(s) this PR fixes**:
Fixes #11782

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
