### PR TITLE
[GEP-30] Deploy proxy-protocol envoy filters if proxy-protocol is enabled for the seed

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/proxy-protocol-envoyfilter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/proxy-protocol-envoyfilter.yaml
@@ -30,6 +30,9 @@ spec:
           typed_config:
             "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
             allow_requests_without_proxy_protocol: true
+{{ end -}}
+{{ end -}}
+{{- if eq .Values.terminateLoadBalancerProxyProtocol true }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -86,5 +89,4 @@ spec:
             '@type': type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol
             allow_requests_without_proxy_protocol: true
         per_connection_buffer_limit_bytes: 32768
-{{ end -}}
 {{ end -}}

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -420,7 +420,11 @@ var _ = Describe("istiod", func() {
 				expectedIstioManifests = append(expectedIstioManifests, istioStripTrailingDotEnvoyFilter())
 			}
 
-			if igw[0].TerminateLoadBalancerProxyProtocol {
+			if igw[0].TerminateLoadBalancerProxyProtocol && !igw[0].ProxyProtocolEnabled {
+				expectedIstioManifests = append(expectedIstioManifests, istioProxyProtocolEnvoyFilterSNI(), istioProxyProtocolEnvoyFilterVPN())
+			}
+
+			if igw[0].TerminateLoadBalancerProxyProtocol && igw[0].ProxyProtocolEnabled {
 				expectedIstioManifests = append(expectedIstioManifests, istioProxyProtocolEnvoyFilterDual(), istioProxyProtocolEnvoyFilterSNI(), istioProxyProtocolEnvoyFilterVPN())
 			}
 
@@ -461,10 +465,21 @@ var _ = Describe("istiod", func() {
 			}
 		}
 
-		Context("with proxy protocol termination", func() {
+		Context("with proxy protocol in apiserver-proxy and with proxy protocol termination", func() {
 			BeforeEach(func() {
 				igw[0].TerminateLoadBalancerProxyProtocol = true
 				igw[0].ProxyProtocolEnabled = true
+			})
+
+			It("should successfully deploy all resources", func() {
+				checkSuccessfulDeployment(nil, nil)
+			})
+		})
+
+		Context("without proxy protocol in apiserver-proxy and proxy protocol termination", func() {
+			BeforeEach(func() {
+				igw[0].TerminateLoadBalancerProxyProtocol = true
+				igw[0].ProxyProtocolEnabled = false
 			})
 
 			It("should successfully deploy all resources", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Enabling `RemoveAPIServerProxyLegacyPort` breaks seeds with load-balancers which use the proxy-protocol (`seed.spec.settings.loadBalancerServices.proxyProtocol.allowed = true`).
This PR ensure that the relevant EnvoyFilters for this scenario are deployed when required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow up to https://github.com/gardener/gardener/pull/11380
Part of https://github.com/gardener/gardener/issues/11214

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue where envoy filters to handle proxy-protocol are not deployed, even if configured for istio load-balancers.
```
