### PR TITLE
[GEP-31] Add usage doc for in-place update

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -9733,7 +9733,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ManualInPlaceUpdate contains the names of the pending worker pools with strategy ManualInPlaceUpdate..</p>
+<p>ManualInPlaceUpdate contains the names of the pending worker pools with strategy ManualInPlaceUpdate.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/usage/shoot-operations/shoot_credentials_rotation.md
+++ b/docs/usage/shoot-operations/shoot_credentials_rotation.md
@@ -147,7 +147,7 @@ Now you can just complete the rotation as usual (see above).
 In case of manual in-place update, shoot CA rotation phase will be at `Preparing` until all the worker pools are successfully in-place updated and there are no pending worker pools with strategy ManualInPlaceUpdate.
 
 You can check which worker pools still need to be updated by reading `.status.inPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate`.
-Once this list is empty, the `phase` transitions to `Prepared`.After this rotation will be completed as usual (see above).
+Once this list is empty, the `phase` transitions to `Prepared`. After this rotation will be completed as usual (see above).
 
 ### Observability Password(s) For Plutono and Prometheus
 
@@ -282,7 +282,7 @@ It works the same way for the `ServiceAccount` token signing key (using `rotate-
 #### Worker Node with ManualInPlaceUpdate Update Strategy
 
 Similar to the rotation of the certificate authorities, in case of manual in-place update, `ServiceAccount` token signing key rotation phase will be at `Preparing` until all the worker pools are successfully in-place updated and there are no pending worker pools with strategy ManualInPlaceUpdate.
-Please read [this section](#worker-node-with-manualinplaceupdate-update-strategy) to get more information.
+Please read [this section](#worker-node-with-manualinplaceupdate-update-strategy) for more information.
 
 ### OpenVPN TLS Auth Keys
 

--- a/docs/usage/shoot-operations/shoot_credentials_rotation.md
+++ b/docs/usage/shoot-operations/shoot_credentials_rotation.md
@@ -142,6 +142,13 @@ You can check which worker pools still need to be rolled by reading `.status.cre
 Once this list is empty, the `phase` transitions to `Prepared`.
 Now you can just complete the rotation as usual (see above).
 
+#### Worker Node with ManualInPlaceUpdate Update Strategy
+
+In case of manual in-place update, shoot CA rotation phase will be at `Preparing` until all the worker pools are successfully in-place updated and there are no pending worker pools with strategy ManualInPlaceUpdate.
+
+You can check which worker pools still need to be updated by reading `.status.inPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate`.
+Once this list is empty, the `phase` transitions to `Prepared`.After this rotation will be completed as usual (see above).
+
 ### Observability Password(s) For Plutono and Prometheus
 
 For `Shoot`s with `.spec.purpose!=testing`, Gardener deploys an observability stack with Prometheus for monitoring, Alertmanager for alerting (optional), Vali for logging, and Plutono for visualization.
@@ -271,6 +278,11 @@ After it is completed, the `.status.credentials.rotation.serviceAccountKey.phase
 Similar to the rotation of the certificate authorities, you can control the worker node rollout individually.
 Please read [this section](#triggering-worker-node-rollout-individually) to get more information.
 It works the same way for the `ServiceAccount` token signing key (using `rotate-serviceaccount-key-start-without-workers-rollout`).
+
+#### Worker Node with ManualInPlaceUpdate Update Strategy
+
+Similar to the rotation of the certificate authorities, in case of manual in-place update, `ServiceAccount` token signing key rotation phase will be at `Preparing` until all the worker pools are successfully in-place updated and there are no pending worker pools with strategy ManualInPlaceUpdate.
+Please read [this section](#worker-node-with-manualinplaceupdate-update-strategy) to get more information.
 
 ### OpenVPN TLS Auth Keys
 

--- a/docs/usage/shoot-operations/shoot_credentials_rotation.md
+++ b/docs/usage/shoot-operations/shoot_credentials_rotation.md
@@ -146,8 +146,9 @@ Now you can just complete the rotation as usual (see above).
 
 In case of manual in-place update, shoot CA rotation phase will be at `Preparing` until all the worker pools are successfully in-place updated and there are no pending worker pools with strategy ManualInPlaceUpdate.
 
-You can check which worker pools still need to be updated by reading `.status.inPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate`.
-Once this list is empty, the `phase` transitions to `Prepared`. After this rotation will be completed as usual (see above).
+You can check which worker pools still need to be updated by reading `.status.inPlaceUpdates.pendingWorkerUpdates.manualInPlaceUpdate`.
+Once this list is empty, the `phase` transitions to `Prepared`.
+After this rotation will be completed as usual (see above).
 
 ### Observability Password(s) For Plutono and Prometheus
 

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -53,21 +53,52 @@ We consider shoot upgrades to change either the:
 Generally, an upgrade is also performed through a reconciliation of the `Shoot` resource, i.e., the same concepts as for [shoot updates](#updates) apply.
 If an end-user triggers an upgrade (e.g., by changing the Kubernetes version) after a new Gardener version was deployed but before the shoot was reconciled again, then this upgrade might incorporate the changes delivered with this new Gardener version.
 
+`UpdateStrategy` field under shoot worker enables the end user to choose between different behaviour of machine-controller-manager (abbrev.: MCM; the component instrumenting this rolling update) during the upgrade process. Currently gardener support three update strategies:
+* `AutoRollingUpdate`
+* `AutoInPlaceUpdate`
+* `ManualInPlaceUpdate`
+
 ### In-Place vs. Rolling Updates
 
-If the Kubernetes patch version is changed, then the upgrade happens in-place.
-This means that the shoot worker nodes remain untouched and only the `kubelet` process restarts with the new Kubernetes version binary.
-The same applies for configuration changes of the kubelet.
+- During an in-place update, worker nodes are updated without replacing the underlying machines.
+- The shoot worker nodes remain intact and are not recreated.
+- Some downtime is expected as the node needs to be drained, and workloads are rescheduled once the update is complete.
+- In certain scenarios, updates can be performed without draining the node:
+  - When the Kubernetes patch version is updated, the upgrade is executed without draining the node. In this case, the shoot worker nodes remain unchanged, and only the `kubelet` process is restarted with the updated Kubernetes version binary.
+  - Similarly, configuration changes to the `kubelet` are applied without draining the node.
 
-If the Kubernetes minor version is changed, then the upgrade is done in a "rolling update" fashion, similar to how pods in Kubernetes are updated (when backed by a `Deployment`).
-The worker nodes will be terminated one after another and replaced by new machines.
-The existing workload is gracefully drained and evicted from the old worker nodes to new worker nodes, respecting the configured `PodDisruptionBudget`s (see [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)).
+- In case of rolling update, upgrade is done in a "rolling update" fashion, similar to how pods in Kubernetes are updated (when backed by a `Deployment`).
+- The worker nodes will be terminated one after another and replaced by new machines.
+- The existing workload is gracefully drained and evicted from the old worker nodes to new worker nodes, respecting the configured `PodDisruptionBudget`s (see [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)).
+
+### AutoRollingUpdate
+
+When the auto rolling update strategy is selected, the upgrade is performed in a "rolling update" manner. The machine-controller-manager sequentially terminates the worker nodes and replaces them with new machines. This is the default update strategy. To create workers with `AutoRollingUpdate`, either omit the `workers.updateStrategy` field (it will default to `AutoInPlaceUpdate`) or explicitly set the field to `AutoInPlaceUpdate` for each worker.
+
+```yaml
+spec:
+  provider:
+    workers:
+      - name: cpu-worker
+        minimum: 5
+        maximum: 5
+        maxSurge: 0
+        maxUnavailable: 2
+        updateStrategy: AutoRollingUpdate
+        machine:
+          type: m5.large
+          image:
+            name: <some-image-name>
+            version: <some-image-version>
+          architecture: <some-cpu-architecture>
+        providerConfig: <some-machine-image-specific-configuration>
+```
 
 #### Customize Rolling Update Behaviour of Shoot Worker Nodes
 
 The `.spec.provider.workers[]` list exposes two fields that you might configure based on your workload's needs: `maxSurge` and `maxUnavailable`.
 The same concepts [like in Kubernetes](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) apply.
-Additionally, you might customize how the machine-controller-manager (abbrev.: MCM; the component instrumenting this rolling update) is behaving. You can configure the following fields in `.spec.provider.worker[].machineControllerManager`:
+Additionally, you might customize how the MCM is behaving. You can configure the following fields in `.spec.provider.worker[].machineControllerManager`:
 
 * `machineDrainTimeout`: Timeout (in duration) used while draining of machine before deletion, beyond which MCM forcefully deletes the machine (default: `2h`).
 * `machineHealthTimeout`: Timeout (in duration) used while re-joining (in case of temporary health issues) of a machine before it is declared as failed (default: `10m`).
@@ -77,7 +108,7 @@ Additionally, you might customize how the machine-controller-manager (abbrev.: M
 
 #### Rolling Update Triggers
 
-Apart from the above mentioned triggers, a rolling update of the shoot worker nodes is also triggered for some changes to your worker pool specification (`.spec.provider.workers[]`, even if you don't change the Kubernetes or machine image version).
+A rolling update of the shoot worker nodes is triggered for some changes to your worker pool specification (`.spec.provider.workers[]`, even if you don't change the Kubernetes or machine image version).
 The complete list of fields that trigger a rolling update:
 
 * `.spec.kubernetes.version` (except for patch version changes)
@@ -108,6 +139,127 @@ Changes to `kubeReserved` or `systemReserved` do not trigger a node roll if thei
 
 Generally, the provider extension controllers might have additional constraints for changes leading to rolling updates, so please consult the respective documentation as well.
 In particular, if the feature gate `NewWorkerPoolHash` is enabled and a worker pool uses the new hash, then the `providerConfig` as a whole is not included. Instead only fields selected by the provider extension are considered.
+
+### InPlace updates
+
+For scenarios where users want to retain the current nodes and avoid their deletion during updates, Gardener provides the option of `in-place` updates. Currently, `in-place` updates are controlled by the `InPlaceNodeUpdates` feature gate.
+
+The machine image version in the `cloudprofile` includes the `inPlaceUpdates` field, which defines the configuration for in-place updates. For an operating system to support in-place updates:
+- The `inPlaceUpdates.supported` field must be set to `true`.
+- The `inPlaceUpdates.minVersionForUpdate` field specifies the minimum version from which an in-place update to the target machine image version can be performed.
+
+```yaml
+machineImages:
+- name: gardenlinux
+  updateStrategy: minor
+  versions:
+  - architectures:
+    - amd64
+    - arm64
+    classification: preview
+    cri:
+    - containerRuntimes:
+      - type: gvisor
+      name: containerd
+    version: 1632.0.0
+    inPlaceUpdates:
+      supported: true
+      minVersionForUpdate: 1630.0.0
+```
+
+The `inPlaceUpdates` field in the Shoot status provides details about in-place updates for the Shoot workers. It includes the `pendingWorkerUpdates` field, which lists the worker pools that are awaiting in-place updates.
+
+#### InPlace Update Triggers
+
+An in-place update of the shoot worker nodes is triggered for rolling update triggers listed under [Rolling Update Triggers](#rolling-update-triggers) except the following:
+* `.spec.provider.workers[].machine.image.name`
+* `.spec.provider.workers[].machine.type`
+* `.spec.provider.workers[].volume.type`
+* `.spec.provider.workers[].volume.size`
+* `.spec.provider.workers[].cri.name`
+* `.spec.systemComponents.nodeLocalDNS.enabled`
+
+#### Validations for In-Place update
+
+When a worker pool is undergoing an in-place update, applying subsequent updates to the same worker pool is restricted.
+If an in-place update fails and nodes are left in a problematic state, user intervention is required to manually fix the nodes. After resolving the issue, users can restart the update by adding the force update annotation `gardener.cloud/operation=force-in-place-update`.
+
+Without this annotation, subsequent updates to the same worker pool are denied. Refer to [Force-update a worker pool with InPlace update strategy](shoot_operations.md#force-update-a-worker-pool-with-inplace-update-strategy) for more details.
+
+> ⚠️ Changing the update strategy from `AutoRollingUpdate` to `AutoInPlaceUpdate` or `ManualInPlaceUpdate` (and vice versa) is not allowed. However, switching between `AutoInPlaceUpdate` and `ManualInPlaceUpdate` is permitted.
+
+#### AutoInPlaceUpdate
+
+In case of AutoInPlaceUpdate update strategy, the update process is fully orchestrated by Gardener and the machine-controller-manager. No user intervention is required.The update strategy should be set to `AutoInPlaceUpdate` in the worker spec.
+
+The `inPlaceUpdates.pendingWorkerUpdates.autoInPlaceUpdate` field in the Shoot status lists the names of worker pools that are pending updates with the `AutoInPlaceUpdate` strategy.
+
+```yaml
+spec:
+  provider:
+    type: <some-provider-name>
+    workers:
+      - name: cpu-worker
+        minimum: 5
+        maximum: 5
+        maxSurge: 0
+        maxUnavailable: 2
+        updateStrategy: AutoInPlaceUpdate
+        machine:
+          type: m5.large
+          image:
+            name: <some-image-name>
+            version: <some-image-version>
+          architecture: <some-cpu-architecture>
+        providerConfig: <some-machine-image-specific-configuration>
+```
+
+#### Customize Auto In-Place Update Behaviour of Shoot Worker Nodes
+
+The `.spec.provider.workers[]` list exposes two fields that you might configure based on your workload's needs: `maxSurge` and `maxUnavailable`.
+The same concepts [like in Kubernetes](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) apply.
+Additionally, you might customize how the machine-controller-manager is behaving. You can configure the following fields in `.spec.provider.worker[].machineControllerManager`:
+
+* `MachineInPlaceUpdateTimeout`:  Timeout (in duration) after which an in-place update is declared as failed.
+* `DisableHealthTimeout`: Boolean value if set to true, health timeout will be ignored, leading to machine never being declared as failed (default: `true` for in-place updates). 
+
+#### ManualInPlaceUpdate
+
+The `ManualInPlaceUpdate` strategy allows users to control and orchestrate the update process manually. Users can select specific nodes for updates by labeling them with:
+`node.machine.sapcloud.io/selected-for-update=true.` Once labeled, the machine-controller-manager updates the selected node.
+The update strategy should be set to `ManualInPlaceUpdate` in the worker spec.
+
+The `ManualInPlaceWorkersUpdated` [constraint](../shoot/shoot_status.md/#constraints) in the shoot status indicates that at least one worker pool with the `ManualInPlaceUpdate` strategy is pending an update. Shoot reconciliation will still succeed even if there are worker pools pending updates.
+
+The `inPlaceUpdates.pendingWorkerUpdates.manualInPlaceUpdate` field in the Shoot status lists the names of worker pools that are pending updates with the `ManualInPlaceUpdate` strategy.
+
+```yaml
+spec:
+  provider:
+    type: <some-provider-name>
+    workers:
+      - name: cpu-worker
+        minimum: 5
+        maximum: 5
+        maxSurge: 0
+        maxUnavailable: 2
+        updateStrategy: ManualInPlaceUpdate
+        machine:
+          type: m5.large
+          image:
+            name: <some-image-name>
+            version: <some-image-version>
+          architecture: <some-cpu-architecture>
+        providerConfig: <some-machine-image-specific-configuration>
+```
+
+#### Customize Manual InPlace Update Behaviour of Shoot Worker Nodes
+
+The `.spec.provider.workers[]` list exposes two fields that you might configure based on your workload's needs: `maxSurge` and `maxUnavailable`. For manual in-place updates:
+- `maxSurge` is always set to `0`, regardless of user configuration.
+- `maxUnavailable` defaults to `1`.
+
+Additionally, `.spec.provider.worker[].machineControllerManager` can be customised in same way as mentioned in [Customize Auto InPlace Update Behaviour of Shoot Worker Nodes](#customize-auto-inplace-update-behaviour-of-shoot-worker-nodes).
 
 ## Related Documentation
 

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -53,45 +53,37 @@ We consider shoot upgrades to change either the:
 Generally, an upgrade is also performed through a reconciliation of the `Shoot` resource, i.e., the same concepts as for [shoot updates](#updates) apply.
 If an end-user triggers an upgrade (e.g., by changing the Kubernetes version) after a new Gardener version was deployed but before the shoot was reconciled again, then this upgrade might incorporate the changes delivered with this new Gardener version.
 
-`UpdateStrategy` field under shoot worker enables the end user to choose between different behaviour of machine-controller-manager (abbrev.: MCM; the component instrumenting this rolling update) during the upgrade process. Currently gardener support three update strategies:
+The `UpdateStrategy` field in the Shoot specification (`.spec.provider.workers[].updateStrategy`) gives users the flexibility to define how the `machine-controller-manager`(MCM) handles worker pool updates during the upgrade process. Currently gardener support three update strategies:
 * `AutoRollingUpdate`
 * `AutoInPlaceUpdate`
 * `ManualInPlaceUpdate`
 
 ### In-Place vs. Rolling Updates
 
-- During an in-place update, worker nodes are updated without replacing the underlying machines.
+#### In-Place Updates
+- The upgrade is performed in a "rolling update" manner, without replacing the underlying machines.
 - The shoot worker nodes remain intact and are not recreated.
-- Some downtime is expected as the node needs to be drained, and workloads are rescheduled once the update is complete.
-- In certain scenarios, updates can be performed without draining the node:
-  - When the Kubernetes patch version is updated, the upgrade is executed without draining the node. In this case, the shoot worker nodes remain unchanged, and only the `kubelet` process is restarted with the updated Kubernetes version binary.
-  - Similarly, configuration changes to the `kubelet` are applied without draining the node.
+- The existing workload is gracefully drained and evicted from the worker nodes, respecting the configured `PodDisruptionBudget`s (see [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)).
+- **No Draining Scenarios**:
+  - When the Kubernetes patch version is updated, the upgrade is executed without draining the node. The shoot worker nodes remain unchanged, and only the `kubelet` process is restarted with the updated Kubernetes version binary.
 
-- In case of rolling update, upgrade is done in a "rolling update" fashion, similar to how pods in Kubernetes are updated (when backed by a `Deployment`).
-- The worker nodes will be terminated one after another and replaced by new machines.
+#### Rolling Updates
+- The upgrade is performed in a "rolling update" manner, during which nodes in the worker pool are replaced. Similar to how pods in Kubernetes are updated when backed by a `Deployment`.
+- Worker nodes are terminated one after another and replaced by new machines.
 - The existing workload is gracefully drained and evicted from the old worker nodes to new worker nodes, respecting the configured `PodDisruptionBudget`s (see [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)).
 
 ### AutoRollingUpdate
 
-When the auto rolling update strategy is selected, the upgrade is performed in a "rolling update" manner. The machine-controller-manager sequentially terminates the worker nodes and replaces them with new machines. This is the default update strategy. To create workers with `AutoRollingUpdate`, either omit the `workers.updateStrategy` field (it will default to `AutoInPlaceUpdate`) or explicitly set the field to `AutoInPlaceUpdate` for each worker.
+When the auto rolling update strategy is selected, the upgrade is performed in a "rolling update" manner. The machine-controller-manager sequentially terminates the worker nodes and replaces them with new nodes. This is the default update strategy. To create workers with `AutoRollingUpdate`, either omit the `workers.updateStrategy` field (it will default to `AutoRollingUpdate`) or explicitly set the field to `AutoRollingUpdate` for each worker.
 
 ```yaml
 spec:
   provider:
     workers:
       - name: cpu-worker
-        minimum: 5
-        maximum: 5
         maxSurge: 0
         maxUnavailable: 2
         updateStrategy: AutoRollingUpdate
-        machine:
-          type: m5.large
-          image:
-            name: <some-image-name>
-            version: <some-image-version>
-          architecture: <some-cpu-architecture>
-        providerConfig: <some-machine-image-specific-configuration>
 ```
 
 #### Customize Rolling Update Behaviour of Shoot Worker Nodes
@@ -144,30 +136,28 @@ In particular, if the feature gate `NewWorkerPoolHash` is enabled and a worker p
 
 For scenarios where users want to retain the current nodes and avoid their deletion during updates, Gardener provides the option of `in-place` updates. Currently, `in-place` updates are controlled by the `InPlaceNodeUpdates` feature gate.
 
-The machine image version in the `cloudprofile` includes the `inPlaceUpdates` field, which defines the configuration for in-place updates. For an operating system to support in-place updates:
+For in-place updates, the first requirement is that the operating system must support them. For a specific machine image version, the configuration for in-place updates must be defined in the `CloudProfile` under spec.machineImages[].inPlaceUpdates:
 - The `inPlaceUpdates.supported` field must be set to `true`.
 - The `inPlaceUpdates.minVersionForUpdate` field specifies the minimum version from which an in-place update to the target machine image version can be performed.
 
 ```yaml
 machineImages:
 - name: gardenlinux
-  updateStrategy: minor
   versions:
-  - architectures:
-    - amd64
-    - arm64
-    classification: preview
-    cri:
-    - containerRuntimes:
-      - type: gvisor
-      name: containerd
-    version: 1632.0.0
+  - version: 1632.0.0
     inPlaceUpdates:
       supported: true
       minVersionForUpdate: 1630.0.0
 ```
 
 The `inPlaceUpdates` field in the Shoot status provides details about in-place updates for the Shoot workers. It includes the `pendingWorkerUpdates` field, which lists the worker pools that are awaiting in-place updates.
+
+#### Customize In-Place Update Behaviour of Shoot Worker Nodes
+
+In addition to customisable fields mentioned in [](#customize-rolling-update-behaviour-of-shoot-worker-nodes) section, you can configure the following fields in `.spec.provider.worker[].machineControllerManager`:
+
+* `MachineInPlaceUpdateTimeout`:  Timeout (in duration) after which an in-place update is declared as failed.
+* `DisableHealthTimeout`: A boolean value that, when set to `true`, ignores the health timeout. As a result, machines are never marked as failed, and unhealthy machines are not deleted. The default value is `true` for in-place updates.
 
 #### InPlace Update Triggers
 
@@ -182,84 +172,50 @@ An in-place update of the shoot worker nodes is triggered for rolling update tri
 #### Validations for In-Place update
 
 When a worker pool is undergoing an in-place update, applying subsequent updates to the same worker pool is restricted.
-If an in-place update fails and nodes are left in a problematic state, user intervention is required to manually fix the nodes. After resolving the issue, users can restart the update by adding the force update annotation `gardener.cloud/operation=force-in-place-update`.
+If an in-place update fails and nodes are left in a problematic state, user intervention is required to manually fix the nodes. In cases where a subsequent update is necessary to resolve the issue, users can update the worker pool after adding the force update annotation `gardener.cloud/operation=force-in-place-update` on the Shoot.
 
 Without this annotation, subsequent updates to the same worker pool are denied. Refer to [Force-update a worker pool with InPlace update strategy](shoot_operations.md#force-update-a-worker-pool-with-inplace-update-strategy) for more details.
 
-> ⚠️ Changing the update strategy from `AutoRollingUpdate` to `AutoInPlaceUpdate` or `ManualInPlaceUpdate` (and vice versa) is not allowed. However, switching between `AutoInPlaceUpdate` and `ManualInPlaceUpdate` is permitted.
+> ⚠️ Changing the update strategy from `AutoRollingUpdate` to `AutoInPlaceUpdate`/`ManualInPlaceUpdate` (and vice versa) is not allowed. However, switching between `AutoInPlaceUpdate` and `ManualInPlaceUpdate` is permitted.
 
 #### AutoInPlaceUpdate
 
-In case of AutoInPlaceUpdate update strategy, the update process is fully orchestrated by Gardener and the machine-controller-manager. No user intervention is required.The update strategy should be set to `AutoInPlaceUpdate` in the worker spec.
+In case of AutoInPlaceUpdate update strategy, the update process is fully orchestrated by Gardener and the machine-controller-manager. No user intervention is required.  Set `.spec.provider.workers[].updateStrategy` field in the `Shoot` spec to `AutoInPlaceUpdate`.
 
 The `inPlaceUpdates.pendingWorkerUpdates.autoInPlaceUpdate` field in the Shoot status lists the names of worker pools that are pending updates with the `AutoInPlaceUpdate` strategy.
 
 ```yaml
 spec:
   provider:
-    type: <some-provider-name>
     workers:
       - name: cpu-worker
-        minimum: 5
-        maximum: 5
         maxSurge: 0
         maxUnavailable: 2
         updateStrategy: AutoInPlaceUpdate
-        machine:
-          type: m5.large
-          image:
-            name: <some-image-name>
-            version: <some-image-version>
-          architecture: <some-cpu-architecture>
-        providerConfig: <some-machine-image-specific-configuration>
 ```
-
-#### Customize Auto In-Place Update Behaviour of Shoot Worker Nodes
-
-The `.spec.provider.workers[]` list exposes two fields that you might configure based on your workload's needs: `maxSurge` and `maxUnavailable`.
-The same concepts [like in Kubernetes](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) apply.
-Additionally, you might customize how the machine-controller-manager is behaving. You can configure the following fields in `.spec.provider.worker[].machineControllerManager`:
-
-* `MachineInPlaceUpdateTimeout`:  Timeout (in duration) after which an in-place update is declared as failed.
-* `DisableHealthTimeout`: Boolean value if set to true, health timeout will be ignored, leading to machine never being declared as failed (default: `true` for in-place updates). 
 
 #### ManualInPlaceUpdate
 
-The `ManualInPlaceUpdate` strategy allows users to control and orchestrate the update process manually. Users can select specific nodes for updates by labeling them with:
-`node.machine.sapcloud.io/selected-for-update=true.` Once labeled, the machine-controller-manager updates the selected node.
-The update strategy should be set to `ManualInPlaceUpdate` in the worker spec.
+The `ManualInPlaceUpdate` strategy allows users to control and orchestrate the update process manually. Set `.spec.provider.workers[].updateStrategy` field in the `Shoot` spec to `ManualInPlaceUpdate`.
+
+Once machine-controller-manager labels nodes with `node.machine.sapcloud.io/candidate-for-update`, user can select the candidate nodes for update by labeling them with `node.machine.sapcloud.io/selected-for-update=true`: 
+```
+kubectl label node <node-name> node.machine.sapcloud.io/selected-for-update=true
+```
 
 The `ManualInPlaceWorkersUpdated` [constraint](../shoot/shoot_status.md/#constraints) in the shoot status indicates that at least one worker pool with the `ManualInPlaceUpdate` strategy is pending an update. Shoot reconciliation will still succeed even if there are worker pools pending updates.
 
-The `inPlaceUpdates.pendingWorkerUpdates.manualInPlaceUpdate` field in the Shoot status lists the names of worker pools that are pending updates with the `ManualInPlaceUpdate` strategy.
+The `inPlaceUpdates.pendingWorkerUpdates.manualInPlaceUpdate` field in the `Shoot` status lists the names of worker pools that are pending updates with the this strategy.
 
 ```yaml
 spec:
   provider:
-    type: <some-provider-name>
     workers:
       - name: cpu-worker
-        minimum: 5
-        maximum: 5
         maxSurge: 0
         maxUnavailable: 2
         updateStrategy: ManualInPlaceUpdate
-        machine:
-          type: m5.large
-          image:
-            name: <some-image-name>
-            version: <some-image-version>
-          architecture: <some-cpu-architecture>
-        providerConfig: <some-machine-image-specific-configuration>
 ```
-
-#### Customize Manual InPlace Update Behaviour of Shoot Worker Nodes
-
-The `.spec.provider.workers[]` list exposes two fields that you might configure based on your workload's needs: `maxSurge` and `maxUnavailable`. For manual in-place updates:
-- `maxSurge` is always set to `0`, regardless of user configuration.
-- `maxUnavailable` defaults to `1`.
-
-Additionally, `.spec.provider.worker[].machineControllerManager` can be customised in same way as mentioned in [Customize Auto InPlace Update Behaviour of Shoot Worker Nodes](#customize-auto-inplace-update-behaviour-of-shoot-worker-nodes).
 
 ## Related Documentation
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2269,7 +2269,7 @@ message PendingWorkerUpdates {
   // +optional
   repeated string autoInPlaceUpdate = 1;
 
-  // ManualInPlaceUpdate contains the names of the pending worker pools with strategy ManualInPlaceUpdate..
+  // ManualInPlaceUpdate contains the names of the pending worker pools with strategy ManualInPlaceUpdate.
   // +optional
   repeated string manualInPlaceUpdate = 2;
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -261,7 +261,7 @@ type PendingWorkerUpdates struct {
 	// AutoInPlaceUpdate contains the names of the pending worker pools with strategy AutoInPlaceUpdate.
 	// +optional
 	AutoInPlaceUpdate []string `json:"autoInPlaceUpdate,omitempty" protobuf:"bytes,1,rep,name=autoInPlaceUpdate"`
-	// ManualInPlaceUpdate contains the names of the pending worker pools with strategy ManualInPlaceUpdate..
+	// ManualInPlaceUpdate contains the names of the pending worker pools with strategy ManualInPlaceUpdate.
 	// +optional
 	ManualInPlaceUpdate []string `json:"manualInPlaceUpdate,omitempty" protobuf:"bytes,2,rep,name=manualInPlaceUpdate"`
 }

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -6743,7 +6743,7 @@ func schema_pkg_apis_core_v1beta1_PendingWorkerUpdates(ref common.ReferenceCallb
 					},
 					"manualInPlaceUpdate": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManualInPlaceUpdate contains the names of the pending worker pools with strategy ManualInPlaceUpdate..",
+							Description: "ManualInPlaceUpdate contains the names of the pending worker pools with strategy ManualInPlaceUpdate.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Adds usage doc for in-place update under shoot_updates.md file.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
