### PR TITLE
Don't return error if node-agent-authorizer webhook is already present

### DIFF
--- a/pkg/component/kubernetes/apiserver/mock/mocks.go
+++ b/pkg/component/kubernetes/apiserver/mock/mocks.go
@@ -16,6 +16,7 @@ import (
 
 	apiserver "github.com/gardener/gardener/pkg/component/apiserver"
 	apiserver0 "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
+	logr "github.com/go-logr/logr"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 )
@@ -45,17 +46,15 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // AppendAuthorizationWebhook mocks base method.
-func (m *MockInterface) AppendAuthorizationWebhook(arg0 apiserver0.AuthorizationWebhook) error {
+func (m *MockInterface) AppendAuthorizationWebhook(arg0 apiserver0.AuthorizationWebhook, arg1 logr.Logger) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendAuthorizationWebhook", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "AppendAuthorizationWebhook", arg0, arg1)
 }
 
 // AppendAuthorizationWebhook indicates an expected call of AppendAuthorizationWebhook.
-func (mr *MockInterfaceMockRecorder) AppendAuthorizationWebhook(arg0 any) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) AppendAuthorizationWebhook(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendAuthorizationWebhook", reflect.TypeOf((*MockInterface)(nil).AppendAuthorizationWebhook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendAuthorizationWebhook", reflect.TypeOf((*MockInterface)(nil).AppendAuthorizationWebhook), arg0, arg1)
 }
 
 // Deploy mocks base method.

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -180,7 +180,9 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context, enableNodeAgentAutho
 			return fmt.Errorf("failed generating authorization webhook kubeconfig: %w", err)
 		}
 
-		if err := b.Shoot.Components.ControlPlane.KubeAPIServer.AppendAuthorizationWebhook(
+		b.Logger.Info("Adding node-agent authorizer webhook to kube-apiserver")
+
+		b.Shoot.Components.ControlPlane.KubeAPIServer.AppendAuthorizationWebhook(
 			kubeapiserver.AuthorizationWebhook{
 				Name:       "node-agent-authorizer",
 				Kubeconfig: kubeconfig,
@@ -198,9 +200,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context, enableNodeAgentAutho
 						Expression: fmt.Sprintf("'%s' in request.groups", v1beta1constants.NodeAgentsGroup),
 					}},
 				},
-			}); err != nil {
-			return fmt.Errorf("failed appending node-agent-authorizer webhook config to kube-apiserver: %w", err)
-		}
+			}, b.Logger)
 	}
 
 	if err := shared.DeployKubeAPIServer(

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -517,7 +518,7 @@ users:
 			kubeAPIServer.EXPECT().SetServiceNetworkCIDRs(gomock.Any())
 			kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 			kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
-			kubeAPIServer.EXPECT().AppendAuthorizationWebhook(expectedAuthorizationWebhook)
+			kubeAPIServer.EXPECT().AppendAuthorizationWebhook(expectedAuthorizationWebhook, logr.Discard())
 			kubeAPIServer.EXPECT().Deploy(ctx)
 
 			Expect(botanist.DeployKubeAPIServer(ctx, true)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/11281 adds the check to prevent adding the `node-agent-authorizer` webhook twice due to a race condition in gardenlet and returns the error if it happens.  This can cause the issue of KAPI never getting deployed because of the error being returned that the `node-agent-authorizer` webhook is already present.

To prevent the above scenario, this PR returns nil instead of the error when the `node-agent-authorizer` webhook is already present.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
