### PR TITLE
[GEP-28] Deploy `gardener-resource-manager` and extension controllers (in bootstrap mode)

### DIFF
--- a/example/gardenadm-local/high-touch/machine.yaml
+++ b/example/gardenadm-local/high-touch/machine.yaml
@@ -25,6 +25,8 @@ spec:
             value: /gardenadm:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           - name: IMAGEVECTOR_OVERWRITE
             value: /gardenadm/imagevector-overwrite.yaml
+          - name: KUBECONFIG
+            value: /etc/kubernetes/admin.conf
         volumeMounts:
         - name: containerd
           mountPath: /var/lib/containerd

--- a/example/provider-local/gardenadm/.gitignore
+++ b/example/provider-local/gardenadm/.gitignore
@@ -1,0 +1,1 @@
+patch-controllerdeployment-provider-local.yaml

--- a/example/provider-local/gardenadm/kustomization.yaml
+++ b/example/provider-local/gardenadm/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 - shoot.yaml
 - https://raw.githubusercontent.com/gardener/gardener-extension-networking-cilium/v1.40.2/example/controller-registration.yaml
 - https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.47.1/example/controller-registration.yaml
+
+patches:
+- path: patch-controllerdeployment-provider-local.yaml
+- path: patch-controllerdeployment-provider-local-disable-coredns.yaml

--- a/example/provider-local/gardenadm/kustomization.yaml
+++ b/example/provider-local/gardenadm/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
 - ../garden/local
 - project.yaml
 - shoot.yaml
+- https://raw.githubusercontent.com/gardener/gardener-extension-networking-cilium/v1.40.2/example/controller-registration.yaml
+- https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.47.1/example/controller-registration.yaml

--- a/example/provider-local/gardenadm/patch-controllerdeployment-provider-local-disable-coredns.yaml
+++ b/example/provider-local/gardenadm/patch-controllerdeployment-provider-local-disable-coredns.yaml
@@ -1,0 +1,8 @@
+apiVersion: core.gardener.cloud/v1
+kind: ControllerDeployment
+metadata:
+  name: provider-local
+helm:
+  values:
+    coredns:
+      enabled: false

--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -42,14 +42,19 @@ type genericActuator struct {
 // It provides a default implementation that allows easier integration of providers.
 // If machine-controller-manager should not be managed then only the delegateFactory must be provided.
 func NewActuator(mgr manager.Manager, gardenCluster cluster.Cluster, delegateFactory DelegateFactory, errorCodeCheckFunc healthcheck.ErrorCodeCheckFunc) worker.Actuator {
-	return &genericActuator{
+	actuator := &genericActuator{
 		delegateFactory:    delegateFactory,
-		gardenReader:       gardenCluster.GetAPIReader(),
 		seedClient:         mgr.GetClient(),
 		seedReader:         mgr.GetAPIReader(),
 		scheme:             mgr.GetScheme(),
 		errorCodeCheckFunc: errorCodeCheckFunc,
 	}
+
+	if gardenCluster != nil {
+		actuator.gardenReader = gardenCluster.GetAPIReader()
+	}
+
+	return actuator
 }
 
 func (a *genericActuator) cleanupMachineDeployments(ctx context.Context, logger logr.Logger, existingMachineDeployments *machinev1alpha1.MachineDeploymentList, wantedMachineDeployments worker.MachineDeployments) error {

--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -44,6 +44,7 @@ run "skaffold-operator.yaml" "gardener-extension-admission-local"        "provid
 # skaffold-gardenadm.yaml
 run "skaffold-gardenadm.yaml" "gardenadm"                                 "gardenadm"
 run "skaffold-gardenadm.yaml" "gardener-node-agent"                       "gardenadm"
+run "skaffold-gardenadm.yaml" "gardener-resource-manager"                 "gardenadm"
 run "skaffold-gardenadm.yaml" "gardener-extension-provider-local"         "provider-local"
 run "skaffold-gardenadm.yaml" "machine-controller-manager-provider-local" "provider-local"
 

--- a/hack/generate-gardenadm-imagevector-overwrite.sh
+++ b/hack/generate-gardenadm-imagevector-overwrite.sh
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -o pipefail
+
+source $(dirname "${0}")/lockfile.sh
+acquire_lockfile "/tmp/generate-gardenadm-imagevector-overwrite.sh.lock"
+
+dir="$(dirname $0)/../example/gardenadm-local"
+patch_file="$dir/.imagevector-overwrite.yaml"
+image_name="$1"
+ref="$SKAFFOLD_IMAGE"
+
+if [[ ! -f "$patch_file" ]]; then
+  cat <<EOF > "$patch_file"
+images: []
+EOF
+fi
+
+images="$(yq e '.' "$patch_file" | yq -o json)"
+
+images="$(echo "$images" | jq -r \
+  --arg name "$image_name" \
+  --arg ref "$ref" \
+  '.images |= if any(.name == $name) then
+      map(if .name == $name then .ref = $ref else . end)
+    else
+      . + [{name: $name, ref: $ref}] end' |\
+ yq eval -P)"
+
+yq eval ". = \"$images\"" -i "$patch_file"

--- a/hack/generate-kustomize-patch-controllerdeployment-provider-local-gardenadm.sh
+++ b/hack/generate-kustomize-patch-controllerdeployment-provider-local-gardenadm.sh
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -o pipefail
+
+source $(dirname "${0}")/lockfile.sh
+acquire_lockfile "/tmp/generate-kustomize-patch-provider-local-gardenadm.sh.lock"
+
+dir="$(dirname $0)/../example/provider-local/gardenadm"
+patch_file="$dir/patch-controllerdeployment-provider-local.yaml"
+ref="$SKAFFOLD_IMAGE"
+
+cat <<EOF > "$patch_file"
+apiVersion: core.gardener.cloud/v1
+kind: ControllerDeployment
+metadata:
+  name: provider-local
+helm:
+  ociRepository:
+    ref: $ref
+EOF

--- a/pkg/component/gardener/resourcemanager/constants/constants.go
+++ b/pkg/component/gardener/resourcemanager/constants/constants.go
@@ -7,6 +7,4 @@ package constants
 const (
 	// ServiceName is the name of the service.
 	ServiceName = "gardener-resource-manager"
-	// ServerPort is the port of the server.
-	ServerPort = 10250
 )

--- a/pkg/component/gardener/resourcemanager/mock/mocks.go
+++ b/pkg/component/gardener/resourcemanager/mock/mocks.go
@@ -97,6 +97,18 @@ func (mr *MockInterfaceMockRecorder) GetValues() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValues", reflect.TypeOf((*MockInterface)(nil).GetValues))
 }
 
+// SetBootstrapControlPlaneNode mocks base method.
+func (m *MockInterface) SetBootstrapControlPlaneNode(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetBootstrapControlPlaneNode", arg0)
+}
+
+// SetBootstrapControlPlaneNode indicates an expected call of SetBootstrapControlPlaneNode.
+func (mr *MockInterfaceMockRecorder) SetBootstrapControlPlaneNode(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBootstrapControlPlaneNode", reflect.TypeOf((*MockInterface)(nil).SetBootstrapControlPlaneNode), arg0)
+}
+
 // SetReplicas mocks base method.
 func (m *MockInterface) SetReplicas(arg0 *int32) {
 	m.ctrl.T.Helper()

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -71,6 +71,7 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -206,6 +207,8 @@ type Interface interface {
 	SetSecrets(Secrets)
 	// GetValues returns the current configuration values of the deployer.
 	GetValues() Values
+	// SetBootstrapControlPlaneNode sets the BootstrapControlPlaneNode field in the Values.
+	SetBootstrapControlPlaneNode(bool)
 }
 
 // New creates a new instance of the gardener-resource-manager.
@@ -229,6 +232,7 @@ type resourceManager struct {
 	secretsManager secretsmanager.Interface
 	values         Values
 	secrets        Secrets
+	port           int32
 }
 
 // Values holds the optional configuration options for the gardener resource manager
@@ -343,6 +347,10 @@ const (
 )
 
 func (r *resourceManager) Deploy(ctx context.Context) error {
+	if err := r.chooseServerPort(); err != nil {
+		return err
+	}
+
 	if r.values.ResponsibilityMode == ForTarget {
 		r.secrets.shootAccess = r.newShootAccessSecret()
 		if err := r.secrets.shootAccess.WithTokenExpirationDuration("24h").Reconcile(ctx, r.client); err != nil {
@@ -539,7 +547,7 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 			},
 			Webhooks: resourcemanagerconfigv1alpha1.HTTPSServer{
 				Server: resourcemanagerconfigv1alpha1.Server{
-					Port: resourcemanagerconstants.ServerPort,
+					Port: int(r.port),
 				},
 				TLS: resourcemanagerconfigv1alpha1.TLSServer{
 					ServerCertDir: volumeMountPathCerts,
@@ -552,7 +560,7 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 			ClusterID:     r.values.ClusterIdentity,
 			ResourceClass: r.values.ResourceClass,
 			GarbageCollector: resourcemanagerconfigv1alpha1.GarbageCollectorControllerConfig{
-				Enabled:    true,
+				Enabled:    !r.values.BootstrapControlPlaneNode,
 				SyncPeriod: &metav1.Duration{Duration: 12 * time.Hour},
 			},
 			Health: resourcemanagerconfigv1alpha1.HealthControllerConfig{
@@ -744,11 +752,11 @@ func (r *resourceManager) ensureService(ctx context.Context) error {
 
 		if r.values.ResponsibilityMode != ForTarget {
 			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, portMetrics))
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingFromWorldToPorts, fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, resourcemanagerconstants.ServerPort))
+			metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingFromWorldToPorts, fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, r.port))
 		} else {
 			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, portMetrics))
 			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForWebhookTargets(service, networkingv1.NetworkPolicyPort{
-				Port:     ptr.To(intstr.FromInt32(resourcemanagerconstants.ServerPort)),
+				Port:     ptr.To(intstr.FromInt32(r.port)),
 				Protocol: ptr.To(corev1.ProtocolTCP),
 			}))
 		}
@@ -773,7 +781,7 @@ func (r *resourceManager) ensureService(ctx context.Context) error {
 				Name:       serverPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       serverServicePort,
-				TargetPort: intstr.FromInt32(resourcemanagerconstants.ServerPort),
+				TargetPort: intstr.FromInt32(r.port),
 			},
 		}
 		service.Spec.Ports = kubernetesutils.ReconcileServicePorts(service.Spec.Ports, desiredPorts, corev1.ServiceTypeClusterIP)
@@ -801,8 +809,10 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 	}
 
 	var (
-		tolerations []corev1.Toleration
-		env         []corev1.EnvVar
+		tolerations       []corev1.Toleration
+		env               []corev1.EnvVar
+		replicas          = r.values.Replicas
+		priorityClassName = r.values.PriorityClassName
 	)
 
 	if r.values.DefaultNotReadyToleration != nil {
@@ -830,23 +840,31 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 		// If 'BootstrapControlPlaneNode', there is typically no CoreDNS running yet, i.e, we cannot rely on the
 		// standard 'kubernetes.default.svc' DNS name but have to explicitly set it to 'localhost'.
 		env = append(env, corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "localhost"})
+		replicas = ptr.To[int32](1)
+		priorityClassName = "system-cluster-critical"
 	}
 
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, r.client, deployment, func() error {
 		deployment.Labels = r.getLabels()
 
-		deployment.Spec.Replicas = r.values.Replicas
+		deployment.Spec.Replicas = replicas
 		deployment.Spec.RevisionHistoryLimit = ptr.To[int32](2)
 		deployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: r.appLabel()}
+
+		if r.values.BootstrapControlPlaneNode {
+			deployment.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
+			deployment.Spec.Strategy.RollingUpdate = nil
+		}
 
 		deployment.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: utils.MergeStringMaps(r.getDeploymentTemplateLabels(), r.getNetworkPolicyLabels(), map[string]string{
-					resourcesv1alpha1.ProjectedTokenSkip: "true",
+					resourcesv1alpha1.ProjectedTokenSkip:         "true",
+					resourcesv1alpha1.SystemComponentsConfigSkip: "true",
 				}),
 			},
 			Spec: corev1.PodSpec{
-				PriorityClassName: r.values.PriorityClassName,
+				PriorityClassName: priorityClassName,
 				SecurityContext: &corev1.PodSecurityContext{
 					SeccompProfile: &corev1.SeccompProfile{
 						Type: corev1.SeccompProfileTypeRuntimeDefault,
@@ -1102,6 +1120,28 @@ func (r *resourceManager) ensureVPA(ctx context.Context) error {
 		return nil
 	})
 	return err
+}
+
+// SuggestPort is an alias for netutils.SuggestPort.
+// Exposed for testing.
+var SuggestPort = netutils.SuggestPort
+
+func (r *resourceManager) chooseServerPort() error {
+	if r.port != 0 {
+		return nil
+	}
+
+	if !r.values.BootstrapControlPlaneNode {
+		r.port = 10250
+		return nil
+	}
+
+	p, _, err := SuggestPort("")
+	if err != nil {
+		return fmt.Errorf("failed to find a usable port: %w", err)
+	}
+	r.port = int32(p) // #nosec G115 -- Value is within [0,65535]
+	return nil
 }
 
 func (r *resourceManager) emptyVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
@@ -2044,6 +2084,11 @@ func (r *resourceManager) SetSecrets(s Secrets) { r.secrets = s }
 
 // GetValues returns the current configuration values of the deployer.
 func (r *resourceManager) GetValues() Values { return r.values }
+
+// SetBootstrapControlPlaneNode sets the BootstrapControlPlaneNode field in the Values.
+func (r *resourceManager) SetBootstrapControlPlaneNode(b bool) {
+	r.values.BootstrapControlPlaneNode = b
+}
 
 // Secrets is collection of secrets for the gardener-resource-manager.
 type Secrets struct {

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -885,6 +885,18 @@ var _ = Describe("ResourceManager", func() {
 		}
 
 		mutatingWebhookConfigurationFor = func(responsibilityMode ResponsibilityMode, bootstrapControlPlaneNode bool) *admissionregistrationv1.MutatingWebhookConfiguration {
+			ignoreStaticPodsInBootstrapMode := func(in []metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
+				if !bootstrapControlPlaneNode {
+					return in
+				}
+
+				return append(in, metav1.LabelSelectorRequirement{
+					Key:      "static-pod",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"true"},
+				})
+			}
+
 			obj := &admissionregistrationv1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gardener-resource-manager",
@@ -913,7 +925,7 @@ var _ = Describe("ResourceManager", func() {
 							}},
 						},
 						ObjectSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
+							MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
 								{
 									Key:      "projected-token-mount.resources.gardener.cloud/skip",
 									Operator: metav1.LabelSelectorOpDoesNotExist,
@@ -923,7 +935,7 @@ var _ = Describe("ResourceManager", func() {
 									Operator: metav1.LabelSelectorOpNotIn,
 									Values:   []string{"gardener-resource-manager"},
 								},
-							},
+							}),
 						},
 						ClientConfig: admissionregistrationv1.WebhookClientConfig{
 							Service: &admissionregistrationv1.ServiceReference{
@@ -1014,7 +1026,7 @@ var _ = Describe("ResourceManager", func() {
 						}},
 					},
 					ObjectSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
+						MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
 							{
 								Key:      "seccompprofile.resources.gardener.cloud/skip",
 								Operator: metav1.LabelSelectorOpDoesNotExist,
@@ -1024,7 +1036,7 @@ var _ = Describe("ResourceManager", func() {
 								Operator: metav1.LabelSelectorOpNotIn,
 								Values:   []string{"gardener-resource-manager"},
 							},
-						},
+						}),
 					},
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						Service: &admissionregistrationv1.ServiceReference{
@@ -1057,13 +1069,13 @@ var _ = Describe("ResourceManager", func() {
 						}},
 					},
 					ObjectSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
+						MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
 							{
 								Key:      resourcesv1alpha1.KubernetesServiceHostInject,
 								Operator: metav1.LabelSelectorOpNotIn,
 								Values:   []string{"disable"},
 							},
-						},
+						}),
 					},
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						Service: &admissionregistrationv1.ServiceReference{
@@ -1140,10 +1152,10 @@ var _ = Describe("ResourceManager", func() {
 							}},
 						},
 						ObjectSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{{
+							MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{{
 								Key:      "system-components-config.resources.gardener.cloud/skip",
 								Operator: metav1.LabelSelectorOpDoesNotExist,
-							}},
+							}}),
 						},
 						ClientConfig: admissionregistrationv1.WebhookClientConfig{
 							Service: &admissionregistrationv1.ServiceReference{
@@ -1179,7 +1191,7 @@ var _ = Describe("ResourceManager", func() {
 					}},
 				},
 				ObjectSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
+					MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
 						{
 							Key:      "app",
 							Operator: metav1.LabelSelectorOpNotIn,
@@ -1189,7 +1201,7 @@ var _ = Describe("ResourceManager", func() {
 							Key:      "topology-spread-constraints.resources.gardener.cloud/skip",
 							Operator: metav1.LabelSelectorOpDoesNotExist,
 						},
-					},
+					}),
 				},
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service: &admissionregistrationv1.ServiceReference{

--- a/pkg/component/kubernetes/apiserver/secrets.go
+++ b/pkg/component/kubernetes/apiserver/secrets.go
@@ -123,6 +123,7 @@ func (k *kubeAPIServer) reconcileSecretUserKubeconfig(ctx context.Context, secre
 	_, err = k.secretsManager.Generate(ctx, &secretsutils.KubeconfigSecretConfig{
 		Name:        SecretNameUserKubeconfig,
 		ContextName: k.namespace,
+		Namespace:   k.namespace,
 		Cluster: clientcmdv1.Cluster{
 			Server:                   "localhost",
 			CertificateAuthorityData: caBundleSecret.Data[secretsutils.DataKeyCertificateBundle],

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
@@ -35,11 +36,19 @@ import (
 type AutonomousBotanist struct {
 	*botanistpkg.Botanist
 
-	HostName string
-	DBus     dbus.DBus
-	FS       afero.Afero
+	HostName   string
+	DBus       dbus.DBus
+	FS         afero.Afero
+	Extensions []Extension
 
 	operatingSystemConfigSecret *corev1.Secret
+}
+
+// Extension contains the ControllerRegistration and ControllerDeployment for an extension registration.
+type Extension struct {
+	ControllerRegistration *gardencorev1beta1.ControllerRegistration
+	ControllerDeployment   *gardencorev1.ControllerDeployment
+	ControllerInstallation *gardencorev1beta1.ControllerInstallation
 }
 
 // NewAutonomousBotanist creates a new botanist.AutonomousBotanist instance for the gardenadm command execution.
@@ -50,6 +59,7 @@ func NewAutonomousBotanist(
 	project *gardencorev1beta1.Project,
 	cloudProfile *gardencorev1beta1.CloudProfile,
 	shoot *gardencorev1beta1.Shoot,
+	extensions []Extension,
 ) (
 	*AutonomousBotanist,
 	error,
@@ -98,9 +108,10 @@ func NewAutonomousBotanist(
 	return &AutonomousBotanist{
 		Botanist: b,
 
-		HostName: hostName,
-		DBus:     dbus.New(log),
-		FS:       afero.Afero{Fs: afero.NewOsFs()},
+		HostName:   hostName,
+		DBus:       dbus.New(log),
+		FS:         afero.Afero{Fs: afero.NewOsFs()},
+		Extensions: extensions,
 	}, nil
 }
 

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -45,7 +45,7 @@ type AutonomousBotanist struct {
 	operatingSystemConfigSecret *corev1.Secret
 }
 
-// Extension contains the ControllerRegistration and ControllerDeployment for an extension registration.
+// Extension contains the resources needed for an extension registration.
 type Extension struct {
 	ControllerRegistration *gardencorev1beta1.ControllerRegistration
 	ControllerDeployment   *gardencorev1.ControllerDeployment

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -46,7 +46,7 @@ type AutonomousBotanist struct {
 func NewAutonomousBotanist(
 	ctx context.Context,
 	log logr.Logger,
-	seedClientSet kubernetes.Interface,
+	clientSet kubernetes.Interface,
 	project *gardencorev1beta1.Project,
 	cloudProfile *gardencorev1beta1.CloudProfile,
 	shoot *gardencorev1beta1.Shoot,
@@ -75,20 +75,21 @@ func NewAutonomousBotanist(
 	}
 
 	keysAndValues := []any{"cloudProfile", cloudProfile, "project", project, "shoot", shoot}
-	if seedClientSet == nil {
-		seedClientSet = newFakeSeedClientSet(seedObj.KubernetesVersion.String())
+	if clientSet == nil {
+		clientSet = newFakeSeedClientSet(seedObj.KubernetesVersion.String())
 		log.Info("Initializing autonomous botanist with fake client set", keysAndValues...) //nolint:logcheck
 	} else {
 		log.Info("Initializing autonomous botanist with control plane client set", keysAndValues...) //nolint:logcheck
 	}
 
 	b, err := botanistpkg.New(ctx, &operation.Operation{
-		Logger:        log,
-		GardenClient:  newFakeGardenClient(),
-		SeedClientSet: seedClientSet,
-		Garden:        gardenObj,
-		Seed:          seedObj,
-		Shoot:         shootObj,
+		Logger:         log,
+		GardenClient:   newFakeGardenClient(),
+		SeedClientSet:  clientSet,
+		ShootClientSet: clientSet,
+		Garden:         gardenObj,
+		Seed:           seedObj,
+		Shoot:          shootObj,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed creating botanist: %w", err)

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -118,8 +118,9 @@ func controllerRegistrationSliceToList(controllerRegistrations []*gardencorev1be
 	return list
 }
 
-// ReconcileExtensionControllerDeployments reconciles the extension controller deployments.
-func (b *AutonomousBotanist) ReconcileExtensionControllerDeployments(ctx context.Context, networkAvailable bool) error {
+// ReconcileExtensionControllerInstallations reconciles the ControllerInstallation resources necessary to deploy the
+// extension controllers.
+func (b *AutonomousBotanist) ReconcileExtensionControllerInstallations(ctx context.Context, networkAvailable bool) error {
 	var (
 		reconcilerCtx = log.IntoContext(ctx, b.Logger.WithName("controllerinstallation-reconciler"))
 		reconciler    = controllerinstallation.Reconciler{

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -12,22 +12,41 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/oci"
 )
 
 // ComputeExtensions takes a list of ControllerRegistrations and ControllerDeployments and computes a corresponding list
 // of Extensions.
-func ComputeExtensions(seedName string, controllerRegistrations []*gardencorev1beta1.ControllerRegistration, controllerDeployments []*gardencorev1.ControllerDeployment) ([]Extension, error) {
+func ComputeExtensions(
+	shoot *gardencorev1beta1.Shoot,
+	controllerRegistrations []*gardencorev1beta1.ControllerRegistration,
+	controllerDeployments []*gardencorev1.ControllerDeployment,
+) (
+	[]Extension,
+	error,
+) {
 	var extensions []Extension
 
+	wantedControllerRegistrationNames, err := computeWantedControllerRegistrationNames(shoot, controllerRegistrations)
+	if err != nil {
+		return nil, fmt.Errorf("failed computing the names of the wanted ControllerRegistrations: %w", err)
+	}
+
 	for _, controllerRegistration := range controllerRegistrations {
+		if !wantedControllerRegistrationNames.Has(controllerRegistration.Name) {
+			continue
+		}
+
 		if controllerRegistration.Spec.Deployment == nil || len(controllerRegistration.Spec.Deployment.DeploymentRefs) != 1 {
 			return nil, fmt.Errorf("ControllerRegistration %s has invalid deployment refs in its spec (must reference exactly one ControllerDeployment)", controllerRegistration.Name)
 		}
@@ -46,7 +65,7 @@ func ComputeExtensions(seedName string, controllerRegistrations []*gardencorev1b
 				Spec: gardencorev1beta1.ControllerInstallationSpec{
 					RegistrationRef: corev1.ObjectReference{Name: controllerRegistration.Name},
 					DeploymentRef:   &corev1.ObjectReference{Name: controllerDeployment.Name},
-					SeedRef:         corev1.ObjectReference{Name: seedName},
+					SeedRef:         corev1.ObjectReference{Name: shoot.Name},
 				},
 			}
 		)
@@ -59,6 +78,44 @@ func ComputeExtensions(seedName string, controllerRegistrations []*gardencorev1b
 	}
 
 	return extensions, nil
+}
+
+func computeWantedControllerRegistrationNames(shoot *gardencorev1beta1.Shoot, controllerRegistrations []*gardencorev1beta1.ControllerRegistration) (sets.Set[string], error) {
+	var (
+		result                                   = sets.New[string]()
+		extensionIDToControllerRegistrationNames = make(map[string][]string)
+	)
+
+	for _, controllerRegistration := range controllerRegistrations {
+		for _, resource := range controllerRegistration.Spec.Resources {
+			id := gardenerutils.ExtensionsID(resource.Kind, resource.Type)
+			extensionIDToControllerRegistrationNames[id] = append(extensionIDToControllerRegistrationNames[id], controllerRegistration.Name)
+		}
+
+		if controllerRegistration.Spec.Deployment != nil && ptr.Deref(controllerRegistration.Spec.Deployment.Policy, "") == gardencorev1beta1.ControllerDeploymentPolicyAlways {
+			result.Insert(controllerRegistration.Name)
+		}
+	}
+
+	for _, extensionID := range gardenerutils.ComputeRequiredExtensionsForShoot(shoot, nil, controllerRegistrationSliceToList(controllerRegistrations), nil, nil).UnsortedList() {
+		names, ok := extensionIDToControllerRegistrationNames[extensionID]
+		if !ok {
+			return nil, fmt.Errorf("need to install an extension controller for %q but no appropriate ControllerRegistration found", extensionID)
+		}
+		result.Insert(names...)
+	}
+
+	return result, nil
+}
+
+func controllerRegistrationSliceToList(controllerRegistrations []*gardencorev1beta1.ControllerRegistration) *gardencorev1beta1.ControllerRegistrationList {
+	list := &gardencorev1beta1.ControllerRegistrationList{}
+	for _, controllerRegistration := range controllerRegistrations {
+		if controllerRegistration != nil {
+			list.Items = append(list.Items, *controllerRegistration)
+		}
+	}
+	return list
 }
 
 // ReconcileExtensionControllerDeployments reconciles the extension controller deployments.

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"fmt"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+// ComputeExtensions takes a list of ControllerRegistrations and ControllerDeployments and computes a corresponding list
+// of Extensions.
+func ComputeExtensions(seedName string, controllerRegistrations []*gardencorev1beta1.ControllerRegistration, controllerDeployments []*gardencorev1.ControllerDeployment) ([]Extension, error) {
+	var extensions []Extension
+
+	for _, controllerRegistration := range controllerRegistrations {
+		if controllerRegistration.Spec.Deployment == nil || len(controllerRegistration.Spec.Deployment.DeploymentRefs) != 1 {
+			return nil, fmt.Errorf("ControllerRegistration %s has invalid deployment refs in its spec (must reference exactly one ControllerDeployment)", controllerRegistration.Name)
+		}
+
+		idx := slices.IndexFunc(controllerDeployments, func(controllerDeployment *gardencorev1.ControllerDeployment) bool {
+			return controllerDeployment.Name == controllerRegistration.Spec.Deployment.DeploymentRefs[0].Name
+		})
+		if idx == -1 {
+			return nil, fmt.Errorf("ControllerDeployment %s referenced in ControllerRegistration %s was not found", controllerRegistration.Spec.Deployment.DeploymentRefs[0].Name, controllerRegistration.Name)
+		}
+
+		var (
+			controllerDeployment   = controllerDeployments[idx]
+			controllerInstallation = &gardencorev1beta1.ControllerInstallation{
+				ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration.Name},
+				Spec: gardencorev1beta1.ControllerInstallationSpec{
+					RegistrationRef: corev1.ObjectReference{Name: controllerRegistration.Name},
+					DeploymentRef:   &corev1.ObjectReference{Name: controllerDeployment.Name},
+					SeedRef:         corev1.ObjectReference{Name: seedName},
+				},
+			}
+		)
+
+		extensions = append(extensions, Extension{
+			ControllerRegistration: controllerRegistration,
+			ControllerDeployment:   controllerDeployment,
+			ControllerInstallation: controllerInstallation,
+		})
+	}
+
+	return extensions, nil
+}

--- a/pkg/gardenadm/botanist/extensions_test.go
+++ b/pkg/gardenadm/botanist/extensions_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -18,13 +19,30 @@ import (
 var _ = Describe("Extensions", func() {
 	Describe("#ComputeExtensions", func() {
 		var (
-			seedName               = "test"
-			controllerRegistration *gardencorev1beta1.ControllerRegistration
-			controllerDeployment   *gardencorev1.ControllerDeployment
+			shoot                   *gardencorev1beta1.Shoot
+			controllerRegistration1 *gardencorev1beta1.ControllerRegistration
+			controllerRegistration2 *gardencorev1beta1.ControllerRegistration
+			controllerRegistration3 *gardencorev1beta1.ControllerRegistration
+			controllerDeployment1   *gardencorev1.ControllerDeployment
+			controllerDeployment3   *gardencorev1.ControllerDeployment
+
+			controllerRegistrations []*gardencorev1beta1.ControllerRegistration
+			controllerDeployments   []*gardencorev1.ControllerDeployment
 		)
 
 		BeforeEach(func() {
-			controllerRegistration = &gardencorev1beta1.ControllerRegistration{
+			shoot = &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Type:    "ext1",
+						Workers: []gardencorev1beta1.Worker{{ControlPlane: &gardencorev1beta1.WorkerControlPlane{}}},
+					},
+					Networking: &gardencorev1beta1.Networking{
+						Type: ptr.To("ext3"),
+					},
+				},
+			}
+			controllerRegistration1 = &gardencorev1beta1.ControllerRegistration{
 				ObjectMeta: metav1.ObjectMeta{Name: "ext1"},
 				Spec: gardencorev1beta1.ControllerRegistrationSpec{
 					Deployment: &gardencorev1beta1.ControllerRegistrationDeployment{
@@ -32,48 +50,85 @@ var _ = Describe("Extensions", func() {
 							{Name: "ext1"},
 						},
 					},
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "ControlPlane", Type: "ext1"},
+					},
 				},
 			}
-			controllerDeployment = &gardencorev1.ControllerDeployment{
+			controllerRegistration2 = &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{Name: "ext2"},
+			}
+			controllerRegistration3 = &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{Name: "ext3"},
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Deployment: &gardencorev1beta1.ControllerRegistrationDeployment{
+						DeploymentRefs: []gardencorev1beta1.DeploymentRef{
+							{Name: "ext3"},
+						},
+					},
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "Network", Type: "ext3"},
+					},
+				},
+			}
+			controllerDeployment1 = &gardencorev1.ControllerDeployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "ext1"},
 			}
+			controllerDeployment3 = &gardencorev1.ControllerDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "ext3"},
+			}
+
+			controllerRegistrations = []*gardencorev1beta1.ControllerRegistration{controllerRegistration1, controllerRegistration2, controllerRegistration3}
+			controllerDeployments = []*gardencorev1.ControllerDeployment{controllerDeployment1, controllerDeployment3}
 		})
 
 		It("should return an error because deployment is not set", func() {
-			controllerRegistration.Spec.Deployment = nil
+			controllerRegistration1.Spec.Deployment = nil
 
-			extensions, err := ComputeExtensions(seedName, []*gardencorev1beta1.ControllerRegistration{controllerRegistration}, []*gardencorev1.ControllerDeployment{controllerDeployment})
+			extensions, err := ComputeExtensions(shoot, controllerRegistrations, controllerDeployments)
 			Expect(err).To(MatchError(ContainSubstring("has invalid deployment refs in its spec")))
 			Expect(extensions).To(BeNil())
 		})
 
 		It("should return an error because more than one deployment ref is set", func() {
-			controllerRegistration.Spec.Deployment.DeploymentRefs = append(controllerRegistration.Spec.Deployment.DeploymentRefs, gardencorev1beta1.DeploymentRef{})
+			controllerRegistration1.Spec.Deployment.DeploymentRefs = append(controllerRegistration1.Spec.Deployment.DeploymentRefs, gardencorev1beta1.DeploymentRef{})
 
-			extensions, err := ComputeExtensions(seedName, []*gardencorev1beta1.ControllerRegistration{controllerRegistration}, []*gardencorev1.ControllerDeployment{controllerDeployment})
+			extensions, err := ComputeExtensions(shoot, controllerRegistrations, controllerDeployments)
 			Expect(err).To(MatchError(ContainSubstring("has invalid deployment refs in its spec")))
 			Expect(extensions).To(BeNil())
 		})
 
 		It("should return an error because matching ControllerDeployment is not found", func() {
-			extensions, err := ComputeExtensions(seedName, []*gardencorev1beta1.ControllerRegistration{controllerRegistration}, nil)
+			extensions, err := ComputeExtensions(shoot, controllerRegistrations, nil)
 			Expect(err).To(MatchError(ContainSubstring("was not found")))
 			Expect(extensions).To(BeNil())
 		})
 
 		It("should return the computed extensions", func() {
-			extensions, err := ComputeExtensions(seedName, []*gardencorev1beta1.ControllerRegistration{controllerRegistration}, []*gardencorev1.ControllerDeployment{controllerDeployment})
+			extensions, err := ComputeExtensions(shoot, controllerRegistrations, controllerDeployments)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(extensions).To(Equal([]Extension{
 				{
-					ControllerRegistration: controllerRegistration,
-					ControllerDeployment:   controllerDeployment,
+					ControllerRegistration: controllerRegistration1,
+					ControllerDeployment:   controllerDeployment1,
 					ControllerInstallation: &gardencorev1beta1.ControllerInstallation{
-						ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration.Name},
+						ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration1.Name},
 						Spec: gardencorev1beta1.ControllerInstallationSpec{
-							RegistrationRef: corev1.ObjectReference{Name: controllerRegistration.Name},
-							DeploymentRef:   &corev1.ObjectReference{Name: controllerDeployment.Name},
-							SeedRef:         corev1.ObjectReference{Name: seedName},
+							RegistrationRef: corev1.ObjectReference{Name: controllerRegistration1.Name},
+							DeploymentRef:   &corev1.ObjectReference{Name: controllerDeployment1.Name},
+							SeedRef:         corev1.ObjectReference{Name: shoot.Name},
+						},
+					},
+				},
+				{
+					ControllerRegistration: controllerRegistration3,
+					ControllerDeployment:   controllerDeployment3,
+					ControllerInstallation: &gardencorev1beta1.ControllerInstallation{
+						ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration3.Name},
+						Spec: gardencorev1beta1.ControllerInstallationSpec{
+							RegistrationRef: corev1.ObjectReference{Name: controllerRegistration3.Name},
+							DeploymentRef:   &corev1.ObjectReference{Name: controllerDeployment3.Name},
+							SeedRef:         corev1.ObjectReference{Name: shoot.Name},
 						},
 					},
 				},

--- a/pkg/gardenadm/botanist/extensions_test.go
+++ b/pkg/gardenadm/botanist/extensions_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
+)
+
+var _ = Describe("Extensions", func() {
+	Describe("#ComputeExtensions", func() {
+		var (
+			seedName               = "test"
+			controllerRegistration *gardencorev1beta1.ControllerRegistration
+			controllerDeployment   *gardencorev1.ControllerDeployment
+		)
+
+		BeforeEach(func() {
+			controllerRegistration = &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{Name: "ext1"},
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Deployment: &gardencorev1beta1.ControllerRegistrationDeployment{
+						DeploymentRefs: []gardencorev1beta1.DeploymentRef{
+							{Name: "ext1"},
+						},
+					},
+				},
+			}
+			controllerDeployment = &gardencorev1.ControllerDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "ext1"},
+			}
+		})
+
+		It("should return an error because deployment is not set", func() {
+			controllerRegistration.Spec.Deployment = nil
+
+			extensions, err := ComputeExtensions(seedName, []*gardencorev1beta1.ControllerRegistration{controllerRegistration}, []*gardencorev1.ControllerDeployment{controllerDeployment})
+			Expect(err).To(MatchError(ContainSubstring("has invalid deployment refs in its spec")))
+			Expect(extensions).To(BeNil())
+		})
+
+		It("should return an error because more than one deployment ref is set", func() {
+			controllerRegistration.Spec.Deployment.DeploymentRefs = append(controllerRegistration.Spec.Deployment.DeploymentRefs, gardencorev1beta1.DeploymentRef{})
+
+			extensions, err := ComputeExtensions(seedName, []*gardencorev1beta1.ControllerRegistration{controllerRegistration}, []*gardencorev1.ControllerDeployment{controllerDeployment})
+			Expect(err).To(MatchError(ContainSubstring("has invalid deployment refs in its spec")))
+			Expect(extensions).To(BeNil())
+		})
+
+		It("should return an error because matching ControllerDeployment is not found", func() {
+			extensions, err := ComputeExtensions(seedName, []*gardencorev1beta1.ControllerRegistration{controllerRegistration}, nil)
+			Expect(err).To(MatchError(ContainSubstring("was not found")))
+			Expect(extensions).To(BeNil())
+		})
+
+		It("should return the computed extensions", func() {
+			extensions, err := ComputeExtensions(seedName, []*gardencorev1beta1.ControllerRegistration{controllerRegistration}, []*gardencorev1.ControllerDeployment{controllerDeployment})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(extensions).To(Equal([]Extension{
+				{
+					ControllerRegistration: controllerRegistration,
+					ControllerDeployment:   controllerDeployment,
+					ControllerInstallation: &gardencorev1beta1.ControllerInstallation{
+						ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration.Name},
+						Spec: gardencorev1beta1.ControllerInstallationSpec{
+							RegistrationRef: corev1.ObjectReference{Name: controllerRegistration.Name},
+							DeploymentRef:   &corev1.ObjectReference{Name: controllerDeployment.Name},
+							SeedRef:         corev1.ObjectReference{Name: seedName},
+						},
+					},
+				},
+			}))
+		})
+	})
+})

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -122,6 +122,13 @@ func run(ctx context.Context, opts *Options) error {
 			Fn:           b.DeployShootSystem,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying extension controllers",
+			Fn: func(ctx context.Context) error {
+				return b.ReconcileExtensionControllerDeployments(ctx, false)
+			},
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+		})
 	)
 
 	if err := g.Compile().Run(ctx, flow.Opts{

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -171,7 +171,7 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Autono
 		return nil, fmt.Errorf("failed reading Kubernetes resources from config directory %s: %w", opts.ConfigDir, err)
 	}
 
-	extensions, err := botanist.ComputeExtensions(shoot.Name, controllerRegistrations, controllerDeployments)
+	extensions, err := botanist.ComputeExtensions(shoot, controllerRegistrations, controllerDeployments)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing extensions: %w", err)
 	}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -125,7 +125,7 @@ func run(ctx context.Context, opts *Options) error {
 		_ = g.Add(flow.Task{
 			Name: "Deploying extension controllers",
 			Fn: func(ctx context.Context) error {
-				return b.ReconcileExtensionControllerDeployments(ctx, false)
+				return b.ReconcileExtensionControllerInstallations(ctx, false)
 			},
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})

--- a/pkg/gardenadm/resources.go
+++ b/pkg/gardenadm/resources.go
@@ -105,21 +105,17 @@ func ReadManifests(
 
 		return nil
 	}); err != nil {
-		err = fmt.Errorf("failed reading Kubernetes resources from config directory: %w", err)
-		return
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed reading Kubernetes resources from config directory: %w", err)
 	}
 
 	if cloudProfile == nil {
-		err = fmt.Errorf("must provide a *gardencorev1beta1.CloudProfile resource, but did not find any")
-		return
+		return nil, nil, nil, nil, nil, fmt.Errorf("must provide a *gardencorev1beta1.CloudProfile resource, but did not find any")
 	}
 	if project == nil {
-		err = fmt.Errorf("must provide a *gardencorev1beta1.Project resource, but did not find any")
-		return
+		return nil, nil, nil, nil, nil, fmt.Errorf("must provide a *gardencorev1beta1.Project resource, but did not find any")
 	}
 	if shoot == nil {
-		err = fmt.Errorf("must provide a *gardencorev1beta1.Shoot resource, but did not find any")
-		return
+		return nil, nil, nil, nil, nil, fmt.Errorf("must provide a *gardencorev1beta1.Shoot resource, but did not find any")
 	}
 
 	return

--- a/pkg/gardenadm/resources.go
+++ b/pkg/gardenadm/resources.go
@@ -25,16 +25,20 @@ import (
 // ReadManifests reads Kubernetes and Gardener manifests in YAML or JSON format.
 // It returns a CloudProfile, Project, and Shoot resource if found, or an error if any issues occur during reading or
 // decoding.
-func ReadManifests(log logr.Logger, fsys fs.FS) (*gardencorev1beta1.CloudProfile, *gardencorev1beta1.Project, *gardencorev1beta1.Shoot, error) {
-	var (
-		cloudProfile *gardencorev1beta1.CloudProfile
-		project      *gardencorev1beta1.Project
-		shoot        *gardencorev1beta1.Shoot
+func ReadManifests(
+	log logr.Logger,
+	fsys fs.FS,
+) (
+	cloudProfile *gardencorev1beta1.CloudProfile,
+	project *gardencorev1beta1.Project,
+	shoot *gardencorev1beta1.Shoot,
+	controllerRegistrations []*gardencorev1beta1.ControllerRegistration,
+	controllerDeployments []*gardencorev1.ControllerDeployment,
+	err error,
+) {
+	decoder := serializer.NewCodecFactory(kubernetes.GardenScheme).UniversalDecoder(gardencorev1.SchemeGroupVersion, gardencorev1beta1.SchemeGroupVersion)
 
-		decoder = serializer.NewCodecFactory(kubernetes.GardenScheme).UniversalDecoder(gardencorev1.SchemeGroupVersion, gardencorev1beta1.SchemeGroupVersion)
-	)
-
-	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+	if err = fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("failed walking directory: %w", err)
 		}
@@ -90,23 +94,33 @@ func ReadManifests(log logr.Logger, fsys fs.FS) (*gardencorev1beta1.CloudProfile
 					return fmt.Errorf("found more than one *gardencorev1beta1.Shoot resource, but only one is allowed")
 				}
 				shoot = typedObj
+
+			case *gardencorev1beta1.ControllerRegistration:
+				controllerRegistrations = append(controllerRegistrations, typedObj)
+
+			case *gardencorev1.ControllerDeployment:
+				controllerDeployments = append(controllerDeployments, typedObj)
 			}
 		}
 
 		return nil
 	}); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed reading Kubernetes resources from config directory: %w", err)
+		err = fmt.Errorf("failed reading Kubernetes resources from config directory: %w", err)
+		return
 	}
 
 	if cloudProfile == nil {
-		return nil, nil, nil, fmt.Errorf("must provide a *gardencorev1beta1.CloudProfile resource, but did not find any")
+		err = fmt.Errorf("must provide a *gardencorev1beta1.CloudProfile resource, but did not find any")
+		return
 	}
 	if project == nil {
-		return nil, nil, nil, fmt.Errorf("must provide a *gardencorev1beta1.Project resource, but did not find any")
+		err = fmt.Errorf("must provide a *gardencorev1beta1.Project resource, but did not find any")
+		return
 	}
 	if shoot == nil {
-		return nil, nil, nil, fmt.Errorf("must provide a *gardencorev1beta1.Shoot resource, but did not find any")
+		err = fmt.Errorf("must provide a *gardencorev1beta1.Shoot resource, but did not find any")
+		return
 	}
 
-	return cloudProfile, project, shoot, nil
+	return
 }

--- a/pkg/gardenadm/staticpod/translator.go
+++ b/pkg/gardenadm/staticpod/translator.go
@@ -40,6 +40,7 @@ func translatePodTemplate(ctx context.Context, c client.Client, objectMeta metav
 	pod := &corev1.Pod{ObjectMeta: podTemplate.ObjectMeta, Spec: podTemplate.Spec}
 	pod.Name = objectMeta.Name
 	pod.Namespace = metav1.NamespaceSystem
+	metav1.SetMetaDataLabel(&podTemplate.ObjectMeta, "static-pod", "true")
 
 	translateSpec(&pod.Spec)
 

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -69,6 +69,7 @@ metadata:
   creationTimestamp: null
   labels:
     baz: foo
+    static-pod: "true"
   name: foo
   namespace: kube-system
 spec:
@@ -185,6 +186,7 @@ metadata:
   creationTimestamp: null
   labels:
     baz: foo
+    static-pod: "true"
   name: foo
   namespace: kube-system
 spec:
@@ -292,6 +294,7 @@ metadata:
   creationTimestamp: null
   labels:
     baz: foo
+    static-pod: "true"
   name: foo
   namespace: kube-system
 spec:
@@ -406,6 +409,7 @@ metadata:
   creationTimestamp: null
   labels:
     baz: foo
+    static-pod: "true"
   name: foo
   namespace: kube-system
 spec:

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
@@ -40,11 +40,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, gard
 		r.Clock = clock.RealClock{}
 	}
 	if r.HelmRegistry == nil {
-		helmRegistry, err := oci.NewHelmRegistry(r.GardenClient)
-		if err != nil {
-			return err
-		}
-		r.HelmRegistry = helmRegistry
+		r.HelmRegistry = oci.NewHelmRegistry(r.GardenClient)
 	}
 
 	return builder.

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
@@ -22,6 +22,7 @@ import (
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/oci"
 )
 
@@ -41,6 +42,9 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, gard
 	}
 	if r.HelmRegistry == nil {
 		r.HelmRegistry = oci.NewHelmRegistry(r.GardenClient)
+	}
+	if r.GardenNamespace == "" {
+		r.GardenNamespace = v1beta1constants.GardenNamespace
 	}
 
 	return builder.

--- a/pkg/gardenlet/controller/gardenlet/add.go
+++ b/pkg/gardenlet/controller/gardenlet/add.go
@@ -5,8 +5,6 @@
 package gardenlet
 
 import (
-	"fmt"
-
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,11 +51,7 @@ func (r *Reconciler) AddToManager(
 		r.GardenNamespace = v1beta1constants.GardenNamespace
 	}
 	if r.HelmRegistry == nil {
-		var err error
-		r.HelmRegistry, err = oci.NewHelmRegistry(r.GardenClient)
-		if err != nil {
-			return fmt.Errorf("failed creating new Helm registry: %w", err)
-		}
+		r.HelmRegistry = oci.NewHelmRegistry(r.GardenClient)
 	}
 	if r.ValuesHelper == nil {
 		r.ValuesHelper = gardenletdeployer.NewValuesHelper(&r.Config)

--- a/pkg/operator/controller/extension/extension/add.go
+++ b/pkg/operator/controller/extension/extension/add.go
@@ -65,10 +65,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	}
 
 	if r.HelmRegistry == nil {
-		r.HelmRegistry, err = oci.NewHelmRegistry(r.RuntimeClientSet.Client())
-		if err != nil {
-			return fmt.Errorf("failed creating Helm registry: %w", err)
-		}
+		r.HelmRegistry = oci.NewHelmRegistry(r.RuntimeClientSet.Client())
 	}
 
 	if r.GardenNamespace == "" {

--- a/pkg/operator/controller/gardenlet/add.go
+++ b/pkg/operator/controller/gardenlet/add.go
@@ -6,7 +6,6 @@ package gardenlet
 
 import (
 	"context"
-	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/clock"
@@ -51,11 +50,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, virt
 		r.Recorder = mgr.GetEventRecorderFor(ControllerName + "-controller")
 	}
 	if r.HelmRegistry == nil {
-		var err error
-		r.HelmRegistry, err = oci.NewHelmRegistry(r.RuntimeCluster.GetClient())
-		if err != nil {
-			return fmt.Errorf("failed creating new Helm registry: %w", err)
-		}
+		r.HelmRegistry = oci.NewHelmRegistry(r.RuntimeCluster.GetClient())
 	}
 
 	return builder.

--- a/pkg/provider-local/controller/worker/actuator.go
+++ b/pkg/provider-local/controller/worker/actuator.go
@@ -48,11 +48,14 @@ type actuator struct {
 // NewActuator creates a new Actuator that updates the status of the handled WorkerPoolConfigs.
 func NewActuator(mgr manager.Manager, gardenCluster cluster.Cluster) worker.Actuator {
 	workerDelegate := &delegateFactory{
-		gardenReader: gardenCluster.GetAPIReader(),
-		seedClient:   mgr.GetClient(),
-		decoder:      serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
-		restConfig:   mgr.GetConfig(),
-		scheme:       mgr.GetScheme(),
+		seedClient: mgr.GetClient(),
+		decoder:    serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+		restConfig: mgr.GetConfig(),
+		scheme:     mgr.GetScheme(),
+	}
+
+	if gardenCluster != nil {
+		workerDelegate.gardenReader = gardenCluster.GetAPIReader()
 	}
 
 	return &actuator{

--- a/pkg/resourcemanager/apis/config/v1alpha1/types.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/types.go
@@ -344,6 +344,8 @@ type SeccompProfileWebhookConfig struct {
 }
 
 const (
-	// DefaultResourceClass is used as resource class if no class is specified on the command line
+	// DefaultResourceClass is used as resource class if no class is specified on the command line.
 	DefaultResourceClass = "resources"
+	// AllResourceClass is used as resource class when all values for resource classes should be covered.
+	AllResourceClass = "*"
 )

--- a/pkg/resourcemanager/predicate/class_filter.go
+++ b/pkg/resourcemanager/predicate/class_filter.go
@@ -42,7 +42,7 @@ func NewClassFilter(class string) *ClassFilter {
 	}
 
 	finalizer := FinalizerName + "-" + class
-	if class == resourcemanagerconfigv1alpha1.DefaultResourceClass {
+	if class == resourcemanagerconfigv1alpha1.DefaultResourceClass || class == resourcemanagerconfigv1alpha1.AllResourceClass {
 		finalizer = FinalizerName
 	}
 
@@ -64,6 +64,10 @@ func (f *ClassFilter) FinalizerName() string {
 
 // Responsible checks whether an object should be managed by the actual controller instance
 func (f *ClassFilter) Responsible(o runtime.Object) bool {
+	if f.resourceClass == resourcemanagerconfigv1alpha1.AllResourceClass {
+		return true
+	}
+
 	r := o.(*resourcesv1alpha1.ManagedResource)
 	c := ptr.Deref(r.Spec.Class, "")
 	return c == f.resourceClass || (c == "" && f.resourceClass == resourcemanagerconfigv1alpha1.DefaultResourceClass)
@@ -78,11 +82,11 @@ func (f *ClassFilter) IsTransferringResponsibility(mr *resourcesv1alpha1.Managed
 func (f *ClassFilter) IsWaitForCleanupRequired(mr *resourcesv1alpha1.ManagedResource) bool {
 	for _, finalizer := range mr.GetFinalizers() {
 		if strings.HasPrefix(finalizer, FinalizerName) {
-			// mr has a controller responsible for it's resources deletion
+			// mr has a controller responsible for its resources deletion
 			return f.Responsible(mr) && finalizer != f.objectFinalizer
 		}
 	}
-	// mr doesn't have a controller responsible for it's resources deletion
+	// mr doesn't have a controller responsible for its resources deletion
 	return false
 }
 

--- a/pkg/resourcemanager/predicate/class_filter_test.go
+++ b/pkg/resourcemanager/predicate/class_filter_test.go
@@ -75,107 +75,123 @@ var _ = Describe("ClassFilter", func() {
 		}
 	)
 
-	BeforeEach(func() {
-		filter = NewClassFilter("")
+	When("class is empty", func() {
+		BeforeEach(func() {
+			filter = NewClassFilter("")
+		})
+
+		DescribeTable("Responsible",
+			func(mr *resourcesv1alpha1.ManagedResource, responsible bool) {
+				resp := filter.Responsible(mr)
+				Expect(resp).To(Equal(responsible))
+			},
+			Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+			Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+			Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, false),
+			Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+			Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+			Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
+		)
+
+		DescribeTable("IsTransferringResponsibility",
+			func(mr *resourcesv1alpha1.ManagedResource, shouldCleanup bool) {
+				cleanup := filter.IsTransferringResponsibility(mr)
+				Expect(cleanup).To(Equal(shouldCleanup))
+			},
+			Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+			Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+			Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+			Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, false),
+			Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, false),
+			Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, false),
+		)
+
+		DescribeTable("IsWaitForCleanupRequired",
+			func(mr *resourcesv1alpha1.ManagedResource, shouldWait bool) {
+				wait := filter.IsWaitForCleanupRequired(mr)
+				Expect(wait).To(Equal(shouldWait))
+			},
+			Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+			Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+			Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, false),
+			Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, false),
+			Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+			Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, false),
+		)
+
+		DescribeTable("Create",
+			func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
+				got := filter.Create(event.CreateEvent{
+					Object: mr,
+				})
+				Expect(got).To(Equal(expected))
+			},
+			Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+			Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+			Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+			Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+			Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+			Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
+		)
+
+		DescribeTable("Delete",
+			func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
+				got := filter.Delete(event.DeleteEvent{
+					Object: mr,
+				})
+				Expect(got).To(Equal(expected))
+			},
+			Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+			Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+			Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+			Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+			Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+			Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
+		)
+
+		DescribeTable("Update",
+			func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
+				got := filter.Update(event.UpdateEvent{
+					ObjectNew: mr,
+				})
+				Expect(got).To(Equal(expected))
+			},
+			Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+			Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+			Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+			Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+			Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+			Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
+		)
+
+		DescribeTable("Generic",
+			func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
+				got := filter.Generic(event.GenericEvent{
+					Object: mr,
+				})
+				Expect(got).To(Equal(expected))
+			},
+			Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+			Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+			Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+			Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+			Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+			Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
+		)
 	})
 
-	DescribeTable("Responsible",
-		func(mr *resourcesv1alpha1.ManagedResource, responsible bool) {
-			resp := filter.Responsible(mr)
-			Expect(resp).To(Equal(responsible))
-		},
-		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
-		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
-		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, false),
-		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
-		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
-		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
-	)
+	When("class is 'all'", func() {
+		BeforeEach(func() {
+			filter = NewClassFilter("*")
+		})
 
-	DescribeTable("IsTransferringResponsibility",
-		func(mr *resourcesv1alpha1.ManagedResource, shouldCleanup bool) {
-			cleanup := filter.IsTransferringResponsibility(mr)
-			Expect(cleanup).To(Equal(shouldCleanup))
-		},
-		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
-		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
-		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
-		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, false),
-		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, false),
-		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, false),
-	)
-
-	DescribeTable("IsWaitForCleanupRequired",
-		func(mr *resourcesv1alpha1.ManagedResource, shouldWait bool) {
-			wait := filter.IsWaitForCleanupRequired(mr)
-			Expect(wait).To(Equal(shouldWait))
-		},
-		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
-		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
-		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, false),
-		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, false),
-		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
-		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, false),
-	)
-
-	DescribeTable("Create",
-		func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
-			got := filter.Create(event.CreateEvent{
-				Object: mr,
+		Describe("#Responsible", func() {
+			It("should be responsible for any class", func() {
+				Expect(filter.Responsible(&resourcesv1alpha1.ManagedResource{})).To(BeTrue())
+				Expect(filter.Responsible(&resourcesv1alpha1.ManagedResource{Spec: resourcesv1alpha1.ManagedResourceSpec{Class: ptr.To("")}})).To(BeTrue())
+				Expect(filter.Responsible(&resourcesv1alpha1.ManagedResource{Spec: resourcesv1alpha1.ManagedResourceSpec{Class: ptr.To("foo")}})).To(BeTrue())
+				Expect(filter.Responsible(&resourcesv1alpha1.ManagedResource{Spec: resourcesv1alpha1.ManagedResourceSpec{Class: ptr.To("bar")}})).To(BeTrue())
 			})
-			Expect(got).To(Equal(expected))
-		},
-		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
-		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
-		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
-		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
-		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
-		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
-	)
-
-	DescribeTable("Delete",
-		func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
-			got := filter.Delete(event.DeleteEvent{
-				Object: mr,
-			})
-			Expect(got).To(Equal(expected))
-		},
-		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
-		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
-		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
-		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
-		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
-		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
-	)
-
-	DescribeTable("Update",
-		func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
-			got := filter.Update(event.UpdateEvent{
-				ObjectNew: mr,
-			})
-			Expect(got).To(Equal(expected))
-		},
-		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
-		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
-		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
-		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
-		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
-		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
-	)
-
-	DescribeTable("Generic",
-		func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
-			got := filter.Generic(event.GenericEvent{
-				Object: mr,
-			})
-			Expect(got).To(Equal(expected))
-		},
-		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
-		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
-		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
-		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
-		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
-		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
-	)
-
+		})
+	})
 })

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1187,9 +1187,7 @@ var _ = Describe("Shoot", func() {
 		})
 
 		It("should compute the correct list of required extensions", func() {
-			result := ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
-
-			Expect(result).To(BeEquivalentTo(sets.New(
+			Expect(ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)).To(Equal(sets.New(
 				ExtensionsID(extensionsv1alpha1.BackupBucketResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.BackupEntryResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
@@ -1209,9 +1207,7 @@ var _ = Describe("Shoot", func() {
 		It("should compute the correct list of required extensions (no seed backup)", func() {
 			seed.Spec.Backup = nil
 
-			result := ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
-
-			Expect(result).To(BeEquivalentTo(sets.New(
+			Expect(ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)).To(Equal(sets.New(
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
 				ExtensionsID(extensionsv1alpha1.InfrastructureResource, shootProvider),
@@ -1232,9 +1228,7 @@ var _ = Describe("Shoot", func() {
 				Disabled: ptr.To(true),
 			})
 
-			result := ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
-
-			Expect(result).To(BeEquivalentTo(sets.New(
+			Expect(ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)).To(Equal(sets.New(
 				ExtensionsID(extensionsv1alpha1.BackupBucketResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.BackupEntryResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
@@ -1253,15 +1247,43 @@ var _ = Describe("Shoot", func() {
 		It("should compute the correct list of required extensions (workerless Shoot)", func() {
 			shoot.Spec.Provider.Workers = nil
 
-			result := ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
-
-			Expect(result).To(BeEquivalentTo(sets.New(
+			Expect(ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)).To(Equal(sets.New(
 				ExtensionsID(extensionsv1alpha1.BackupBucketResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.BackupEntryResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
 				ExtensionsID(extensionsv1alpha1.ExtensionResource, extensionType1),
 				ExtensionsID(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
 				ExtensionsID(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
+			)))
+		})
+
+		It("should compute the correct list of required extensions (no seed)", func() {
+			Expect(ComputeRequiredExtensionsForShoot(shoot, nil, controllerRegistrationList, internalDomain, externalDomain)).To(Equal(sets.New(
+				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				ExtensionsID(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				ExtensionsID(extensionsv1alpha1.NetworkResource, networkingType),
+				ExtensionsID(extensionsv1alpha1.WorkerResource, shootProvider),
+				ExtensionsID(extensionsv1alpha1.ExtensionResource, extensionType1),
+				ExtensionsID(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				ExtensionsID(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				ExtensionsID(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
+				ExtensionsID(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
+				ExtensionsID(extensionsv1alpha1.ExtensionResource, extensionType2),
+			)))
+		})
+
+		It("should compute the correct list of required extensions (autonomous shoot)", func() {
+			shoot.Spec.Provider.Workers[0].ControlPlane = &gardencorev1beta1.WorkerControlPlane{}
+
+			Expect(ComputeRequiredExtensionsForShoot(shoot, nil, controllerRegistrationList, internalDomain, externalDomain)).To(Equal(sets.New(
+				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				ExtensionsID(extensionsv1alpha1.NetworkResource, networkingType),
+				ExtensionsID(extensionsv1alpha1.ExtensionResource, extensionType1),
+				ExtensionsID(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				ExtensionsID(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				ExtensionsID(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
+				ExtensionsID(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
+				ExtensionsID(extensionsv1alpha1.ExtensionResource, extensionType2),
 			)))
 		})
 
@@ -1308,9 +1330,7 @@ var _ = Describe("Shoot", func() {
 				},
 			}
 
-			result := ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
-
-			Expect(result).To(BeEquivalentTo(sets.New(
+			Expect(ComputeRequiredExtensionsForShoot(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)).To(Equal(sets.New(
 				ExtensionsID(extensionsv1alpha1.BackupBucketResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.BackupEntryResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, seedProvider),

--- a/pkg/utils/kubernetes/pod.go
+++ b/pkg/utils/kubernetes/pod.go
@@ -257,3 +257,23 @@ func GetPodLogs(ctx context.Context, podInterface corev1client.PodInterface, nam
 
 	return io.ReadAll(stream)
 }
+
+// InjectKubernetesServiceHostEnv injects the KUBERNETES_SERVICE_HOST env var into all containers if not already
+// defined.
+func InjectKubernetesServiceHostEnv(containers []corev1.Container, host string) {
+	for i, container := range containers {
+		if slices.ContainsFunc(container.Env, func(envVar corev1.EnvVar) bool { return envVar.Name == "KUBERNETES_SERVICE_HOST" }) {
+			continue
+		}
+
+		if container.Env == nil {
+			container.Env = make([]corev1.EnvVar, 0, 1)
+		}
+
+		containers[i].Env = append(containers[i].Env, corev1.EnvVar{
+			Name:      "KUBERNETES_SERVICE_HOST",
+			Value:     host,
+			ValueFrom: nil,
+		})
+	}
+}

--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -564,4 +564,26 @@ var _ = Describe("Pod Utils", func() {
 			Expect(actual).To(Equal(logs))
 		})
 	})
+
+	Describe("#InjectKubernetesServiceHost", func() {
+		var (
+			host       = "host"
+			containers []corev1.Container
+		)
+
+		BeforeEach(func() {
+			containers = []corev1.Container{{}}
+		})
+
+		It("should do nothing because env var is already present", func() {
+			containers[0].Env = []corev1.EnvVar{{Name: "KUBERNETES_SERVICE_HOST", Value: "foo"}}
+			InjectKubernetesServiceHostEnv(containers, host)
+			Expect(containers[0].Env[0].Value).To(Equal("foo"))
+		})
+
+		It("should do nothing because env var is already present", func() {
+			InjectKubernetesServiceHostEnv(containers, host)
+			Expect(containers[0].Env[0].Value).To(Equal(host))
+		})
+	})
 })

--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -48,11 +48,11 @@ type HelmRegistry struct {
 
 // NewHelmRegistry creates a new HelmRegistry.
 // The client is used to get pull secrets if needed.
-func NewHelmRegistry(c client.Client) (*HelmRegistry, error) {
+func NewHelmRegistry(c client.Client) *HelmRegistry {
 	return &HelmRegistry{
 		cache:  defaultCache,
 		client: c,
-	}, nil
+	}
 }
 
 // Pull from the repository and return the compressed archive.

--- a/pkg/utils/secrets/kubeconfig.go
+++ b/pkg/utils/secrets/kubeconfig.go
@@ -21,6 +21,7 @@ type KubeconfigSecretConfig struct {
 	ContextName string
 	Cluster     clientcmdv1.Cluster
 	AuthInfo    clientcmdv1.AuthInfo
+	Namespace   string
 }
 
 // Kubeconfig contains the name and the generated kubeconfig.
@@ -38,6 +39,7 @@ func (s *KubeconfigSecretConfig) GetName() string {
 // Generate implements ConfigInterface.
 func (s *KubeconfigSecretConfig) Generate() (DataInterface, error) {
 	kubeconfig := kubernetesutils.NewKubeconfig(s.ContextName, s.Cluster, s.AuthInfo)
+	kubeconfig.Contexts[0].Context.Namespace = s.Namespace
 
 	raw, err := runtime.Encode(clientcmdlatest.Codec, kubeconfig)
 	if err != nil {

--- a/pkg/utils/secrets/kubeconfig_test.go
+++ b/pkg/utils/secrets/kubeconfig_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Kubeconfig Secrets", func() {
 		contextName = "shoot--foo--bar"
 		cluster     = clientcmdv1.Cluster{Server: "server", CertificateAuthority: "/some/path"}
 		authInfo    = clientcmdv1.AuthInfo{Token: "token"}
+		namespace   = "default"
 	)
 
 	Describe("Configuration", func() {
@@ -32,6 +33,7 @@ var _ = Describe("Kubeconfig Secrets", func() {
 				ContextName: contextName,
 				Cluster:     cluster,
 				AuthInfo:    authInfo,
+				Namespace:   namespace,
 			}
 		})
 
@@ -49,8 +51,11 @@ var _ = Describe("Kubeconfig Secrets", func() {
 				kubeconfig, ok := obj.(*Kubeconfig)
 				Expect(ok).To(BeTrue())
 
+				expected := kubernetesutils.NewKubeconfig(contextName, cluster, authInfo)
+				expected.Contexts[0].Context.Namespace = namespace
+
 				Expect(kubeconfig.Name).To(Equal(name))
-				Expect(kubeconfig.Kubeconfig).To(Equal(kubernetesutils.NewKubeconfig(contextName, cluster, authInfo)))
+				Expect(kubeconfig.Kubeconfig).To(Equal(expected))
 			})
 		})
 

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -432,13 +432,120 @@ build:
         after:
           - command:
               - bash
-              - -ec
-              - |
-                cat <<EOF > example/gardenadm-local/.imagevector-overwrite.yaml
-                images:
-                - name: gardener-node-agent
-                  ref: "$SKAFFOLD_IMAGE"
-                EOF
+              - hack/generate-gardenadm-imagevector-overwrite.sh
+              - gardener-node-agent
+    - image: local-skaffold/gardener-resource-manager
+      ko:
+        dependencies:
+          paths:
+            - cmd/gardener-resource-manager
+            - cmd/gardener-resource-manager/app
+            - cmd/gardener-resource-manager/app/bootstrappers
+            - cmd/utils
+            - cmd/utils/initrun
+            - pkg/api/extensions
+            - pkg/api/indexer
+            - pkg/apis/authentication
+            - pkg/apis/core
+            - pkg/apis/core/install
+            - pkg/apis/core/v1
+            - pkg/apis/core/v1beta1
+            - pkg/apis/core/v1beta1/constants
+            - pkg/apis/core/v1beta1/helper
+            - pkg/apis/extensions
+            - pkg/apis/extensions/v1alpha1
+            - pkg/apis/extensions/v1alpha1/helper
+            - pkg/apis/extensions/validation
+            - pkg/apis/operations
+            - pkg/apis/operations/install
+            - pkg/apis/operations/v1alpha1
+            - pkg/apis/operator
+            - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
+            - pkg/apis/resources
+            - pkg/apis/resources/v1alpha1
+            - pkg/apis/resources/v1alpha1/helper
+            - pkg/apis/security
+            - pkg/apis/security/install
+            - pkg/apis/security/v1alpha1
+            - pkg/apis/seedmanagement
+            - pkg/apis/seedmanagement/encoding
+            - pkg/apis/seedmanagement/install
+            - pkg/apis/seedmanagement/v1alpha1
+            - pkg/apis/settings
+            - pkg/apis/settings/install
+            - pkg/apis/settings/v1alpha1
+            - pkg/chartrenderer
+            - pkg/client/kubernetes
+            - pkg/client/kubernetes/cache
+            - pkg/controller/tokenrequestor
+            - pkg/controllerutils
+            - pkg/controllerutils/predicate
+            - pkg/controllerutils/reconciler
+            - pkg/controllerutils/routes
+            - pkg/gardenlet/apis/config/v1alpha1
+            - pkg/healthz
+            - pkg/logger
+            - pkg/resourcemanager/apis/config/v1alpha1
+            - pkg/resourcemanager/apis/config/v1alpha1/validation
+            - pkg/resourcemanager/client
+            - pkg/resourcemanager/controller
+            - pkg/resourcemanager/controller/csrapprover
+            - pkg/resourcemanager/controller/garbagecollector
+            - pkg/resourcemanager/controller/garbagecollector/references
+            - pkg/resourcemanager/controller/health
+            - pkg/resourcemanager/controller/health/health
+            - pkg/resourcemanager/controller/health/progressing
+            - pkg/resourcemanager/controller/health/utils
+            - pkg/resourcemanager/controller/managedresource
+            - pkg/resourcemanager/controller/networkpolicy
+            - pkg/resourcemanager/controller/node
+            - pkg/resourcemanager/controller/node/agentreconciliationdelay
+            - pkg/resourcemanager/controller/node/criticalcomponents
+            - pkg/resourcemanager/controller/node/criticalcomponents/helper
+            - pkg/resourcemanager/predicate
+            - pkg/resourcemanager/webhook
+            - pkg/resourcemanager/webhook/crddeletionprotection
+            - pkg/resourcemanager/webhook/endpointslicehints
+            - pkg/resourcemanager/webhook/extensionvalidation
+            - pkg/resourcemanager/webhook/highavailabilityconfig
+            - pkg/resourcemanager/webhook/kubernetesservicehost
+            - pkg/resourcemanager/webhook/nodeagentauthorizer
+            - pkg/resourcemanager/webhook/podschedulername
+            - pkg/resourcemanager/webhook/podtopologyspreadconstraints
+            - pkg/resourcemanager/webhook/projectedtokenmount
+            - pkg/resourcemanager/webhook/seccompprofile
+            - pkg/resourcemanager/webhook/systemcomponentsconfig
+            - pkg/utils
+            - pkg/utils/context
+            - pkg/utils/errors
+            - pkg/utils/flow
+            - pkg/utils/gardener
+            - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/client
+            - pkg/utils/kubernetes/health
+            - pkg/utils/kubernetes/unstructured
+            - pkg/utils/retry
+            - pkg/utils/secrets
+            - pkg/utils/time
+            - pkg/utils/timewindow
+            - pkg/utils/validation
+            - pkg/utils/validation/cidr
+            - pkg/utils/validation/kubernetes/core
+            - pkg/utils/validation/kubernetesversion
+            - pkg/utils/version
+            - pkg/webhook/authorizer
+            - third_party/gopkg.in/yaml.v2
+            - VERSION
+        ldflags:
+          - '{{.LD_FLAGS}}'
+        main: ./cmd/gardener-resource-manager
+      hooks:
+        after:
+          - command:
+              - bash
+              - hack/generate-gardenadm-imagevector-overwrite.sh
+              - gardener-resource-manager
   insecureRegistries:
     - garden.local.gardener.cloud:5001
   tagPolicy:

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -224,6 +224,7 @@ build:
             - pkg/component/observability/plutono/dashboards/garden-shoot
             - pkg/component/observability/plutono/dashboards/seed
             - pkg/component/observability/plutono/dashboards/shoot
+            - pkg/component/seed/system
             - pkg/component/shared
             - pkg/component/shoot/namespaces
             - pkg/component/shoot/system
@@ -248,6 +249,8 @@ build:
             - pkg/gardenadm/staticpod
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/gardenlet/apis/config/v1alpha1/helper
+            - pkg/gardenlet/controller/controllerinstallation/controllerinstallation
+            - pkg/gardenlet/controller/controllerinstallation/utils
             - pkg/gardenlet/features
             - pkg/gardenlet/operation
             - pkg/gardenlet/operation/botanist
@@ -282,6 +285,7 @@ build:
             - pkg/utils/errors
             - pkg/utils/flow
             - pkg/utils/gardener
+            - pkg/utils/gardener/gardenlet
             - pkg/utils/gardener/secretsrotation
             - pkg/utils/gardener/tokenrequest
             - pkg/utils/imagevector
@@ -295,6 +299,7 @@ build:
             - pkg/utils/managedresources
             - pkg/utils/managedresources/builder
             - pkg/utils/net
+            - pkg/utils/oci
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
@@ -445,7 +450,6 @@ build:
             - cmd/utils/initrun
             - pkg/api/extensions
             - pkg/api/indexer
-            - pkg/apis/authentication
             - pkg/apis/core
             - pkg/apis/core/install
             - pkg/apis/core/v1
@@ -461,7 +465,6 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
-            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/resources/v1alpha1/helper

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -783,6 +783,11 @@ build:
       requires:
         - image: local-skaffold/gardener-extension-provider-local
           alias: IMG
+      hooks:
+        after:
+          - command:
+              - bash
+              - hack/generate-kustomize-patch-controllerdeployment-provider-local-gardenadm.sh
   insecureRegistries:
     - garden.local.gardener.cloud:5001
   tagPolicy:

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -126,8 +126,9 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-apiserver-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-controller-manager-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-scheduler-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("gardener-resource-manager")})}),
 			))
-		}, SpecTimeout(5*time.Second))
+		}, SpecTimeout(time.Minute))
 
 		It("should join as worker node", func(ctx SpecContext) {
 			_, stdErr, err := execute(ctx, 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR is the next increment for `gardenadm init`. It deploys `gardener-resource-manager`, the seed/shoot system components (which mostly are `PriorityClass`es, and the extension controllers in bootstrap mode).

Result:

```
root@machine-0:/# k get po,pc -A
NAMESPACE                     NAME                                                        READY   STATUS    RESTARTS   AGE
extension-networking-calico   pod/gardener-extension-networking-calico-6bb84d9879-zg4hm   1/1     Running   0          16m
extension-provider-local      pod/gardener-extension-provider-local-794c9976b7-tn8hx      1/1     Running   0          16m
kube-system                   pod/etcd-events-0-machine-0                                 1/1     Running   0          15m
kube-system                   pod/etcd-main-0-machine-0                                   1/1     Running   0          15m
kube-system                   pod/gardener-resource-manager-6f9cf4c994-2f8px              1/1     Running   0          17m
kube-system                   pod/kube-apiserver-machine-0                                1/1     Running   0          15m
kube-system                   pod/kube-controller-manager-machine-0                       1/1     Running   0          15m
kube-system                   pod/kube-scheduler-machine-0                                1/1     Running   0          15m

NAMESPACE   NAME                                                               VALUE        GLOBAL-DEFAULT   AGE   PREEMPTIONPOLICY
            priorityclass.scheduling.k8s.io/gardener-reserve-excess-capacity   -5           false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-shoot-system-600          999999600    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-shoot-system-700          999999700    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-shoot-system-800          999999800    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-shoot-system-900          999999900    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-100                999998100    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-200                999998200    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-300                999998300    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-400                999998400    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-500                999998500    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-600                999998600    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-700                999998700    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-800                999998800    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/gardener-system-900                999998900    false            16m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/system-cluster-critical            2000000000   false            17m   PreemptLowerPriority
            priorityclass.scheduling.k8s.io/system-node-critical               2000001000   false            17m   PreemptLowerPriority
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
