### PR TITLE
Extend Dual-Stack Migration Documentation to Mention Overlay Network Removal as Precondition.

### DIFF
--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -26,7 +26,7 @@ Gardener supports multiple different network configurations, including running w
 
 At the moment, this only affects IPv4-only clusters, which should be migrated to dual-stack networking. IPv6-only clusters always use native routing.
 
-You can check whether you cluster uses overlay network or native routing by looking for `spec.networking.providerConfig.overlay.enabled` in your cluster's manifest. If it is set to `true` or not present, the cluster is using the pod overlay network. If it is set to `false`, the cluster is using native routing.
+You can check whether your cluster uses overlay network or native routing by looking for `spec.networking.providerConfig.overlay.enabled` in your cluster's manifest. If it is set to `true` or not present, the cluster is using the pod overlay network. If it is set to `false`, the cluster is using native routing.
 
 Please note that there are infrastructure-specific limitations with regards to cluster size due to one route being added per node. Therefore, please consult the documentation of your infrastructure if your cluster should grow beyond 50 nodes and adapt the route limit quotas accordingly before switching to native routing.
 

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -20,6 +20,28 @@ Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protoco
 - Adding a new protocol is only allowed as the second element in the array, ensuring the primary protocol remains unchanged.
 - Migration involves multiple reconciliation runs to ensure a smooth transition without disruptions.
 
+## Preconditions
+
+Gardener supports multiple different network configurations, including running with pod overlay network or native routing. Currently, there is only native routing as supported operating mode for dual-stack networking in Gardener. This means that the pod overlay network needs to be disabled before starting the dual-stack migration. Otherwise, pod-to-pod cross-node communication may not work as expected after the migration.
+
+At the moment, this only affects IPv4-only clusters, which should be migrated to dual-stack networking. IPv6-only clusters always use native routing.
+
+You can check whether you cluster uses overlay network or native routing by looking for `spec.networking.providerConfig.overlay.enabled` in your cluster's manifest. If it is set to `true` or not present, the cluster is using the pod overlay network. If it is set to `false`, the cluster is using native routing.
+
+Please note that there are infrastructure-specific limitations with regards to cluster size due to one route being added per node. Therefore, please consult the documentation of your infrastructure if your cluster should grow beyond 50 nodes and adapt the route limit quotas accordingly before switching to native routing.
+
+To disable the pod overlay network and thereby switch to native routing, adjust your cluster specification as follows:
+
+```yaml
+spec:
+  ...
+  networking:
+    providerConfig:
+      overlay:
+        enabled: false
+  ...
+```
+
 ## Migration Process
 
 ### Step 1: Update Networking Configuration


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area documentation
/kind enhancement

**What this PR does / why we need it**:

Extend Dual-Stack Migration Documentation to Mention Overlay Network Removal as Precondition.

At the moment, dual-stack networking in Gardener is expected to work only with native routing. Therefore, a cluster needs to be in native routing mode before triggering the dual-stack migration. This change extends the documentation so that this is more obvious.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Dual-Stack Migration documentation now clearly states the precondition of overlay removal.
```

/cc @axel7born @DockToFuture 