### PR TITLE
vpa-recommender: Sync `--pod-recommendation-min-cpu-millicores` value with the smallest CPU histogram bucket size (`10m`)

### DIFF
--- a/pkg/component/autoscaling/vpa/recommender.go
+++ b/pkg/component/autoscaling/vpa/recommender.go
@@ -322,7 +322,7 @@ func (v *vpa) computeRecommenderArgs() []string {
 	out := []string{
 		"--v=3",
 		"--stderrthreshold=info",
-		"--pod-recommendation-min-cpu-millicores=5",
+		"--pod-recommendation-min-cpu-millicores=10",
 		"--pod-recommendation-min-memory-mb=10",
 		fmt.Sprintf("--recommendation-margin-fraction=%f", ptr.Deref(v.values.Recommender.RecommendationMarginFraction, gardencorev1beta1.DefaultRecommendationMarginFraction)),
 		fmt.Sprintf("--recommender-interval=%s", ptr.Deref(v.values.Recommender.Interval, gardencorev1beta1.DefaultRecommenderInterval).Duration),

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -752,7 +752,7 @@ var _ = Describe("VPA", func() {
 								Args: []string{
 									"--v=3",
 									"--stderrthreshold=info",
-									"--pod-recommendation-min-cpu-millicores=5",
+									"--pod-recommendation-min-cpu-millicores=10",
 									"--pod-recommendation-min-memory-mb=10",
 									fmt.Sprintf("--recommendation-margin-fraction=%f", ptr.Deref(recommendationMarginFraction, 0.15)),
 									fmt.Sprintf("--recommender-interval=%s", ptr.Deref(interval, metav1.Duration{Duration: time.Minute}).Duration),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
In the context of #12030 @voelzmo noticed that having `--pod-recommendation-min-cpu-millicores=5` as configuration option in vpa-recommender is confusing because of the internal implementation detail of vpa-recommender that the smallest CPU histogram bucket size is `10m`. See https://github.com/kubernetes/autoscaler/issues/6415.
Hence, setting `--pod-recommendation-min-cpu-millicores=5` creates the confusion that the smallest CPU recommendation could be `5m` however due to the smallest CPU histogram bucket size it is `10m`.

This PR sets `--pod-recommendation-min-cpu-millicores=10` so that there is no such confusion.

**Which issue(s) this PR fixes**:
In the context of #12030

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
