### PR TITLE
`gardener-operator` can forcefully re-deploy `Gardenlet`s on demand

### DIFF
--- a/docs/deployment/deploy_gardenlet_via_operator.md
+++ b/docs/deployment/deploy_gardenlet_via_operator.md
@@ -13,7 +13,7 @@ If you have used the [`gardener/controlplane` Helm chart](../../charts/gardener/
 ## Deployment of gardenlets
 
 Using this method, `gardener-operator` is only taking care of the very first deployment of gardenlet.
-Once running, the gardenlet leverages the [self upgrade](deploy_gardenlet_manually.md#self-upgrades) strategy in order to keep itself up-to-date.
+Once running, the gardenlet leverages the [self-upgrade](deploy_gardenlet_manually.md#self-upgrades) strategy in order to keep itself up-to-date.
 Concretely, `gardener-operator` only acts when there is no respective `Seed` resource yet.
 
 In order to request a gardenlet deployment, create following resource in the (virtual) garden cluster:
@@ -127,3 +127,20 @@ spec:
 > After successful deployment of gardenlet, `gardener-operator` will delete the `remote-cluster-kubeconfig` `Secret` and set `.spec.kubeconfigSecretRef` to `nil`.
 > This is because the kubeconfig will never ever be needed anymore (`gardener-operator` is only responsible for initial deployment, and gardenlet updates itself with an in-cluster kubeconfig).
 > In case your landscape is managed via a GitOps approach, you might want to reflect this change in your repository.
+
+### Forceful Re-Deployment
+
+In certain scenarios, it might be necessary to forcefully re-deploy the gardenlet.
+For example, in case the gardenlet client certificate has been expired or is "lost", or the gardenlet `Deployment` has been "accidentally" (😉) deleted from the seed cluster.
+
+You can trigger the forceful re-deployment by annotating the `Gardenlet` with
+
+```
+gardener.cloud/operation=force-redeploy
+```
+
+> [!TIP]
+> Do not forget to create the kubeconfig `Secret` and re-add the `.spec.kubeconfigSecretRef` to the `Gardenlet` specification if this is a remote cluster.
+
+`gardener-operator` will remove the operation annotation after it's done.
+Just like after the initial deployment, it'll also delete the kubeconfig `Secret` and set `.spec.kubeconfigSecretRef` to `nil`, see above.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -208,6 +208,9 @@ const (
 	// GardenerOperationReconcile is a constant for the value of the operation annotation describing a reconcile
 	// operation.
 	GardenerOperationReconcile = "reconcile"
+	// OperationForceRedeploy is a constant for the value of the operation annotation describing a forceful redeployment
+	// of the gardenlet via gardener-operator.
+	OperationForceRedeploy = "force-redeploy"
 	// GardenerTimestamp is a constant for an annotation on a resource that describes the timestamp when a reconciliation has been requested.
 	// It is only used to guarantee an update event for watching clients in case the operation-annotation is already present.
 	GardenerTimestamp = "gardener.cloud/timestamp"

--- a/pkg/apis/seedmanagement/validation/gardenlet.go
+++ b/pkg/apis/seedmanagement/validation/gardenlet.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 )
 
-var availableGardenletOperations = availableManagedSeedOperations.Clone()
+var availableGardenletOperations = availableManagedSeedOperations.Clone().Insert(v1beta1constants.OperationForceRedeploy)
 
 // ValidateGardenlet validates a Gardenlet object.
 func ValidateGardenlet(gardenlet *seedmanagement.Gardenlet) field.ErrorList {

--- a/pkg/apis/seedmanagement/validation/gardenlet_test.go
+++ b/pkg/apis/seedmanagement/validation/gardenlet_test.go
@@ -173,6 +173,7 @@ var _ = Describe("Gardenlet Validation Tests", func() {
 			},
 				Entry("reconcile", "reconcile"),
 				Entry("renew-kubeconfig", "renew-kubeconfig"),
+				Entry("force-redeploy", "force-redeploy"),
 			)
 		})
 

--- a/pkg/apiserver/registry/seedmanagement/gardenlet/strategy.go
+++ b/pkg/apiserver/registry/seedmanagement/gardenlet/strategy.go
@@ -72,8 +72,9 @@ func mustIncreaseGeneration(oldGardenlet, newGardenlet *seedmanagement.Gardenlet
 		return true
 	}
 
-	// The operation annotation was added with value "renew-kubeconfig"
-	if kubernetesutils.HasMetaDataAnnotation(&newGardenlet.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRenewKubeconfig) {
+	// The operation annotation was added with value "renew-kubeconfig" or "force-redeploy"
+	if kubernetesutils.HasMetaDataAnnotation(&newGardenlet.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRenewKubeconfig) ||
+		kubernetesutils.HasMetaDataAnnotation(&newGardenlet.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.OperationForceRedeploy) {
 		return true
 	}
 

--- a/pkg/operator/controller/gardenlet/add_test.go
+++ b/pkg/operator/controller/gardenlet/add_test.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardenlet_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	. "github.com/gardener/gardener/pkg/operator/controller/gardenlet"
+)
+
+var _ = Describe("Add", func() {
+	Describe("#OperatorResponsiblePredicate", func() {
+		var (
+			ctx = context.Background()
+
+			fakeClient client.Client
+			predicate  predicate.Predicate
+			gardenlet  *seedmanagementv1alpha1.Gardenlet
+
+			test = func(object client.Object, matcher gomegatypes.GomegaMatcher) {
+				ExpectWithOffset(1, predicate.Create(event.CreateEvent{Object: object})).To(matcher)
+				ExpectWithOffset(1, predicate.Update(event.UpdateEvent{ObjectNew: object})).To(matcher)
+				ExpectWithOffset(1, predicate.Delete(event.DeleteEvent{Object: object})).To(matcher)
+				ExpectWithOffset(1, predicate.Generic(event.GenericEvent{Object: object})).To(matcher)
+			}
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.VirtualScheme).Build()
+			predicate = (&Reconciler{VirtualClient: fakeClient}).OperatorResponsiblePredicate(ctx)
+			gardenlet = &seedmanagementv1alpha1.Gardenlet{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+		})
+
+		It("should return true when the seed object does not exist", func() {
+			test(gardenlet, BeTrue())
+		})
+
+		When("seed object exists", func() {
+			BeforeEach(func() {
+				Expect(fakeClient.Create(ctx, &gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: gardenlet.Name}})).To(Succeed())
+			})
+
+			It("should return false because there is no force-redeploy annotation and no kubeconfig secret ref", func() {
+				test(gardenlet, BeFalse())
+			})
+
+			It("should return true because there is a kubeconfig secret ref", func() {
+				gardenlet.Spec.KubeconfigSecretRef = &corev1.LocalObjectReference{Name: "kubeconfig"}
+				test(gardenlet, BeTrue())
+			})
+
+			It("should return true because there is the force-redeploy operation annotation", func() {
+				metav1.SetMetaDataAnnotation(&gardenlet.ObjectMeta, "gardener.cloud/operation", "force-redeploy")
+				test(gardenlet, BeTrue())
+			})
+
+			It("should return false because there is an unhandled operation annotation", func() {
+				metav1.SetMetaDataAnnotation(&gardenlet.ObjectMeta, "gardener.cloud/operation", "foo")
+				test(gardenlet, BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/operator/controller/gardenlet/gardenlet_suite_test.go
+++ b/pkg/operator/controller/gardenlet/gardenlet_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardenlet_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGardenlet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Controller Gardenlet Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
In certain scenarios, it might be necessary to forcefully re-deploy the gardenlet.
For example, in case the gardenlet client certificate has been expired or is "lost", or the gardenlet `Deployment` has been "accidentally" (😉) deleted from the seed cluster.

You can trigger the forceful re-deployment by annotating the `Gardenlet` with

```
gardener.cloud/operation=force-redeploy
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11949

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible forcing `gardener-operator` to re-deploy `gardenlet`s by annotating the responsible `seedmanagement.gardener.cloud/v1alpha1.Gardenlet` resource with `gardener.cloud/operation=force-redeploy`. Read all about it [here](https://github.com/gardener/gardener/tree/master/docs/deployment/deploy_gardenlet_via_operator.md#forceful-re-deployment).
```
