### PR TITLE
[GEP-28] `gardenadm bootstrap`: Initialize client and perform safety check

### DIFF
--- a/pkg/gardenadm/botanist/controlplane.go
+++ b/pkg/gardenadm/botanist/controlplane.go
@@ -154,13 +154,18 @@ func (b *AutonomousBotanist) filesForStaticControlPlanePods(ctx context.Context)
 	return files, nil
 }
 
-// CreateClientSet creates a client set for the control plane.
-func (b *AutonomousBotanist) CreateClientSet(ctx context.Context) (kubernetes.Interface, error) {
-	clientSet, err := kubernetes.NewClientFromFile("", PathKubeconfig,
+// NewClientSetFromFile creates a client set from the specified kubeconfig file.
+func NewClientSetFromFile(kubeconfigPath string) (kubernetes.Interface, error) {
+	return kubernetes.NewClientFromFile("", kubeconfigPath,
 		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
 		kubernetes.WithClientConnectionOptions(componentbaseconfigv1alpha1.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
 		kubernetes.WithDisabledCachedClient(),
 	)
+}
+
+// CreateClientSet creates a client set for the control plane.
+func (b *AutonomousBotanist) CreateClientSet(ctx context.Context) (kubernetes.Interface, error) {
+	clientSet, err := NewClientSetFromFile(PathKubeconfig)
 	if err != nil {
 		b.Logger.Info("Waiting for kube-apiserver to start", "error", err.Error())
 		return nil, fmt.Errorf("failed creating client set: %w", err)

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -6,9 +6,15 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 )
 
@@ -46,7 +52,44 @@ gardenadm bootstrap --kubeconfig ~/.kube/config`,
 	return cmd
 }
 
-func run(_ context.Context, opts *Options) error {
-	opts.Log.Info("Not implemented as well")
+// NewClientSetFromFile in alias for botanist.NewClientSetFromFile.
+// Exposed for unit testing.
+var NewClientSetFromFile = botanist.NewClientSetFromFile
+
+func run(ctx context.Context, opts *Options) error {
+	clientSet, err := NewClientSetFromFile(opts.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed creating client: %w", err)
+	}
+
+	if err := ensureNoGardenletOrOperator(ctx, clientSet.Client()); err != nil {
+		return err
+	}
+
+	opts.Log.Info("Command is work in progress")
+	return nil
+}
+
+// ensureNoGardenletOrOperator is a safety check that prevents operators from accidentally executing
+// `gardenadm bootstrap` on a cluster that is already used as a runtime cluster with gardener-operator or as a seed
+// cluster. Doing so would lead to conflicts when `gardenadm bootstrap` starts deploying components like provider
+// extensions.
+func ensureNoGardenletOrOperator(ctx context.Context, c client.Reader) error {
+	for _, key := range []client.ObjectKey{
+		{Namespace: v1beta1constants.GardenNamespace, Name: "gardener-operator"},
+		{Namespace: v1beta1constants.GardenNamespace, Name: "gardenlet"},
+	} {
+		if err := c.Get(ctx, key, &appsv1.Deployment{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed checking if %q deployment exists: %w", key, err)
+		}
+
+		return fmt.Errorf("deployment %q exists on the targeted cluster. "+
+			"`gardenadm bootstrap` does not support targeting a cluster that is already used as a runtime cluster with gardener-operator or as a seed cluster. "+
+			"Please consult the gardenadm documentation", key)
+	}
+
 	return nil
 }

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap_test.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap_test.go
@@ -5,23 +5,37 @@
 package bootstrap_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/bootstrap"
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils/test"
 	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
 var _ = Describe("Bootstrap", func() {
 	var (
+		ctx = context.Background()
+
 		globalOpts *cmd.Options
 		stdErr     *Buffer
 		command    *cobra.Command
+
+		fakeClient client.Client
+		clientSet  kubernetes.Interface
 	)
 
 	BeforeEach(func() {
@@ -29,15 +43,38 @@ var _ = Describe("Bootstrap", func() {
 		globalOpts.IOStreams, _, _, stdErr = clitest.NewTestIOStreams()
 		globalOpts.Log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(stdErr))
 		command = NewCommand(globalOpts)
+
+		fakeClient = fakeclient.NewClientBuilder().Build()
+		clientSet = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
+
+		DeferCleanup(test.WithVar(&NewClientSetFromFile, func(string) (kubernetes.Interface, error) { return clientSet, nil }))
 	})
 
 	Describe("#RunE", func() {
-		It("should return the expected output", func() {
+		BeforeEach(func() {
 			Expect(command.Flags().Set("kubeconfig", "some-path-to-kubeconfig")).To(Succeed())
+		})
 
+		It("should return the expected output", func() {
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			Eventually(stdErr).Should(Say("Not implemented as well"))
+			Eventually(stdErr).Should(Say("work in progress"))
+		})
+
+		Describe("safety check", func() {
+			It("should abort the execution if gardener-operator is deployed on the targeted cluster", func() {
+				Expect(fakeClient.Create(ctx, &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "garden", Name: "gardener-operator"},
+				})).To(Succeed())
+				Expect(command.RunE(command, nil)).To(MatchError(ContainSubstring(`deployment "garden/gardener-operator" exists on the targeted cluster`)))
+			})
+
+			It("should abort the execution if gardenlet is deployed on the targeted cluster", func() {
+				Expect(fakeClient.Create(ctx, &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "garden", Name: "gardenlet"},
+				})).To(Succeed())
+				Expect(command.RunE(command, nil)).To(MatchError(ContainSubstring(`deployment "garden/gardenlet" exists on the targeted cluster`)))
+			})
 		})
 	})
 })

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -19,7 +19,7 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 
 	Describe("Prepare infrastructure and machines", Ordered, func() {
 		It("should bootstrap the machine pods", func(SpecContext) {
-			Eventually(RunAndWait("bootstrap").Err).Should(gbytes.Say("Not implemented as well"))
+			Eventually(RunAndWait("bootstrap").Err).Should(gbytes.Say("work in progress"))
 		}, SpecTimeout(time.Minute))
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR starts implementing the `gardenadm bootstrap` command.
The first step is to initialize a client and perform a safety check that the user is not targeting an existing runtime/seed cluster with gardener-operator/gardenlet.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ @maboehm 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
