### PR TITLE
Increase CPU requests of istio-ingress gateway when `IstioTLSTermination` feature gate is enabled

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 300m
+              cpu: {{ .Values.cpuRequests }}
               memory: 600Mi
             limits:
               memory: 4800Mi

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
@@ -23,6 +23,7 @@ serviceName: istio-ingressgateway
 ingressVersion: "1.25.1"
 #externalTrafficPolicy: Cluster
 replicas: 2
+cpuRequests: 300m
 minReplicas: 2
 maxReplicas: 9
 enforceSpreadAcrossHosts: false

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -76,6 +76,11 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			}
 		}
 
+		cpuRequests := "300m"
+		if enableAPIServerTLSTermination {
+			cpuRequests = "500m"
+		}
+
 		values := map[string]any{
 			"trustDomain":                        istioIngressGateway.TrustDomain,
 			"labels":                             istioIngressGateway.Labels,
@@ -100,6 +105,7 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			"apiServerRequestHeaderUserName":            kubeapiserverconstants.RequestHeaderUserName,
 			"apiServerRequestHeaderGroup":               kubeapiserverconstants.RequestHeaderGroup,
 			"apiServerAuthenticationDynamicMetadataKey": apiserverexposure.AuthenticationDynamicMetadataKey,
+			"cpuRequests":                               cpuRequests,
 		}
 
 		if istioIngressGateway.MinReplicas != nil {

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -64,8 +64,8 @@ var _ = Describe("istiod", func() {
 		renderer chartrenderer.Interface
 
 		expectedCPURequests string
-		minReplicas         = 2
-		maxReplicas         = 9
+		expectedMinReplicas int
+		expectedMaxReplicas int
 
 		externalTrafficPolicy corev1.ServiceExternalTrafficPolicy
 
@@ -260,6 +260,8 @@ var _ = Describe("istiod", func() {
 		networkLabels = map[string]string{"to-target": "allowed"}
 		expectAPIServerTLSTermination = false
 		expectedCPURequests = "300m"
+		expectedMinReplicas = 2
+		expectedMaxReplicas = 9
 
 		c = fake.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 		renderer = chartrenderer.NewWithServerVersion(&version.Info{GitVersion: "v1.31.1"})
@@ -516,10 +518,10 @@ var _ = Describe("istiod", func() {
 
 		Context("horizontal ingress gateway scaling", func() {
 			BeforeEach(func() {
-				minReplicas = 3
-				maxReplicas = 8
-				igw[0].MinReplicas = &minReplicas
-				igw[0].MaxReplicas = &maxReplicas
+				expectedMinReplicas = 3
+				expectedMaxReplicas = 8
+				igw[0].MinReplicas = &expectedMinReplicas
+				igw[0].MaxReplicas = &expectedMaxReplicas
 				istiod = NewIstio(
 					c,
 					renderer,
@@ -538,7 +540,7 @@ var _ = Describe("istiod", func() {
 			})
 
 			It("should successfully deploy correct autoscaling", func() {
-				checkSuccessfulDeployment(&minReplicas, &maxReplicas)
+				checkSuccessfulDeployment(&expectedMinReplicas, &expectedMaxReplicas)
 			})
 		})
 

--- a/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
@@ -74,7 +74,7 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 300m
+              cpu: <CPU_REQUESTS>
               memory: 600Mi
             limits:
               memory: 4800Mi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Since there is more load on the istio-gateways when they terminate TLS connection, we should increase their resource requests slightly if the feature gate is enabled.

**Which issue(s) this PR fixes**:
Part of #8810

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
When `IstioTLSTermination` feature gate is enabled, istio-ingress gateway pods request `500m` CPUs now.
```
