### PR TITLE
[GEP-26] Stale project controller considers workload identities

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -234,6 +234,7 @@ This reconciler is enabled by default and works as follows:
     1. `Shoot` resources.
     1. `BackupEntry` resources.
     1. `Secret` resources that are referenced by a `SecretBinding` or a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
+    1. `WorkloadIdentity` resources that are referenced a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
     1. `Quota` resources that are referenced by a `SecretBinding` or a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
     1. The time period when the project was used for the last time (`status.lastActivityTimestamp`) is longer than the configured `minimumLifetimeDays`
 

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -234,7 +234,7 @@ This reconciler is enabled by default and works as follows:
     1. `Shoot` resources.
     1. `BackupEntry` resources.
     1. `Secret` resources that are referenced by a `SecretBinding` or a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
-    1. `WorkloadIdentity` resources that are referenced a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
+    1. `WorkloadIdentity` resources that are referenced by a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
     1. `Quota` resources that are referenced by a `SecretBinding` or a `CredentialsBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
     1. The time period when the project was used for the last time (`status.lastActivityTimestamp`) is longer than the configured `minimumLifetimeDays`
 

--- a/pkg/controllermanager/controller/project/stale/reconciler.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler.go
@@ -157,14 +157,13 @@ func (r *Reconciler) projectInUseDueToWorkloadIdentities(ctx context.Context, na
 		ctx,
 		workloadIdentityList,
 		client.InNamespace(namespace),
-		gardenerutils.UncontrolledSecretSelector,
 		client.MatchingLabels{v1beta1constants.LabelCredentialsBindingReference: "true"},
 	)
 	if err != nil {
 		return false, err
 	}
 
-	workloadIdentityNames := sets.New[string]()
+	workloadIdentityNames := make(sets.Set[string], len(workloadIdentityList.Items))
 	for _, workloadIdentity := range workloadIdentityList.Items {
 		workloadIdentityNames.Insert(workloadIdentity.Name)
 	}

--- a/pkg/controllermanager/controller/project/stale/reconciler.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler.go
@@ -163,12 +163,13 @@ func (r *Reconciler) projectInUseDueToWorkloadIdentities(ctx context.Context, na
 		return false, err
 	}
 
+	if len(workloadIdentityList.Items) == 0 {
+		return false, nil
+	}
+
 	workloadIdentityNames := make(sets.Set[string], len(workloadIdentityList.Items))
 	for _, workloadIdentity := range workloadIdentityList.Items {
 		workloadIdentityNames.Insert(workloadIdentity.Name)
-	}
-	if workloadIdentityNames.Len() == 0 {
-		return false, nil
 	}
 
 	return r.relevantCredentialsBindingsInUse(ctx, func(credentialsBinding securityv1alpha1.CredentialsBinding) bool {
@@ -221,12 +222,13 @@ func (r *Reconciler) projectInUseDueToSecrets(ctx context.Context, namespace str
 		return false, err
 	}
 
-	credentialsBindingsSecretNames := sets.New[string]()
+	if len(credentialsBindingRefSecretList.Items) == 0 {
+		return false, nil
+	}
+
+	credentialsBindingsSecretNames := make(sets.Set[string], len(credentialsBindingRefSecretList.Items))
 	for _, secret := range credentialsBindingRefSecretList.Items {
 		credentialsBindingsSecretNames.Insert(secret.Name)
-	}
-	if credentialsBindingsSecretNames.Len() == 0 {
-		return false, nil
 	}
 
 	return r.relevantCredentialsBindingsInUse(ctx, func(credentialsBinding securityv1alpha1.CredentialsBinding) bool {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
/cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The [Stale Project Controller](https://gardener.cloud/docs/gardener/concepts/controller-manager/#stale-projects-reconcilerhttpsgithubcomgardenergardenertreemasterpkgcontrollermanagercontrollerprojectstale) now also considers `WorkloadIdentity` resources when deciding if a `Project` is stale or not.
```
