### PR TITLE
Allow the Gardenlet to see the ManagedSeed object of its own cluster

### DIFF
--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -238,7 +238,7 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, _ admis
 	}
 	allErrs = append(allErrs, errs...)
 
-	gardenerutils.MaintainSeedNameLabels(managedSeed, shoot.Spec.SeedName)
+	gardenerutils.MaintainSeedNameLabels(managedSeed, shoot.Spec.SeedName, &managedSeed.Name)
 
 	switch a.GetOperation() {
 	case admission.Create:

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -374,22 +374,24 @@ var _ = Describe("ManagedSeed", func() {
 					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).To(Succeed())
 				})
 
-				It("should add the label for the parent seed name", func() {
+				It("should add the label for the parent and the current seed name", func() {
 					Expect(admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)).To(Succeed())
 
 					Expect(managedSeed.Labels).To(And(
 						HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
+						HaveKeyWithValue("name.seed.gardener.cloud/foo", "true"),
 					))
 				})
 
 				It("should remove unneeded labels", func() {
-					metav1.SetMetaDataLabel(&seed.ObjectMeta, "name.seed.gardener.cloud/foo", "true")
+					metav1.SetMetaDataLabel(&seed.ObjectMeta, "name.seed.gardener.cloud/bar", "true")
 
 					Expect(admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)).To(Succeed())
 
 					Expect(managedSeed.Labels).To(And(
 						HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
-						Not(HaveKey("name.seed.gardener.cloud/foo")),
+						HaveKeyWithValue("name.seed.gardener.cloud/foo", "true"),
+						Not(HaveKey("name.seed.gardener.cloud/bar")),
 					))
 				})
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:

Allow the Gardenlet to see the ManagedSeed object of its own cluster

In `pkg/gardenlet/controller/seed/seed/reconciler.go`

    (r *Reconciler) Reconcile(...) ...

the gardenlet tries to detect if it is running in a managed seed:

    managedSeed, err := kubernetesutils.GetManagedSeedByName(ctx, r.GardenClient, seed.Name)
    if err != nil {
      if !apierrors.IsNotFound(err) {
        return reconcile.Result{}, fmt.Errorf("failed to get managed seed: %w", err)
      }
    }
    isManagedSeed := managedSeed != nil

by getting the ManagedSeed object for its own name. If it finds a ManagedSeed object, then it knows that it is running in a Gardener managed seed cluster.

This information, whether the gardenlet is running in a managed seed or not, is used for this older PR: https://github.com/gardener/gardener/pull/9716

If it is a managed seed, the CA of the kubelet's certificate is not issued by the Kubernetes cluster's root CA (see details in that PR) and hence the TLS verification should be skipped in the cadvisor/kubelet scrape job of the cache Prometheus.

The PR https://github.com/gardener/gardener/pull/11773, https://github.com/gardener/gardener/pull/11773/commits/d19cb61f7bb1a93e40941b9ea25ecb94335f4026 that was released first with v1.117.0 introduced a change, such that the gardenlet can no longer see the ManagedSeed object of its own cluster anymore.

This breaks the heuristic above to detect if the gardenlet is running in a managed seed or not.

Conceptually it is valid that the gardenlet should be able to see the ManagedSeed object of its own cluster. Currently this is controlled by the

    name.seed.gardener.cloud/<seed-name>: "true"

labels on the ManagedSeed object using admission webhooks.

By adding a new label to the ManagedSeed object for the gardenlet's own cluster, the gardenlet will be able to see the ManagedSeed object again, not only for its seed, but also for its own cluster.

<details>

<summary>We confirmed this fix in a managed seed in a local setup</summary>

Create a shoot and upgrade it to a managed seed and add an `/etc/hosts` entry for the managed seed's API `api.managedseed.garden.external.local.gardener.cloud`:

    k apply -f example/provider-local/managedseeds/shoot-managedseed.yaml
    k apply -f example/provider-local/managedseeds/managedseed.yaml

In the managed seed's garden namespace:

    k port-forward prometheus-cache-0 9090
    curl -sS localhost:9090/api/v1/status/config | jq .data.yaml -r | grep "job_name: cadvisor" -A 20 | grep skip
    --> verify the expected Prometheus configuration: TLS verification should be skipped

In the virtual Garden cluster:

    k get managedseeds -n garden managedseed -o yaml | yq .metadata.labels | grep name.seed.gardener.cloud
    --> verify the new label on the ManagedSeed object

</details>

**Which issue(s) this PR fixes**:

The cache Prometheus in a Gardener managed seed can not scrape the cadvisor and kubelet metrics of the seed nodes, and hence the shoot control plane Plutono dashboards can not show e.g. the CPU usage of the control plane components.

**Special notes for your reviewer**:

cc @vicwicker @rfranzke

The regression was introduced with `v1.117.0`, so this PR should be cherry-picked to the release branch of `v1.117.x`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a regression that prevented the cache Prometheus in a Gardener managed seed from scraping the cadvisor and kubelet metrics of the seed nodes, and hence the shoot control plane Plutono dashboards could not show e.g. the CPU usage of the control plane components.
```
