### PR TITLE
Improve utilization of vpn-seed-server, vpn-client-* and vpn-path-controller.

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -2761,11 +2761,8 @@ kind: AuthorizationConfiguration
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("20m"),
-							corev1.ResourceMemory: resource.MustParse("10Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("5M"),
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
@@ -2914,10 +2911,7 @@ kind: AuthorizationConfiguration
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),
-							corev1.ResourceMemory: resource.MustParse("10Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceMemory: resource.MustParse("5M"),
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -839,11 +839,8 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("20m"),
-				corev1.ResourceMemory: resource.MustParse("10Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("100Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("5M"),
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
@@ -950,10 +947,7 @@ func (k *kubeAPIServer) vpnSeedPathControllerContainer() *corev1.Container {
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("10Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceMemory: resource.MustParse("5M"),
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -385,11 +385,8 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("100m"),
-							corev1.ResourceMemory: resource.MustParse("20Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceMemory: resource.MustParse("5M"),
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
@@ -507,11 +504,8 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("20m"),
-					corev1.ResourceMemory: resource.MustParse("100Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("850M"),
+					corev1.ResourceCPU:    resource.MustParse("5m"),
+					corev1.ResourceMemory: resource.MustParse("25M"),
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{
@@ -618,11 +612,7 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("10Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("20Mi"),
+					corev1.ResourceMemory: resource.MustParse("20M"),
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{
@@ -950,18 +940,16 @@ func (v *vpnSeedServer) deployVPA(ctx context.Context) error {
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 				{
-					ContainerName: deploymentName,
-					MinAllowed: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("20Mi"),
-					},
+					ContainerName:    deploymentName,
 					ControlledValues: &controlledValues,
 				},
 				{
-					ContainerName: envoyProxyContainerName,
-					MinAllowed: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("100Mi"),
-					},
+					ContainerName:    envoyProxyContainerName,
 					ControlledValues: &controlledValues,
+				},
+				{
+					ContainerName: "openvpn-exporter",
+					Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 				},
 			},
 		}

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -386,8 +386,8 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("5m"),
-							corev1.ResourceMemory: resource.MustParse("5M"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("7.5M"),
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
@@ -505,7 +505,7 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("5m"),
+					corev1.ResourceCPU:    resource.MustParse("10m"),
 					corev1.ResourceMemory: resource.MustParse("25M"),
 				},
 			},

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -185,11 +185,8 @@ var _ = Describe("VpnSeedServer", func() {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("20Mi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("100Mi"),
+									corev1.ResourceCPU:    resource.MustParse("5m"),
+									corev1.ResourceMemory: resource.MustParse("5M"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
@@ -351,11 +348,7 @@ var _ = Describe("VpnSeedServer", func() {
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("10m"),
-							corev1.ResourceMemory: resource.MustParse("10Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("20Mi"),
+							corev1.ResourceMemory: resource.MustParse("20M"),
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{mount},
@@ -405,11 +398,8 @@ var _ = Describe("VpnSeedServer", func() {
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("20m"),
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("850M"),
+							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceMemory: resource.MustParse("25M"),
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
@@ -783,18 +773,16 @@ var _ = Describe("VpnSeedServer", func() {
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 							{
-								ContainerName: "vpn-seed-server",
-								MinAllowed: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("20Mi"),
-								},
+								ContainerName:    "vpn-seed-server",
 								ControlledValues: &controlledValues,
 							},
 							{
-								ContainerName: "envoy-proxy",
-								MinAllowed: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("100Mi"),
-								},
+								ContainerName:    "envoy-proxy",
 								ControlledValues: &controlledValues,
+							},
+							{
+								ContainerName: "openvpn-exporter",
+								Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 							},
 						},
 					},

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -184,8 +184,8 @@ var _ = Describe("VpnSeedServer", func() {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("5m"),
-									corev1.ResourceMemory: resource.MustParse("5M"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("7.5M"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
@@ -397,7 +397,7 @@ var _ = Describe("VpnSeedServer", func() {
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
 							corev1.ResourceMemory: resource.MustParse("25M"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
* Remove `MinAllowed` from  VPA configuration of `vpn-seed-server`
* Remove limits
* Reduce initial/static requests
* Switch container `openvpn-exporter` to mode `Off`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The utilization of the VPN containers running in the seed is now improved by adapting their initial/static requests and by changing the corresponding VPA configuration:
- autoscaling is disabled for the `vpn-seed-server` and `openvpn-exporter` containers
- initial/static resource requests are reduced
- limits are removed
- `minAllowed` for the `envoy-proxy` container is removed
```
