### PR TITLE
Stop serving the `autoscaling.k8s.io/v1beta2` API version

### DIFF
--- a/example/seed-crds/10-crd-autoscaling.k8s.io_verticalpodautoscalercheckpoints.yaml
+++ b/example/seed-crds/10-crd-autoscaling.k8s.io_verticalpodautoscalercheckpoints.yaml
@@ -213,5 +213,5 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false

--- a/example/seed-crds/10-crd-autoscaling.k8s.io_verticalpodautoscalers.yaml
+++ b/example/seed-crds/10-crd-autoscaling.k8s.io_verticalpodautoscalers.yaml
@@ -607,7 +607,7 @@ spec:
         required:
         - spec
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -158,17 +158,6 @@ generate_group () {
     if $add_keep_object_annotation; then
       sed -i '/^  annotations:.*/a\    resources.gardener.cloud/keep-object: "true"' "$crd_out"
     fi
-
-    # Continue serving the "autoscaling.k8s.io/v1beta2" API version for backwards-compatibility reasons.
-    # Starting VPA 1.3.0, the "autoscaling.k8s.io/v1beta2" API version is no longer served.
-    # Gardener continues to serve the "autoscaling.k8s.io/v1beta2" API version for several more release to allow
-    # end users to adapt their manifests to no longer use this API version.
-    # For more details, see https://github.com/kubernetes/autoscaler/blob/e27059ea483694cb9c7ad5d990c6cdeb42ca311b/vertical-pod-autoscaler/MIGRATE.md#notice-on-switching-to-v1-version-04x-12x-to-13x.
-    #
-    # TODO(ialidzhikov): Remove this workaround in Gardener v1.119.
-    if [[ ${group} == "autoscaling.k8s.io" ]]; then
-      sed -i "s/^    served: false$/    served: true/" "$crd_out"
-    fi
   done < <(ls "$output_dir_temp/$sanitized_group_name"_*.yaml)
 
   # garbage collection - clean all generated files for this group to account for changed prefix or removed resources

--- a/pkg/component/autoscaling/vpa/templates/crd-autoscaling.k8s.io_verticalpodautoscalercheckpoints.yaml
+++ b/pkg/component/autoscaling/vpa/templates/crd-autoscaling.k8s.io_verticalpodautoscalercheckpoints.yaml
@@ -218,5 +218,5 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false

--- a/pkg/component/autoscaling/vpa/templates/crd-autoscaling.k8s.io_verticalpodautoscalers.yaml
+++ b/pkg/component/autoscaling/vpa/templates/crd-autoscaling.k8s.io_verticalpodautoscalers.yaml
@@ -608,7 +608,7 @@ spec:
         required:
         - spec
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
Follow-up after https://github.com/gardener/gardener/pull/11774.

**Which issue(s) this PR fixes**:
Part of #11774 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The already deprecated `autoscaling.k8s.io/v1beta2` API version is no longer served. Instead, use the `autoscaling.k8s.io/v1` API version for managing VerticalPodAutoscaler resources.
```

```breaking operator
The already deprecated `autoscaling.k8s.io/v1beta2` API version is no longer served. Before upgrading to this version of Gardener, make sure that all components use the `autoscaling.k8s.io/v1` API version for managing VerticalPodAutoscaler resources.
```
