### PR TITLE
Remove sum for VPA Pod metrics in 'recommendations' dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-dashboard.json
@@ -148,7 +148,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\",pod=~\"(?i:$targetKind-)?$targetName(.+)\", container=~\"$container\"}) by (pod)",
+          "expr": "container_memory_working_set_bytes{namespace=~\"$namespace\",pod=~\"(?i:$targetKind-)?$targetName(.+)\", container=~\"$container\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -158,7 +158,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -168,7 +168,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -178,7 +178,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -188,7 +188,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_minallowed_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_minallowed_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -198,7 +198,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -307,7 +307,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_requests{namespace=~\"$namespace\",resource=\"memory\", unit=\"byte\", pod=~\"(?i:$targetKind-)?$targetName(.+)\",  container=~\"$container\"}) by (pod)",
+          "expr": "kube_pod_container_resource_requests{namespace=~\"$namespace\",resource=\"memory\", unit=\"byte\", pod=~\"(?i:$targetKind-)?$targetName(.+)\",  container=~\"$container\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -316,7 +316,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_limits{namespace=~\"$namespace\",resource=\"memory\", unit=\"byte\", pod=~\"(?i:$targetKind-)?$targetName(.+)\",  container=~\"$container\"})  by (pod)",
+          "expr": "kube_pod_container_resource_limits{namespace=~\"$namespace\",resource=\"memory\", unit=\"byte\", pod=~\"(?i:$targetKind-)?$targetName(.+)\",  container=~\"$container\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -325,7 +325,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_memory{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -448,7 +448,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -458,7 +458,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -468,7 +468,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -478,7 +478,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_minallowed_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_minallowed_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -488,7 +488,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container|\\\\*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -596,7 +596,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"(?i:$targetKind-)?$targetName(.+)\",  container=~\"$container\"}) by (pod)",
+          "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"(?i:$targetKind-)?$targetName(.+)\",  container=~\"$container\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -605,7 +605,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"(?i:$targetKind-)?$targetName(.+)\",  container=~\"$container\"}) by (pod)",
+          "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"(?i:$targetKind-)?$targetName(.+)\",  container=~\"$container\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -614,7 +614,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"})",
+          "expr": "kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu{namespace=~\"$namespace\", target_kind=~\"$targetKind\", target_name=~\"$targetName\", container=~\"$container\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/area autoscaling
/kind bug

**What this PR does / why we need it**:
Remove the `sum` statements from the VPA Pod metrics and display the individual Pods instead. This gets a little bit more messy for things like the `requests`, as you don't end up with a connected graph, but with several, discrete sections. But, it also is more accurate, even when other issues exist with metrics scraping or label configuration.

Previously, we saw sometimes a bit misleading graphs like this, showing small spikes of _twice_ the actual memory requests. This is due to the fact that when a Pod was evicted and a new one was created, there was a temporary state in which you were seeing data for two Pods, which got summed up. For `prometheus` the `Pod` identifier is always `prometheus-shoot-0`, therefore we have this effect. 
<img width="1190" alt="Screenshot 2025-05-13 at 09 03 03" src="https://github.com/user-attachments/assets/1b08a261-c815-4ba4-82bb-47380e3fb243" />

In other cases, the data showed the sum of the `target` recommendation, because we had two data points with different `origins` (e.g. `shoot` and `seed`)

<img width="2147" alt="Screenshot 2025-05-13 at 09 17 01" src="https://github.com/user-attachments/assets/12f1b10a-0f01-41fb-83c4-e34e332f12fb" />

All these issues can be solved by adjusting things in the dashboard, like switching to UID `sum` (if you want to keep a `sum` statement) and ensuring that we don't record the same things twice from the `seed` and `shoot` perspective – however, if we keep the `sum` statements, we don't even see this, but rather get confused with values which don't match with reality.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove sum for VPA Pod metrics in 'recommendations' dashboard
```
