### PR TITLE
Check if the seed is a shoot via the `kube-system/shoot-info` ConfigMap

### DIFF
--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -217,11 +217,11 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 			}
 		}
 
-		managedSeeds := &seedmanagementv1alpha1.ManagedSeedList{}
-		if err := mgr.GetClient().List(ctx, managedSeeds); err != nil {
+		managedSeedList := &seedmanagementv1alpha1.ManagedSeedList{}
+		if err := mgr.GetClient().List(ctx, managedSeedList); err != nil {
 			return fmt.Errorf("failed listing objects: %w", err)
 		}
-		if err := meta.EachListItem(managedSeeds, func(o runtime.Object) error {
+		if err := meta.EachListItem(managedSeedList, func(o runtime.Object) error {
 			fns = append(fns, func(ctx context.Context) error {
 				obj := o.(client.Object)
 
@@ -250,7 +250,7 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 			})
 			return nil
 		}); err != nil {
-			return fmt.Errorf("failed preparing managed seed mutating tasks for %T: %w", managedSeeds, err)
+			return fmt.Errorf("failed preparing managed seed mutating tasks for %T: %w", managedSeedList, err)
 		}
 		return flow.Parallel(fns...)(ctx)
 	})); err != nil {

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/api/indexer"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
@@ -216,6 +217,41 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 			}
 		}
 
+		managedSeeds := &seedmanagementv1alpha1.ManagedSeedList{}
+		if err := mgr.GetClient().List(ctx, managedSeeds); err != nil {
+			return fmt.Errorf("failed listing objects: %w", err)
+		}
+		if err := meta.EachListItem(managedSeeds, func(o runtime.Object) error {
+			fns = append(fns, func(ctx context.Context) error {
+				obj := o.(client.Object)
+
+				logger := mgr.GetLogger().WithValues("objectKey", client.ObjectKeyFromObject(obj))
+				logger.Info("Check the seed name label for itself")
+				label := v1beta1constants.LabelPrefixSeedName + obj.GetName()
+				logger = logger.WithValues("label", label)
+				if _, ok := obj.GetLabels()[label]; ok {
+					logger.Info("Label exists, send an empty patch to the ManagedSeed so that the mutating webhook can remove the superfluous seed name label")
+					emptyPatch := client.MergeFrom(obj)
+					if err := mgr.GetClient().Patch(ctx, obj, emptyPatch); err != nil {
+						return fmt.Errorf("failed to patch managed seed %s: %w", client.ObjectKeyFromObject(obj), err)
+					}
+
+					// assert the mutating webhook runs on the correct version and removed the label
+					managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
+					if err := mgr.GetClient().Get(ctx, client.ObjectKey{Name: obj.GetName()}, managedSeed); err != nil {
+						return fmt.Errorf("failed to get managed seed %s: %w", client.ObjectKeyFromObject(obj), err)
+					} else if _, ok := managedSeed.GetLabels()[label]; ok {
+						return fmt.Errorf("the label %s on the managed seed %s is still present, the mutating webhook is running in an older version", label, client.ObjectKeyFromObject(obj))
+					}
+				} else {
+					logger.Info("The label on the managed seed is not present, nothing to do")
+				}
+				return nil
+			})
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed preparing managed seed mutating tasks for %T: %w", managedSeeds, err)
+		}
 		return flow.Parallel(fns...)(ctx)
 	})); err != nil {
 		return fmt.Errorf("failed adding seed name label removal runnable to manager: %w", err)

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -219,7 +219,7 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 
 		managedSeedList := &seedmanagementv1alpha1.ManagedSeedList{}
 		if err := mgr.GetClient().List(ctx, managedSeedList); err != nil {
-			return fmt.Errorf("failed listing objects: %w", err)
+			return fmt.Errorf("failed listing managed seeds: %w", err)
 		}
 		if err := meta.EachListItem(managedSeedList, func(o runtime.Object) error {
 			fns = append(fns, func(ctx context.Context) error {

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -237,10 +237,7 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 					}
 
 					// assert the mutating webhook runs on the correct version and removed the label
-					managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-					if err := mgr.GetClient().Get(ctx, client.ObjectKey{Name: obj.GetName()}, managedSeed); err != nil {
-						return fmt.Errorf("failed to get managed seed %s: %w", client.ObjectKeyFromObject(obj), err)
-					} else if _, ok := managedSeed.GetLabels()[label]; ok {
+					if _, ok := obj.GetLabels()[label]; ok {
 						return fmt.Errorf("the label %s on the managed seed %s is still present, the mutating webhook is running in an older version", label, client.ObjectKeyFromObject(obj))
 					}
 				} else {

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -221,9 +221,9 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 		if err := mgr.GetClient().List(ctx, managedSeedList); err != nil {
 			return fmt.Errorf("failed listing managed seeds: %w", err)
 		}
-		if err := meta.EachListItem(managedSeedList, func(o runtime.Object) error {
+		for _, managedSeed := range managedSeedList.Items {
 			fns = append(fns, func(ctx context.Context) error {
-				obj := o.(client.Object)
+				obj := &managedSeed
 
 				logger := mgr.GetLogger().WithValues("objectKey", client.ObjectKeyFromObject(obj))
 				logger.Info("Check the seed name label for itself")
@@ -245,9 +245,6 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 				}
 				return nil
 			})
-			return nil
-		}); err != nil {
-			return fmt.Errorf("failed preparing managed seed mutating tasks for %T: %w", managedSeedList, err)
 		}
 		return flow.Parallel(fns...)(ctx)
 	})); err != nil {

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -224,13 +224,8 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 		for _, managedSeed := range managedSeedList.Items {
 			fns = append(fns, func(ctx context.Context) error {
 				obj := &managedSeed
-
-				logger := mgr.GetLogger().WithValues("objectKey", client.ObjectKeyFromObject(obj))
-				logger.Info("Check the seed name label for itself")
 				label := v1beta1constants.LabelPrefixSeedName + obj.GetName()
-				logger = logger.WithValues("label", label)
 				if _, ok := obj.GetLabels()[label]; ok {
-					logger.Info("Label exists, send an empty patch to the ManagedSeed so that the mutating webhook can remove the superfluous seed name label")
 					emptyPatch := client.MergeFrom(obj)
 					if err := mgr.GetClient().Patch(ctx, obj, emptyPatch); err != nil {
 						return fmt.Errorf("failed to patch managed seed %s: %w", client.ObjectKeyFromObject(obj), err)
@@ -238,8 +233,6 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 					if _, ok := obj.GetLabels()[label]; ok {
 						return fmt.Errorf("the label %s on the managed seed %s is still present, the mutating webhook is running in an older version", label, client.ObjectKeyFromObject(obj))
 					}
-				} else {
-					logger.Info("The label on the managed seed is not present, nothing to do")
 				}
 				return nil
 			})

--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -235,8 +235,6 @@ func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alp
 					if err := mgr.GetClient().Patch(ctx, obj, emptyPatch); err != nil {
 						return fmt.Errorf("failed to patch managed seed %s: %w", client.ObjectKeyFromObject(obj), err)
 					}
-
-					// assert the mutating webhook runs on the correct version and removed the label
 					if _, ok := obj.GetLabels()[label]; ok {
 						return fmt.Errorf("the label %s on the managed seed %s is still present, the mutating webhook is running in an older version", label, client.ObjectKeyFromObject(obj))
 					}

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
@@ -6,7 +6,7 @@ metrics_path: /metrics/cadvisor
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: {{.IsManagedSeed}}
+  insecure_skip_verify: {{.SeedIsShoot}}
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/kubelet.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/kubelet.yaml
@@ -4,7 +4,7 @@ scheme: https
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: {{.IsManagedSeed}}
+  insecure_skip_verify: {{.SeedIsShoot}}
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs.go
@@ -20,20 +20,20 @@ var (
 
 // Data represents the data for the template.
 type Data struct {
-	IsManagedSeed bool
+	SeedIsShoot bool
 }
 
 // AdditionalScrapeConfigs returns the additional scrape configs for the cache prometheus.
-func AdditionalScrapeConfigs(isManagedSeed bool) ([]string, error) {
+func AdditionalScrapeConfigs(seedIsShoot bool) ([]string, error) {
 	var out []string
 
-	if result, err := process(cAdvisor, isManagedSeed); err != nil {
+	if result, err := process(cAdvisor, seedIsShoot); err != nil {
 		return nil, fmt.Errorf("failed processing cadvisor scrape config template: %w", err)
 	} else {
 		out = append(out, result)
 	}
 
-	if result, err := process(kubelet, isManagedSeed); err != nil {
+	if result, err := process(kubelet, seedIsShoot); err != nil {
 		return nil, fmt.Errorf("failed processing kubelet scrape config template: %w", err)
 	} else {
 		out = append(out, result)
@@ -42,9 +42,9 @@ func AdditionalScrapeConfigs(isManagedSeed bool) ([]string, error) {
 	return out, nil
 }
 
-func process(text string, isManagedSeed bool) (string, error) {
+func process(text string, seedIsShoot bool) (string, error) {
 	data := Data{
-		IsManagedSeed: isManagedSeed,
+		SeedIsShoot: seedIsShoot,
 	}
 
 	tmpl, err := template.New("Template").Parse(text)

--- a/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("PrometheusRules", func() {
 	Describe("#AdditionalScrapeConfigs", func() {
-		When("isManagedSeed", func() {
+		When("seedIsShoot", func() {
 			It("should return the expected objects  (with TLS verification skipped)", func() {
 				result, err := cache.AdditionalScrapeConfigs(true)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -124,7 +124,7 @@ func (r *Reconciler) instantiateComponents(
 	globalMonitoringSecretSeed *corev1.Secret,
 	alertingSMTPSecret *corev1.Secret,
 	wildCardCertSecret *corev1.Secret,
-	isManagedSeed bool,
+	seedIsShoot bool,
 ) (
 	c components,
 	err error,
@@ -232,7 +232,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.cachePrometheus, err = r.newCachePrometheus(log, seed, isManagedSeed)
+	c.cachePrometheus, err = r.newCachePrometheus(log, seed, seedIsShoot)
 	if err != nil {
 		return
 	}
@@ -536,8 +536,8 @@ func (r *Reconciler) newPlutono(seed *seedpkg.Seed, secretsManager secretsmanage
 	)
 }
 
-func (r *Reconciler) newCachePrometheus(log logr.Logger, seed *seedpkg.Seed, isManagedSeed bool) (component.DeployWaiter, error) {
-	additionalScrapeConfigs, err := cacheprometheus.AdditionalScrapeConfigs(isManagedSeed)
+func (r *Reconciler) newCachePrometheus(log logr.Logger, seed *seedpkg.Seed, seedIsShoot bool) (component.DeployWaiter, error) {
+	additionalScrapeConfigs, err := cacheprometheus.AdditionalScrapeConfigs(seedIsShoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed getting additional scrape configs: %w", err)
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -59,7 +59,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	var isManagedSeed bool
+	var seedIsShoot bool
 	if err := r.SeedClientSet.Client().Get(ctx, client.ObjectKey{
 		Namespace: metav1.NamespaceSystem,
 		Name:      v1beta1constants.ConfigMapNameShootInfo,
@@ -67,9 +67,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, fmt.Errorf("failed to check if this seed is a shoot: %w", err)
 		}
-		isManagedSeed = false
+		seedIsShoot = false
 	} else {
-		isManagedSeed = true
+		seedIsShoot = true
 	}
 
 	operationType := gardencorev1beta1.LastOperationTypeReconcile
@@ -110,14 +110,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if seed.DeletionTimestamp != nil {
-		result, err := r.delete(ctx, log, seedObj, seedIsGarden, isManagedSeed)
+		result, err := r.delete(ctx, log, seedObj, seedIsGarden, seedIsShoot)
 		if err != nil {
 			return result, r.updateStatusOperationError(ctx, seed, err, operationType)
 		}
 		return result, nil
 	}
 
-	if err := r.reconcile(ctx, log, seedObj, seedIsGarden, isManagedSeed); err != nil {
+	if err := r.reconcile(ctx, log, seedObj, seedIsGarden, seedIsShoot); err != nil {
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
 	}
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -34,7 +34,7 @@ func (r *Reconciler) delete(
 	log logr.Logger,
 	seedObj *seedpkg.Seed,
 	seedIsGarden bool,
-	isManagedSeed bool,
+	seedIsShoot bool,
 ) (
 	reconcile.Result,
 	error,
@@ -80,7 +80,7 @@ func (r *Reconciler) delete(
 	}
 
 	log.Info("No Shoots or BackupBuckets are referencing the Seed, deletion accepted")
-	if err := r.runDeleteSeedFlow(ctx, log, seedObj, seedIsGarden, isManagedSeed); err != nil {
+	if err := r.runDeleteSeedFlow(ctx, log, seedObj, seedIsGarden, seedIsShoot); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -100,10 +100,10 @@ func (r *Reconciler) runDeleteSeedFlow(
 	log logr.Logger,
 	seed *seedpkg.Seed,
 	seedIsGarden bool,
-	isManagedSeed bool,
+	seedIsShoot bool,
 ) error {
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, isManagedSeed)
+	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -52,7 +52,7 @@ func (r *Reconciler) reconcile(
 	log logr.Logger,
 	seedObj *seedpkg.Seed,
 	seedIsGarden bool,
-	isManagedSeed bool,
+	seedIsShoot bool,
 ) error {
 	seed := seedObj.GetInfo()
 
@@ -68,7 +68,7 @@ func (r *Reconciler) reconcile(
 		return err
 	}
 
-	if err := r.runReconcileSeedFlow(ctx, log, seedObj, seedIsGarden, isManagedSeed); err != nil {
+	if err := r.runReconcileSeedFlow(ctx, log, seedObj, seedIsGarden, seedIsShoot); err != nil {
 		return err
 	}
 
@@ -102,7 +102,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	log logr.Logger,
 	seed *seedpkg.Seed,
 	seedIsGarden bool,
-	isManagedSeed bool,
+	seedIsShoot bool,
 ) error {
 	// VPA is a prerequisite. If it's enabled then we deploy the CRD (and later also the related components) as part of
 	// the flow. However, when it's disabled then we check whether it is indeed available (and fail, otherwise).
@@ -191,7 +191,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	}
 
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, isManagedSeed)
+	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot)
 	if err != nil {
 		return err
 	}

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -238,7 +238,7 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, _ admis
 	}
 	allErrs = append(allErrs, errs...)
 
-	gardenerutils.MaintainSeedNameLabels(managedSeed, shoot.Spec.SeedName, &managedSeed.Name)
+	gardenerutils.MaintainSeedNameLabels(managedSeed, shoot.Spec.SeedName)
 
 	switch a.GetOperation() {
 	case admission.Create:

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -374,24 +374,22 @@ var _ = Describe("ManagedSeed", func() {
 					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).To(Succeed())
 				})
 
-				It("should add the label for the parent and the current seed name", func() {
+				It("should add the label for the parent seed name", func() {
 					Expect(admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)).To(Succeed())
 
 					Expect(managedSeed.Labels).To(And(
 						HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
-						HaveKeyWithValue("name.seed.gardener.cloud/foo", "true"),
 					))
 				})
 
 				It("should remove unneeded labels", func() {
-					metav1.SetMetaDataLabel(&seed.ObjectMeta, "name.seed.gardener.cloud/bar", "true")
+					metav1.SetMetaDataLabel(&seed.ObjectMeta, "name.seed.gardener.cloud/foo", "true")
 
 					Expect(admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)).To(Succeed())
 
 					Expect(managedSeed.Labels).To(And(
 						HaveKeyWithValue("name.seed.gardener.cloud/parent-seed", "true"),
-						HaveKeyWithValue("name.seed.gardener.cloud/foo", "true"),
-						Not(HaveKey("name.seed.gardener.cloud/bar")),
+						Not(HaveKey("name.seed.gardener.cloud/foo")),
 					))
 				})
 			})


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind regression

**What this PR does / why we need it**:

With #11965 we attempted to fix a regression in the monitoring stack. Unfortunately that fix was incomplete (needed a manual reconciliation of the `ManagedSeed` and `Seed` resources) and "incorrect": it introduced a minor regression, new error logs are written by the `gardenlet`.

This PR reverts #11965 and uses a different approach to fix the original issue. It checks if the seed is a shoot via the `kube-system/shoot-info` ConfigMap. Hence the gardenlet no longer needs to check its own `ManagedSeed` resource to decide if the kubelet and cadvisor Prometheus scrape configuration should skip the TLS verification.

**Which issue(s) this PR fixes**:

The cache Prometheus in a Gardener managed seed can not scrape the cadvisor and kubelet metrics of the seed nodes, and hence the shoot control plane Plutono dashboards can not show e.g. the CPU usage of the control plane components.

**Special notes for your reviewer**:

cc @vicwicker @rfranzke

The regression was initially introduced with v1.117.0, so this PR should be cherry-picked to the release branch of v1.117.x and v1.118.x.

<details>
<summary>Verification steps in the local setup</summary>

# Verify the second fix for the regression

## 1. Reproduce the regression

Checkout the broken state with the regression:

    git checkout v1.117.1

Create a local setup

    nice make kind-operator-down kind-operator-up && kubectl wait --for=condition=ready pod -A --all --timeout=-1s
    nice make operator-up
    nice make operator-seed-up

Create 2 managed seeds:

    k apply -f example/provider-local/managedseeds/shoot-managedseed.yaml
    k apply -f example/provider-local/managedseeds/managedseed.yaml

    k apply -f <(yq '.metadata.name="managedseed2"' example/provider-local/managedseeds/shoot-managedseed.yaml)
    k apply -f <(yq '.metadata.name="managedseed2" | .spec.shoot.name="managedseed2"' example/provider-local/managedseeds/managedseed.yaml)

Make sure to add `/etc/hosts` entries for
`api.managedseed{2}.garden.external.local.gardener.cloud` for
`172.18.255.1{0,1,2}` depending on in which zone the non-HA shoot was created.

Verify that the setup is broken:

    eval $(gardenctl kubectl-env bash)
    g target --garden local --shoot managedseed

    eval $(gardenctl kubectl-env bash)
    g target --garden local --shoot managedseed2

    k port-forward -n garden prometheus-cache-0 9090 &>/dev/null & while ! curl -s localhost:9090 >/dev/null; do sleep 1; done &&
    curl -Ss "http://localhost:9090/api/v1/targets?scrapePool=cadvisor" | jq -r '.data[]' | grep health && kill %1
      "health": "down"

Note that the top level seed, the soil, which is the runtime cluster in the local setup, should be OK:

    k port-forward -n garden prometheus-cache-0 9092:9090 &
    curl -Ss -g "http://localhost:9092/api/v1/targets?scrapePool=cadvisor" | jq -r '.data[]' | grep health
      "health": "up"
      "health": "up"
      "health": "up"

Verify that there are no error logs in the 3 gardenlets (soil + 2 managed seeds):

    stern -n garden deployment/gardenlet | grep "failed to get Shoot object"

## 2. Show that the first fix is incomplete (needs a manual step) and incorrect

Deploy the first attempt to fix the regression, that was incomplete and incorrect:

    git checkout v1.117.2
    nice make operator-up

Verify that the monitoring stack is still broken:

    eval $(gardenctl kubectl-env bash)
    g target --garden local --shoot managedseed

    eval $(gardenctl kubectl-env bash)
    g target --garden local --shoot managedseed2

    k port-forward -n garden prometheus-cache-0 9090 &>/dev/null & while ! curl -s localhost:9090 >/dev/null; do sleep 1; done &&
    curl -Ss "http://localhost:9090/api/v1/targets?scrapePool=cadvisor" | jq -r '.data[]' | grep health && kill %1
      "health": "down"

### 2.a. Apply the manual step

Apply the manual mutation (e.g. via a reconciliation) to one of the 2 managed seeds: (the fix was incomplete)

    k -n garden get managedseed managedseed -o yaml | yq .metadata.labels | grep name
      name.seed.gardener.cloud/local: "true"

    k annotate managedseed managedseed gardener.cloud/operation=reconcile

As a side effect, a new label is added:

    k -n garden get managedseed managedseed -o yaml | yq .metadata.labels | grep name
      name.seed.gardener.cloud/local: "true"
      name.seed.gardener.cloud/managedseed: "true"

Trigger the reconciliation of the seed resource:

    k annotate seed managedseed gardener.cloud/operation=reconcile

### Show that the initial fix is incomplete and incorrect

The monitoring stack is fixed in that seed, but that gardenlet in that seed starts logging errors:

    k port-forward -n garden prometheus-cache-0 9090 &>/dev/null & while ! curl -s localhost:9090 >/dev/null; do sleep 1; done &&
    curl -Ss "http://localhost:9090/api/v1/targets?scrapePool=cadvisor" | jq -r '.data[]' | grep health && kill %1
      "health": "up"

    stern --no-follow -n garden deployment/gardenlet | grep --line-buffered "failed to get Shoot object" | tail -n 1

    tmux show-buffer | jq .error -r | sed 's/: /:\n/g'
      could not reconcile ManagedSeed garden/managedseed creation or update:
      could not get target client:
      error creating new ClientSet for key "garden/managedseed":
      failed to get Shoot object "garden/managedseed":
      Shoot.core.gardener.cloud "managedseed" not found

So now the initial fix was deployed, and in `managedseed` the manual step was
carried out, hence the monitoring stack is fixed, but the gardenlet logs errors.
In `managedseed2`, without the manual steps, the monitoring stack is still
broken and the gardenlet logs no errors.

## 3. Deploy this PR

Deploying this PR fixes both the managed seeds without any manual steps.

    git fetch origin pull/12029/head
    git rebase --onto HEAD origin/master FETCH_HEAD

    nice make operator-up
    nice make operator-seed-up # to redeploy the top level seed

Verify that the superfluous label is removed:

    k -n garden get managedseed managedseed -o yaml | yq .metadata.labels | grep name
      name.seed.gardener.cloud/local: "true"

The monitoring stack is fixed in both the managed seeds:

    eval $(gardenctl kubectl-env bash)
    g target --garden local --shoot managedseed

    eval $(gardenctl kubectl-env bash)
    g target --garden local --shoot managedseed2

    k port-forward -n garden prometheus-cache-0 9090 &>/dev/null & while ! curl -s localhost:9090 >/dev/null; do sleep 1; done &&
    curl -Ss "http://localhost:9090/api/v1/targets?scrapePool=cadvisor" | jq -r '.data[]' | grep health && kill %1
      "health": "up"

The gardenlet is not logging any errors any more:

    stern --no-follow -n garden deployment/gardenlet | grep --line-buffered "failed to get Shoot object" | tail -n 1

</details>

**Release note**:

```bugfix operator
Fix a regression that prevented the cache Prometheus in a Gardener managed seed from scraping the cadvisor and kubelet metrics of the seed nodes, and hence the shoot control plane Plutono dashboards could not show e.g. the CPU usage of the control plane components. (part 2)
```