### PR TITLE
e2e: Refactor `renew_gardenlet_kubeconfig` test to ordered containers

### DIFF
--- a/test/e2e/gardener/context.go
+++ b/test/e2e/gardener/context.go
@@ -219,3 +219,28 @@ func (s *GardenContext) WithVirtualClusterClientSet(clientSet kubernetes.Interfa
 	s.VirtualClusterKomega = komega.New(s.VirtualClusterClient)
 	return s
 }
+
+// SeedContext is a test case-specific TestContext that carries test state and helpers through multiple steps of the
+// same test case, i.e., within the same ordered container.
+// Accordingly, SeedContext values must not be reused across multiple test cases (ordered containers). Make sure to
+// declare SeedContext variables within the ordered container and initialize them during ginkgo tree construction,
+// e.g., in a BeforeTestSetup node or when invoking a shared `test` func.
+//
+// A SeedContext can be initialized using TestContext.ForSeed.
+type SeedContext struct {
+	TestContext
+
+	// Seed object the test is working with
+	Seed *gardencorev1beta1.Seed
+}
+
+// ForSeed copies the receiver TestContext for deriving a SeedContext.
+func (t *TestContext) ForSeed(seed *gardencorev1beta1.Seed) *SeedContext {
+	s := &SeedContext{
+		TestContext: *t,
+		Seed:        seed,
+	}
+	s.Log = s.Log.WithValues("seed", client.ObjectKeyFromObject(seed))
+
+	return s
+}

--- a/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
+++ b/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
@@ -30,10 +30,11 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			// However, this test should not use "e2e-managedseed", because it is created and deleted in a separate e2e test.
 			// This e2e test already includes tests for the "Renew gardenlet kubeconfig" functionality. Additionally,
 			// it might be already gone before the kubeconfig was renewed.
+			ctx := context.Background()
 			seedList := &gardencorev1beta1.SeedList{}
-			if err := testContext.GardenClient.List(context.Background(), seedList); err != nil {
+			if err := testContext.GardenClient.List(ctx, seedList); err != nil {
 				testContext.Log.Error(err, "Failed to list seeds")
-				panic(err)
+				Fail(err.Error())
 			}
 
 			seedIndex := slices.IndexFunc(seedList.Items, func(item gardencorev1beta1.Seed) bool {
@@ -41,7 +42,7 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			})
 
 			if seedIndex == -1 {
-				panic("failed to find applicable seed")
+				Fail("failed to find applicable seed")
 			}
 
 			s = testContext.ForSeed(&seedList.Items[seedIndex])

--- a/test/e2e/gardener/seed/seed.go
+++ b/test/e2e/gardener/seed/seed.go
@@ -22,9 +22,9 @@ func ItShouldAnnotateSeed(s *SeedContext, annotations map[string]string) {
 	It("Annotate Seed", func(ctx SpecContext) {
 		patch := client.MergeFrom(s.Seed.DeepCopy())
 
-		for annotationKey, annotationValue := range annotations {
-			s.Log.Info("Setting annotation", "annotation", annotationKey, "value", annotationValue)
-			metav1.SetMetaDataAnnotation(&s.Seed.ObjectMeta, annotationKey, annotationValue)
+		for key, value := range annotations {
+			s.Log.Info("Setting annotation", "annotation", key, "value", value)
+			metav1.SetMetaDataAnnotation(&s.Seed.ObjectMeta, key, value)
 		}
 
 		Eventually(ctx, func() error {

--- a/test/e2e/gardener/seed/seed.go
+++ b/test/e2e/gardener/seed/seed.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package seed
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/gardener/gardener/test/e2e/gardener"
+)
+
+// ItShouldAnnotateSeed sets the given annotation within the seed metadata to the specified value and patches the seed object
+func ItShouldAnnotateSeed(s *SeedContext, annotations map[string]string) {
+	GinkgoHelper()
+
+	It("Annotate Seed", func(ctx SpecContext) {
+		patch := client.MergeFrom(s.Seed.DeepCopy())
+
+		for annotationKey, annotationValue := range annotations {
+			s.Log.Info("Setting annotation", "annotation", annotationKey, "value", annotationValue)
+			metav1.SetMetaDataAnnotation(&s.Seed.ObjectMeta, annotationKey, annotationValue)
+		}
+
+		Eventually(ctx, func() error {
+			return s.GardenClient.Patch(ctx, s.Seed, patch)
+		}).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the mentioned test to the ordered containers approach.
See https://github.com/gardener/gardener/issues/11379

I have deliberately not yet refactored the verifiers and their interface in this step, as this will happen in a later stage for all verifiers.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
