### PR TITLE
Automatically add network label to `Gardenlet`

### DIFF
--- a/example/gardener-local/gardenlet/operator/gardenlet.yaml
+++ b/example/gardener-local/gardenlet/operator/gardenlet.yaml
@@ -5,9 +5,6 @@ metadata:
   name: local
   namespace: garden
 spec:
-  deployment:
-    podLabels:
-      networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
   config:
     apiVersion: gardenlet.config.gardener.cloud/v1alpha1
     kind: GardenletConfiguration

--- a/test/integration/operator/gardenlet/gardenlet_test.go
+++ b/test/integration/operator/gardenlet/gardenlet_test.go
@@ -130,6 +130,7 @@ var _ = Describe("Gardenlet controller test", func() {
 
 		EventuallyWithOffset(1, func(g Gomega) {
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(gardenlet), gardenlet)).To(Succeed())
+			g.Expect(gardenlet.Spec.Deployment.PodLabels).To(HaveKeyWithValue("networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443", "allowed"))
 			g.Expect(gardenlet.Status.ObservedGeneration).To(Equal(gardenlet.Generation))
 			condition := v1beta1helper.GetCondition(gardenlet.Status.Conditions, seedmanagementv1alpha1.SeedRegistered)
 			g.Expect(condition).NotTo(BeNil())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/area usability
/kind enhancement

**What this PR does / why we need it**:
Automatically add the `networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed` label to `Gardenlet` if deployed to the garden runtime cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-operator` automatically adds the `networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed` label to `Gardenlet` in case the gardenlet is deployed to the garden runtime cluster.
```
