### PR TITLE
Fix the recording rules shoot:apiserver_latency:percentage which is stopping after last release

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -722,7 +722,7 @@ var _ = Describe("KubeAPIServer", func() {
 								// API server request duration greater than 1s percentage
 								{
 									Record: "shoot:apiserver_latency:percentage",
-									Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h]))`),
+									Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1.0",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h]))`),
 								},
 
 								{

--- a/pkg/component/kubernetes/apiserver/prometheusrule.go
+++ b/pkg/component/kubernetes/apiserver/prometheusrule.go
@@ -180,7 +180,7 @@ func (k *kubeAPIServer) reconcilePrometheusRule(ctx context.Context, prometheusR
 					// API server request duration greater than 1s percentage
 					{
 						Record: "shoot:apiserver_latency:percentage",
-						Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h]))`),
+						Expr:   intstr.FromString(`1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1.0",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h]))`),
 					},
 
 					{

--- a/pkg/component/kubernetes/apiserver/testdata/shoot-kube-apiserver.prometheusrule.test.yaml
+++ b/pkg/component/kubernetes/apiserver/testdata/shoot-kube-apiserver.prometheusrule.test.yaml
@@ -21,9 +21,9 @@ tests:
   # in this example the request duration is always greater than 3s and less than or equal to 5s.
   - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="+Inf"}'
     values: '0+1x62'
-  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="5"}'
+  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="5.0"}'
     values: '0+1x62'
-  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="3"}'
+  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="3.0"}'
     values: '0+0x62'
   # KubeApiServerTooManyAuditlogFailures
   - series: 'apiserver_audit_error_total{plugin="webhook", job="kube-apiserver"}'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
From the latest release, the metrics apiserver_request_duration_seconds_bucket threshold le changed from "x" to "x.0", so the recording rule based on the metrics is not working from April 3. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
