### PR TITLE
Add check for rolling update in `CheckNodesScaling`

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -788,7 +788,6 @@ func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList [
 			}
 			if condition.Type == machinev1alpha1.MachineDeploymentAvailable && condition.Status != machinev1alpha1.ConditionTrue {
 				checkScaleUp = true
-				break
 			}
 		}
 	}

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -795,7 +795,7 @@ func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList [
 	if checkRollingUpdate {
 		// Use the checkNodesScalingUp function since it checks for machines that may be stuck in the pending state, which can happen when rolling out critical components that are stuck.
 		if err := checkNodesScalingUp(machineList, readyAndSchedulableNodes, desiredMachines); err != nil {
-			return "NodeRollOut", err
+			return "NodesRollOutScalingUp", err
 		}
 	}
 

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -738,7 +738,7 @@ func CheckForExpiredNodeLeases(nodeList *corev1.NodeList, leaseList *coordinatio
 	return nil
 }
 
-// CheckNodesScaling checks whether cluster nodes are being scaled up or down. If scaling is in progress, it returns a string describing the action. An error is returned if any failure occurs.
+// CheckNodesScaling checks whether cluster nodes are in a rolling update or being scaled up or down. If scaling is in progress, it returns a string describing the action. An error is returned if any failure occurs.
 func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList []*corev1.Node, machineDeploymentList *machinev1alpha1.MachineDeploymentList, controlPlaneNamespace string) (string, error) {
 	var (
 		readyAndSchedulableNodes int

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -424,7 +424,7 @@ var _ = Describe("health check", func() {
 
 	Describe("#CheckNodesScaling", func() {
 		Describe("Rolling update", func() {
-			It("should priotitise NodeRollOut over NodesScalingUp when returning an error if not enough machine objects as desired were created", func() {
+			It("should prioritize NodesRollOutScalingUp over NodesScalingUp when returning an error if not enough machine objects as desired were created", func() {
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
 					Items: []machinev1alpha1.MachineDeployment{
 						{
@@ -438,7 +438,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 				msg, err := CheckNodesScaling(ctx, fakeClient, []*corev1.Node{}, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(msg).To(Equal("NodesRollOutScalingUp"))
 				Expect(err).To(MatchError(ContainSubstring("not enough machine objects created yet")))
 			})
 
@@ -455,7 +455,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 				msg, err := CheckNodesScaling(ctx, fakeClient, []*corev1.Node{}, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(msg).To(Equal("NodesRollOutScalingUp"))
 				Expect(err).To(MatchError(ContainSubstring("not enough machine objects created yet")))
 			})
 
@@ -486,7 +486,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 				msg, err := CheckNodesScaling(ctx, fakeClient, []*corev1.Node{}, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(msg).To(Equal("NodesRollOutScalingUp"))
 				Expect(err).To(MatchError(ContainSubstring("is erroneous")))
 			})
 
@@ -517,7 +517,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(msg).To(Equal("NodesRollOutScalingUp"))
 				Expect(err).To(MatchError(ContainSubstring("not enough ready worker nodes registered in the cluster")))
 			})
 
@@ -548,7 +548,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(msg).To(Equal("NodesRollOutScalingUp"))
 				Expect(err).To(MatchError(ContainSubstring("provisioning and should join the cluster soon")))
 			})
 
@@ -574,7 +574,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(msg).To(Equal("NodesRollOutScalingUp"))
 				Expect(err).To(MatchError(ContainSubstring("provisioning and should join the cluster soon")))
 			})
 		})

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -427,7 +427,7 @@ var _ = Describe("health check", func() {
 			It("should return true if number of ready nodes equal number of desired machines", func() {
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
 					Items: []machinev1alpha1.MachineDeployment{
-						machinev1alpha1.MachineDeployment{
+						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
 						},
@@ -453,7 +453,7 @@ var _ = Describe("health check", func() {
 			It("should return an error if not enough machine objects as desired were created", func() {
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
 					Items: []machinev1alpha1.MachineDeployment{
-						machinev1alpha1.MachineDeployment{
+						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
 							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
@@ -482,7 +482,7 @@ var _ = Describe("health check", func() {
 
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
 					Items: []machinev1alpha1.MachineDeployment{
-						machinev1alpha1.MachineDeployment{
+						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
 							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
@@ -511,7 +511,7 @@ var _ = Describe("health check", func() {
 				nodeList := []*corev1.Node{{}}
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
 					Items: []machinev1alpha1.MachineDeployment{
-						machinev1alpha1.MachineDeployment{
+						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
 							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
@@ -540,7 +540,7 @@ var _ = Describe("health check", func() {
 				nodeList := []*corev1.Node{{}}
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
 					Items: []machinev1alpha1.MachineDeployment{
-						machinev1alpha1.MachineDeployment{
+						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
 							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
@@ -564,7 +564,7 @@ var _ = Describe("health check", func() {
 				nodeList := []*corev1.Node{{}}
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
 					Items: []machinev1alpha1.MachineDeployment{
-						machinev1alpha1.MachineDeployment{
+						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
 							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
@@ -582,7 +582,7 @@ var _ = Describe("health check", func() {
 				nodeList := []*corev1.Node{{}}
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
 					Items: []machinev1alpha1.MachineDeployment{
-						machinev1alpha1.MachineDeployment{
+						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
 						},

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -423,6 +423,162 @@ var _ = Describe("health check", func() {
 	})
 
 	Describe("#CheckNodesScaling", func() {
+		Describe("Rolling update", func() {
+			It("should priotitise NodeRollOut over NodesScalingUp when returning an error if not enough machine objects as desired were created", func() {
+				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
+					Items: []machinev1alpha1.MachineDeployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse},
+								{Type: machinev1alpha1.MachineDeploymentProgressing, Status: machinev1alpha1.ConditionTrue, Reason: "NewMachineSetNotAvailable"},
+							}},
+						},
+					},
+				}
+				msg, err := CheckNodesScaling(ctx, fakeClient, []*corev1.Node{}, machineDeploymentList, controlPlaneNamespace)
+				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(err).To(MatchError(ContainSubstring("not enough machine objects created yet")))
+			})
+
+			It("should return an error if not enough machine objects as desired were created", func() {
+				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
+					Items: []machinev1alpha1.MachineDeployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentProgressing, Status: machinev1alpha1.ConditionTrue, Reason: "NewMachineSetNotAvailable"}, {},
+							}},
+						},
+					},
+				}
+				msg, err := CheckNodesScaling(ctx, fakeClient, []*corev1.Node{}, machineDeploymentList, controlPlaneNamespace)
+				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(err).To(MatchError(ContainSubstring("not enough machine objects created yet")))
+			})
+
+			It("should return an error when detecting erroneous machines", func() {
+				machineList := &machinev1alpha1.MachineList{
+					Items: []machinev1alpha1.Machine{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace},
+							Status: machinev1alpha1.MachineStatus{
+								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachineUnknown},
+							},
+						},
+					},
+				}
+				for _, machine := range machineList.Items {
+					Expect(fakeClient.Create(ctx, &machine)).To(Succeed())
+				}
+
+				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
+					Items: []machinev1alpha1.MachineDeployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentProgressing, Status: machinev1alpha1.ConditionTrue, Reason: "NewMachineSetNotAvailable"}, {},
+							}},
+						},
+					},
+				}
+				msg, err := CheckNodesScaling(ctx, fakeClient, []*corev1.Node{}, machineDeploymentList, controlPlaneNamespace)
+				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(err).To(MatchError(ContainSubstring("is erroneous")))
+			})
+
+			It("should return an error when not enough ready nodes are registered", func() {
+				machineList := &machinev1alpha1.MachineList{
+					Items: []machinev1alpha1.Machine{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace},
+							Status: machinev1alpha1.MachineStatus{
+								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachineRunning},
+							},
+						},
+					},
+				}
+				for _, machine := range machineList.Items {
+					Expect(fakeClient.Create(ctx, &machine)).To(Succeed())
+				}
+				nodeList := []*corev1.Node{{}}
+				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
+					Items: []machinev1alpha1.MachineDeployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentProgressing, Status: machinev1alpha1.ConditionTrue, Reason: "NewMachineSetNotAvailable"}, {},
+							}},
+						},
+					},
+				}
+				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
+				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(err).To(MatchError(ContainSubstring("not enough ready worker nodes registered in the cluster")))
+			})
+
+			It("should return progressing when detecting a regular node rollout (pending status)", func() {
+				machineList := &machinev1alpha1.MachineList{
+					Items: []machinev1alpha1.Machine{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace},
+							Status: machinev1alpha1.MachineStatus{
+								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachinePending},
+							},
+						},
+					},
+				}
+				for _, machine := range machineList.Items {
+					Expect(fakeClient.Create(ctx, &machine)).To(Succeed())
+				}
+				nodeList := []*corev1.Node{{}}
+				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
+					Items: []machinev1alpha1.MachineDeployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentProgressing, Status: machinev1alpha1.ConditionTrue, Reason: "NewMachineSetNotAvailable"}, {},
+							}},
+						},
+					},
+				}
+				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
+				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(err).To(MatchError(ContainSubstring("provisioning and should join the cluster soon")))
+			})
+
+			It("should return progressing when detecting a regular node rollout (no status)", func() {
+				machineList := &machinev1alpha1.MachineList{
+					Items: []machinev1alpha1.Machine{
+						{ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace}},
+					},
+				}
+				for _, machine := range machineList.Items {
+					Expect(fakeClient.Create(ctx, &machine)).To(Succeed())
+				}
+				nodeList := []*corev1.Node{{}}
+				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
+					Items: []machinev1alpha1.MachineDeployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentProgressing, Status: machinev1alpha1.ConditionTrue, Reason: "NewMachineSetNotAvailable"}, {},
+							}},
+						},
+					},
+				}
+				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
+				Expect(msg).To(Equal("NodeRollOut"))
+				Expect(err).To(MatchError(ContainSubstring("provisioning and should join the cluster soon")))
+			})
+		})
+
 		Describe("Scaling up", func() {
 			It("should return true if number of ready nodes equal number of desired machines", func() {
 				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
@@ -456,7 +612,9 @@ var _ = Describe("health check", func() {
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {},
+							}},
 						},
 					},
 				}
@@ -485,7 +643,9 @@ var _ = Describe("health check", func() {
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {},
+							}},
 						},
 					},
 				}
@@ -514,7 +674,9 @@ var _ = Describe("health check", func() {
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {},
+							}},
 						},
 					},
 				}
@@ -543,7 +705,9 @@ var _ = Describe("health check", func() {
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {},
+							}},
 						},
 					},
 				}
@@ -567,7 +731,9 @@ var _ = Describe("health check", func() {
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-							Status:     machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {}}},
+							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {},
+							}},
 						},
 					},
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR is the implementation for the agreed upon https://github.com/gardener/gardener/pull/11084#issuecomment-2639137008

test run:

![- lastTransitionTime 2025-04-01T071249Z](https://github.com/user-attachments/assets/ac13ed39-7152-42b2-8ea9-dcfa786ec333)


**Which issue(s) this PR fixes**:
Fixes #10227 

**Special notes for your reviewer**:
cc @plkokanov @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
gardenlet's shoot-care controller : An issue causing gardenlet to report a misleading reason (`NodesScalingDown`) during rolling update of Shoot Nodes is now fixed.
```
