### PR TITLE
node-agent: Probe registry endpoints when registry config is updated

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/osc_changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/osc_changes.go
@@ -63,8 +63,9 @@ type containerd struct {
 }
 
 type containerdRegistries struct {
-	Desired []extensionsv1alpha1.RegistryConfig `json:"desired,omitempty"`
-	Deleted []extensionsv1alpha1.RegistryConfig `json:"deleted,omitempty"`
+	UpstreamsToProbe []string                            `json:"upstreamsToProbe,omitempty"`
+	Desired          []extensionsv1alpha1.RegistryConfig `json:"desired,omitempty"`
+	Deleted          []extensionsv1alpha1.RegistryConfig `json:"deleted,omitempty"`
 }
 
 type inPlaceUpdates struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR is a rework of https://github.com/gardener/gardener/pull/11008.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-node-agent` now executes readiness probe when the registry config is updated. Previously, the readiness probe was not executed if the corresponding `hosts.toml` file was present.
```
