### PR TITLE
[GEP-28] Fix Extension Webhook Registration for Autonomous Shoot Clusters.

### DIFF
--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -326,6 +326,13 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 					return nil, fmt.Errorf("failed computing new client config while merging shoot validating webhook %q into seed webhooks: %w", webhook.Name, err)
 				}
 				webhook.ClientConfig = mutatedClientConfig
+
+				if seedWebhookConfigs.ValidatingWebhookConfig == nil {
+					seedWebhookConfigs.ValidatingWebhookConfig = &admissionregistrationv1.ValidatingWebhookConfiguration{
+						ObjectMeta: extensionswebhook.InitialWebhookConfig(extensionswebhook.NamePrefix + c.extensionName),
+					}
+				}
+
 				seedWebhookConfigs.ValidatingWebhookConfig.Webhooks = append(seedWebhookConfigs.ValidatingWebhookConfig.Webhooks, webhook)
 			}
 		}
@@ -337,6 +344,13 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 					return nil, fmt.Errorf("failed computing new client config while merging shoot mutating webhook %q into seed webhooks: %w", webhook.Name, err)
 				}
 				webhook.ClientConfig = mutatedClientConfig
+
+				if seedWebhookConfigs.MutatingWebhookConfig == nil {
+					seedWebhookConfigs.MutatingWebhookConfig = &admissionregistrationv1.MutatingWebhookConfiguration{
+						ObjectMeta: extensionswebhook.InitialWebhookConfig(extensionswebhook.NamePrefix + c.extensionName),
+					}
+				}
+
 				seedWebhookConfigs.MutatingWebhookConfig.Webhooks = append(seedWebhookConfigs.MutatingWebhookConfig.Webhooks, webhook)
 			}
 		}

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -369,18 +369,13 @@ func createAndAddToWebhookConfig(
 	clientConfig admissionregistrationv1.WebhookClientConfig,
 	sideEffects *admissionregistrationv1.SideEffectClass,
 ) {
-	objectMeta := metav1.ObjectMeta{
-		Name:   name,
-		Labels: map[string]string{v1beta1constants.LabelExcludeWebhookFromRemediation: "true"},
-	}
-
 	// Create a validating or mutating webhook configuration based on the webhooks action. If the action is not set or
 	// unknown fall back to mutating webhook since this is the safest option to pick.
 	switch webhook.Action {
 	case ActionValidating:
 		if webhookConfigs.ValidatingWebhookConfig == nil {
 			webhookConfigs.ValidatingWebhookConfig = &admissionregistrationv1.ValidatingWebhookConfiguration{
-				ObjectMeta: objectMeta,
+				ObjectMeta: InitialWebhookConfig(name),
 			}
 		}
 		webhookToRegister := admissionregistrationv1.ValidatingWebhook{
@@ -404,7 +399,7 @@ func createAndAddToWebhookConfig(
 	default:
 		if webhookConfigs.MutatingWebhookConfig == nil {
 			webhookConfigs.MutatingWebhookConfig = &admissionregistrationv1.MutatingWebhookConfiguration{
-				ObjectMeta: objectMeta,
+				ObjectMeta: InitialWebhookConfig(name),
 			}
 		}
 
@@ -426,5 +421,13 @@ func createAndAddToWebhookConfig(
 		webhookToRegister.MatchPolicy = matchPolicy
 		webhookToRegister.ClientConfig = clientConfig
 		webhookConfigs.MutatingWebhookConfig.Webhooks = append(webhookConfigs.MutatingWebhookConfig.Webhooks, webhookToRegister)
+	}
+}
+
+// InitialWebhookConfig returns the initial object meta for a webhook configuration.
+func InitialWebhookConfig(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:   name,
+		Labels: map[string]string{v1beta1constants.LabelExcludeWebhookFromRemediation: "true"},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind bug

**What this PR does / why we need it**:

Fix Extension Webhook Registration for Autonomous Shoot Clusters.

The change merging the shoot and seed webhooks for autonomous shoot clusters (#11892) assumed that extensions always had both validating as well as mutating webhooks. However, there are extensions, which only have one of them. They might also not have seed webhooks at all, but only shoot webhooks. In all those cases the initialisation was incomplete leading to potential nil dereferences when adding the shoot webhooks.
This change resolves these problems.

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix extension webhook registration for autonomous shoot clusters.
```
