### PR TITLE
vpa-updater: Allow patch and update for events

### DIFF
--- a/pkg/component/autoscaling/vpa/general.go
+++ b/pkg/component/autoscaling/vpa/general.go
@@ -75,9 +75,9 @@ func (v *vpa) reconcileGeneralClusterRoleActor(clusterRole *rbacv1.ClusterRole) 
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
-			APIGroups: []string{""},
+			APIGroups: []string{"", "events.k8s.io"},
 			Resources: []string{"events"},
-			Verbs:     []string{"get", "list", "watch", "create"},
+			Verbs:     []string{"create", "get", "list", "watch", "patch", "update"},
 		},
 		{
 			APIGroups: []string{"autoscaling.k8s.io"},

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1260,9 +1260,9 @@ var _ = Describe("VPA", func() {
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
-					APIGroups: []string{""},
+					APIGroups: []string{"", "events.k8s.io"},
 					Resources: []string{"events"},
-					Verbs:     []string{"get", "list", "watch", "create"},
+					Verbs:     []string{"create", "get", "list", "watch", "patch", "update"},
 				},
 				{
 					APIGroups: []string{"autoscaling.k8s.io"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
See https://github.com/kubernetes/autoscaler/pull/8091

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue preventing vpa-updater to patch events when recording eviction event on VerticalPodAutoscaler resource is now fixed.
```
