### PR TITLE
fix: support multiple containers per pod when dumping logs

### DIFF
--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -189,11 +189,9 @@ func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Conte
 
 // DumpLogsForPodInNamespace prints the logs of the pod with the given namespace and name.
 func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, k8sClient kubernetes.Interface, namespace, name string, options *corev1.PodLogOptions) error {
-	var log logr.Logger
-	if options != nil {
-		log = f.Logger.WithValues("pod", client.ObjectKey{Namespace: namespace, Name: name}, "container", options.Container)
-	} else {
-		log = f.Logger.WithValues("pod", client.ObjectKey{Namespace: namespace, Name: name})
+	log := f.Logger.WithValues("pod", client.ObjectKey{Namespace: namespace, Name: name})
+	if options != nil && options.Container != "" {
+		log = log.WithValues("container", options.Container)
 	}
 	log.Info("Dumping logs for corev1.Pod")
 

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -163,7 +163,7 @@ func (f *GardenerFramework) dumpGardenerExtension(log logr.Logger, extension ext
 	}
 }
 
-// DumpLogsForPodsWithLabelsInNamespace prints the logs of pods in the given namespace selected by the given list options.
+// DumpLogsForPodsWithLabelsInNamespace prints the logs of all containers of pods in the given namespace selected by the given list options.
 func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Context, k8sClient kubernetes.Interface, namespace string, opts ...client.ListOption) error {
 	pods := &corev1.PodList{}
 	opts = append(opts, client.InNamespace(namespace))
@@ -173,8 +173,15 @@ func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Conte
 
 	var result error
 	for _, pod := range pods.Items {
-		if err := f.DumpLogsForPodInNamespace(ctx, k8sClient, namespace, pod.Name, &corev1.PodLogOptions{}); err != nil {
-			result = multierror.Append(result, err)
+		for _, container := range pod.Spec.InitContainers {
+			if err := f.DumpLogsForPodInNamespace(ctx, k8sClient, namespace, pod.Name, &corev1.PodLogOptions{Container: container.Name}); err != nil {
+				result = multierror.Append(result, fmt.Errorf("error reading logs from pod %q init container %q: %w", pod.Name, container.Name, err))
+			}
+		}
+		for _, container := range pod.Spec.Containers {
+			if err := f.DumpLogsForPodInNamespace(ctx, k8sClient, namespace, pod.Name, &corev1.PodLogOptions{Container: container.Name}); err != nil {
+				result = multierror.Append(result, fmt.Errorf("error reading logs from pod %q container %q: %w", pod.Name, container.Name, err))
+			}
 		}
 	}
 	return result
@@ -182,7 +189,12 @@ func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Conte
 
 // DumpLogsForPodInNamespace prints the logs of the pod with the given namespace and name.
 func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, k8sClient kubernetes.Interface, namespace, name string, options *corev1.PodLogOptions) error {
-	log := f.Logger.WithValues("pod", client.ObjectKey{Namespace: namespace, Name: name})
+	var log logr.Logger
+	if options != nil {
+		log = f.Logger.WithValues("pod", client.ObjectKey{Namespace: namespace, Name: name}, "container", options.Container)
+	} else {
+		log = f.Logger.WithValues("pod", client.ObjectKey{Namespace: namespace, Name: name})
+	}
 	log.Info("Dumping logs for corev1.Pod")
 
 	podIf := k8sClient.Kubernetes().CoreV1().Pods(namespace)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

- The [DumpLogsForPodsWithLabelsInNamespace](https://github.com/gardener/gardener/blob/master/test/framework/dump.go#L167) function does work only if the pod has just one container. If there is more than one container you will get this exception:
```
             <*errors.StatusError | 0xc00045d220>{
                  ErrStatus: {
                      TypeMeta: {Kind: "", APIVersion: ""},
                      ListMeta: {
                          SelfLink: "",
                          ResourceVersion: "",
                          Continue: "",
                          RemainingItemCount: nil,
                      },
                      Status: "Failure",
                      Message: "a container name must be specified for pod <test pod>, choose one of: [container-a container-b]",
                      Reason: "BadRequest",
                      Details: nil,
                      Code: 400,
                  },
```
- This PR changes the function such that on the set of pods selected by the given label, all init-containers and regular containers are iterated and their logs are dumped.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The `DumpLogsForPodsWithLabelsInNamespace` function in the test framework now supports dumping pods with multiple containers.
```
