### PR TITLE
Deflake `node-agent` integration test

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -288,7 +288,7 @@ PRETTY_NAME="Garden Linux 1592"
 				return []byte("network problems"), errors.New("command failed")
 			}))
 
-			Expect(reconciler.updateOSInPlace(ctx, log, oscChanges, osc, node)).To(Succeed())
+			Expect(reconciler.updateOSInPlace(ctx, log, oscChanges, osc, node)).To(MatchError(ContainSubstring("retriable error detected: command failed, output: network problems")))
 
 			Expect(reconciler.Client.Get(ctx, client.ObjectKey{Name: node.Name}, node)).To(Succeed())
 			Expect(node.Annotations).To(HaveKeyWithValue("node-agent.gardener.cloud/updating-operating-system-version", "1.2.3"))
@@ -301,7 +301,7 @@ PRETTY_NAME="Garden Linux 1592"
 				return []byte("invalid arguments"), errors.New("command failed")
 			}))
 
-			Expect(reconciler.updateOSInPlace(ctx, log, oscChanges, osc, node)).To(Succeed())
+			Expect(reconciler.updateOSInPlace(ctx, log, oscChanges, osc, node)).To(MatchError(ContainSubstring("non-retriable error detected: command failed, output: invalid arguments")))
 
 			Expect(reconciler.Client.Get(ctx, client.ObjectKey{Name: node.Name}, node)).To(Succeed())
 			Expect(node.Annotations).To(HaveKeyWithValue("node-agent.gardener.cloud/updating-operating-system-version", "1.2.3"))

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_suite_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_suite_test.go
@@ -45,6 +45,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *envtest.Environment
 	testClient client.Client
+	mgrClient  client.Client
 
 	testRunID = "test-" + gardenerutils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 )

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -104,6 +104,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(indexer.AddPodNodeName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+		mgrClient = mgr.GetClient()
 
 		node = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -439,7 +440,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 	})
 
 	It("should reconcile the configuration when there is no previous OSC", func() {
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that files and units have been created")
@@ -531,7 +532,7 @@ units: {}
 	})
 
 	It("should reconcile only parts of the configuration that were not applied yet", func() {
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
@@ -551,7 +552,7 @@ units: {}
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that unit actions have been applied")
@@ -569,7 +570,7 @@ units: {}
 	})
 
 	It("should reconcile the configuration when there is a previous OSC", func() {
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
@@ -618,7 +619,7 @@ units: {}
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that files and units have been created")
@@ -683,7 +684,7 @@ units: {}
 	})
 
 	It("should reconcile the configuration when the containerd registries change", func() {
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
@@ -702,7 +703,7 @@ units: {}
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that files and directories have been created")
@@ -724,7 +725,7 @@ units: {}
 	})
 
 	It("should reconcile the configuration when the containerd plugins change", func() {
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
@@ -748,7 +749,7 @@ units: {}
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that containerd config was updated properly")
@@ -765,7 +766,7 @@ units: {}
 	})
 
 	It("should reconcile the configuration when the cgroup driver changes", func() {
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
@@ -786,7 +787,7 @@ units: {}
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-		waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 		By("Assert that containerd config was updated properly")
@@ -853,7 +854,7 @@ units: {}
 		})
 
 		It("should not handle containerd configs", func() {
-			waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+			waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 			waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 			By("Assert that files and units have been created")
@@ -990,7 +991,7 @@ kind: NodeAgentConfiguration
 		})
 
 		JustBeforeEach(func() {
-			waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+			waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 			waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 			fakeDBus.Actions = nil // reset actions on dbus to not repeat assertions from above for update scenario
@@ -1028,7 +1029,7 @@ kind: NodeAgentConfiguration
 			oscSecret.Data["osc.yaml"] = oscRaw
 			Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-			waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+			waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 			waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
@@ -1069,7 +1070,7 @@ kubeReserved:
 			oscSecret.Data["osc.yaml"] = oscRaw
 			Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-			waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+			waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 			waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 			By("Assert that unit actions have been applied")
@@ -1105,7 +1106,7 @@ kubeReserved:
 			oscSecret.Data["osc.yaml"] = oscRaw
 			Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
-			waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+			waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 			waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 			By("Assert that unit actions have been applied")
@@ -1146,7 +1147,7 @@ kubeReserved:
 				Expect(event.Object.GetNamespace()).To(Equal("kube-system"))
 			}
 
-			waitForUpdatedNodeAnnotationCloudConfig(node, utils.ComputeSHA256Hex(oscRaw))
+			waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
 			waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
 
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
@@ -1199,6 +1200,13 @@ preferences: {}
 				))
 			}).Should(Succeed())
 
+			By("Wait for the manager to observe the updated secret")
+			EventuallyWithOffset(1, func(g Gomega) []byte {
+				updatedSecret := &corev1.Secret{}
+				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(oscSecret), updatedSecret)).To(Succeed())
+				return updatedSecret.Data["osc.yaml"]
+			}).Should(Equal(oscSecret.Data["osc.yaml"]))
+
 			Expect(cancelFunc.called).To(BeTrue())
 
 			Expect(fakeFS.DirExists(kubeletCertDir)).To(BeFalse())
@@ -1242,7 +1250,14 @@ func (c *cancelFuncEnsurer) cancel() {
 	c.called = true
 }
 
-func waitForUpdatedNodeAnnotationCloudConfig(node *corev1.Node, value string) {
+func waitForUpdatedNodeAnnotationCloudConfig(node *corev1.Node, oscSecret *corev1.Secret, value string) {
+	By("Wait for the manager to observe the updated secret")
+	EventuallyWithOffset(1, func(g Gomega) []byte {
+		updatedSecret := &corev1.Secret{}
+		g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(oscSecret), updatedSecret)).To(Succeed())
+		return updatedSecret.Data["osc.yaml"]
+	}).Should(Equal(oscSecret.Data["osc.yaml"]))
+
 	By("Wait for node annotations to be updated")
 	EventuallyWithOffset(1, func(g Gomega) map[string]string {
 		updatedNode := &corev1.Node{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
Fixes a flake in `node-agent` integration test.
Now we wait for the manager to observe the updated secret before moving on to assertions.
I also moved around some assertions because I noticed flakes in other tests as well.

In the process, I also noticed we were not returning errors in case the OS update command fails. Fixed that too.

**Which issue(s) this PR fixes**:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11892/pull-gardener-integration/1912533873196011520
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/11913/pull-gardener-integration/1914604859466715136

**Special notes for your reviewer**:
Before:
```
❯ stress -ignore "unable to grab random port" -p 12 ./test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig.test

2m40s: 102 runs so far, 5 failures (4.90%)
2m45s: 108 runs so far, 5 failures (4.63%)
2m50s: 109 runs so far, 5 failures (4.59%)
2m55s: 114 runs so far, 5 failures (4.39%)
…
6m35s: 270 runs so far, 13 failures (4.81%)
6m40s: 277 runs so far, 13 failures (4.69%)
6m45s: 277 runs so far, 13 failures (4.69%)
6m50s: 281 runs so far, 13 failures (4.63%)
6m55s: 284 runs so far, 13 failures (4.58%)
```
After:
```
❯ stress -ignore "unable to grab random port" -p 12 ./test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig.test

10m0s: 618 runs so far, 0 failures
10m5s: 626 runs so far, 0 failures
10m10s: 629 runs so far, 0 failures
10m15s: 635 runs so far, 0 failures
10m20s: 639 runs so far, 0 failures
10m25s: 644 runs so far, 0 failures
10m30s: 650 runs so far, 0 failures
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
 NONE
```
