### PR TITLE
chore: Deprecate the Shoot field `.kubeAPIServer.enableAnonymousAuthentication`

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1430,6 +1430,9 @@ spec:
                             type: integer
                           enableAnonymousAuthentication:
                             description: |-
+                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Please use anonymous authentication configuration instead.
+                              For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
                               EnableAnonymousAuthentication defines whether anonymous requests to the secure port
                               of the API server should be allowed (flag `--anonymous-auth`).
                               See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -6439,7 +6439,11 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>EnableAnonymousAuthentication defines whether anonymous requests to the secure port
+<p>Deprecated: This field is deprecated and will be removed in a future release.
+Please use anonymous authentication configuration instead.
+For more information see: <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration">https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration</a>
+TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
+EnableAnonymousAuthentication defines whether anonymous requests to the secure port
 of the API server should be allowed (flag <code>--anonymous-auth</code>).
 See: <a href="https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/">https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/</a></p>
 </td>

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -215,7 +215,7 @@ spec:
   #   requests:
   #     maxNonMutatingInflight: 400
   #     maxMutatingInflight: 200
-  #   enableAnonymousAuthentication: false # See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+  #   enableAnonymousAuthentication: false # Deprecated, will be removed in a future version of gardener. Use anonymous authentication configuration instead, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
   #   apiAudiences:
   #   - foo
   #   serviceAccountConfig:

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1430,6 +1430,9 @@ spec:
                             type: integer
                           enableAnonymousAuthentication:
                             description: |-
+                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Please use anonymous authentication configuration instead.
+                              For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
                               EnableAnonymousAuthentication defines whether anonymous requests to the secure port
                               of the API server should be allowed (flag `--anonymous-auth`).
                               See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -160,7 +160,7 @@ spec:
     #   requests:
     #     maxNonMutatingInflight: 400
     #     maxMutatingInflight: 200
-    #   enableAnonymousAuthentication: false # See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+    #   enableAnonymousAuthentication: false # Deprecated, will be removed in a future version of gardener. Use anonymous authentication configuration instead, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
     #   serviceAccountConfig:
     #     issuer: foo
     #     acceptedIssuers:

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -36,6 +36,10 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 		warnings = append(warnings, "you are setting the spec.kubernetes.enableStaticTokenKubeconfig field. The field is deprecated and will be removed in Gardener v1.120. Please adapt your machinery to no longer set this field")
 	}
 
+	if helper.IsLegacyAnonymousAuthenticationEnabled(shoot.Spec.Kubernetes.KubeAPIServer) {
+		warnings = append(warnings, "you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.31 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")
+	}
+
 	return warnings
 }
 

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -252,5 +252,10 @@ var _ = Describe("Warnings", func() {
 			shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = ptr.To(false)
 			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.enableStaticTokenKubeconfig field. The field is deprecated and will be removed in Gardener v1.120. Please adapt your machinery to no longer set this field")))
 		})
+
+		It("should return a warning when enableAnonymousAuthentication is set", func() {
+			shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.31 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")))
+		})
 	})
 })

--- a/pkg/apis/core/helper/shoot.go
+++ b/pkg/apis/core/helper/shoot.go
@@ -284,3 +284,10 @@ func IsUpdateStrategyInPlace(updateStrategy *core.MachineUpdateStrategy) bool {
 	}
 	return *updateStrategy == core.AutoInPlaceUpdate || *updateStrategy == core.ManualInPlaceUpdate
 }
+
+// IsLegacyAnonymousAuthenticationEnabled checks if the legacy anonymous authentication is enabled in the given kubeAPIServerConfig.
+func IsLegacyAnonymousAuthenticationEnabled(kubeAPIServerConfig *core.KubeAPIServerConfig) bool {
+	return kubeAPIServerConfig != nil &&
+		kubeAPIServerConfig.EnableAnonymousAuthentication != nil &&
+		*kubeAPIServerConfig.EnableAnonymousAuthentication
+}

--- a/pkg/apis/core/helper/shoot_test.go
+++ b/pkg/apis/core/helper/shoot_test.go
@@ -594,4 +594,15 @@ var _ = Describe("Helper", func() {
 		Entry("with AutoInPlaceUpdate update strategy", ptr.To(core.AutoInPlaceUpdate), true),
 		Entry("with ManualInPlaceUpdate  update strategy", ptr.To(core.ManualInPlaceUpdate), true),
 	)
+
+	DescribeTable("#IsLegacyAnonymousAuthenticationEnabled",
+		func(kubeAPIServerConfig *core.KubeAPIServerConfig, expected bool) {
+			Expect(IsLegacyAnonymousAuthenticationEnabled(kubeAPIServerConfig)).To(Equal(expected))
+		},
+		Entry("kubeAPIServerConfig is nil", nil, false),
+		Entry("kubeAPIServerConfig is empty", &core.KubeAPIServerConfig{}, false),
+		Entry("EnableAnonymousAuthentication is nil", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: nil}, false),
+		Entry("EnableAnonymousAuthentication is false", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(false)}, false),
+		Entry("EnableAnonymousAuthentication is true", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}, true),
+	)
 })

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -674,6 +674,10 @@ type KubeAPIServerConfig struct {
 	WatchCacheSizes *WatchCacheSizes
 	// Requests contains configuration for request-specific settings for the kube-apiserver.
 	Requests *APIServerRequests
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Please use anonymous authentication configuration instead.
+	// For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
+	// TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
 	// EnableAnonymousAuthentication defines whether anonymous requests to the secure port
 	// of the API server should be allowed (flag `--anonymous-auth`).
 	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1304,6 +1304,10 @@ message KubeAPIServerConfig {
   // +optional
   optional APIServerRequests requests = 10;
 
+  // Deprecated: This field is deprecated and will be removed in a future release.
+  // Please use anonymous authentication configuration instead.
+  // For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
+  // TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
   // EnableAnonymousAuthentication defines whether anonymous requests to the secure port
   // of the API server should be allowed (flag `--anonymous-auth`).
   // See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -891,6 +891,10 @@ type KubeAPIServerConfig struct {
 	// Requests contains configuration for request-specific settings for the kube-apiserver.
 	// +optional
 	Requests *APIServerRequests `json:"requests,omitempty" protobuf:"bytes,10,opt,name=requests"`
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Please use anonymous authentication configuration instead.
+	// For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
+	// TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
 	// EnableAnonymousAuthentication defines whether anonymous requests to the secure port
 	// of the API server should be allowed (flag `--anonymous-auth`).
 	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -4551,7 +4551,7 @@ func schema_pkg_apis_core_v1beta1_KubeAPIServerConfig(ref common.ReferenceCallba
 					},
 					"enableAnonymousAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EnableAnonymousAuthentication defines whether anonymous requests to the secure port of the API server should be allowed (flag `--anonymous-auth`). See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/",
+							Description: "Deprecated: This field is deprecated and will be removed in a future release. Please use anonymous authentication configuration instead. For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration EnableAnonymousAuthentication defines whether anonymous requests to the secure port of the API server should be allowed (flag `--anonymous-auth`). See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area robustness
/kind task
/kind api-change

**What this PR does / why we need it**:

This PR deprecates the `Shoot` field `spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication`.
It adds validation that prevents users from configuring the legacy setting in the `Shoot` spec at the same time as the preferred [anonymous authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration).

Once the Kubernetes feature gate `AnonymousAuthConfigurableEndpoints` graduates, we should forbid setting `.kubeAPIServer.enableAnonymousAuthentication` in the `Shoot` spec ([it remains in Beta state with Kubernetes v1.33](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#:~:text=1.31-,AnonymousAuthConfigurableEndpoints,-true)).
Finally, further out in the future, when Gardener only supports Kubernetes versions with the stable `AnonymousAuthConfigurableEndpoints` feature, we should drop the legacy field altogether.

**Which issue(s) this PR fixes**:

Fixes #11657

**Special notes for your reviewer**:

Reviewing the [individual commits](https://github.com/gardener/gardener/pull/11984/commits) is easier.

/cc @LucaBernstein @dimityrmirchev 

I used #10666 as a reference. Thanks for the well-structured PR @AleksandarSavchev!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The `spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication` field in the `Shoot` API is deprecated and will be removed in a future release. Before removal, it will be forbidden to set the field when using a future Kubernetes version that graduates the feature gate `AnonymousAuthConfigurableEndpoints`.
```
