### PR TITLE
Add IPv6 support for `fluent-bit`

### DIFF
--- a/pkg/component/observability/logging/fluentbit/fluentbit.go
+++ b/pkg/component/observability/logging/fluentbit/fluentbit.go
@@ -509,7 +509,7 @@ func (f *fluentBit) getClusterFluentBitConfig() *fluentbitv1alpha2.ClusterFluent
 				LogLevel:     "error",
 				ParsersFile:  "parsers.conf",
 				HttpServer:   ptr.To(true),
-				HttpListen:   "0.0.0.0",
+				HttpListen:   "::",
 				HttpPort:     ptr.To[int32](2020),
 			},
 			InputSelector: metav1.LabelSelector{


### PR DESCRIPTION
**How to categorize this PR?**
/area logging
/kind enhancement

**What this PR does / why we need it**:
Enhance `fluent-bit`'s `ConfigMap` to listen on `::`, so both IPv6 and IPv4 are bound. The change is needed for IronCore, having a single-node IPv6-only setup

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
`fluent-bit` now supports IPv6 as well.
```
