### PR TITLE
[GEP-31] Support inplace update for shoot with OSC version `1`

### DIFF
--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -130,7 +130,8 @@ func WorkerPoolHashV1(pool extensionsv1alpha1.WorkerPool, cluster *extensionscon
 		}
 	}
 
-	if pool.ProviderConfig != nil && pool.ProviderConfig.Raw != nil {
+	// In the case of an in-place update, the following data is omitted here and added on the provider extension side.
+	if !v1beta1helper.IsUpdateStrategyInPlace(pool.UpdateStrategy) && pool.ProviderConfig != nil && pool.ProviderConfig.Raw != nil {
 		data = append(data, string(pool.ProviderConfig.Raw))
 	}
 

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -244,7 +244,7 @@ var _ = Describe("health check", func() {
 			nodeName                   = "node1"
 			oscSecretMeta              = map[string]metav1.ObjectMeta{
 				workerPoolName1: {
-					Name:        operatingsystemconfig.KeyV1(workerPoolName1, kubernetesVersion, nil),
+					Name:        operatingsystemconfig.KeyV1(workerPoolName1, false, kubernetesVersion, nil),
 					Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
 					Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
 				},
@@ -393,7 +393,7 @@ var _ = Describe("health check", func() {
 				},
 				map[string]metav1.ObjectMeta{
 					workerPoolName1: {
-						Name:        operatingsystemconfig.KeyV1(workerPoolName1, kubernetesVersion, nil),
+						Name:        operatingsystemconfig.KeyV1(workerPoolName1, false, kubernetesVersion, nil),
 						Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
 						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
 					},
@@ -413,7 +413,7 @@ var _ = Describe("health check", func() {
 				},
 				map[string]metav1.ObjectMeta{
 					workerPoolName1: {
-						Name:        operatingsystemconfig.KeyV1(workerPoolName1, kubernetesVersion, nil),
+						Name:        operatingsystemconfig.KeyV1(workerPoolName1, false, kubernetesVersion, nil),
 						Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
 						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
 					},

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -224,11 +224,11 @@ var _ = Describe("operatingsystemconfig", func() {
 			namespace = "shoot--foo--bar"
 
 			worker1Name = "worker1"
-			worker1Key  = operatingsystemconfig.KeyV1(worker1Name, semver.MustParse(kubernetesVersion), nil)
+			worker1Key  = operatingsystemconfig.KeyV1(worker1Name, false, semver.MustParse(kubernetesVersion), nil)
 
 			worker2Name                  = "worker2"
 			worker2KubernetesVersion     = "4.5.6"
-			worker2Key                   = operatingsystemconfig.KeyV1(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
+			worker2Key                   = operatingsystemconfig.KeyV1(worker2Name, false, semver.MustParse(worker2KubernetesVersion), nil)
 			worker2KubeletDataVolumeName = "vol"
 
 			workerNameToOperatingSystemConfigMaps = map[string]*operatingsystemconfig.OperatingSystemConfigs{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane delivery open-source scalability
/kind enhancement

**What this PR does / why we need it**:
When `NewWorkerPoolHash` feature gate is set to false, shoots are created with OSC version 1, This PR makes the necessary change so the shoots with OSCs version `1` can also be updated inplace.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
