### PR TITLE
[GEP-26] Require seed backup credential to exist if referenced through the seed spec

### DIFF
--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gardener/gardener/charts"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -34,7 +33,6 @@ import (
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Reconciler reconciles the ManagedSeed.
@@ -104,34 +102,6 @@ func (r *Reconciler) newActuator(shoot *gardencorev1beta1.Shoot) gardenletdeploy
 				return false, err
 			}
 			return true, nil
-		},
-		GetInfrastructureSecret: func(ctx context.Context) (*corev1.Secret, error) {
-			if shoot.Spec.SecretBindingName == nil && shoot.Spec.CredentialsBindingName == nil {
-				return nil, fmt.Errorf("both secretBindingName and credentialsBindingName are nil for the Shoot: %s/%s", shoot.Namespace, shoot.Name)
-			}
-
-			if shoot.Spec.SecretBindingName != nil {
-				shootSecretBinding := &gardencorev1beta1.SecretBinding{}
-				if err := r.GardenClient.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.SecretBindingName}, shootSecretBinding); err != nil {
-					return nil, err
-				}
-				return kubernetesutils.GetSecretByReference(ctx, r.GardenClient, &shootSecretBinding.SecretRef)
-			}
-
-			// TODO(dimityrmirchev): This code should eventually handle credentials binding referencing workload
-			//  identities.
-			shootCredentialsBinding := &securityv1alpha1.CredentialsBinding{}
-			if err := r.GardenClient.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.CredentialsBindingName}, shootCredentialsBinding); err != nil {
-				return nil, err
-			}
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      shootCredentialsBinding.CredentialsRef.Name,
-					Namespace: shootCredentialsBinding.CredentialsRef.Namespace,
-				},
-			}
-
-			return secret, r.GardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
 		},
 		GetTargetDomain: func() string {
 			if shoot.Spec.DNS == nil {

--- a/pkg/operator/controller/gardenlet/reconciler.go
+++ b/pkg/operator/controller/gardenlet/reconciler.go
@@ -24,7 +24,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	"github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -94,18 +93,6 @@ func (r *Reconciler) newActuator(gardenlet *seedmanagementv1alpha1.Gardenlet) ga
 		},
 		CheckIfVPAAlreadyExists: func(_ context.Context) (bool, error) {
 			return false, nil
-		},
-		GetInfrastructureSecret: func(ctx context.Context) (*corev1.Secret, error) {
-			seedTemplate, _, err := helper.ExtractSeedTemplateAndGardenletConfig(gardenlet.GetName(), &gardenlet.Spec.Config)
-			if err != nil {
-				return nil, fmt.Errorf("failed to extract seed template and gardenlet config: %w", err)
-			}
-
-			if seedTemplate.Spec.Backup == nil {
-				return nil, nil
-			}
-			// TODO(vpnachev): Add support for WorkloadIdentity
-			return kubernetesutils.GetSecretByObjectReference(ctx, r.VirtualClient, seedTemplate.Spec.Backup.CredentialsRef)
 		},
 		GetTargetDomain: func() string {
 			return ""

--- a/plugin/pkg/seed/validator/admission.go
+++ b/plugin/pkg/seed/validator/admission.go
@@ -10,9 +10,13 @@ import (
 	"fmt"
 	"io"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	kubeinformers "k8s.io/client-go/informers"
+	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
@@ -35,15 +39,18 @@ func Register(plugins *admission.Plugins) {
 // ValidateSeed contains listers and admission handler.
 type ValidateSeed struct {
 	*admission.Handler
+	authorizer             authorizer.Authorizer
 	seedLister             gardencorev1beta1listers.SeedLister
 	shootLister            gardencorev1beta1listers.ShootLister
 	workloadIdentityLister gardensecurityv1alpha1listers.WorkloadIdentityLister
+	secretLister           kubecorev1listers.SecretLister
 	readyFunc              admission.ReadyFunc
 }
 
 var (
 	_ = admissioninitializer.WantsCoreInformerFactory(&ValidateSeed{})
 	_ = admissioninitializer.WantsSecurityInformerFactory(&ValidateSeed{})
+	_ = admissioninitializer.WantsKubeInformerFactory(&ValidateSeed{})
 
 	readyFuncs []admission.ReadyFunc
 )
@@ -59,6 +66,11 @@ func New() (*ValidateSeed, error) {
 func (v *ValidateSeed) AssignReadyFunc(f admission.ReadyFunc) {
 	v.readyFunc = f
 	v.SetReadyFunc(f)
+}
+
+// SetAuthorizer gets the authorizer.
+func (v *ValidateSeed) SetAuthorizer(authorizer authorizer.Authorizer) {
+	v.authorizer = authorizer
 }
 
 // SetCoreInformerFactory gets Lister from SharedInformerFactory.
@@ -82,8 +94,19 @@ func (v *ValidateSeed) SetSecurityInformerFactory(f gardensecurityinformers.Shar
 	readyFuncs = append(readyFuncs, wiInformer.Informer().HasSynced)
 }
 
+// SetKubeInformerFactory gets Lister from SharedInformerFactory.
+func (v *ValidateSeed) SetKubeInformerFactory(f kubeinformers.SharedInformerFactory) {
+	secretInformer := f.Core().V1().Secrets()
+	v.secretLister = secretInformer.Lister()
+
+	readyFuncs = append(readyFuncs, secretInformer.Informer().HasSynced)
+}
+
 // ValidateInitialization checks whether the plugin was correctly initialized.
 func (v *ValidateSeed) ValidateInitialization() error {
+	if v.authorizer == nil {
+		return errors.New("missing authorizer")
+	}
 	if v.seedLister == nil {
 		return errors.New("missing seed lister")
 	}
@@ -93,13 +116,16 @@ func (v *ValidateSeed) ValidateInitialization() error {
 	if v.workloadIdentityLister == nil {
 		return errors.New("missing workloadidentity lister")
 	}
+	if v.secretLister == nil {
+		return errors.New("missing secret lister")
+	}
 	return nil
 }
 
 var _ admission.ValidationInterface = &ValidateSeed{}
 
 // Validate validates the Seed details against existing Shoots and BackupBuckets
-func (v *ValidateSeed) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+func (v *ValidateSeed) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Wait until the caches have been synced
 	if v.readyFunc == nil {
 		v.AssignReadyFunc(func() bool {
@@ -128,9 +154,9 @@ func (v *ValidateSeed) Validate(_ context.Context, a admission.Attributes, _ adm
 
 	switch a.GetOperation() {
 	case admission.Create:
-		return v.validateSeedCreate(a)
+		return v.validateSeedCreate(ctx, a)
 	case admission.Update:
-		return v.validateSeedUpdate(a)
+		return v.validateSeedUpdate(ctx, a)
 	case admission.Delete:
 		return v.validateSeedDeletion(a)
 	}
@@ -138,7 +164,7 @@ func (v *ValidateSeed) Validate(_ context.Context, a admission.Attributes, _ adm
 	return nil
 }
 
-func (v *ValidateSeed) validateSeedUpdate(a admission.Attributes) error {
+func (v *ValidateSeed) validateSeedUpdate(ctx context.Context, a admission.Attributes) error {
 	oldSeed, newSeed, err := getOldAndNewSeeds(a)
 	if err != nil {
 		return err
@@ -148,16 +174,16 @@ func (v *ValidateSeed) validateSeedUpdate(a admission.Attributes) error {
 		return err
 	}
 
-	return v.validateCredentialsRef(a, newSeed)
+	return v.validateBackupCredentialsRef(ctx, a, newSeed, oldSeed)
 }
 
-func (v *ValidateSeed) validateSeedCreate(a admission.Attributes) error {
+func (v *ValidateSeed) validateSeedCreate(ctx context.Context, a admission.Attributes) error {
 	seed, ok := a.GetObject().(*core.Seed)
 	if !ok {
 		return apierrors.NewInternalError(errors.New("failed to convert resource into Seed object"))
 	}
 
-	return v.validateCredentialsRef(a, seed)
+	return v.validateBackupCredentialsRef(ctx, a, seed, nil)
 }
 
 func (v *ValidateSeed) validateSeedDeletion(a admission.Attributes) error {
@@ -191,22 +217,93 @@ func getOldAndNewSeeds(attrs admission.Attributes) (*core.Seed, *core.Seed, erro
 	return oldSeed, newSeed, nil
 }
 
-func (v *ValidateSeed) validateCredentialsRef(attrs admission.Attributes, seed *core.Seed) error {
-	if seed.Spec.Backup == nil {
+func (v *ValidateSeed) validateBackupCredentialsRef(ctx context.Context, attrs admission.Attributes, newSeed, oldSeed *core.Seed) error {
+	if newSeed.Spec.Backup == nil {
 		return nil
 	}
 
-	if seed.Spec.Backup.CredentialsRef.APIVersion != securityv1alpha1.SchemeGroupVersion.String() || seed.Spec.Backup.CredentialsRef.Kind != "WorkloadIdentity" {
-		return nil
+	var (
+		backup              = newSeed.Spec.Backup
+		getAttributesRecord = func(ref *corev1.ObjectReference) (authorizer.AttributesRecord, error) {
+			var (
+				apiGroup   string
+				apiVersion string
+				resource   string
+			)
+			if ref.APIVersion == corev1.SchemeGroupVersion.String() {
+				apiGroup = corev1.SchemeGroupVersion.Group
+				apiVersion = corev1.SchemeGroupVersion.Version
+				resource = "secrets"
+			} else if ref.APIVersion == securityv1alpha1.SchemeGroupVersion.String() {
+				apiGroup = securityv1alpha1.SchemeGroupVersion.Group
+				apiVersion = securityv1alpha1.SchemeGroupVersion.Version
+				resource = "workloadidentities"
+			} else {
+				return authorizer.AttributesRecord{}, errors.New("unsupported credentials reference: backup config is referencing neither a Secret nor a WorkloadIdentity")
+			}
+			return authorizer.AttributesRecord{
+				User:            attrs.GetUserInfo(),
+				Verb:            "get",
+				APIGroup:        apiGroup,
+				APIVersion:      apiVersion,
+				Resource:        resource,
+				Namespace:       ref.Namespace,
+				Name:            ref.Name,
+				ResourceRequest: true,
+			}, nil
+		}
+	)
+
+	switch {
+	case backup.CredentialsRef.APIVersion == securityv1alpha1.SchemeGroupVersion.String() &&
+		backup.CredentialsRef.Kind == "WorkloadIdentity":
+		workloadIdentity, err := v.workloadIdentityLister.WorkloadIdentities(backup.CredentialsRef.Namespace).Get(backup.CredentialsRef.Name)
+		if err != nil {
+			return apierrors.NewInternalError(err)
+		}
+
+		if seedBackupType, workloadIdentityType := backup.Provider, workloadIdentity.Spec.TargetSystem.Type; seedBackupType != workloadIdentityType {
+			return admission.NewForbidden(attrs, fmt.Errorf("seed using backup of type %q cannot use WorkloadIdentity of type %q", seedBackupType, workloadIdentityType))
+		}
+	case backup.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() &&
+		backup.CredentialsRef.Kind == "Secret":
+		_, err := v.secretLister.Secrets(backup.CredentialsRef.Namespace).Get(backup.CredentialsRef.Name)
+		if err != nil {
+			return apierrors.NewInternalError(err)
+		}
+	default:
+		return apierrors.NewBadRequest("unsupported credentials reference: backup config is referencing neither a Secret nor a WorkloadIdentity")
 	}
 
-	workloadIdentity, err := v.workloadIdentityLister.WorkloadIdentities(seed.Spec.Backup.CredentialsRef.Namespace).Get(seed.Spec.Backup.CredentialsRef.Name)
+	if oldSeed != nil && oldSeed.Spec.Backup != nil {
+		oldBackup := oldSeed.Spec.Backup
+
+		// If credentials reference has not changed, we can skip the authorization check
+		if oldBackup.CredentialsRef.Kind == backup.CredentialsRef.Kind &&
+			oldBackup.CredentialsRef.APIVersion == backup.CredentialsRef.APIVersion &&
+			oldBackup.CredentialsRef.Name == backup.CredentialsRef.Name &&
+			oldBackup.CredentialsRef.Namespace == backup.CredentialsRef.Namespace {
+			return nil
+		}
+		record, err := getAttributesRecord(oldSeed.Spec.Backup.CredentialsRef)
+		if err != nil {
+			return admission.NewForbidden(attrs, err)
+		}
+		if decision, _, err := v.authorizer.Authorize(ctx, record); err != nil {
+			return apierrors.NewInternalError(fmt.Errorf("could not authorize read request for old backup credentials: %w", err))
+		} else if decision != authorizer.DecisionAllow {
+			return admission.NewForbidden(attrs, fmt.Errorf("user %q is not allowed to read the previously referenced %s %q", attrs.GetUserInfo().GetName(), oldSeed.Spec.Backup.CredentialsRef.Kind, oldSeed.Spec.Backup.CredentialsRef.Namespace+"/"+oldSeed.Spec.Backup.CredentialsRef.Name))
+		}
+	}
+
+	record, err := getAttributesRecord(backup.CredentialsRef)
 	if err != nil {
-		return apierrors.NewInternalError(err)
+		return admission.NewForbidden(attrs, err)
 	}
-
-	if seedBackupType, workloadIdentityType := seed.Spec.Backup.Provider, workloadIdentity.Spec.TargetSystem.Type; seedBackupType != workloadIdentityType {
-		return admission.NewForbidden(attrs, fmt.Errorf("seed using backup of type %q cannot use WorkloadIdentity of type %q", seedBackupType, workloadIdentityType))
+	if decision, _, err := v.authorizer.Authorize(ctx, record); err != nil {
+		return apierrors.NewInternalError(fmt.Errorf("could not authorize read request for new backup credentials: %w", err))
+	} else if decision != authorizer.DecisionAllow {
+		return admission.NewForbidden(attrs, fmt.Errorf("user %q is not allowed to read the newly referenced %s %q", attrs.GetUserInfo().GetName(), backup.CredentialsRef.Kind, backup.CredentialsRef.Namespace+"/"+backup.CredentialsRef.Name))
 	}
 
 	return nil

--- a/test/integration/gardenlet/managedseed/managedseed_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_test.go
@@ -45,14 +45,6 @@ var _ = Describe("ManagedSeed controller test", func() {
 			ExpectWithOffset(1, testClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
 		}
 
-		checkIfSeedSecretsCreated = func() {
-			By("Verify if seed secrets are created")
-			EventuallyWithOffset(1, func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)).To(Succeed())
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(backupSecret), backupSecret)).To(Succeed())
-			}).Should(Succeed())
-		}
-
 		checkIfGardenletWasDeployed = func() {
 			By("Verify if gardenlet is deployed")
 			EventuallyWithOffset(1, func(g Gomega) {
@@ -91,42 +83,10 @@ var _ = Describe("ManagedSeed controller test", func() {
 				Name:      backupSecretName,
 				Namespace: gardenNamespaceGarden.Name,
 			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
 		}
-
-		gardenletConfig, err := encoding.EncodeGardenletConfiguration(&gardenletconfigv1alpha1.GardenletConfiguration{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
-				Kind:       "GardenletConfiguration",
-			},
-			GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
-				KubeconfigSecret: &corev1.SecretReference{
-					Name:      "gardenlet-kubeconfig",
-					Namespace: gardenNamespaceGarden.Name,
-				},
-			},
-			SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
-				SeedTemplate: gardencorev1beta1.SeedTemplate{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							"bar": "baz",
-						},
-					},
-					Spec: gardencorev1beta1.SeedSpec{
-						Backup: &gardencorev1beta1.SeedBackup{
-							Provider: "test",
-							Region:   ptr.To("bar"),
-							CredentialsRef: &corev1.ObjectReference{
-								APIVersion: "v1",
-								Kind:       "Secret",
-								Name:       backupSecret.Name,
-								Namespace:  backupSecret.Namespace,
-							},
-						},
-					},
-				},
-			},
-		})
-		Expect(err).NotTo(HaveOccurred())
 
 		managedSeed = &seedmanagementv1alpha1.ManagedSeed{
 			ObjectMeta: metav1.ObjectMeta{
@@ -143,7 +103,6 @@ var _ = Describe("ManagedSeed controller test", func() {
 							PullPolicy: ptr.To(corev1.PullIfNotPresent),
 						},
 					},
-					Config:    *gardenletConfig,
 					Bootstrap: ptr.To(seedmanagementv1alpha1.BootstrapToken),
 				},
 			},
@@ -283,7 +242,54 @@ var _ = Describe("ManagedSeed controller test", func() {
 			}).Should(BeNotFoundError())
 		})
 
+		By("Ensure backup secret is created")
+		Expect(testClient.Create(ctx, backupSecret)).To(Succeed())
+		DeferCleanup(func() {
+			By("Delete backup secret")
+			Expect(testClient.Delete(ctx, backupSecret)).To(Or(Succeed(), BeNotFoundError()))
+
+			By("Wait for backup secret to be gone")
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(backupSecret), backupSecret)
+			}).Should(BeNotFoundError())
+		})
+
 		By("Create ManagedSeed")
+		gardenletConfig, err := encoding.EncodeGardenletConfiguration(&gardenletconfigv1alpha1.GardenletConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
+				Kind:       "GardenletConfiguration",
+			},
+			GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
+				KubeconfigSecret: &corev1.SecretReference{
+					Name:      "gardenlet-kubeconfig",
+					Namespace: gardenNamespaceGarden.Name,
+				},
+			},
+			SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
+				SeedTemplate: gardencorev1beta1.SeedTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"bar": "baz",
+						},
+					},
+					Spec: gardencorev1beta1.SeedSpec{
+						Backup: &gardencorev1beta1.SeedBackup{
+							Provider: "test",
+							Region:   ptr.To("bar"),
+							CredentialsRef: &corev1.ObjectReference{
+								APIVersion: "v1",
+								Kind:       "Secret",
+								Name:       backupSecret.Name,
+								Namespace:  backupSecret.Namespace,
+							},
+						},
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		managedSeed.Spec.Gardenlet.Config = *gardenletConfig
 		managedSeed.Spec.Shoot = &seedmanagementv1alpha1.Shoot{Name: shoot.Name}
 		Expect(testClient.Create(ctx, managedSeed)).To(Succeed())
 		log.Info("Created ManagedSeed for test", "managedseed", client.ObjectKeyFromObject(managedSeed))
@@ -322,7 +328,7 @@ var _ = Describe("ManagedSeed controller test", func() {
 			reconcileShoot()
 		})
 
-		It("should set the ShootReconciled status to true,create seed secrets specified in spec.backup.secretRef and spec.secretRef field of seed template and deploy gardenlet ", func() {
+		It("should set the ShootReconciled status to true, create seed secrets specified in spec.backup.secretRef and spec.secretRef field of seed template and deploy gardenlet ", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)).To(Succeed())
 				condition := v1beta1helper.GetCondition(managedSeed.Status.Conditions, seedmanagementv1alpha1.ManagedSeedShootReconciled)
@@ -331,7 +337,6 @@ var _ = Describe("ManagedSeed controller test", func() {
 				g.Expect(condition.Reason).To(Equal(gardencorev1beta1.EventReconciled))
 			}).Should(Succeed())
 
-			checkIfSeedSecretsCreated()
 			checkIfGardenletWasDeployed()
 		})
 	})
@@ -339,7 +344,6 @@ var _ = Describe("ManagedSeed controller test", func() {
 	Context("deletion", func() {
 		JustBeforeEach(func() {
 			reconcileShoot()
-			checkIfSeedSecretsCreated()
 			checkIfGardenletWasDeployed()
 		})
 
@@ -348,7 +352,7 @@ var _ = Describe("ManagedSeed controller test", func() {
 			Expect(testClient.Delete(ctx, managedSeed)).To(Succeed())
 
 			Eventually(func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKey{Name: backupSecretName, Namespace: gardenNamespaceGarden.Name}, &corev1.Secret{})).To(BeNotFoundError())
+				g.Expect(testClient.Get(ctx, client.ObjectKey{Name: backupSecretName, Namespace: gardenNamespaceGarden.Name}, &corev1.Secret{})).To(Succeed()) // secret is not cleaned up by the controller
 				g.Expect(testClient.Get(ctx, client.ObjectKey{Name: "gardenlet", Namespace: gardenNamespaceShoot}, &appsv1.Deployment{})).To(BeNotFoundError())
 				g.Expect(testClient.Get(ctx, client.ObjectKey{Name: gardenNamespaceShoot}, &corev1.Namespace{})).To(BeNotFoundError())
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)).To(BeNotFoundError())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security backup
/kind enhancement

**What this PR does / why we need it**:
The managed seed controller tries to read the shoot's infrastructure credential. This was needed because of a feature that enables referencing a non-existent secret through the seed `.spec.backup.credentialsRef`. When this is the case the managed seed controller gets the shoot infrastructure secret and and copies it in the target `.spec.backup.credentialsRef`. Although helpful for easier seed setup this behaviour has a couple of disadvantages:
- Promotes the usage of shoot infrastructure credentials as backup credentials. It is best that these are segregated.
- Causes some confusion w.r.t. referencing a non-existent credential because of the implicit copying.
- Works for `Secret` credentials, but does not work for `WorkloadIdentity` because the latter is uniquely identified by its ID meaning that a copy of the original `WorkloadIdentity` would not produce the identity.

With this PR I propose:
- Removal of the copying logic.
- Requiring an existent backup credential if such is referenced through the seed spec. The credentials can be of kind `Secret` or `WorkloadIdentity`.
- ~An authorization check that verifies that if a seed is updated the user issuing the request can read both old and new backup credentials.~ Edit: Removed from this PR as this should probably be tackled separately if at all.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
/cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `Seed` backup secret is no longer copied from the `Shoot` infrastructure credentials in case an operator does not provide an existent backup secret. If you configure `seed.spec.backup.credentialsRef` or `seed.spec.backup.secretRef` make sure that the referred credential already exists. For production setups it is advised that operators configure a separate set of credentials for `Seed` backup and `Shoot` infrastructure.
```
