### PR TITLE
[gardenet] Sync seed backup credentials on start-up

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -127,3 +127,41 @@ func verifyRemoveAPIServerProxyLegacyPortFeatureGate(ctx context.Context, garden
 
 	return nil
 }
+
+// syncBackupSecretRefAndCredentialsRef syncs the seed backup credentials when possible.
+// TODO(vpnachev): Remove this function after v1.121.0 has been released.
+func syncBackupSecretRefAndCredentialsRef(backup *gardencorev1beta1.SeedBackup) {
+	if backup == nil {
+		return
+	}
+
+	emptySecretRef := corev1.SecretReference{}
+
+	// secretRef is set and credentialsRef is not, sync both fields.
+	if backup.SecretRef != emptySecretRef && backup.CredentialsRef == nil {
+		backup.CredentialsRef = &corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Namespace:  backup.SecretRef.Namespace,
+			Name:       backup.SecretRef.Name,
+		}
+
+		return
+	}
+
+	// secretRef is unset and credentialsRef refer a secret, sync both fields.
+	if backup.SecretRef == emptySecretRef && backup.CredentialsRef != nil &&
+		backup.CredentialsRef.APIVersion == "v1" && backup.CredentialsRef.Kind == "Secret" {
+		backup.SecretRef = corev1.SecretReference{
+			Namespace: backup.CredentialsRef.Namespace,
+			Name:      backup.CredentialsRef.Name,
+		}
+
+		return
+	}
+
+	// in all other cases we can do nothing:
+	// - both fields are unset -> we have nothing to sync
+	// - both fields are set -> let the validation check if they are correct
+	// - credentialsRef refer to WorkloadIdentity -> secretRef should stay unset
+}

--- a/cmd/gardenlet/app/options.go
+++ b/cmd/gardenlet/app/options.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -78,42 +77,4 @@ func (o *options) Validate() error {
 
 func (o *options) LogConfig() (string, string) {
 	return o.config.LogLevel, o.config.LogFormat
-}
-
-// syncBackupSecretRefAndCredentialsRef syncs the seed backup credentials when possible.
-// TODO(vpnachev): Remove this function after v1.121.0 has been released.
-func syncBackupSecretRefAndCredentialsRef(backup *gardencorev1beta1.SeedBackup) {
-	if backup == nil {
-		return
-	}
-
-	emptySecretRef := corev1.SecretReference{}
-
-	// secretRef is set and credentialsRef is not, sync both fields.
-	if backup.SecretRef != emptySecretRef && backup.CredentialsRef == nil {
-		backup.CredentialsRef = &corev1.ObjectReference{
-			APIVersion: "v1",
-			Kind:       "Secret",
-			Namespace:  backup.SecretRef.Namespace,
-			Name:       backup.SecretRef.Name,
-		}
-
-		return
-	}
-
-	// secretRef is unset and credentialsRef refer a secret, sync both fields.
-	if backup.SecretRef == emptySecretRef && backup.CredentialsRef != nil &&
-		backup.CredentialsRef.APIVersion == "v1" && backup.CredentialsRef.Kind == "Secret" {
-		backup.SecretRef = corev1.SecretReference{
-			Namespace: backup.CredentialsRef.Namespace,
-			Name:      backup.CredentialsRef.Name,
-		}
-
-		return
-	}
-
-	// in all other cases we can do nothing:
-	// - both fields are unset -> we have nothing to sync
-	// - both fields are set -> let the validation check if they are correct
-	// - credentialsRef refer to WorkloadIdentity -> secretRef should stay unset
 }

--- a/cmd/gardenlet/app/options.go
+++ b/cmd/gardenlet/app/options.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -66,6 +67,9 @@ func (o *options) Complete() error {
 }
 
 func (o *options) Validate() error {
+	// TODO(vpnachev): Remove once the backup.secretRef field is removed.
+	syncBackupSecretRefAndCredentialsRef(o.config.SeedConfig.Spec.Backup)
+
 	if errs := gardenletvalidation.ValidateGardenletConfiguration(o.config, nil, false); len(errs) > 0 {
 		return errs.ToAggregate()
 	}
@@ -74,4 +78,42 @@ func (o *options) Validate() error {
 
 func (o *options) LogConfig() (string, string) {
 	return o.config.LogLevel, o.config.LogFormat
+}
+
+// syncBackupSecretRefAndCredentialsRef syncs the seed backup credentials when possible.
+// TODO(vpnachev): Remove this function after v1.121.0 has been released.
+func syncBackupSecretRefAndCredentialsRef(backup *gardencorev1beta1.SeedBackup) {
+	if backup == nil {
+		return
+	}
+
+	emptySecretRef := corev1.SecretReference{}
+
+	// secretRef is set and credentialsRef is not, sync both fields.
+	if backup.SecretRef != emptySecretRef && backup.CredentialsRef == nil {
+		backup.CredentialsRef = &corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Namespace:  backup.SecretRef.Namespace,
+			Name:       backup.SecretRef.Name,
+		}
+
+		return
+	}
+
+	// secretRef is unset and credentialsRef refer a secret, sync both fields.
+	if backup.SecretRef == emptySecretRef && backup.CredentialsRef != nil &&
+		backup.CredentialsRef.APIVersion == "v1" && backup.CredentialsRef.Kind == "Secret" {
+		backup.SecretRef = corev1.SecretReference{
+			Namespace: backup.CredentialsRef.Namespace,
+			Name:      backup.CredentialsRef.Name,
+		}
+
+		return
+	}
+
+	// in all other cases we can do nothing:
+	// - both fields are unset -> we have nothing to sync
+	// - both fields are set -> let the validation check if they are correct
+	// - credentialsRef refer to WorkloadIdentity -> secretRef should stay unset
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind bug

**What this PR does / why we need it**:
Gardenlet sync seed backup credentials on start-up. 
In some cases, where gardenlet upgrade itself from a `Gardenlet` resource for example, the `seed.spec.backup.credentialsRef` field may be unavailable in the `gardenlet-config` ConfigMap because the old gardenlet is not aware about this new field and do not preserve it when deploying the newer gardenlet. 

For example, here https://github.com/gardener/gardener/blob/5a40e73805a404441acb4868397689be91c4202f/pkg/gardenlet/controller/gardenlet/reconciler.go#L67 the `credentialsRef` field get lost when the old gardenlet reads the seed template from the `Gardenlet` resource, therefore the newer gardenlet is started only with `secretRef` set which is now invalid configuration and it fails with 
```error
Error: seedConfig.spec.backup.credentialsRef: Required value: must be set to refer a Secret or WorkloadIdentity
```

**Which issue(s) this PR fixes**:
Follow-up on #11583
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
cc @acumino 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
