### PR TITLE
Use `/livez` endpoint of `kube-proxy` instead of `/healthz` endpoint for probes.

### DIFF
--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -600,7 +600,7 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 										ReadinessProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{
 												HTTPGet: &corev1.HTTPGetAction{
-													Path:   "/healthz",
+													Path:   "/livez",
 													Port:   intstr.FromInt32(10256),
 													Scheme: corev1.URISchemeHTTP,
 												},

--- a/pkg/component/kubernetes/proxy/resources.go
+++ b/pkg/component/kubernetes/proxy/resources.go
@@ -606,7 +606,7 @@ func (k *kubeProxy) getKubeProxyContainer(k8sGreaterEqual129 bool, image string,
 		container.ReadinessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/healthz",
+					Path:   "/livez",
 					Port:   intstr.FromInt32(portHealthz),
 					Scheme: corev1.URISchemeHTTP,
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area ops-productivity
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Use `/livez` endpoint of `kube-proxy` instead of `/healthz` endpoint for probes.

`kube-proxy` serves two paths on the health endpoint (port 10256) `/livez` and `/healthz`. Both check whether `kube-proxy` is healthy, but the latter also takes the node into account. It reports failure if the node either has a deletion timestamp or a taint by `cluster-autoscaler` indicating that the node is about to be deleted.
Previously, we used the `/healthz` endpoint for the readiness probe, which worked fine for indicating that `kube-proxy` as critical component was ready. However, it could lead to prolonged readiness failures in case a node was about to be deleted by `cluster-autoscaler`, but some `PodDisruptionBudget` or `terminationGracePeriod` delayed the removal. The result was failures in the system components health check. Now, these failures should not be present anymore.

**Which issue(s) this PR fixes**:
Fixes #11858

**Special notes for your reviewer**:

`kube-proxy` health check: https://github.com/kubernetes/kubernetes/blob/288b044e0f3617c7ec3c832edf925bfe7014e392/pkg/proxy/healthcheck/proxy_health.go#L204

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`kube-proxy` no longer fails its readiness probe in case the node is about to be deleted by `cluster-autoscaler`.
```

/cc @rfranzke @dguendisch @kon-angelo @LucaBernstein 