### PR TITLE
Wait for `gardener-apiserver` service to get created by MR before getting it

### DIFF
--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -45,14 +45,13 @@ const (
 // deleted.
 var TimeoutWaitForManagedResource = 5 * time.Minute
 
-// exposed for testing
-var (
-	// IntervalWaitServiceGardenerApiserver is the interval when waiting for
+const (
+	// intervalWaitServiceRuntime is the interval when waiting for
 	// gardener-apiserver service to get created by gardener-resource-manager
-	IntervalWaitServiceGardenerApiserver = 5 * time.Second
-	// TimeoutWaitServiceGardenerApiserver is the timeout when waiting for
+	intervalWaitServiceRuntime = 5 * time.Second
+	// timeoutWaitServiceRuntime is the timeout when waiting for
 	// gardener-apiserver service to get created by gardener-resource-manager
-	TimeoutWaitServiceGardenerApiserver = 30 * time.Second
+	timeoutWaitServiceRuntime = 30 * time.Second
 )
 
 // Interface contains functions for a gardener-apiserver deployer.
@@ -197,9 +196,9 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	serviceRuntime := &corev1.Service{}
-	if err := retry.UntilTimeout(ctx, IntervalWaitServiceGardenerApiserver, TimeoutWaitServiceGardenerApiserver, func(ctx context.Context) (bool, error) {
-		if err := g.client.Get(ctx, client.ObjectKey{Name: serviceName, Namespace: g.namespace}, serviceRuntime); err != nil {
+	serviceRuntime := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: g.namespace}}
+	if err := retry.UntilTimeout(ctx, intervalWaitServiceRuntime, timeoutWaitServiceRuntime, func(ctx context.Context) (bool, error) {
+		if err := g.client.Get(ctx, client.ObjectKeyFromObject(serviceRuntime), serviceRuntime); err != nil {
 			if apierrors.IsNotFound(err) {
 				return retry.MinorError(fmt.Errorf("service %s was not yet created", client.ObjectKeyFromObject(serviceRuntime)))
 			}

--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -201,13 +201,13 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	if err := retry.UntilTimeout(ctx, IntervalWaitServiceGardenerApiserver, TimeoutWaitServiceGardenerApiserver, func(ctx context.Context) (bool, error) {
 		if err := g.client.Get(ctx, client.ObjectKey{Name: serviceName, Namespace: g.namespace}, serviceRuntime); err != nil {
 			if apierrors.IsNotFound(err) {
-				return retry.MinorError(fmt.Errorf("service gardener-apiserver was not yet created"))
+				return retry.MinorError(fmt.Errorf("service %s was not yet created", client.ObjectKeyFromObject(serviceRuntime)))
 			}
-			return retry.SevereError(fmt.Errorf("unexpected error while retrieving gardener-apiserver service: %w", err))
+			return retry.SevereError(fmt.Errorf("unexpected error while retrieving service %s: %w", client.ObjectKeyFromObject(serviceRuntime), err))
 		}
 		return retry.Ok()
 	}); err != nil {
-		return fmt.Errorf("failed waiting for service gardener-apiserver to get created by gardener-resource-manager: %w", err)
+		return fmt.Errorf("failed waiting for service %s to get created by gardener-resource-manager: %w", client.ObjectKeyFromObject(serviceRuntime), err)
 	}
 
 	virtualResources, err := virtualRegistry.AddAllAndSerialize(

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -1275,6 +1275,11 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 
 			Context("ManagedResource reconciliation delay", func() {
 				It("should fail if gardener-apiserver service does not get created from ManagedResource", func() {
+					DeferCleanup(test.WithVars(
+						&IntervalWaitServiceGardenerApiserver, time.Millisecond,
+						&TimeoutWaitServiceGardenerApiserver, 5*time.Millisecond,
+					))
+
 					Expect(fakeClient.Delete(ctx, serviceRuntime)).To(Succeed())
 					Eventually(ctx, func(g Gomega) {
 						g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(serviceRuntime), &corev1.Service{})).To(BeNotFoundError())
@@ -1315,7 +1320,6 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					}
 					Expect(managedResourceVirtual).To(Equal(expectedVirtualMr))
 				})
-
 			})
 
 			Context("resources generation", func() {

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -1286,7 +1286,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 						g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(serviceRuntime), &corev1.Service{})).To(BeNotFoundError())
 					}).Should(Succeed())
 
-					Expect(deployer.Deploy(ctx)).To(MatchError(ContainSubstring("failed waiting for service gardener-apiserver to get created by gardener-resource-manager")))
+					Expect(deployer.Deploy(ctx)).To(MatchError(ContainSubstring("failed waiting for service some-namespace/gardener-apiserver to get created by gardener-resource-manager")))
 				})
 			})
 

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -114,7 +114,6 @@ var _ = Describe("GardenerAPIServer", func() {
 	BeforeEach(func() {
 		fakeOps = &retryfake.Ops{MaxAttempts: 2}
 		DeferCleanup(test.WithVars(
-			&retry.Until, fakeOps.Until,
 			&retry.UntilTimeout, fakeOps.UntilTimeout,
 		))
 


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind flake

**What this PR does / why we need it**:
Prior to this change we create `gardener-apiserver-runtime` MR and after that try to get the `gardener-apiserver` service. But if it does not get created by GRM in-between those steps the flow step will fail and the whole reconciliation will get re-triggered

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11787

**Special notes for your reviewer**:
Did not test it by stress tool because the access of `gardener-system-public` is not synchronised https://github.com/gardener/gardener/blob/master/test/integration/operator/garden/garden/garden_test.go#L279

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
