### PR TITLE
Add option to set `injectGardenKubeconfig: true` when generating `ControllerDeployment`s and `Extension`s

### DIFF
--- a/example/provider-local/garden/operator/extension.yaml
+++ b/example/provider-local/garden/operator/extension.yaml
@@ -17,6 +17,7 @@ spec:
       helm:
         ociRepository:
           ref: local-skaffold/gardener-extension-provider-local/charts/extension:v0.0.0
+      injectGardenKubeconfig: true
   resources:
   - kind: BackupBucket
     type: local

--- a/hack/generate-controller-registration.sh
+++ b/hack/generate-controller-registration.sh
@@ -17,6 +17,8 @@ generate-controller-registration [options] <name> <chart-dir> <version> <dest> <
     -e, --pod-security-enforce[=pod-security-standard]
                       Sets 'security.gardener.cloud/pod-security-enforce' annotation in the
                       controller registration. Defaults to 'baseline'.
+    -i, --inject-garden-kubeconfig
+                      Sets 'injectGardenKubeconfig: true' for the controller deployment.
     <name>            Name of the controller registration to generate.
     <chart-dir>       Location of the chart directory.
     <version>         Version to use for the Helm chart and the tag in the ControllerDeployment.
@@ -31,6 +33,8 @@ EOM
 }
 
 POD_SECURITY_ENFORCE="baseline"
+INJECT_GARDEN_KUBECONFIG=false
+
 while :; do
   case $1 in
     -h|--help)
@@ -45,6 +49,9 @@ while :; do
       ;;
     --pod-security-enforce=*)
       POD_SECURITY_ENFORCE=${1#*=}
+      ;;
+    -i|--inject-garden-kubeconfig)
+      INJECT_GARDEN_KUBECONFIG=true
       ;;
     --)
       shift
@@ -117,6 +124,13 @@ else
     image: $default_image
 EOM
 fi
+
+if [ "${INJECT_GARDEN_KUBECONFIG}" = true ]; then
+  cat <<EOM >> "$DEST"
+injectGardenKubeconfig: true
+EOM
+fi
+
 cat <<EOM >> "$DEST"
 ---
 apiVersion: core.gardener.cloud/v1beta1

--- a/hack/tools/extension-generator/extension.go
+++ b/hack/tools/extension-generator/extension.go
@@ -21,6 +21,10 @@ import (
 func GenerateExtension(opts *Options) ([]byte, error) {
 	extension := newBaseExtension(opts)
 
+	if opts.InjectGardenKubeconfig {
+		extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig = &opts.InjectGardenKubeconfig
+	}
+
 	if opts.AdmissionRuntimeOCIRepository != "" && opts.AdmissionApplicationOCIRepository != "" {
 		ensureAdmission(extension, opts)
 	}

--- a/hack/tools/extension-generator/extension.go
+++ b/hack/tools/extension-generator/extension.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
@@ -20,10 +21,6 @@ import (
 // GenerateExtension generates the extension in YAML format.
 func GenerateExtension(opts *Options) ([]byte, error) {
 	extension := newBaseExtension(opts)
-
-	if opts.InjectGardenKubeconfig {
-		extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig = &opts.InjectGardenKubeconfig
-	}
 
 	if opts.AdmissionRuntimeOCIRepository != "" && opts.AdmissionApplicationOCIRepository != "" {
 		ensureAdmission(extension, opts)
@@ -143,4 +140,5 @@ func ensureProviderExtension(extension *operatorv1alpha1.Extension, opts *Option
 		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.InfrastructureResource, Type: opts.ProviderType},
 		gardencorev1beta1.ControllerResource{Kind: extensionsv1alpha1.WorkerResource, Type: opts.ProviderType},
 	)
+	extension.Spec.Deployment.ExtensionDeployment.InjectGardenKubeconfig = ptr.To(true)
 }

--- a/hack/tools/extension-generator/options.go
+++ b/hack/tools/extension-generator/options.go
@@ -23,8 +23,6 @@ type Options struct {
 	ExtensionOCIRepository            string
 	AdmissionRuntimeOCIRepository     string
 	AdmissionApplicationOCIRepository string
-
-	InjectGardenKubeconfig bool
 }
 
 var validCategories = sets.New(slices.Collect(maps.Keys(categoryToEnsurer))...)
@@ -38,7 +36,6 @@ func (o *Options) AddFlags(flags *flag.FlagSet) {
 	flags.StringVar(&o.ExtensionOCIRepository, "extension-oci-repository", "", "URL to OCI image containing the extension chart")
 	flags.StringVar(&o.AdmissionRuntimeOCIRepository, "admission-runtime-oci-repository", "", "OPTIONAL: URL to OCI image containing the admission runtime chart")
 	flags.StringVar(&o.AdmissionApplicationOCIRepository, "admission-application-oci-repository", "", "OPTIONAL: URL to OCI image containing the admission application chart")
-	flags.BoolVar(&o.InjectGardenKubeconfig, "inject-garden-kubeconfig", false, "OPTIONAL: When set, the `.spec.deployment.extension.injectGardenKubeconfig: true` field is added to the generated extension")
 }
 
 // Validate returns an error if the Options configuration is incomplete.

--- a/hack/tools/extension-generator/options.go
+++ b/hack/tools/extension-generator/options.go
@@ -23,6 +23,8 @@ type Options struct {
 	ExtensionOCIRepository            string
 	AdmissionRuntimeOCIRepository     string
 	AdmissionApplicationOCIRepository string
+
+	InjectGardenKubeconfig bool
 }
 
 var validCategories = sets.New(slices.Collect(maps.Keys(categoryToEnsurer))...)
@@ -36,6 +38,7 @@ func (o *Options) AddFlags(flags *flag.FlagSet) {
 	flags.StringVar(&o.ExtensionOCIRepository, "extension-oci-repository", "", "URL to OCI image containing the extension chart")
 	flags.StringVar(&o.AdmissionRuntimeOCIRepository, "admission-runtime-oci-repository", "", "OPTIONAL: URL to OCI image containing the admission runtime chart")
 	flags.StringVar(&o.AdmissionApplicationOCIRepository, "admission-application-oci-repository", "", "OPTIONAL: URL to OCI image containing the admission application chart")
+	flags.BoolVar(&o.InjectGardenKubeconfig, "inject-garden-kubeconfig", false, "OPTIONAL: When set, the `.spec.deployment.extension.injectGardenKubeconfig: true` field is added to the generated extension")
 }
 
 // Validate returns an error if the Options configuration is incomplete.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
This PR adds an option to the `hack/generate-controller-registration.sh` script and the so that the `injectGardenKubeconfig: true` field can be added to generated `ControllerDeployment`s and `Extension`s . 
This could be useful for extensions which need access to the garden cluster. 

The `hack/tools/extension-generator/extension.go` tool also automatically adds `.spec.deployment.extension.injectGardenKubeconfig: true` to generated provider extensions.

Note that for extensions that are responsible for `Worker` resources, the `injectGardenKubeconfig: true` field is automatically added as part of the defaulting logic: https://github.com/gardener/gardener/blob/ef6b8e77e351199aaa6a14ac332750f6ec044fe2/pkg/operator/webhook/defaulting/extension/handler.go#L24-L37
We plan to add similar defaulting logic for `ControllerDeployments` defaulting, in a separate PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
A new flag `-i|--inject-garden-kubeconfig` was added to the `hack/generate-controller-registration.sh` script. When the flag is set, the `injectGardenKubeconfig: true` field is added to the generated `ControllerDeployment`.
```
```other developer
The `hack/tools/extension-generator` tool now automatically sets the `.spec.deployment.extension.injectGardenKubeconfig: true` field in the generated provider `Extension` resources .
```
