### PR TITLE
Deploy apiserver-proxy envoy filter only when apiserver-proxy is required

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -110,6 +110,7 @@ type SNIValues struct {
 // APIServerProxy contains values for the APIServer proxy protocol configuration.
 type APIServerProxy struct {
 	APIServerClusterIP string
+	UseProxyProtocol   bool
 }
 
 // IstioIngressGateway contains the values for istio ingress gateway configuration.
@@ -217,20 +218,14 @@ func (s *sni) Deploy(ctx context.Context) error {
 
 	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
-	if values.APIServerProxy != nil || values.IstioTLSTermination {
+	if values.APIServerProxy != nil && (values.APIServerProxy.UseProxyProtocol || values.IstioTLSTermination) {
 		envoyFilter := s.emptyEnvoyFilterAPIServerProxy()
 
-		var (
-			err                         error
-			apiServerClusterIPPrefixLen int
-		)
-
-		if values.APIServerProxy != nil {
-			apiServerClusterIPPrefixLen, err = netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
-			if err != nil {
-				return err
-			}
+		apiServerClusterIPPrefixLen, err := netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
+		if err != nil {
+			return err
 		}
+
 		targetClusterProxyProtocol := fmt.Sprintf("outbound|%d||%s", kubeapiserverconstants.Port, hostName)
 		if values.IstioTLSTermination {
 			targetClusterProxyProtocol = GetAPIServerProxyTargetClusterName(s.namespace)
@@ -305,7 +300,7 @@ func (s *sni) Deploy(ctx context.Context) error {
 		}
 	}
 
-	if values.APIServerProxy != nil || values.IstioTLSTermination {
+	if (values.APIServerProxy != nil && values.APIServerProxy.UseProxyProtocol) || values.IstioTLSTermination {
 		serializedObjects, err := registry.SerializedObjects()
 		if err != nil {
 			return err

--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -172,7 +172,7 @@ type envoyFilterAPIServerProxyTemplateValues struct {
 	APIServerAuthenticationDynamicMetadataKey string
 	IstioTLSTermination                       bool
 	IstioTLSSecret                            string
-	TargetClusterProxyProtocol                string
+	TargetClusterAPIServerProxy               string
 }
 
 type envoyFilterIstioTLSTerminationTemplateValues struct {
@@ -226,9 +226,9 @@ func (s *sni) Deploy(ctx context.Context) error {
 			return err
 		}
 
-		targetClusterProxyProtocol := fmt.Sprintf("outbound|%d||%s", kubeapiserverconstants.Port, hostName)
+		targetClusterAPIServerProxy := fmt.Sprintf("outbound|%d||%s", kubeapiserverconstants.Port, hostName)
 		if values.IstioTLSTermination {
-			targetClusterProxyProtocol = GetAPIServerProxyTargetClusterName(s.namespace)
+			targetClusterAPIServerProxy = GetAPIServerProxyTargetClusterName(s.namespace)
 		}
 
 		var envoyFilterAPIServerProxy bytes.Buffer
@@ -249,7 +249,7 @@ func (s *sni) Deploy(ctx context.Context) error {
 			APIServerAuthenticationDynamicMetadataKey: authenticationDynamicMetadataKeyAPIServerProxy,
 			IstioTLSTermination:                       values.IstioTLSTermination,
 			IstioTLSSecret:                            s.emptyIstioTLSSecret().Name,
-			TargetClusterProxyProtocol:                targetClusterProxyProtocol,
+			TargetClusterAPIServerProxy:               targetClusterAPIServerProxy,
 		}); err != nil {
 			return err
 		}

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -86,6 +86,7 @@ var _ = Describe("#SNI", func() {
 
 		apiServerProxyValues = &APIServerProxy{
 			APIServerClusterIP: "1.1.1.1",
+			UseProxyProtocol:   true,
 		}
 		namespace = "test-namespace"
 		istioLabels = map[string]string{"foo": "bar"}
@@ -357,7 +358,7 @@ var _ = Describe("#SNI", func() {
 				},
 			}
 
-			if apiServerProxyValues != nil || istioTLSTermination {
+			if (apiServerProxyValues != nil && apiServerProxyValues.UseProxyProtocol) || istioTLSTermination {
 				mrData := validateManagedResourceAndGetData(ctx, c, expectedManagedResourceSNI)
 
 				var envoyFilterObjectsMetas []metav1.ObjectMeta
@@ -374,7 +375,7 @@ var _ = Describe("#SNI", func() {
 					envoyFilterObjectsMetas = append(envoyFilterObjectsMetas, actualEnvoyFilter.ObjectMeta)
 				}
 
-				if apiServerProxyValues != nil {
+				if apiServerProxyValues != nil && apiServerProxyValues.UseProxyProtocol {
 					Expect(envoyFilterObjectsMetas).To(ContainElement(expectedEnvoyFilterObjectMetaAPIServerProxy))
 				}
 

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -11,7 +11,7 @@ spec:
       {{ $k }}: {{ $v }}
 {{- end }}
   configPatches:
-  {{- if .APIServerProxy }}
+  {{- if .UseProxyProtocol }}
   - applyTo: FILTER_CHAIN
     match:
       context: ANY

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -24,8 +24,8 @@ spec:
         - name: envoy.filters.network.tcp_proxy
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-            stat_prefix: {{ .TargetClusterProxyProtocol }}
-            cluster: {{ .TargetClusterProxyProtocol }}
+            stat_prefix: {{ .TargetClusterAPIServerProxy }}
+            cluster: {{ .TargetClusterAPIServerProxy }}
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -50,7 +50,7 @@ spec:
     patch:
       operation: ADD
       value:
-        name: {{ .TargetClusterProxyProtocol }}
+        name: {{ .TargetClusterAPIServerProxy }}
         address:
           pipe:
             path: "@kube-apiservers/{{ .ControlPlaneNamespace }}"
@@ -59,11 +59,11 @@ spec:
           - name: envoy.filters.network.http_connection_manager
             typed_config:
               "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
-              stat_prefix: {{ .TargetClusterProxyProtocol }}
+              stat_prefix: {{ .TargetClusterAPIServerProxy }}
               route_config:
-                name: {{ .TargetClusterProxyProtocol }}
+                name: {{ .TargetClusterAPIServerProxy }}
                 virtual_hosts:
-                - name: {{ .TargetClusterProxyProtocol }}
+                - name: {{ .TargetClusterAPIServerProxy }}
                   domains:
                   - "*"
                   routes:
@@ -176,11 +176,11 @@ spec:
     patch:
       operation: ADD
       value:
-        name: {{ .TargetClusterProxyProtocol }}
+        name: {{ .TargetClusterAPIServerProxy }}
         type: STATIC
         connect_timeout: 1s
         load_assignment:
-          cluster_name: {{ .TargetClusterProxyProtocol }}
+          cluster_name: {{ .TargetClusterAPIServerProxy }}
           endpoints:
           - lb_endpoints:
             - endpoint:

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -163,6 +163,7 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 				},
 				APIServerProxy: &kubeapiserverexposure.APIServerProxy{
 					APIServerClusterIP: b.APIServerClusterIP,
+					UseProxyProtocol:   !features.DefaultFeatureGate.Enabled(features.RemoveAPIServerProxyLegacyPort),
 				},
 				IstioIngressGateway: kubeapiserverexposure.IstioIngressGateway{
 					Namespace: b.IstioNamespace(),
@@ -170,10 +171,6 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 				},
 				IstioTLSTermination:   features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
 				WildcardConfiguration: wildcardConfiguration,
-			}
-
-			if features.DefaultFeatureGate.Enabled(features.RemoveAPIServerProxyLegacyPort) {
-				values.APIServerProxy = nil
 			}
 
 			return values


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Since #11587 the apiserver-proxy related EnvoyFilter are deployed when `IstioTLSTermination` feature gate is enabled.
This means that it is also deployed for the virtual-garden when the feature gate is active. This should not be the case.
Thus, with this PR the EnvoyFilter is deployed only when apiserver-proxy is enabled.

**Which issue(s) this PR fixes**:
Part of #8810

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When `IstioTLSTermination` feature gate is enabled the apiserver-proxy related EnvoyFilter is not deployed for the virtual-garden anymore. 
```
