### PR TITLE
Set minAllowed CPU for prometheus-shoot to avoid frequent evictions

### DIFF
--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -93,7 +93,7 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		RetentionSize:       "15GB",
 		RestrictToNamespace: true,
 		ResourceRequests: &corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceCPU:    resource.MustParse("150m"),
 			corev1.ResourceMemory: resource.MustParse("400M"),
 		},
 		AdditionalPodLabels: map[string]string{
@@ -119,6 +119,10 @@ func (b *Botanist) DefaultPrometheus() (prometheus.Interface, error) {
 		TargetCluster: &prometheus.TargetClusterValues{
 			ServiceAccountName: shootprometheus.ServiceAccountName,
 			ScrapesMetrics:     true,
+		},
+		VPAMinAllowed: &corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("150m"),
+			corev1.ResourceMemory: resource.MustParse("100M"),
 		},
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR sets a `minAllowed` CPU value for prometheus-shoot to `150mCores`. We have seen way too frequent evictions on the `prometheus-shoot` instances for very small absolute CPU values (e.g ~20 changes in 24 hours for moving between `70mCores` and `130mCores` in intermediate steps of `~20mCores` and back again).

We want to address this upstream by adjusting how the vpa computes the upper and lower bounds around the `target` recommendation. In theory, this is the mechanism that should take care of not evicting for very small changes. In practice, however, the `lowerBound` and `upperBound` are way too close to the `target`, sometimes even identical.

So this is a temporary fix to spend more resources in order to avoid too frequent evictions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The PR also adds `100M` for memory to the `minAllowed` structure, in order to keep the existing behavior. Currently, no values are defined for `VPAMinAllowed`, [therefore it is defaulted to `memory: 100M`](https://github.com/gardener/gardener/blob/30a37320badd4a8190b26f1271411e36fcaaef0d/pkg/component/observability/monitoring/prometheus/vpa.go#L42-L44).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set minAllowed CPU to `150m` for prometheus-shoot to avoid frequent evictions
```
