### PR TITLE
[GEP-28] Handle networking and control plane components

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -90,9 +90,9 @@ spec:
         {{- if .Values.gardener.version }}
         - --gardener-version={{ .Values.gardener.version }}
         {{- end }}
-        - {{- if .Values.gardener.autonomousShootCluster }}
+        {{- if .Values.gardener.autonomousShootCluster }}
         - --autonomous-shoot-cluster={{ .Values.gardener.autonomousShootCluster }}
-        - {{- end }}
+        {{- end }}
         - --log-level={{ .Values.logLevel | default "info"  }}
         - --log-format={{ .Values.logFormat | default "json"  }}
         env:

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
         {{- if .Values.gardener.version }}
         - --gardener-version={{ .Values.gardener.version }}
         {{- end }}
+        - {{- if .Values.gardener.autonomousShootCluster }}
+        - --autonomous-shoot-cluster={{ .Values.gardener.autonomousShootCluster }}
+        - {{- end }}
         - --log-level={{ .Values.logLevel | default "info"  }}
         - --log-format={{ .Values.logFormat | default "json"  }}
         env:

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -96,6 +96,7 @@ gardener:
     provider: local
   runtimeCluster:
     enabled: false
+  autonomousShootCluster: false
 
 usablePorts:
 - 8080  # metrics

--- a/cmd/gardenadm/main.go
+++ b/cmd/gardenadm/main.go
@@ -13,12 +13,18 @@ import (
 
 	"github.com/gardener/gardener/cmd/gardenadm/app"
 	"github.com/gardener/gardener/cmd/utils"
+	featuregates "github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
+
+	// TODO(rfranzke): Revisit this once autonomous shoot clusters progress.
+	if err := featuregates.DefaultFeatureGate.Set("NodeAgentAuthorizer=false"); err != nil {
+		panic(err)
+	}
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
 		os.Exit(1)

--- a/cmd/gardener-extension-admission-local/app/app.go
+++ b/cmd/gardener-extension-admission-local/app/app.go
@@ -148,7 +148,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			}
 
 			log.Info("Setting up webhook server")
-			if _, err := webhookOptions.Completed().AddToManager(ctx, mgr, sourceCluster); err != nil {
+			if _, err := webhookOptions.Completed().AddToManager(ctx, mgr, sourceCluster, false); err != nil {
 				return err
 			}
 

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -287,7 +287,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not add readycheck of webhook to manager: %w", err)
 			}
 
-			atomicShootWebhookConfig, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil)
+			atomicShootWebhookConfig, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil, generalOpts.Completed().AutonomousShootCluster)
 			if err != nil {
 				return fmt.Errorf("could not add webhooks to manager: %w", err)
 			}

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -242,12 +242,12 @@ The chart and the values can be updated at any time - Gardener will recognize it
 In order to allow extension controller deployments to get information about the garden and the seed cluster, additional properties are mixed into the values (root level) of every deployed Helm chart:
 
 - Additional properties for garden deployment
-```yaml
-  gardener:
-    runtimeCluster:
-      enabled: true
-      priorityClassName: <priority-class-name-for-extension>
-```
+  ```yaml
+    gardener:
+      runtimeCluster:
+        enabled: true
+        priorityClassName: <priority-class-name-for-extension>
+  ```
 
 - Additional properties for seed deployment
   ```yaml
@@ -275,6 +275,7 @@ In order to allow extension controller deployments to get information about the 
     gardenlet:
       featureGates: <gardenlet-feature-gates>
   ```
+- If the extension is deployed in an [autonomous shoot cluster](../proposals/28-autonomous-shoot-clusters.md), then the `.gardener.autonomousShootCluster` field is additionally propagated and set to `true`.
 
 Extension controller deployments can use this information in their Helm chart in case they require knowledge about the garden and the seed environment.
 The list might be extended in the future.

--- a/docs/extensions/shoot-webhooks.md
+++ b/docs/extensions/shoot-webhooks.md
@@ -21,3 +21,9 @@ The provider extension doesn't need to care about the same.
 The shoot's kube-apiserver must be allowed to talk to the provider extension.
 To achieve this, you need to make sure that the relevant `NetworkPolicy` get created for allowing the network traffic.
 Please refer to [this guide](../operations/network_policies.md#webhook-servers) for more information.
+
+## Autonomous Shoot Clusters
+
+If running in an autonomous shoot cluster, the shoot webhooks should be merged into the seed webhooks.
+You can do so by setting the `mergeShootWebhooksIntoSeedWebhooks` to `true` in the `extensions/pkg/webhook/cmd.AddToManager` function.
+Take a look at [this document](registration.md#helm-values) in order to determine whether the extension runs in an autonomous shoot cluster.

--- a/example/gardenadm-local/high-touch/kustomization.yaml
+++ b/example/gardenadm-local/high-touch/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 
 resources:
 - namespace.yaml
+- service.yaml
 - machine.yaml
-

--- a/example/gardenadm-local/high-touch/machine.yaml
+++ b/example/gardenadm-local/high-touch/machine.yaml
@@ -35,6 +35,10 @@ spec:
           readOnly: true
         - name: gardenadm
           mountPath: /gardenadm
+      hostAliases:
+        - hostnames:
+          - api.root.garden.internal.gardenadm.local
+          ip: 10.2.0.99
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/example/gardenadm-local/high-touch/service.yaml
+++ b/example/gardenadm-local/high-touch/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: machine-0
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: machine
+    apps.kubernetes.io/pod-index: "0"
+  sessionAffinity: None
+  type: ClusterIP
+  clusterIP: 10.2.0.99

--- a/example/provider-local/gardenadm/shoot.yaml
+++ b/example/provider-local/gardenadm/shoot.yaml
@@ -4,6 +4,7 @@ metadata:
   name: root
   namespace: garden
 spec:
+  region: local
   provider:
     type: local
     workers:

--- a/example/provider-local/gardenadm/shoot.yaml
+++ b/example/provider-local/gardenadm/shoot.yaml
@@ -27,4 +27,4 @@ spec:
     type: calico
     pods: 10.3.0.0/16
     services: 10.4.0.0/16
-    nodes: 10.10.0.0/16
+    nodes: 10.1.0.0/16 # pod network range of the kind cluster

--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -66,6 +66,9 @@ const (
 
 	// GardenerVersionFlag is the name of the command line flag containing the Gardener version.
 	GardenerVersionFlag = "gardener-version"
+	// AutonomousShootClusterFlag is the name of the command line flag indicating that the extension runs in an
+	// autonomous shoot cluster.
+	AutonomousShootClusterFlag = "autonomous-shoot-cluster"
 
 	// LogLevelFlag is the name of the command line flag containing the log level.
 	LogLevelFlag = "log-level"
@@ -476,6 +479,8 @@ type SwitchConfig struct {
 type GeneralOptions struct {
 	// GardenerVersion is the version of the Gardener.
 	GardenerVersion string
+	// AutonomousShootCluster indicates whether the extension runs in an autonomous shoot cluster.
+	AutonomousShootCluster bool
 
 	config *GeneralConfig
 }
@@ -484,11 +489,13 @@ type GeneralOptions struct {
 type GeneralConfig struct {
 	// GardenerVersion is the version of the Gardener.
 	GardenerVersion string
+	// AutonomousShootCluster indicates whether the extension runs in an autonomous shoot cluster.
+	AutonomousShootCluster bool
 }
 
 // Complete implements Complete.
 func (r *GeneralOptions) Complete() error {
-	r.config = &GeneralConfig{r.GardenerVersion}
+	r.config = &GeneralConfig{r.GardenerVersion, r.AutonomousShootCluster}
 	return nil
 }
 
@@ -500,4 +507,5 @@ func (r *GeneralOptions) Completed() *GeneralConfig {
 // AddFlags implements Flagger.AddFlags.
 func (r *GeneralOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&r.GardenerVersion, GardenerVersionFlag, "", "Version of the gardenlet.")
+	fs.BoolVar(&r.AutonomousShootCluster, AutonomousShootClusterFlag, false, "Does the extension run in an autonomous shoot cluster?")
 }

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -553,7 +553,7 @@ func (a *actuator) computeChecksums(
 ) (map[string]string, error) {
 	// Get cloud provider secret and config from cluster
 	cpSecret := &corev1.Secret{}
-	if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameCloudProvider}, cpSecret); err != nil {
+	if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameCloudProvider}, cpSecret); client.IgnoreNotFound(err) != nil {
 		return nil, fmt.Errorf("could not get secret '%s/%s': %w", namespace, v1beta1constants.SecretNameCloudProvider, err)
 	}
 

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -232,7 +232,7 @@ func (a *actuator) reconcileControlPlane(
 	bool,
 	error,
 ) {
-	if a.atomicShootWebhookConfig != nil {
+	if a.hasShootWebhooks(cluster.Shoot) {
 		value := a.atomicShootWebhookConfig.Load()
 		webhookConfig, ok := value.(*webhook.Configs)
 		if !ok {
@@ -523,7 +523,7 @@ func (a *actuator) deleteControlPlane(
 		}
 	}
 
-	if a.atomicShootWebhookConfig != nil {
+	if a.hasShootWebhooks(cluster.Shoot) {
 		if err := managedresources.Delete(ctx, a.client, cp.Namespace, ShootWebhooksResourceName, false); err != nil {
 			return fmt.Errorf("could not delete managed resource containing shoot webhooks for controlplane '%s': %w", client.ObjectKeyFromObject(cp), err)
 		}
@@ -538,6 +538,10 @@ func (a *actuator) deleteControlPlane(
 	}
 
 	return nil
+}
+
+func (a *actuator) hasShootWebhooks(shoot *gardencorev1beta1.Shoot) bool {
+	return a.atomicShootWebhookConfig != nil && !v1beta1helper.IsShootAutonomous(shoot)
 }
 
 // computeChecksums computes and returns all needed checksums. This includes the checksums for the given deployed secrets,

--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -311,7 +311,7 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 			} else if u := in.URL; u != nil {
 				parsedURL, err := url.Parse(*u)
 				if err != nil {
-					return admissionregistrationv1.WebhookClientConfig{}, fmt.Errorf("failed to parse URL: %v", err)
+					return admissionregistrationv1.WebhookClientConfig{}, fmt.Errorf("failed to parse URL %q: %w", *u, err)
 				}
 				path = parsedURL.Path
 			}

--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -7,12 +7,15 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync/atomic"
 
 	"github.com/spf13/pflag"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -193,7 +196,13 @@ type AddToManagerOptions struct {
 
 // NewAddToManagerOptions creates new AddToManagerOptions with the given server name, server, and switch options.
 // It is supposed to be used for webhooks which should be automatically registered in the cluster via a MutatingWebhookConfiguration.
-func NewAddToManagerOptions(extensionName string, shootWebhookManagedResourceName string, shootNamespaceSelector map[string]string, serverOpts *ServerOptions, switchOpts *SwitchOptions) *AddToManagerOptions {
+func NewAddToManagerOptions(
+	extensionName string,
+	shootWebhookManagedResourceName string,
+	shootNamespaceSelector map[string]string,
+	serverOpts *ServerOptions,
+	switchOpts *SwitchOptions,
+) *AddToManagerOptions {
 	return &AddToManagerOptions{
 		extensionName:                   extensionName,
 		shootWebhookManagedResourceName: shootWebhookManagedResourceName,
@@ -244,7 +253,7 @@ type AddToManagerConfig struct {
 // AddToManager instantiates all webhooks of this configuration. If there are any webhooks, it creates a
 // webhook server, registers the webhooks and adds the server to the manager. Otherwise, it is a no-op.
 // It generates and registers the seed targeted webhooks via a MutatingWebhookConfiguration.
-func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manager, sourceCluster cluster.Cluster) (*atomic.Value, error) {
+func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manager, sourceCluster cluster.Cluster, mergeShootWebhooksIntoSeedWebhooks bool) (*atomic.Value, error) {
 	if c.Clock == nil {
 		c.Clock = &clock.RealClock{}
 	}
@@ -292,6 +301,45 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not create webhooks: %w", err)
+	}
+
+	if mergeShootWebhooksIntoSeedWebhooks {
+		clientConfig := func(in admissionregistrationv1.WebhookClientConfig) (admissionregistrationv1.WebhookClientConfig, error) {
+			var path string
+			if in.Service != nil {
+				path = ptr.Deref(in.Service.Path, "")
+			} else if u := in.URL; u != nil {
+				parsedURL, err := url.Parse(*u)
+				if err != nil {
+					return admissionregistrationv1.WebhookClientConfig{}, fmt.Errorf("failed to parse URL: %v", err)
+				}
+				path = parsedURL.Path
+			}
+
+			return extensionswebhook.BuildClientConfigFor(path, c.Server.Namespace, c.extensionName, servicePort, c.Server.Mode, c.Server.URL, nil), nil
+		}
+
+		if shootWebhookConfigs.ValidatingWebhookConfig != nil {
+			for _, webhook := range shootWebhookConfigs.ValidatingWebhookConfig.Webhooks {
+				mutatedClientConfig, err := clientConfig(webhook.ClientConfig)
+				if err != nil {
+					return nil, fmt.Errorf("failed computing new client config while merging shoot validating webhook %q into seed webhooks: %w", webhook.Name, err)
+				}
+				webhook.ClientConfig = mutatedClientConfig
+				seedWebhookConfigs.ValidatingWebhookConfig.Webhooks = append(seedWebhookConfigs.ValidatingWebhookConfig.Webhooks, webhook)
+			}
+		}
+
+		if shootWebhookConfigs.MutatingWebhookConfig != nil {
+			for _, webhook := range shootWebhookConfigs.MutatingWebhookConfig.Webhooks {
+				mutatedClientConfig, err := clientConfig(webhook.ClientConfig)
+				if err != nil {
+					return nil, fmt.Errorf("failed computing new client config while merging shoot mutating webhook %q into seed webhooks: %w", webhook.Name, err)
+				}
+				webhook.ClientConfig = mutatedClientConfig
+				seedWebhookConfigs.MutatingWebhookConfig.Webhooks = append(seedWebhookConfigs.MutatingWebhookConfig.Webhooks, webhook)
+			}
+		}
 	}
 
 	atomicShootWebhookConfigs := &atomic.Value{}

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -458,7 +458,8 @@ const (
 	// LabelKeyAggregateToProjectMember is a constant for a label on ClusterRoles that are aggregated to the project
 	// member ClusterRole.
 	LabelKeyAggregateToProjectMember = "rbac.gardener.cloud/aggregate-to-project-member"
-
+	// LabelAutonomousShootCluster is a constant for a label on a Seed indicating that it is an autonomous shoot cluster.
+	LabelAutonomousShootCluster = "seed.gardener.cloud/autonomous-shoot-cluster"
 	// LabelSecretBindingReference is used to identify secrets which are referred by a SecretBinding (not necessarily in the same namespace).
 	LabelSecretBindingReference = "reference.gardener.cloud/secretbinding"
 	// LabelCredentialsBindingReference is used to identify credentials which are referred by a CredentialsBinding (not necessarily in the same namespace).

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -55,10 +55,6 @@ func ValidateOperatingSystemConfigUpdate(new, old *extensionsv1alpha1.OperatingS
 func ValidateOperatingSystemConfigSpec(spec *extensionsv1alpha1.OperatingSystemConfigSpec, pathsFromFiles sets.Set[string], fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(spec.Type) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "field is required"))
-	}
-
 	if len(spec.Purpose) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("purpose"), "field is required"))
 	} else {

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -107,9 +107,6 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 				"Field": Equal("metadata.namespace"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.type"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("spec.purpose"),
 			}))))
 		})

--- a/pkg/component/etcd/bootstrap/etcd.go
+++ b/pkg/component/etcd/bootstrap/etcd.go
@@ -101,6 +101,7 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 
 	statefulSet := e.emptyStatefulSet()
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, e.client, statefulSet, func() error {
+		statefulSet.Labels = e.labels()
 		statefulSet.Spec = appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: e.labels(),
@@ -256,12 +257,6 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 					},
 				},
 			},
-		}
-
-		statefulSet.Labels = map[string]string{
-			v1beta1constants.LabelApp:   "etcd",
-			v1beta1constants.LabelRole:  e.values.Role,
-			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		}
 
 		return nil

--- a/pkg/component/etcd/bootstrap/etcd.go
+++ b/pkg/component/etcd/bootstrap/etcd.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,160 +99,169 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 		return fmt.Errorf("failed to generate etcd peer certificates: %w", err)
 	}
 
-	pod := e.emptyPod()
+	statefulSet := e.emptyStatefulSet()
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, e.client, statefulSet, func() error {
+		statefulSet.Spec = appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: e.labels(),
+			},
+			Replicas: ptr.To[int32](0),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: e.labels()},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Command: []string{
+							"etcd",
+							"--name=" + statefulSet.Name,
+							"--data-dir=" + volumeMountPathData,
+							"--experimental-initial-corrupt-check=true",
+							"--experimental-watch-progress-notify-interval=5s",
+							"--snapshot-count=10000",
+							fmt.Sprintf("--advertise-client-urls=https://localhost:%d", e.values.PortClient),
+							fmt.Sprintf("--initial-advertise-peer-urls=https://localhost:%d", e.values.PortPeer),
+							fmt.Sprintf("--listen-client-urls=https://localhost:%d", e.values.PortClient),
+							fmt.Sprintf("--initial-cluster=%s=https://localhost:%d", statefulSet.Name, e.values.PortPeer),
+							fmt.Sprintf("--listen-peer-urls=https://localhost:%d", e.values.PortPeer),
+							fmt.Sprintf("--listen-metrics-urls=http://localhost:%d", e.values.PortMetrics),
+							"--client-cert-auth=true",
+							fmt.Sprintf("--trusted-ca-file=%s/%s", volumeMountPathETCDCA, secretsutils.DataKeyCertificateBundle),
+							fmt.Sprintf("--cert-file=%s/%s", volumeMountPathServerTLS, secretsutils.DataKeyCertificate),
+							fmt.Sprintf("--key-file=%s/%s", volumeMountPathServerTLS, secretsutils.DataKeyPrivateKey),
+							"--peer-client-cert-auth=true",
+							fmt.Sprintf("--peer-trusted-ca-file=%s/%s", volumeMountPathPeerCA, secretsutils.DataKeyCertificateBundle),
+							fmt.Sprintf("--peer-cert-file=%s/%s", volumeMountPathPeerServerTLS, secretsutils.DataKeyCertificate),
+							fmt.Sprintf("--peer-key-file=%s/%s", volumeMountPathPeerServerTLS, secretsutils.DataKeyPrivateKey),
+						},
+						Image:           e.values.Image,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Host:   "localhost",
+									Path:   "/livez",
+									Scheme: corev1.URISchemeHTTP,
+									Port:   intstr.FromInt32(e.values.PortMetrics),
+								},
+							},
+							SuccessThreshold:    1,
+							FailureThreshold:    8,
+							InitialDelaySeconds: 10,
+							PeriodSeconds:       10,
+							TimeoutSeconds:      15,
+						},
+						Name: "etcd",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+							},
+						},
+						StartupProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Host:   "localhost",
+									Path:   "/health",
+									Scheme: corev1.URISchemeHTTP,
+									Port:   intstr.FromInt32(e.values.PortMetrics),
+								},
+							},
+							SuccessThreshold:    1,
+							FailureThreshold:    24,
+							InitialDelaySeconds: 10,
+							PeriodSeconds:       10,
+							TimeoutSeconds:      15,
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: volumeMountPathData,
+								Name:      volumeNameData,
+							},
+							{
+								MountPath: volumeMountPathETCDCA,
+								Name:      volumeNameETCDCA,
+							},
+							{
+								MountPath: volumeMountPathServerTLS,
+								Name:      volumeNameServerTLS,
+							},
+							{
+								MountPath: "/var/etcd/ssl/client",
+								Name:      volumeNameClientTLS,
+							},
+							{
+								MountPath: volumeMountPathPeerCA,
+								Name:      volumeNamePeerCA,
+							},
+							{
+								MountPath: volumeMountPathPeerServerTLS,
+								Name:      volumeNamePeerServerTLS,
+							},
+						},
+					}},
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: volumeNameData,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/lib/" + statefulSet.Name + "/data",
+									Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+								},
+							},
+						},
+						{
+							Name: volumeNameETCDCA,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: etcdCASecret.Name,
+								},
+							},
+						},
+						{
+							Name: volumeNamePeerCA,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: etcdPeerCASecretName,
+								},
+							},
+						},
+						{
+							Name: volumeNameServerTLS,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: serverSecret.Name,
+								},
+							},
+						},
+						{
+							Name: volumeNameClientTLS,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: clientSecret.Name,
+								},
+							},
+						},
+						{
+							Name: volumeNamePeerServerTLS,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: peerServerSecretName,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
 
-	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, e.client, pod, func() error {
-		pod.Labels = map[string]string{
+		statefulSet.Labels = map[string]string{
 			v1beta1constants.LabelApp:   "etcd",
 			v1beta1constants.LabelRole:  e.values.Role,
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
-		}
-		pod.Spec = corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Command: []string{
-					"etcd",
-					"--name=" + pod.Name,
-					"--data-dir=" + volumeMountPathData,
-					"--experimental-initial-corrupt-check=true",
-					"--experimental-watch-progress-notify-interval=5s",
-					"--snapshot-count=10000",
-					fmt.Sprintf("--advertise-client-urls=https://localhost:%d", e.values.PortClient),
-					fmt.Sprintf("--initial-advertise-peer-urls=https://localhost:%d", e.values.PortPeer),
-					fmt.Sprintf("--listen-client-urls=https://localhost:%d", e.values.PortClient),
-					fmt.Sprintf("--initial-cluster=%s=https://localhost:%d", pod.Name, e.values.PortPeer),
-					fmt.Sprintf("--listen-peer-urls=https://localhost:%d", e.values.PortPeer),
-					fmt.Sprintf("--listen-metrics-urls=http://localhost:%d", e.values.PortMetrics),
-					"--client-cert-auth=true",
-					fmt.Sprintf("--trusted-ca-file=%s/%s", volumeMountPathETCDCA, secretsutils.DataKeyCertificateBundle),
-					fmt.Sprintf("--cert-file=%s/%s", volumeMountPathServerTLS, secretsutils.DataKeyCertificate),
-					fmt.Sprintf("--key-file=%s/%s", volumeMountPathServerTLS, secretsutils.DataKeyPrivateKey),
-					"--peer-client-cert-auth=true",
-					fmt.Sprintf("--peer-trusted-ca-file=%s/%s", volumeMountPathPeerCA, secretsutils.DataKeyCertificateBundle),
-					fmt.Sprintf("--peer-cert-file=%s/%s", volumeMountPathPeerServerTLS, secretsutils.DataKeyCertificate),
-					fmt.Sprintf("--peer-key-file=%s/%s", volumeMountPathPeerServerTLS, secretsutils.DataKeyPrivateKey),
-				},
-				Image:           e.values.Image,
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				LivenessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Host:   "localhost",
-							Path:   "/livez",
-							Scheme: corev1.URISchemeHTTP,
-							Port:   intstr.FromInt32(e.values.PortMetrics),
-						},
-					},
-					SuccessThreshold:    1,
-					FailureThreshold:    8,
-					InitialDelaySeconds: 10,
-					PeriodSeconds:       10,
-					TimeoutSeconds:      15,
-				},
-				Name: "etcd",
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("100m"),
-						corev1.ResourceMemory: resource.MustParse("100Mi"),
-					},
-				},
-				StartupProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Host:   "localhost",
-							Path:   "/health",
-							Scheme: corev1.URISchemeHTTP,
-							Port:   intstr.FromInt32(e.values.PortMetrics),
-						},
-					},
-					SuccessThreshold:    1,
-					FailureThreshold:    24,
-					InitialDelaySeconds: 10,
-					PeriodSeconds:       10,
-					TimeoutSeconds:      15,
-				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						MountPath: volumeMountPathData,
-						Name:      volumeNameData,
-					},
-					{
-						MountPath: volumeMountPathETCDCA,
-						Name:      volumeNameETCDCA,
-					},
-					{
-						MountPath: volumeMountPathServerTLS,
-						Name:      volumeNameServerTLS,
-					},
-					{
-						MountPath: "/var/etcd/ssl/client",
-						Name:      volumeNameClientTLS,
-					},
-					{
-						MountPath: volumeMountPathPeerCA,
-						Name:      volumeNamePeerCA,
-					},
-					{
-						MountPath: volumeMountPathPeerServerTLS,
-						Name:      volumeNamePeerServerTLS,
-					},
-				},
-			}},
-			SecurityContext: &corev1.PodSecurityContext{
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			Volumes: []corev1.Volume{
-				{
-					Name: volumeNameData,
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/var/lib/" + pod.Name + "/data",
-							Type: ptr.To(corev1.HostPathDirectoryOrCreate),
-						},
-					},
-				},
-				{
-					Name: volumeNameETCDCA,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: etcdCASecret.Name,
-						},
-					},
-				},
-				{
-					Name: volumeNamePeerCA,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: etcdPeerCASecretName,
-						},
-					},
-				},
-				{
-					Name: volumeNameServerTLS,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: serverSecret.Name,
-						},
-					},
-				},
-				{
-					Name: volumeNameClientTLS,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: clientSecret.Name,
-						},
-					},
-				},
-				{
-					Name: volumeNamePeerServerTLS,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: peerServerSecretName,
-						},
-					},
-				},
-			},
 		}
 
 		return nil
@@ -264,6 +274,14 @@ func (e *etcdDeployer) Destroy(_ context.Context) error {
 	return nil
 }
 
-func (e *etcdDeployer) emptyPod() *corev1.Pod {
-	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + e.values.Role + "-0", Namespace: e.namespace}}
+func (e *etcdDeployer) emptyStatefulSet() *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + e.values.Role + "-0", Namespace: e.namespace}}
+}
+
+func (e *etcdDeployer) labels() map[string]string {
+	return map[string]string{
+		v1beta1constants.LabelApp:   "etcd",
+		v1beta1constants.LabelRole:  e.values.Role,
+		v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+	}
 }

--- a/pkg/component/etcd/bootstrap/etcd_test.go
+++ b/pkg/component/etcd/bootstrap/etcd_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,13 +27,13 @@ import (
 
 var _ = Describe("Etcd", func() {
 	var (
-		c         client.Client
-		sm        secretsmanager.Interface
-		etcd      component.Deployer
-		ctx       = context.Background()
-		namespace = "shoot--foo--bar"
-		image     = "some-image"
-		pod       = &corev1.Pod{
+		c           client.Client
+		sm          secretsmanager.Interface
+		etcd        component.Deployer
+		ctx         = context.Background()
+		namespace   = "shoot--foo--bar"
+		image       = "some-image"
+		statefulSet = &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "etcd-main-0",
 				Namespace: namespace,
@@ -52,13 +53,13 @@ var _ = Describe("Etcd", func() {
 
 	Describe("#Deploy", func() {
 		It("should successfully deploy bootstrap etcd", func() {
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(BeNotFoundError())
 			Expect(etcd.Deploy(ctx)).To(Succeed())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
-			Expect(pod.Spec.Containers).To(HaveLen(1))
-			Expect(pod.Spec.Containers[0].Image).To(Equal(image))
-			Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(6))
-			Expect(pod.Spec.Containers[0].VolumeMounts).Should(ContainElements([]gomegatypes.GomegaMatcher{
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(Succeed())
+			Expect(statefulSet.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(statefulSet.Spec.Template.Spec.Containers[0].Image).To(Equal(image))
+			Expect(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(6))
+			Expect(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts).Should(ContainElements([]gomegatypes.GomegaMatcher{
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("data"), "MountPath": Equal("/var/etcd/data")}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-ca"), "MountPath": Equal("/var/etcd/ssl/ca")}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-server-tls"), "MountPath": Equal("/var/etcd/ssl/server")}),
@@ -66,8 +67,8 @@ var _ = Describe("Etcd", func() {
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-peer-ca"), "MountPath": Equal("/var/etcd/ssl/peer/ca")}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-peer-server-tls"), "MountPath": Equal("/var/etcd/ssl/peer/server")}),
 			}))
-			Expect(pod.Spec.Volumes).To(HaveLen(6))
-			Expect(pod.Spec.Volumes).Should(ContainElements([]gomegatypes.GomegaMatcher{
+			Expect(statefulSet.Spec.Template.Spec.Volumes).To(HaveLen(6))
+			Expect(statefulSet.Spec.Template.Spec.Volumes).Should(ContainElements([]gomegatypes.GomegaMatcher{
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("data")}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-ca")}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-server-tls")}),

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -127,6 +127,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						{Path: cctx.KubernetesVersion.String()},
 						{Path: fmt.Sprintf("%s", cctx.SSHPublicKeys)},
 						{Path: strconv.FormatBool(cctx.ValitailEnabled)},
+						{Path: fmt.Sprintf("%+v", cctx.Taints)},
 					},
 					nil
 			}
@@ -145,6 +146,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						},
 					},
 					KubeletDataVolumeName: &kubeletDataVolumeName,
+					ControlPlane:          &gardencorev1beta1.WorkerControlPlane{},
 				},
 				{
 					Name: worker2Name,
@@ -282,6 +284,15 @@ var _ = Describe("OperatingSystemConfig", func() {
 					SSHPublicKeys:         sshPublicKeys,
 					ValitailEnabled:       valitailEnabled,
 				}
+
+				if worker.ControlPlane != nil {
+					componentsContext.KubeletConfigParameters.WithStaticPodPath = true
+					componentsContext.Taints = append(componentsContext.Taints, corev1.Taint{
+						Key:    "node-role.kubernetes.io/control-plane",
+						Effect: corev1.TaintEffectNoSchedule,
+					})
+				}
+
 				originalUnits, originalFiles, _ := originalConfigFn(componentsContext)
 
 				oscInit := &extensionsv1alpha1.OperatingSystemConfig{

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -2067,18 +2067,7 @@ func (r *resourceManager) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForDeployment)
 	defer cancel()
 
-	return Until(timeoutCtx, IntervalWaitForDeployment, func(ctx context.Context) (done bool, err error) {
-		deployment := r.emptyDeployment()
-		if err := r.client.Get(ctx, client.ObjectKeyFromObject(deployment), deployment); err != nil {
-			return retry.SevereError(err)
-		}
-
-		if err := health.CheckDeployment(deployment); err != nil {
-			return retry.MinorError(err)
-		}
-
-		return retry.Ok()
-	})
+	return Until(timeoutCtx, IntervalWaitForDeployment, health.IsDeploymentUpdated(r.client, r.emptyDeployment()))
 }
 
 // WaitCleanup for destruction to finish and component to be fully removed. Gardener-Resource-manager does not need to wait for cleanup.

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1128,12 +1128,12 @@ func (r *resourceManager) ensureVPA(ctx context.Context) error {
 var SuggestPort = netutils.SuggestPort
 
 func (r *resourceManager) chooseServerPort() error {
-	if r.port != 0 {
+	if !r.values.BootstrapControlPlaneNode {
+		r.port = 10250
 		return nil
 	}
 
-	if !r.values.BootstrapControlPlaneNode {
-		r.port = 10250
+	if r.port != 0 {
 		return nil
 	}
 

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -816,6 +816,15 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 		priorityClassName = r.values.PriorityClassName
 	)
 
+	// If system component pods shall tolerate the control plane taint, we should add it for gardener-resource-manager
+	// itself as well (otherwise, it cannot be scheduled in order to add the toleration to other pods).
+	for _, toleration := range r.values.SystemComponentTolerations {
+		if toleration.Key == "node-role.kubernetes.io/control-plane" {
+			tolerations = append(tolerations, toleration)
+			break
+		}
+	}
+
 	if r.values.DefaultNotReadyToleration != nil {
 		tolerations = append(tolerations, corev1.Toleration{
 			Key:               corev1.TaintNodeNotReady,

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1972,15 +1972,24 @@ func GetEndpointSliceHintsMutatingWebhook(
 }
 
 func (r *resourceManager) buildWebhookNamespaceSelector() *metav1.LabelSelector {
-	namespaceSelectorOperator := metav1.LabelSelectorOpIn
+	if r.values.ResponsibilityMode == ForSourceAndTarget {
+		return &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      v1beta1constants.GardenRole,
+				Operator: metav1.LabelSelectorOpExists,
+			}},
+		}
+	}
+
+	operator := metav1.LabelSelectorOpIn
 	if r.values.ResponsibilityMode != ForTarget {
-		namespaceSelectorOperator = metav1.LabelSelectorOpNotIn
+		operator = metav1.LabelSelectorOpNotIn
 	}
 
 	return &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
 			Key:      v1beta1constants.GardenerPurpose,
-			Operator: namespaceSelectorOperator,
+			Operator: operator,
 			Values:   []string{metav1.NamespaceSystem, "kubernetes-dashboard"},
 		}},
 	}

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -323,6 +323,7 @@ var _ = Describe("ResourceManager", func() {
 				{Key: "a"},
 				{Key: "b"},
 				{Key: "c"},
+				{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists},
 			},
 			ResponsibilityMode:                        ForTarget,
 			TargetDisableCache:                        &targetDisableCache,
@@ -494,6 +495,7 @@ var _ = Describe("ResourceManager", func() {
 						{Key: "a"},
 						{Key: "b"},
 						{Key: "c"},
+						{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists},
 					},
 				}
 				config.Controllers.NodeCriticalComponents.Enabled = !isWorkerless
@@ -619,6 +621,10 @@ var _ = Describe("ResourceManager", func() {
 								},
 							},
 							Tolerations: []corev1.Toleration{
+								{
+									Key:      "node-role.kubernetes.io/control-plane",
+									Operator: corev1.TolerationOpExists,
+								},
 								{
 									Key:               corev1.TaintNodeNotReady,
 									Operator:          corev1.TolerationOpExists,

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -885,6 +885,28 @@ var _ = Describe("ResourceManager", func() {
 		}
 
 		mutatingWebhookConfigurationFor = func(responsibilityMode ResponsibilityMode, bootstrapControlPlaneNode bool) *admissionregistrationv1.MutatingWebhookConfiguration {
+			var namespaceSelectorMatchExpressions []metav1.LabelSelectorRequirement
+
+			switch responsibilityMode {
+			case ForSource:
+				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{{
+					Key:      "gardener.cloud/purpose",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"kube-system", "kubernetes-dashboard"},
+				}}
+			case ForTarget:
+				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{{
+					Key:      "gardener.cloud/purpose",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"kube-system", "kubernetes-dashboard"},
+				}}
+			case ForSourceAndTarget:
+				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{{
+					Key:      "gardener.cloud/role",
+					Operator: metav1.LabelSelectorOpExists,
+				}}
+			}
+
 			ignoreStaticPodsInBootstrapMode := func(in []metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
 				if !bootstrapControlPlaneNode {
 					return in
@@ -917,13 +939,7 @@ var _ = Describe("ResourceManager", func() {
 							},
 							Operations: []admissionregistrationv1.OperationType{"CREATE"},
 						}},
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{{
-								Key:      "gardener.cloud/purpose",
-								Operator: metav1.LabelSelectorOpNotIn,
-								Values:   []string{"kube-system", "kubernetes-dashboard"},
-							}},
-						},
+						NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 						ObjectSelector: &metav1.LabelSelector{
 							MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
 								{
@@ -975,11 +991,7 @@ var _ = Describe("ResourceManager", func() {
 						},
 					},
 					NamespaceSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "gardener.cloud/purpose",
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"kube-system", "kubernetes-dashboard"},
-						}},
+						MatchExpressions: namespaceSelectorMatchExpressions,
 						MatchLabels: map[string]string{
 							"high-availability-config.resources.gardener.cloud/consider": "true",
 						},
@@ -1018,13 +1030,7 @@ var _ = Describe("ResourceManager", func() {
 						},
 						Operations: []admissionregistrationv1.OperationType{"CREATE"},
 					}},
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "gardener.cloud/purpose",
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"kube-system", "kubernetes-dashboard"},
-						}},
-					},
+					NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 					ObjectSelector: &metav1.LabelSelector{
 						MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
 							{
@@ -1106,13 +1112,7 @@ var _ = Describe("ResourceManager", func() {
 							},
 							Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
 						}},
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{{
-								Key:      "gardener.cloud/purpose",
-								Operator: metav1.LabelSelectorOpNotIn,
-								Values:   []string{"kube-system", "kubernetes-dashboard"},
-							}},
-						},
+						NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 						ObjectSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"endpoint-slice-hints.resources.gardener.cloud/consider": "true",
@@ -1144,13 +1144,7 @@ var _ = Describe("ResourceManager", func() {
 							},
 							Operations: []admissionregistrationv1.OperationType{"CREATE"},
 						}},
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{{
-								Key:      "gardener.cloud/purpose",
-								Operator: metav1.LabelSelectorOpNotIn,
-								Values:   []string{"kube-system", "kubernetes-dashboard"},
-							}},
-						},
+						NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 						ObjectSelector: &metav1.LabelSelector{
 							MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{{
 								Key:      "system-components-config.resources.gardener.cloud/skip",
@@ -1183,13 +1177,7 @@ var _ = Describe("ResourceManager", func() {
 					},
 					Operations: []admissionregistrationv1.OperationType{"CREATE"},
 				}},
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{{
-						Key:      "gardener.cloud/purpose",
-						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"kube-system", "kubernetes-dashboard"},
-					}},
-				},
+				NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 				ObjectSelector: &metav1.LabelSelector{
 					MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
 						{

--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -432,7 +432,11 @@ winkernel:
 				return &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
+							"app":                 "kubernetes",
+							"gardener.cloud/role": "system-component",
 							"resources.gardener.cloud/garbage-collectable-reference": "true",
+							"role":   "proxy",
+							"origin": "gardener",
 						},
 						Name:      configMapNameFor(ipvsEnabled),
 						Namespace: "kube-system",

--- a/pkg/component/kubernetes/proxy/resources.go
+++ b/pkg/component/kubernetes/proxy/resources.go
@@ -122,7 +122,7 @@ func (k *kubeProxy) computeCentralResourcesData() (map[string][]byte, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: metav1.NamespaceSystem,
-				Labels:    getLabels(),
+				Labels:    GetLabels(),
 			},
 			Spec: corev1.ServiceSpec{
 				Type:      corev1.ServiceTypeClusterIP,
@@ -132,7 +132,7 @@ func (k *kubeProxy) computeCentralResourcesData() (map[string][]byte, error) {
 					Port:     int32(portMetrics),
 					Protocol: corev1.ProtocolTCP,
 				}},
-				Selector: getLabels(),
+				Selector: GetLabels(),
 			},
 		}
 
@@ -149,6 +149,7 @@ func (k *kubeProxy) computeCentralResourcesData() (map[string][]byte, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ConfigNamePrefix,
 				Namespace: metav1.NamespaceSystem,
+				Labels:    utils.MergeStringMaps(GetLabels(), getSystemComponentLabels()),
 			},
 			Data: map[string]string{dataKeyConfig: componentConfigRaw},
 		}
@@ -157,7 +158,7 @@ func (k *kubeProxy) computeCentralResourcesData() (map[string][]byte, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kube-proxy-conntrack-fix-script",
 				Namespace: metav1.NamespaceSystem,
-				Labels:    utils.MergeStringMaps(getLabels(), getSystemComponentLabels()),
+				Labels:    utils.MergeStringMaps(GetLabels(), getSystemComponentLabels()),
 			},
 			Data: map[string]string{dataKeyConntrackFixScript: conntrackFixScript},
 		}
@@ -166,7 +167,7 @@ func (k *kubeProxy) computeCentralResourcesData() (map[string][]byte, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kube-proxy-cleanup-script",
 				Namespace: metav1.NamespaceSystem,
-				Labels:    utils.MergeStringMaps(getLabels(), getSystemComponentLabels()),
+				Labels:    utils.MergeStringMaps(GetLabels(), getSystemComponentLabels()),
 			},
 			Data: map[string]string{dataKeyCleanupScript: cleanupScript},
 		}
@@ -429,7 +430,8 @@ func (k *kubeProxy) computePoolResourcesDataForMajorMinorVersionOnly(pool Worker
 	return registry.AddAllAndSerialize(vpa)
 }
 
-func getLabels() map[string]string {
+// GetLabels returns the default labels for kube-proxy resources.
+func GetLabels() map[string]string {
 	return map[string]string{
 		v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
 		v1beta1constants.LabelRole: v1beta1constants.LabelProxy,
@@ -444,7 +446,7 @@ func getSystemComponentLabels() map[string]string {
 }
 
 func getPoolLabels(pool WorkerPool) map[string]string {
-	return utils.MergeStringMaps(getLabels(), map[string]string{
+	return utils.MergeStringMaps(GetLabels(), map[string]string{
 		"pool":    pool.Name,
 		"version": pool.KubernetesVersion.String(),
 	})

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -46,10 +46,11 @@ import (
 const (
 	// DeploymentName is the name of the coredns Deployment.
 	DeploymentName = "coredns"
+	// ManagedResourceName is the name of the ManagedResource.
+	ManagedResourceName = "shoot-core-coredns"
 
 	clusterProportionalAutoscalerDeploymentName = "coredns-autoscaler"
 	clusterProportionalDNSAutoscalerLabelValue  = "coredns-autoscaler"
-	managedResourceName                         = "shoot-core-coredns"
 
 	containerName = "coredns"
 	serviceName   = "kube-dns" // this is due to legacy reasons
@@ -187,7 +188,7 @@ func (c *coreDNS) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, c.client, c.namespace, managedResourceName, managedresources.LabelValueGardener, false, data)
+	return managedresources.CreateForShoot(ctx, c.client, c.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (c *coreDNS) Destroy(ctx context.Context) error {
@@ -198,7 +199,7 @@ func (c *coreDNS) Destroy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.DeleteForShoot(ctx, c.client, c.namespace, managedResourceName)
+	return managedresources.DeleteForShoot(ctx, c.client, c.namespace, ManagedResourceName)
 }
 
 // TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
@@ -209,14 +210,14 @@ func (c *coreDNS) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, c.client, c.namespace, managedResourceName)
+	return managedresources.WaitUntilHealthy(timeoutCtx, c.client, c.namespace, ManagedResourceName)
 }
 
 func (c *coreDNS) WaitCleanup(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilDeleted(timeoutCtx, c.client, c.namespace, managedResourceName)
+	return managedresources.WaitUntilDeleted(timeoutCtx, c.client, c.namespace, ManagedResourceName)
 }
 
 func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -128,9 +128,6 @@ func combinedGardenerResourceManagerDefaultValues() resourcemanager.Values {
 
 	values.ResourceClass = ptr.To(resourcemanagerconfigv1alpha1.AllResourceClass)
 	values.ResponsibilityMode = resourcemanager.ForSourceAndTarget
-	// TODO(rfranzke): Later, we should deploy two replicas (as usual) when there are at least two nodes in the
-	//  autonomous shoot cluster.
-	values.Replicas = ptr.To[int32](1)
 
 	return values
 }
@@ -153,6 +150,11 @@ func NewCombinedGardenerResourceManager(c client.Client,
 
 	defaultValues := combinedGardenerResourceManagerDefaultValues()
 	defaultValues.Image = image.String()
+
+	values.Replicas = ptr.To[int32](2)
+	if values.BootstrapControlPlaneNode {
+		values.Replicas = ptr.To[int32](1)
+	}
 
 	applyDefaults(&values, defaultValues)
 	return resourcemanager.New(c, namespaceName, secretsManager, values), nil

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -149,7 +149,7 @@ func (r *Reconciler) reconcileNetworkPolicy(ctx context.Context, log logr.Logger
 		return nil
 	}
 
-	log.Info("Reconciling NetworkPolicy")
+	log.Info("Reconciling NetworkPolicy", "networkPolicy", client.ObjectKeyFromObject(networkPolicy))
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.RuntimeClient, networkPolicy, func() error {
 		mutateFunc(networkPolicy)

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -101,7 +101,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 
 		if err := healthFunc(obj); err != nil {
 			lastObservedError = err
-			log.Error(err, "Object did not get ready yet")
+			log.Info("Object did not get ready yet", "reason", err.Error())
 
 			if retry.IsRetriable(err) {
 				return retry.MinorOrSevereError(retryCountUntilSevere, int(severeThreshold.Nanoseconds()/interval.Nanoseconds()), err)

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -187,6 +187,7 @@ func newShootObject(ctx context.Context, projectName string, cloudProfile *garde
 		WithProjectName(projectName).
 		WithCloudProfileObject(cloudProfile).
 		WithShootObject(shoot).
+		WithInternalDomain(&gardenerutils.Domain{Domain: "gardenadm.local"}).
 		Build(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed building shoot object: %w", err)

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -21,6 +21,7 @@ import (
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
@@ -153,8 +154,11 @@ func newGardenObject(ctx context.Context, project *gardencorev1beta1.Project) (*
 
 func newSeedObject(ctx context.Context, shootObj *shootpkg.Shoot) (*seedpkg.Seed, error) {
 	seed := &gardencorev1beta1.Seed{
-		ObjectMeta: metav1.ObjectMeta{Name: shootObj.GetInfo().Name},
-		Status:     gardencorev1beta1.SeedStatus{ClusterIdentity: ptr.To(shootObj.GetInfo().Name)},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   shootObj.GetInfo().Name,
+			Labels: map[string]string{v1beta1constants.LabelAutonomousShootCluster: "true"},
+		},
+		Status: gardencorev1beta1.SeedStatus{ClusterIdentity: ptr.To(shootObj.GetInfo().Name)},
 	}
 	kubernetes.GardenScheme.Default(seed)
 

--- a/pkg/gardenadm/botanist/controlplane.go
+++ b/pkg/gardenadm/botanist/controlplane.go
@@ -57,6 +57,7 @@ func (b *AutonomousBotanist) deployETCD(role string) func(context.Context) error
 
 func (b *AutonomousBotanist) deployKubeAPIServer(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.KubeAPIServer.EnableStaticTokenKubeconfig()
+	b.Shoot.Components.ControlPlane.KubeAPIServer.SetAutoscalingReplicas(nil)
 	return b.DeployKubeAPIServer(ctx, false)
 }
 
@@ -68,8 +69,8 @@ type staticControlPlaneComponent struct {
 
 func (b *AutonomousBotanist) staticControlPlaneComponents() []staticControlPlaneComponent {
 	return []staticControlPlaneComponent{
-		{b.deployETCD(v1beta1constants.ETCDRoleMain), "etcd-" + v1beta1constants.ETCDRoleMain + "-0", &corev1.Pod{}},
-		{b.deployETCD(v1beta1constants.ETCDRoleEvents), "etcd-" + v1beta1constants.ETCDRoleEvents + "-0", &corev1.Pod{}},
+		{b.deployETCD(v1beta1constants.ETCDRoleMain), "etcd-" + v1beta1constants.ETCDRoleMain + "-0", &appsv1.StatefulSet{}},
+		{b.deployETCD(v1beta1constants.ETCDRoleEvents), "etcd-" + v1beta1constants.ETCDRoleEvents + "-0", &appsv1.StatefulSet{}},
 		{b.deployKubeAPIServer, v1beta1constants.DeploymentNameKubeAPIServer, &appsv1.Deployment{}},
 		{b.DeployKubeControllerManager, v1beta1constants.DeploymentNameKubeControllerManager, &appsv1.Deployment{}},
 		{b.Shoot.Components.ControlPlane.KubeScheduler.Deploy, v1beta1constants.DeploymentNameKubeScheduler, &appsv1.Deployment{}},

--- a/pkg/gardenadm/botanist/controlplane.go
+++ b/pkg/gardenadm/botanist/controlplane.go
@@ -140,6 +140,7 @@ func (b *AutonomousBotanist) CreateClientSet(ctx context.Context) (kubernetes.In
 	clientSet, err := kubernetes.NewClientFromFile("", PathKubeconfig,
 		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
 		kubernetes.WithClientConnectionOptions(componentbaseconfigv1alpha1.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
+		kubernetes.WithDisabledCachedClient(),
 	)
 	if err != nil {
 		b.Logger.Info("Waiting for kube-apiserver to start", "error", err.Error())

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -123,7 +123,7 @@ func controllerRegistrationSliceToList(controllerRegistrations []*gardencorev1be
 
 // ReconcileExtensionControllerInstallations reconciles the ControllerInstallation resources necessary to deploy the
 // extension controllers.
-func (b *AutonomousBotanist) ReconcileExtensionControllerInstallations(ctx context.Context, networkAvailable bool) error {
+func (b *AutonomousBotanist) ReconcileExtensionControllerInstallations(ctx context.Context, bootstrapMode bool) error {
 	var (
 		reconcilerCtx = log.IntoContext(ctx, b.Logger.WithName("controllerinstallation-reconciler"))
 		reconciler    = controllerinstallation.Reconciler{
@@ -133,7 +133,7 @@ func (b *AutonomousBotanist) ReconcileExtensionControllerInstallations(ctx conte
 			Clock:                     clock.RealClock{},
 			Identity:                  &b.Shoot.GetInfo().Status.Gardener,
 			GardenNamespace:           b.Shoot.ControlPlaneNamespace,
-			BootstrapControlPlaneNode: !networkAvailable,
+			BootstrapControlPlaneNode: bootstrapMode,
 		}
 	)
 

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -62,7 +62,7 @@ func ComputeExtensions(
 		}
 
 		var (
-			controllerDeployment   = controllerDeployments[idx]
+			controllerDeployment   = controllerDeployments[idx].DeepCopy()
 			controllerInstallation = &gardencorev1beta1.ControllerInstallation{
 				ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration.Name},
 				Spec: gardencorev1beta1.ControllerInstallationSpec{
@@ -72,6 +72,10 @@ func ComputeExtensions(
 				},
 			}
 		)
+
+		// Remove the InjectGardenKubeconfig field from the ControllerDeployment because we don't have any information
+		// about a potentially existing garden cluster.
+		controllerDeployment.InjectGardenKubeconfig = nil
 
 		extensions = append(extensions, Extension{
 			ControllerRegistration: controllerRegistration,

--- a/pkg/gardenadm/botanist/extensions_test.go
+++ b/pkg/gardenadm/botanist/extensions_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Extensions", func() {
 			Expect(b.WaitUntilExtensionControllerInstallationsHealthy(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 		})
 
-		It("should fail if all ManagedResource are healthy", func() {
+		It("should succeed if all ManagedResource are healthy", func() {
 			Expect(fakeClient.Create(ctx, managedResource1)).To(Succeed())
 			Expect(fakeClient.Create(ctx, managedResource2)).To(Succeed())
 

--- a/pkg/gardenadm/botanist/extensions_test.go
+++ b/pkg/gardenadm/botanist/extensions_test.go
@@ -5,15 +5,27 @@
 package botanist_test
 
 import (
+	"context"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Extensions", func() {
@@ -135,4 +147,89 @@ var _ = Describe("Extensions", func() {
 			}))
 		})
 	})
+
+	Describe("#WaitUntilExtensionControllerInstallationsHealthy", func() {
+		var (
+			ctx                   = context.Background()
+			controlPlaneNamespace = "foo"
+			extension1            = "ext1"
+			extension2            = "ext2"
+
+			fakeClient client.Client
+			b          *AutonomousBotanist
+
+			managedResource1 *resourcesv1alpha1.ManagedResource
+			managedResource2 *resourcesv1alpha1.ManagedResource
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).WithStatusSubresource(&resourcesv1alpha1.ManagedResource{}).Build()
+			b = &AutonomousBotanist{
+				Botanist: &botanistpkg.Botanist{
+					Operation: &operation.Operation{
+						SeedClientSet: fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build(),
+						Shoot: &shootpkg.Shoot{
+							ControlPlaneNamespace: controlPlaneNamespace,
+						},
+					},
+				},
+				Extensions: []Extension{
+					{ControllerInstallation: &gardencorev1beta1.ControllerInstallation{ObjectMeta: metav1.ObjectMeta{Name: extension1}}},
+					{ControllerInstallation: &gardencorev1beta1.ControllerInstallation{ObjectMeta: metav1.ObjectMeta{Name: extension2}}},
+				},
+			}
+
+			managedResource1 = &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: extension1, Namespace: controlPlaneNamespace}}
+			managedResource2 = &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: extension2, Namespace: controlPlaneNamespace}}
+
+			DeferCleanup(test.WithVar(&TimeoutManagedResourceHealthCheck, time.Millisecond))
+		})
+
+		It("should fail if a ManagedResource does not exist", func() {
+			Expect(b.WaitUntilExtensionControllerInstallationsHealthy(ctx)).To(MatchError(ContainSubstring("not found")))
+		})
+
+		It("should fail if a ManagedResource is not healthy", func() {
+			Expect(fakeClient.Create(ctx, managedResource1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResource2)).To(Succeed())
+
+			Expect(b.WaitUntilExtensionControllerInstallationsHealthy(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+		})
+
+		It("should fail if all ManagedResource are healthy", func() {
+			Expect(fakeClient.Create(ctx, managedResource1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResource2)).To(Succeed())
+
+			Expect(makeManagedResourceHealthy(ctx, fakeClient, managedResource1)).To(Succeed())
+			Expect(makeManagedResourceHealthy(ctx, fakeClient, managedResource2)).To(Succeed())
+
+			Expect(b.WaitUntilExtensionControllerInstallationsHealthy(ctx)).To(Succeed())
+		})
+	})
 })
+
+func makeManagedResourceHealthy(ctx context.Context, fakeClient client.Client, mr *resourcesv1alpha1.ManagedResource) error {
+	patch := client.MergeFrom(mr.DeepCopy())
+	mr.Status.ObservedGeneration = mr.Generation
+	mr.Status.Conditions = []gardencorev1beta1.Condition{
+		{
+			Type:               "ResourcesHealthy",
+			Status:             "True",
+			LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
+			LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
+		},
+		{
+			Type:               "ResourcesApplied",
+			Status:             "True",
+			LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
+			LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
+		},
+		{
+			Type:               "ResourcesProgressing",
+			Status:             "False",
+			LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
+			LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
+		},
+	}
+	return fakeClient.Status().Patch(ctx, mr, patch)
+}

--- a/pkg/gardenadm/botanist/extensions_test.go
+++ b/pkg/gardenadm/botanist/extensions_test.go
@@ -84,10 +84,12 @@ var _ = Describe("Extensions", func() {
 				},
 			}
 			controllerDeployment1 = &gardencorev1.ControllerDeployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "ext1"},
+				ObjectMeta:             metav1.ObjectMeta{Name: "ext1"},
+				InjectGardenKubeconfig: ptr.To(true),
 			}
 			controllerDeployment3 = &gardencorev1.ControllerDeployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "ext3"},
+				ObjectMeta:             metav1.ObjectMeta{Name: "ext3"},
+				InjectGardenKubeconfig: ptr.To(false),
 			}
 
 			controllerRegistrations = []*gardencorev1beta1.ControllerRegistration{controllerRegistration1, controllerRegistration2, controllerRegistration3}
@@ -122,7 +124,7 @@ var _ = Describe("Extensions", func() {
 			Expect(extensions).To(Equal([]Extension{
 				{
 					ControllerRegistration: controllerRegistration1,
-					ControllerDeployment:   controllerDeployment1,
+					ControllerDeployment:   controllerDeploymentWithoutInjectGardenKubeconfig(controllerDeployment1),
 					ControllerInstallation: &gardencorev1beta1.ControllerInstallation{
 						ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration1.Name},
 						Spec: gardencorev1beta1.ControllerInstallationSpec{
@@ -134,7 +136,7 @@ var _ = Describe("Extensions", func() {
 				},
 				{
 					ControllerRegistration: controllerRegistration3,
-					ControllerDeployment:   controllerDeployment3,
+					ControllerDeployment:   controllerDeploymentWithoutInjectGardenKubeconfig(controllerDeployment3),
 					ControllerInstallation: &gardencorev1beta1.ControllerInstallation{
 						ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration3.Name},
 						Spec: gardencorev1beta1.ControllerInstallationSpec{
@@ -232,4 +234,10 @@ func makeManagedResourceHealthy(ctx context.Context, fakeClient client.Client, m
 		},
 	}
 	return fakeClient.Status().Patch(ctx, mr, patch)
+}
+
+func controllerDeploymentWithoutInjectGardenKubeconfig(in *gardencorev1.ControllerDeployment) *gardencorev1.ControllerDeployment {
+	out := in.DeepCopy()
+	out.InjectGardenKubeconfig = nil
+	return out
 }

--- a/pkg/gardenadm/botanist/network.go
+++ b/pkg/gardenadm/botanist/network.go
@@ -7,14 +7,21 @@ package botanist
 import (
 	"context"
 	"fmt"
+	"net"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/networking/coredns"
+	"github.com/gardener/gardener/pkg/controller/networkpolicy"
+	"github.com/gardener/gardener/pkg/controller/networkpolicy/hostnameresolver"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
@@ -29,4 +36,43 @@ func (b *AutonomousBotanist) IsPodNetworkAvailable(ctx context.Context) (bool, e
 		return false, fmt.Errorf("failed reading ManagedResource %s: %w", client.ObjectKeyFromObject(managedResource), err)
 	}
 	return health.CheckManagedResource(managedResource) == nil, nil
+}
+
+// ApplyNetworkPolicies reconciles all namespaces in the cluster in order to apply the network policies.
+func (b *AutonomousBotanist) ApplyNetworkPolicies(ctx context.Context) error {
+	var (
+		reconcilerCtx = log.IntoContext(ctx, b.Logger.WithName("networkpolicy-reconciler"))
+		reconciler    = &networkpolicy.Reconciler{
+			RuntimeClient: b.SeedClientSet.Client(),
+			Resolver:      hostnameresolver.NewNoOpProvider(),
+			RuntimeNetworks: networkpolicy.RuntimeNetworkConfig{
+				IPFamilies: b.Shoot.GetInfo().Spec.Networking.IPFamilies,
+				Pods:       netIPNetSliceToStringSlice(b.Shoot.Networks.Pods),
+				Services:   netIPNetSliceToStringSlice(b.Shoot.Networks.Services),
+				Nodes:      netIPNetSliceToStringSlice(b.Shoot.Networks.Nodes),
+			},
+		}
+	)
+
+	namespaceList := &corev1.NamespaceList{}
+	if err := b.SeedClientSet.Client().List(ctx, namespaceList); err != nil {
+		return fmt.Errorf("failed listing namespaces: %w", err)
+	}
+
+	for _, namespace := range namespaceList.Items {
+		b.Logger.Info("Reconciling NetworkPolicies using gardenlet's reconciliation logic", "namespaceName", namespace.Name)
+		if _, err := reconciler.Reconcile(reconcilerCtx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespace.Name}}); err != nil {
+			return fmt.Errorf("failed running NetworkPolicy controller for %q: %w", namespace.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func netIPNetSliceToStringSlice(in []net.IPNet) []string {
+	out := make([]string, 0, len(in))
+	for _, ip := range in {
+		out = append(out, ip.String())
+	}
+	return out
 }

--- a/pkg/gardenadm/botanist/network.go
+++ b/pkg/gardenadm/botanist/network.go
@@ -26,7 +26,7 @@ import (
 )
 
 // IsPodNetworkAvailable checks if the ManagedResource for CoreDNS is deployed and ready. If yes, pod network must be
-// available (otherwise, CoreDNS (which runs in this network) wouldn't be available).
+// available. Otherwise, CoreDNS which runs in this network wouldn't be available.
 func (b *AutonomousBotanist) IsPodNetworkAvailable(ctx context.Context) (bool, error) {
 	managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: coredns.ManagedResourceName, Namespace: b.Shoot.ControlPlaneNamespace}}
 	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource); err != nil {
@@ -61,7 +61,7 @@ func (b *AutonomousBotanist) ApplyNetworkPolicies(ctx context.Context) error {
 
 		reconcilerCtx := log.IntoContext(ctx, b.Logger.WithName("networkpolicy-reconciler").WithValues("namespaceName", namespace.Name))
 		if _, err := reconciler.Reconcile(reconcilerCtx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespace.Name}}); err != nil {
-			return fmt.Errorf("failed running NetworkPolicy controller for %q: %w", namespace.Name, err)
+			return fmt.Errorf("failed running NetworkPolicy controller for namespace %q: %w", namespace.Name, err)
 		}
 	}
 

--- a/pkg/gardenadm/botanist/network.go
+++ b/pkg/gardenadm/botanist/network.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/networking/coredns"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+// IsPodNetworkAvailable checks if the ManagedResource for CoreDNS is deployed and ready. If yes, pod network must be
+// available (otherwise, CoreDNS (which runs in this network) wouldn't be available).
+func (b *AutonomousBotanist) IsPodNetworkAvailable(ctx context.Context) (bool, error) {
+	managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: coredns.ManagedResourceName, Namespace: b.Shoot.ControlPlaneNamespace}}
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource); err != nil {
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed reading ManagedResource %s: %w", client.ObjectKeyFromObject(managedResource), err)
+	}
+	return health.CheckManagedResource(managedResource) == nil, nil
+}

--- a/pkg/gardenadm/botanist/network_test.go
+++ b/pkg/gardenadm/botanist/network_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+)
+
+var _ = Describe("Network", func() {
+	var (
+		ctx       context.Context
+		namespace = "kube-system"
+
+		b *AutonomousBotanist
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		b = &AutonomousBotanist{
+			Botanist: &botanistpkg.Botanist{
+				Operation: &operation.Operation{
+					Shoot: &shoot.Shoot{
+						ControlPlaneNamespace: namespace,
+					},
+					SeedClientSet: fakekubernetes.
+						NewClientSetBuilder().
+						WithClient(fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()).
+						Build(),
+				},
+			},
+		}
+	})
+
+	Describe("#IsPodNetworkAvailable", func() {
+		var (
+			managedResource *resourcesv1alpha1.ManagedResource
+		)
+
+		BeforeEach(func() {
+			managedResource = &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shoot-core-coredns",
+					Namespace: namespace,
+				},
+			}
+		})
+
+		It("should return false because the ManagedResource does not exist", func() {
+			available, err := b.IsPodNetworkAvailable(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(available).To(BeFalse())
+		})
+
+		It("should return false because the ManagedResource is unhealthy", func() {
+			Expect(b.SeedClientSet.Client().Create(ctx, managedResource)).To(Succeed())
+
+			available, err := b.IsPodNetworkAvailable(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(available).To(BeFalse())
+		})
+
+		It("should return true because the ManagedResource is healthy", func() {
+			managedResource.Status.ObservedGeneration = managedResource.Generation
+			managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+				{
+					Type:               "ResourcesHealthy",
+					Status:             "True",
+					LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
+					LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
+				},
+				{
+					Type:               "ResourcesApplied",
+					Status:             "True",
+					LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
+					LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
+				},
+			}
+			Expect(b.SeedClientSet.Client().Create(ctx, managedResource)).To(Succeed())
+
+			available, err := b.IsPodNetworkAvailable(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(available).To(BeTrue())
+		})
+	})
+})

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -106,7 +106,7 @@ func (b *AutonomousBotanist) ApplyOperatingSystemConfig(ctx context.Context) err
 	}
 
 	reconcilerCtx, cancelFunc := context.WithCancel(ctx)
-	reconcilerCtx = log.IntoContext(reconcilerCtx, b.Logger.WithName("operatingsystemconfig-reconciler"))
+	reconcilerCtx = log.IntoContext(reconcilerCtx, b.Logger.WithName("operatingsystemconfig-reconciler").WithValues("secret", client.ObjectKeyFromObject(b.operatingSystemConfigSecret)))
 
 	_, err := (&operatingsystemconfigcontroller.Reconciler{
 		Client: b.SeedClientSet.Client(),

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -33,6 +33,10 @@ import (
 // DeployOperatingSystemConfigSecretForNodeAgent deploys the OperatingSystemConfig resource and adds its content into
 // a Secret so that gardener-node-agent can read it and reconcile its content.
 func (b *AutonomousBotanist) DeployOperatingSystemConfigSecretForNodeAgent(ctx context.Context) error {
+	if err := b.DeployControlPlaneDeployments(ctx); err != nil {
+		return fmt.Errorf("failed deploying control plane deployments: %w", err)
+	}
+
 	oscData, controlPlaneWorkerPoolName, err := b.deployOperatingSystemConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("failed deploying OperatingSystemConfig: %w", err)

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -232,10 +232,15 @@ func run(ctx context.Context, opts *Options) error {
 			Fn:           b.Shoot.Components.Extensions.ControlPlane.Wait,
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
-		_ = g.Add(flow.Task{
+		deployControlPlaneDeployments = g.Add(flow.Task{
 			Name:         "Deploying control plane components as Deployments for static pod translation",
 			Fn:           b.DeployControlPlaneDeployments,
 			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying OperatingSystemConfig and activating gardener-node-agent",
+			Fn:           b.ActivateGardenerNodeAgent,
+			Dependencies: flow.NewTaskIDs(deployControlPlaneDeployments),
 		})
 	)
 

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -122,12 +122,17 @@ func run(ctx context.Context, opts *Options) error {
 			Fn:           b.DeployShootSystem,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
-		_ = g.Add(flow.Task{
+		deployExtensionControllers = g.Add(flow.Task{
 			Name: "Deploying extension controllers",
 			Fn: func(ctx context.Context) error {
 				return b.ReconcileExtensionControllerInstallations(ctx, false)
 			},
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+		})
+		waitForExtensionControllersReady = g.Add(flow.Task{
+			Name:         "Waiting until extension controllers report readiness",
+			Fn:           b.WaitUntilExtensionControllerInstallationsHealthy,
+			Dependencies: flow.NewTaskIDs(deployExtensionControllers),
 		})
 	)
 

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -138,6 +138,16 @@ func run(ctx context.Context, opts *Options) error {
 			Fn:           b.WaitUntilExtensionControllerInstallationsHealthy,
 			Dependencies: flow.NewTaskIDs(deployExtensionControllers),
 		})
+		deployShootNamespaces = g.Add(flow.Task{
+			Name:         "Deploying shoot namespaces system component",
+			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
+		})
+		waitUntilShootNamespacesReady = g.Add(flow.Task{
+			Name:         "Waiting until shoot namespaces have been reconciled",
+			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Wait,
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, deployShootNamespaces),
+		})
 	)
 
 	if err := g.Compile().Run(ctx, flow.Opts{

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -164,12 +164,6 @@ func run(ctx context.Context, opts *Options) error {
 			SkipIf:       !kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady, waitUntilExtensionControllersReady),
 		})
-		_ = g.Add(flow.Task{
-			Name:         "Deleting kube-proxy system component",
-			Fn:           b.Shoot.Components.SystemComponents.KubeProxy.Destroy,
-			SkipIf:       kubeProxyEnabled,
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
-		})
 		deployNetwork = g.Add(flow.Task{
 			Name:         "Deploying shoot network plugin",
 			Fn:           b.DeployNetwork,
@@ -183,7 +177,7 @@ func run(ctx context.Context, opts *Options) error {
 		deployCoreDNS = g.Add(flow.Task{
 			Name:         "Deploying CoreDNS system component",
 			Fn:           b.DeployCoreDNS,
-			Dependencies: flow.NewTaskIDs(waitUntilNetworkReady),
+			Dependencies: flow.NewTaskIDs(waitUntilNetworkReady, deployNetworkPolicies),
 		})
 		waitUntilCoreDNSReady = g.Add(flow.Task{
 			Name:         "Waiting until CoreDNS system component is ready",

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -143,6 +143,11 @@ func run(ctx context.Context, opts *Options) error {
 			Fn:           b.WaitUntilExtensionControllerInstallationsHealthy,
 			Dependencies: flow.NewTaskIDs(deployExtensionControllers),
 		})
+		deployNetworkPolicies = g.Add(flow.Task{
+			Name:         "Deploying network policies",
+			Fn:           b.ApplyNetworkPolicies,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployExtensionControllers),
+		})
 		deployShootNamespaces = g.Add(flow.Task{
 			Name:         "Deploying shoot namespaces system component",
 			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Deploy,
@@ -216,6 +221,7 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(deployExtensionControllersIntoPodNetwork),
 		})
 		syncPointBootstrapped = flow.NewTaskIDs(
+			deployNetworkPolicies,
 			waitUntilGardenerResourceManagerReady,
 			waitUntilGardenerResourceManagerInPodNetworkReady,
 			waitUntilExtensionControllersReady,

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -232,6 +232,11 @@ func run(ctx context.Context, opts *Options) error {
 			Fn:           b.Shoot.Components.Extensions.ControlPlane.Wait,
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying control plane components as Deployments for static pod translation",
+			Fn:           b.DeployControlPlaneDeployments,
+			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
+		})
 	)
 
 	if err := g.Compile().Run(ctx, flow.Opts{

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -64,6 +64,10 @@ func run(ctx context.Context, opts *Options) error {
 	var (
 		g = flow.NewGraph("init")
 
+		deployNamespace = g.Add(flow.Task{
+			Name: "Deploying control plane namespace",
+			Fn:   b.DeployControlPlaneNamespace,
+		})
 		reconcileCustomResourceDefinitions = g.Add(flow.Task{
 			Name: "Reconciling CustomResourceDefinitions",
 			Fn:   b.ReconcileCustomResourceDefinitions,
@@ -103,7 +107,7 @@ func run(ctx context.Context, opts *Options) error {
 				b.Shoot.Components.ControlPlane.ResourceManager.SetBootstrapControlPlaneNode(true)
 				return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)
 			},
-			Dependencies: flow.NewTaskIDs(initializeSecretsManagement),
+			Dependencies: flow.NewTaskIDs(deployNamespace, initializeSecretsManagement),
 		})
 		waitUntilGardenerResourceManagerReady = g.Add(flow.Task{
 			Name:         "Waiting until gardener-resource-manager reports readiness",

--- a/pkg/gardenadm/staticpod/translator.go
+++ b/pkg/gardenadm/staticpod/translator.go
@@ -28,9 +28,10 @@ func Translate(ctx context.Context, c client.Client, o client.Object) ([]extensi
 	switch obj := o.(type) {
 	case *appsv1.Deployment:
 		return translatePodTemplate(ctx, c, obj.ObjectMeta, obj.Spec.Template)
+	case *appsv1.StatefulSet:
+		return translatePodTemplate(ctx, c, obj.ObjectMeta, obj.Spec.Template)
 	case *corev1.Pod:
 		return translatePodTemplate(ctx, c, obj.ObjectMeta, corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: obj.Labels, Annotations: obj.Annotations}, Spec: obj.Spec})
-	// TODO(rfranzke): Consider adding support for StatefulSet in the future.
 	default:
 		return nil, fmt.Errorf("unsupported object type %T", o)
 	}

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -266,6 +266,240 @@ kind: Config
 			})
 		})
 
+		When("object is a StatefulSet", func() {
+			var statefulSet *appsv1.StatefulSet
+
+			BeforeEach(func() {
+				statefulSet = &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "bar",
+						Labels:      map[string]string{"will": "be-ignored"},
+						Annotations: map[string]string{"this-as": "well"},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels:      map[string]string{"baz": "foo"},
+								Annotations: map[string]string{"bar": "baz"},
+							},
+							Spec: corev1.PodSpec{
+								SecurityContext: &corev1.PodSecurityContext{FSGroup: ptr.To[int64](65534)},
+							},
+						},
+					},
+				}
+			})
+
+			It("should successfully translate a statefulSet w/o volumes", func() {
+				Expect(Translate(ctx, fakeClient, statefulSet)).To(HaveExactElements(extensionsv1alpha1.File{
+					Path:        "/etc/kubernetes/manifests/" + statefulSet.Name + ".yaml",
+					Permissions: ptr.To[uint32](0640),
+					Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bar: baz
+  creationTimestamp: null
+  labels:
+    baz: foo
+    static-pod: "true"
+  name: foo
+  namespace: kube-system
+spec:
+  containers: null
+  hostAliases:
+  - hostnames:
+    - kubernetes
+    - kubernetes.default
+    - kubernetes.default.svc
+    - kubernetes.default.svc.cluster.local
+    ip: 127.0.0.1
+  - hostnames:
+    - kubernetes
+    - kubernetes.default
+    - kubernetes.default.svc
+    - kubernetes.default.svc.cluster.local
+    ip: ::1
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  securityContext:
+    fsGroup: 0
+status: {}
+`))}},
+				}))
+			})
+
+			It("should fail translate a statefulSet whose ConfigMap volumes refer to non-existing objects", func() {
+				statefulSet.Spec.Template.Spec.Volumes = []corev1.Volume{
+					{Name: "foo", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "some-configmap"}}}},
+				}
+
+				Expect(Translate(ctx, fakeClient, statefulSet)).Error().To(MatchError(ContainSubstring("failed reading ConfigMap")))
+			})
+
+			It("should fail translate a statefulSet whose Secret volumes refer to non-existing objects", func() {
+				statefulSet.Spec.Template.Spec.Volumes = []corev1.Volume{
+					{Name: "foo", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "some-secret"}}},
+				}
+
+				Expect(Translate(ctx, fakeClient, statefulSet)).Error().To(MatchError(ContainSubstring("failed reading Secret")))
+			})
+
+			It("should fail translate a statefulSet whose projected ConfigMap volumes refer to non-existing objects", func() {
+				statefulSet.Spec.Template.Spec.Volumes = []corev1.Volume{
+					{Name: "foo", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "some-configmap"}}}}}}},
+				}
+
+				Expect(Translate(ctx, fakeClient, statefulSet)).Error().To(MatchError(ContainSubstring("failed reading ConfigMap")))
+			})
+
+			It("should fail translate a statefulSet whose Secret volumes refer to non-existing objects", func() {
+				statefulSet.Spec.Template.Spec.Volumes = []corev1.Volume{
+					{Name: "foo", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "some-secret"}}}}}}},
+				}
+
+				Expect(Translate(ctx, fakeClient, statefulSet)).Error().To(MatchError(ContainSubstring("failed reading Secret")))
+			})
+
+			It("should successfully translate a statefulSet w/ volumes", func() {
+				var (
+					configMap1 = &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: statefulSet.Namespace},
+						Data:       map[string]string{"cm1file1.txt": "some-content", "cm1file2.txt": "more-content"},
+					}
+					configMap2 = &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: statefulSet.Namespace},
+						Data: map[string]string{"cm2file1.txt": "even-more-content", "cm2file2.txt": `apiVersion: v1
+clusters:
+- cluster:
+    server: https://foo.local.gardener.cloud
+  name: test
+kind: Config
+`},
+					}
+					secret1 = &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: statefulSet.Namespace},
+						Data:       map[string][]byte{"secret1file1.txt": []byte("very-secret"), "secret1file2.txt": []byte("super-secret")},
+					}
+					secret2 = &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: statefulSet.Namespace},
+						Data:       map[string][]byte{"secret2file1.txt": []byte("highly-secret"), "secret2file2.txt": []byte("please-dont-detect")},
+					}
+				)
+
+				Expect(fakeClient.Create(ctx, configMap1)).To(Succeed())
+				Expect(fakeClient.Create(ctx, configMap2)).To(Succeed())
+				Expect(fakeClient.Create(ctx, secret1)).To(Succeed())
+				Expect(fakeClient.Create(ctx, secret2)).To(Succeed())
+
+				statefulSet.Spec.Template.Spec.Volumes = []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "cm1"}}}},
+					{Name: "v2", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "secret1"}}},
+					{Name: "v3", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "cm2"}}},
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "secret2"},
+								Items:                []corev1.KeyToPath{{Key: "secret2file2.txt", Path: "mystery.txt"}},
+							}},
+						},
+						DefaultMode: ptr.To[int32](0666),
+					}}},
+				}
+
+				Expect(Translate(ctx, fakeClient, statefulSet)).To(ConsistOf(
+					extensionsv1alpha1.File{
+						Path:        "/etc/kubernetes/manifests/" + statefulSet.Name + ".yaml",
+						Permissions: ptr.To[uint32](0640),
+						Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bar: baz
+  creationTimestamp: null
+  labels:
+    baz: foo
+    static-pod: "true"
+  name: foo
+  namespace: kube-system
+spec:
+  containers: null
+  hostAliases:
+  - hostnames:
+    - kubernetes
+    - kubernetes.default
+    - kubernetes.default.svc
+    - kubernetes.default.svc.cluster.local
+    ip: 127.0.0.1
+  - hostnames:
+    - kubernetes
+    - kubernetes.default
+    - kubernetes.default.svc
+    - kubernetes.default.svc.cluster.local
+    ip: ::1
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  securityContext:
+    fsGroup: 0
+  volumes:
+  - hostPath:
+      path: /var/lib/foo/v1
+    name: v1
+  - hostPath:
+      path: /var/lib/foo/v2
+    name: v2
+  - hostPath:
+      path: /var/lib/foo/v3
+    name: v3
+status: {}
+`))}},
+					},
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[0].Name + "/cm1file1.txt",
+						Permissions: ptr.To[uint32](0640),
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap1.Data["cm1file1.txt"]))}},
+					},
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[0].Name + "/cm1file2.txt",
+						Permissions: ptr.To[uint32](0640),
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap1.Data["cm1file2.txt"]))}},
+					},
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[1].Name + "/secret1file1.txt",
+						Permissions: ptr.To[uint32](0640),
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret1.Data["secret1file1.txt"])}},
+					},
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[1].Name + "/secret1file2.txt",
+						Permissions: ptr.To[uint32](0640),
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret1.Data["secret1file2.txt"])}},
+					},
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/cm2file1.txt",
+						Permissions: ptr.To[uint32](0640),
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap2.Data["cm2file1.txt"]))}},
+					},
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/cm2file2.txt",
+						Permissions: ptr.To[uint32](0640),
+						Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://foo.local.gardener.cloud
+  name: test
+kind: Config
+`))}},
+					},
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/mystery.txt",
+						Permissions: ptr.To[uint32](0640),
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret2.Data["secret2file2.txt"])}},
+					},
+				))
+			})
+		})
+
 		When("object is a Pod", func() {
 			var pod *corev1.Pod
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -263,6 +263,10 @@ func (r *Reconciler) reconcile(
 		},
 	}
 
+	if metav1.HasLabel(seed.ObjectMeta, v1beta1constants.LabelAutonomousShootCluster) {
+		gardenerValues["gardener"].(map[string]any)["autonomousShootCluster"] = true
+	}
+
 	if genericGardenKubeconfigSecretName != "" {
 		gardenerValues["gardener"].(map[string]any)["garden"].(map[string]any)["genericKubeconfigSecretName"] = genericGardenKubeconfigSecretName
 	}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -202,7 +202,7 @@ func (r *Reconciler) reconcile(
 	}
 
 	var (
-		injectGardenKubeconfig            = !r.BootstrapControlPlaneNode && ptr.Deref(controllerDeployment.InjectGardenKubeconfig, false)
+		injectGardenKubeconfig            = ptr.Deref(controllerDeployment.InjectGardenKubeconfig, false)
 		genericGardenKubeconfigSecretName string
 	)
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -163,7 +163,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 
 		deployNamespace = g.Add(flow.Task{
 			Name:   "Deploying Shoot namespace in Seed",
-			Fn:     flow.TaskFn(botanist.DeploySeedNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(botanist.DeployControlPlaneNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: !nonTerminatingNamespace,
 		})
 		ensureShootClusterIdentity = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
@@ -122,7 +122,7 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 
 		deployNamespace = g.Add(flow.Task{
 			Name:   "Deploying Shoot namespace in Seed",
-			Fn:     flow.TaskFn(botanist.DeploySeedNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(botanist.DeployControlPlaneNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: !nonTerminatingNamespace,
 		})
 		initializeSecretsManagement = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -144,7 +144,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 		deployNamespace = g.Add(flow.Task{
 			Name: "Deploying Shoot namespace in Seed",
-			Fn:   flow.TaskFn(botanist.DeploySeedNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:   flow.TaskFn(botanist.DeployControlPlaneNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
 		ensureShootClusterIdentity = g.Add(flow.Task{
 			Name:         "Ensuring Shoot cluster identity",

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
@@ -43,6 +43,10 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if b.Shoot.RunsControlPlane() {
+		replicaCount = 0
+	}
+
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetReplicaCount(replicaCount)
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetRuntimeConfig(b.Shoot.Components.ControlPlane.KubeAPIServer.GetValues().RuntimeConfig)
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetServiceNetworks(b.Shoot.Networks.Services)

--- a/pkg/gardenlet/operation/botanist/kubescheduler.go
+++ b/pkg/gardenlet/operation/botanist/kubescheduler.go
@@ -18,12 +18,17 @@ func (b *Botanist) DefaultKubeScheduler() (component.DeployWaiter, error) {
 		return nil, err
 	}
 
+	replicas := b.Shoot.GetReplicas(1)
+	if b.Shoot.RunsControlPlane() {
+		replicas = 0
+	}
+
 	return kubescheduler.New(
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		b.SecretsManager,
 		image.String(),
-		b.Shoot.GetReplicas(1),
+		replicas,
 		b.Shoot.GetInfo().Spec.Kubernetes.KubeScheduler,
 	), nil
 }

--- a/pkg/gardenlet/operation/botanist/namespaces.go
+++ b/pkg/gardenlet/operation/botanist/namespaces.go
@@ -32,10 +32,10 @@ import (
 	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
-// DeploySeedNamespace creates a namespace in the Seed cluster which is used to deploy all the control plane
+// DeployControlPlaneNamespace creates a namespace in the Seed cluster which is used to deploy all the control plane
 // components for the Shoot cluster. Moreover, the cloud provider configuration and all the secrets will be
 // stored as ConfigMaps/Secrets.
-func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
+func (b *Botanist) DeployControlPlaneNamespace(ctx context.Context) error {
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: b.Shoot.ControlPlaneNamespace,

--- a/pkg/gardenlet/operation/botanist/namespaces_test.go
+++ b/pkg/gardenlet/operation/botanist/namespaces_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Namespaces", func() {
 		}
 	})
 
-	Describe("#DeploySeedNamespace", func() {
+	Describe("#DeployControlPlaneNamespace", func() {
 		var (
 			seedProviderType       = "seed-provider"
 			seedZones              = []string{"a", "b", "c", "d", "e"}
@@ -173,7 +173,7 @@ var _ = Describe("Namespaces", func() {
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 			Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations("", 1)
 		})
@@ -185,7 +185,7 @@ var _ = Describe("Namespaces", func() {
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 			Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations("", 0)
 		})
@@ -197,7 +197,7 @@ var _ = Describe("Namespaces", func() {
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 			Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations("", 1)
 			Expect(botanist.SeedNamespaceObject.Labels).To(And(
@@ -216,7 +216,7 @@ var _ = Describe("Namespaces", func() {
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 			Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations("", 1)
 			Expect(botanist.SeedNamespaceObject.Labels).To(And(
@@ -238,13 +238,13 @@ var _ = Describe("Namespaces", func() {
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 			Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations(gardencorev1beta1.FailureToleranceTypeZone, 3)
 		})
 
 		It("should successfully deploy the namespace when failure tolerance type is zone and zones annotation already exists with too less zones", func() {
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations("", 1)
 			zone := botanist.SeedNamespaceObject.Annotations["high-availability-config.resources.gardener.cloud/zones"]
@@ -258,7 +258,7 @@ var _ = Describe("Namespaces", func() {
 			}
 			botanist.Shoot.SetInfo(defaultShootInfo)
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations(gardencorev1beta1.FailureToleranceTypeZone, 3)
 			Expect(strings.Split(botanist.SeedNamespaceObject.Annotations["high-availability-config.resources.gardener.cloud/zones"], ",")).To(ContainElement(zone))
@@ -274,12 +274,12 @@ var _ = Describe("Namespaces", func() {
 			}
 			botanist.Shoot.SetInfo(defaultShootInfo)
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations(gardencorev1beta1.FailureToleranceTypeZone, 3)
 			zones := botanist.SeedNamespaceObject.Annotations["high-availability-config.resources.gardener.cloud/zones"]
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations(gardencorev1beta1.FailureToleranceTypeZone, 3)
 			Expect(botanist.SeedNamespaceObject.Annotations["high-availability-config.resources.gardener.cloud/zones"]).To(Equal(zones))
@@ -301,7 +301,7 @@ var _ = Describe("Namespaces", func() {
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 			Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-			Expect(botanist.DeploySeedNamespace(ctx)).To(MatchError(ContainSubstring("cannot select 3 zones for shoot because seed only specifies 2 zones in its specification")))
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(MatchError(ContainSubstring("cannot select 3 zones for shoot because seed only specifies 2 zones in its specification")))
 		})
 
 		Context("zone pinning backwards compatibility", func() {
@@ -357,7 +357,7 @@ var _ = Describe("Namespaces", func() {
 					Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 					Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-					Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+					Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 					defaultExpectations("", 2)
 					Expect(botanist.SeedNamespaceObject.Annotations).To(HaveKeyWithValue("high-availability-config.resources.gardener.cloud/zones", "a,b"))
@@ -376,7 +376,7 @@ var _ = Describe("Namespaces", func() {
 					Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 					Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-					Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+					Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 					defaultExpectations(gardencorev1beta1.FailureToleranceTypeZone, 3)
 					Expect(strings.Split(botanist.SeedNamespaceObject.Annotations["high-availability-config.resources.gardener.cloud/zones"], ",")).To(ConsistOf(
@@ -407,7 +407,7 @@ var _ = Describe("Namespaces", func() {
 
 					Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-					Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+					Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 					defaultExpectations(gardencorev1beta1.FailureToleranceTypeZone, 3)
 					Expect(strings.Split(botanist.SeedNamespaceObject.Annotations["high-availability-config.resources.gardener.cloud/zones"], ",")).To(ConsistOf(
@@ -423,7 +423,7 @@ var _ = Describe("Namespaces", func() {
 					Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 					Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-					Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+					Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 					defaultExpectations("", 1)
 					Expect(strings.Split(botanist.SeedNamespaceObject.Annotations["high-availability-config.resources.gardener.cloud/zones"], ",")).To(ConsistOf(
@@ -453,7 +453,7 @@ var _ = Describe("Namespaces", func() {
 
 					Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-					Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+					Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 					defaultExpectations(gardencorev1beta1.FailureToleranceTypeZone, 4)
 					Expect(botanist.SeedNamespaceObject.Annotations).To(HaveKeyWithValue("high-availability-config.resources.gardener.cloud/zones", "1,2,a,b"))
@@ -476,7 +476,7 @@ var _ = Describe("Namespaces", func() {
 					Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNotFoundError())
 					Expect(botanist.SeedNamespaceObject).To(BeNil())
 
-					Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+					Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 					defaultExpectations("", 1)
 				})
@@ -510,7 +510,7 @@ var _ = Describe("Namespaces", func() {
 			})).To(Succeed())
 
 			Expect(botanist.SeedNamespaceObject).To(BeNil())
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 
 			defaultExpectations("", 1)
 			Expect(botanist.SeedNamespaceObject.Labels).To(And(
@@ -530,7 +530,7 @@ var _ = Describe("Namespaces", func() {
 			})).To(Succeed())
 
 			Expect(botanist.SeedNamespaceObject).To(BeNil())
-			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.DeployControlPlaneNamespace(ctx)).To(Succeed())
 			Expect(botanist.SeedNamespaceObject.Annotations).To(HaveKeyWithValue("foo", "bar"))
 			Expect(botanist.SeedNamespaceObject.Labels).To(HaveKeyWithValue("bar", "foo"))
 		})

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -72,7 +72,7 @@ func (b *Botanist) lastSecretRotationStartTimes() map[string]time.Time {
 
 	if shootStatus := b.Shoot.GetInfo().Status; shootStatus.Credentials != nil && shootStatus.Credentials.Rotation != nil {
 		if shootStatus.Credentials.Rotation.CertificateAuthorities != nil && shootStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime != nil {
-			for _, config := range caCertConfigurations(b.Shoot.IsWorkerless) {
+			for _, config := range caCertConfigurations(b.Shoot.IsWorkerless, b.Shoot.RunsControlPlane()) {
 				rotation[config.GetName()] = shootStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time
 			}
 			// The static token secret contains token for the health check of the kube-apiserver.
@@ -131,7 +131,7 @@ func (b *Botanist) restoreSecretsFromShootStateForSecretsManagerAdoption(ctx con
 	return flow.Parallel(fns...)(ctx)
 }
 
-func caCertConfigurations(isWorkerless bool) []secretsutils.ConfigInterface {
+func caCertConfigurations(isWorkerless, runsControlPlane bool) []secretsutils.ConfigInterface {
 	certificateSecretConfigs := []secretsutils.ConfigInterface{
 		// The CommonNames for CA certificates will be overridden with the secret name by the secrets manager when
 		// generated to ensure that each CA has a unique common name. For backwards-compatibility, we still keep the
@@ -148,8 +148,13 @@ func caCertConfigurations(isWorkerless bool) []secretsutils.ConfigInterface {
 		certificateSecretConfigs = append(certificateSecretConfigs,
 			&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAKubelet, CommonName: "kubelet", CertType: secretsutils.CACert},
 			&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAMetricsServer, CommonName: "metrics-server", CertType: secretsutils.CACert},
-			&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAVPN, CommonName: "vpn", CertType: secretsutils.CACert},
 		)
+
+		if !runsControlPlane {
+			certificateSecretConfigs = append(certificateSecretConfigs,
+				&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAVPN, CommonName: "vpn", CertType: secretsutils.CACert},
+			)
+		}
 	}
 
 	return certificateSecretConfigs
@@ -187,7 +192,7 @@ func (b *Botanist) caCertGenerateOptionsFor(configName string) []secretsmanager.
 func (b *Botanist) generateCertificateAuthorities(ctx context.Context) error {
 	var caClientSecret *corev1.Secret
 
-	for _, config := range caCertConfigurations(b.Shoot.IsWorkerless) {
+	for _, config := range caCertConfigurations(b.Shoot.IsWorkerless, b.Shoot.RunsControlPlane()) {
 		caSecret, err := b.SecretsManager.Generate(ctx, config, b.caCertGenerateOptionsFor(config.GetName())...)
 		if err != nil {
 			return err

--- a/pkg/provider-local/charts/shoot-system-components/charts/local-path-provisioner/templates/deployment.yaml
+++ b/pkg/provider-local/charts/shoot-system-components/charts/local-path-provisioner/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       labels:
         app: local-path-provisioner
+        networking.gardener.cloud/to-runtime-apiserver: allowed
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: local-path-provisioner-service-account

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -69,3 +69,9 @@ func (e *ensurer) EnsureKubeletConfiguration(_ context.Context, _ extensionscont
 
 	return nil
 }
+
+// EnsureKubeSchedulerDeployment ensures that the kube-scheduler deployment conforms to the provider requirements.
+func (e *ensurer) EnsureKubeSchedulerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, newObj, _ *appsv1.Deployment) error {
+	newObj.Spec.Template.Labels["injected-by"] = "provider-local"
+	return nil
+}

--- a/pkg/provider-local/webhook/shoot/add.go
+++ b/pkg/provider-local/webhook/shoot/add.go
@@ -7,11 +7,13 @@ package shoot
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/shoot"
+	kubeproxy "github.com/gardener/gardener/pkg/component/kubernetes/proxy"
 )
 
 var (
@@ -34,6 +36,9 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebh
 		Types:         []extensionswebhook.Type{{Obj: &corev1.ConfigMap{}}},
 		Mutator:       NewMutator(),
 		FailurePolicy: &failurePolicy,
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: kubeproxy.GetLabels(),
+		},
 	})
 }
 

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -530,6 +530,10 @@ func ExtractSystemComponentsTolerations(workers []gardencorev1beta1.Worker) []co
 	)
 
 	for _, worker := range workers {
+		if worker.ControlPlane != nil {
+			tolerations.Insert(corev1.Toleration{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists})
+		}
+
 		if v1beta1helper.SystemComponentsAllowed(&worker) {
 			for _, taint := range worker.Taints {
 				toleration := kubernetesutils.TolerationForTaint(taint)

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -733,6 +733,19 @@ var _ = Describe("Shoot", func() {
 			})).To(BeEmpty())
 		})
 
+		It("should return the control plane toleration when the pool is a control plane pool", func() {
+			Expect(ExtractSystemComponentsTolerations([]gardencorev1beta1.Worker{
+				{
+					ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+				},
+			})).To(HaveExactElements(
+				corev1.Toleration{
+					Key:      "node-role.kubernetes.io/control-plane",
+					Operator: corev1.TolerationOpExists,
+				},
+			))
+		})
+
 		It("should return tolerations in order", func() {
 			Expect(ExtractSystemComponentsTolerations([]gardencorev1beta1.Worker{
 				{

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -228,6 +228,9 @@ build:
             - pkg/component/shared
             - pkg/component/shoot/namespaces
             - pkg/component/shoot/system
+            - pkg/controller/networkpolicy
+            - pkg/controller/networkpolicy/helper
+            - pkg/controller/networkpolicy/hostnameresolver
             - pkg/controllerutils
             - pkg/controllerutils/predicate
             - pkg/extensions

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -175,6 +175,14 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 			}).Should(gbytes.Say(`Active: active \(running\)`))
 		}, SpecTimeout(time.Minute))
 
+		It("should ensure that extension webhooks on control plane components are functioning", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) map[string]string {
+				pod := &corev1.Pod{}
+				g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKey{Name: "kube-scheduler-machine-0", Namespace: "kube-system"}, pod)).To(Succeed())
+				return pod.Labels
+			}).Should(HaveKeyWithValue("injected-by", "provider-local"))
+		}, SpecTimeout(time.Minute))
+
 		It("should join as worker node", func(ctx SpecContext) {
 			_, stdErr, err := execute(ctx, 1, "gardenadm", "join")
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -141,14 +141,6 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 			}).Should(HaveKeyWithValue("gardener.cloud/role", "shoot"))
 		}, SpecTimeout(time.Minute))
 
-		It("should ensure the control plane namespace is properly labeled", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) map[string]string {
-				namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
-				g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(namespace), namespace)).To(Succeed())
-				return namespace.Labels
-			}).Should(HaveKeyWithValue("gardener.cloud/role", "shoot"))
-		}, SpecTimeout(time.Minute))
-
 		It("should ensure extensions and gardener-resource-manager run in pod network", func(ctx SpecContext) {
 			By("Check extensions")
 			Eventually(ctx, func(g Gomega) {

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -120,7 +120,7 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				podList := &corev1.PodList{}
 				g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace("kube-system"))).To(Succeed())
 				return podList.Items
-			}).Should(ConsistOf(
+			}).Should(ContainElements(
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-events-0-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-main-0-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-apiserver-machine-0")})}),
@@ -128,6 +128,8 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-scheduler-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("kube-proxy")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("gardener-resource-manager")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("calico")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("coredns")})}),
 			))
 		}, SpecTimeout(time.Minute))
 

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -126,6 +126,7 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-apiserver-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-controller-manager-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-scheduler-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("kube-proxy")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("gardener-resource-manager")})}),
 			))
 		}, SpecTimeout(time.Minute))

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -63,9 +63,7 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 		})
 
 		It("should initialize as control plane node", func(ctx SpecContext) {
-			stdOut, _, err := execute(ctx, 0,
-				"gardenadm", "init", "-d", "/gardenadm/resources",
-			)
+			stdOut, _, err := execute(ctx, 0, "gardenadm", "init", "-d", "/gardenadm/resources")
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(ctx, stdOut).Should(gbytes.Say("Your Shoot cluster control-plane has initialized successfully!"))
@@ -169,10 +167,16 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 			}).Should(Succeed())
 		}, SpecTimeout(time.Minute))
 
+		It("should ensure gardener-node-agent is running", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) *gbytes.Buffer {
+				stdOut, _, err := execute(ctx, 0, "systemctl", "status", "gardener-node-agent")
+				g.Expect(err).NotTo(HaveOccurred())
+				return stdOut
+			}).Should(gbytes.Say(`Active: active \(running\)`))
+		}, SpecTimeout(time.Minute))
+
 		It("should join as worker node", func(ctx SpecContext) {
-			_, stdErr, err := execute(ctx, 1,
-				"gardenadm", "join",
-			)
+			_, stdErr, err := execute(ctx, 1, "gardenadm", "join")
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(ctx, stdErr).Should(gbytes.Say("Not implemented either"))

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -130,6 +130,14 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 			))
 		}, SpecTimeout(time.Minute))
 
+		It("should ensure the control plane namespace is properly labeled", func(ctx SpecContext) {
+			Eventually(ctx, func(g Gomega) map[string]string {
+				namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
+				g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(namespace), namespace)).To(Succeed())
+				return namespace.Labels
+			}).Should(HaveKeyWithValue("gardener.cloud/role", "shoot"))
+		}, SpecTimeout(time.Minute))
+
 		It("should join as worker node", func(ctx SpecContext) {
 			_, stdErr, err := execute(ctx, 1,
 				"gardenadm", "join",

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -130,6 +130,7 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("gardener-resource-manager")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("calico")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("coredns")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("local-path-provisioner")})}),
 			))
 		}, SpecTimeout(time.Minute))
 

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Certificates tests", func() {
 			Expect(webhookOptions.Complete()).To(Succeed())
 			webhookConfig := webhookOptions.Completed()
 			webhookConfig.Clock = fakeClock
-			atomicShootWebhookConfig, err = webhookConfig.AddToManager(ctx, mgr, nil)
+			atomicShootWebhookConfig, err = webhookConfig.AddToManager(ctx, mgr, nil, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			defaultServer, ok = mgr.GetWebhookServer().(*webhook.DefaultServer)
@@ -427,7 +427,7 @@ var _ = Describe("Certificates tests", func() {
 			Expect(webhookOptions.Complete()).To(Succeed())
 			webhookConfig := webhookOptions.Completed()
 			webhookConfig.Clock = fakeClock
-			atomicShootWebhookConfig, err = webhookConfig.AddToManager(ctx, mgr, nil)
+			atomicShootWebhookConfig, err = webhookConfig.AddToManager(ctx, mgr, nil, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			defaultServer, ok = mgr.GetWebhookServer().(*webhook.DefaultServer)

--- a/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
+++ b/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
@@ -181,6 +181,6 @@ func addTestWebhookToManager(mgr manager.Manager) error {
 		return err
 	}
 
-	_, err := addToManagerOptions.Completed().AddToManager(ctx, mgr, nil)
+	_, err := addToManagerOptions.Completed().AddToManager(ctx, mgr, nil, false)
 	return err
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR is the next increment for `gardenadm init`. It deploys `kube-proxy`, the `Network` extension, CoreDNS, the `NetworkPolicy`s, and finally re-deploys `gardener-resource-manager` and extension controllers into the pod network.

In addition, the `ControlPlane` resource is deployed as well as `Deployment`s/`StatefulSet` for the control plane components that have to be translated to static pods. These resources are used to make extension webhooks work (i.e., still allow extensions to modify the control plane components).

Finally, the `gardener-node-agent` systemd unit is activated, and the node is properly tainted with the common `node-role.kubernetes.io/control-plane` taint.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 
~~Still in draft because some unit tests are still missing.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
