### PR TITLE
Prioritize etcd and apiserver request configuration according to minAllowed and reduce minValue request in shoot api

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -877,7 +877,7 @@ func validateETCD(etcd *core.ETCD, fldPath *field.Path) field.ErrorList {
 
 	if etcd != nil {
 		if etcd.Main != nil {
-			allErrs = append(allErrs, ValidateControlPlaneAutoscaling(etcd.Main.Autoscaling, corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("300M")}, fldPath.Child("main", "autoscaling"))...)
+			allErrs = append(allErrs, ValidateControlPlaneAutoscaling(etcd.Main.Autoscaling, corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("150M")}, fldPath.Child("main", "autoscaling"))...)
 		}
 
 		if etcd.Events != nil {

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -964,13 +964,14 @@ func (e *etcd) computeMinAllowedForETCDContainer() corev1.ResourceList {
 }
 
 func (e *etcd) computeETCDContainerResources(minAllowedETCD corev1.ResourceList) *corev1.ResourceRequirements {
-	resourcesETCD := kubernetesutils.MaximumResourcesFromResourceList(
-		corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("300m"),
-			corev1.ResourceMemory: resource.MustParse("1G"),
-		},
-		minAllowedETCD,
-	)
+	resourcesETCD := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("300m"),
+		corev1.ResourceMemory: resource.MustParse("1G"),
+	}
+
+	if len(minAllowedETCD) > 0 {
+		return &corev1.ResourceRequirements{Requests: minAllowedETCD}
+	}
 
 	return &corev1.ResourceRequirements{Requests: resourcesETCD}
 }

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -105,13 +105,15 @@ func (b *Botanist) computeKubeAPIServerAutoscalingConfig() kubeapiserver.Autosca
 
 	return kubeapiserver.AutoscalingConfig{
 		APIServerResources: corev1.ResourceRequirements{
-			Requests: kubernetesutils.MaximumResourcesFromResourceList(
-				corev1.ResourceList{
+			Requests: func() corev1.ResourceList {
+				if len(minAllowed) > 0 {
+					return minAllowed
+				}
+				return corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("250m"),
 					corev1.ResourceMemory: resource.MustParse("500Mi"),
-				},
-				minAllowed,
-			),
+				}
+			}(),
 		},
 		MinReplicas:       minReplicas,
 		MaxReplicas:       maxReplicas,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...
"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Prioritize etcd and apiserver request configuration according to minAllowed and reduce minValue request in shoot api to optimize the resources for the shoot controlplane for different shoot cluster sizes.

**Which issue(s) this PR fixes**:
Fixes #11885 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
