### PR TITLE
Allow setting file mode for projected volumes injected by GRM webhook for etcd pods

### DIFF
--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -108,6 +108,9 @@ const (
 	// ProjectedTokenExpirationSeconds is a constant for an annotation on a Pod which overwrites the default token expiration
 	// seconds for the automatic mount of a projected ServiceAccount token.
 	ProjectedTokenExpirationSeconds = "projected-token-mount.resources.gardener.cloud/expiration-seconds"
+	// ProjectedTokenFileMode is a constant for an annotation on a Pod which overwrites the default file mode for the automatic mount of a
+	// projected ServiceAccount token.
+	ProjectedTokenFileMode = "projected-token-mount.resources.gardener.cloud/file-mode"
 
 	// HighAvailabilityConfigConsider is a constant for a label on a Namespace which indicates that the workload
 	// resources in this namespace should be considered by the HA config webhook.

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -213,7 +213,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			Policy:  &compressionPolicy,
 		}
 
-		annotations         map[string]string
+		annotations         = map[string]string{resourcesv1alpha1.ProjectedTokenFileMode: "416"} // 0640
 		metrics             = druidcorev1alpha1.Basic
 		volumeClaimTemplate = e.etcd.Name
 
@@ -225,7 +225,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 
 	if e.values.Class == ClassImportant {
 		if !e.values.HighAvailabilityEnabled {
-			annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
+			annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
 		}
 		metrics = druidcorev1alpha1.Extensive
 		volumeClaimTemplate = e.values.Role + "-" + strings.TrimSuffix(e.etcd.Name, "-"+e.values.Role)

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -208,6 +208,9 @@ var _ = Describe("Etcd", func() {
 						"networking.gardener.cloud/to-private-networks":  "allowed",
 						"networking.gardener.cloud/to-runtime-apiserver": "allowed",
 					},
+					Annotations: map[string]string{
+						"projected-token-mount.resources.gardener.cloud/file-mode": "416",
+					},
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"gardener.cloud/role": "controlplane",
@@ -279,7 +282,10 @@ var _ = Describe("Etcd", func() {
 			switch class {
 			case ClassImportant:
 				if replicas == 1 {
-					obj.Spec.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
+					if obj.Spec.Annotations == nil {
+						obj.Spec.Annotations = map[string]string{}
+					}
+					obj.Spec.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
 				}
 				obj.Spec.Backup.Resources = &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security compliance
/kind task

**What this PR does / why we need it**:
Ensure etcd pods have files with permissions 0640 or lesser, as per [DISA STIG](https://www.stigviewer.com/stig/kubernetes/) standards, which includes projected volume mount files.

**Which issue(s) this PR fixes**:
Fixes #11088 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow specifying file mode for GRM projected-token-mount webhook, via pod annotation `projected-token-mount.resources.gardener.cloud/file-mode`. This is now applied to etcd pods by default.
```
