### PR TITLE
Drop annotations and labels for referenced resources

### DIFF
--- a/pkg/gardenlet/operation/botanist/resources_test.go
+++ b/pkg/gardenlet/operation/botanist/resources_test.go
@@ -142,10 +142,8 @@ var _ = Describe("Resources", func() {
 			expectReferencedResourcesInSeed(
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "ref-" + resource.Name,
-						Namespace:   controlPlaneNamespace,
-						Labels:      resource.Labels,
-						Annotations: resource.Annotations,
+						Name:      "ref-" + resource.Name,
+						Namespace: controlPlaneNamespace,
 					},
 					Type: resource.Type,
 					Data: resource.Data,

--- a/pkg/utils/gardener/resources.go
+++ b/pkg/utils/gardener/resources.go
@@ -37,13 +37,9 @@ func PrepareReferencedResourcesForSeedCopy(ctx context.Context, cl client.Client
 		unstructuredObj.SetNamespace(targetNamespace)
 		unstructuredObj.SetName(v1beta1constants.ReferencedResourcesPrefix + unstructuredObj.GetName())
 
-		// Drop unwanted annotations before copying the resource to the seed.
-		// All annotations contained in the ManagedResource secret will end up in `ManagedResource.status.resources[].annotations`.
-		// We don't want this to happen for the last applied annotation of secrets, which includes the secret data in plain
-		// text. This would put sensitive secret data into the ManagedResource object which is probably unencrypted in etcd.
-		annotations := unstructuredObj.GetAnnotations()
-		delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
-		unstructuredObj.SetAnnotations(annotations)
+		// We don't want to keep user-defined annotations or labels when copying the resource to the seed.
+		unstructuredObj.SetAnnotations(nil)
+		unstructuredObj.SetLabels(nil)
 
 		unstructuredObjs = append(unstructuredObjs, unstructuredObj)
 	}

--- a/pkg/utils/gardener/resources_test.go
+++ b/pkg/utils/gardener/resources_test.go
@@ -7,7 +7,6 @@ package gardener_test
 import (
 	"context"
 	"encoding/base64"
-	"maps"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -107,13 +106,10 @@ var _ = Describe("Resources", func() {
 
 			for _, unstructuredObj := range unstructuredObjs {
 				Expect(unstructuredObj.GetNamespace()).To(Equal(targetNamespace), unstructuredObj.GetName()+" should have target namespace "+targetNamespace)
-				Expect(unstructuredObj.GetLabels()).To(Equal(secret.Labels), unstructuredObj.GetName()+" should have no finalizers")
+				Expect(unstructuredObj.GetAnnotations()).To(BeEmpty(), unstructuredObj.GetName()+" should have no annotations")
+				Expect(unstructuredObj.GetLabels()).To(BeEmpty(), unstructuredObj.GetName()+" should have no labels")
 				Expect(unstructuredObj.GetFinalizers()).To(BeEmpty(), unstructuredObj.GetName()+" should have no finalizers")
 				Expect(unstructuredObj.Object).To(HaveKey("data"), unstructuredObj.GetName()+" should have data field")
-
-				expectedAnnotations := maps.Clone(annotations)
-				delete(expectedAnnotations, "kubectl.kubernetes.io/last-applied-configuration")
-				Expect(unstructuredObj.GetAnnotations()).To(Equal(expectedAnnotations), unstructuredObj.GetName()+" should have no annotations")
 
 				switch unstructuredObj.GetKind() {
 				case "Secret":


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind cleanup

**What this PR does / why we need it**:
Instead of only removing the `kubectl.kubernetes.io/last-applied-configuration` annotation, we can simply ignore all labels and annotations from the source object.

Fixes https://github.com/gardener/gardener/issues/12136

**Special notes for your reviewer**:
/cc @ScheererJ @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Annotations and labels are now ignored when creating referenced resources in the shoot control plane namespaces in seed clusters.
```
