### PR TITLE
Remove empty cidr check

### DIFF
--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -510,10 +510,20 @@ func networksAreDisjointed(seed *gardencorev1beta1.Seed, shoot *gardencorev1beta
 
 	if seed.Spec.Networks.ShootDefaults != nil {
 		if shootPodsNetwork == nil && !workerless {
-			shootPodsNetwork = seed.Spec.Networks.ShootDefaults.Pods
+			if cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Pods, field.NewPath("spec", "networks", "shootDefaults", "pods")).IsIPv6() &&
+				slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv6) ||
+				cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Pods, field.NewPath("spec", "networks", "shootDefaults", "pods")).IsIPv4() &&
+					slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv4) {
+				shootPodsNetwork = seed.Spec.Networks.ShootDefaults.Pods
+			}
 		}
 		if shootServicesNetwork == nil {
-			shootServicesNetwork = seed.Spec.Networks.ShootDefaults.Services
+			if cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Services, field.NewPath("spec", "networks", "shootDefaults", "services")).IsIPv6() &&
+				slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv6) ||
+				cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Services, field.NewPath("spec", "networks", "shootDefaults", "services")).IsIPv4() &&
+					slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv4) {
+				shootServicesNetwork = seed.Spec.Networks.ShootDefaults.Services
+			}
 		}
 	}
 

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -510,18 +510,16 @@ func networksAreDisjointed(seed *gardencorev1beta1.Seed, shoot *gardencorev1beta
 
 	if seed.Spec.Networks.ShootDefaults != nil {
 		if shootPodsNetwork == nil && !workerless {
-			if cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Pods, field.NewPath("spec", "networks", "shootDefaults", "pods")).IsIPv6() &&
+			if defaultPods := cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Pods, field.NewPath("spec", "networks", "shootDefaults", "pods")); defaultPods.IsIPv6() &&
 				slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv6) ||
-				cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Pods, field.NewPath("spec", "networks", "shootDefaults", "pods")).IsIPv4() &&
-					slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv4) {
+				defaultPods.IsIPv4() && slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv4) {
 				shootPodsNetwork = seed.Spec.Networks.ShootDefaults.Pods
 			}
 		}
 		if shootServicesNetwork == nil {
-			if cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Services, field.NewPath("spec", "networks", "shootDefaults", "services")).IsIPv6() &&
+			if defaultServices := cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Services, field.NewPath("spec", "networks", "shootDefaults", "services")); defaultServices.IsIPv6() &&
 				slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv6) ||
-				cidrvalidation.NewCIDR(*seed.Spec.Networks.ShootDefaults.Services, field.NewPath("spec", "networks", "shootDefaults", "services")).IsIPv4() &&
-					slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv4) {
+				defaultServices.IsIPv4() && slices.Contains(shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv4) {
 				shootServicesNetwork = seed.Spec.Networks.ShootDefaults.Services
 			}
 		}

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -535,7 +535,6 @@ func networksAreDisjointed(seed *gardencorev1beta1.Seed, shoot *gardencorev1beta
 		seed.Spec.Networks.Nodes,
 		seed.Spec.Networks.Pods,
 		seed.Spec.Networks.Services,
-		workerless,
 		!haVPN,
 	) {
 		errorMessages = append(errorMessages, e.ErrorBody())

--- a/pkg/scheduler/controller/shoot/reconciler_test.go
+++ b/pkg/scheduler/controller/shoot/reconciler_test.go
@@ -728,18 +728,6 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(bestSeed).To(BeNil())
 		})
 
-		It("should fail because it cannot find a seed cluster due to no shoot networks specified and no defaults", func() {
-			seed.Spec.Networks.ShootDefaults = nil
-			shoot.Spec.Networking = &gardencorev1beta1.Networking{}
-
-			Expect(fakeGardenClient.Create(ctx, cloudProfile)).To(Succeed())
-			Expect(fakeGardenClient.Create(ctx, seed)).To(Succeed())
-
-			bestSeed, err := reconciler.DetermineSeed(ctx, log, shoot)
-			Expect(err).To(HaveOccurred())
-			Expect(bestSeed).To(BeNil())
-		})
-
 		It("should fail because it cannot find a seed cluster due to region that no seed supports", func() {
 			shoot.Spec.Region = "another-region"
 

--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -17,8 +17,8 @@ func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, s
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateOverlapWithSeedWrapper(fldPath.Child("nodes"), shootNodes, "node", false, allowOverlap, seedNodes, seedPods, seedServices)...)
-	allErrs = append(allErrs, validateOverlapWithSeedWrapper(fldPath.Child("services"), shootServices, "service", true, allowOverlap, seedNodes, seedPods, seedServices)...)
-	allErrs = append(allErrs, validateOverlapWithSeedWrapper(fldPath.Child("pods"), shootPods, "pod", !workerless, allowOverlap, seedNodes, seedPods, seedServices)...)
+	allErrs = append(allErrs, validateOverlapWithSeedWrapper(fldPath.Child("services"), shootServices, "service", false, allowOverlap, seedNodes, seedPods, seedServices)...)
+	allErrs = append(allErrs, validateOverlapWithSeedWrapper(fldPath.Child("pods"), shootPods, "pod", false, allowOverlap, seedNodes, seedPods, seedServices)...)
 
 	return allErrs
 }

--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ValidateNetworkDisjointedness validates that the given <seedNetworks> and <k8sNetworks> are disjoint.
-func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, shootServices, seedNodes *string, seedPods, seedServices string, workerless, allowOverlap bool) field.ErrorList {
+func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, shootServices, seedNodes *string, seedPods, seedServices string, allowOverlap bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateOverlapWithSeedWrapper(fldPath.Child("nodes"), shootNodes, "node", false, allowOverlap, seedNodes, seedPods, seedServices)...)

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -157,37 +157,7 @@ var _ = Describe("utils", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should not fail due to missing fields (workerless Shoots)", func() {
-			errorList := ValidateNetworkDisjointedness(
-				field.NewPath(""),
-				nil,
-				nil,
-				nil,
-				&seedNodesCIDR,
-				seedPodsCIDR,
-				seedServicesCIDR,
-				false,
-			)
-
-			Expect(errorList).To(BeEmpty())
-		})
-
 		It("should not fail due to missing fields (HA VPN)", func() {
-			errorList := ValidateNetworkDisjointedness(
-				field.NewPath(""),
-				nil,
-				nil,
-				nil,
-				&seedNodesCIDR,
-				seedPodsCIDR,
-				seedServicesCIDR,
-				true,
-			)
-
-			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should not fail due to missing fields (workerless Shoots + HA VPN)", func() {
 			errorList := ValidateNetworkDisjointedness(
 				field.NewPath(""),
 				nil,
@@ -641,36 +611,6 @@ var _ = Describe("utils", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should not fail due to missing fields (workerless Shoots)", func() {
-			errorList := ValidateNetworkDisjointedness(
-				field.NewPath(""),
-				nil,
-				nil,
-				nil,
-				&seedNodesCIDRIPv6,
-				seedPodsCIDRIPv6,
-				seedServicesCIDRIPv6,
-				false,
-			)
-
-			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should not fail due to missing fields (workerless Shoots, HA VPN)", func() {
-			errorList := ValidateNetworkDisjointedness(
-				field.NewPath(""),
-				nil,
-				nil,
-				nil,
-				&seedNodesCIDRIPv6,
-				seedPodsCIDRIPv6,
-				seedServicesCIDRIPv6,
-				true,
-			)
-
-			Expect(errorList).To(BeEmpty())
-		})
-
 		It("should fail due to default vpn range overlap in pod cidr", func() {
 			var (
 				podsCIDR     = "fd8f:6d53:b97a:1::/120"
@@ -1022,21 +962,6 @@ var _ = Describe("utils", func() {
 			))
 		})
 
-		It("should fail due to missing fields (workerless Shoot)", func() {
-			errorList := ValidateShootNetworkDisjointedness(
-				field.NewPath(""),
-				nil,
-				nil,
-				nil,
-				true,
-			)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("[].services"),
-			}))))
-		})
-
 		It("should fail due to disjointedness of node, service and pod networks", func() {
 			var (
 				nodesCIDR    = "10.241.0.0/16"
@@ -1102,21 +1027,6 @@ var _ = Describe("utils", func() {
 				"Field": Equal("[].pods"),
 			})),
 			))
-		})
-
-		It("should fail due to missing fields (workerless Shoot)", func() {
-			errorList := ValidateShootNetworkDisjointedness(
-				field.NewPath(""),
-				nil,
-				nil,
-				nil,
-				true,
-			)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("[].services"),
-			}))))
 		})
 
 		It("should fail due to disjointedness of node, service and pod networks", func() {

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -147,7 +147,7 @@ var _ = Describe("utils", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should fail due to missing fields", func() {
+		It("should not fail due to missing fields", func() {
 			errorList := ValidateNetworkDisjointedness(
 				field.NewPath(""),
 				nil,
@@ -160,19 +160,10 @@ var _ = Describe("utils", func() {
 				false,
 			)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].services"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].pods"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should fail due to missing fields (workerless Shoots)", func() {
+		It("should not fail due to missing fields (workerless Shoots)", func() {
 			errorList := ValidateNetworkDisjointedness(
 				field.NewPath(""),
 				nil,
@@ -185,15 +176,10 @@ var _ = Describe("utils", func() {
 				false,
 			)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].services"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should fail due to missing fields (HA VPN)", func() {
+		It("should not fail due to missing fields (HA VPN)", func() {
 			errorList := ValidateNetworkDisjointedness(
 				field.NewPath(""),
 				nil,
@@ -206,19 +192,10 @@ var _ = Describe("utils", func() {
 				true,
 			)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].services"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].pods"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should fail due to missing fields (workerless Shoots + HA VPN)", func() {
+		It("should not fail due to missing fields (workerless Shoots + HA VPN)", func() {
 			errorList := ValidateNetworkDisjointedness(
 				field.NewPath(""),
 				nil,
@@ -231,12 +208,7 @@ var _ = Describe("utils", func() {
 				true,
 			)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].services"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
 		It("should fail due to reserved kube-apiserver mapping range overlap in pod cidr", func() {
@@ -679,7 +651,7 @@ var _ = Describe("utils", func() {
 			)
 		})
 
-		It("should fail due to missing fields", func() {
+		It("should not fail due to missing fields", func() {
 			errorList := ValidateNetworkDisjointedness(
 				field.NewPath(""),
 				nil,
@@ -692,19 +664,10 @@ var _ = Describe("utils", func() {
 				false,
 			)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].services"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].pods"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should fail due to missing fields (workerless Shoots)", func() {
+		It("should not fail due to missing fields (workerless Shoots)", func() {
 			errorList := ValidateNetworkDisjointedness(
 				field.NewPath(""),
 				nil,
@@ -717,15 +680,10 @@ var _ = Describe("utils", func() {
 				false,
 			)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].services"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should fail due to missing fields (workerless Shoots, HA VPN)", func() {
+		It("should not fail due to missing fields (workerless Shoots, HA VPN)", func() {
 			errorList := ValidateNetworkDisjointedness(
 				field.NewPath(""),
 				nil,
@@ -738,12 +696,7 @@ var _ = Describe("utils", func() {
 				true,
 			)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("[].services"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
 		It("should fail due to default vpn range overlap in pod cidr", func() {

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -37,7 +37,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDR,
 				seedServicesCIDR,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(BeEmpty())
@@ -58,7 +57,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				false,
 			)
 
@@ -89,7 +87,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				true,
 			)
 
@@ -111,7 +108,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				false,
 			)
 
@@ -140,7 +136,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				true,
 			)
 
@@ -157,7 +152,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDR,
 				seedServicesCIDR,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(BeEmpty())
@@ -172,7 +166,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				true,
 				false,
 			)
 
@@ -188,7 +181,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				true,
 			)
 
@@ -204,7 +196,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				true,
 				true,
 			)
 
@@ -226,7 +217,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				false,
 			)
 
@@ -253,7 +243,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDR,
 				seedServicesCIDR,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -279,7 +268,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDR,
 				seedServicesCIDR,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -304,7 +292,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				true,
 			)
 
@@ -342,7 +329,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				true,
 			)
 
@@ -371,7 +357,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDR,
 				seedServicesCIDR,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -399,7 +384,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				true,
 			)
 
@@ -421,7 +405,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				false,
 			)
 
@@ -446,7 +429,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				true,
 			)
 
@@ -468,7 +450,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				false,
 			)
 
@@ -494,7 +475,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDR,
 				seedPodsCIDR,
 				seedServicesCIDR,
-				false,
 				true,
 			)
 
@@ -525,7 +505,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(BeEmpty())
@@ -546,7 +525,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				false,
 				true,
 			)
 
@@ -578,7 +556,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -608,7 +585,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				false,
 				true,
 			)
 
@@ -638,7 +614,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -661,7 +636,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(BeEmpty())
@@ -676,7 +650,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				true,
 				false,
 			)
 
@@ -692,7 +665,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				true,
 				true,
 			)
 
@@ -714,7 +686,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				false,
 				false,
 			)
 
@@ -741,7 +712,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -767,7 +737,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -792,7 +761,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				false,
 				true,
 			)
 
@@ -822,7 +790,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -850,7 +817,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				false,
 				true,
 			)
 
@@ -876,7 +842,6 @@ var _ = Describe("utils", func() {
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
 				false,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -900,7 +865,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				false,
 				true,
 			)
 
@@ -926,7 +890,6 @@ var _ = Describe("utils", func() {
 				&seedNodesCIDRIPv6,
 				seedPodsCIDRIPv6,
 				seedServicesCIDRIPv6,
-				false,
 				false,
 			)
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -959,7 +959,6 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 					c.seed.Spec.Networks.Nodes,
 					c.seed.Spec.Networks.Pods,
 					c.seed.Spec.Networks.Services,
-					workerless,
 					!haVPN,
 				)...)
 			}
@@ -974,7 +973,6 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 					c.seed.Spec.Networks.Nodes,
 					c.seed.Spec.Networks.Pods,
 					c.seed.Spec.Networks.Services,
-					workerless,
 					!haVPN,
 				)...)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
In general, IPv6 shoots don't have pod and service ranges configured. For IPv4 shoots the ranges are required and checked during admission [here](https://github.com/gardener/gardener/blob/4026f2e30e4e6bacf185dd33393549da6b0a55cf/plugin/pkg/shoot/validator/admission.go#L921-L939).
We never ran into this issues, as all our seeds have IPv4 shootDefaults.

**Which issue(s) this PR fixes**:
Fixes #11943

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue, where IPv6 shoots without configured pod and service ranges can't be scheduled on seeds without configured shootDefaults.
```
