### PR TITLE
Remove custom cleanup logic of old MachineSets in worker controller

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -146,25 +146,6 @@ func (a *genericActuator) cleanupMachineClassSecrets(ctx context.Context, logger
 	return nil
 }
 
-// cleanupMachineSets deletes MachineSets having number of desired and actual replicas equaling 0
-func (a *genericActuator) cleanupMachineSets(ctx context.Context, logger logr.Logger, namespace string) error {
-	logger.Info("Cleaning up machine sets")
-	machineSetList := &machinev1alpha1.MachineSetList{}
-	if err := a.seedClient.List(ctx, machineSetList, client.InNamespace(namespace)); err != nil {
-		return err
-	}
-
-	for _, machineSet := range machineSetList.Items {
-		if machineSet.Spec.Replicas == 0 && machineSet.Status.Replicas == 0 {
-			logger.Info("Deleting MachineSet as the number of desired and actual replicas is 0", "machineSet", &machineSet)
-			if err := a.seedClient.Delete(ctx, machineSet.DeepCopy()); client.IgnoreNotFound(err) != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // IsMachineControllerStuck determines if the machine controller pod is stuck.
 func (a *genericActuator) IsMachineControllerStuck(ctx context.Context, worker *extensionsv1alpha1.Worker) (bool, *string, error) {
 	machineDeployments := &machinev1alpha1.MachineDeploymentList{}

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -248,9 +248,10 @@ func deployMachineDeployments(
 				metav1.SetMetaDataAnnotation(&machineDeployment.ObjectMeta, k, v)
 			}
 			machineDeployment.Spec = machinev1alpha1.MachineDeploymentSpec{
-				Replicas:        replicas,
-				MinReadySeconds: 500,
-				Strategy:        deployment.Strategy,
+				Replicas:             replicas,
+				RevisionHistoryLimit: ptr.To[int32](0),
+				MinReadySeconds:      500,
+				Strategy:             deployment.Strategy,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -158,11 +158,6 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 		}
 	}
 
-	// Delete MachineSets having number of desired and actual replicas equaling 0
-	if err := a.cleanupMachineSets(ctx, log, worker.Namespace); err != nil {
-		return fmt.Errorf("failed to cleanup the machine sets: %w", err)
-	}
-
 	// Scale down machine-controller-manager if shoot is hibernated.
 	if isHibernationEnabled {
 		if err := scaleMachineControllerManager(ctx, log, a.seedClient, worker, 0); err != nil {

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"html/template"
 
+	machinecontroller "github.com/gardener/machine-controller-manager/pkg/util/provider/machinecontroller"
 	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -70,12 +71,7 @@ WantedBy=multi-user.target`),
 				Permissions: ptr.To[uint32](0640),
 				Content: extensionsv1alpha1.FileContent{
 					Inline: &extensionsv1alpha1.FileContentInline{
-						// The bootstrap token will be created by the machine-controller-manager when creating an actual
-						// machine, and it will replace this "magic" string with the actual token in the user data. See
-						// https://github.com/gardener/gardener/blob/master/docs/extensions/resources/operatingsystemconfig.md#bootstrap-tokens
-						// for more details.
-						// TODO(oliver-goetz): Replace string with constant when machine-controller-manager v0.55.0 is released.
-						Data: "<<BOOTSTRAP_TOKEN>>",
+						Data: machinecontroller.BootstrapTokenPlaceholder,
 					},
 					TransmitUnencoded: ptr.To(true),
 				},
@@ -100,11 +96,7 @@ WantedBy=multi-user.target`),
 				Permissions: ptr.To[uint32](0640),
 				Content: extensionsv1alpha1.FileContent{
 					Inline: &extensionsv1alpha1.FileContentInline{
-						// The machine name will be created by the machine-controller-manager when creating an actual
-						// machine, and it will replace this "magic" string with the machine name in the user data.
-						// This works similar to the replacement of <<BOOTSTRAP_TOKEN>>.
-						// TODO(oliver-goetz): Replace string with constant when machine-controller-manager v0.55.0 is released.
-						Data: "<<MACHINE_NAME>>",
+						Data: machinecontroller.MachineNamePlaceholder,
 					},
 					TransmitUnencoded: ptr.To(true),
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement cleanup

**What this PR does / why we need it**:
The PR removes the custom cleanup logic of old MachineSets in the worker controller in favor of MCM cleaning it based on `RevisionHistoryLimit`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11936

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
