### PR TITLE
[GEP-28] Enhance test artifacts with `systemd` unit and pod logs

### DIFF
--- a/example/gardenadm-local/high-touch/namespace.yaml
+++ b/example/gardenadm-local/high-touch/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gardenadm-high-touch
+  labels:
+    # Use shoot label so that machine pods are considered in export_artifacts() during test runs.
+    # This provides the usual systemd and pod logs for each machine.
+    gardener.cloud/role: shoot

--- a/example/gardenadm-local/high-touch/namespace.yaml
+++ b/example/gardenadm-local/high-touch/namespace.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   name: gardenadm-high-touch
   labels:
-    # Use shoot label so that machine pods are considered in export_artifacts() during test runs.
-    # This provides the usual systemd and pod logs for each machine.
+    # Use shoot label so that machine pods are considered in the export_artifacts() helper function during test runs in Prow.
+    # This makes sure that the usual systemd and pod logs get exported for each machine pod in this namespace.
     gardener.cloud/role: shoot


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind test

**What this PR does / why we need it**:

Enhance test artifacts with `systemd` unit and pod logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Example output after a test run:

```
# ls -ls /tmp/artifacts/gardenadm-high-touch/machine-0/
total 984
  4 -rw-r--r--  1 root root    591 Apr 15 10:02 alternatives.log
  0 drwxr-xr-x  2 root root     40 Apr 15 10:02 apparmor
  0 drwxr-xr-x  2 root root    100 Apr 15 10:02 apt
  0 -rw-r--r--  1 root root      0 Apr 15 10:02 btmp
  4 -rw-r--r--  1 root root     17 Apr 15 10:02 containerd-configuration-local-setup.log
 72 -rw-r--r--  1 root root  72219 Apr 15 10:02 containerd.log
  0 drwxr-xr-x  2 root root     40 Apr 15 10:02 containers
  8 -rw-r--r--  1 root root   7449 Apr 15 10:02 dpkg.log
  4 -rw-r--r--  1 root root     17 Apr 15 10:02 gardener-node-agent.log
  4 -rw-r--r--  1 root root   1734 Apr 15 10:02 images.log
484 -rw-r--r--  1 root root 494122 Apr 15 10:02 journal.log
392 -rw-r--r--  1 root root 400203 Apr 15 10:02 kubelet.log
  0 -rw-r--r--  1 root root      0 Apr 15 10:02 lastlog
 12 -rw-r--r--  1 root root   8959 Apr 15 10:02 pod.yaml
  0 drwxr-xr-x 10 root root    200 Apr 15 10:02 pods
  0 drwxr-xr-x  2 root root     40 Apr 15 10:02 private
  0 drwxr-xr-x  3 root root     60 Apr 15 10:02 runit
  0 -rw-r--r--  1 root root      0 Apr 15 10:02 wtmp
```
```
]# ls -ls /tmp/artifacts/gardenadm-high-touch/machine-0/pods
total 0
0 drwxr-xr-x 3 root root 60 Apr 15 10:02 extension-networking-calico_gardener-extension-networking-calico-68d55779d9-f5c9v_cb181a0d-7f0a-42ef-b50c-3f1ebe510904
0 drwxr-xr-x 3 root root 60 Apr 15 10:02 extension-provider-local_gardener-extension-provider-local-cbcd8f5d5-dlkv5_d150bb6a-546a-4f3a-b2fc-5d69d7a17b09
0 drwxr-xr-x 3 root root 60 Apr 15 10:02 kube-system_etcd-events-0-machine-0_8dc7b5392a86e4757cb36fe7b4e133ad
0 drwxr-xr-x 3 root root 60 Apr 15 10:02 kube-system_etcd-main-0-machine-0_f6dabebe46aa96f79a201a693c6db2b2
0 drwxr-xr-x 3 root root 60 Apr 15 10:02 kube-system_gardener-resource-manager-5766bc66cf-rm74v_8e9b0301-beb5-48f1-856c-9192de11dab5
0 drwxr-xr-x 3 root root 60 Apr 15 10:02 kube-system_kube-apiserver-machine-0_12022b86916ba8a131e2f8e655831a68
0 drwxr-xr-x 3 root root 60 Apr 15 10:02 kube-system_kube-controller-manager-machine-0_96035a7960298d089d45ed4d1c0bed58
0 drwxr-xr-x 3 root root 60 Apr 15 10:02 kube-system_kube-scheduler-machine-0_b8a77b24e1f1c71f34552a2b951f318f
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```

cc @rfranzke 