### PR TITLE
Increase MCM processing throughput

### DIFF
--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -217,6 +217,9 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 						"--safety-up=2",
 						"--safety-down=1",
 						"--target-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
+						"--concurrent-syncs=30",
+						"--kube-api-qps=150",
+						"--kube-api-burst=200",
 						"--v=3",
 					},
 					LivenessProbe: &corev1.Probe{

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -211,6 +211,9 @@ var _ = Describe("MachineControllerManager", func() {
 								"--safety-up=2",
 								"--safety-down=1",
 								"--target-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+								"--concurrent-syncs=30",
+								"--kube-api-qps=150",
+								"--kube-api-burst=200",
 								"--v=3",
 							},
 							LivenessProbe: &corev1.Probe{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance
/kind enhancement

**What this PR does / why we need it**:

Deploy MCM with custom parameters for `concurrent-syncs`, `kube-api-qps` and `kube-api-burst` instead of relying on the [default values](https://github.com/gardener/machine-controller-manager/blob/57dad3e97b4b0d18e576c8f3ec5ae3d17a062782/cmd/machine-controller-manager/app/options/options.go#L89-L90)

We've seen MCM pods getting deleted when users configure a high number of machine deployments. Essentially, MCM is not fast enough to process them and get's killed as a result of [this failing check](https://github.com/gardener/gardener/blob/98a8da46a80a950aae3e9f3f3c088aaf4bc968b7/extensions/pkg/controller/worker/genericactuator/actuator.go#L195-L216), which has a timeout of 2min. Shoots are stuck and fail to reconcile for hours, if the number of machine deployments is high enough.

With the custom config, MCM is able to process even larger amounts of machine deployments.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Deploy MCM with higher `concurrent-syncs`, `kube-api-qps` and `kube-api-burst`.
```
