### PR TITLE
gardener-node-agent: support images built by ko

### DIFF
--- a/example/provider-extensions/registry-seed/kyverno-policies/add-registry-to-osc.yaml
+++ b/example/provider-extensions/registry-seed/kyverno-policies/add-registry-to-osc.yaml
@@ -128,21 +128,3 @@ spec:
           - path: "/spec/units/{{elementIndex}}/dropIns"
             op: add
             value: [{"name":"start-seed-registry-cache.conf","content":"{{startDropIn|base64_decode(@)}}"}]
-  - name: modify-gardener-node-agent-path
-    match:
-      all:
-      - resources:
-          kinds:
-          - OperatingSystemConfig
-    mutate:
-      foreach:
-      - list: "request.object.spec.files[]"
-        preconditions:
-          all:
-          - key: "{{ element.path  || '' }}"
-            operator: Equals
-            value: "/opt/bin/gardener-node-agent"
-        patchesJson6902: |-
-          - path: "/spec/files/{{elementIndex}}"
-            op: replace
-            value: {"content":{"imageRef":{"filePathInImage":"/ko-app/gardener-node-agent","image":"{{element.content.imageRef.image}}"}},"path":"/opt/bin/gardener-node-agent","permissions":0755}

--- a/example/provider-extensions/registry-seed/kyverno-policies/add-registry-to-osc.yaml
+++ b/example/provider-extensions/registry-seed/kyverno-policies/add-registry-to-osc.yaml
@@ -128,24 +128,6 @@ spec:
           - path: "/spec/units/{{elementIndex}}/dropIns"
             op: add
             value: [{"name":"start-seed-registry-cache.conf","content":"{{startDropIn|base64_decode(@)}}"}]
-  - name: modify-gardener-node-init-path
-    match:
-      all:
-      - resources:
-          kinds:
-          - OperatingSystemConfig
-    mutate:
-      foreach:
-      - list: "request.object.spec.files[]"
-        preconditions:
-          all:
-          - key: "{{ element.path  || '' }}"
-            operator: Equals
-            value: "/var/lib/gardener-node-agent/init.sh"
-        patchesJson6902: |-
-          - path: "/spec/files/{{elementIndex}}"
-            op: replace
-            value: {"content":{"inline":{"data":"{{base64_encode('{{replace_all('{{base64_decode(element.content.inline.data)}}','$tmp_dir/gardener-node-agent','$tmp_dir/ko-app/gardener-node-agent')}}')}}","encoding":"b64"}},"path":"/var/lib/gardener-node-agent/init.sh","permissions":0755}
   - name: modify-gardener-node-agent-path
     match:
       all:

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -143,10 +143,9 @@ func init() {
 func generateInitScript(nodeAgentImage string) ([]byte, error) {
 	var initScript bytes.Buffer
 	if err := initScriptTpl.Execute(&initScript, map[string]any{
-		"image":                 nodeAgentImage,
-		"binaryDirectory":       nodeagentconfigv1alpha1.BinaryDir,
-		"binaryFilePathInImage": nodeagent.FilePathInImage(nodeAgentImage),
-		"configFile":            nodeagentconfigv1alpha1.ConfigFilePath,
+		"image":           nodeAgentImage,
+		"binaryDirectory": nodeagentconfigv1alpha1.BinaryDir,
+		"configFile":      nodeagentconfigv1alpha1.ConfigFilePath,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -130,7 +130,7 @@ ctr images mount "` + image + `" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"
 mkdir -p "/opt/bin"
-cp -f "$tmp_dir/gardener-node-agent" "/opt/bin/gardener-node-agent"
+cp -f "$tmp_dir/gardener-node-agent" "/opt/bin" || cp -f "$tmp_dir/ko-app/gardener-node-agent" "/opt/bin"
 chmod +x "/opt/bin/gardener-node-agent"
 
 echo "> Bootstrap gardener-node-agent"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -17,7 +17,13 @@ ctr images mount "{{ .image }}" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host ({{ .binaryDirectory }}) and make it executable"
 mkdir -p "{{ .binaryDirectory }}"
-cp -f "$tmp_dir{{ .binaryFilePathInImage }}" "{{ .binaryDirectory }}/gardener-node-agent"
+
+{{- /*
+Fall back to /ko-app/gardener-node-agent if /gardener-node-agent doesn't exist in image to support images built with ko.
+TODO(timebertt): remove this fallback once https://github.com/ko-build/ko/pull/1403 has been released and is used to
+ build images in the skaffold-based setup (add a breaking release note!).
+*/}}
+cp -f "$tmp_dir/gardener-node-agent" "{{ .binaryDirectory }}" || cp -f "$tmp_dir/ko-app/gardener-node-agent" "{{ .binaryDirectory }}"
 chmod +x "{{ .binaryDirectory }}/gardener-node-agent"
 
 echo "> Bootstrap gardener-node-agent"

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -170,6 +170,7 @@ func fileContentImageRef(image string) *extensionsv1alpha1.FileContentImageRef {
 
 // FilePathInImage returns the path of the gardener-node-agent binary file in its container image.
 func FilePathInImage(image string) string {
+	// TODO(timebertt): drop this workaround after https://github.com/gardener/gardener/pull/12021 has been released
 	var prefix string
 	if strings.HasPrefix(image, "garden.local.gardener.cloud:5001") {
 		prefix = "/ko-app"

--- a/pkg/nodeagent/registry/containerd_extractor.go
+++ b/pkg/nodeagent/registry/containerd_extractor.go
@@ -79,12 +79,14 @@ func (e *containerdExtractor) CopyFromImage(ctx context.Context, imageRef string
 		return err
 	}
 
+	defer func() { utilruntime.HandleError(unmountImage(ctx, snapshotter, imageMountDirectory)) }()
+
 	source := path.Join(imageMountDirectory, filePathInImage)
 	if err := files.Copy(fs, source, destination, permissions); err != nil {
 		return fmt.Errorf("error copying file %s to %s: %w", source, destination, err)
 	}
 
-	return unmountImage(ctx, snapshotter, imageMountDirectory)
+	return nil
 }
 
 func mountImage(ctx context.Context, image containerd.Image, snapshotter snapshots.Snapshotter, directory string) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR adds built-in support for gardener-node-agent built by ko, i.e., images where the binary is not in the root directory but in `/ko-app`.
For this, we add a fallback from the original binary path `/gardener-node-agent` to `/ko-app/gardener-node-agent` in both `gardener-node-init` and the `FileContentImageRef` handling.

This allows us to drop the special handling from the provider-local and provider extensions setup. Additionally, this allows Gardener consumers to build custom images (e.g., from a fork) with ko without special handling (e.g., https://github.com/stackitcloud/gardener/pull/146/commits/3ba976e932d9dd57aa73f40d67cd8df5235d7855).

Along the way, this PR fixes a bug that orphans directories in `/var/lib/gardener-node-agent/tmp` if the `filePathInImage` does not exist.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

As discussed with @rfranzke, the better solution would be to make the binary path configurable in ko: https://github.com/ko-build/ko/pull/1403
Until that is merged, released, and used in gardener's development setups and environments with custom images, we use this fallback as a shortcut.
The fallback can be fully dropped once ko supports configurable in-image binary paths.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener supports gardener-node-agent images built by [ko](https://github.com/ko-build/ko).
```
