### PR TITLE
Switch to manage resource for kube-scheduler components

### DIFF
--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -47,10 +47,10 @@ const (
 	// scheduling profile is configured.
 	BinPackingSchedulerName = "bin-packing-scheduler"
 
-	serviceName             = "kube-scheduler"
-	secretNameServer        = "kube-scheduler-server" // #nosec G101 -- No credential.
-	managedResourceName     = "shoot-core-kube-scheduler"
-	seedManagedResourceName = "seed-core-kube-scheduler"
+	serviceName              = "kube-scheduler"
+	secretNameServer         = "kube-scheduler-server" // #nosec G101 -- No credential.
+	shootManagedResourceName = "shoot-core-kube-scheduler"
+	seedManagedResourceName  = "seed-core-kube-scheduler"
 
 	containerName   = v1beta1constants.DeploymentNameKubeScheduler
 	portNameMetrics = "metrics"
@@ -593,7 +593,7 @@ func (k *kubeScheduler) reconcileShootResources(ctx context.Context, serviceAcco
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, k.client, k.namespace, managedResourceName, managedresources.LabelValueGardener, false, data)
+	return managedresources.CreateForShoot(ctx, k.client, k.namespace, shootManagedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (k *kubeScheduler) computeEnvironmentVariables() []corev1.EnvVar {

--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -149,30 +149,6 @@ func (k *kubeScheduler) Destroy(_ context.Context) error     { return nil }
 func (k *kubeScheduler) Wait(_ context.Context) error        { return nil }
 func (k *kubeScheduler) WaitCleanup(_ context.Context) error { return nil }
 
-func (k *kubeScheduler) emptyVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
-	return &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "kube-scheduler-vpa", Namespace: k.namespace}}
-}
-
-func (k *kubeScheduler) emptyPodDisruptionBudget() *policyv1.PodDisruptionBudget {
-	return &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler, Namespace: k.namespace}}
-}
-
-func (k *kubeScheduler) emptyService() *corev1.Service {
-	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: k.namespace}}
-}
-
-func (k *kubeScheduler) emptyPrometheusRule() *monitoringv1.PrometheusRule {
-	return &monitoringv1.PrometheusRule{ObjectMeta: monitoringutils.ConfigObjectMeta(v1beta1constants.DeploymentNameKubeScheduler, k.namespace, shoot.Label)}
-}
-
-func (k *kubeScheduler) emptyServiceMonitor() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{ObjectMeta: monitoringutils.ConfigObjectMeta(v1beta1constants.DeploymentNameKubeScheduler, k.namespace, shoot.Label)}
-}
-
-func (k *kubeScheduler) emptyDeployment() *appsv1.Deployment {
-	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler, Namespace: k.namespace}}
-}
-
 func (k *kubeScheduler) newShootAccessSecret() *gardenerutils.AccessSecret {
 	return gardenerutils.NewShootAccessSecret(v1beta1constants.DeploymentNameKubeScheduler, k.namespace)
 }

--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -33,7 +33,6 @@ import (
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -48,9 +47,10 @@ const (
 	// scheduling profile is configured.
 	BinPackingSchedulerName = "bin-packing-scheduler"
 
-	serviceName         = "kube-scheduler"
-	secretNameServer    = "kube-scheduler-server" // #nosec G101 -- No credential.
-	managedResourceName = "shoot-core-kube-scheduler"
+	serviceName             = "kube-scheduler"
+	secretNameServer        = "kube-scheduler-server" // #nosec G101 -- No credential.
+	managedResourceName     = "shoot-core-kube-scheduler"
+	seedManagedResourceName = "seed-core-kube-scheduler"
 
 	containerName   = v1beta1constants.DeploymentNameKubeScheduler
 	portNameMetrics = "metrics"
@@ -118,359 +118,21 @@ type kubeScheduler struct {
 }
 
 func (k *kubeScheduler) Deploy(ctx context.Context) error {
-	serverSecret, err := k.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
-		Name:                        secretNameServer,
-		CommonName:                  v1beta1constants.DeploymentNameKubeScheduler,
-		DNSNames:                    kubernetesutils.DNSNamesForService(serviceName, k.namespace),
-		CertType:                    secrets.ServerCert,
-		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return err
-	}
-
-	genericTokenKubeconfigSecret, found := k.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
-	if !found {
-		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
-	}
-
-	clientCASecret, found := k.secretsManager.Get(v1beta1constants.SecretNameCAClient)
-	if !found {
-		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAClient)
-	}
-
-	componentConfigYAML, err := k.computeComponentConfig()
-	if err != nil {
-		return err
-	}
-
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-scheduler-config",
-			Namespace: k.namespace,
-		},
-		Data: map[string]string{dataKeyComponentConfig: componentConfigYAML},
-	}
-	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
-
 	var (
-		vpa                 = k.emptyVPA()
-		service             = k.emptyService()
-		shootAccessSecret   = k.newShootAccessSecret()
-		deployment          = k.emptyDeployment()
-		podDisruptionBudget = k.emptyPodDisruptionBudget()
-		serviceMonitor      = k.emptyServiceMonitor()
-		prometheusRule      = k.emptyPrometheusRule()
-
-		port           int32 = 10259
-		probeURIScheme       = corev1.URISchemeHTTPS
-		env                  = k.computeEnvironmentVariables()
-		command              = k.computeCommand(port)
+		shootAccessSecret = k.newShootAccessSecret()
 	)
-
-	if err := k.client.Create(ctx, configMap); client.IgnoreAlreadyExists(err) != nil {
-		return err
-	}
-
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client, service, func() error {
-		service.Labels = getLabels()
-
-		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, networkingv1.NetworkPolicyPort{
-			Port:     ptr.To(intstr.FromInt32(port)),
-			Protocol: ptr.To(corev1.ProtocolTCP),
-		}))
-
-		service.Spec.Selector = getLabels()
-		service.Spec.Type = corev1.ServiceTypeClusterIP
-		desiredPorts := []corev1.ServicePort{{
-			Name:     portNameMetrics,
-			Protocol: corev1.ProtocolTCP,
-			Port:     port,
-		}}
-		service.Spec.Ports = kubernetesutils.ReconcileServicePorts(service.Spec.Ports, desiredPorts, corev1.ServiceTypeClusterIP)
-
-		return nil
-	}); err != nil {
-		return err
-	}
 
 	if err := shootAccessSecret.Reconcile(ctx, k.client); err != nil {
 		return err
 	}
 
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client, deployment, func() error {
-		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
-			v1beta1constants.GardenRole:                                         v1beta1constants.GardenRoleControlPlane,
-			resourcesv1alpha1.HighAvailabilityConfigType:                        resourcesv1alpha1.HighAvailabilityConfigTypeController,
-			v1beta1constants.LabelExtensionProviderMutatedByControlplaneWebhook: "true",
-		})
-		deployment.Spec.Replicas = &k.replicas
-		deployment.Spec.RevisionHistoryLimit = ptr.To[int32](1)
-		deployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: getLabels()}
-		deployment.Spec.Template = corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
-					v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleControlPlane,
-					v1beta1constants.LabelPodMaintenanceRestart: "true",
-					v1beta1constants.LabelNetworkPolicyToDNS:    v1beta1constants.LabelNetworkPolicyAllowed,
-					gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
-				}),
-			},
-			Spec: corev1.PodSpec{
-				AutomountServiceAccountToken: ptr.To(false),
-				SecurityContext: &corev1.PodSecurityContext{
-					// use the nonroot user from a distroless container
-					// https://github.com/GoogleContainerTools/distroless/blob/1a8918fcaa7313fd02ae08089a57a701faea999c/base/base.bzl#L8
-					RunAsNonRoot: ptr.To(true),
-					RunAsUser:    ptr.To[int64](65532),
-					RunAsGroup:   ptr.To[int64](65532),
-					FSGroup:      ptr.To[int64](65532),
-				},
-				Containers: []corev1.Container{
-					{
-						Name:            containerName,
-						Image:           k.image,
-						ImagePullPolicy: corev1.PullIfNotPresent,
-						Command:         command,
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/healthz",
-									Scheme: probeURIScheme,
-									Port:   intstr.FromInt32(port),
-								},
-							},
-							SuccessThreshold:    1,
-							FailureThreshold:    2,
-							InitialDelaySeconds: 15,
-							PeriodSeconds:       10,
-							TimeoutSeconds:      15,
-						},
-						Ports: []corev1.ContainerPort{
-							{
-								Name:          portNameMetrics,
-								ContainerPort: port,
-								Protocol:      corev1.ProtocolTCP,
-							},
-						},
-						Env: env,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("5m"),
-								corev1.ResourceMemory: resource.MustParse("30M"),
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: ptr.To(false),
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      volumeNameClientCA,
-								MountPath: volumeMountPathClientCA,
-							},
-							{
-								Name:      volumeNameServer,
-								MountPath: volumeMountPathServer,
-							},
-							{
-								Name:      volumeNameConfig,
-								MountPath: volumeMountPathConfig,
-							},
-						},
-					},
-				},
-				PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane300,
-				Volumes: []corev1.Volume{
-					{
-						Name: volumeNameClientCA,
-						VolumeSource: corev1.VolumeSource{
-							Projected: &corev1.ProjectedVolumeSource{
-								DefaultMode: ptr.To[int32](420),
-								Sources: []corev1.VolumeProjection{
-									{
-										Secret: &corev1.SecretProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: clientCASecret.Name,
-											},
-											Items: []corev1.KeyToPath{{
-												Key:  secrets.DataKeyCertificateBundle,
-												Path: fileNameClientCA,
-											}},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Name: volumeNameServer,
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName:  serverSecret.Name,
-								DefaultMode: ptr.To[int32](0640),
-							},
-						},
-					},
-					{
-						Name: volumeNameConfig,
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: configMap.Name,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		utilruntime.Must(gardenerutils.InjectGenericKubeconfig(deployment, genericTokenKubeconfigSecret.Name, shootAccessSecret.Secret.Name))
-		utilruntime.Must(references.InjectAnnotations(deployment))
-		return nil
-	}); err != nil {
-		return err
+	data, err := k.computeSeedResourceData(ctx, shootAccessSecret.Secret.Name)
+	if err != nil {
+		return fmt.Errorf("failed to compute seed resource: %w", err)
 	}
 
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client, podDisruptionBudget, func() error {
-		podDisruptionBudget.Labels = getLabels()
-		podDisruptionBudget.Spec = policyv1.PodDisruptionBudgetSpec{
-			MaxUnavailable:             ptr.To(intstr.FromInt32(1)),
-			Selector:                   deployment.Spec.Selector,
-			UnhealthyPodEvictionPolicy: ptr.To(policyv1.AlwaysAllow),
-		}
-
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client, vpa, func() error {
-		vpa.Spec.TargetRef = &autoscalingv1.CrossVersionObjectReference{
-			APIVersion: appsv1.SchemeGroupVersion.String(),
-			Kind:       "Deployment",
-			Name:       v1beta1constants.DeploymentNameKubeScheduler,
-		}
-		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{
-			UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
-		}
-		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
-			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-				ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
-				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-			}},
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client, prometheusRule, func() error {
-		metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", shoot.Label)
-		prometheusRule.Spec = monitoringv1.PrometheusRuleSpec{
-			Groups: []monitoringv1.RuleGroup{{
-				Name: "kube-scheduler.rules",
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "KubeSchedulerDown",
-						Expr:  intstr.FromString(`absent(up{job="kube-scheduler"} == 1)`),
-						For:   ptr.To(monitoringv1.Duration("15m")),
-						Labels: map[string]string{
-							"service":    v1beta1constants.DeploymentNameKubeScheduler,
-							"severity":   "critical",
-							"type":       "seed",
-							"visibility": "all",
-						},
-						Annotations: map[string]string{
-							"summary":     "Kube Scheduler is down.",
-							"description": "New pods are not being assigned to nodes.",
-						},
-					},
-					// Scheduling duration
-					{
-						Record: "cluster:scheduler_e2e_scheduling_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.99, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.99"},
-					},
-					{
-						Record: "cluster:scheduler_e2e_scheduling_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.9, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.9"},
-					},
-					{
-						Record: "cluster:scheduler_e2e_scheduling_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.5, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.5"},
-					},
-					{
-						Record: "cluster:scheduler_scheduling_algorithm_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.99, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.99"},
-					},
-					{
-						Record: "cluster:scheduler_scheduling_algorithm_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.9, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.9"},
-					},
-					{
-						Record: "cluster:scheduler_scheduling_algorithm_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.5, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.5"},
-					},
-					{
-						Record: "cluster:scheduler_binding_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.99, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.99"},
-					},
-					{
-						Record: "cluster:scheduler_binding_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.9, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.9"},
-					},
-					{
-						Record: "cluster:scheduler_binding_duration_seconds:quantile",
-						Expr:   intstr.FromString(`histogram_quantile(0.5, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))`),
-						Labels: map[string]string{"quantile": "0.5"},
-					},
-				},
-			}},
-		}
-
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client, serviceMonitor, func() error {
-		metav1.SetMetaDataLabel(&serviceMonitor.ObjectMeta, "prometheus", shoot.Label)
-		serviceMonitor.Spec = monitoringv1.ServiceMonitorSpec{
-			Selector: metav1.LabelSelector{MatchLabels: getLabels()},
-			Endpoints: []monitoringv1.Endpoint{{
-				Port:      portNameMetrics,
-				Scheme:    "https",
-				TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
-				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: shoot.AccessSecretName},
-					Key:                  resourcesv1alpha1.DataKeyToken,
-				}},
-				RelabelConfigs: []monitoringv1.RelabelConfig{{
-					Action: "labelmap",
-					Regex:  `__meta_kubernetes_service_label_(.+)`,
-				}},
-				MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
-					"scheduler_binding_duration_seconds_bucket",
-					"scheduler_e2e_scheduling_duration_seconds_bucket",
-					"scheduler_scheduling_algorithm_duration_seconds_bucket",
-					"rest_client_requests_total",
-					"process_max_fds",
-					"process_open_fds",
-				),
-			}},
-		}
-
-		return nil
-	}); err != nil {
-		return err
+	if err := managedresources.CreateForSeed(ctx, k.client, k.namespace, seedManagedResourceName, false, data); err != nil {
+		return fmt.Errorf("failed to create kube-scheduler objects for seed: %w", err)
 	}
 
 	return k.reconcileShootResources(ctx, shootAccessSecret.ServiceAccountName)
@@ -513,6 +175,381 @@ func (k *kubeScheduler) emptyDeployment() *appsv1.Deployment {
 
 func (k *kubeScheduler) newShootAccessSecret() *gardenerutils.AccessSecret {
 	return gardenerutils.NewShootAccessSecret(v1beta1constants.DeploymentNameKubeScheduler, k.namespace)
+}
+
+func (k *kubeScheduler) computeSeedResourceData(ctx context.Context, shootAccessSecretName string) (map[string][]byte, error) {
+	var registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+
+	componentConfigYAML, err := k.computeComponentConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		configMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kube-scheduler-config",
+				Namespace: k.namespace,
+			},
+			Data: map[string]string{dataKeyComponentConfig: componentConfigYAML},
+		}
+	)
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+
+	serverSecret, err := k.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
+		Name:                        secretNameServer,
+		CommonName:                  v1beta1constants.DeploymentNameKubeScheduler,
+		DNSNames:                    kubernetesutils.DNSNamesForService(serviceName, k.namespace),
+		CertType:                    secrets.ServerCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster), secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, err
+	}
+
+	genericTokenKubeconfigSecret, found := k.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
+	if !found {
+		return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
+	}
+
+	clientCASecret, found := k.secretsManager.Get(v1beta1constants.SecretNameCAClient)
+	if !found {
+		return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAClient)
+	}
+
+	var (
+		port           int32 = 10259
+		probeURIScheme       = corev1.URISchemeHTTPS
+		env                  = k.computeEnvironmentVariables()
+		command              = k.computeCommand(port)
+	)
+
+	// Service Resource
+	var (
+		service = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        serviceName,
+				Namespace:   k.namespace,
+				Labels:      getLabels(),
+				Annotations: map[string]string{},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: getLabels(),
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+		}
+	)
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(port)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}))
+	desiredPorts := []corev1.ServicePort{{
+		Name:     portNameMetrics,
+		Protocol: corev1.ProtocolTCP,
+		Port:     port,
+	}}
+	service.Spec.Ports = kubernetesutils.ReconcileServicePorts(service.Spec.Ports, desiredPorts, corev1.ServiceTypeClusterIP)
+
+	// Deployment Resource
+	var (
+		deployment = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      v1beta1constants.DeploymentNameKubeScheduler,
+				Namespace: k.namespace,
+				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+					v1beta1constants.GardenRole:                                         v1beta1constants.GardenRoleControlPlane,
+					resourcesv1alpha1.HighAvailabilityConfigType:                        resourcesv1alpha1.HighAvailabilityConfigTypeController,
+					v1beta1constants.LabelExtensionProviderMutatedByControlplaneWebhook: "true",
+				}),
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas:             &k.replicas,
+				RevisionHistoryLimit: ptr.To[int32](1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: getLabels(),
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+							v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleControlPlane,
+							v1beta1constants.LabelPodMaintenanceRestart: "true",
+							v1beta1constants.LabelNetworkPolicyToDNS:    v1beta1constants.LabelNetworkPolicyAllowed,
+							gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						}),
+					},
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: ptr.To(false),
+						SecurityContext: &corev1.PodSecurityContext{
+							// use the nonroot user from a distroless container
+							// https://github.com/GoogleContainerTools/distroless/blob/1a8918fcaa7313fd02ae08089a57a701faea999c/base/base.bzl#L8
+							RunAsNonRoot: ptr.To(true),
+							RunAsUser:    ptr.To[int64](65532),
+							RunAsGroup:   ptr.To[int64](65532),
+							FSGroup:      ptr.To[int64](65532),
+						},
+						Containers: []corev1.Container{
+							{
+								Name:            containerName,
+								Image:           k.image,
+								ImagePullPolicy: corev1.PullIfNotPresent,
+								Command:         command,
+								LivenessProbe: &corev1.Probe{
+									ProbeHandler: corev1.ProbeHandler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Path:   "/healthz",
+											Scheme: probeURIScheme,
+											Port:   intstr.FromInt32(port),
+										},
+									},
+									SuccessThreshold:    1,
+									FailureThreshold:    2,
+									InitialDelaySeconds: 15,
+									PeriodSeconds:       10,
+									TimeoutSeconds:      15,
+								},
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          portNameMetrics,
+										ContainerPort: port,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+								Env: env,
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("5m"),
+										corev1.ResourceMemory: resource.MustParse("30M"),
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptr.To(false),
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      volumeNameClientCA,
+										MountPath: volumeMountPathClientCA,
+									},
+									{
+										Name:      volumeNameServer,
+										MountPath: volumeMountPathServer,
+									},
+									{
+										Name:      volumeNameConfig,
+										MountPath: volumeMountPathConfig,
+									},
+								},
+							},
+						},
+						PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane300,
+						Volumes: []corev1.Volume{
+							{
+								Name: volumeNameClientCA,
+								VolumeSource: corev1.VolumeSource{
+									Projected: &corev1.ProjectedVolumeSource{
+										DefaultMode: ptr.To[int32](420),
+										Sources: []corev1.VolumeProjection{
+											{
+												Secret: &corev1.SecretProjection{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: clientCASecret.Name,
+													},
+													Items: []corev1.KeyToPath{{
+														Key:  secrets.DataKeyCertificateBundle,
+														Path: fileNameClientCA,
+													}},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: volumeNameServer,
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName:  serverSecret.Name,
+										DefaultMode: ptr.To[int32](0640),
+									},
+								},
+							},
+							{
+								Name: volumeNameConfig,
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: configMap.Name,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	)
+	utilruntime.Must(gardenerutils.InjectGenericKubeconfig(deployment, genericTokenKubeconfigSecret.Name, shootAccessSecretName))
+	utilruntime.Must(references.InjectAnnotations(deployment))
+
+	// Pod Disruption Budget
+	var (
+		podDisruptionBudget = &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      v1beta1constants.DeploymentNameKubeScheduler,
+				Namespace: k.namespace,
+				Labels:    getLabels(),
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MaxUnavailable:             ptr.To(intstr.FromInt32(1)),
+				Selector:                   deployment.Spec.Selector,
+				UnhealthyPodEvictionPolicy: ptr.To(policyv1.AlwaysAllow),
+			},
+		}
+	)
+
+	// Vertical Pod Autoscaler
+	var (
+		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kube-scheduler-vpa",
+				Namespace: k.namespace,
+			},
+			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+				TargetRef: &autoscalingv1.CrossVersionObjectReference{
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+					Kind:       "Deployment",
+					Name:       v1beta1constants.DeploymentNameKubeScheduler,
+				},
+				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+					UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
+				},
+				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+						ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					}},
+				},
+			},
+		}
+	)
+
+	// Prometheus Rule and ServiceMonitor
+	var (
+		prometheusRule = &monitoringv1.PrometheusRule{
+			ObjectMeta: monitoringutils.ConfigObjectMeta(v1beta1constants.DeploymentNameKubeScheduler, k.namespace, shoot.Label),
+			Spec: monitoringv1.PrometheusRuleSpec{
+				Groups: []monitoringv1.RuleGroup{{
+					Name: "kube-scheduler.rules",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "KubeSchedulerDown",
+							Expr:  intstr.FromString(`absent(up{job="kube-scheduler"} == 1)`),
+							For:   ptr.To(monitoringv1.Duration("15m")),
+							Labels: map[string]string{
+								"service":    v1beta1constants.DeploymentNameKubeScheduler,
+								"severity":   "critical",
+								"type":       "seed",
+								"visibility": "all",
+							},
+							Annotations: map[string]string{
+								"summary":     "Kube Scheduler is down.",
+								"description": "New pods are not being assigned to nodes.",
+							},
+						},
+						// Scheduling duration
+						{
+							Record: "cluster:scheduler_e2e_scheduling_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.99, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.99"},
+						},
+						{
+							Record: "cluster:scheduler_e2e_scheduling_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.9, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.9"},
+						},
+						{
+							Record: "cluster:scheduler_e2e_scheduling_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.5, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.5"},
+						},
+						{
+							Record: "cluster:scheduler_scheduling_algorithm_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.99, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.99"},
+						},
+						{
+							Record: "cluster:scheduler_scheduling_algorithm_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.9, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.9"},
+						},
+						{
+							Record: "cluster:scheduler_scheduling_algorithm_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.5, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.5"},
+						},
+						{
+							Record: "cluster:scheduler_binding_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.99, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.99"},
+						},
+						{
+							Record: "cluster:scheduler_binding_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.9, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.9"},
+						},
+						{
+							Record: "cluster:scheduler_binding_duration_seconds:quantile",
+							Expr:   intstr.FromString(`histogram_quantile(0.5, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))`),
+							Labels: map[string]string{"quantile": "0.5"},
+						},
+					},
+				}},
+			},
+		}
+	)
+	metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", shoot.Label)
+
+	// Service Monitor
+	var (
+		serviceMonitor = &monitoringv1.ServiceMonitor{
+			ObjectMeta: monitoringutils.ConfigObjectMeta(v1beta1constants.DeploymentNameKubeScheduler, k.namespace, shoot.Label),
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Selector: metav1.LabelSelector{MatchLabels: getLabels()},
+				Endpoints: []monitoringv1.Endpoint{{
+					Port:      portNameMetrics,
+					Scheme:    "https",
+					TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
+					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: shoot.AccessSecretName},
+						Key:                  resourcesv1alpha1.DataKeyToken,
+					}},
+					RelabelConfigs: []monitoringv1.RelabelConfig{{
+						Action: "labelmap",
+						Regex:  `__meta_kubernetes_service_label_(.+)`,
+					}},
+					MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig(
+						"scheduler_binding_duration_seconds_bucket",
+						"scheduler_e2e_scheduling_duration_seconds_bucket",
+						"scheduler_scheduling_algorithm_duration_seconds_bucket",
+						"rest_client_requests_total",
+						"process_max_fds",
+						"process_open_fds",
+					),
+				}},
+			},
+		}
+	)
+	metav1.SetMetaDataLabel(&serviceMonitor.ObjectMeta, "prometheus", shoot.Label)
+
+	return registry.AddAllAndSerialize(
+		configMap,
+		service,
+		deployment,
+		podDisruptionBudget,
+		vpa,
+		prometheusRule,
+		serviceMonitor,
+	)
 }
 
 func (k *kubeScheduler) reconcileShootResources(ctx context.Context, serviceAccountName string) error {

--- a/pkg/component/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/component/kubernetes/scheduler/scheduler_test.go
@@ -514,7 +514,7 @@ var _ = Describe("KubeScheduler", func() {
 		var expectedObjects []client.Object
 
 		DescribeTable("success tests for shoot w and w/o config",
-			func(config *gardencorev1beta1.KubeSchedulerConfig, expectedComponentConfigFilePath string) {
+			func(config *gardencorev1beta1.KubeSchedulerConfig, _ string) {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceShoot), managedResourceShoot)).To(BeNotFoundError())
 
 				kubeScheduler = New(c, namespace, sm, image, replicas, config)

--- a/pkg/component/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/component/kubernetes/scheduler/scheduler_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/kubernetes/scheduler"
-	//componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -68,13 +67,11 @@ var _ = Describe("KubeScheduler", func() {
 		genericTokenKubeconfigSecretName = "generic-token-kubeconfig"
 		vpaName                          = "kube-scheduler-vpa"
 		pdbName                          = "kube-scheduler"
-		//prometheusRuleName               = "shoot-kube-scheduler"
-		//serviceMonitorName               = "shoot-kube-scheduler"
-		serviceName             = "kube-scheduler"
-		secretName              = "shoot-access-kube-scheduler"
-		deploymentName          = "kube-scheduler"
-		managedResourceName     = "shoot-core-kube-scheduler"
-		seedManagedResourceName = "seed-core-kube-scheduler"
+		serviceName                      = "kube-scheduler"
+		secretName                       = "shoot-access-kube-scheduler"
+		deploymentName                   = "kube-scheduler"
+		managedResourceName              = "shoot-core-kube-scheduler"
+		seedManagedResourceName          = "seed-core-kube-scheduler"
 
 		managedResourceShoot *resourcesv1alpha1.ManagedResource
 		managedResourceSeed  *resourcesv1alpha1.ManagedResource
@@ -90,7 +87,6 @@ var _ = Describe("KubeScheduler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kube-scheduler-config",
 					Namespace: namespace,
-					//ResourceVersion: "1",
 				},
 				Data: map[string]string{"config.yaml": componentConfigYAML},
 			}
@@ -123,7 +119,6 @@ var _ = Describe("KubeScheduler", func() {
 					"app":  "kubernetes",
 					"role": "scheduler",
 				},
-				//ResourceVersion: "1",
 			},
 			Spec: policyv1.PodDisruptionBudgetSpec{
 				MaxUnavailable: &pdbMaxUnavailable,
@@ -141,7 +136,6 @@ var _ = Describe("KubeScheduler", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      vpaName,
 				Namespace: namespace,
-				//ResourceVersion: "1",
 			},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 				TargetRef: &autoscalingv1.CrossVersionObjectReference{
@@ -171,7 +165,6 @@ var _ = Describe("KubeScheduler", func() {
 				Annotations: map[string]string{
 					"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":10259}]`,
 				},
-				//ResourceVersion: "1",
 			},
 			Spec: corev1.ServiceSpec{
 				Selector: map[string]string{
@@ -210,7 +203,6 @@ var _ = Describe("KubeScheduler", func() {
 						"high-availability-config.resources.gardener.cloud/type":             "controller",
 						"provider.extensions.gardener.cloud/mutated-by-controlplane-webhook": "true",
 					},
-					//ResourceVersion: "1",
 				},
 				Spec: appsv1.DeploymentSpec{
 					RevisionHistoryLimit: ptr.To[int32](1),
@@ -351,7 +343,6 @@ var _ = Describe("KubeScheduler", func() {
 				Name:      "shoot-kube-scheduler",
 				Namespace: namespace,
 				Labels:    map[string]string{"prometheus": "shoot"},
-				//ResourceVersion: "1",
 			},
 			Spec: monitoringv1.PrometheusRuleSpec{
 				Groups: []monitoringv1.RuleGroup{{
@@ -426,7 +417,6 @@ var _ = Describe("KubeScheduler", func() {
 				Name:      "shoot-kube-scheduler",
 				Namespace: namespace,
 				Labels:    map[string]string{"prometheus": "shoot"},
-				//ResourceVersion: "1",
 			},
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
@@ -609,69 +599,6 @@ var _ = Describe("KubeScheduler", func() {
 				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 				Expect(managedResourceSeed).To(consistOf(expectedObjects...))
-
-				//actualConfigMap := &corev1.ConfigMap{
-				//	ObjectMeta: metav1.ObjectMeta{
-				//		Name:      expectedConfigMap.Name,
-				//		Namespace: namespace,
-				//	},
-				//}
-				//Expect(c.Get(ctx, client.ObjectKeyFromObject(actualConfigMap), actualConfigMap)).To(Succeed())
-				//Expect(managedResourceSeed).To(consistOf(expectedConfigMap))
-				//Expect(actualConfigMap).To(DeepEqual(expectedConfigMap))
-
-				//actualDeployment := &appsv1.Deployment{
-				//	ObjectMeta: metav1.ObjectMeta{
-				//		Name:      deploymentName,
-				//		Namespace: namespace,
-				//	},
-				//}
-				//Expect(c.Get(ctx, client.ObjectKeyFromObject(actualDeployment), actualDeployment)).To(Succeed())
-				//Expect(actualDeployment).To(DeepEqual(deploymentFor(config, expectedComponentConfigFilePath)))
-
-				//actualVPA := &vpaautoscalingv1.VerticalPodAutoscaler{
-				//	ObjectMeta: metav1.ObjectMeta{Name: vpaName, Namespace: namespace},
-				//}
-				//Expect(c.Get(ctx, client.ObjectKeyFromObject(actualVPA), actualVPA)).To(Succeed())
-				//Expect(actualVPA).To(DeepEqual(vpa))
-
-				//actualService := &corev1.Service{
-				//	ObjectMeta: metav1.ObjectMeta{
-				//		Name:      serviceName,
-				//		Namespace: namespace,
-				//	},
-				//}
-				//Expect(c.Get(ctx, client.ObjectKeyFromObject(actualService), actualService)).To(Succeed())
-				//Expect(actualService).To(DeepEqual(service))
-
-				//actualPDB := &policyv1.PodDisruptionBudget{
-				//	ObjectMeta: metav1.ObjectMeta{
-				//		Name:      pdbName,
-				//		Namespace: namespace,
-				//	},
-				//}
-				//Expect(c.Get(ctx, client.ObjectKeyFromObject(actualPDB), actualPDB)).To(Succeed())
-				//Expect(actualPDB).To(DeepEqual(pdb))
-
-				//actualPrometheusRule := &monitoringv1.PrometheusRule{
-				//	ObjectMeta: metav1.ObjectMeta{
-				//		Name:      prometheusRuleName,
-				//		Namespace: namespace,
-				//	},
-				//}
-				//Expect(c.Get(ctx, client.ObjectKeyFromObject(actualPrometheusRule), actualPrometheusRule)).To(Succeed())
-				//Expect(actualPrometheusRule).To(DeepEqual(prometheusRule))
-
-				//componenttest.PrometheusRule(prometheusRule, "testdata/shoot-kube-scheduler.prometheusrule.test.yaml")
-
-				//actualServiceMonitor := &monitoringv1.ServiceMonitor{
-				//	ObjectMeta: metav1.ObjectMeta{
-				//		Name:      serviceMonitorName,
-				//		Namespace: namespace,
-				//	},
-				//}
-				//Expect(c.Get(ctx, client.ObjectKeyFromObject(actualServiceMonitor), actualServiceMonitor)).To(Succeed())
-				//Expect(actualServiceMonitor).To(DeepEqual(serviceMonitor))
 			},
 
 			Entry("w/o config", configEmpty, "testdata/component-config.yaml"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement


**What this PR does / why we need it**:
Switch to managed resources while creating controlplane component instead of kubernetes client.

**Which issue(s) this PR fixes**:
Part of #8241 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       other
- target_group:   user
-->
```other operator

```
