### PR TITLE
[GEP-28] `gardenadm bootstrap`: Deploy gardener-resource-manager and provider extension

### DIFF
--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -147,6 +147,7 @@ This will first build the needed images and then render the needed manifests for
 Afterward, you can use `go run` to execute `gardenadm` commands on your machine:
 
 ```shell
+$ export IMAGEVECTOR_OVERWRITE=$PWD/example/gardenadm-local/.imagevector-overwrite.yaml
 $ go run ./cmd/gardenadm bootstrap -d ./example/gardenadm-local/medium-touch
 ...
 Command is work in progress

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -45,21 +45,6 @@ func ValidateControllerRegistration(controllerRegistration *core.ControllerRegis
 	return allErrs
 }
 
-// SupportedExtensionKinds contains all supported extension kinds.
-var SupportedExtensionKinds = sets.New(
-	extensionsv1alpha1.BackupBucketResource,
-	extensionsv1alpha1.BackupEntryResource,
-	extensionsv1alpha1.BastionResource,
-	extensionsv1alpha1.ContainerRuntimeResource,
-	extensionsv1alpha1.ControlPlaneResource,
-	extensionsv1alpha1.DNSRecordResource,
-	extensionsv1alpha1.ExtensionResource,
-	extensionsv1alpha1.InfrastructureResource,
-	extensionsv1alpha1.NetworkResource,
-	extensionsv1alpha1.OperatingSystemConfigResource,
-	extensionsv1alpha1.WorkerResource,
-)
-
 // ValidateControllerRegistrationSpec validates the specification of a ControllerRegistration object.
 func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -79,8 +64,8 @@ func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, f
 			allErrs = append(allErrs, field.Required(idxPath.Child("kind"), "field is required"))
 		}
 
-		if !SupportedExtensionKinds.Has(resource.Kind) {
-			allErrs = append(allErrs, field.NotSupported(idxPath.Child("kind"), resource.Kind, SupportedExtensionKinds.UnsortedList()))
+		if !extensionsv1alpha1.AllExtensionKinds.Has(resource.Kind) {
+			allErrs = append(allErrs, field.NotSupported(idxPath.Child("kind"), resource.Kind, extensionsv1alpha1.AllExtensionKinds.UnsortedList()))
 		}
 
 		if len(resource.Type) == 0 {

--- a/pkg/apis/core/validation/controllerregistration_test.go
+++ b/pkg/apis/core/validation/controllerregistration_test.go
@@ -117,8 +117,8 @@ var _ = Describe("validation", func() {
 		})
 
 		It("should allow all known extension kinds", func() {
-			controllerRegistration.Spec.Resources = make([]core.ControllerResource, 0, len(SupportedExtensionKinds))
-			for kind := range SupportedExtensionKinds {
+			controllerRegistration.Spec.Resources = make([]core.ControllerResource, 0, len(extensionsv1alpha1.AllExtensionKinds))
+			for kind := range extensionsv1alpha1.AllExtensionKinds {
 				controllerRegistration.Spec.Resources = append(controllerRegistration.Spec.Resources,
 					core.ControllerResource{
 						Kind: kind,

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -7,8 +7,24 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+// AllExtensionKinds contains all supported extension kinds.
+var AllExtensionKinds = sets.New[string](
+	BackupBucketResource,
+	BackupEntryResource,
+	BastionResource,
+	ContainerRuntimeResource,
+	ControlPlaneResource,
+	DNSRecordResource,
+	ExtensionResource,
+	InfrastructureResource,
+	NetworkResource,
+	OperatingSystemConfigResource,
+	WorkerResource,
 )
 
 // Status is the status of an Object.

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -72,7 +72,7 @@ func NewAutonomousBotanistFromManifests(
 		return nil, fmt.Errorf("failed reading Kubernetes resources from config directory %s: %w", dir, err)
 	}
 
-	extensions, err := ComputeExtensions(shoot, controllerRegistrations, controllerDeployments)
+	extensions, err := ComputeExtensions(shoot, controllerRegistrations, controllerDeployments, runsControlPlane)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing extensions: %w", err)
 	}

--- a/pkg/gardenadm/botanist/botanist_test.go
+++ b/pkg/gardenadm/botanist/botanist_test.go
@@ -40,11 +40,11 @@ var _ = Describe("AutonomousBotanist", func() {
 		})
 
 		It("should fail if the directory does not exist", func() {
-			Expect(NewAutonomousBotanistFromManifests(ctx, log, nil, "does/not/exist")).Error().To(MatchError(fs.ErrNotExist))
+			Expect(NewAutonomousBotanistFromManifests(ctx, log, nil, "does/not/exist", false)).Error().To(MatchError(fs.ErrNotExist))
 		})
 
 		It("should create a new Autonomous Botanist", func() {
-			b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir)
+			b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(b.Shoot.CloudProfile.Name).To(Equal("stackit"))
@@ -54,6 +54,22 @@ var _ = Describe("AutonomousBotanist", func() {
 				HaveField("ControllerRegistration.Name", "provider-stackit"),
 				HaveField("ControllerRegistration.Name", "networking-cilium"),
 			))
+		})
+
+		When("running the control plane (acting on the autonomous shoot cluster)", func() {
+			It("should use kube-system as the control plane namespace", func() {
+				b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(b.Shoot.ControlPlaneNamespace).To(Equal("kube-system"))
+			})
+		})
+
+		When("not running the control plane (acting on the bootstrap cluster)", func() {
+			It("should use the technical ID as the control plane namespace", func() {
+				b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir, false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(b.Shoot.ControlPlaneNamespace).To(Equal("shoot--gardenadm--gardenadm"))
+			})
 		})
 	})
 })

--- a/pkg/gardenadm/botanist/botanist_test.go
+++ b/pkg/gardenadm/botanist/botanist_test.go
@@ -43,20 +43,20 @@ var _ = Describe("AutonomousBotanist", func() {
 			Expect(NewAutonomousBotanistFromManifests(ctx, log, nil, "does/not/exist", false)).Error().To(MatchError(fs.ErrNotExist))
 		})
 
-		It("should create a new Autonomous Botanist", func() {
-			b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir, false)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(b.Shoot.CloudProfile.Name).To(Equal("stackit"))
-			Expect(b.Shoot.GetInfo().Name).To(Equal("gardenadm"))
-			Expect(b.Garden.Project.Name).To(Equal("gardenadm"))
-			Expect(b.Extensions).To(ConsistOf(
-				HaveField("ControllerRegistration.Name", "provider-stackit"),
-				HaveField("ControllerRegistration.Name", "networking-cilium"),
-			))
-		})
-
 		When("running the control plane (acting on the autonomous shoot cluster)", func() {
+			It("should create a new Autonomous Botanist", func() {
+				b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir, true)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(b.Shoot.CloudProfile.Name).To(Equal("stackit"))
+				Expect(b.Shoot.GetInfo().Name).To(Equal("gardenadm"))
+				Expect(b.Garden.Project.Name).To(Equal("gardenadm"))
+				Expect(b.Extensions).To(ConsistOf(
+					HaveField("ControllerRegistration.Name", "provider-stackit"),
+					HaveField("ControllerRegistration.Name", "networking-cilium"),
+				))
+			})
+
 			It("should use kube-system as the control plane namespace", func() {
 				b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir, true)
 				Expect(err).NotTo(HaveOccurred())
@@ -65,6 +65,18 @@ var _ = Describe("AutonomousBotanist", func() {
 		})
 
 		When("not running the control plane (acting on the bootstrap cluster)", func() {
+			It("should create a new Autonomous Botanist", func() {
+				b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(b.Shoot.CloudProfile.Name).To(Equal("stackit"))
+				Expect(b.Shoot.GetInfo().Name).To(Equal("gardenadm"))
+				Expect(b.Garden.Project.Name).To(Equal("gardenadm"))
+				Expect(b.Extensions).To(ConsistOf(
+					HaveField("ControllerRegistration.Name", "provider-stackit"),
+				))
+			})
+
 			It("should use the technical ID as the control plane namespace", func() {
 				b, err := NewAutonomousBotanistFromManifests(ctx, log, nil, configDir, false)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/gardenadm/botanist/system.go
+++ b/pkg/gardenadm/botanist/system.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils"
+)
+
+// DeployPriorityClassCritical deploys the gardener-system-critical PriorityClass needed for running
+// gardener-resource-manager. This is usually deployed to seed clusters via the gardenlet helm chart. When bootstrapping
+// an autonomous shoot cluster with `gardenadm bootstrap` there is no gardenlet. Hence, we need to deploy the
+// PriorityClass for gardener-resource-manager manually, as it is not taken over by the seedsystem component (it uses a
+// ManagedResource for deploying the seed PriorityClasses).
+// Using system-cluster-critical for gardener-resource-manager could also be good enough, but it's very simple to deploy
+// the gardener-system-critical PriorityClass, so we can also choose the cleaner way.
+func (b *AutonomousBotanist) DeployPriorityClassCritical(ctx context.Context) error {
+	priorityClass := &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.PriorityClassNameSeedSystemCritical}}
+	_, err := controllerutils.CreateOrGetAndMergePatch(ctx, b.SeedClientSet.Client(), priorityClass, func() error {
+		priorityClass.Value = int32(999998950)
+		priorityClass.GlobalDefault = false
+		priorityClass.Description = "This class is used to ensure that the gardener-resource-manager has a high priority and is not preempted in favor of other pods."
+		return nil
+	})
+	return err
+}

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -7,6 +7,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,8 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	seedsystem "github.com/gardener/gardener/pkg/component/seed/system"
+	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
+	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
 // NewCommand creates a new cobra.Command.
@@ -71,7 +75,88 @@ func run(ctx context.Context, opts *Options) error {
 		return err
 	}
 
-	_ = b
+	var (
+		g = flow.NewGraph("bootstrap")
+
+		deployNamespace = g.Add(flow.Task{
+			Name: "Deploying control plane namespace",
+			Fn:   b.DeployControlPlaneNamespace,
+		})
+		reconcileCustomResourceDefinitions = g.Add(flow.Task{
+			Name: "Reconciling CustomResourceDefinitions",
+			Fn:   b.ReconcileCustomResourceDefinitions,
+		})
+		ensureCustomResourceDefinitionsReady = g.Add(flow.Task{
+			Name:         "Ensuring CustomResourceDefinitions are ready",
+			Fn:           flow.TaskFn(b.EnsureCustomResourceDefinitionsReady).RetryUntilTimeout(time.Second, time.Minute),
+			Dependencies: flow.NewTaskIDs(reconcileCustomResourceDefinitions),
+		})
+		reconcileClusterResource = g.Add(flow.Task{
+			Name: "Reconciling extensions.gardener.cloud/v1alpha1.Cluster resource",
+			Fn: func(ctx context.Context) error {
+				return gardenerextensions.SyncClusterResourceToSeed(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, b.Shoot.GetInfo(), b.Shoot.CloudProfile, b.Seed.GetInfo())
+			},
+			Dependencies: flow.NewTaskIDs(ensureCustomResourceDefinitionsReady),
+		})
+		initializeSecretsManagement = g.Add(flow.Task{
+			Name:         "Initializing internal state of Gardener secrets manager",
+			Fn:           b.InitializeSecretsManagement,
+			Dependencies: flow.NewTaskIDs(reconcileClusterResource),
+		})
+		deployPriorityClassCritical = g.Add(flow.Task{
+			Name:         "Deploying PriorityClass for gardener-resource-manager",
+			Fn:           b.DeployPriorityClassCritical,
+			Dependencies: flow.NewTaskIDs(deployNamespace, initializeSecretsManagement),
+		})
+		deployGardenerResourceManager = g.Add(flow.Task{
+			Name:         "Deploying gardener-resource-manager",
+			Fn:           b.Shoot.Components.ControlPlane.ResourceManager.Deploy,
+			Dependencies: flow.NewTaskIDs(deployNamespace, initializeSecretsManagement, deployPriorityClassCritical),
+		})
+		waitUntilGardenerResourceManagerReady = g.Add(flow.Task{
+			Name:         "Waiting until gardener-resource-manager reports readiness",
+			Fn:           b.Shoot.Components.ControlPlane.ResourceManager.Wait,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying seed system resources",
+			Fn: func(ctx context.Context) error {
+				return seedsystem.New(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, seedsystem.Values{}).Deploy(ctx)
+			},
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+		})
+		deployExtensionControllers = g.Add(flow.Task{
+			Name: "Deploying extension controllers",
+			Fn: func(ctx context.Context) error {
+				return b.ReconcileExtensionControllerInstallations(ctx, false)
+			},
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+		})
+		waitUntilExtensionControllersReady = g.Add(flow.Task{
+			Name:         "Waiting until extension controllers report readiness",
+			Fn:           b.WaitUntilExtensionControllerInstallationsHealthy,
+			Dependencies: flow.NewTaskIDs(deployExtensionControllers),
+		})
+		deployNetworkPolicies = g.Add(flow.Task{
+			Name:         "Deploying network policies",
+			Fn:           b.ApplyNetworkPolicies,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployExtensionControllers),
+		})
+		syncPointBootstrapped = flow.NewTaskIDs(
+			deployNetworkPolicies,
+			waitUntilGardenerResourceManagerReady,
+			waitUntilExtensionControllersReady,
+		)
+
+		_ = syncPointBootstrapped
+	)
+
+	if err := g.Compile().Run(ctx, flow.Opts{
+		Log: opts.Log,
+	}); err != nil {
+		return flow.Errors(err)
+	}
+
 	opts.Log.Info("Command is work in progress")
 	return nil
 }

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -66,7 +66,7 @@ func run(ctx context.Context, opts *Options) error {
 		return err
 	}
 
-	b, err := botanist.NewAutonomousBotanistFromManifests(ctx, opts.Log, clientSet, opts.ConfigDir)
+	b, err := botanist.NewAutonomousBotanistFromManifests(ctx, opts.Log, clientSet, opts.ConfigDir, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -289,7 +289,7 @@ see https://gardener.cloud/docs/gardener/shoot/shoot_access/.
 }
 
 func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.AutonomousBotanist, error) {
-	b, err := botanist.NewAutonomousBotanistFromManifests(ctx, opts.Log, nil, opts.ConfigDir)
+	b, err := botanist.NewAutonomousBotanistFromManifests(ctx, opts.Log, nil, opts.ConfigDir, true)
 	if err != nil {
 		return nil, err
 	}
@@ -354,5 +354,5 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Autono
 		return nil, flow.Errors(err)
 	}
 
-	return botanist.NewAutonomousBotanistFromManifests(ctx, opts.Log, clientSet, opts.ConfigDir)
+	return botanist.NewAutonomousBotanistFromManifests(ctx, opts.Log, clientSet, opts.ConfigDir, true)
 }

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -116,7 +116,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	gardenNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: r.GardenNamespace}}
 	log.Info("Labeling and annotating namespace", "namespaceName", gardenNamespace.Name)
 	if _, err := controllerutils.CreateOrGetAndMergePatch(ctx, r.SeedClientSet.Client(), gardenNamespace, func() error {
-		metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, "role", v1beta1constants.GardenNamespace)
+		metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, v1beta1constants.LabelRole, v1beta1constants.GardenNamespace)
 
 		// When the seed is the garden cluster then this information is managed by gardener-operator.
 		if !seedIsGarden {

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -32,7 +32,8 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 
 	var (
 		newFunc = shared.NewTargetGardenerResourceManager
-		values  = resourcemanager.Values{
+
+		values = resourcemanager.Values{
 			ClusterIdentity:                           b.Seed.GetInfo().Status.ClusterIdentity,
 			DefaultNotReadyToleration:                 defaultNotReadyTolerationSeconds,
 			DefaultUnreachableToleration:              defaultUnreachableTolerationSeconds,
@@ -56,11 +57,19 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		}
 	)
 
-	if b.Shoot.RunsControlPlane() {
-		newFunc = shared.NewCombinedGardenerResourceManager
-		values.NodeAgentAuthorizerEnabled = false // TODO(rfranzke): Revisit this once autonomous shoot clusters progress.
-		values.TargetNamespaces = nil
-		values.KubernetesServiceHost = nil
+	if b.Shoot.IsAutonomous() {
+		if b.Shoot.RunsControlPlane() {
+			newFunc = shared.NewCombinedGardenerResourceManager
+			values.NodeAgentAuthorizerEnabled = false // TODO(rfranzke): Revisit this once autonomous shoot clusters progress.
+			values.TargetNamespaces = nil
+			values.KubernetesServiceHost = nil
+		} else {
+			newFunc = shared.NewRuntimeGardenerResourceManager
+			// TODO(timebertt): consider disabling the highavailabilityconfig webhook
+			values.PriorityClassName = v1beta1constants.PriorityClassNameSeedSystemCritical
+			values.NodeAgentAuthorizerEnabled = false
+			values.KubernetesServiceHost = nil
+		}
 	}
 
 	return newFunc(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, b.SecretsManager, values)

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -58,17 +58,16 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	)
 
 	if b.Shoot.IsAutonomous() {
+		values.NodeAgentAuthorizerEnabled = false // TODO(rfranzke): Revisit this once autonomous shoot clusters progress.
+		values.KubernetesServiceHost = nil
+
 		if b.Shoot.RunsControlPlane() {
 			newFunc = shared.NewCombinedGardenerResourceManager
-			values.NodeAgentAuthorizerEnabled = false // TODO(rfranzke): Revisit this once autonomous shoot clusters progress.
 			values.TargetNamespaces = nil
-			values.KubernetesServiceHost = nil
 		} else {
 			newFunc = shared.NewRuntimeGardenerResourceManager
 			// TODO(timebertt): consider disabling the highavailabilityconfig webhook
 			values.PriorityClassName = v1beta1constants.PriorityClassNameSeedSystemCritical
-			values.NodeAgentAuthorizerEnabled = false
-			values.KubernetesServiceHost = nil
 		}
 	}
 

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -72,7 +72,7 @@ func (b *Botanist) lastSecretRotationStartTimes() map[string]time.Time {
 
 	if shootStatus := b.Shoot.GetInfo().Status; shootStatus.Credentials != nil && shootStatus.Credentials.Rotation != nil {
 		if shootStatus.Credentials.Rotation.CertificateAuthorities != nil && shootStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime != nil {
-			for _, config := range caCertConfigurations(b.Shoot.IsWorkerless, b.Shoot.RunsControlPlane()) {
+			for _, config := range caCertConfigurations(b.Shoot.IsWorkerless, b.Shoot.IsAutonomous()) {
 				rotation[config.GetName()] = shootStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time
 			}
 			// The static token secret contains token for the health check of the kube-apiserver.
@@ -131,7 +131,7 @@ func (b *Botanist) restoreSecretsFromShootStateForSecretsManagerAdoption(ctx con
 	return flow.Parallel(fns...)(ctx)
 }
 
-func caCertConfigurations(isWorkerless, runsControlPlane bool) []secretsutils.ConfigInterface {
+func caCertConfigurations(isWorkerless, isAutonomous bool) []secretsutils.ConfigInterface {
 	certificateSecretConfigs := []secretsutils.ConfigInterface{
 		// The CommonNames for CA certificates will be overridden with the secret name by the secrets manager when
 		// generated to ensure that each CA has a unique common name. For backwards-compatibility, we still keep the
@@ -150,7 +150,7 @@ func caCertConfigurations(isWorkerless, runsControlPlane bool) []secretsutils.Co
 			&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAMetricsServer, CommonName: "metrics-server", CertType: secretsutils.CACert},
 		)
 
-		if !runsControlPlane {
+		if !isAutonomous {
 			certificateSecretConfigs = append(certificateSecretConfigs,
 				&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAVPN, CommonName: "vpn", CertType: secretsutils.CACert},
 			)
@@ -192,7 +192,7 @@ func (b *Botanist) caCertGenerateOptionsFor(configName string) []secretsmanager.
 func (b *Botanist) generateCertificateAuthorities(ctx context.Context) error {
 	var caClientSecret *corev1.Secret
 
-	for _, config := range caCertConfigurations(b.Shoot.IsWorkerless, b.Shoot.RunsControlPlane()) {
+	for _, config := range caCertConfigurations(b.Shoot.IsWorkerless, b.Shoot.IsAutonomous()) {
 		caSecret, err := b.SecretsManager.Generate(ctx, config, b.caCertGenerateOptionsFor(config.GetName())...)
 		if err != nil {
 			return err

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -662,7 +662,14 @@ func copyUniqueCIDRs(src []string, dst []net.IPNet, networkType string) ([]net.I
 	return dst, nil
 }
 
-// RunsControlPlane returns true in case the Kubernetes control plane runs inside the shoot cluster.
+// IsAutonomous returns true in case of an autonomous shoot cluster.
+func (s *Shoot) IsAutonomous() bool {
+	return v1beta1helper.IsShootAutonomous(s.GetInfo())
+}
+
+// RunsControlPlane returns true in case the Kubernetes control plane runs inside the cluster.
+// In contrast to IsAutonomous, this function returns false when bootstrapping autonomous shoot clusters using
+// `gardenadm bootstrap` (medium-touch scenario).
 func (s *Shoot) RunsControlPlane() bool {
 	return s.ControlPlaneNamespace == metav1.NamespaceSystem
 }

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -265,6 +265,35 @@ var _ = Describe("shoot", func() {
 			})
 		})
 
+		Describe("#IsAutonomous", func() {
+			It("should return true", func() {
+				shoot.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Provider: gardencorev1beta1.Provider{
+							Workers: []gardencorev1beta1.Worker{{
+								Name:         "control-plane",
+								ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+							}},
+						},
+					},
+				})
+				Expect(shoot.IsAutonomous()).To(BeTrue())
+			})
+
+			It("should return false", func() {
+				shoot.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Provider: gardencorev1beta1.Provider{
+							Workers: []gardencorev1beta1.Worker{{
+								Name: "worker",
+							}},
+						},
+					},
+				})
+				Expect(shoot.IsAutonomous()).To(BeFalse())
+			})
+		})
+
 		Describe("#RunsControlPlane", func() {
 			It("should return true", func() {
 				Expect((&Shoot{ControlPlaneNamespace: "kube-system"}).RunsControlPlane()).To(BeTrue())

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -670,12 +670,8 @@ func ComputeRequiredExtensionsForShoot(shoot *gardencorev1beta1.Shoot, seed *gar
 
 	if !v1beta1helper.IsWorkerless(shoot) {
 		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.ControlPlaneResource, shoot.Spec.Provider.Type))
-
-		// TODO(timebertt): in the medium-touch scenario we require Infrastructure and Worker extensions too
-		if !v1beta1helper.IsShootAutonomous(shoot) {
-			requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.InfrastructureResource, shoot.Spec.Provider.Type))
-			requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.WorkerResource, shoot.Spec.Provider.Type))
-		}
+		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.InfrastructureResource, shoot.Spec.Provider.Type))
+		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.WorkerResource, shoot.Spec.Provider.Type))
 
 		if shoot.Spec.Networking != nil && shoot.Spec.Networking.Type != nil {
 			requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.NetworkResource, *shoot.Spec.Networking.Type))

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1286,21 +1286,6 @@ var _ = Describe("Shoot", func() {
 			)))
 		})
 
-		It("should compute the correct list of required extensions (autonomous shoot)", func() {
-			shoot.Spec.Provider.Workers[0].ControlPlane = &gardencorev1beta1.WorkerControlPlane{}
-
-			Expect(ComputeRequiredExtensionsForShoot(shoot, nil, controllerRegistrationList, internalDomain, externalDomain)).To(Equal(sets.New(
-				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-				ExtensionsID(extensionsv1alpha1.NetworkResource, networkingType),
-				ExtensionsID(extensionsv1alpha1.ExtensionResource, extensionType1),
-				ExtensionsID(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-				ExtensionsID(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-				ExtensionsID(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
-				ExtensionsID(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
-				ExtensionsID(extensionsv1alpha1.ExtensionResource, extensionType2),
-			)))
-		})
-
 		It("should compute the correct list of required extensions (workerless Shoot and globally enabled extension)", func() {
 			shoot.Spec.Extensions = []gardencorev1beta1.Extension{}
 			shoot.Spec.Provider.Workers = nil

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -18,10 +18,10 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 	}, NodeTimeout(time.Minute))
 
 	Describe("Prepare infrastructure and machines", Ordered, func() {
-		It("should bootstrap the machine pods", func(SpecContext) {
-			Eventually(RunAndWait(
+		It("should bootstrap the machine pods", func(ctx SpecContext) {
+			Eventually(RunAndWait(ctx,
 				"bootstrap", "-d", "../../../example/gardenadm-local/medium-touch",
 			).Err).Should(gbytes.Say("work in progress"))
-		}, SpecTimeout(time.Minute))
+		}, SpecTimeout(2*time.Minute))
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR continues https://github.com/gardener/gardener/pull/12041 and deploys both gardener-resource-manager and the provider extension in `gardenadm bootstrap`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

Although gardener-resource-manager runs in the control plane namespace (`shoot--project--name`), it is configured like the runtime/seed resource manager in the garden namespace.
Furthermore, the `ManagedResources` of extensions are deployed into the control plane namespace.

This deployment mode makes cleanup very simple. Even though we probably don't want to automate this in `gardenadm`, it helps with development. Instead of recreating the kind cluster, you can reset the state using (orphans global resources like CRDs though):
```
k -n shoot--garden--root delete mr --all && k delete ns shoot--garden--root extension-provider-local
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
