### PR TITLE
Cache sync health check with deadline

### DIFF
--- a/cmd/gardener-admission-controller/app/app.go
+++ b/cmd/gardener-admission-controller/app/app.go
@@ -105,6 +105,9 @@ func run(ctx context.Context, log logr.Logger, cfg *admissioncontrollerconfigv1a
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+		return err
+	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
 		return err
 	}

--- a/cmd/gardener-admission-controller/app/app.go
+++ b/cmd/gardener-admission-controller/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/version/verflag"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -105,7 +106,7 @@ func run(ctx context.Context, log logr.Logger, cfg *admissioncontrollerconfigv1a
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
-	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 		return err
 	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/version/verflag"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -129,7 +130,7 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
-	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 		return err
 	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -129,6 +129,9 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+		return err
+	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
 		return err
 	}

--- a/cmd/gardener-extension-admission-local/app/app.go
+++ b/cmd/gardener-extension-admission-local/app/app.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/version/verflag"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -138,7 +139,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 					return err
 				}
 
-				if err := mgr.AddHealthzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(sourceCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+				if err := mgr.AddHealthzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, sourceCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 					return err
 				}
 				if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
@@ -158,7 +159,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 				return fmt.Errorf("could not add healthcheck: %w", err)
 			}
-			if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+			if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 				return err
 			}
 			if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {

--- a/cmd/gardener-extension-admission-local/app/app.go
+++ b/cmd/gardener-extension-admission-local/app/app.go
@@ -138,6 +138,9 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 					return err
 				}
 
+				if err := mgr.AddHealthzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(sourceCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+					return err
+				}
 				if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
 					return err
 				}
@@ -152,14 +155,15 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
-				return fmt.Errorf("could not add readycheck for informers: %w", err)
-			}
-
 			if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 				return fmt.Errorf("could not add healthcheck: %w", err)
 			}
-
+			if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+				return err
+			}
+			if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
+				return fmt.Errorf("could not add readycheck for informers: %w", err)
+			}
 			if err := mgr.AddReadyzCheck("webhook-server", mgr.GetWebhookServer().StartedChecker()); err != nil {
 				return fmt.Errorf("could not add readycheck of webhook to manager: %w", err)
 			}

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -241,6 +241,14 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 					return fmt.Errorf("failed creating garden cluster object: %w", err)
 				}
 
+				log.Info("Setting up checks for garden cluster cache")
+				if err := mgr.AddHealthzCheck("garden-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(gardenCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+					return err
+				}
+				if err := mgr.AddReadyzCheck("garden-informer-sync", gardenerhealthz.NewCacheSyncHealthz(gardenCluster.GetCache())); err != nil {
+					return err
+				}
+
 				log.Info("Adding garden cluster to manager")
 				if err := mgr.Add(gardenCluster); err != nil {
 					return fmt.Errorf("failed adding garden cluster to manager: %w", err)

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -242,7 +243,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				}
 
 				log.Info("Setting up checks for garden cluster cache")
-				if err := mgr.AddHealthzCheck("garden-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(gardenCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+				if err := mgr.AddHealthzCheck("garden-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, gardenCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 					return err
 				}
 				if err := mgr.AddReadyzCheck("garden-informer-sync", gardenerhealthz.NewCacheSyncHealthz(gardenCluster.GetCache())); err != nil {
@@ -289,7 +290,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 				return fmt.Errorf("could not add healthcheck: %w", err)
 			}
-			if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+			if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 				return err
 			}
 			if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {

--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -159,6 +159,9 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *n
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+		return err
+	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
 		return err
 	}

--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/version/verflag"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -159,7 +160,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *n
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
-	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 		return err
 	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {

--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -129,7 +129,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *o
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
-	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 		return err
 	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {

--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -129,6 +129,9 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *o
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+		return err
+	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
 		return err
 	}

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -22,6 +22,7 @@ import (
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/version/verflag"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -156,7 +157,7 @@ func run(ctx context.Context, log logr.Logger, cfg *resourcemanagerconfigv1alpha
 	if err := mgr.AddHealthzCheck("apiserver-healthz", gardenerhealthz.NewAPIServerHealthz(ctx, sourceClientSet.RESTClient())); err != nil {
 		return err
 	}
-	if err := mgr.AddHealthzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+	if err := mgr.AddHealthzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 		return err
 	}
 	if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
@@ -200,7 +201,7 @@ func run(ctx context.Context, log logr.Logger, cfg *resourcemanagerconfigv1alpha
 		}
 
 		log.Info("Setting up checks for target informer sync")
-		if err := mgr.AddHealthzCheck("target-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(targetCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+		if err := mgr.AddHealthzCheck("target-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, targetCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 			return err
 		}
 		if err := mgr.AddReadyzCheck("target-informer-sync", gardenerhealthz.NewCacheSyncHealthz(targetCluster.GetCache())); err != nil {

--- a/cmd/gardener-scheduler/app/app.go
+++ b/cmd/gardener-scheduler/app/app.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/component-base/version/verflag"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -122,7 +123,7 @@ func run(ctx context.Context, log logr.Logger, cfg *schedulerconfigv1alpha1.Sche
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
-	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 		return err
 	}
 	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {

--- a/cmd/gardener-scheduler/app/app.go
+++ b/cmd/gardener-scheduler/app/app.go
@@ -119,10 +119,13 @@ func run(ctx context.Context, log logr.Logger, cfg *schedulerconfigv1alpha1.Sche
 	}
 
 	log.Info("Adding health check endpoints to manager")
-	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
-	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+		return err
+	}
+	if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
 		return err
 	}
 

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -166,6 +166,9 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *g
 	if err := mgr.AddHealthzCheck("periodic-health", gardenerhealthz.CheckerFunc(healthManager)); err != nil {
 		return err
 	}
+	if err := mgr.AddHealthzCheck("seed-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+		return err
+	}
 	if err := mgr.AddReadyzCheck("seed-informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
 		return err
 	}

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -166,7 +166,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *g
 	if err := mgr.AddHealthzCheck("periodic-health", gardenerhealthz.CheckerFunc(healthManager)); err != nil {
 		return err
 	}
-	if err := mgr.AddHealthzCheck("seed-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+	if err := mgr.AddHealthzCheck("seed-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, mgr.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
 		return err
 	}
 	if err := mgr.AddReadyzCheck("seed-informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {

--- a/pkg/healthz/informer.go
+++ b/pkg/healthz/informer.go
@@ -13,20 +13,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
+func cacheSyncCheckFunc(cacheSyncWaiter cacheSyncWaiter) error {
+	// cache.Cache.WaitForCacheSync is racy for closed context, so use context with 1ms timeout instead.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	if !cacheSyncWaiter.WaitForCacheSync(ctx) {
+		return errors.New("informers not synced yet")
+	}
+	return nil
+}
+
 type cacheSyncWaiter interface {
 	WaitForCacheSync(ctx context.Context) bool
 }
 
 // NewCacheSyncHealthz returns a new healthz.Checker that will pass only if all informers in the given cacheSyncWaiter sync.
 func NewCacheSyncHealthz(cacheSyncWaiter cacheSyncWaiter) healthz.Checker {
-	return func(_ *http.Request) error {
-		// cache.Cache.WaitForCacheSync is racy for closed context, so use context with 1ms timeout instead.
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-		defer cancel()
-
-		if !cacheSyncWaiter.WaitForCacheSync(ctx) {
-			return errors.New("informers not synced yet")
-		}
-		return nil
-	}
+	return func(_ *http.Request) error { return cacheSyncCheckFunc(cacheSyncWaiter) }
 }

--- a/pkg/healthz/informer.go
+++ b/pkg/healthz/informer.go
@@ -34,6 +34,9 @@ func NewCacheSyncHealthz(cacheSyncWaiter cacheSyncWaiter) healthz.Checker {
 	return func(_ *http.Request) error { return cacheSyncCheckFunc(cacheSyncWaiter) }
 }
 
+// DefaultCacheSyncDeadline is a default deadline for the cache sync healthz check.
+const DefaultCacheSyncDeadline = 3 * time.Minute
+
 // Now is an alias for time.Now.
 // Exposed for unit testing.
 var Now = time.Now

--- a/pkg/healthz/informer_test.go
+++ b/pkg/healthz/informer_test.go
@@ -6,11 +6,14 @@ package healthz_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	. "github.com/gardener/gardener/pkg/healthz"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Informer", func() {
@@ -23,6 +26,72 @@ var _ = Describe("Informer", func() {
 		It("should fail if informers don't sync", func() {
 			checker := NewCacheSyncHealthz(&fakeSyncWaiter{false})
 			Expect(checker(nil)).To(MatchError(ContainSubstring("not synced")))
+		})
+	})
+
+	Describe("#NewCacheSyncHealthzWithDeadline", func() {
+		var (
+			deadline = time.Minute
+			checker  healthz.Checker
+		)
+
+		It("should succeed if all informers sync", func() {
+			checker = NewCacheSyncHealthzWithDeadline(&fakeSyncWaiter{true}, deadline)
+			Expect(checker(nil)).To(Succeed())
+		})
+
+		When("the informers are not synced", func() {
+			var (
+				waiter *fakeSyncWaiter
+				now    time.Time
+			)
+
+			BeforeEach(func() {
+				waiter = &fakeSyncWaiter{false}
+				checker = NewCacheSyncHealthzWithDeadline(waiter, deadline)
+				now = time.Now()
+
+				DeferCleanup(test.WithVar(&Now, func() time.Time { return now }))
+			})
+
+			It("should succeed as long as the deadline is not hit even if not all informers sync", func() {
+				By("succeed because deadline is not hit")
+				Expect(checker(nil)).To(Succeed())
+				now = now.Add(deadline / 2)
+
+				By("succeed because deadline is not hit")
+				Expect(checker(nil)).To(Succeed())
+				now = now.Add(deadline / 2)
+
+				By("fail because deadline is hit")
+				Expect(checker(nil)).To(MatchError(ContainSubstring("not synced")))
+			})
+
+			It("should reset the time all informers are synced after not working for a certain time", func() {
+				By("succeed because deadline is not hit")
+				Expect(checker(nil)).To(Succeed())
+				now = now.Add(deadline / 2)
+
+				By("succeed because deadline is not hit")
+				Expect(checker(nil)).To(Succeed())
+				now = now.Add(deadline / 2)
+
+				By("succeed because caches are synced")
+				waiter.value = true
+				Expect(checker(nil)).To(Succeed())
+
+				By("succeed because deadline is not hit")
+				waiter.value = false
+				Expect(checker(nil)).To(Succeed())
+				now = now.Add(deadline / 2)
+
+				By("succeed because deadline is not hit")
+				Expect(checker(nil)).To(Succeed())
+				now = now.Add(deadline / 2)
+
+				By("fail because deadline is hit")
+				Expect(checker(nil)).To(MatchError(ContainSubstring("not synced")))
+			})
 		})
 	})
 })

--- a/pkg/healthz/informer_test.go
+++ b/pkg/healthz/informer_test.go
@@ -10,22 +10,25 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/gardener/gardener/pkg/healthz"
+	. "github.com/gardener/gardener/pkg/healthz"
 )
 
-var _ = Describe("NewCacheSyncHealthz", func() {
-	It("should succeed if all informers sync", func() {
-		checker := healthz.NewCacheSyncHealthz(fakeSyncWaiter(true))
-		Expect(checker(nil)).NotTo(HaveOccurred())
-	})
-	It("should fail if informers don't sync", func() {
-		checker := healthz.NewCacheSyncHealthz(fakeSyncWaiter(false))
-		Expect(checker(nil)).To(MatchError(ContainSubstring("not synced")))
+var _ = Describe("Informer", func() {
+	Describe("#NewCacheSyncHealthz", func() {
+		It("should succeed if all informers sync", func() {
+			checker := NewCacheSyncHealthz(&fakeSyncWaiter{true})
+			Expect(checker(nil)).To(Succeed())
+		})
+
+		It("should fail if informers don't sync", func() {
+			checker := NewCacheSyncHealthz(&fakeSyncWaiter{false})
+			Expect(checker(nil)).To(MatchError(ContainSubstring("not synced")))
+		})
 	})
 })
 
-type fakeSyncWaiter bool
-
-func (f fakeSyncWaiter) WaitForCacheSync(_ context.Context) bool {
-	return bool(f)
+type fakeSyncWaiter struct {
+	value bool
 }
+
+func (f *fakeSyncWaiter) WaitForCacheSync(_ context.Context) bool { return f.value }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a new liveness probe for all Gardener components which fails if their watch caches don't sync of `3m`. This will result in `kubelet` restarting them to allow them to rebuild their caches.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11944

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener core components are automatically restarted (due to a failing liveness probe) in case their Kubernetes API server watch caches do not sync for `3m`.
```
