### PR TITLE
Allow `gardener-internal` service account to update restricted resources

### DIFF
--- a/docs/concepts/admission-controller.md
+++ b/docs/concepts/admission-controller.md
@@ -100,6 +100,10 @@ This information can be used by third parties so that they establish trust to sp
 This handler protects `secrets` and `configmaps` against tampering.
 It denies `CREATE`, `UPDATE` and `DELETE` requests if the resource is labeled with `gardener.cloud/update-restriction=true` and the request is not made by a `gardenlet`.
 
+In addition, the following service accounts are allowed to perform certain operations:
+- `system:serviceaccount:kube-system:generic-garbage-collector` is allowed to `DELETE` restricted resources.
+- `system:serviceaccount:kube-system:gardener-internal` is allowed to `UPDATE` restricted resources.
+
 ## Authorization Webhook Handlers
 
 This section describes the authorization webhook handlers that are currently served.

--- a/pkg/admissioncontroller/webhook/admission/updaterestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/updaterestriction/handler.go
@@ -29,6 +29,12 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 		return admission.Allowed("generic-garbage-collector is allowed to delete system resources")
 	}
 
+	// Allow the gardener-internal service account to update resources.
+	// This service account is used by the gardener-operator to label all encrypted resources with the name of the current ETCD encryption key secret.
+	if req.UserInfo.Username == "system:serviceaccount:kube-system:gardener-internal" && req.Operation == admissionv1.Update {
+		return admission.Allowed("system:serviceaccount:kube-system:gardener-internal is allowed to update system resources")
+	}
+
 	if slices.Contains(req.UserInfo.Groups, v1beta1constants.SeedsGroup) {
 		return admission.Allowed("gardenlet is allowed to modify system resources")
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
The `gardener-operator` tries to label encrypted resources with the name of the current ETCD encryption key secret using the `system:serviceaccount:kube-system:gardener-internal` service account. This cannot happen as this service account is not permitted.

https://github.com/gardener/gardener/blob/2e5ee0343e812d15ae2101459d7e50d3a6c5365c/pkg/operator/controller/garden/garden/reconciler_reconcile.go#L472-L480

See the following discussion for more info https://gardener-cloud.slack.com/archives/CAPMD6DCG/p1746452123980829

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/pull/11216
Introduced with Introduced with https://github.com/gardener/gardener/pull/11108

**Special notes for your reviewer**:
invite @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug preventing the `system:serviceaccount:kube-system:gardener-internal` service account, used by `gardener-operator`, to label restricted resources was fixed.
```
