### PR TITLE
Delay check for SNI secret during `Garden` reconciliation

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -313,7 +313,7 @@ var _ = Describe("#SNI", func() {
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver", Namespace: namespace}})).To(Succeed())
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-current", Namespace: namespace}})).To(Succeed())
 
-		defaultDepWaiter = NewSNI(c, v1beta1constants.DeploymentNameKubeAPIServer, namespace, sm, func() *SNIValues {
+		defaultDepWaiter = NewSNI(c, v1beta1constants.DeploymentNameKubeAPIServer, namespace, sm, func() (*SNIValues, error) {
 			val := &SNIValues{
 				Hosts:          hosts,
 				APIServerProxy: apiServerProxyValues,
@@ -324,7 +324,7 @@ var _ = Describe("#SNI", func() {
 				IstioTLSTermination:   istioTLSTermination,
 				WildcardConfiguration: wildcardConfiguration,
 			}
-			return val
+			return val, nil
 		})
 	})
 

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -76,7 +76,7 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 		v1beta1constants.DeploymentNameKubeAPIServer,
 		b.Shoot.ControlPlaneNamespace,
 		b.SecretsManager,
-		func() *kubeapiserverexposure.SNIValues {
+		func() (*kubeapiserverexposure.SNIValues, error) {
 			var wildcardConfiguration *kubeapiserverexposure.WildcardConfiguration
 
 			if b.ControlPlaneWildcardCert != nil {
@@ -102,7 +102,7 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 				},
 				IstioTLSTermination:   features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
 				WildcardConfiguration: wildcardConfiguration,
-			}
+			}, nil
 		},
 	))
 }
@@ -137,7 +137,7 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 		v1beta1constants.DeploymentNameKubeAPIServer,
 		b.Shoot.ControlPlaneNamespace,
 		b.SecretsManager,
-		func() *kubeapiserverexposure.SNIValues {
+		func() (*kubeapiserverexposure.SNIValues, error) {
 			var wildcardConfiguration *kubeapiserverexposure.WildcardConfiguration
 
 			if b.ControlPlaneWildcardCert != nil {
@@ -173,7 +173,7 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 				WildcardConfiguration: wildcardConfiguration,
 			}
 
-			return values
+			return values, nil
 		},
 	)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
If the `Garden` resources specifies a `SNI` section for the `virtual-garden-kube-apiserver`, its reconciliation fails very early if the SNI TLS secret is missing.
If the SNI TLS secret should be provided by an extension, bootstrapping is not working as expected, as the extension resources are not deployed during this early failing reconciliation.
With this change, the check for the existence of the SNI secret is moved from component initialisation to the execution of the task `"Deploying Kubernetes API server service SNI"`. The reconciliation still fails as it should, but the task `"Deploying extension resources"` is running, too.
Additionally, the task `"Deploying Kubernetes API Server"` ignores the SNI configuration if the SNI TLS secret is not existing. This prevents the deployment of the virtual-garden-kube-apiserver from being blocked due to a missing secret.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The SNI TLS secret check for the virtual-garden-kube-apiserver has been moved to the `"Deploying Kubernetes API server service SNI"` task, allowing extension resources to be deployed even if the secret is missing. This change prevents deployment blockage while ensuring reconciliation fails as expected if the secret is absent.
```
