### PR TITLE
[GEP-28] Move `KUBECONFIG` from machine level to `~/.bashrc`

### DIFF
--- a/example/gardenadm-local/high-touch/machine.yaml
+++ b/example/gardenadm-local/high-touch/machine.yaml
@@ -25,8 +25,6 @@ spec:
             value: /gardenadm:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           - name: IMAGEVECTOR_OVERWRITE
             value: /gardenadm/imagevector-overwrite.yaml
-          - name: KUBECONFIG
-            value: /etc/kubernetes/admin.conf
         volumeMounts:
         - name: containerd
           mountPath: /var/lib/containerd
@@ -35,6 +33,8 @@ spec:
           readOnly: true
         - name: gardenadm
           mountPath: /gardenadm
+      # we don't want components of the autonomous shoot cluster to communicate with the kind API server
+      automountServiceAccountToken: false
       hostAliases:
         - hostnames:
           - api.root.garden.internal.gardenadm.local

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -850,29 +850,6 @@ deploy:
         - --force-conflicts
     hooks:
       after:
-        - container:
-            command:
-              - bash
-              - -ec
-              - |
-                set -o errexit
-                set -o nounset
-                set -o pipefail
-
-                echo "> Prepare machine pods"
-                rm -rf /gardenadm/resources
-                
-                # shell profile for the developer's convenience
-                if ! grep 'kubectl environment' ~/.bashrc >/dev/null ; then
-                  cat <<EOF >> ~/.bashrc
-                # BEGIN kubectl environment
-                export KUBECONFIG=/etc/kubernetes/admin.conf
-                alias k=kubectl
-                # END kubectl environment
-                EOF
-                fi
-            podName: machine-*
-            containerName: node
         - host:
             command:
               - bash
@@ -880,6 +857,8 @@ deploy:
               - |
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/.skaffold-image machine-0:/tmp/.skaffold-image
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/.skaffold-image machine-1:/tmp/.skaffold-image
+                kubectl -n $SKAFFOLD_NAMESPACES exec machine-0 -- /bin/sh -c 'rm -rf /gardenadm/resources'
+                kubectl -n $SKAFFOLD_NAMESPACES exec machine-1 -- /bin/sh -c 'rm -rf /gardenadm/resources'
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/resources machine-0:/gardenadm/resources
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/resources machine-1:/gardenadm/resources
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/.imagevector-overwrite.yaml machine-0:/gardenadm/imagevector-overwrite.yaml
@@ -910,5 +889,15 @@ deploy:
                 mkdir -p "/gardenadm"
                 cp -f "$tmp_dir/ko-app/gardenadm" "/gardenadm"
                 chmod +x "/gardenadm/gardenadm"
+
+                echo "> Prepare shell profile"
+                if ! grep 'kubectl environment' ~/.bashrc >/dev/null ; then
+                  cat <<EOF >> ~/.bashrc
+                # BEGIN kubectl environment
+                export KUBECONFIG=/etc/kubernetes/admin.conf
+                alias k=kubectl
+                # END kubectl environment
+                EOF
+                fi
             podName: machine-*
             containerName: node

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -850,6 +850,29 @@ deploy:
         - --force-conflicts
     hooks:
       after:
+        - container:
+            command:
+              - bash
+              - -ec
+              - |
+                set -o errexit
+                set -o nounset
+                set -o pipefail
+
+                echo "> Prepare machine pods"
+                rm -rf /gardenadm/resources
+                
+                # shell profile for the developer's convenience
+                if ! grep 'kubectl environment' ~/.bashrc >/dev/null ; then
+                  cat <<EOF >> ~/.bashrc
+                # BEGIN kubectl environment
+                export KUBECONFIG=/etc/kubernetes/admin.conf
+                alias k=kubectl
+                # END kubectl environment
+                EOF
+                fi
+            podName: machine-*
+            containerName: node
         - host:
             command:
               - bash
@@ -857,8 +880,6 @@ deploy:
               - |
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/.skaffold-image machine-0:/tmp/.skaffold-image
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/.skaffold-image machine-1:/tmp/.skaffold-image
-                kubectl -n $SKAFFOLD_NAMESPACES exec machine-0 -- /bin/sh -c 'rm -rf /gardenadm/resources'
-                kubectl -n $SKAFFOLD_NAMESPACES exec machine-1 -- /bin/sh -c 'rm -rf /gardenadm/resources'
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/resources machine-0:/gardenadm/resources
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/resources machine-1:/gardenadm/resources
                 kubectl -n $SKAFFOLD_NAMESPACES cp example/gardenadm-local/.imagevector-overwrite.yaml machine-0:/gardenadm/imagevector-overwrite.yaml


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR ensures that the ASC's components running in the machine pod don't accidentally use the `KUBECONFIG` env var or any credentials for the underlying kind cluster.
We still keep the convenience for developers by adding the `KUBECONFIG` env var to `~/.bashrc`. Additionally, the `k` alias is added.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
