### PR TITLE
Enforce "spread across hosts" only for zonal Istio ingress-gateways

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -211,17 +211,3 @@ spec:
           secretName: "istio-ingressgateway-ca-certs"
           optional: true
       priorityClassName: {{ .Values.priorityClassName }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                {{- range $key, $value := .Values.labels }}
-                - key: {{ $key }}
-                  operator: In
-                  values:
-                  - {{ $value }}
-                {{- end }}
-              topologyKey: "kubernetes.io/hostname"

--- a/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
@@ -204,19 +204,3 @@ spec:
           secretName: "istio-ingressgateway-ca-certs"
           optional: true
       priorityClassName: gardener-system-critical
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - istio-ingressgateway
-                - key: foo
-                  operator: In
-                  values:
-                  - bar
-              topologyKey: "kubernetes.io/hostname"

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -291,7 +291,7 @@ var _ = Describe("Istio", func() {
 			Context("with nodes in the zones", func() {
 				JustBeforeEach(func() {
 					testValues.client = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
-					testValues.enforceSpreadAcrossHosts = true
+					testValues.enforceSpreadAcrossHosts = false
 					Expect(testValues.client.Create(context.Background(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "1"}}})).To(Succeed())
 					Expect(testValues.client.Create(context.Background(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "1"}}})).To(Succeed())
 					Expect(testValues.client.Create(context.Background(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2", Labels: map[string]string{"topology.kubernetes.io/zone": "2"}}})).To(Succeed())
@@ -558,7 +558,7 @@ var _ = Describe("Istio", func() {
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-2", Labels: map[string]string{"topology.kubernetes.io/zone": "z2"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-3", Labels: map[string]string{"topology.kubernetes.io/zone": "z2"}}},
-		}, []string{"z1", "z2"}, true),
+		}, []string{"z1", "z2"}, false),
 		Entry("four nodes with different zones targeting different zone", []corev1.Node{
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling cost
/kind enhancement

**What this PR does / why we need it**:
With this PR Gardener enforces spreading Istio ingress-gateway pods across hosts only for zonal deployments.
For zonal Istio ingress-gateway deployments this enforcement is beneficial for the availability of the endpoints served by Istio since the failure of a single node does not lead to unavailable endpoints.
In case of regional Istio ingress-gateway deployments there are at least 4 other pods in the other zones even when the distribution across nodes is only preferred since we enforce a zonal spread in this case anyway. This saves some resources  in the Garden runtime cluster and on small HA Seeds since it reduces the minimum node count from 6 to 3. 

Additionally, this PR removes the pod anti affinity since according to the Gardener component check list it is best practice to add HA relevant settings via GRM HA webhook.

**Which issue(s) this PR fixes**:
Part of #8810

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Spreading Istio ingress-gateway pods across hosts is enforced only for zonal Istio deployments now.
```
