### PR TITLE
[GEP-28] Do not watch `Machine`s in `Worker` controller

### DIFF
--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -263,6 +263,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			serviceCtrlOpts.Completed().Apply(&localservice.DefaultAddOptions)
 			workerCtrlOpts.Completed().Apply(&localworker.DefaultAddOptions.Controller)
 			localworker.DefaultAddOptions.GardenCluster = gardenCluster
+			localworker.DefaultAddOptions.AutonomousShootCluster = generalOpts.Completed().AutonomousShootCluster
 			localBackupBucketOptions.Completed().Apply(&localbackupbucket.DefaultAddOptions)
 			localBackupBucketOptions.Completed().Apply(&localbackupentry.DefaultAddOptions)
 			heartbeatCtrlOptions.Completed().Apply(&heartbeat.DefaultAddOptions)

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -117,7 +116,7 @@ func wantMachineWatch(isAutonomousShootCluster bool, restMapper meta.RESTMapper)
 }
 
 func machineAPIPresent(restMapper meta.RESTMapper) (bool, error) {
-	if _, err := restMapper.KindsFor(schema.GroupVersionResource{Group: machinev1alpha1.GroupName, Version: machinev1alpha1.SchemeGroupVersion.Version, Resource: "machines"}); err != nil {
+	if _, err := restMapper.KindsFor(machinev1alpha1.SchemeGroupVersion.WithResource("machines")); err != nil {
 		if !meta.IsNoMatchError(err) {
 			return false, fmt.Errorf("failed checking %s APIs: %w", machinev1alpha1.GroupName, err)
 		}

--- a/pkg/provider-local/controller/worker/add.go
+++ b/pkg/provider-local/controller/worker/add.go
@@ -33,6 +33,8 @@ type AddOptions struct {
 	IgnoreOperationAnnotation bool
 	// ExtensionClass defines the extension class this extension is responsible for.
 	ExtensionClass extensionsv1alpha1.ExtensionClass
+	// AutonomousShootCluster indicates whether the extension runs in an autonomous shoot cluster.
+	AutonomousShootCluster bool
 }
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
@@ -47,11 +49,12 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 	}
 
 	return worker.Add(ctx, mgr, worker.AddArgs{
-		Actuator:          NewActuator(mgr, opts.GardenCluster),
-		ControllerOptions: opts.Controller,
-		Predicates:        worker.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
-		Type:              local.Type,
-		ExtensionClass:    opts.ExtensionClass,
+		Actuator:               NewActuator(mgr, opts.GardenCluster),
+		ControllerOptions:      opts.Controller,
+		Predicates:             worker.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
+		Type:                   local.Type,
+		ExtensionClass:         opts.ExtensionClass,
+		AutonomousShootCluster: opts.AutonomousShootCluster,
 	})
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind bug

**What this PR does / why we need it**:
Currently, `provider-local` goes into a `CrashLoopBackoff` after some time in ASCs. Note the restarts:

```
root@machine-0:/# k get po -A | grep provider-local
extension-provider-local      gardener-extension-provider-local-56d999bb56-l4kv5     1/1     Running            17 (5m30s ago)   110m
extension-provider-local      gardener-extension-provider-local-56d999bb56-sxfcr     0/1     CrashLoopBackOff   16 (3m6s ago)    110m
```

Logs:

```
{"level":"error","ts":"2025-04-22T11:11:43.069Z","msg":"Error executing the main controller command","error":"error running manager: failed to wait for worker caches to sync kind source: *v1alpha1.Machine: timed out waiting for cache to be synced for Kind *v1alpha1.Machine","stacktrace":"main.main\n\tgithub.com/gardener/gardener/cmd/gardener-extension-provider-local/main.go:24\nruntime.main\n\truntime/proc.go:283"}
```

This is because the `Machine` API is not present (at least for the high-touch scenario).

With this PR, we can check if the `Machine` API is present in case we are reconciling an ASC. If yes, we are in the medium-touch case, i.e., we can watch `Machine`s. If no, we are in the high-touch case, i.e., we cannot watch them. This works because CRDs are always applied before extensions are deployed in the ASC scenario.

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:
/cc @timebertt @maboehm 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
