### PR TITLE
Skip the flaky credentials rotation with in-place update strategy e2e test for ipv6

### DIFF
--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -7,6 +7,7 @@ package shoot
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -360,6 +361,14 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 					s = NewTestContext().ForShoot(shoot)
 				})
+
+				// Skip the test for IPv6 single-stack Shoot as it is extremely flaky (success rate < 30%).
+				//
+				// TODO(shafeeqes, acumino, ary1992): Debug and fix the flaky test for ipv6.
+				if os.Getenv("IPFAMILY") == "ipv6" {
+					s.Log.Info("Skip the flaky credentials rotation with in-place update strategy e2e test for ipv6")
+					return
+				}
 
 				test(s, false, true)
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
The test is introduced with https://github.com/gardener/gardener/pull/11953.

Right now the success rate of `pull-gardener-e2e-kind-ipv6` for the last 12h is 27%:

![Screenshot 2025-05-07 at 17 05 51](https://github.com/user-attachments/assets/220973c0-3ca5-4a70-b144-7681888209b3)

The failures prevent PRs to be merged.

**Which issue(s) this PR fixes**:
Mitigates https://github.com/gardener/gardener/issues/12020

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
