### PR TITLE
[GEP-28] Preparations for `etcd-druid` taking over management of `etcd`

### DIFF
--- a/hack/resolve-etcd-version-from-etcd-druid.sh
+++ b/hack/resolve-etcd-version-from-etcd-druid.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+# Temp dirs
+WORKDIR=$(mktemp -d)
+ETCD_DRUID_REPO="https://github.com/gardener/etcd-druid"
+ETCD_WRAPPER_REPO="https://github.com/gardener/etcd-wrapper"
+ETCD_REPO="https://github.com/etcd-io/etcd.git"
+
+echo "Cloning etcd-druid..."
+git clone -q --depth 1 "$ETCD_DRUID_REPO" "$WORKDIR/etcd-druid"
+
+# Extract etcd-wrapper tag from images.yaml
+WRAPPER_TAG=$(yq '.images[] | select(.name == "etcd-wrapper") | .tag' "$WORKDIR/etcd-druid/internal/images/images.yaml")
+echo "Found etcd-wrapper tag: $WRAPPER_TAG"
+
+echo "Cloning etcd-wrapper at tag $WRAPPER_TAG..."
+git clone -q --depth 1 --branch "$WRAPPER_TAG" "$ETCD_WRAPPER_REPO" "$WORKDIR/etcd-wrapper" 2>/dev/null
+
+# Extract etcd version from go.mod
+ETCD_LINE=$(grep 'go.etcd.io/etcd' "$WORKDIR/etcd-wrapper/go.mod" | head -n1)
+ETCD_VERSION=$(echo "$ETCD_LINE" | awk '{print $2}')
+echo "Found etcd version string: $ETCD_VERSION"
+
+# Check if it's a real tag (vX.Y.Z) or a pseudo-version
+# TODO: This if-else handling can be removed after https://github.com/gardener/etcd-druid/issues/445 is resolved (with
+#  v3.5, the etcd-io/etcd repo supports proper usage of the direct tag, i.e., no commit hash is needed anymore).
+if [[ "$ETCD_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Resolved etcd tag directly: $ETCD_VERSION"
+else
+  # Extract commit hash from pseudo-version
+  COMMIT_HASH=$(echo "$ETCD_VERSION" | sed -E 's/.*-([a-f0-9]{12})$/\1/')
+
+  if [ -z "$COMMIT_HASH" ]; then
+    echo "Could not parse commit hash from version string: $ETCD_VERSION"
+    exit 1
+  fi
+
+  echo "Extracted commit hash: $COMMIT_HASH"
+
+  echo "Cloning etcd repo to resolve tag..."
+  git clone -q "$ETCD_REPO" "$WORKDIR/etcd"
+  pushd "$WORKDIR/etcd" > /dev/null
+
+  # Find tag that contains the commit
+  FULL_COMMIT=$(git rev-parse "$COMMIT_HASH") || {
+    echo "Commit $COMMIT_HASH not found in etcd repo"
+    exit 1
+  }
+
+  ETCD_TAG=$(git tag --contains "$FULL_COMMIT" | grep '^v' | sort -V | head -n 1)
+  popd > /dev/null
+fi
+
+if [ -n "$ETCD_TAG" ]; then
+  echo "Resolved etcd tag: $ETCD_TAG"
+else
+  echo "No tag found containing commit $FULL_COMMIT"
+  exit 1
+fi
+
+# Update images.yaml with the resolved etcd tag
+echo "Updating $1 with etcd $ETCD_TAG tag"
+yq -i "(.images[] | select(.name == \"etcd\") ).tag = \"$ETCD_TAG\"" "$1"

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -4,780 +4,768 @@
 # the respective tag can be used. The syntax must be as described in the
 # Masterminds/semver package: https://github.com/Masterminds/semver#hyphen-range-comparisons.
 images:
-# Gardener components
-- name: gardener-apiserver
-  sourceRepository: github.com/gardener/gardener
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/apiserver
-  resourceId:
-    name: apiserver
-- name: gardener-admission-controller
-  sourceRepository: github.com/gardener/gardener
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/admission-controller
-  resourceId:
-    name: admission-controller
-- name: gardener-controller-manager
-  sourceRepository: github.com/gardener/gardener
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/controller-manager
-  resourceId:
-    name: controller-manager
-- name: gardener-scheduler
-  sourceRepository: github.com/gardener/gardener
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/scheduler
-  resourceId:
-    name: scheduler
-- name: gardenlet
-  sourceRepository: github.com/gardener/gardener
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/gardenlet
-- name: gardener-resource-manager
-  sourceRepository: github.com/gardener/gardener
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager
-  resourceId:
-    name: resource-manager
-- name: gardener-node-agent
-  sourceRepository: github.com/gardener/gardener
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/node-agent
-  resourceId:
-    name: node-agent
-- name: gardener-discovery-server
-  sourceRepository: github.com/gardener/gardener-discovery-server
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/gardener-discovery-server
-  tag: "v0.6.0"
+  # Gardener components
+  - name: gardener-apiserver
+    sourceRepository: github.com/gardener/gardener
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/apiserver
+    resourceId:
+      name: apiserver
+  - name: gardener-admission-controller
+    sourceRepository: github.com/gardener/gardener
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/admission-controller
+    resourceId:
+      name: admission-controller
+  - name: gardener-controller-manager
+    sourceRepository: github.com/gardener/gardener
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/controller-manager
+    resourceId:
+      name: controller-manager
+  - name: gardener-scheduler
+    sourceRepository: github.com/gardener/gardener
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/scheduler
+    resourceId:
+      name: scheduler
+  - name: gardenlet
+    sourceRepository: github.com/gardener/gardener
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/gardenlet
+  - name: gardener-resource-manager
+    sourceRepository: github.com/gardener/gardener
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager
+    resourceId:
+      name: resource-manager
+  - name: gardener-node-agent
+    sourceRepository: github.com/gardener/gardener
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/node-agent
+    resourceId:
+      name: node-agent
+  - name: gardener-discovery-server
+    sourceRepository: github.com/gardener/gardener-discovery-server
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/gardener-discovery-server
+    tag: "v0.6.0"
+  # Gardener Dashboard components
+  - name: gardener-dashboard
+    sourceRepository: github.com/gardener/dashboard
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
+    tag: "1.80.1"
+  - name: terminal-controller-manager
+    sourceRepository: github.com/gardener/terminal-controller-manager
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager
+    tag: "v0.34.0"
+  # Seed bootstrap
+  - name: pause-container
+    sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
+    repository: registry.k8s.io/pause
+    tag: "3.10"
+    labels:
+      - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
+        value:
+          policy: skip
+          comment: >
+            pause-container is not accessible from outside k8s clusters and not interacted with from other containers or other systems
 
-# Gardener Dashboard components
-- name: gardener-dashboard
-  sourceRepository: github.com/gardener/dashboard
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
-  tag: "1.80.1"
-- name: terminal-controller-manager
-  sourceRepository: github.com/gardener/terminal-controller-manager
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager
-  tag: "v0.34.0"
+  - name: etcd-druid
+    sourceRepository: github.com/gardener/etcd-druid
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
+    tag: "v0.29.1"
+  - name: etcd
+    sourceRepository: github.com/etcd-io/etcd
+    repository: quay.io/coreos/etcd
+    tag: "v3.4.34"
+  - name: dependency-watchdog
+    sourceRepository: github.com/gardener/dependency-watchdog
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog
+    tag: "v1.4.0"
+  - name: nginx-ingress-controller
+    sourceRepository: github.com/kubernetes/ingress-nginx
+    repository: registry.k8s.io/ingress-nginx/controller-chroot
+    tag: "v1.12.2"
+    targetVersion: ">= 1.28"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'public'
+          authentication_enforced: true
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'high'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+  - name: nginx-ingress-controller
+    sourceRepository: github.com/kubernetes/ingress-nginx
+    repository: registry.k8s.io/ingress-nginx/controller-chroot
+    tag: "v1.11.6"
+    targetVersion: "1.27.x"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'public'
+          authentication_enforced: true
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'high'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+  - name: ingress-default-backend
+    sourceRepository: github.com/gardener/ingress-default-backend
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/ingress-default-backend
+    tag: "0.23.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'none'
+          integrity_requirement: 'none'
+          availability_requirement: 'none'
+          comment: Show static page when no path is found
+  # Seed controlplane
+  #   hyperkube is used for kubectl + kubelet binaries on the worker nodes
+  - name: hyperkube
+    sourceRepository: github.com/gardener/hyperkube
+    repository: europe-docker.pkg.dev/gardener-project/releases/hyperkube
+  - name: kube-apiserver
+    sourceRepository: github.com/kubernetes/kubernetes
+    repository: registry.k8s.io/kube-apiserver
+  - name: kube-controller-manager
+    sourceRepository: github.com/kubernetes/kubernetes
+    repository: registry.k8s.io/kube-controller-manager
+  - name: kube-scheduler
+    sourceRepository: github.com/kubernetes/kubernetes
+    repository: registry.k8s.io/kube-scheduler
+  - name: kube-proxy
+    sourceRepository: github.com/kubernetes/kubernetes
+    repository: registry.k8s.io/kube-proxy
+  - name: machine-controller-manager
+    sourceRepository: github.com/gardener/machine-controller-manager
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager
+    tag: "v0.58.0"
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: protected
+          authentication_enforced: false
+          user_interaction: gardener-operator
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+  - name: cluster-autoscaler
+    sourceRepository: github.com/gardener/autoscaler
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+    tag: "v1.32.0"
+    targetVersion: ">= 1.32"
+  - name: cluster-autoscaler
+    sourceRepository: github.com/gardener/autoscaler
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+    tag: "v1.31.0"
+    targetVersion: "1.31.x"
+  - name: cluster-autoscaler
+    sourceRepository: github.com/gardener/autoscaler
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+    tag: "v1.30.2"
+    targetVersion: "1.30.x"
+  - name: cluster-autoscaler
+    sourceRepository: github.com/gardener/autoscaler
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+    tag: "v1.29.2"
+    targetVersion: "1.29.x"
+  - name: cluster-autoscaler
+    sourceRepository: github.com/gardener/autoscaler
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+    tag: "v1.28.3"
+    targetVersion: "1.28.x"
+  - name: cluster-autoscaler
+    sourceRepository: github.com/gardener/autoscaler
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+    tag: "v1.27.3"
+    targetVersion: "1.27.x"
+  - name: vpn-server
+    sourceRepository: github.com/gardener/vpn2
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-server
+    tag: "0.37.3"
+  # Monitoring
+  - name: prometheus-operator
+    sourceRepository: github.com/prometheus-operator/prometheus-operator
+    repository: quay.io/prometheus-operator/prometheus-operator
+    tag: v0.82.2
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'low'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: alertmanager
+    sourceRepository: github.com/prometheus/alertmanager
+    repository: quay.io/prometheus/alertmanager
+    tag: v0.28.1
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: public
+          authentication_enforced: true
+          user_interaction: end-user
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: prometheus
+    sourceRepository: github.com/prometheus/prometheus
+    repository: quay.io/prometheus/prometheus
+    tag: v3.3.1
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: public
+          authentication_enforced: true
+          user_interaction: end-user
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: configmap-reloader
+    sourceRepository: github.com/prometheus-operator/prometheus-operator
+    repository: quay.io/prometheus-operator/prometheus-config-reloader
+    tag: v0.82.2
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: private
+          authentication_enforced: false
+          user_interaction: gardener-operator
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: cortex
+    repository: quay.io/cortexproject/cortex
+    tag: v1.19.0
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: public
+          authentication_enforced: true
+          user_interaction: gardener-operator
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: kube-state-metrics
+    sourceRepository: github.com/kubernetes/kube-state-metrics
+    repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+    tag: v2.15.0
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: private
+          authentication_enforced: false
+          user_interaction: gardener-operator
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: gardener-metrics-exporter
+    sourceRepository: github.com/gardener/gardener-metrics-exporter
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/metrics-exporter
+    tag: "0.38.0"
+    resourceId:
+      name: metrics-exporter
+  - name: node-exporter
+    sourceRepository: github.com/prometheus/node_exporter
+    repository: quay.io/prometheus/node-exporter
+    tag: v1.9.1
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: protected
+          authentication_enforced: false
+          user_interaction: end-user
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+          comment: the node-exporter is also deployed to the shoot cluster
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: plutono
+    sourceRepository: github.com/credativ/plutono
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/plutono
+    tag: "v7.5.37"
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: public
+          authentication_enforced: true
+          user_interaction: end-user
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: plutono-dashboard-refresher
+    sourceRepository: github.com/kiwigrid/k8s-sidecar
+    repository: quay.io/kiwigrid/k8s-sidecar
+    tag: "1.30.3"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'low'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: blackbox-exporter
+    sourceRepository: github.com/prometheus/blackbox_exporter
+    repository: quay.io/prometheus/blackbox-exporter
+    tag: v0.26.0
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: protected
+          authentication_enforced: false
+          user_interaction: end-user
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+          comment: the blackbox-exporter is also deployed to the shoot cluster
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  - name: metrics-server
+    sourceRepository: github.com/kubernetes-sigs/metrics-server
+    repository: registry.k8s.io/metrics-server/metrics-server
+    tag: v0.7.2
+    labels:
+      - name: gardener.cloud/cve-categorisation
+        value:
+          network_exposure: private
+          authentication_enforced: false
+          user_interaction: gardener-operator
+          confidentiality_requirement: high
+          integrity_requirement: high
+          availability_requirement: low
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/monitoring-maintainers'
+  # Shoot core addons
+  - name: vpn-client
+    sourceRepository: github.com/gardener/vpn2
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-client
+    tag: "0.37.3"
+  # TODO(DockToFuture): When updating coredns to v1.13.x check if the NET_BIND_SERVICE capability can be removed.
+  - name: coredns
+    sourceRepository: github.com/coredns/coredns
+    repository: registry.k8s.io/coredns/coredns
+    tag: "v1.12.1"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'protected'
+          authentication_enforced: false
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'high'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/gardener-core-networking-maintainers'
+  # TODO(vicwicker): A node-local-dns version that uses coredns 1.11 or higher requires adapting the node-local-dns Plutono dashboards.
+  - name: node-local-dns
+    sourceRepository: github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns
+    repository: registry.k8s.io/dns/k8s-dns-node-cache
+    tag: "1.25.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'high'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/gardener-core-networking-maintainers'
+  - name: node-problem-detector
+    sourceRepository: github.com/kubernetes/node-problem-detector
+    repository: registry.k8s.io/node-problem-detector/node-problem-detector
+    tag: "v0.8.20"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/mcm-maintainers'
+  # Shoot optional addons
+  - name: kubernetes-dashboard
+    sourceRepository: github.com/kubernetes/dashboard
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubernetesui/dashboard
+    tag: v2.7.0
+    labels: &optionalAddonLabels
+      - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
+        value:
+          policy: skip
+          comment: >
+            not deployed as part of gardener infrastructure. Offered to users for development purposes only, accompanied w/ warning that no support be provided.
 
-# Seed bootstrap
-- name: pause-container
-  sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
-  repository: registry.k8s.io/pause
-  tag: "3.10"
-  labels:
-  - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
-    value:
-      policy: skip
-      comment: >
-        pause-container is not accessible from outside k8s clusters and not
-        interacted with from other containers or other systems
-- name: etcd-druid
-  sourceRepository: github.com/gardener/etcd-druid
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
-  tag: "v0.29.1"
-- name: etcd
-  sourceRepository: github.com/etcd-io/etcd
-  repository: quay.io/coreos/etcd
-  tag: "v3.5.21"
-- name: dependency-watchdog
-  sourceRepository: github.com/gardener/dependency-watchdog
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog
-  tag: "v1.4.0"
-- name: nginx-ingress-controller
-  sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.12.2"
-  targetVersion: ">= 1.28"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'public'
-      authentication_enforced: true
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: nginx-ingress-controller
-  sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.11.6"
-  targetVersion: "1.27.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'public'
-      authentication_enforced: true
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: ingress-default-backend
-  sourceRepository: github.com/gardener/ingress-default-backend
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/ingress-default-backend
-  tag: "0.23.0"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'none'
-      integrity_requirement: 'none'
-      availability_requirement: 'none'
-      comment: Show static page when no path is found
+  - name: kubernetes-dashboard-metrics-scraper
+    sourceRepository: github.com/kubernetes/dashboard
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubernetesui/metrics-scraper
+    tag: v1.0.9
+    labels: *optionalAddonLabels
+  # Miscellaneous
+  - name: alpine-conntrack
+    sourceRepository: github.com/gardener/alpine-conntrack
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/alpine-conntrack
+    tag: "3.21.3"
+  # Logging
+  - name: fluent-operator
+    sourceRepository: github.com/fluent/fluent-operator
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-operator
+    tag: "v3.3.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'low'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: fluent-bit
+    sourceRepository: github.com/fluent/fluent-operator
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
+    tag: "v3.2.5"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'high'
+          integrity_requirement: 'low'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: fluent-bit-plugin-installer
+    resourceId:
+      name: fluent-bit-to-vali
+    sourceRepository: github.com/gardener/logging
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
+    tag: "v0.65.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'none'
+          integrity_requirement: 'none'
+          availability_requirement: 'none'
+          comment: no data is stored or processed by the installer
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: vali
+    sourceRepository: github.com/credativ/vali
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali
+    tag: "v2.2.22"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'high'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: vali-curator
+    sourceRepository: github.com/gardener/logging
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
+    tag: "v0.65.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'none'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: kube-rbac-proxy
+    sourceRepository: github.com/brancz/kube-rbac-proxy
+    repository: quay.io/brancz/kube-rbac-proxy
+    tag: v0.19.1
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'public'
+          authentication_enforced: true
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'high'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+          comment: kube-rbac-proxy is an authentication proxy working with credentials
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: valitail
+    sourceRepository: github.com/credativ/vali
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/valitail
+    # Do not update valitail version due to hard dependency on glibc version of the target nodes.
+    tag: "v2.2.15"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'high'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+          comment: valitail is running as a client (not as a server) and as such is not publicly exposed to the internet. Vulnerabilities with Attack Vector:Network are not exploitable.
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: telegraf
+    resourceId:
+      name: telegraf-iptables
+    sourceRepository: github.com/gardener/logging
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
+    tag: "v0.65.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'none'
+          integrity_requirement: 'none'
+          availability_requirement: 'none'
+          comment: >
+            telegraf is not accessible from outside the seed cluster and does not interact with confidential data
 
-# Seed controlplane
-#   hyperkube is used for kubectl + kubelet binaries on the worker nodes
-- name: hyperkube
-  sourceRepository: github.com/gardener/hyperkube
-  repository: europe-docker.pkg.dev/gardener-project/releases/hyperkube
-- name: kube-apiserver
-  sourceRepository: github.com/kubernetes/kubernetes
-  repository: registry.k8s.io/kube-apiserver
-- name: kube-controller-manager
-  sourceRepository: github.com/kubernetes/kubernetes
-  repository: registry.k8s.io/kube-controller-manager
-- name: kube-scheduler
-  sourceRepository: github.com/kubernetes/kubernetes
-  repository: registry.k8s.io/kube-scheduler
-- name: kube-proxy
-  sourceRepository: github.com/kubernetes/kubernetes
-  repository: registry.k8s.io/kube-proxy
-- name: machine-controller-manager
-  sourceRepository: github.com/gardener/machine-controller-manager
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager
-  tag: "v0.58.0"
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: protected
-      authentication_enforced: false
-      user_interaction: gardener-operator
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-- name: cluster-autoscaler
-  sourceRepository: github.com/gardener/autoscaler
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.32.0"
-  targetVersion: ">= 1.32"
-- name: cluster-autoscaler
-  sourceRepository: github.com/gardener/autoscaler
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.31.0"
-  targetVersion: "1.31.x"
-- name: cluster-autoscaler
-  sourceRepository: github.com/gardener/autoscaler
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.30.2"
-  targetVersion: "1.30.x"
-- name: cluster-autoscaler
-  sourceRepository: github.com/gardener/autoscaler
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.29.2"
-  targetVersion: "1.29.x"
-- name: cluster-autoscaler
-  sourceRepository: github.com/gardener/autoscaler
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.28.3"
-  targetVersion: "1.28.x"
-- name: cluster-autoscaler
-  sourceRepository: github.com/gardener/autoscaler
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.27.3"
-  targetVersion: "1.27.x"
-- name: vpn-server
-  sourceRepository: github.com/gardener/vpn2
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-server
-  tag: "0.37.3"
-
-# Monitoring
-- name: prometheus-operator
-  sourceRepository: github.com/prometheus-operator/prometheus-operator
-  repository: quay.io/prometheus-operator/prometheus-operator
-  tag: v0.82.2
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'low'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: alertmanager
-  sourceRepository: github.com/prometheus/alertmanager
-  repository: quay.io/prometheus/alertmanager
-  tag: v0.28.1
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: public
-      authentication_enforced: true
-      user_interaction: end-user
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: prometheus
-  sourceRepository: github.com/prometheus/prometheus
-  repository: quay.io/prometheus/prometheus
-  tag: v3.3.1
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: public
-      authentication_enforced: true
-      user_interaction: end-user
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: configmap-reloader
-  sourceRepository: github.com/prometheus-operator/prometheus-operator
-  repository: quay.io/prometheus-operator/prometheus-config-reloader
-  tag: v0.82.2
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: private
-      authentication_enforced: false
-      user_interaction: gardener-operator
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: cortex
-  repository: quay.io/cortexproject/cortex
-  tag: v1.19.0
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: public
-      authentication_enforced: true
-      user_interaction: gardener-operator
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: kube-state-metrics
-  sourceRepository: github.com/kubernetes/kube-state-metrics
-  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-  tag: v2.15.0
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: private
-      authentication_enforced: false
-      user_interaction: gardener-operator
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: gardener-metrics-exporter
-  sourceRepository: github.com/gardener/gardener-metrics-exporter
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/metrics-exporter
-  tag: "0.38.0"
-  resourceId:
-    name: metrics-exporter
-- name: node-exporter
-  sourceRepository: github.com/prometheus/node_exporter
-  repository: quay.io/prometheus/node-exporter
-  tag: v1.9.1
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: protected
-      authentication_enforced: false
-      user_interaction: end-user
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-      comment: the node-exporter is also deployed to the shoot cluster
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: plutono
-  sourceRepository: github.com/credativ/plutono
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/plutono
-  tag: "v7.5.37"
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: public
-      authentication_enforced: true
-      user_interaction: end-user
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: plutono-dashboard-refresher
-  sourceRepository: github.com/kiwigrid/k8s-sidecar
-  repository: quay.io/kiwigrid/k8s-sidecar
-  tag: "1.30.3"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'low'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: blackbox-exporter
-  sourceRepository: github.com/prometheus/blackbox_exporter
-  repository: quay.io/prometheus/blackbox-exporter
-  tag: v0.26.0
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: protected
-      authentication_enforced: false
-      user_interaction: end-user
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-      comment: the blackbox-exporter is also deployed to the shoot cluster
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-- name: metrics-server
-  sourceRepository: github.com/kubernetes-sigs/metrics-server
-  repository: registry.k8s.io/metrics-server/metrics-server
-  tag: v0.7.2
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: private
-      authentication_enforced: false
-      user_interaction: gardener-operator
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'
-
-# Shoot core addons
-- name: vpn-client
-  sourceRepository: github.com/gardener/vpn2
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-client
-  tag: "0.37.3"
-# TODO(DockToFuture): When updating coredns to v1.13.x check if the NET_BIND_SERVICE capability can be removed.
-- name: coredns
-  sourceRepository: github.com/coredns/coredns
-  repository: registry.k8s.io/coredns/coredns
-  tag: "v1.12.1"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'high'
-      availability_requirement: 'high'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/gardener-core-networking-maintainers'
-# TODO(vicwicker): A node-local-dns version that uses coredns 1.11 or higher requires adapting the node-local-dns Plutono dashboards.
-- name: node-local-dns
-  sourceRepository: github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns
-  repository: registry.k8s.io/dns/k8s-dns-node-cache
-  tag: "1.25.0"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'high'
-      availability_requirement: 'high'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/gardener-core-networking-maintainers'
-- name: node-problem-detector
-  sourceRepository: github.com/kubernetes/node-problem-detector
-  repository: registry.k8s.io/node-problem-detector/node-problem-detector
-  tag: "v0.8.20"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/mcm-maintainers'
-
-# Shoot optional addons
-- name: kubernetes-dashboard
-  sourceRepository: github.com/kubernetes/dashboard
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubernetesui/dashboard
-  tag: v2.7.0
-  labels: &optionalAddonLabels
-  - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
-    value:
-      policy: skip
-      comment: >
-        not deployed as part of gardener infrastructure. Offered to users for development
-        purposes only, accompanied w/ warning that no support be provided.
-- name: kubernetes-dashboard-metrics-scraper
-  sourceRepository: github.com/kubernetes/dashboard
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubernetesui/metrics-scraper
-  tag: v1.0.9
-  labels: *optionalAddonLabels
-
-# Miscellaneous
-- name: alpine-conntrack
-  sourceRepository: github.com/gardener/alpine-conntrack
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/alpine-conntrack
-  tag: "3.21.3"
-
-# Logging
-- name: fluent-operator
-  sourceRepository: github.com/fluent/fluent-operator
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-operator
-  tag: "v3.3.0"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'low'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: fluent-bit
-  sourceRepository: github.com/fluent/fluent-operator
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
-  tag: "v3.2.5"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'low'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: fluent-bit-plugin-installer
-  resourceId:
-    name: fluent-bit-to-vali
-  sourceRepository: github.com/gardener/logging
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-  tag: "v0.65.0"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'none'
-      integrity_requirement: 'none'
-      availability_requirement: 'none'
-      comment: no data is stored or processed by the installer
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: vali
-  sourceRepository: github.com/credativ/vali
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali
-  tag: "v2.2.22"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: vali-curator
-  sourceRepository: github.com/gardener/logging
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-  tag: "v0.65.0"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'none'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: kube-rbac-proxy
-  sourceRepository: github.com/brancz/kube-rbac-proxy
-  repository: quay.io/brancz/kube-rbac-proxy
-  tag: v0.19.1
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'public'
-      authentication_enforced: true
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-      comment: kube-rbac-proxy is an authentication proxy working with credentials
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: valitail
-  sourceRepository: github.com/credativ/vali
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/valitail
-  # Do not update valitail version due to hard dependency on glibc version of the target nodes.
-  tag: "v2.2.15"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-      comment: valitail is running as a client (not as a server) and as such is not publicly exposed to the internet. Vulnerabilities with Attack Vector:Network are not exploitable.
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: telegraf
-  resourceId:
-    name: telegraf-iptables
-  sourceRepository: github.com/gardener/logging
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-  tag: "v0.65.0"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'none'
-      integrity_requirement: 'none'
-      availability_requirement: 'none'
-      comment: >
-        telegraf is not accessible from outside the seed cluster and does not
-        interact with confidential data
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: event-logger
-  sourceRepository: github.com/gardener/logging
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-  tag: "v0.65.0"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-- name: tune2fs
-  sourceRepository: github.com/gardener/logging
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-  tag: "v0.65.0"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'private'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'none'
-      integrity_requirement: 'none'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/logging-maintainers'
-
-# VPA
-- name: vpa-admission-controller
-  sourceRepository: github.com/kubernetes/autoscaler
-  repository: registry.k8s.io/autoscaling/vpa-admission-controller
-  tag: "1.3.1"
-  labels:
-    - name: 'gardener.cloud/cve-categorisation'
-      value:
-        network_exposure: 'private'
-        authentication_enforced: false
-        user_interaction: 'gardener-operator'
-        confidentiality_requirement: 'low'
-        integrity_requirement: 'high'
-        availability_requirement: 'high'
-- name: vpa-recommender
-  sourceRepository: github.com/kubernetes/autoscaler
-  repository: registry.k8s.io/autoscaling/vpa-recommender
-  tag: "1.3.1"
-  labels:
-    - name: 'gardener.cloud/cve-categorisation'
-      value:
-        network_exposure: 'private'
-        authentication_enforced: false
-        user_interaction: 'gardener-operator'
-        confidentiality_requirement: 'low'
-        integrity_requirement: 'high'
-        availability_requirement: 'high'
-- name: vpa-updater
-  sourceRepository: github.com/kubernetes/autoscaler
-  repository: registry.k8s.io/autoscaling/vpa-updater
-  tag: "1.3.1"
-  labels:
-    - name: 'gardener.cloud/cve-categorisation'
-      value:
-        network_exposure: 'private'
-        authentication_enforced: false
-        user_interaction: 'gardener-operator'
-        confidentiality_requirement: 'low'
-        integrity_requirement: 'high'
-        availability_requirement: 'high'
-
-# Horizontal cluster-proportional-autoscaler
-- name: cluster-proportional-autoscaler
-  sourceRepository: https://github.com/kubernetes-sigs/cluster-proportional-autoscaler
-  repository: registry.k8s.io/cpa/cluster-proportional-autoscaler
-  tag: "v1.9.0"
-  labels:
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/gardener-core-networking-maintainers'
-
-# Istio
-- name: istio-proxy
-  sourceRepository: github.com/istio/istio
-  repository: gcr.io/istio-release/proxyv2
-  tag: "1.25.2-distroless"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'public'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'high'
-      availability_requirement: 'high'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/gardener-core-networking-maintainers'
-- name: istio-istiod
-  sourceRepository: github.com/istio/istio
-  repository: gcr.io/istio-release/pilot
-  tag: "1.25.2-distroless"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/gardener-core-networking-maintainers'
-
-# API Server SNI
-- name: apiserver-proxy
-  sourceRepository: github.com/envoyproxy/envoy
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy-distroless
-  tag: "v1.34.1"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'low'
-      integrity_requirement: 'high'
-      availability_requirement: 'high'
-  - name: 'cloud.gardener.cnudie/responsibles'
-    value:
-    - type: 'githubTeam'
-      teamname: 'gardener/gardener-core-networking-maintainers'
-  - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
-    value:
-    # https://www.envoyproxy.io/docs/envoy/v1.29.2/intro/arch_overview/security/external_deps
-    - name: 'v8'
-      version: '10.7.193.13'
-    - name: 'grpc'
-      version: '1.59.4'
-    - name: 'luajit'
-      version: '2.1.0.beta3'
-    - name: 'nghttp2'
-      version: '1.58.0'
-    - name: 'protobuf'
-      version: '23.4'
-    - name: 'fmt'
-      version: '9.1.0'
-    - name: 'boringssl'
-      version: '45cf810'
-    # lua version is unclear. lua runtime is luajit.
-    # luajit is compatible with lua 5.1 but contains feature of lua 5.2 and 5.3
-    # https://luajit.org/extensions.html
-    - name: 'lua'
-      version: '5.1'
-- name: apiserver-proxy-sidecar
-  resourceId:
-    name: apiserver-proxy
-  sourceRepository: github.com/gardener/apiserver-proxy
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/apiserver-proxy
-  tag: "v0.19.0"
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: event-logger
+    sourceRepository: github.com/gardener/logging
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
+    tag: "v0.65.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'high'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  - name: tune2fs
+    sourceRepository: github.com/gardener/logging
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
+    tag: "v0.65.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'none'
+          integrity_requirement: 'none'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/logging-maintainers'
+  # VPA
+  - name: vpa-admission-controller
+    sourceRepository: github.com/kubernetes/autoscaler
+    repository: registry.k8s.io/autoscaling/vpa-admission-controller
+    tag: "1.3.1"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'high'
+  - name: vpa-recommender
+    sourceRepository: github.com/kubernetes/autoscaler
+    repository: registry.k8s.io/autoscaling/vpa-recommender
+    tag: "1.3.1"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'high'
+  - name: vpa-updater
+    sourceRepository: github.com/kubernetes/autoscaler
+    repository: registry.k8s.io/autoscaling/vpa-updater
+    tag: "1.3.1"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'high'
+  # Horizontal cluster-proportional-autoscaler
+  - name: cluster-proportional-autoscaler
+    sourceRepository: https://github.com/kubernetes-sigs/cluster-proportional-autoscaler
+    repository: registry.k8s.io/cpa/cluster-proportional-autoscaler
+    tag: "v1.9.0"
+    labels:
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/gardener-core-networking-maintainers'
+  # Istio
+  - name: istio-proxy
+    sourceRepository: github.com/istio/istio
+    repository: gcr.io/istio-release/proxyv2
+    tag: "1.25.2-distroless"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'public'
+          authentication_enforced: false
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'high'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/gardener-core-networking-maintainers'
+  - name: istio-istiod
+    sourceRepository: github.com/istio/istio
+    repository: gcr.io/istio-release/pilot
+    tag: "1.25.2-distroless"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'protected'
+          authentication_enforced: false
+          user_interaction: 'gardener-operator'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'low'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/gardener-core-networking-maintainers'
+  # API Server SNI
+  - name: apiserver-proxy
+    sourceRepository: github.com/envoyproxy/envoy
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy-distroless
+    tag: "v1.34.1"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'protected'
+          authentication_enforced: false
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'high'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/gardener-core-networking-maintainers'
+      - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
+        value:
+          # https://www.envoyproxy.io/docs/envoy/v1.29.2/intro/arch_overview/security/external_deps
+          - name: 'v8'
+            version: '10.7.193.13'
+          - name: 'grpc'
+            version: '1.59.4'
+          - name: 'luajit'
+            version: '2.1.0.beta3'
+          - name: 'nghttp2'
+            version: '1.58.0'
+          - name: 'protobuf'
+            version: '23.4'
+          - name: 'fmt'
+            version: '9.1.0'
+          - name: 'boringssl'
+            version: '45cf810'
+          # lua version is unclear. lua runtime is luajit.
+          # luajit is compatible with lua 5.1 but contains feature of lua 5.2 and 5.3
+          # https://luajit.org/extensions.html
+          - name: 'lua'
+            version: '5.1'
+  - name: apiserver-proxy-sidecar
+    resourceId:
+      name: apiserver-proxy
+    sourceRepository: github.com/gardener/apiserver-proxy
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/apiserver-proxy
+    tag: "v0.19.0"

--- a/imagevector/imagevector.go
+++ b/imagevector/imagevector.go
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:generate ../hack/generate-imagename-constants.sh imagevector containers.yaml Container
+//go:generate ../hack/resolve-etcd-version-from-etcd-druid.sh containers.yaml
 //go:generate ../hack/generate-imagename-constants.sh imagevector charts.yaml Chart
 
 package imagevector

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -116,7 +116,7 @@ func New(
 	secretsManager secretsmanager.Interface,
 	values Values,
 ) Interface {
-	name := values.NamePrefix + "etcd-" + values.Role
+	name := values.NamePrefix + Name(values.Role)
 	log = log.WithValues("etcd", client.ObjectKey{Namespace: namespace, Name: name})
 
 	return &etcd{
@@ -1100,4 +1100,9 @@ func GenerateClientServerCertificates(
 	}
 
 	return etcdCASecret, serverSecret, clientSecret, nil
+}
+
+// Name returns the name of the etcd based on its role.
+func Name(role string) string {
+	return "etcd-" + role
 }

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -2194,4 +2194,10 @@ var _ = Describe("Etcd", func() {
 			})
 		})
 	})
+
+	Describe("#Name", func() {
+		It("should return the expected name", func() {
+			Expect(Name("foo")).To(Equal("etcd-foo"))
+		})
+	})
 })

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1372,7 +1372,7 @@ func (r *resourceManager) getMutatingWebhookConfigurationWebhooks(
 		webhooks = append(webhooks, GetPodTopologySpreadConstraintsMutatingWebhook(r.values.NamePrefix, namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	r.skipStaticPodsDuringBootstrapMode(webhooks)
+	r.skipStaticPods(webhooks)
 	return webhooks
 }
 
@@ -2099,8 +2099,8 @@ func (r *resourceManager) SetBootstrapControlPlaneNode(b bool) {
 	r.values.BootstrapControlPlaneNode = b
 }
 
-func (r *resourceManager) skipStaticPodsDuringBootstrapMode(webhooks []admissionregistrationv1.MutatingWebhook) {
-	if !r.values.BootstrapControlPlaneNode {
+func (r *resourceManager) skipStaticPods(webhooks []admissionregistrationv1.MutatingWebhook) {
+	if r.values.ResponsibilityMode != ForSourceAndTarget {
 		return
 	}
 

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -913,8 +913,8 @@ var _ = Describe("ResourceManager", func() {
 				}}
 			}
 
-			ignoreStaticPodsInBootstrapMode := func(in []metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
-				if !bootstrapControlPlaneNode {
+			ignoreStaticPods := func(in []metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
+				if responsibilityMode != ForSourceAndTarget {
 					return in
 				}
 
@@ -947,7 +947,7 @@ var _ = Describe("ResourceManager", func() {
 						}},
 						NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 						ObjectSelector: &metav1.LabelSelector{
-							MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
+							MatchExpressions: ignoreStaticPods([]metav1.LabelSelectorRequirement{
 								{
 									Key:      "projected-token-mount.resources.gardener.cloud/skip",
 									Operator: metav1.LabelSelectorOpDoesNotExist,
@@ -1038,7 +1038,7 @@ var _ = Describe("ResourceManager", func() {
 					}},
 					NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 					ObjectSelector: &metav1.LabelSelector{
-						MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
+						MatchExpressions: ignoreStaticPods([]metav1.LabelSelectorRequirement{
 							{
 								Key:      "seccompprofile.resources.gardener.cloud/skip",
 								Operator: metav1.LabelSelectorOpDoesNotExist,
@@ -1081,7 +1081,7 @@ var _ = Describe("ResourceManager", func() {
 						}},
 					},
 					ObjectSelector: &metav1.LabelSelector{
-						MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
+						MatchExpressions: ignoreStaticPods([]metav1.LabelSelectorRequirement{
 							{
 								Key:      resourcesv1alpha1.KubernetesServiceHostInject,
 								Operator: metav1.LabelSelectorOpNotIn,
@@ -1152,7 +1152,7 @@ var _ = Describe("ResourceManager", func() {
 						}},
 						NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 						ObjectSelector: &metav1.LabelSelector{
-							MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{{
+							MatchExpressions: ignoreStaticPods([]metav1.LabelSelectorRequirement{{
 								Key:      "system-components-config.resources.gardener.cloud/skip",
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							}}),
@@ -1185,7 +1185,7 @@ var _ = Describe("ResourceManager", func() {
 				}},
 				NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
 				ObjectSelector: &metav1.LabelSelector{
-					MatchExpressions: ignoreStaticPodsInBootstrapMode([]metav1.LabelSelectorRequirement{
+					MatchExpressions: ignoreStaticPods([]metav1.LabelSelectorRequirement{
 						{
 							Key:      "app",
 							Operator: metav1.LabelSelectorOpNotIn,

--- a/pkg/gardenadm/botanist/controlplane.go
+++ b/pkg/gardenadm/botanist/controlplane.go
@@ -72,8 +72,8 @@ type staticControlPlaneComponent struct {
 
 func (b *AutonomousBotanist) staticControlPlaneComponents() []staticControlPlaneComponent {
 	return []staticControlPlaneComponent{
-		{b.deployETCD(v1beta1constants.ETCDRoleMain), "etcd-" + v1beta1constants.ETCDRoleMain + "-0", &appsv1.StatefulSet{}},
-		{b.deployETCD(v1beta1constants.ETCDRoleEvents), "etcd-" + v1beta1constants.ETCDRoleEvents + "-0", &appsv1.StatefulSet{}},
+		{b.deployETCD(v1beta1constants.ETCDRoleMain), bootstrapetcd.Name(v1beta1constants.ETCDRoleMain), &appsv1.StatefulSet{}},
+		{b.deployETCD(v1beta1constants.ETCDRoleEvents), bootstrapetcd.Name(v1beta1constants.ETCDRoleEvents), &appsv1.StatefulSet{}},
 		{b.deployKubeAPIServer, v1beta1constants.DeploymentNameKubeAPIServer, &appsv1.Deployment{}},
 		{b.DeployKubeControllerManager, v1beta1constants.DeploymentNameKubeControllerManager, &appsv1.Deployment{}},
 		{b.Shoot.Components.ControlPlane.KubeScheduler.Deploy, v1beta1constants.DeploymentNameKubeScheduler, &appsv1.Deployment{}},

--- a/pkg/gardenadm/botanist/customresourcedefinitions.go
+++ b/pkg/gardenadm/botanist/customresourcedefinitions.go
@@ -11,6 +11,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/gardener/gardener/pkg/component/autoscaling/vpa"
+	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	extensioncrds "github.com/gardener/gardener/pkg/component/extensions/crds"
 	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
@@ -39,11 +40,17 @@ func (b *AutonomousBotanist) ReconcileCustomResourceDefinitions(ctx context.Cont
 		return fmt.Errorf("failed creating extension CRD deployer: %w", err)
 	}
 
+	etcdCRDDeployer, err := etcd.NewCRD(b.SeedClientSet.Client(), b.SeedClientSet.Applier(), b.Shoot.KubernetesVersion)
+	if err != nil {
+		return fmt.Errorf("failed creating etcd CRD deployer: %w", err)
+	}
+
 	for description, deploy := range map[string]func(context.Context) error{
 		"VPA":        vpaCRDDeployer.Deploy,
 		"Prometheus": prometheusCRDDeployer.Deploy,
 		"Fluent":     fluentCRDDeployer.Deploy,
 		"Extension":  extensionCRDDeployer.Deploy,
+		"ETCD":       etcdCRDDeployer.Deploy,
 	} {
 		if err := deploy(ctx); err != nil {
 			return fmt.Errorf("failed to deploy CustomResourceDefinition related to %s: %w", description, err)

--- a/pkg/gardenadm/botanist/customresourcedefinitions_test.go
+++ b/pkg/gardenadm/botanist/customresourcedefinitions_test.go
@@ -7,6 +7,7 @@ package botanist_test
 import (
 	"context"
 
+	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -23,6 +24,7 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 )
 
 var _ = Describe("CustomResourceDefinitions", func() {
@@ -52,6 +54,7 @@ var _ = Describe("CustomResourceDefinitions", func() {
 						WithApplier(applier).
 						WithRESTConfig(&rest.Config{}).
 						Build(),
+					Shoot: &shoot.Shoot{KubernetesVersion: semver.MustParse("1.33.0")},
 				},
 			},
 		}
@@ -82,6 +85,8 @@ var _ = Describe("CustomResourceDefinitions", func() {
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("containerruntimes.extensions.gardener.cloud")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("controlplanes.extensions.gardener.cloud")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dnsrecords.extensions.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("extensions.extensions.gardener.cloud")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("filters.fluentbit.fluent.io")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbitconfigs.fluentbit.fluent.io")})}),

--- a/pkg/gardenadm/botanist/etcd.go
+++ b/pkg/gardenadm/botanist/etcd.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
+)
+
+// DeployEtcdDruid deploys the etcd-druid component.
+func (b *AutonomousBotanist) DeployEtcdDruid(ctx context.Context) error {
+	var componentImageVectors imagevectorutils.ComponentImageVectors
+	if path := os.Getenv(imagevectorutils.ComponentOverrideEnv); path != "" {
+		var err error
+		componentImageVectors, err = imagevectorutils.ReadComponentOverwriteFile(path)
+		if err != nil {
+			return fmt.Errorf("failed reading component-specific image vector override: %w", err)
+		}
+	}
+
+	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
+	gardenletconfigv1alpha1.SetObjectDefaults_GardenletConfiguration(gardenletConfig)
+
+	deployer, err := sharedcomponent.NewEtcdDruid(
+		b.SeedClientSet.Client(),
+		b.Shoot.ControlPlaneNamespace,
+		b.Shoot.KubernetesVersion,
+		componentImageVectors,
+		gardenletConfig.ETCDConfig,
+		b.SecretsManager,
+		v1beta1constants.SecretNameCACluster,
+		v1beta1constants.PriorityClassNameSeedSystem800,
+	)
+	if err != nil {
+		return fmt.Errorf("failed creating etcd-druid deployer: %w", err)
+	}
+
+	return deployer.Deploy(ctx)
+}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -236,7 +236,7 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
 		})
 		deployControlPlaneDeployments = g.Add(flow.Task{
-			Name:         "Deploying control plane components as Deployments for static pod translation",
+			Name:         "Deploying control plane components as Deployments/StatefulSets for static pod translation",
 			Fn:           b.DeployControlPlaneDeployments,
 			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
 		})

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -230,6 +230,11 @@ func run(ctx context.Context, opts *Options) error {
 			Fn:           b.Shoot.Components.Extensions.ControlPlane.Wait,
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying ETCD Druid",
+			Fn:           b.DeployEtcdDruid,
+			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
+		})
 		deployControlPlaneDeployments = g.Add(flow.Task{
 			Name:         "Deploying control plane components as Deployments for static pod translation",
 			Fn:           b.DeployControlPlaneDeployments,

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -291,6 +291,10 @@ kind: Config
 								DeprecatedServiceAccount: "remove-me",
 							},
 						},
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{ObjectMeta: metav1.ObjectMeta{Name: "pvc1"}, Spec: corev1.PersistentVolumeClaimSpec{VolumeName: "foo"}},
+							{ObjectMeta: metav1.ObjectMeta{Name: "pvc2"}, Spec: corev1.PersistentVolumeClaimSpec{VolumeName: "bar"}},
+						},
 					},
 				}
 			})
@@ -329,6 +333,13 @@ spec:
   priorityClassName: system-node-critical
   securityContext:
     fsGroup: 0
+  volumes:
+  - hostPath:
+      path: /var/lib/pvc1/data
+    name: pvc1
+  - hostPath:
+      path: /var/lib/pvc2/data
+    name: pvc2
 status: {}
 `))}},
 				}))
@@ -456,6 +467,12 @@ spec:
   - hostPath:
       path: /var/lib/foo/v3
     name: v3
+  - hostPath:
+      path: /var/lib/pvc1/data
+    name: pvc1
+  - hostPath:
+      path: /var/lib/pvc2/data
+    name: pvc2
 status: {}
 `))}},
 					},
@@ -733,6 +750,12 @@ kind: Config
 			It("should return an error", func() {
 				Expect(Translate(ctx, fakeClient, &corev1.ConfigMap{})).Error().To(MatchError(ContainSubstring("unsupported object type")))
 			})
+		})
+	})
+
+	Describe("#StatefulSetVolumeClaimTemplateHostPath", func() {
+		It("should return the expected path", func() {
+			Expect(StatefulSetVolumeClaimTemplateHostPath("foo")).To(Equal("/var/lib/foo/data"))
 		})
 	})
 })

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -50,7 +50,9 @@ var _ = Describe("Translator", func() {
 								Annotations: map[string]string{"bar": "baz"},
 							},
 							Spec: corev1.PodSpec{
-								SecurityContext: &corev1.PodSecurityContext{FSGroup: ptr.To[int64](65534)},
+								SecurityContext:          &corev1.PodSecurityContext{FSGroup: ptr.To[int64](65534)},
+								ServiceAccountName:       "remove-me",
+								DeprecatedServiceAccount: "remove-me",
 							},
 						},
 					},
@@ -284,7 +286,9 @@ kind: Config
 								Annotations: map[string]string{"bar": "baz"},
 							},
 							Spec: corev1.PodSpec{
-								SecurityContext: &corev1.PodSecurityContext{FSGroup: ptr.To[int64](65534)},
+								SecurityContext:          &corev1.PodSecurityContext{FSGroup: ptr.To[int64](65534)},
+								ServiceAccountName:       "remove-me",
+								DeprecatedServiceAccount: "remove-me",
 							},
 						},
 					},
@@ -512,6 +516,10 @@ kind: Config
 						ResourceVersion: "1",
 						Finalizers:      []string{"bar"},
 						OwnerReferences: []metav1.OwnerReference{{}},
+					},
+					Spec: corev1.PodSpec{
+						ServiceAccountName:       "remove-me",
+						DeprecatedServiceAccount: "remove-me",
 					},
 				}
 			})

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -121,8 +121,8 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace("kube-system"))).To(Succeed())
 				return podList.Items
 			}).Should(ContainElements(
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-events-0-machine-0")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-main-0-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-bootstrap-events-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-bootstrap-main-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-apiserver-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-controller-manager-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-scheduler-machine-0")})}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR prepares for `etcd-druid` taking over management of `etcd` (this itself is not yet part of this PR and will follow later).


**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @ScheererJ @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
