### PR TITLE
Add instruction in component checklist to not set `podAntiAffinity`

### DIFF
--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -159,9 +159,9 @@ This document provides a checklist for them that you can walk through.
 
    Enable leader election unconditionally for controllers independently from the number of replicas or from the high availability configurations. Having leader election enabled even for a single replica Deployment prevents having two Pods active at the same time. Otherwise, there are some corner cases that can result in two active Pods - Deployment rolling update or kubelet stops running on a Node and is not able to terminate the old replica while kube-controller-manager creates a new replica to match the Deployment's desired replicas count.
 
-8. **Do not set a `podAntiAffinity` in the deployment**
+8. **Do not set a `pod{Anti}Affinity` for spreading across nodes or zones**
 
-   Spread across nodes is handled by the TopologySpreadConstraint configuration. Setting a `podAntiAffinity` additionally makes it harder to run the component locally or in smaller setups with only a single node. 
+   Spread across nodes and zones is handled by the [HighAvailabilityConfig](../concepts/resource-manager.md#high-availability-config) webhook. Specifying another `pod{Anti}Affinity` makes it harder to run the component locally or in smaller setups with only a single node. 
 
 ## Scalability
 

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -159,6 +159,10 @@ This document provides a checklist for them that you can walk through.
 
    Enable leader election unconditionally for controllers independently from the number of replicas or from the high availability configurations. Having leader election enabled even for a single replica Deployment prevents having two Pods active at the same time. Otherwise, there are some corner cases that can result in two active Pods - Deployment rolling update or kubelet stops running on a Node and is not able to terminate the old replica while kube-controller-manager creates a new replica to match the Deployment's desired replicas count.
 
+8. **Do not set a `podAntiAffinity` in the deployment**
+
+   Spread across nodes is handled by the TopologySpreadConstraint configuration. Setting a `podAntiAffinity` additionally makes it harder to run the component locally or in smaller setups with only a single node. 
+
 ## Scalability
 
 1. **Provide resource requirements** ([example](https://github.com/gardener/gardener/blob/b0de7db96ad436fe32c25daae5e8cb552dac351f/pkg/component/metricsserver/metrics_server.go#L345-L353))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation high-availability
/kind cleanup

**What this PR does / why we need it**:
Add instruction in component checklist to not set `podAntiAffinity`, as it will make local of single-node setups harder and functionality is ensured by TopologySpreadConstraints.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
