### PR TITLE
[GEP-30] Promote feature gate `RemoveAPIServerProxyLegacyPort` to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -30,8 +30,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | NodeAgentAuthorizer                      | `true`  | `Beta`  | `1.116` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
-| RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` | `1.117` |
-| RemoveAPIServerProxyLegacyPort           | `true`  | `Beta`  | `1.118` |         |
+| RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` | `1.118` |
+| RemoveAPIServerProxyLegacyPort           | `true`  | `Beta`  | `1.119` |         |
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
 
 ## Feature Gates for Graduated or Deprecated Features

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -30,7 +30,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | NodeAgentAuthorizer                      | `true`  | `Beta`  | `1.116` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
-| RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` |         |
+| RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` | `1.117` |
+| RemoveAPIServerProxyLegacyPort           | `true`  | `Beta`  | `1.118` |         |
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
 
 ## Feature Gates for Graduated or Deprecated Features

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -39,7 +39,6 @@ config:
     DefaultSeccompProfile: true
     NewWorkerPoolHash: true
     IstioTLSTermination: true
-    RemoveAPIServerProxyLegacyPort: true
   logging:
     enabled: true
     vali:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -87,7 +87,7 @@ const (
 	// proxy protocol headers of untrusted clients on the apiserver-proxy port.
 	// owner: @Wieneo @timebertt
 	// alpha: v1.113.0
-	// beta: v1.118.0
+	// beta: v1.119.0
 	RemoveAPIServerProxyLegacyPort featuregate.Feature = "RemoveAPIServerProxyLegacyPort"
 
 	// IstioTLSTermination enables TLS termination for the Istio Ingress Gateway instead of TLS termination at the kube-apiserver.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -87,6 +87,7 @@ const (
 	// proxy protocol headers of untrusted clients on the apiserver-proxy port.
 	// owner: @Wieneo @timebertt
 	// alpha: v1.113.0
+	// beta: v1.118.0
 	RemoveAPIServerProxyLegacyPort featuregate.Feature = "RemoveAPIServerProxyLegacyPort"
 
 	// IstioTLSTermination enables TLS termination for the Istio Ingress Gateway instead of TLS termination at the kube-apiserver.
@@ -130,7 +131,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	NodeAgentAuthorizer:                      {Default: true, PreRelease: featuregate.Beta},
 	CredentialsRotationWithoutWorkersRollout: {Default: false, PreRelease: featuregate.Alpha},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},
-	RemoveAPIServerProxyLegacyPort:           {Default: false, PreRelease: featuregate.Alpha},
+	RemoveAPIServerProxyLegacyPort:           {Default: true, PreRelease: featuregate.Beta},
 	IstioTLSTermination:                      {Default: false, PreRelease: featuregate.Alpha},
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR promotes the mentioned feature gate back to beta.
We had to roll back https://github.com/gardener/gardener/pull/11734 as it caused problems with the SAP Gardener landscapes.

Since then, we improved the feature gate validation (https://github.com/gardener/gardener/pull/11874) and discussed how we handle shoots with permanent errors.

@ialidzhikov you can just merge this PR once your landscapes are ready :)

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `RemoveAPIServerProxyLegacyPort` feature gate has been promoted to beta and is now turned on by default.
```
