### PR TITLE
etcd-druid: Remove resource limits

### DIFF
--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -260,10 +260,11 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ContainerName: Druid,
 						MinAllowed: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("100M"),
 						},
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					}},
 				},
 			},
@@ -453,9 +454,6 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("50m"),
 										corev1.ResourceMemory: resource.MustParse("128Mi"),
-									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("512Mi"),
 									},
 								},
 								Ports: []corev1.ContainerPort{{

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -238,10 +238,11 @@ var _ = Describe("Etcd", func() {
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 							{
-								ContainerName: "*",
+								ContainerName: "etcd-druid",
 								MinAllowed: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("100M"),
 								},
+								ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 							},
 						},
 					},
@@ -329,9 +330,6 @@ var _ = Describe("Etcd", func() {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("50m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -433,9 +431,6 @@ var _ = Describe("Etcd", func() {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("50m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
According to the [Shoot Pod Autoscaling Best practices guide](https://github.com/gardener/gardener/blob/v1.117.1/docs/usage/autoscaling/shoot_pod_autoscaling_best_practices.md), it is not recommended to have resource limits.

Along the way, this PR sets by default `controlledValues: RequestsOnly` in the etcd-druid VPA.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The etcd-druid component no longer defines resource limits.
```
