### PR TITLE
[GEP-31] Add TM test for worker pools with InPlace update strategy 

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -724,7 +724,7 @@ func (r *Reconciler) checkKubeletHealth(ctx context.Context, log logr.Logger, no
 		return err
 	}
 
-	if err := retryutils.UntilTimeout(ctx, KubeletHealthCheckRetryInterval, KubeletHealthCheckRetryTimeout, func(ctx context.Context) (bool, error) {
+	if err := retryutils.UntilTimeout(ctx, KubeletHealthCheckRetryInterval, KubeletHealthCheckRetryTimeout, func(_ context.Context) (bool, error) {
 		if response, err2 := httpClient.Do(request); err2 != nil {
 			return retryutils.MinorError(fmt.Errorf("HTTP request to kubelet health endpoint failed: %w", err2))
 		} else if response.StatusCode == http.StatusOK {

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -130,7 +130,7 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		}, SpecTimeout(5*time.Minute))
 	}
 
-	nodesOfInPlaceWorkersBeforeTest := inplace.ItShouldFindAllNodesOfInPlaceWorker(s)
+	nodesOfInPlaceWorkersBeforeTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 
 	ItShouldAnnotateShoot(s, map[string]string{
 		v1beta1constants.GardenerOperation: v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout,
@@ -154,7 +154,7 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		}).Should(Succeed())
 	}, SpecTimeout(time.Minute))
 
-	nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindAllNodesOfInPlaceWorker(s)
+	nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 	Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
 
 	It("Ensure all worker pools are marked as 'pending for roll out'", func() {
@@ -315,7 +315,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			var nodesOfInPlaceWorkersBeforeTest sets.Set[string]
 
 			if inPlaceUpdate {
-				nodesOfInPlaceWorkersBeforeTest = inplace.ItShouldFindAllNodesOfInPlaceWorker(s)
+				nodesOfInPlaceWorkersBeforeTest = inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 				inplace.ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s)
 			}
 
@@ -332,7 +332,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				inclusterclient.VerifyInClusterAccessToAPIServer(s)
 
 				if inPlaceUpdate {
-					nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindAllNodesOfInPlaceWorker(s)
+					nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 					Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
 					inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
 				}

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -330,12 +330,12 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				// renew shoot clients after rotation
 				ItShouldInitializeShootClient(s)
 				inclusterclient.VerifyInClusterAccessToAPIServer(s)
-			}
 
-			if inPlaceUpdate {
-				nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindAllNodesOfInPlaceWorker(s)
-				Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
-				inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+				if inPlaceUpdate {
+					nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindAllNodesOfInPlaceWorker(s)
+					Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
+					inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+				}
 			}
 
 			ItShouldDeleteShoot(s)

--- a/test/e2e/gardener/shoot/create_update-in-place_delete.go
+++ b/test/e2e/gardener/shoot/create_update-in-place_delete.go
@@ -64,7 +64,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			verifyNodeKubernetesVersions(s)
 
 			var (
-				nodesOfInPlaceWorkersBeforeTest = inplace.ItShouldFindAllNodesOfInPlaceWorker(s)
+				nodesOfInPlaceWorkersBeforeTest = inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 				cloudProfile                    *gardencorev1beta1.CloudProfile
 				controlPlaneKubernetesVersion   string
 				poolNameToKubernetesVersion     map[string]string
@@ -123,7 +123,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			verifyNodeKubernetesVersions(s)
 			inclusterclient.VerifyInClusterAccessToAPIServer(s)
 
-			nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindAllNodesOfInPlaceWorker(s)
+			nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 			Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
 			inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
 

--- a/test/e2e/gardener/shoot/shoot.go
+++ b/test/e2e/gardener/shoot/shoot.go
@@ -8,19 +8,15 @@ import (
 	"flag"
 	"time"
 
-	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -264,114 +260,4 @@ func ItShouldAnnotateShoot(s *ShootContext, annotations map[string]string) {
 			return s.GardenClient.Patch(ctx, s.Shoot, patch)
 		}).Should(Succeed())
 	}, SpecTimeout(time.Minute))
-}
-
-// ItShouldLabelManualInPlaceNodesWithSelectedForUpdate labels all manual in-place nodes with the selected-for-update label.
-// In the actual scenario, this should be done by the user, but for testing purposes, we do it here.
-func ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s *ShootContext) {
-	GinkgoHelper()
-
-	It("should label all the manual in-place nodes with selected-for-update", func(ctx SpecContext) {
-		for _, pool := range s.Shoot.Spec.Provider.Workers {
-			if !v1beta1helper.IsUpdateStrategyManualInPlace(pool.UpdateStrategy) {
-				continue
-			}
-
-			nodeList := &corev1.NodeList{}
-			Eventually(
-				ctx,
-				s.ShootKomega.List(nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name}),
-			).Should(Succeed(), "nodes for pool %s should be listed", pool.Name)
-
-			for _, node := range nodeList.Items {
-				if metav1.HasLabel(node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate) {
-					continue
-				}
-
-				Eventually(ctx, s.ShootKomega.Update(&node, func() {
-					metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate, "true")
-				})).Should(Succeed(), "node %s should be labeled", node.Name)
-			}
-		}
-	}, SpecTimeout(2*time.Minute))
-}
-
-// ItShouldFindAllMachinePodsBefore finds all machine pods before running the required tests and returns their names.
-func ItShouldFindAllMachinePodsBefore(s *ShootContext) sets.Set[string] {
-	GinkgoHelper()
-
-	machinePodNamesBeforeTest := sets.New[string]()
-
-	It("Find all machine pods to ensure later that they weren't rolled out", func(ctx SpecContext) {
-		beforeStartMachinePodList := &corev1.PodList{}
-		Eventually(ctx, s.SeedKomega.List(beforeStartMachinePodList, client.InNamespace(s.Shoot.Status.TechnicalID), client.MatchingLabels{
-			"app":              "machine",
-			"machine-provider": "local",
-		})).Should(Succeed())
-
-		for _, item := range beforeStartMachinePodList.Items {
-			machinePodNamesBeforeTest.Insert(item.Name)
-		}
-	}, SpecTimeout(time.Minute))
-
-	return machinePodNamesBeforeTest
-}
-
-// ItShouldCompareMachinePodNamesAfter compares the machine pod names before and after running the required tests.
-func ItShouldCompareMachinePodNamesAfter(s *ShootContext, machinePodNamesBeforeTest sets.Set[string]) {
-	GinkgoHelper()
-
-	It("Compare machine pod names", func(ctx SpecContext) {
-		machinePodListAfterTest := &corev1.PodList{}
-		Eventually(ctx, s.SeedKomega.List(machinePodListAfterTest, client.InNamespace(s.Shoot.Status.TechnicalID), client.MatchingLabels{
-			"app":              "machine",
-			"machine-provider": "local",
-		})).Should(Succeed())
-
-		machinePodNamesAfterTest := sets.New[string]()
-		for _, item := range machinePodListAfterTest.Items {
-			machinePodNamesAfterTest.Insert(item.Name)
-		}
-
-		Expect(machinePodNamesBeforeTest.UnsortedList()).To(ConsistOf(machinePodNamesAfterTest.UnsortedList()))
-	}, SpecTimeout(time.Minute))
-}
-
-// ItShouldVerifyInPlaceUpdateStart verifies that the starting of in-place update  by checking the
-// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
-func ItShouldVerifyInPlaceUpdateStart(s *ShootContext) {
-	GinkgoHelper()
-
-	It("Verify in-place update start", func(ctx SpecContext) {
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(s.GardenClient.Get(ctx, client.ObjectKeyFromObject(s.Shoot), s.Shoot)).Should(Succeed())
-
-			g.Expect(s.Shoot.Status.InPlaceUpdates).NotTo(BeNil())
-			g.Expect(s.Shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
-			g.Expect(s.Shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).NotTo(BeEmpty())
-			g.Expect(s.Shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).NotTo(BeEmpty())
-			g.Expect(s.Shoot.Status.Constraints).To(ContainCondition(
-				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
-				WithReason("WorkerPoolsWithManualInPlaceUpdateStrategyPending"),
-				Or(WithStatus(gardencorev1beta1.ConditionFalse), WithStatus(gardencorev1beta1.ConditionProgressing)),
-			))
-		}).Should(Succeed())
-	}, SpecTimeout(2*time.Minute))
-}
-
-// ItShouldVerifyInPlaceUpdateCompletion verifies that the in-place update was completed successfully by checking the
-// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
-func ItShouldVerifyInPlaceUpdateCompletion(s *ShootContext) {
-	GinkgoHelper()
-
-	It("Verify in-place update completion", func(ctx SpecContext) {
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(s.GardenClient.Get(ctx, client.ObjectKeyFromObject(s.Shoot), s.Shoot)).Should(Succeed())
-
-			g.Expect(s.Shoot.Status.InPlaceUpdates).To(BeNil())
-			g.Expect(s.Shoot.Status.Constraints).NotTo(ContainCondition(
-				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
-			))
-		}).Should(Succeed())
-	}, SpecTimeout(2*time.Minute))
 }

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -277,7 +277,7 @@ func (f *GardenerFramework) DeleteShoot(ctx context.Context, shoot *gardencorev1
 	return nil
 }
 
-// UpdateShoot Updates a shoot from a shoot Object and waits for its reconciliation
+// UpdateShoot updates the spec of a given Shoot resource and waits for it to be reconciled successfully.
 func (f *GardenerFramework) UpdateShoot(ctx context.Context, shoot *gardencorev1beta1.Shoot, update func(shoot *gardencorev1beta1.Shoot) error) error {
 	log := f.Logger.WithValues("shoot", client.ObjectKeyFromObject(shoot))
 
@@ -293,7 +293,7 @@ func (f *GardenerFramework) UpdateShoot(ctx context.Context, shoot *gardencorev1
 	return nil
 }
 
-// UpdateShootSpec updates a shoot from a shoot Object
+// UpdateShootSpec updates the spec of a given Shoot resource.
 func (f *GardenerFramework) UpdateShootSpec(ctx context.Context, shoot *gardencorev1beta1.Shoot, update func(shoot *gardencorev1beta1.Shoot) error) error {
 	log := f.Logger.WithValues("shoot", client.ObjectKeyFromObject(shoot))
 

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -285,7 +285,6 @@ func (f *GardenerFramework) UpdateShoot(ctx context.Context, shoot *gardencorev1
 		return err
 	}
 
-	// Then we wait for the shoot to be created
 	if err := f.WaitForShootToBeReconciled(ctx, shoot); err != nil {
 		return err
 	}

--- a/test/testmachinery/system/shoot_update/update_test.go
+++ b/test/testmachinery/system/shoot_update/update_test.go
@@ -113,21 +113,21 @@ func RunTest(
 		By("Update .kubernetes.version to " + kubernetesVersion + " for pool " + poolName)
 	}
 
-	var hasAutoInplaceUpdate, hasManualInplaceUpdate, hasInplaceUpdate bool
+	var hasAutoInPlaceUpdate, hasManualInPlaceUpdate, hasInPlaceUpdate bool
 
 	for _, worker := range f.Shoot.Spec.Provider.Workers {
 		switch ptr.Deref(worker.UpdateStrategy, "") {
 		case gardencorev1beta1.AutoInPlaceUpdate:
-			hasAutoInplaceUpdate = true
+			hasAutoInPlaceUpdate = true
 		case gardencorev1beta1.ManualInPlaceUpdate:
-			hasManualInplaceUpdate = true
+			hasManualInPlaceUpdate = true
 		}
 	}
 
-	hasInplaceUpdate = hasAutoInplaceUpdate || hasManualInplaceUpdate
+	hasInPlaceUpdate = hasAutoInPlaceUpdate || hasManualInPlaceUpdate
 
 	var nodesOfInPlaceWorkersBeforeTest sets.Set[string]
-	if hasInplaceUpdate {
+	if hasInPlaceUpdate {
 		nodesOfInPlaceWorkersBeforeTest = inplace.FindNodesOfInPlaceWorkers(ctx, f.ShootClient.Client(), f.Shoot)
 	}
 
@@ -145,9 +145,9 @@ func RunTest(
 		return nil
 	})).To(Succeed())
 
-	if hasInplaceUpdate {
-		inplace.ItShouldVerifyInPlaceUpdateStart(f.GardenClient.Client(), f.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate)
-		if hasManualInplaceUpdate {
+	if hasInPlaceUpdate {
+		inplace.ItShouldVerifyInPlaceUpdateStart(f.GardenClient.Client(), f.Shoot, hasAutoInPlaceUpdate, hasManualInPlaceUpdate)
+		if hasManualInPlaceUpdate {
 			inplace.LabelManualInPlaceNodesWithSelectedForUpdate(ctx, f.ShootClient.Client(), f.Shoot)
 		}
 	}
@@ -159,7 +159,7 @@ func RunTest(
 	shootClient, err = access.CreateShootClientFromAdminKubeconfig(ctx, f.GardenClient, f.Shoot)
 	Expect(err).NotTo(HaveOccurred())
 
-	if hasInplaceUpdate {
+	if hasInPlaceUpdate {
 		nodesOfInPlaceWorkersAfterTest := inplace.FindNodesOfInPlaceWorkers(ctx, f.ShootClient.Client(), f.Shoot)
 		Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
 

--- a/test/testmachinery/system/shoot_update/update_test.go
+++ b/test/testmachinery/system/shoot_update/update_test.go
@@ -26,6 +26,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -115,13 +116,11 @@ func RunTest(
 	var hasAutoInplaceUpdate, hasManualInplaceUpdate, hasInplaceUpdate bool
 
 	for _, worker := range f.Shoot.Spec.Provider.Workers {
-		if strategy := worker.UpdateStrategy; strategy != nil {
-			switch *strategy {
-			case gardencorev1beta1.AutoInPlaceUpdate:
-				hasAutoInplaceUpdate = true
-			case gardencorev1beta1.ManualInPlaceUpdate:
-				hasManualInplaceUpdate = true
-			}
+		switch ptr.Deref(worker.UpdateStrategy, "") {
+		case gardencorev1beta1.AutoInPlaceUpdate:
+			hasAutoInplaceUpdate = true
+		case gardencorev1beta1.ManualInPlaceUpdate:
+			hasManualInplaceUpdate = true
 		}
 	}
 

--- a/test/testmachinery/system/shoot_update/update_test.go
+++ b/test/testmachinery/system/shoot_update/update_test.go
@@ -128,7 +128,7 @@ func RunTest(
 
 	var nodesOfInPlaceWorkersBeforeTest sets.Set[string]
 	if hasInplaceUpdate {
-		nodesOfInPlaceWorkersBeforeTest = inplace.FindAllNodesOfInPlaceWorker(ctx, f.ShootClient.Client(), f.Shoot)
+		nodesOfInPlaceWorkersBeforeTest = inplace.FindNodesOfInPlaceWorkers(ctx, f.ShootClient.Client(), f.Shoot)
 	}
 
 	Expect(f.UpdateShootSpec(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
@@ -152,7 +152,6 @@ func RunTest(
 		}
 	}
 
-	// wait for the shoot to be created
 	err = f.WaitForShootToBeReconciled(ctx, f.Shoot)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -161,7 +160,7 @@ func RunTest(
 	Expect(err).NotTo(HaveOccurred())
 
 	if hasInplaceUpdate {
-		nodesOfInPlaceWorkersAfterTest := inplace.FindAllNodesOfInPlaceWorker(ctx, f.ShootClient.Client(), f.Shoot)
+		nodesOfInPlaceWorkersAfterTest := inplace.FindNodesOfInPlaceWorkers(ctx, f.ShootClient.Client(), f.Shoot)
 		Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
 
 		inplace.ItShouldVerifyInPlaceUpdateCompletion(f.GardenClient.Client(), f.Shoot)

--- a/test/utils/shoots/update/inplace/inplace.go
+++ b/test/utils/shoots/update/inplace/inplace.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package inplace
+
+import (
+	"context"
+	"time"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+)
+
+// ItShouldVerifyInPlaceUpdateStart verifies that the starting of in-place update  by checking the
+// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
+func ItShouldVerifyInPlaceUpdateStart(gardenClient client.Client, shoot *gardencorev1beta1.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate bool) {
+	GinkgoHelper()
+
+	It("Verify in-place update start", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
+
+			g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
+			if hasAutoInplaceUpdate {
+				g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).NotTo(BeEmpty())
+			}
+			if hasManualInplaceUpdate {
+				g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).NotTo(BeEmpty())
+				g.Expect(shoot.Status.Constraints).To(ContainCondition(
+					OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
+					WithReason("WorkerPoolsWithManualInPlaceUpdateStrategyPending"),
+					Or(WithStatus(gardencorev1beta1.ConditionFalse), WithStatus(gardencorev1beta1.ConditionProgressing)),
+				))
+			}
+		}).Should(Succeed())
+	}, SpecTimeout(2*time.Minute))
+}
+
+// LabelManualInPlaceNodesWithSelectedForUpdate labels all manual in-place nodes with the selected-for-update label.
+// In the actual scenario, this should be done by the user, but for testing purposes, we do it here.
+func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, shootClient client.Client, shoot *gardencorev1beta1.Shoot) {
+	GinkgoHelper()
+
+	for _, pool := range shoot.Spec.Provider.Workers {
+		if !v1beta1helper.IsUpdateStrategyManualInPlace(pool.UpdateStrategy) {
+			continue
+		}
+		nodeList := &corev1.NodeList{}
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(shootClient.List(ctx, nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})).To(Succeed())
+		}).Should(Succeed())
+
+		for _, node := range nodeList.Items {
+			if metav1.HasLabel(node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate) {
+				continue
+			}
+
+			metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate, "true")
+			Eventually(ctx, func(g Gomega) {
+				g.Expect(shootClient.Update(ctx, &node)).To(Succeed())
+			}).Should(Succeed(), "node %s should be labeled", node.Name)
+		}
+	}
+}
+
+// FindAllNodesOfInPlaceWorker finds all nodes of in-place workers and returns their names.
+func FindAllNodesOfInPlaceWorker(ctx context.Context, shootClient client.Client, shoot *gardencorev1beta1.Shoot) sets.Set[string] {
+	GinkgoHelper()
+
+	nodesOfInPlaceWorkers := sets.New[string]()
+
+	for _, pool := range shoot.Spec.Provider.Workers {
+		if !v1beta1helper.IsUpdateStrategyInPlace(pool.UpdateStrategy) {
+			continue
+		}
+		nodeList := &corev1.NodeList{}
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(shootClient.List(context.Background(), nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})).To(Succeed())
+		}).Should(Succeed())
+
+		for _, node := range nodeList.Items {
+			nodesOfInPlaceWorkers.Insert(node.Name)
+		}
+	}
+
+	return nodesOfInPlaceWorkers
+}
+
+// ItShouldVerifyInPlaceUpdateCompletion verifies that the in-place update was completed successfully by checking the
+// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
+func ItShouldVerifyInPlaceUpdateCompletion(gardenClient client.Client, shoot *gardencorev1beta1.Shoot) {
+	GinkgoHelper()
+
+	It("Verify in-place update completion", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
+
+			g.Expect(shoot.Status.InPlaceUpdates).To(BeNil())
+			g.Expect(shoot.Status.Constraints).NotTo(ContainCondition(
+				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
+			))
+		}).Should(Succeed())
+	}, SpecTimeout(2*time.Minute))
+}
+
+// ItShouldFindAllNodesOfInPlaceWorker finds all nodes of in-place workers and returns their names.
+func ItShouldFindAllNodesOfInPlaceWorker(s *ShootContext) sets.Set[string] {
+	GinkgoHelper()
+
+	nodesOfInPlaceWorkers := sets.New[string]()
+
+	It("should get the nodes of worker with in-place update strategy", func(ctx SpecContext) {
+		nodesOfInPlaceWorkers = FindAllNodesOfInPlaceWorker(ctx, s.ShootClient, s.Shoot)
+	}, SpecTimeout(2*time.Minute))
+
+	return nodesOfInPlaceWorkers
+}
+
+// ItShouldLabelManualInPlaceNodesWithSelectedForUpdate labels all manual in-place nodes with the selected-for-update label.
+// In the actual scenario, this should be done by the user, but for testing purposes, we do it here.
+func ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s *ShootContext) {
+	GinkgoHelper()
+
+	It("should label all the manual in-place nodes with selected-for-update", func(ctx SpecContext) {
+		LabelManualInPlaceNodesWithSelectedForUpdate(ctx, s.ShootClient, s.Shoot)
+	}, SpecTimeout(2*time.Minute))
+}

--- a/test/utils/shoots/update/inplace/nodes.go
+++ b/test/utils/shoots/update/inplace/nodes.go
@@ -19,35 +19,8 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/gardener/gardener/test/e2e/gardener"
 )
-
-// ItShouldVerifyInPlaceUpdateStart verifies that the starting of in-place update  by checking the
-// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
-func ItShouldVerifyInPlaceUpdateStart(gardenClient client.Client, shoot *gardencorev1beta1.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate bool) {
-	GinkgoHelper()
-
-	It("Verify in-place update start", func(ctx SpecContext) {
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
-
-			g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
-			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
-			if hasAutoInplaceUpdate {
-				g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).NotTo(BeEmpty())
-			}
-			if hasManualInplaceUpdate {
-				g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).NotTo(BeEmpty())
-				g.Expect(shoot.Status.Constraints).To(ContainCondition(
-					OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
-					WithReason("WorkerPoolsWithManualInPlaceUpdateStrategyPending"),
-					Or(WithStatus(gardencorev1beta1.ConditionFalse), WithStatus(gardencorev1beta1.ConditionProgressing)),
-				))
-			}
-		}).Should(Succeed())
-	}, SpecTimeout(2*time.Minute))
-}
 
 // LabelManualInPlaceNodesWithSelectedForUpdate labels all manual in-place nodes with the selected-for-update label.
 // In the actual scenario, this should be done by the user, but for testing purposes, we do it here.
@@ -58,6 +31,7 @@ func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, shootClie
 		if !v1beta1helper.IsUpdateStrategyManualInPlace(pool.UpdateStrategy) {
 			continue
 		}
+
 		nodeList := &corev1.NodeList{}
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(shootClient.List(ctx, nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})).To(Succeed())
@@ -76,8 +50,8 @@ func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, shootClie
 	}
 }
 
-// FindAllNodesOfInPlaceWorker finds all nodes of in-place workers and returns their names.
-func FindAllNodesOfInPlaceWorker(ctx context.Context, shootClient client.Client, shoot *gardencorev1beta1.Shoot) sets.Set[string] {
+// FindNodesOfInPlaceWorkers finds all nodes of in-place workers and returns their names.
+func FindNodesOfInPlaceWorkers(ctx context.Context, shootClient client.Client, shoot *gardencorev1beta1.Shoot) sets.Set[string] {
 	GinkgoHelper()
 
 	nodesOfInPlaceWorkers := sets.New[string]()
@@ -86,6 +60,7 @@ func FindAllNodesOfInPlaceWorker(ctx context.Context, shootClient client.Client,
 		if !v1beta1helper.IsUpdateStrategyInPlace(pool.UpdateStrategy) {
 			continue
 		}
+
 		nodeList := &corev1.NodeList{}
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(shootClient.List(context.Background(), nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})).To(Succeed())
@@ -99,31 +74,14 @@ func FindAllNodesOfInPlaceWorker(ctx context.Context, shootClient client.Client,
 	return nodesOfInPlaceWorkers
 }
 
-// ItShouldVerifyInPlaceUpdateCompletion verifies that the in-place update was completed successfully by checking the
-// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
-func ItShouldVerifyInPlaceUpdateCompletion(gardenClient client.Client, shoot *gardencorev1beta1.Shoot) {
-	GinkgoHelper()
-
-	It("Verify in-place update completion", func(ctx SpecContext) {
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
-
-			g.Expect(shoot.Status.InPlaceUpdates).To(BeNil())
-			g.Expect(shoot.Status.Constraints).NotTo(ContainCondition(
-				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
-			))
-		}).Should(Succeed())
-	}, SpecTimeout(2*time.Minute))
-}
-
-// ItShouldFindAllNodesOfInPlaceWorker finds all nodes of in-place workers and returns their names.
-func ItShouldFindAllNodesOfInPlaceWorker(s *ShootContext) sets.Set[string] {
+// ItShouldFindNodesOfInPlaceWorkers finds all nodes of in-place workers and returns their names.
+func ItShouldFindNodesOfInPlaceWorkers(s *ShootContext) sets.Set[string] {
 	GinkgoHelper()
 
 	nodesOfInPlaceWorkers := sets.New[string]()
 
 	It("should get the nodes of worker with in-place update strategy", func(ctx SpecContext) {
-		nodesOfInPlaceWorkers = FindAllNodesOfInPlaceWorker(ctx, s.ShootClient, s.Shoot)
+		nodesOfInPlaceWorkers = FindNodesOfInPlaceWorkers(ctx, s.ShootClient, s.Shoot)
 	}, SpecTimeout(2*time.Minute))
 
 	return nodesOfInPlaceWorkers

--- a/test/utils/shoots/update/inplace/shoot.go
+++ b/test/utils/shoots/update/inplace/shoot.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package inplace
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+// ItShouldVerifyInPlaceUpdateStart verifies that the starting of in-place update  by checking the
+// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
+func ItShouldVerifyInPlaceUpdateStart(gardenClient client.Client, shoot *gardencorev1beta1.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate bool) {
+	GinkgoHelper()
+
+	It("Verify in-place update start", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
+
+			g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
+			if hasAutoInplaceUpdate {
+				g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).NotTo(BeEmpty())
+			}
+			if hasManualInplaceUpdate {
+				g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).NotTo(BeEmpty())
+				g.Expect(shoot.Status.Constraints).To(ContainCondition(
+					OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
+					WithReason("WorkerPoolsWithManualInPlaceUpdateStrategyPending"),
+					Or(WithStatus(gardencorev1beta1.ConditionFalse), WithStatus(gardencorev1beta1.ConditionProgressing)),
+				))
+			}
+		}).Should(Succeed())
+	}, SpecTimeout(2*time.Minute))
+}
+
+// ItShouldVerifyInPlaceUpdateCompletion verifies that the in-place update was completed successfully by checking the
+// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
+func ItShouldVerifyInPlaceUpdateCompletion(gardenClient client.Client, shoot *gardencorev1beta1.Shoot) {
+	GinkgoHelper()
+
+	It("Verify in-place update completion", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
+
+			g.Expect(shoot.Status.InPlaceUpdates).To(BeNil())
+			g.Expect(shoot.Status.Constraints).NotTo(ContainCondition(
+				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
+			))
+		}).Should(Succeed())
+	}, SpecTimeout(2*time.Minute))
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area test delivery open-source scalability
/kind enhancement

**What this PR does / why we need it**:
This PR adds TM test for the worker pools with InPlace update strategy, the test verifies that after performing update the nodes should remain the same.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
