### PR TITLE
[GEP-31] Controller optimizations and Add e2e tests

### DIFF
--- a/charts/gardener/provider-local/templates/rbac.yaml
+++ b/charts/gardener/provider-local/templates/rbac.yaml
@@ -112,6 +112,7 @@ rules:
   - jobs
   - pods
   - pods/log
+  - pods/exec
   - mutatingwebhookconfigurations
   - customresourcedefinitions
   - networkpolicies

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -270,6 +270,8 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 api.e2e-default.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-default-wl.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-default-wl.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-default-ip.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-default-ip.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-force-delete.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-force-delete.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-fd-hib.local.external.local.gardener.cloud

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -264,6 +264,8 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 api.e2e-rotate-wl.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-rot-noroll.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-rot-noroll.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-rot-ip.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-rot-ip.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-default.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-default.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-default-wl.local.external.local.gardener.cloud
@@ -291,6 +293,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 gu-local--e2e-rotate.ingress.local.seed.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rotate-wl.ingress.local.seed.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rot-noroll.ingress.local.seed.local.gardener.cloud
+172.18.255.1 gu-local--e2e-rot-ip.ingress.local.seed.local.gardener.cloud
 # End of Gardener local setup section
 EOF
 ```

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -158,6 +158,7 @@ global:
       ShootForceDeletion: true
       CredentialsRotationWithoutWorkersRollout: true
       CloudProfileCapabilities: true
+      InPlaceNodeUpdates: true
     resources: {}
     podLabels:
       networking.resources.gardener.cloud/to-all-webhook-targets: allowed

--- a/example/provider-local/garden/cloudprofile/cloudprofile.yaml
+++ b/example/provider-local/garden/cloudprofile/cloudprofile.yaml
@@ -24,9 +24,19 @@ spec:
   machineImages:
   - name: local
     versions:
+    # This version is just used for in-place update e2e tests.
+    - version: 2.0.0
+      classification: preview
+      cri:
+      - name: containerd
+      inPlaceUpdates:
+        supported: true
+        minVersionForUpdate: 1.0.0
     - version: 1.0.0
       cri:
       - name: containerd
+      inPlaceUpdates:
+        supported: true
   providerConfig:
     apiVersion: local.provider.extensions.gardener.cloud/v1alpha1
     kind: CloudProfileConfig
@@ -34,4 +44,7 @@ spec:
     - name: local
       versions:
       - version: 1.0.0
+        image: local-skaffold/gardener-extension-provider-local-node:v1.0.0
+      # This version is just used for in-place update e2e tests.
+      - version: 2.0.0
         image: local-skaffold/gardener-extension-provider-local-node:v1.0.0

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -109,6 +109,7 @@ func MachineConditionChangedPredicate(ctx context.Context, log logr.Logger, c cl
 
 			machineDeploymentName, ok := machine.Labels[LabelKeyMachineDeploymentName]
 			if !ok {
+				log.Error(nil, "Machine does not have machine deployment label", "machine", machine.Name)
 				return false
 			}
 
@@ -162,8 +163,8 @@ func MachineConditionChangedPredicate(ctx context.Context, log logr.Logger, c cl
 			oldCond := GetMachineCondition(oldMachine, machinev1alpha1.NodeInPlaceUpdate)
 			newCond := GetMachineCondition(newMachine, machinev1alpha1.NodeInPlaceUpdate)
 
-			// Consider only the condition transition from UpdateCandidate to SelectedForUpdate
-			return oldCond != nil && newCond != nil && oldCond.Reason == machinev1alpha1.CandidateForUpdate && newCond.Reason == machinev1alpha1.SelectedForUpdate
+			// Consider only the condition transition from CandidateForUpdate to SelectedForUpdate
+			return oldCond != nil && newCond != nil && oldCond.Reason == machinev1alpha1.CandidateForUpdate && newCond.Reason != machinev1alpha1.CandidateForUpdate
 		},
 		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -109,7 +109,7 @@ func MachineConditionChangedPredicate(ctx context.Context, log logr.Logger, c cl
 
 			machineDeploymentName, ok := machine.Labels[LabelKeyMachineDeploymentName]
 			if !ok {
-				log.Error(nil, "Machine does not have machine deployment label", "machine", machine.Name)
+				log.Info("Machine does not have machine deployment label", "machine", machine.Name)
 				return false
 			}
 
@@ -163,7 +163,7 @@ func MachineConditionChangedPredicate(ctx context.Context, log logr.Logger, c cl
 			oldCond := GetMachineCondition(oldMachine, machinev1alpha1.NodeInPlaceUpdate)
 			newCond := GetMachineCondition(newMachine, machinev1alpha1.NodeInPlaceUpdate)
 
-			// Consider only the condition transition from CandidateForUpdate to another condition
+			// Consider only the condition transition from CandidateForUpdate to another condition.
 			return oldCond != nil && newCond != nil && oldCond.Reason == machinev1alpha1.CandidateForUpdate && newCond.Reason != machinev1alpha1.CandidateForUpdate
 		},
 		DeleteFunc: func(_ event.DeleteEvent) bool {

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -163,7 +163,7 @@ func MachineConditionChangedPredicate(ctx context.Context, log logr.Logger, c cl
 			oldCond := GetMachineCondition(oldMachine, machinev1alpha1.NodeInPlaceUpdate)
 			newCond := GetMachineCondition(newMachine, machinev1alpha1.NodeInPlaceUpdate)
 
-			// Consider only the condition transition from CandidateForUpdate to SelectedForUpdate
+			// Consider only the condition transition from CandidateForUpdate to another condition
 			return oldCond != nil && newCond != nil && oldCond.Reason == machinev1alpha1.CandidateForUpdate && newCond.Reason != machinev1alpha1.CandidateForUpdate
 		},
 		DeleteFunc: func(_ event.DeleteEvent) bool {

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -96,6 +96,7 @@ case $TYPE in
       e2e-rot-ip.local
       e2e-default.local
       e2e-default-wl.local
+      e2e-default-ip.local
       e2e-force-delete.local
       e2e-fd-hib.local
       e2e-upd-node.local

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -93,6 +93,7 @@ case $TYPE in
       e2e-rotate.local
       e2e-rotate-wl.local
       e2e-rot-noroll.local
+      e2e-rot-ip.local
       e2e-default.local
       e2e-default-wl.local
       e2e-force-delete.local
@@ -114,6 +115,7 @@ case $TYPE in
       gu-local--e2e-rotate
       gu-local--e2e-rotate-wl
       gu-local--e2e-rot-noroll
+      gu-local--e2e-rot-ip
     )
 
     if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -383,6 +383,11 @@ func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *fi
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))...)
 
 	for i, newWorker := range newProvider.Workers {
+		var (
+			idxPath              = fldPath.Child("workers").Index(i)
+			newStrategyIsInPlace = helper.IsUpdateStrategyInPlace(newWorker.UpdateStrategy)
+		)
+
 		var oldWorker core.Worker
 
 		oldWorkerIndex := slices.IndexFunc(oldProvider.Workers, func(worker core.Worker) bool {
@@ -391,15 +396,15 @@ func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *fi
 		})
 
 		if oldWorkerIndex == -1 {
+			// Only validate the feature gate if the worker is new. We don't want to break existing workers.
+			if !features.DefaultFeatureGate.Enabled(features.InPlaceNodeUpdates) && newStrategyIsInPlace {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("updateStrategy"), *newWorker.UpdateStrategy, "can not configure `AutoInPlaceUpdate` or `ManualInPlaceUpdate` update strategies when the `InPlaceNodeUpdates` feature gate is disabled."))
+			}
+
 			continue
 		}
 
-		var (
-			idxPath              = fldPath.Child("workers").Index(i)
-			oldStrategyIsInPlace = helper.IsUpdateStrategyInPlace(oldWorker.UpdateStrategy)
-			newStrategyIsInPlace = helper.IsUpdateStrategyInPlace(newWorker.UpdateStrategy)
-		)
-
+		oldStrategyIsInPlace := helper.IsUpdateStrategyInPlace(oldWorker.UpdateStrategy)
 		if oldStrategyIsInPlace && !newStrategyIsInPlace {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("updateStrategy"), newWorker.UpdateStrategy, "update strategy cannot be changed from AutoInPlaceUpdate/ManualInPlaceUpdate to AutoRollingUpdate"))
 		}

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -178,6 +178,8 @@ func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Error
 	allErrs = append(allErrs, validation.ValidateShoot(shoot)...)
 	allErrs = append(allErrs, validation.ValidateForceDeletion(shoot, nil)...)
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
+	allErrs = append(allErrs, validation.ValidateInPlaceUpdateStrategyOnCreation(shoot)...)
+
 	return allErrs
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -522,7 +522,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				}
 
 				if !apiequality.Semantic.DeepEqual(o.Shoot.ResourcesToEncrypt, o.Shoot.EncryptedResources) {
-					if err := o.Shoot.UpdateInfoStatus(ctx, o.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+					if err := o.Shoot.UpdateInfoStatus(ctx, o.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
 						var encryptedResources []string
 						if o.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer != nil {
 							encryptedResources = shared.GetResourcesForEncryptionFromConfig(o.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig)
@@ -1085,7 +1085,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	if _, ok := o.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootSkipReadiness]; ok {
 		o.Logger.Info("Removing skip-readiness annotation")
 
-		if err := o.Shoot.UpdateInfo(ctx, o.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
+		if err := o.Shoot.UpdateInfo(ctx, o.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 			delete(shoot.Annotations, v1beta1constants.AnnotationShootSkipReadiness)
 			return nil
 		}); err != nil {
@@ -1109,7 +1109,7 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 		return nil
 	}
 
-	return o.Shoot.UpdateInfo(ctx, o.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
+	return o.Shoot.UpdateInfo(ctx, o.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 		controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
 		return nil
 	})

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -16,7 +16,7 @@ import (
 // UpdateAdvertisedAddresses updates the shoot.status.advertisedAddresses with the list of
 // addresses on which the API server of the shoot is accessible.
 func (b *Botanist) UpdateAdvertisedAddresses(ctx context.Context) error {
-	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
+	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 		addresses, err := b.ToAdvertisedAddresses()
 		if err != nil {
 			return err

--- a/pkg/gardenlet/operation/botanist/apiserverproxy.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy.go
@@ -60,7 +60,7 @@ func (b *Botanist) DeployAPIServerProxy(ctx context.Context) error {
 		return err
 	}
 
-	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
 		condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootAPIServerProxyUsesHTTPProxy)
 		condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, gardencorev1beta1.ConditionTrue, "APIServerProxyUsesHTTPProxy", "The API server proxy was reconfigured to use the HTTP proxy method.")
 		shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -330,7 +330,7 @@ func (b *Botanist) SetInPlaceUpdatePendingWorkers(ctx context.Context, worker *e
 		return nil
 	}
 
-	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
 		if shoot.Status.InPlaceUpdates == nil {
 			shoot.Status.InPlaceUpdates = &gardencorev1beta1.InPlaceUpdatesStatus{}
 		}

--- a/pkg/gardenlet/operation/botanist/botanist_test.go
+++ b/pkg/gardenlet/operation/botanist/botanist_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Botanist", func() {
 			Expect(botanist.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).To(Equal([]string{"pool-1", "pool-3", "pool-4"}))
 			Expect(botanist.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).To(Equal([]string{"pool-2", "pool-5", "pool-6"}))
 
-			Expect(botanist.Shoot.UpdateInfo(ctx, gardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+			Expect(botanist.Shoot.UpdateInfo(ctx, gardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
 				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
 					{
 						Name:           "pool-1",
@@ -287,7 +287,7 @@ var _ = Describe("Botanist", func() {
 			Expect(botanist.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).To(Equal([]string{"pool-1", "pool-3", "pool-4"}))
 			Expect(botanist.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).To(Equal([]string{"pool-2", "pool-5", "pool-6"}))
 
-			Expect(botanist.Shoot.UpdateInfo(ctx, gardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+			Expect(botanist.Shoot.UpdateInfo(ctx, gardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
 				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
 					{
 						Name:           "pool-1",

--- a/pkg/gardenlet/operation/botanist/clusteridentity.go
+++ b/pkg/gardenlet/operation/botanist/clusteridentity.go
@@ -19,7 +19,7 @@ func (b *Botanist) EnsureShootClusterIdentity(ctx context.Context) error {
 	if b.Shoot.GetInfo().Status.ClusterIdentity == nil {
 		clusterIdentity := fmt.Sprintf("%s-%s-%s", b.Shoot.ControlPlaneNamespace, b.Shoot.GetInfo().Status.UID, b.GardenClusterIdentity)
 
-		if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
+		if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 			shoot.Status.ClusterIdentity = &clusterIdentity
 			return nil
 		}); err != nil {

--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -75,7 +75,7 @@ func (b *Botanist) CheckPodCIDRsInNodes(ctx context.Context) error {
 
 	networkReadyForDualStackMigration := len(network.Status.IPFamilies) == 2
 	updateFunction := b.DetermineUpdateFunction(networkReadyForDualStackMigration, nodeList)
-	if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, updateFunction); err != nil {
+	if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, updateFunction); err != nil {
 		return fmt.Errorf("failed to update shoot info status during dual-stack migration: %w", err)
 	}
 	return nil
@@ -87,7 +87,7 @@ func (b *Botanist) UpdateDualStackMigrationConditionIfNeeded(ctx context.Context
 
 	constraint := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
 	if constraint == nil && len(shoot.Spec.Networking.IPFamilies) == 2 && shoot.Status.Networking != nil && len(shoot.Status.Networking.Nodes) == 1 {
-		if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+		if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
 			constraint := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
 			constraint = v1beta1helper.UpdatedConditionWithClock(b.Clock, constraint, gardencorev1beta1.ConditionFalse, "DualStackMigration", "The shoot is migrating to dual-stack networking.")
 			shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, constraint)

--- a/pkg/gardenlet/operation/botanist/infrastructure.go
+++ b/pkg/gardenlet/operation/botanist/infrastructure.go
@@ -66,7 +66,7 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 	if nodesCIDRs := b.Shoot.Components.Extensions.Infrastructure.NodesCIDRs(); len(nodesCIDRs) > 0 {
 		// Only update node CIDR if it's not already set.
 		if b.Shoot.GetInfo().Spec.Networking.Nodes == nil {
-			if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+			if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
 				shoot.Spec.Networking.Nodes = &nodesCIDRs[0]
 				return nil
 			}); err != nil {
@@ -87,7 +87,7 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 		networkingStatus.EgressCIDRs = egressCIDRs
 	}
 
-	if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+	if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
 		shoot.Status.Networking = networkingStatus
 		return nil
 	}); err != nil {

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -357,7 +357,7 @@ func (o *Operation) ReportShootProgress(ctx context.Context, stats *flow.Stats) 
 		lastUpdateTime = metav1.Now()
 	)
 
-	if err := o.Shoot.UpdateInfoStatus(ctx, o.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
+	if err := o.Shoot.UpdateInfoStatus(ctx, o.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
 		if shoot.Status.LastOperation == nil {
 			return fmt.Errorf("last operation of Shoot %s/%s is unset", shoot.Namespace, shoot.Name)
 		}
@@ -378,7 +378,7 @@ func (o *Operation) ReportShootProgress(ctx context.Context, stats *flow.Stats) 
 // CleanShootTaskError removes the error with taskID from the Shoot's status.LastErrors array.
 // If the status.LastErrors array is empty then status.LastErrors is also removed.
 func (o *Operation) CleanShootTaskError(ctx context.Context, taskID string) {
-	if err := o.Shoot.UpdateInfoStatus(ctx, o.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
+	if err := o.Shoot.UpdateInfoStatus(ctx, o.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 		shoot.Status.LastErrors = v1beta1helper.DeleteLastErrorByTaskID(shoot.Status.LastErrors, taskID)
 		return nil
 	}); err != nil {

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -376,7 +376,7 @@ func (s *Shoot) SetShootState(shootState *gardencorev1beta1.ShootState) {
 // using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
 // This method is protected by a mutex, so only a single UpdateInfo or UpdateInfoStatus operation can be
 // executed at any point in time.
-func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMerge bool, f func(*gardencorev1beta1.Shoot) error) error {
+func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMerge, mergeWithOptimisticLock bool, f func(*gardencorev1beta1.Shoot) error) error {
 	s.infoMutex.Lock()
 	defer s.infoMutex.Unlock()
 
@@ -384,8 +384,14 @@ func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMer
 	var patch client.Patch
 	if useStrategicMerge {
 		patch = client.StrategicMergeFrom(shoot.DeepCopy())
+		if mergeWithOptimisticLock {
+			patch = client.StrategicMergeFrom(shoot.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		}
 	} else {
 		patch = client.MergeFrom(shoot.DeepCopy())
+		if mergeWithOptimisticLock {
+			patch = client.MergeFromWithOptions(shoot.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		}
 	}
 	if err := f(shoot); err != nil {
 		return err
@@ -403,7 +409,7 @@ func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMer
 // using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
 // This method is protected by a mutex, so only a single UpdateInfo or UpdateInfoStatus operation can be
 // executed at any point in time.
-func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, useStrategicMerge bool, f func(*gardencorev1beta1.Shoot) error) error {
+func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, useStrategicMerge, mergeWithOptimisticLock bool, f func(*gardencorev1beta1.Shoot) error) error {
 	s.infoMutex.Lock()
 	defer s.infoMutex.Unlock()
 
@@ -411,8 +417,14 @@ func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, useStrate
 	var patch client.Patch
 	if useStrategicMerge {
 		patch = client.StrategicMergeFrom(shoot.DeepCopy())
+		if mergeWithOptimisticLock {
+			patch = client.StrategicMergeFrom(shoot.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		}
 	} else {
 		patch = client.MergeFrom(shoot.DeepCopy())
+		if mergeWithOptimisticLock {
+			patch = client.MergeFromWithOptions(shoot.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		}
 	}
 	if err := f(shoot); err != nil {
 		return err

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -669,7 +669,7 @@ func (r *Reconciler) performInPlaceUpdate(ctx context.Context, log logr.Logger, 
 		return fmt.Errorf("failed to perform certificate rotation in-place: %w", err)
 	}
 
-	if nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(node.Status.Conditions) {
+	if nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(node.Status.Conditions) && !kubernetesutils.HasMetaDataLabel(node, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateSuccessful) {
 		if err := r.deleteRemainingPods(ctx, log, node); err != nil {
 			return fmt.Errorf("failed to delete remaining pods: %w", err)
 		}

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -172,8 +172,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if isInPlaceUpdate(oscChanges) {
 		if !nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(node.Status.Conditions) {
-			log.Info("Node is not ready for in-place update, will be requeued when the node has the ready-for-update condition", "node", node.Name)
-			return reconcile.Result{}, nil
+			if node.Labels[machinev1alpha1.LabelKeyNodeUpdateResult] != machinev1alpha1.LabelValueNodeUpdateFailed {
+				log.Info("Node is not ready for in-place update, will be requeued when the node has the ready-for-update condition", "node", node.Name)
+				return reconcile.Result{}, nil
+			}
+
+			log.Info("Node has label update-result with failed value, will continue retrying the update")
 		}
 
 		log.Info("In-place update is in progress", "osUpdate", oscChanges.InPlaceUpdates.OperatingSystem,

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -67,7 +67,7 @@ const (
 
 var (
 	codec                         runtime.Codec
-	osVersionRegex                = regexp.MustCompile(`\d+(?:\.\d+)+`)
+	osVersionRegex                = regexp.MustCompile(`\b\d+(?:\.\d+)*\b`)
 	retriableErrorPatternRegex    = regexp.MustCompile(`(?i)network problems`)
 	nonRetriableErrorPatternRegex = regexp.MustCompile(`(?i)invalid arguments|system failure`)
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -423,6 +423,43 @@ PRETTY_NAME="Garden Linux 1592Foo"
 			Expect(podList.Items).To(HaveLen(2))
 		})
 
+		It("should not patch the node as update successful or delete the pods if the node is already labelled with update-result successful", func() {
+			metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateSuccessful)
+
+			pods := []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-2",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+					},
+				},
+			}
+
+			for _, pod := range pods {
+				Expect(c.Create(ctx, pod)).To(Succeed())
+			}
+
+			DeferCleanup(func() {
+				Expect(c.DeleteAllOf(ctx, &corev1.Pod{})).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			Expect(reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, &osVersion)).To(Succeed())
+
+			podList := &corev1.PodList{}
+			Expect(c.List(ctx, podList)).To(Succeed())
+			Expect(podList.Items).To(HaveLen(2))
+		})
+
 		It("should patch the node as update successful and delete the pods if the node has InPlaceUpdate condition with reason ReadyForUpdate", func() {
 			node.Status.Conditions = []corev1.NodeCondition{
 				{

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -132,6 +132,34 @@ GARDENLINUX_COMMIT_ID_LONG=5b20e1c0436d229b051f0481a72d0a366315b220
 			Expect(version).To(PointTo(Equal("1592.6")))
 		})
 
+		It("should return the OS version when patch version is also present", func() {
+			Expect(fs.WriteFile("/etc/os-release", []byte(`ID=gardenlinux
+NAME="Garden Linux"
+PRETTY_NAME="Garden Linux 1592.6.3"
+`), 0600)).To(Succeed())
+
+			version, err := GetOSVersion(&extensionsv1alpha1.InPlaceUpdates{}, fs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(PointTo(Equal("1592.6.3")))
+		})
+
+		It("should return the OS version when only major version is present", func() {
+			Expect(fs.WriteFile("/etc/os-release", []byte(`PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"
+`), 0600)).To(Succeed())
+
+			version, err := GetOSVersion(&extensionsv1alpha1.InPlaceUpdates{}, fs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(PointTo(Equal("12")))
+		})
+
 		It("should return nil when inPlaceUpdates is nil", func() {
 			version, err := GetOSVersion(nil, fs)
 			Expect(err).NotTo(HaveOccurred())
@@ -159,7 +187,7 @@ NAME="Garden Linux"
 		It("should return an error when it is not able to parse the version", func() {
 			Expect(fs.WriteFile("/etc/os-release", []byte(`ID=gardenlinux
 NAME="Garden Linux"
-PRETTY_NAME="Garden Linux 1592"
+PRETTY_NAME="Garden Linux 1592Foo"
 `), 0600)).To(Succeed())
 
 			version, err := GetOSVersion(&extensionsv1alpha1.InPlaceUpdates{}, fs)

--- a/pkg/provider-local/controller/operatingsystemconfig/actuator.go
+++ b/pkg/provider-local/controller/operatingsystemconfig/actuator.go
@@ -35,8 +35,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, osc *extensions
 		return []byte(userData), nil, nil, nil, err
 
 	case extensionsv1alpha1.OperatingSystemConfigPurposeReconcile:
-		extensionUnits, extensionFiles, inPlaceUpdates, err := a.handleReconcileOSC(osc)
-		return nil, extensionUnits, extensionFiles, inPlaceUpdates, err
+		return a.handleReconcileOSC(osc)
 
 	default:
 		return nil, nil, nil, nil, fmt.Errorf("unknown purpose: %s", purpose)
@@ -79,13 +78,14 @@ systemctl daemon-reload
 	return operatingsystemconfig.WrapProvisionOSCIntoOneshotScript(script), nil
 }
 
-func (a *actuator) handleReconcileOSC(osc *extensionsv1alpha1.OperatingSystemConfig) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, *extensionsv1alpha1.InPlaceUpdatesStatus, error) {
+func (a *actuator) handleReconcileOSC(osc *extensionsv1alpha1.OperatingSystemConfig) ([]byte, []extensionsv1alpha1.Unit, []extensionsv1alpha1.File, *extensionsv1alpha1.InPlaceUpdatesStatus, error) {
 	if osc.Spec.InPlaceUpdates == nil {
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, nil
 	}
 
 	// provider-local does not add any additional units or additional files
 	return nil,
+		nil,
 		nil,
 		&extensionsv1alpha1.InPlaceUpdatesStatus{
 			OSUpdate: &extensionsv1alpha1.OSUpdate{

--- a/pkg/provider-local/controller/worker/actuator.go
+++ b/pkg/provider-local/controller/worker/actuator.go
@@ -148,6 +148,7 @@ func (d *delegateFactory) WorkerDelegate(_ context.Context, worker *extensionsv1
 		d.decoder,
 		d.scheme,
 		seedChartApplier,
+		kubernetesclient.NewPodExecutor(d.restConfig),
 		serverVersion.GitVersion,
 		worker,
 		cluster,
@@ -160,6 +161,7 @@ type workerDelegate struct {
 	scheme  *runtime.Scheme
 
 	seedChartApplier    kubernetesclient.ChartApplier
+	podExecutor         kubernetesclient.PodExecutor
 	serverVersion       string
 	cloudProfileConfig  *api.CloudProfileConfig
 	cluster             *extensionscontroller.Cluster
@@ -176,6 +178,7 @@ func NewWorkerDelegate(
 	decoder runtime.Decoder,
 	scheme *runtime.Scheme,
 	seedChartApplier kubernetesclient.ChartApplier,
+	podExecutor kubernetesclient.PodExecutor,
 	serverVersion string,
 	worker *extensionsv1alpha1.Worker,
 	cluster *extensionscontroller.Cluster,
@@ -193,6 +196,7 @@ func NewWorkerDelegate(
 		client:             client,
 		decoder:            decoder,
 		seedChartApplier:   seedChartApplier,
+		podExecutor:        podExecutor,
 		serverVersion:      serverVersion,
 		cloudProfileConfig: config,
 		cluster:            cluster,

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -184,6 +184,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			Minimum:                      pool.Minimum,
 			Maximum:                      pool.Maximum,
 			Strategy:                     machineDeploymentStrategy,
+			PoolName:                     pool.Name,
 			Priority:                     pool.Priority,
 			Labels:                       pool.Labels,
 			Annotations:                  pool.Annotations,

--- a/pkg/provider-local/machine-provider/local/create_machine.go
+++ b/pkg/provider-local/machine-provider/local/create_machine.go
@@ -24,6 +24,9 @@ import (
 	"github.com/gardener/gardener/pkg/provider-local/machine-provider/api/validation"
 )
 
+// MachinePodContainerName is a constant for the name of the container in the machine pod.
+const MachinePodContainerName = "node"
+
 func (d *localDriver) CreateMachine(ctx context.Context, req *driver.CreateMachineRequest) (*driver.CreateMachineResponse, error) {
 	if req.MachineClass.Provider != apiv1alpha1.Provider {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("requested for provider '%s', we only support '%s'", req.MachineClass.Provider, apiv1alpha1.Provider))
@@ -90,7 +93,7 @@ func (d *localDriver) applyPod(
 	pod.Spec = corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
-				Name:            "node",
+				Name:            MachinePodContainerName,
 				Image:           providerSpec.Image,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				SecurityContext: &corev1.SecurityContext{

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -83,6 +83,12 @@ func SetAnnotationAndUpdate(ctx context.Context, c client.Client, obj client.Obj
 	return nil
 }
 
+// HasMetaDataLabel checks if the passed meta object has the given key, value set in the labels section.
+func HasMetaDataLabel(meta metav1.Object, key, value string) bool {
+	val, ok := meta.GetLabels()[key]
+	return ok && val == value
+}
+
 // ObjectKeyFromSecretRef returns an ObjectKey for the given SecretReference.
 func ObjectKeyFromSecretRef(ref corev1.SecretReference) client.ObjectKey {
 	return client.ObjectKey{

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -119,6 +119,19 @@ var _ = Describe("kubernetes", func() {
 		Entry("no matching value", map[string]string{"key": "value"}, "key", "value1", false),
 	)
 
+	DescribeTable("#HasMetaDataLabel",
+		func(labels map[string]string, key, value string, result bool) {
+			meta := &metav1.ObjectMeta{
+				Labels: labels,
+			}
+			Expect(HasMetaDataLabel(meta, key, value)).To(BeIdenticalTo(result))
+		},
+		Entry("no labels", map[string]string{}, "key", "value", false),
+		Entry("matching label", map[string]string{"key": "value"}, "key", "value", true),
+		Entry("no matching key", map[string]string{"key": "value"}, "key1", "value", false),
+		Entry("no matching value", map[string]string{"key": "value"}, "key", "value1", false),
+	)
+
 	Describe("#WaitUntilResourceDeleted", func() {
 		var (
 			namespace = "bar"

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -732,6 +732,9 @@ build:
             - pkg/provider-local/imagevector
             - pkg/provider-local/imagevector/images.yaml
             - pkg/provider-local/local
+            - pkg/provider-local/machine-provider/api/v1alpha1
+            - pkg/provider-local/machine-provider/api/validation
+            - pkg/provider-local/machine-provider/local
             - pkg/provider-local/webhook/controlplane
             - pkg/provider-local/webhook/dnsconfig
             - pkg/provider-local/webhook/networkpolicy

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1137,6 +1137,9 @@ build:
             - pkg/provider-local/imagevector
             - pkg/provider-local/imagevector/images.yaml
             - pkg/provider-local/local
+            - pkg/provider-local/machine-provider/api/v1alpha1
+            - pkg/provider-local/machine-provider/api/validation
+            - pkg/provider-local/machine-provider/local
             - pkg/provider-local/webhook/controlplane
             - pkg/provider-local/webhook/dnsconfig
             - pkg/provider-local/webhook/networkpolicy

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -779,6 +779,9 @@ build:
             - pkg/provider-local/imagevector
             - pkg/provider-local/imagevector/images.yaml
             - pkg/provider-local/local
+            - pkg/provider-local/machine-provider/api/v1alpha1
+            - pkg/provider-local/machine-provider/api/validation
+            - pkg/provider-local/machine-provider/local
             - pkg/provider-local/webhook/controlplane
             - pkg/provider-local/webhook/dnsconfig
             - pkg/provider-local/webhook/networkpolicy

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -82,20 +82,7 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 		Type:  ptr.To("calico"),
 		Nodes: ptr.To("10.10.0.0/16"),
 	}
-	shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, gardencorev1beta1.Worker{
-		Name: "local",
-		Machine: gardencorev1beta1.Machine{
-			Type: "local",
-		},
-		CRI: &gardencorev1beta1.CRI{
-			Name: gardencorev1beta1.CRINameContainerD,
-		},
-		Labels: map[string]string{
-			"foo": "bar",
-		},
-		Minimum: 1,
-		Maximum: 1,
-	})
+	shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, DefaultWorker("local", nil))
 	shoot.Spec.Extensions = append(shoot.Spec.Extensions, gardencorev1beta1.Extension{Type: "local-ext-shoot-after-worker"})
 
 	if os.Getenv("IPFAMILY") == "ipv6" {
@@ -118,6 +105,25 @@ func DefaultWorkerlessShoot(name string) *gardencorev1beta1.Shoot {
 	}
 
 	return shoot
+}
+
+// DefaultWorker returns a Worker object with default values for the e2e tests.
+func DefaultWorker(name string, updateStrategy *gardencorev1beta1.MachineUpdateStrategy) gardencorev1beta1.Worker {
+	return gardencorev1beta1.Worker{
+		Name: name,
+		Machine: gardencorev1beta1.Machine{
+			Type: "local",
+		},
+		CRI: &gardencorev1beta1.CRI{
+			Name: gardencorev1beta1.CRINameContainerD,
+		},
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+		UpdateStrategy: ptr.To(ptr.Deref(updateStrategy, gardencorev1beta1.AutoRollingUpdate)),
+		Minimum:        1,
+		Maximum:        1,
+	}
 }
 
 // DefaultNamespacedCloudProfile returns a NamespacedCloudProfile object with default values for the e2e tests.

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -50,9 +50,8 @@ func baseShoot(name string) *gardencorev1beta1.Shoot {
 				Name: "local",
 			},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.32.0",
-				EnableStaticTokenKubeconfig: ptr.To(false),
-				KubeAPIServer:               &gardencorev1beta1.KubeAPIServerConfig{},
+				Version:       "1.32.0",
+				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 			},
 			Provider: gardencorev1beta1.Provider{
 				Type: "local",

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -128,7 +128,7 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		}, SpecTimeout(5*time.Minute))
 	}
 
-	beforeStartMachinePodNames := ItShouldFindAllMachinePodsBefore(s)
+	machinePodNamesBeforeTest := ItShouldFindAllMachinePodsBefore(s)
 
 	ItShouldAnnotateShoot(s, map[string]string{
 		v1beta1constants.GardenerOperation: v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout,
@@ -152,7 +152,7 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		}).Should(Succeed())
 	}, SpecTimeout(time.Minute))
 
-	ItShouldCompareMachinePodNamesAfter(s, beforeStartMachinePodNames)
+	ItShouldCompareMachinePodNamesAfter(s, machinePodNamesBeforeTest)
 
 	It("Ensure all worker pools are marked as 'pending for roll out'", func() {
 		for _, worker := range s.Shoot.Spec.Provider.Workers {
@@ -309,11 +309,11 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				shootVerifiers = append(shootVerifiers, &rotation.SSHKeypairVerifier{ShootContext: s})
 			}
 
-			var beforeStartMachinePodNames sets.Set[string]
+			var machinePodNamesBeforeTest sets.Set[string]
 
 			if inPlaceUpdate {
 				ItShouldRewriteOsRelease(s)
-				beforeStartMachinePodNames = ItShouldFindAllMachinePodsBefore(s)
+				machinePodNamesBeforeTest = ItShouldFindAllMachinePodsBefore(s)
 				ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s)
 			}
 
@@ -325,7 +325,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			}
 
 			if inPlaceUpdate {
-				ItShouldCompareMachinePodNamesAfter(s, beforeStartMachinePodNames)
+				ItShouldCompareMachinePodNamesAfter(s, machinePodNamesBeforeTest)
 				ItShouldVerifyInPlaceUpdateCompletion(s)
 			}
 

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -312,7 +312,6 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			var machinePodNamesBeforeTest sets.Set[string]
 
 			if inPlaceUpdate {
-				ItShouldRewriteOS(s)
 				machinePodNamesBeforeTest = ItShouldFindAllMachinePodsBefore(s)
 				ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s)
 			}

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -312,7 +312,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			var machinePodNamesBeforeTest sets.Set[string]
 
 			if inPlaceUpdate {
-				ItShouldRewriteOsRelease(s)
+				ItShouldRewriteOS(s)
 				machinePodNamesBeforeTest = ItShouldFindAllMachinePodsBefore(s)
 				ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s)
 			}

--- a/test/e2e/gardener/shoot/create_update-in-place_delete.go
+++ b/test/e2e/gardener/shoot/create_update-in-place_delete.go
@@ -57,7 +57,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			ItShouldGetResponsibleSeed(s)
 			ItShouldInitializeSeedClient(s)
 
-			ItShouldRewriteOsRelease(s)
+			ItShouldRewriteOS(s)
 			ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s)
 			verifyWorkerNodeLabels(s)
 			inclusterclient.VerifyInClusterAccessToAPIServer(s)

--- a/test/e2e/gardener/shoot/create_update-in-place_delete.go
+++ b/test/e2e/gardener/shoot/create_update-in-place_delete.go
@@ -57,7 +57,6 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			ItShouldGetResponsibleSeed(s)
 			ItShouldInitializeSeedClient(s)
 
-			ItShouldRewriteOS(s)
 			ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s)
 			verifyWorkerNodeLabels(s)
 			inclusterclient.VerifyInClusterAccessToAPIServer(s)

--- a/test/e2e/gardener/shoot/create_update-in-place_delete.go
+++ b/test/e2e/gardener/shoot/create_update-in-place_delete.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shoot
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
+	shootupdatesuite "github.com/gardener/gardener/test/utils/shoots/update"
+)
+
+var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
+	Describe("Create, Update, Delete", Label("simple"), func() {
+		Context("Shoot with in-place workers", Label("basic", "in-place"), Ordered, func() {
+			shoot := DefaultShoot("e2e-default-ip")
+
+			s := NewTestContext().ForShoot(shoot)
+
+			s.Shoot.Spec.Kubernetes.Version = kubernetesTargetVersion
+
+			// create two worker pools which explicitly specify the kubernetes version
+			pool1 := DefaultWorker("auto", ptr.To(gardencorev1beta1.AutoInPlaceUpdate))
+			pool1.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: &s.Shoot.Spec.Kubernetes.Version}
+			pool1.Minimum = 2
+			pool1.Maximum = 2
+			pool1.MaxUnavailable = ptr.To(intstr.FromInt(1))
+			pool1.MaxSurge = ptr.To(intstr.FromInt(0))
+
+			pool2 := DefaultWorker("manual", ptr.To(gardencorev1beta1.ManualInPlaceUpdate))
+			pool2.Kubernetes = &gardencorev1beta1.WorkerKubernetes{
+				Version: ptr.To(kubernetesSourceVersion),
+				Kubelet: &gardencorev1beta1.KubeletConfig{
+					CPUManagerPolicy: ptr.To("none"),
+					EvictionHard: &gardencorev1beta1.KubeletConfigEviction{
+						MemoryAvailable: ptr.To("100Mi"),
+						NodeFSAvailable: ptr.To("100Mi"),
+					},
+				},
+			}
+
+			s.Shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{pool1, pool2}
+
+			ItShouldCreateShoot(s)
+			ItShouldWaitForShootToBeReconciledAndHealthy(s)
+			ItShouldInitializeShootClient(s)
+			ItShouldGetResponsibleSeed(s)
+			ItShouldInitializeSeedClient(s)
+
+			ItShouldRewriteOsRelease(s)
+			ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s)
+			verifyWorkerNodeLabels(s)
+			inclusterclient.VerifyInClusterAccessToAPIServer(s)
+			verifyNodeKubernetesVersions(s)
+
+			var (
+				beforeStartMachinePodNames    = ItShouldFindAllMachinePodsBefore(s)
+				cloudProfile                  *gardencorev1beta1.CloudProfile
+				controlPlaneKubernetesVersion string
+				poolNameToKubernetesVersion   map[string]string
+			)
+
+			It("Get CloudProfile", func(ctx SpecContext) {
+				Eventually(ctx, func() error {
+					var err error
+					cloudProfile, err = gardenerutils.GetCloudProfile(ctx, s.GardenClient, s.Shoot)
+					return err
+				}).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+
+			It("Compute new Kubernetes version for control plane and worker pools", func() {
+				var err error
+				controlPlaneKubernetesVersion, poolNameToKubernetesVersion, err = shootupdatesuite.ComputeNewKubernetesVersions(cloudProfile, s.Shoot, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("Update Shoot", func(ctx SpecContext) {
+				patch := client.StrategicMergeFrom(s.Shoot.DeepCopy())
+				if controlPlaneKubernetesVersion != "" {
+					s.Log.Info("Updating control plane Kubernetes version", "version", controlPlaneKubernetesVersion)
+					s.Shoot.Spec.Kubernetes.Version = controlPlaneKubernetesVersion
+				}
+				for i, worker := range s.Shoot.Spec.Provider.Workers {
+					if workerPoolVersion, ok := poolNameToKubernetesVersion[worker.Name]; ok {
+						s.Log.Info("Updating worker pool Kubernetes version", "pool", worker.Name, "version", workerPoolVersion)
+						s.Shoot.Spec.Provider.Workers[i].Kubernetes.Version = &workerPoolVersion
+					}
+				}
+
+				// Update machine image version for pool1
+				s.Log.Info("Updating worker pool machine image version", "pool", s.Shoot.Spec.Provider.Workers[0].Name, "version", "2.0.0")
+				s.Shoot.Spec.Provider.Workers[0].Machine.Image.Version = ptr.To("2.0.0")
+
+				// Update Kubelet config for pool2
+				s.Log.Info("Updating worker pool Kubelet config", "pool", s.Shoot.Spec.Provider.Workers[1].Name)
+				s.Shoot.Spec.Provider.Workers[1].Kubernetes.Kubelet = &gardencorev1beta1.KubeletConfig{
+					CPUManagerPolicy: ptr.To("static"),
+					EvictionHard: &gardencorev1beta1.KubeletConfigEviction{
+						MemoryAvailable: ptr.To("200Mi"),
+						NodeFSAvailable: ptr.To("200Mi"),
+					},
+				}
+
+				Eventually(ctx, func() error {
+					return s.GardenClient.Patch(ctx, s.Shoot, patch)
+				}).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+
+			ItShouldVerifyInPlaceUpdateStart(s)
+
+			ItShouldWaitForShootToBeReconciledAndHealthy(s)
+			ItShouldInitializeShootClient(s)
+			verifyNodeKubernetesVersions(s)
+			inclusterclient.VerifyInClusterAccessToAPIServer(s)
+
+			ItShouldCompareMachinePodNamesAfter(s, beforeStartMachinePodNames)
+			ItShouldVerifyInPlaceUpdateCompletion(s)
+
+			ItShouldDeleteShoot(s)
+			ItShouldWaitForShootToBeDeleted(s)
+		})
+	})
+})

--- a/test/e2e/gardener/shoot/create_update-in-place_delete.go
+++ b/test/e2e/gardener/shoot/create_update-in-place_delete.go
@@ -64,7 +64,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			verifyNodeKubernetesVersions(s)
 
 			var (
-				beforeStartMachinePodNames    = ItShouldFindAllMachinePodsBefore(s)
+				machinePodNamesBeforeTest     = ItShouldFindAllMachinePodsBefore(s)
 				cloudProfile                  *gardencorev1beta1.CloudProfile
 				controlPlaneKubernetesVersion string
 				poolNameToKubernetesVersion   map[string]string
@@ -123,7 +123,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			verifyNodeKubernetesVersions(s)
 			inclusterclient.VerifyInClusterAccessToAPIServer(s)
 
-			ItShouldCompareMachinePodNamesAfter(s, beforeStartMachinePodNames)
+			ItShouldCompareMachinePodNamesAfter(s, machinePodNamesBeforeTest)
 			ItShouldVerifyInPlaceUpdateCompletion(s)
 
 			ItShouldDeleteShoot(s)

--- a/test/e2e/gardener/shoot/shoot.go
+++ b/test/e2e/gardener/shoot/shoot.go
@@ -304,7 +304,7 @@ func ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s *ShootContext) {
 func ItShouldFindAllMachinePodsBefore(s *ShootContext) sets.Set[string] {
 	GinkgoHelper()
 
-	beforeStartMachinePodNames := sets.New[string]()
+	machinePodNamesBeforeTest := sets.New[string]()
 
 	It("Find all machine pods to ensure later that they weren't rolled out", func(ctx SpecContext) {
 		beforeStartMachinePodList := &corev1.PodList{}
@@ -314,30 +314,30 @@ func ItShouldFindAllMachinePodsBefore(s *ShootContext) sets.Set[string] {
 		})).Should(Succeed())
 
 		for _, item := range beforeStartMachinePodList.Items {
-			beforeStartMachinePodNames.Insert(item.Name)
+			machinePodNamesBeforeTest.Insert(item.Name)
 		}
 	}, SpecTimeout(time.Minute))
 
-	return beforeStartMachinePodNames
+	return machinePodNamesBeforeTest
 }
 
 // ItShouldCompareMachinePodNamesAfter compares the machine pod names before and after running the required tests.
-func ItShouldCompareMachinePodNamesAfter(s *ShootContext, beforeStartMachinePodNames sets.Set[string]) {
+func ItShouldCompareMachinePodNamesAfter(s *ShootContext, machinePodNamesBeforeTest sets.Set[string]) {
 	GinkgoHelper()
 
 	It("Compare machine pod names", func(ctx SpecContext) {
-		afterStartMachinePodList := &corev1.PodList{}
-		Eventually(ctx, s.SeedKomega.List(afterStartMachinePodList, client.InNamespace(s.Shoot.Status.TechnicalID), client.MatchingLabels{
+		machinePodListAfterTest := &corev1.PodList{}
+		Eventually(ctx, s.SeedKomega.List(machinePodListAfterTest, client.InNamespace(s.Shoot.Status.TechnicalID), client.MatchingLabels{
 			"app":              "machine",
 			"machine-provider": "local",
 		})).Should(Succeed())
 
-		afterStartMachinePodNames := sets.New[string]()
-		for _, item := range afterStartMachinePodList.Items {
-			afterStartMachinePodNames.Insert(item.Name)
+		machinePodNamesAfterTest := sets.New[string]()
+		for _, item := range machinePodListAfterTest.Items {
+			machinePodNamesAfterTest.Insert(item.Name)
 		}
 
-		Expect(beforeStartMachinePodNames.UnsortedList()).To(ConsistOf(afterStartMachinePodNames.UnsortedList()))
+		Expect(machinePodNamesBeforeTest.UnsortedList()).To(ConsistOf(machinePodNamesAfterTest.UnsortedList()))
 	}, SpecTimeout(time.Minute))
 }
 

--- a/test/e2e/gardener/shoot/shoot.go
+++ b/test/e2e/gardener/shoot/shoot.go
@@ -285,7 +285,10 @@ func ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s *ShootContext) {
 			}
 
 			nodeList := &corev1.NodeList{}
-			Eventually(ctx, s.ShootKomega.List(nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})).Should(Succeed())
+			Eventually(
+				ctx,
+				s.ShootKomega.List(nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name}),
+			).Should(Succeed(), "nodes for pool %s should be listed", pool.Name)
 
 			for _, node := range nodeList.Items {
 				if metav1.HasLabel(node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate) {
@@ -294,7 +297,7 @@ func ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s *ShootContext) {
 
 				Eventually(ctx, s.ShootKomega.Update(&node, func() {
 					metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate, "true")
-				})).Should(Succeed())
+				})).Should(Succeed(), "node %s should be labeled", node.Name)
 			}
 		}
 	}, SpecTimeout(2*time.Minute))
@@ -341,9 +344,9 @@ func ItShouldCompareMachinePodNamesAfter(s *ShootContext, machinePodNamesBeforeT
 	}, SpecTimeout(time.Minute))
 }
 
-// ItShouldRewriteOsRelease rewrites the /etc/os-release file for all machine pods to ensure that the version is overwritten for tests.
+// ItShouldRewriteOS rewrites the /etc/os-release file for all machine pods to ensure that the version is overwritten for tests.
 // This is a workaround for the fact that the machine image version is not available in the os-release file in the local provider.
-func ItShouldRewriteOsRelease(s *ShootContext) {
+func ItShouldRewriteOS(s *ShootContext) {
 	GinkgoHelper()
 
 	It("should rewrite the /etc/os-release for all machines", func(ctx SpecContext) {
@@ -360,7 +363,7 @@ func ItShouldRewriteOsRelease(s *ShootContext) {
 			node := &corev1.Node{}
 			Eventually(func() error {
 				return s.ShootClient.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name}, node)
-			}).Should(Succeed())
+			}).Should(Succeed(), "should get node for pod %s", pod.Name)
 
 			Expect(node.Labels).To(HaveKey(v1beta1constants.LabelWorkerPool))
 
@@ -382,7 +385,7 @@ func ItShouldRewriteOsRelease(s *ShootContext) {
 				"/etc/os-release",
 			)
 
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "should rewrite /etc/os-release for pod %s", pod.Name)
 		}
 	}, SpecTimeout(2*time.Minute))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane delivery open-source scalability
/kind enhancement

**What this PR does / why we need it**:
- This PR adds optimization to some of the controllers for handling edge cases
- Add e2e test for in-place credentials rotation
- Add e2e tests for machine image, kubernetes version, and kubelet config updates.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:
/hold until https://github.com/gardener/gardener/pull/11963 is merged

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
