### PR TITLE
[GEP-26] Overwrite existing cloud provider secret data when using workload identity config

### DIFF
--- a/pkg/utils/workloadidentity/secret.go
+++ b/pkg/utils/workloadidentity/secret.go
@@ -170,9 +170,9 @@ func (s *Secret) Reconcile(ctx context.Context, c client.Client) error {
 		}
 
 		// preserve the data token key if present but overwrite all other data keys
-		if v, ok := s.secret.Data[securityv1alpha1constants.DataKeyToken]; ok {
-			s.secret.Data[securityv1alpha1constants.DataKeyToken] = v
-		}
+		maps.DeleteFunc(s.secret.Data, func(k string, _ []byte) bool {
+			return k != securityv1alpha1constants.DataKeyToken
+		})
 
 		if len(s.workloadIdentityProviderConfig) > 0 {
 			s.secret.Data[securityv1alpha1constants.DataKeyConfig] = s.workloadIdentityProviderConfig

--- a/pkg/utils/workloadidentity/secret_test.go
+++ b/pkg/utils/workloadidentity/secret_test.go
@@ -125,6 +125,7 @@ var _ = Describe("#Secret", func() {
 			Data: map[string][]byte{
 				"config": []byte(`{"foo":"bar"}`),
 				"token":  []byte("token"),
+				"foo":    []byte("bar"), // should be removed after the reconciliation of the secret
 			},
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
When migrating from static credentials to workload identity the cloud provider secret should change its contents. Before this PR the reconciliation of the secret was preserving the old data keys, causing a conflict between the two authentication methods as they are mutually exclusive. This PR overwrites all existing data keys (except the token that is written by the token requestor) of the secret when workload identity is enabled.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing the `cloudprovider` Secret to contain both static credentials and workload identity config, which are mutually exclusive, when migrating to workload identity is now fixed.
```
