### PR TITLE
[Operator] Make gardener-dashboard OIDC ca field configurable

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1136,6 +1136,22 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              caSecretRef:
+                                description: CaSecretRef is the reference to a secret
+                                  in the garden namespace containing a custom CA certificate
+                                  under the "ca.crt" key
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
                               clientIDPublic:
                                 description: |-
                                   ClientIDPublic is the public client ID.

--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1136,10 +1136,10 @@ spec:
                                 items:
                                   type: string
                                 type: array
-                              caSecretRef:
-                                description: CaSecretRef is the reference to a secret
-                                  in the garden namespace containing a custom CA certificate
-                                  under the "ca.crt" key
+                              certificateAuthoritySecretRef:
+                                description: CertificateAuthoritySecretRef is the
+                                  reference to a secret in the garden namespace containing
+                                  a custom CA certificate under the "ca.crt" key
                                 properties:
                                   name:
                                     default: ""

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -774,7 +774,7 @@ Kubernetes core/v1.LocalObjectReference
 </tr>
 <tr>
 <td>
-<code>caSecretRef</code></br>
+<code>certificateAuthoritySecretRef</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#localobjectreference-v1-core">
 Kubernetes core/v1.LocalObjectReference
@@ -783,7 +783,7 @@ Kubernetes core/v1.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CaSecretRef is the reference to a secret in the garden namespace containing a custom CA certificate under the &ldquo;ca.crt&rdquo; key</p>
+<p>CertificateAuthoritySecretRef is the reference to a secret in the garden namespace containing a custom CA certificate under the &ldquo;ca.crt&rdquo; key</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -772,6 +772,20 @@ Kubernetes core/v1.LocalObjectReference
 <p>SecretRef is the reference to a secret in the garden namespace containing the OIDC client ID and secret for the dashboard.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>caSecretRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CaSecretRef is the reference to a secret in the garden namespace containing a custom CA certificate under the &ldquo;ca.crt&rdquo; key</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="operator.gardener.cloud/v1alpha1.DashboardTerminal">DashboardTerminal

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -280,6 +280,7 @@ This section highlights the most prominent fields:
   `issuerURL` is the URL of the JWT issuer.
   `sessionLifetime` is the duration after which a session is terminated (i.e., after which a user is automatically logged out).
   `additionalScopes` allows to extend the list of scopes of the JWT token that are to be recognized.
+  `certificateAuthoritySecretRef` allows you to specify a secret containing a custom CA certificate for communicating with the OIDC issuer.  
   You must reference a `Secret` in the `garden` namespace containing the client and, if applicable, the client secret for the dashboard:
   ```yaml
   apiVersion: v1

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1136,6 +1136,22 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              caSecretRef:
+                                description: CaSecretRef is the reference to a secret
+                                  in the garden namespace containing a custom CA certificate
+                                  under the "ca.crt" key
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
                               clientIDPublic:
                                 description: |-
                                   ClientIDPublic is the public client ID.

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1136,10 +1136,10 @@ spec:
                                 items:
                                   type: string
                                 type: array
-                              caSecretRef:
-                                description: CaSecretRef is the reference to a secret
-                                  in the garden namespace containing a custom CA certificate
-                                  under the "ca.crt" key
+                              certificateAuthoritySecretRef:
+                                description: CertificateAuthoritySecretRef is the
+                                  reference to a secret in the garden namespace containing
+                                  a custom CA certificate under the "ca.crt" key
                                 properties:
                                   name:
                                     default: ""

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -284,6 +284,8 @@ spec:
     #     additionalScopes: [ profile, offline_access ]
     #     secretRef:
     #       name: gardener-dashboard-oidc
+    #     certificateAuthoritySecretRef:
+    #       name: gardener-dashboard-oidc-ca
     #   terminal:
     #     allowedHosts:
     #     - "*.seed.local.gardener.cloud"

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -655,9 +655,9 @@ type DashboardOIDC struct {
 	AdditionalScopes []string `json:"additionalScopes,omitempty"`
 	// SecretRef is the reference to a secret in the garden namespace containing the OIDC client ID and secret for the dashboard.
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
-	// CaSecretRef is the reference to a secret in the garden namespace containing a custom CA certificate under the "ca.crt" key
+	// CertificateAuthoritySecretRef is the reference to a secret in the garden namespace containing a custom CA certificate under the "ca.crt" key
 	// +optional
-	CaSecretRef *corev1.LocalObjectReference `json:"caSecretRef,omitempty"`
+	CertificateAuthoritySecretRef *corev1.LocalObjectReference `json:"certificateAuthoritySecretRef,omitempty"`
 }
 
 // DashboardTerminal contains configuration for the terminal settings.

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -655,6 +655,9 @@ type DashboardOIDC struct {
 	AdditionalScopes []string `json:"additionalScopes,omitempty"`
 	// SecretRef is the reference to a secret in the garden namespace containing the OIDC client ID and secret for the dashboard.
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
+	// CaSecretRef is the reference to a secret in the garden namespace containing a custom CA certificate under the "ca.crt" key
+	// +optional
+	CaSecretRef *corev1.LocalObjectReference `json:"caSecretRef,omitempty"`
 }
 
 // DashboardTerminal contains configuration for the terminal settings.

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -10,9 +10,9 @@
 package v1alpha1
 
 import (
-	corev1 "github.com/gardener/gardener/pkg/apis/core/v1"
+	apiscorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -368,6 +368,11 @@ func (in *DashboardOIDC) DeepCopyInto(out *DashboardOIDC) {
 		copy(*out, *in)
 	}
 	out.SecretRef = in.SecretRef
+	if in.CaSecretRef != nil {
+		in, out := &in.CaSecretRef, &out.CaSecretRef
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	return
 }
 
@@ -629,7 +634,7 @@ func (in *ExtensionHelm) DeepCopyInto(out *ExtensionHelm) {
 	*out = *in
 	if in.OCIRepository != nil {
 		in, out := &in.OCIRepository, &out.OCIRepository
-		*out = new(corev1.OCIRepository)
+		*out = new(apiscorev1.OCIRepository)
 		(*in).DeepCopyInto(*out)
 	}
 	return
@@ -1059,12 +1064,12 @@ func (in *GardenerDashboardConfig) DeepCopyInto(out *GardenerDashboardConfig) {
 	}
 	if in.FrontendConfigMapRef != nil {
 		in, out := &in.FrontendConfigMapRef, &out.FrontendConfigMapRef
-		*out = new(apicorev1.LocalObjectReference)
+		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
 	if in.AssetsConfigMapRef != nil {
 		in, out := &in.AssetsConfigMapRef, &out.AssetsConfigMapRef
-		*out = new(apicorev1.LocalObjectReference)
+		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
 	if in.GitHub != nil {

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -368,8 +368,8 @@ func (in *DashboardOIDC) DeepCopyInto(out *DashboardOIDC) {
 		copy(*out, *in)
 	}
 	out.SecretRef = in.SecretRef
-	if in.CaSecretRef != nil {
-		in, out := &in.CaSecretRef, &out.CaSecretRef
+	if in.CertificateAuthoritySecretRef != nil {
+		in, out := &in.CertificateAuthoritySecretRef, &out.CertificateAuthoritySecretRef
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}

--- a/pkg/component/gardener/dashboard/config/config.go
+++ b/pkg/component/gardener/dashboard/config/config.go
@@ -83,6 +83,7 @@ type OIDC struct {
 	Scope              string     `yaml:"scope"`
 	RejectUnauthorized bool       `yaml:"rejectUnauthorized"`
 	Public             OIDCPublic `yaml:"public"`
+	CA                 string     `yaml:"ca,omitempty"`
 }
 
 // OIDCPublic is the public OIDC configuration.

--- a/pkg/component/gardener/dashboard/configmap.go
+++ b/pkg/component/gardener/dashboard/configmap.go
@@ -127,10 +127,10 @@ func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, e
 			},
 		}
 
-		if g.values.OIDC.CaSecretRef != nil {
+		if g.values.OIDC.CertificateAuthoritySecretRef != nil {
 			caSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      g.values.OIDC.CaSecretRef.Name,
+					Name:      g.values.OIDC.CertificateAuthoritySecretRef.Name,
 					Namespace: g.namespace,
 				},
 			}

--- a/pkg/component/gardener/dashboard/configmap.go
+++ b/pkg/component/gardener/dashboard/configmap.go
@@ -146,7 +146,7 @@ func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, e
 			}
 
 			if _, err := utils.DecodeCertificate(caData); err != nil {
-				return nil, fmt.Errorf("failed decoding ca certificate: %w", err)
+				return nil, fmt.Errorf("invalid ca certificate: failed decoding ca certificate: %w", err)
 			}
 
 			cfg.OIDC.CA = string(caData)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind api-change
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new field (`certificateAuthoritySecretRef`) to the OIDC configuration of the gardener-dashboard within the `Garden` object, allowing the user to specify a custom CA certificate for talking to the OIDC endpoint.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`Garden.spec.virtualCluster.gardener.gardenerDashboard.oidcConfig.certificateAuthoritySecretRef` can now be used to specify a secret containing a custom CA certificate for talking to the OIDC endpoint. The certificate must be stored under the `ca.crt` key.
```
