### PR TITLE
Clarify extension generator usage

### DIFF
--- a/hack/tools/extension-generator/options.go
+++ b/hack/tools/extension-generator/options.go
@@ -14,6 +14,10 @@ import (
 )
 
 // Options contain the generate configuration.
+// `Extension` API fields are not supposed to be added as command line options.
+// Instead, an opinionated value can be set per component category.
+// Further adjustments can be made by the consumer via Kustomize or similar tools.
+// The OCI repository values are an exception, since they are usually calculated just before the example is generated (e.g. in the scope of a release process).
 type Options struct {
 	ExtensionName       string
 	ProviderType        string


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds a hint to the `extension-generator` tool for developers, as described in https://github.com/gardener/gardener/pull/11593#discussion_r1982240280. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
