### PR TITLE
Ensure extension admission webhooks validated `WorkloadIdentity`s and `Secret`s when used

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/mutatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/mutatingwebhook-admission-controller.yaml
@@ -3,5 +3,33 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: gardener-admission-controller
-webhooks: []
+webhooks:
+- name: sync-provider-secret-labels.gardener.cloud
+  admissionReviewVersions: ["v1", "v1beta1"]
+  timeoutSeconds: 10
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+  failurePolicy: Fail
+  namespaceSelector:
+    matchExpressions:
+    - {key: gardener.cloud/role, operator: In, values: [project]}
+  clientConfig:
+    {{- if .Values.global.deployment.virtualGarden.enabled }}
+    url: https://gardener-admission-controller.garden/webhooks/sync-provider-secret-labels
+    {{- else }}
+    service:
+      namespace: garden
+      name: gardener-admission-controller
+      path: /webhooks/sync-provider-secret-labels
+    {{- end }}
+    caBundle: {{ required ".Values.global.admission.config.server.webhooks.tls.caBundle is required" (b64enc .Values.global.admission.config.server.webhooks.tls.caBundle) }}
+  sideEffects: None
 {{- end }}

--- a/cmd/gardener-extension-admission-local/app/app.go
+++ b/cmd/gardener-extension-admission-local/app/app.go
@@ -26,8 +26,9 @@ import (
 	extensionscmdcontroller "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionscmdwebhook "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
-	"github.com/gardener/gardener/pkg/apis/core/install"
+	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	securityinstall "github.com/gardener/gardener/pkg/apis/security/install"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	admissioncmd "github.com/gardener/gardener/pkg/provider-local/admission/cmd"
 	localinstall "github.com/gardener/gardener/pkg/provider-local/apis/local/install"
@@ -123,7 +124,8 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not instantiate manager: %w", err)
 			}
 
-			install.Install(mgr.GetScheme())
+			gardencoreinstall.Install(mgr.GetScheme())
+			securityinstall.Install(mgr.GetScheme())
 
 			if err := localinstall.AddToScheme(mgr.GetScheme()); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -74,6 +74,15 @@ _(enabled by default)_
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `NamespacedCloudProfile`s, `Seed`s, `SecretBinding`s, `CredentialsBinding`s, `WorkloadIdentity`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
 
+## `FinalizerRemoval`
+
+_(enabled by default)_
+
+This admission controller reacts on `UPDATE` operations for `CredentialsBinding`s, `SecretBinding`s, `Shoot`s. 
+It ensures that the finalizers of these resources are not removed by users, as long as the affected resource is still in use.
+For `CredentialsBinding`s and `SecretBinding`s this means, that the `gardener` finalizer can only be removed if the binding is not referenced by any `Shoot`.
+In case of `Shoot`s, the `gardener` finalizer can only be removed if the last operation of the `Shoot` indicates a successful deletion. 
+
 ## `ProjectValidator`
 
 _(enabled by default)_

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -87,10 +87,14 @@ In case of `Shoot`s, the `gardener` finalizer can only be removed if the last op
 
 _(enabled by default)_
 
-This admission controller reacts on `CREATE` operations for `Project`s.
+This admission controller reacts on `CREATE` and `UPDATE` operations for `Project`s.
 It prevents creating `Project`s with a non-empty `.spec.namespace` if the value in `.spec.namespace` does not start with `garden-`.
 
-⚠️ This admission plugin will be removed in a future release and its business logic will be incorporated into the static validation of the `gardener-apiserver`.
+In addition, the project specification is initialized during creation:
+- `.spec.createdBy` is set to the user creating the project.
+- `.spec.owner` defaults to the value of `.spec.createdBy` if it is not specified.
+
+During subsequent updates, it ensures that the project owner is included in the `.spec.members` list.
 
 ## `ResourceQuota`
 
@@ -105,11 +109,9 @@ _(enabled by default)_
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `CloudProfile`s, `Project`s, `SecretBinding`s, `Seed`s, and `Shoot`s.
 Generally, it checks whether referred resources stated in the specifications of these objects exist in the system (e.g., if a referenced `Secret` exists).
-However, it also has some special behaviours for certain resources:
 
+However, it also has some special behaviours for certain resources:
 * `CloudProfile`s: It rejects removing Kubernetes or machine image versions if there is at least one `Shoot` that refers to them.
-* `Project`s: It sets the `.spec.createdBy` field for newly created `Project` resources, and defaults the `.spec.owner` field in case it is empty (to the same value of `.spec.createdBy`).
-* `Shoot`s: It sets the `gardener.cloud/created-by=<username>` annotation for newly created `Shoot` resources.
 
 ## `SeedValidator`
 
@@ -196,7 +198,7 @@ _(enabled by default)_
 This admission controller reacts on `CREATE`, `UPDATE` and `DELETE` operations for `Shoot`s.
 It validates certain configurations in the specification against the referred `CloudProfile` (e.g., machine images, machine types, used Kubernetes version, ...).
 Generally, it performs validations that cannot be handled by the static API validation due to their dynamic nature (e.g., when something needs to be checked against referred resources).
-Additionally, it takes over certain defaulting tasks (e.g., default machine image for worker pools, default Kubernetes version).
+Additionally, it takes over certain defaulting tasks (e.g., default machine image for worker pools, default Kubernetes version) and setting the `gardener.cloud/created-by=<username>` annotation for newly created `Shoot` resources.
 
 ## `ShootManagedSeed`
 

--- a/pkg/admissioncontroller/webhook/add.go
+++ b/pkg/admissioncontroller/webhook/add.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/internaldomainsecret"
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/kubeconfigsecret"
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/namespacedeletion"
+	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/providersecretlabels"
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/resourcesize"
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/seedrestriction"
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/shootkubeconfigsecretref"
@@ -63,6 +64,13 @@ func AddToManager(
 		Client:    mgr.GetClient(),
 	}).AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed adding %s webhook handler: %w", namespacedeletion.HandlerName, err)
+	}
+
+	if err := (&providersecretlabels.Handler{
+		Logger: mgr.GetLogger().WithName("webhook").WithName(providersecretlabels.HandlerName),
+		Client: mgr.GetClient(),
+	}).AddToManager(mgr); err != nil {
+		return fmt.Errorf("failed adding %s webhook handler: %w", providersecretlabels.HandlerName, err)
 	}
 
 	if err := (&resourcesize.Handler{

--- a/pkg/admissioncontroller/webhook/admission/providersecretlabels/add.go
+++ b/pkg/admissioncontroller/webhook/admission/providersecretlabels/add.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providersecretlabels
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	// HandlerName is the name of this admission webhook handler.
+	HandlerName = "sync-provider-secret-labels"
+	// WebhookPath is the HTTP handler path for this admission webhook handler.
+	WebhookPath = "/webhooks/sync-provider-secret-labels"
+)
+
+// AddToManager adds Handler to the given manager.
+func (h *Handler) AddToManager(mgr manager.Manager) error {
+	webhook := admission.
+		WithCustomDefaulter(mgr.GetScheme(), &corev1.Secret{}, h).
+		WithRecoverPanic(true)
+
+	mgr.GetWebhookServer().Register(WebhookPath, webhook)
+	return nil
+}

--- a/pkg/admissioncontroller/webhook/admission/providersecretlabels/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/providersecretlabels/handler.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providersecretlabels
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+)
+
+// Handler syncs the provider labels on Secrets referenced in SecretBindings or CredentialsBindings.
+type Handler struct {
+	Logger logr.Logger
+	Client client.Client
+}
+
+// Default syncs the provider labels.
+func (h *Handler) Default(ctx context.Context, obj runtime.Object) error {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return fmt.Errorf("expected secret but got %T", obj)
+	}
+
+	typesFromSecretBindings, err := h.fetchProviderTypesFromSecretBindings(ctx, secret)
+	if err != nil {
+		return fmt.Errorf("failed fetching provider types from SecretBindings: %w", err)
+	}
+
+	typesFromCredentialsBindings, err := h.fetchProviderTypesFromCredentialsBindings(ctx, secret)
+	if err != nil {
+		return fmt.Errorf("failed fetching provider types from CredentialsBindings: %w", err)
+	}
+
+	if len(typesFromSecretBindings)+len(typesFromCredentialsBindings) > 0 {
+		maintainLabels(secret, sets.New(typesFromSecretBindings...).Insert(typesFromCredentialsBindings...).UnsortedList()...)
+	}
+
+	return nil
+}
+
+func (h *Handler) fetchProviderTypesFromSecretBindings(ctx context.Context, secret *corev1.Secret) ([]string, error) {
+	secretBindingList := &gardencorev1beta1.SecretBindingList{}
+	if err := h.Client.List(ctx, secretBindingList); err != nil {
+		return nil, fmt.Errorf("failed to list SecretBindings: %w", err)
+	}
+
+	var providerTypes []string
+	for _, secretBinding := range secretBindingList.Items {
+		if secretBinding.SecretRef.Name == secret.Name &&
+			secretBinding.SecretRef.Namespace == secret.Namespace {
+			providerTypes = append(providerTypes, v1beta1helper.GetSecretBindingTypes(&secretBinding)...)
+		}
+	}
+	return providerTypes, nil
+}
+
+func (h *Handler) fetchProviderTypesFromCredentialsBindings(ctx context.Context, secret *corev1.Secret) ([]string, error) {
+	credentialsBindingList := &securityv1alpha1.CredentialsBindingList{}
+	if err := h.Client.List(ctx, credentialsBindingList); err != nil {
+		return nil, fmt.Errorf("failed to list CredentialsBindings: %w", err)
+	}
+
+	var providerTypes []string
+	for _, credentialsBinding := range credentialsBindingList.Items {
+		if credentialsBinding.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() &&
+			credentialsBinding.CredentialsRef.Kind == "Secret" &&
+			credentialsBinding.CredentialsRef.Name == secret.Name &&
+			credentialsBinding.CredentialsRef.Namespace == secret.Namespace {
+			providerTypes = append(providerTypes, credentialsBinding.Provider.Type)
+		}
+	}
+	return providerTypes, nil
+}
+
+func maintainLabels(secret *corev1.Secret, providerTypes ...string) {
+	for k := range secret.Labels {
+		if strings.HasPrefix(k, v1beta1constants.LabelShootProviderPrefix) {
+			delete(secret.Labels, k)
+		}
+	}
+
+	for _, providerType := range providerTypes {
+		metav1.SetMetaDataLabel(&secret.ObjectMeta, v1beta1constants.LabelShootProviderPrefix+providerType, "true")
+	}
+}

--- a/pkg/admissioncontroller/webhook/admission/providersecretlabels/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/providersecretlabels/handler_test.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providersecretlabels_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/providersecretlabels"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+)
+
+var _ = Describe("handler", func() {
+	var (
+		ctx context.Context
+
+		log        logr.Logger
+		fakeClient client.Client
+		handler    *Handler
+
+		namespace            string
+		provider1, provider2 string
+		secret               *corev1.Secret
+		secretBinding        *gardencorev1beta1.SecretBinding
+		credentialsBinding   *securityv1alpha1.CredentialsBinding
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		handler = &Handler{
+			Logger: log,
+			Client: fakeClient,
+		}
+
+		namespace = "test"
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: namespace,
+			},
+		}
+
+		provider1 = "provider1"
+		provider2 = "provider2"
+
+		secretBinding = &gardencorev1beta1.SecretBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret-binding",
+				Namespace: namespace,
+			},
+			SecretRef: corev1.SecretReference{
+				Name:      "test-secret",
+				Namespace: namespace,
+			},
+			Provider: &gardencorev1beta1.SecretBindingProvider{
+				Type: provider1,
+			},
+		}
+
+		credentialsBinding = &securityv1alpha1.CredentialsBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-credentials-binding",
+				Namespace: "another-namespace",
+			},
+			CredentialsRef: corev1.ObjectReference{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Secret",
+				Name:       "test-secret",
+				Namespace:  namespace,
+			},
+			Provider: securityv1alpha1.CredentialsBindingProvider{
+				Type: provider2,
+			},
+		}
+	})
+
+	It("should set the provider label based on the available credential and secret bindings", func() {
+		Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
+		Expect(fakeClient.Create(ctx, credentialsBinding)).To(Succeed())
+
+		Expect(handler.Default(ctx, secret)).To(Succeed())
+
+		Expect(secret.Labels).To(HaveKeyWithValue("provider.shoot.gardener.cloud/provider1", "true"))
+		Expect(secret.Labels).To(HaveKeyWithValue("provider.shoot.gardener.cloud/provider2", "true"))
+	})
+
+	It("should remove undesired provider type", func() {
+		Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
+		Expect(fakeClient.Create(ctx, credentialsBinding)).To(Succeed())
+		secret.Labels = map[string]string{
+			"provider.shoot.gardener.cloud/provider1": "true",
+			"provider.shoot.gardener.cloud/provider2": "true",
+			"provider.shoot.gardener.cloud/provider3": "true",
+		}
+
+		Expect(handler.Default(ctx, secret)).To(Succeed())
+
+		Expect(secret.Labels).To(HaveKeyWithValue("provider.shoot.gardener.cloud/provider1", "true"))
+		Expect(secret.Labels).To(HaveKeyWithValue("provider.shoot.gardener.cloud/provider2", "true"))
+		Expect(secret.Labels).NotTo(HaveKey("provider.shoot.gardener.cloud/provider3"))
+	})
+
+	It("should add the missing provider and delete the wrong one", func() {
+		Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
+		Expect(fakeClient.Create(ctx, credentialsBinding)).To(Succeed())
+		secret.Labels = map[string]string{
+			"provider.shoot.gardener.cloud/provider1": "true",
+			"provider.shoot.gardener.cloud/provider3": "true",
+		}
+
+		Expect(handler.Default(ctx, secret)).To(Succeed())
+
+		Expect(secret.Labels).To(HaveKeyWithValue("provider.shoot.gardener.cloud/provider1", "true"))
+		Expect(secret.Labels).To(HaveKeyWithValue("provider.shoot.gardener.cloud/provider2", "true"))
+		Expect(secret.Labels).NotTo(HaveKey("provider.shoot.gardener.cloud/provider3"))
+	})
+
+	It("should not add provider labels when secret is unreferenced", func() {
+		Expect(handler.Default(ctx, secret)).To(Succeed())
+		Expect(secret.Labels).To(BeEmpty())
+	})
+})

--- a/pkg/admissioncontroller/webhook/admission/providersecretlabels/providersecretlabels_suite_test.go
+++ b/pkg/admissioncontroller/webhook/admission/providersecretlabels/providersecretlabels_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providersecretlabels_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProviderSecretLabels(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AdmissionController Webhook Admission ProviderSecretLabels Suite")
+}

--- a/pkg/apis/core/helper/secretbinding.go
+++ b/pkg/apis/core/helper/secretbinding.go
@@ -12,5 +12,8 @@ import (
 
 // GetSecretBindingTypes returns the SecretBinding provider types.
 func GetSecretBindingTypes(secretBinding *core.SecretBinding) []string {
+	if secretBinding.Provider == nil {
+		return []string{}
+	}
 	return strings.Split(secretBinding.Provider.Type, ",")
 }

--- a/pkg/apis/core/helper/secretbinding_test.go
+++ b/pkg/apis/core/helper/secretbinding_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Helper", func() {
 			Expect(actual).To(Equal(expected))
 		},
 
+		Entry("with nil provider type", &core.SecretBinding{Provider: nil}, []string{}),
 		Entry("with single-value provider type", &core.SecretBinding{Provider: &core.SecretBindingProvider{Type: "foo"}}, []string{"foo"}),
 		Entry("with multi-value provider type", &core.SecretBinding{Provider: &core.SecretBindingProvider{Type: "foo,bar,baz"}}, []string{"foo", "bar", "baz"}),
 	)

--- a/pkg/apis/core/v1beta1/helper/secretbinding.go
+++ b/pkg/apis/core/v1beta1/helper/secretbinding.go
@@ -44,5 +44,8 @@ func AddTypeToSecretBinding(secretBinding *gardencorev1beta1.SecretBinding, prov
 
 // GetSecretBindingTypes returns the SecretBinding provider types.
 func GetSecretBindingTypes(secretBinding *gardencorev1beta1.SecretBinding) []string {
+	if secretBinding.Provider == nil {
+		return []string{}
+	}
 	return strings.Split(secretBinding.Provider.Type, ",")
 }

--- a/pkg/apis/core/v1beta1/helper/secretbinding_test.go
+++ b/pkg/apis/core/v1beta1/helper/secretbinding_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Helper", func() {
 			Expect(actual).To(Equal(expected))
 		},
 
+		Entry("with nil provider type", &gardencorev1beta1.SecretBinding{Provider: nil}, []string{}),
 		Entry("with single-value provider type", &gardencorev1beta1.SecretBinding{Provider: &gardencorev1beta1.SecretBindingProvider{Type: "foo"}}, []string{"foo"}),
 		Entry("with multi-value provider type", &gardencorev1beta1.SecretBinding{Provider: &gardencorev1beta1.SecretBindingProvider{Type: "foo,bar,baz"}}, []string{"foo", "bar", "baz"}),
 	)

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
 	"github.com/gardener/gardener/plugin/pkg/global/extensionlabels"
 	"github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
+	"github.com/gardener/gardener/plugin/pkg/global/finalizerremoval"
 	"github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
 	managedseedshoot "github.com/gardener/gardener/plugin/pkg/managedseed/shoot"
 	managedseedvalidator "github.com/gardener/gardener/plugin/pkg/managedseed/validator"
@@ -39,6 +40,7 @@ import (
 func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	resourcereferencemanager.Register(plugins)
 	deletionconfirmation.Register(plugins)
+	finalizerremoval.Register(plugins)
 	extensionvalidation.Register(plugins)
 	extensionlabels.Register(plugins)
 	shoottolerationrestriction.Register(plugins)

--- a/pkg/apiserver/registry/core/backupbucket/backupbucket_suite_test.go
+++ b/pkg/apiserver/registry/core/backupbucket/backupbucket_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestBackupBucket(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core BackupBucket Suite")
+	RunSpecs(t, "APIServer Registry Core BackupBucket Suite")
 }

--- a/pkg/apiserver/registry/core/backupentry/backupentry_suite_test.go
+++ b/pkg/apiserver/registry/core/backupentry/backupentry_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestBackupEntry(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core BackupEntry Suite")
+	RunSpecs(t, "APIServer Registry Core BackupEntry Suite")
 }

--- a/pkg/apiserver/registry/core/cloudprofile/cloudprofile_suite_test.go
+++ b/pkg/apiserver/registry/core/cloudprofile/cloudprofile_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestCloudProfile(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core CloudProfile Suite")
+	RunSpecs(t, "APIServer Registry Core CloudProfile Suite")
 }

--- a/pkg/apiserver/registry/core/controllerinstallation/strategy_test.go
+++ b/pkg/apiserver/registry/core/controllerinstallation/strategy_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestControllerInstallation(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry ControllerInstallation Suite")
+	RunSpecs(t, "APIServer Registry ControllerInstallation Suite")
 }
 
 var _ = Describe("ToSelectableFields", func() {

--- a/pkg/apiserver/registry/core/namespacedcloudprofile/namespacedcloudprofile_suite_test.go
+++ b/pkg/apiserver/registry/core/namespacedcloudprofile/namespacedcloudprofile_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestNamespacedCloudProfile(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core NamespacedCloudProfile Suite")
+	RunSpecs(t, "APIServer Registry Core NamespacedCloudProfile Suite")
 }

--- a/pkg/apiserver/registry/core/project/project_suite_test.go
+++ b/pkg/apiserver/registry/core/project/project_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestProject(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core Project Suite")
+	RunSpecs(t, "APIServer Registry Core Project Suite")
 }

--- a/pkg/apiserver/registry/core/secretbinding/secretbinding_suite_test.go
+++ b/pkg/apiserver/registry/core/secretbinding/secretbinding_suite_test.go
@@ -16,5 +16,5 @@ import (
 func TestSecretBinding(t *testing.T) {
 	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core SecretBinding Suite")
+	RunSpecs(t, "APIServer Registry Core SecretBinding Suite")
 }

--- a/pkg/apiserver/registry/core/secretbinding/strategy.go
+++ b/pkg/apiserver/registry/core/secretbinding/strategy.go
@@ -28,7 +28,12 @@ func (secretBindingStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (secretBindingStrategy) PrepareForCreate(_ context.Context, _ runtime.Object) {
+func (s secretBindingStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
+	binding := obj.(*core.SecretBinding)
+
+	if binding.GetName() == "" {
+		binding.SetName(s.GenerateName(binding.GetGenerateName()))
+	}
 }
 
 func (secretBindingStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/apiserver/registry/core/secretbinding/strategy_test.go
+++ b/pkg/apiserver/registry/core/secretbinding/strategy_test.go
@@ -34,6 +34,35 @@ var _ = Describe("Strategy", func() {
 		}
 	})
 
+	Describe("#PrepareForCreate", func() {
+		It("should set the name if not set", func() {
+			secretBinding.SetName("")
+
+			secretbindingregistry.Strategy.PrepareForCreate(context.TODO(), secretBinding)
+
+			Expect(secretBinding.GetName()).NotTo(BeEmpty())
+		})
+
+		It("should set name with generateName as prefix", func() {
+			genName := "prefix-"
+			secretBinding.GenerateName = genName
+			secretBinding.Name = ""
+
+			secretbindingregistry.Strategy.PrepareForCreate(context.TODO(), secretBinding)
+
+			Expect(secretBinding.GetGenerateName()).To(Equal(genName))
+			Expect(secretBinding.GetName()).To(HavePrefix(genName))
+		})
+
+		It("should not overwrite already set name", func() {
+			secretBinding.SetName("bar")
+
+			secretbindingregistry.Strategy.PrepareForCreate(context.TODO(), secretBinding)
+
+			Expect(secretBinding.GetName()).To(Equal("bar"))
+		})
+	})
+
 	Describe("#Validate", func() {
 		It("should forbid creating SecretBinding when provider is nil or empty", func() {
 			secretBinding.Provider = nil

--- a/pkg/apiserver/registry/core/seed/seed_suite_test.go
+++ b/pkg/apiserver/registry/core/seed/seed_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestSeed(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core Seed Suite")
+	RunSpecs(t, "APIServer Registry Core Seed Suite")
 }

--- a/pkg/apiserver/registry/core/shoot/shoot_suite_test.go
+++ b/pkg/apiserver/registry/core/shoot/shoot_suite_test.go
@@ -16,5 +16,5 @@ import (
 func TestShoot(t *testing.T) {
 	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core Shoot Suite")
+	RunSpecs(t, "APIServer Registry Core Shoot Suite")
 }

--- a/pkg/apiserver/registry/core/shoot/storage/storage_suite_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/storage_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestStorage(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Core Shoot Storage Suite")
+	RunSpecs(t, "APIServer Registry Core Shoot Storage Suite")
 }

--- a/pkg/apiserver/registry/operations/bastion/bastion_suite_test.go
+++ b/pkg/apiserver/registry/operations/bastion/bastion_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestBastion(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Operations Bastion Suite")
+	RunSpecs(t, "APIServer Registry Operations Bastion Suite")
 }

--- a/pkg/apiserver/registry/security/credentialsbinding/credentialsbinding_suite_test.go
+++ b/pkg/apiserver/registry/security/credentialsbinding/credentialsbinding_suite_test.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package credentialsbinding_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/apiserver/features"
+)
+
+func TestCredentialsBinding(t *testing.T) {
+	features.RegisterFeatureGates()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry Security CredentialsBinding Suite")
+}

--- a/pkg/apiserver/registry/security/credentialsbinding/credentialsbinding_suite_test.go
+++ b/pkg/apiserver/registry/security/credentialsbinding/credentialsbinding_suite_test.go
@@ -16,5 +16,5 @@ import (
 func TestCredentialsBinding(t *testing.T) {
 	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Security CredentialsBinding Suite")
+	RunSpecs(t, "APIServer Registry Security CredentialsBinding Suite")
 }

--- a/pkg/apiserver/registry/security/credentialsbinding/strategy.go
+++ b/pkg/apiserver/registry/security/credentialsbinding/strategy.go
@@ -28,8 +28,12 @@ func (credentialsBindingStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (credentialsBindingStrategy) PrepareForCreate(_ context.Context, _ runtime.Object) {
+func (c credentialsBindingStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
+	credentialsbinding := obj.(*security.CredentialsBinding)
 
+	if credentialsbinding.GetName() == "" {
+		credentialsbinding.SetName(c.GenerateName(credentialsbinding.GetGenerateName()))
+	}
 }
 
 func (credentialsBindingStrategy) PrepareForUpdate(_ context.Context, _, _ runtime.Object) {

--- a/pkg/apiserver/registry/security/credentialsbinding/strategy_test.go
+++ b/pkg/apiserver/registry/security/credentialsbinding/strategy_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package credentialsbinding_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/apis/security"
+	credentialsbindingregistry "github.com/gardener/gardener/pkg/apiserver/registry/security/credentialsbinding"
+)
+
+var _ = Describe("Strategy", func() {
+	var credentialsBinding *security.CredentialsBinding
+
+	BeforeEach(func() {
+		credentialsBinding = &security.CredentialsBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "profile",
+				Namespace: "garden",
+			},
+		}
+	})
+
+	Describe("#PrepareForCreate", func() {
+		It("should set the name if not set", func() {
+			credentialsBinding.SetName("")
+
+			credentialsbindingregistry.Strategy.PrepareForCreate(context.TODO(), credentialsBinding)
+
+			Expect(credentialsBinding.GetName()).NotTo(BeEmpty())
+		})
+
+		It("should set name with generateName as prefix", func() {
+			genName := "prefix-"
+			credentialsBinding.GenerateName = genName
+			credentialsBinding.Name = ""
+
+			credentialsbindingregistry.Strategy.PrepareForCreate(context.TODO(), credentialsBinding)
+
+			Expect(credentialsBinding.GetGenerateName()).To(Equal(genName))
+			Expect(credentialsBinding.GetName()).To(HavePrefix(genName))
+		})
+
+		It("should not overwrite already set name", func() {
+			credentialsBinding.SetName("bar")
+
+			credentialsbindingregistry.Strategy.PrepareForCreate(context.TODO(), credentialsBinding)
+
+			Expect(credentialsBinding.GetName()).To(Equal("bar"))
+		})
+	})
+})

--- a/pkg/apiserver/registry/security/workloadidentity/storage/storage_suite_test.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/storage_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestStorage(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Security WorkloadIdentity Storage Suite")
+	RunSpecs(t, "APIServer Registry Security WorkloadIdentity Storage Suite")
 }

--- a/pkg/apiserver/registry/security/workloadidentity/workloadidentity_suite_test.go
+++ b/pkg/apiserver/registry/security/workloadidentity/workloadidentity_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestWorkloadIdentity(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry Security WorkloadIdentity Suite")
+	RunSpecs(t, "APIServer Registry Security WorkloadIdentity Suite")
 }

--- a/pkg/apiserver/registry/seedmanagement/managedseed/managedseed_suite_test.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseed/managedseed_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestManagedSeed(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry SeedManagement ManagedSeed Suite")
+	RunSpecs(t, "APIServer Registry SeedManagement ManagedSeed Suite")
 }

--- a/pkg/apiserver/registry/seedmanagement/managedseedset/managedseedset_suite_test.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseedset/managedseedset_suite_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestManagedSeedSet(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Registry SeedManagement ManagedSeedSet Suite")
+	RunSpecs(t, "APIServer Registry SeedManagement ManagedSeedSet Suite")
 }

--- a/pkg/component/gardener/admissioncontroller/admission_controller.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller.go
@@ -131,6 +131,7 @@ func (a *gardenerAdmissionController) Deploy(ctx context.Context) error {
 		a.clusterRole(),
 		a.clusterRoleBinding(virtualGardenAccessSecret.ServiceAccountName),
 		a.validatingWebhookConfiguration(caSecret),
+		a.mutatingWebhookConfiguration(caSecret),
 	)
 	if err != nil {
 		return err

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -143,17 +143,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	if secretBinding.Provider != nil {
-		types := v1beta1helper.GetSecretBindingTypes(secretBinding)
-		for _, t := range types {
-			labelKey := v1beta1constants.LabelShootProviderPrefix + t
+	types := v1beta1helper.GetSecretBindingTypes(secretBinding)
+	for _, t := range types {
+		labelKey := v1beta1constants.LabelShootProviderPrefix + t
 
-			if !metav1.HasLabel(secret.ObjectMeta, labelKey) {
-				patch := client.MergeFrom(secret.DeepCopy())
-				metav1.SetMetaDataLabel(&secret.ObjectMeta, labelKey, "true")
-				if err := r.Client.Patch(ctx, secret, patch); err != nil {
-					return reconcile.Result{}, fmt.Errorf("failed to add provider type label to Secret referenced in SecretBinding: %w", err)
-				}
+		if !metav1.HasLabel(secret.ObjectMeta, labelKey) {
+			patch := client.MergeFrom(secret.DeepCopy())
+			metav1.SetMetaDataLabel(&secret.ObjectMeta, labelKey, "true")
+			if err := r.Client.Patch(ctx, secret, patch); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to add provider type label to Secret referenced in SecretBinding: %w", err)
 			}
 		}
 	}

--- a/pkg/provider-local/admission/cmd/options.go
+++ b/pkg/provider-local/admission/cmd/options.go
@@ -14,6 +14,7 @@ import (
 func GardenWebhookSwitchOptions() *extensionscmdwebhook.SwitchOptions {
 	return extensionscmdwebhook.NewSwitchOptions(
 		extensionscmdwebhook.Switch(validator.Name, validator.New),
+		extensionscmdwebhook.Switch(validator.SecretsValidatorName, validator.NewSecretsWebhook),
 		extensionscmdwebhook.Switch(mutator.Name, mutator.New),
 	)
 }

--- a/pkg/provider-local/admission/validator/secret.go
+++ b/pkg/provider-local/admission/validator/secret.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+)
+
+type secret struct{}
+
+// NewSecretValidator returns a new instance of a secret validator.
+func NewSecretValidator() extensionswebhook.Validator {
+	return &secret{}
+}
+
+// Validate checks whether the data is empty.
+func (s *secret) Validate(_ context.Context, newObj, oldObj client.Object) error {
+	secret, ok := newObj.(*corev1.Secret)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if oldObj != nil {
+		oldSecret, ok := oldObj.(*corev1.Secret)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", oldObj)
+		}
+
+		if apiequality.Semantic.DeepEqual(secret.Data, oldSecret.Data) {
+			return nil
+		}
+	}
+
+	if len(secret.Data) != 0 {
+		return fmt.Errorf("secret data should be empty")
+	}
+
+	return nil
+}

--- a/pkg/provider-local/admission/validator/secret.go
+++ b/pkg/provider-local/admission/validator/secret.go
@@ -15,15 +15,15 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 )
 
-type secret struct{}
+type secretValidator struct{}
 
 // NewSecretValidator returns a new instance of a secret validator.
 func NewSecretValidator() extensionswebhook.Validator {
-	return &secret{}
+	return &secretValidator{}
 }
 
 // Validate checks whether the data is empty.
-func (s *secret) Validate(_ context.Context, newObj, oldObj client.Object) error {
+func (s *secretValidator) Validate(_ context.Context, newObj, oldObj client.Object) error {
 	secret, ok := newObj.(*corev1.Secret)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)

--- a/pkg/provider-local/admission/validator/webhook.go
+++ b/pkg/provider-local/admission/validator/webhook.go
@@ -5,18 +5,22 @@
 package validator
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 )
 
 const (
 	// Name is a name for a validation webhook.
 	Name = "validator"
+	// SecretsValidatorName is the name of the secrets validator.
+	SecretsValidatorName = "secrets." + Name
 )
 
 var logger = log.Log.WithName("local-validator-webhook")
@@ -31,10 +35,29 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:     "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
 			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
+			NewWorkloadIdentityValidator():          {{Obj: &securityv1alpha1.WorkloadIdentity{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{"provider.extensions.gardener.cloud/local": "true"},
+			MatchLabels: map[string]string{"provider.extensions.gardener.cloud/" + local.Type: "true"},
+		},
+	})
+}
+
+// NewSecretsWebhook creates a new validation webhook for Secrets.
+func NewSecretsWebhook(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger.Info("Setting up webhook", "name", SecretsValidatorName)
+
+	return extensionswebhook.New(mgr, extensionswebhook.Args{
+		Provider: local.Type,
+		Name:     SecretsValidatorName,
+		Path:     "/webhooks/validate/secrets",
+		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
+			NewSecretValidator(): {{Obj: &corev1.Secret{}}},
+		},
+		Target: extensionswebhook.TargetSeed,
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"provider.shoot.gardener.cloud/" + local.Type: "true"},
 		},
 	})
 }

--- a/pkg/provider-local/admission/validator/workloadidentity.go
+++ b/pkg/provider-local/admission/validator/workloadidentity.go
@@ -15,16 +15,16 @@ import (
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 )
 
-type workloadIdentity struct {
+type workloadIdentityValidator struct {
 }
 
 // NewWorkloadIdentityValidator returns a new instance of a WorkloadIdentity validator.
 func NewWorkloadIdentityValidator() extensionswebhook.Validator {
-	return &workloadIdentity{}
+	return &workloadIdentityValidator{}
 }
 
 // Validate checks whether the provider config is empty.
-func (wi *workloadIdentity) Validate(_ context.Context, newObj, _ client.Object) error {
+func (wi *workloadIdentityValidator) Validate(_ context.Context, newObj, _ client.Object) error {
 	workloadIdentity, ok := newObj.(*securityv1alpha1.WorkloadIdentity)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)

--- a/pkg/provider-local/admission/validator/workloadidentity.go
+++ b/pkg/provider-local/admission/validator/workloadidentity.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+)
+
+type workloadIdentity struct {
+}
+
+// NewWorkloadIdentityValidator returns a new instance of a WorkloadIdentity validator.
+func NewWorkloadIdentityValidator() extensionswebhook.Validator {
+	return &workloadIdentity{}
+}
+
+// Validate checks whether the provider config is empty.
+func (wi *workloadIdentity) Validate(_ context.Context, newObj, _ client.Object) error {
+	workloadIdentity, ok := newObj.(*securityv1alpha1.WorkloadIdentity)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if workloadIdentity.Spec.TargetSystem.ProviderConfig != nil {
+		return errors.New("target system provider config must be empty")
+	}
+
+	return nil
+}

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -242,11 +242,9 @@ func addMetaDataLabelsSeed(seed *core.Seed) {
 }
 
 func addMetaDataLabelsSecretBinding(secretBinding *core.SecretBinding) {
-	if secretBinding.Provider != nil {
-		types := gardencorehelper.GetSecretBindingTypes(secretBinding)
-		for _, t := range types {
-			metav1.SetMetaDataLabel(&secretBinding.ObjectMeta, v1beta1constants.LabelExtensionProviderTypePrefix+t, "true")
-		}
+	types := gardencorehelper.GetSecretBindingTypes(secretBinding)
+	for _, t := range types {
+		metav1.SetMetaDataLabel(&secretBinding.ObjectMeta, v1beta1constants.LabelExtensionProviderTypePrefix+t, "true")
 	}
 }
 

--- a/plugin/pkg/global/finalizerremoval/admission.go
+++ b/plugin/pkg/global/finalizerremoval/admission.go
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package finalizerremoval
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/security"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(plugin.PluginNameFinalizerRemoval, func(_ io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+// FinalizerRemoval contains listers and admission handler.
+type FinalizerRemoval struct {
+	*admission.Handler
+	shootLister gardencorev1beta1listers.ShootLister
+	readyFunc   admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsCoreInformerFactory(&FinalizerRemoval{})
+
+	readyFuncs []admission.ReadyFunc
+)
+
+// New creates a new FinalizerRemoval admission plugin.
+func New() (*FinalizerRemoval, error) {
+	return &FinalizerRemoval{
+		Handler: admission.NewHandler(admission.Update),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (f *FinalizerRemoval) AssignReadyFunc(fn admission.ReadyFunc) {
+	f.readyFunc = fn
+	f.SetReadyFunc(fn)
+}
+
+// SetCoreInformerFactory gets Lister from SharedInformerFactory.
+func (f *FinalizerRemoval) SetCoreInformerFactory(g gardencoreinformers.SharedInformerFactory) {
+	shootInformer := g.Core().V1beta1().Shoots()
+	f.shootLister = shootInformer.Lister()
+
+	readyFuncs = append(readyFuncs,
+		shootInformer.Informer().HasSynced,
+	)
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (f *FinalizerRemoval) ValidateInitialization() error {
+	if f.shootLister == nil {
+		return errors.New("missing shoot lister")
+	}
+	return nil
+}
+
+// Admit ensures that finalizers from objects can only be removed if they are not needed anymore.
+func (f *FinalizerRemoval) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	// Wait until the caches have been synced
+	if f.readyFunc == nil {
+		f.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+	if !f.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	var (
+		err            error
+		newObj, oldObj client.Object
+	)
+
+	oldObj, ok := a.GetOldObject().(client.Object)
+	if !ok {
+		return nil
+	}
+
+	newObj, ok = a.GetObject().(client.Object)
+	if !ok {
+		return nil
+	}
+
+	switch a.GetKind().GroupKind() {
+	case core.Kind("SecretBinding"):
+		binding, ok := a.GetObject().(*core.SecretBinding)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert resource into SecretBinding object")
+		}
+
+		// Allow removal of `gardener` finalizer only if the SecretBinding is not used by any shoot.
+		if isFinalizerRemoved(oldObj, newObj, gardencorev1beta1.GardenerName) {
+			inUse, err := f.isUsedByShoot(binding.Namespace, func(shoot *gardencorev1beta1.Shoot) bool {
+				return ptr.Deref(shoot.Spec.SecretBindingName, "") == binding.Name
+			})
+			if err != nil {
+				return apierrors.NewInternalError(fmt.Errorf("error checking if credentials binding is in use: %w", err))
+			}
+			if inUse {
+				return admission.NewForbidden(a, fmt.Errorf("finalizer must not be removed - secret binding %s/%s is still in use by at least one shoot", binding.Namespace, binding.Name))
+			}
+		}
+	case security.Kind("CredentialsBinding"):
+		binding, ok := a.GetObject().(*security.CredentialsBinding)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert resource into CredentialsBinding object")
+		}
+
+		// Allow removal of `gardener` finalizer only if the CredentialsBinding is not used by any shoot.
+		if isFinalizerRemoved(oldObj, newObj, gardencorev1beta1.GardenerName) {
+			inUse, err := f.isUsedByShoot(binding.Namespace, func(shoot *gardencorev1beta1.Shoot) bool {
+				return ptr.Deref(shoot.Spec.CredentialsBindingName, "") == binding.Name
+			})
+			if err != nil {
+				return apierrors.NewInternalError(fmt.Errorf("error checking if secret binding is in use: %w", err))
+			}
+			if inUse {
+				return admission.NewForbidden(a, fmt.Errorf("finalizer must not be removed - secret binding %s/%s is still in use by at least one shoot", binding.Namespace, binding.Name))
+			}
+		}
+	case core.Kind("Shoot"):
+		shoot, ok := a.GetObject().(*core.Shoot)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert resource into Shoot object")
+		}
+
+		// Allow removal of `gardener` finalizer only if the Shoot deletion has completed successfully.
+		if isFinalizerRemoved(oldObj, newObj, gardencorev1beta1.GardenerName) && !shootDeletionSucceeded(shoot) {
+			return admission.NewForbidden(a, fmt.Errorf("finalizer %q cannot be removed because shoot deletion has not completed successfully yet", core.GardenerName))
+		}
+	}
+
+	if err != nil {
+		return admission.NewForbidden(a, err)
+	}
+	return nil
+}
+
+func (f *FinalizerRemoval) isUsedByShoot(namespace string, inUse func(*gardencorev1beta1.Shoot) bool) (bool, error) {
+	shoots, err := f.shootLister.Shoots(namespace).List(labels.Everything())
+	if err != nil {
+		return false, fmt.Errorf("error retrieving shoots: %w", err)
+	}
+
+	for _, shoot := range shoots {
+		if inUse(shoot) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func shootDeletionSucceeded(shoot *core.Shoot) bool {
+	if len(shoot.Status.TechnicalID) == 0 || shoot.Status.LastOperation == nil {
+		return true
+	}
+
+	lastOperation := shoot.Status.LastOperation
+	return lastOperation.Type == core.LastOperationTypeDelete &&
+		lastOperation.State == core.LastOperationStateSucceeded &&
+		lastOperation.Progress == 100
+}
+
+func isFinalizerRemoved(old, new metav1.Object, finalizerName string) bool {
+	var (
+		oldFinalizers = sets.New(old.GetFinalizers()...)
+		newFinalizer  = sets.New(new.GetFinalizers()...)
+	)
+
+	return oldFinalizers.Has(finalizerName) && !newFinalizer.Has(finalizerName)
+}

--- a/plugin/pkg/global/finalizerremoval/admission_test.go
+++ b/plugin/pkg/global/finalizerremoval/admission_test.go
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package finalizerremoval_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/security"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	. "github.com/gardener/gardener/plugin/pkg/global/finalizerremoval"
+)
+
+var _ = Describe("finalizerremoval", func() {
+	Describe("#Admit", func() {
+		var (
+			ctx                       context.Context
+			admissionHandler          *FinalizerRemoval
+			gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
+
+			finalizers []string
+
+			namespace              = "default"
+			secretBindingName      = "binding-1"
+			credentialsBindingName = "credentials-binding-1"
+			shootName              = "shoot-1"
+
+			shoot *gardencorev1beta1.Shoot
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			admissionHandler, _ = New()
+			admissionHandler.AssignReadyFunc(func() bool { return true })
+
+			finalizers = []string{core.GardenerName}
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shootName,
+					Namespace: namespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					CredentialsBindingName: ptr.To(credentialsBindingName),
+					SecretBindingName:      ptr.To(secretBindingName),
+				},
+			}
+
+			gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
+			admissionHandler.SetCoreInformerFactory(gardenCoreInformerFactory)
+		})
+
+		Context("SecretBinding", func() {
+			var coreSecretBinding *core.SecretBinding
+
+			BeforeEach(func() {
+				coreSecretBinding = &core.SecretBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       secretBindingName,
+						Namespace:  namespace,
+						Finalizers: finalizers,
+					},
+				}
+			})
+
+			It("should admit the removal because object is not used by any shoot", func() {
+				attrs := admission.NewAttributesRecord(&core.SecretBinding{}, coreSecretBinding, core.Kind("SecretBinding").WithVersion("version"), "", coreSecretBinding.Name, core.Resource("SecretBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+			})
+
+			It("should admit the removal because finalizer is irrelevant", func() {
+				newSecretBinding := coreSecretBinding.DeepCopy()
+				coreSecretBinding.Finalizers = append(coreSecretBinding.Finalizers, "irrelevant-finalizer")
+
+				attrs := admission.NewAttributesRecord(newSecretBinding, coreSecretBinding, core.Kind("SecretBinding").WithVersion("version"), "", coreSecretBinding.Name, core.Resource("SecretBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+			})
+
+			It("should reject the removal because object is not used by any shoot", func() {
+				newSecretBinding := coreSecretBinding.DeepCopy()
+				newSecretBinding.Finalizers = nil
+
+				secondShoot := shoot.DeepCopy()
+				secondShoot.Name = shootName + "-2"
+				secondShoot.Spec.SecretBindingName = ptr.To(secretBindingName + "-2")
+
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(secondShoot)).To(Succeed())
+
+				attrs := admission.NewAttributesRecord(newSecretBinding, coreSecretBinding, core.Kind("SecretBinding").WithVersion("version"), "", coreSecretBinding.Name, core.Resource("SecretBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(MatchError(ContainSubstring("finalizer must not be removed")))
+			})
+		})
+
+		Context("CredentialsBinding", func() {
+			var coreCredentialsBinding *security.CredentialsBinding
+
+			BeforeEach(func() {
+				coreCredentialsBinding = &security.CredentialsBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       credentialsBindingName,
+						Namespace:  namespace,
+						Finalizers: finalizers,
+					},
+				}
+			})
+
+			It("should admit the removal because object is not used by any shoot", func() {
+				attrs := admission.NewAttributesRecord(&security.CredentialsBinding{}, coreCredentialsBinding, security.Kind("CredentialsBinding").WithVersion("version"), "", coreCredentialsBinding.Name, security.Resource("CredentialsBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+			})
+
+			It("should admit the removal because finalizer is irrelevant", func() {
+				newCredentialsBinding := coreCredentialsBinding.DeepCopy()
+				coreCredentialsBinding.Finalizers = append(coreCredentialsBinding.Finalizers, "irrelevant-finalizer")
+
+				attrs := admission.NewAttributesRecord(newCredentialsBinding, coreCredentialsBinding, security.Kind("CredentialsBinding").WithVersion("version"), "", coreCredentialsBinding.Name, security.Resource("CredentialsBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+			})
+
+			It("should reject the removal because object is not used by any shoot", func() {
+				newCredentialsBinding := coreCredentialsBinding.DeepCopy()
+				newCredentialsBinding.Finalizers = nil
+
+				secondShoot := shoot.DeepCopy()
+				secondShoot.Name = shootName + "-2"
+				secondShoot.Spec.CredentialsBindingName = ptr.To(secretBindingName + "-2")
+
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(secondShoot)).To(Succeed())
+
+				attrs := admission.NewAttributesRecord(newCredentialsBinding, coreCredentialsBinding, security.Kind("CredentialsBinding").WithVersion("version"), "", coreCredentialsBinding.Name, security.Resource("CredentialsBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(MatchError(ContainSubstring("finalizer must not be removed")))
+			})
+		})
+
+		Context("shoot", func() {
+			var coreShoot *core.Shoot
+
+			BeforeEach(func() {
+				coreShoot = &core.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: finalizers,
+					},
+					Status: core.ShootStatus{
+						TechnicalID: "some-id",
+						LastOperation: &core.LastOperation{
+							Type:     core.LastOperationTypeReconcile,
+							State:    core.LastOperationStateSucceeded,
+							Progress: 100,
+						},
+					},
+				}
+			})
+
+			It("should allow the removal because finalizer is irrelevant", func() {
+				newShoot := coreShoot.DeepCopy()
+				coreShoot.Finalizers = append(coreShoot.Finalizers, "irrelevant-finalizer")
+
+				attrs := admission.NewAttributesRecord(newShoot, coreShoot, security.Kind("Shoot").WithVersion("version"), "", coreShoot.Name, security.Resource("Shoot").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+			})
+
+			It("should admit the removal if the shoot deletion succeeded ", func() {
+				newShoot := coreShoot.DeepCopy()
+				newShoot.Finalizers = nil
+				newShoot.Status.LastOperation.Type = core.LastOperationTypeDelete
+
+				attrs := admission.NewAttributesRecord(newShoot, coreShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+			})
+
+			It("should reject the removal if the shoot has not yet been deleted successfully", func() {
+				newShoot := coreShoot.DeepCopy()
+				newShoot.Finalizers = nil
+
+				attrs := admission.NewAttributesRecord(newShoot, coreShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(MatchError(ContainSubstring("shoot deletion has not completed successfully yet")))
+			})
+
+			It("should admit the removal if the shoot has not yet a last operation", func() {
+				newShoot := coreShoot.DeepCopy()
+				newShoot.Finalizers = nil
+				newShoot.Status.LastOperation = nil
+
+				attrs := admission.NewAttributesRecord(newShoot, coreShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+			})
+
+			It("should admit the removal if the shoot has not yet a technical id", func() {
+				newShoot := coreShoot.DeepCopy()
+				newShoot.Finalizers = nil
+				newShoot.Status.TechnicalID = ""
+
+				attrs := admission.NewAttributesRecord(newShoot, coreShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+			})
+		})
+	})
+})

--- a/plugin/pkg/global/finalizerremoval/finalizerremoval_suite_test.go
+++ b/plugin/pkg/global/finalizerremoval/finalizerremoval_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package finalizerremoval_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFinalizerRemoval(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AdmissionPlugin Global FinalizerRemoval Suite")
+}

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
@@ -30,7 +29,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/security"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
@@ -471,13 +469,13 @@ var _ = Describe("resourcereferencemanager", func() {
 		It("should return nil because the resource is not BackupBucket and operation is delete", func() {
 			attrs := admission.NewAttributesRecord(&controllerRegistration, nil, core.Kind("ControllerRegistration").WithVersion("version"), "", controllerRegistration.Name, core.Resource("controllerregistrations").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 
 			attrs = admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), "", controllerRegistration.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-			err = admissionHandler.Admit(context.TODO(), attrs, nil)
+			err = admissionHandler.Validate(context.TODO(), attrs, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -489,7 +487,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&controllerRegistration, nil, core.Kind("ControllerRegistration").WithVersion("version"), "", controllerRegistration.Name, core.Resource("controllerregistrations").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -502,7 +500,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&controllerRegistration, nil, core.Kind("ControllerRegistration").WithVersion("version"), "", controllerRegistration.Name, core.Resource("controllerregistrations").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -514,7 +512,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					return true, nil, errors.New("nope, out of luck")
 				})
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("nope, out of luck"))
@@ -529,7 +527,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -552,7 +550,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					return true, nil, nil
 				})
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -575,7 +573,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					return true, nil, fmt.Errorf("sanity check failed")
 				})
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("test provider secret sanity check failed: sanity check failed")))
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("test provider secret sanity check failed: sanity check failed")))
 			})
 
 			It("should reject because the referenced secret does not exist", func() {
@@ -587,7 +585,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -599,7 +597,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -610,7 +608,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -622,7 +620,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -657,7 +655,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -692,7 +690,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -707,7 +705,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(`SecretBinding is referenced by shoot "shoot-1", but provider types ([another-provider]) do not match with the shoot provider type "local"`)))
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(`SecretBinding is referenced by shoot "shoot-1", but provider types ([another-provider]) do not match with the shoot provider type "local"`)))
 			})
 		})
 
@@ -719,7 +717,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -742,7 +740,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					return true, nil, nil
 				})
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -765,7 +763,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					return true, nil, fmt.Errorf("sanity check failed")
 				})
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("test provider secret sanity check failed: sanity check failed")))
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("test provider secret sanity check failed: sanity check failed")))
 			})
 
 			It("should reject because the referenced secret does not exist", func() {
@@ -777,7 +775,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -789,7 +787,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -800,7 +798,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -812,7 +810,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -847,7 +845,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -882,7 +880,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -897,7 +895,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(`CredentialsBinding is referenced by shoot "shoot-1", but provider types ([another-provider]) do not match with the shoot provider type "local"`)))
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(`CredentialsBinding is referenced by shoot "shoot-1", but provider types ([another-provider]) do not match with the shoot provider type "local"`)))
 			})
 		})
 
@@ -909,7 +907,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -923,7 +921,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -936,7 +934,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(MatchError(ContainSubstring("does not match with WorkloadIdentity provider type")))
 			})
@@ -950,7 +948,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -962,7 +960,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -973,7 +971,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -985,7 +983,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -1021,7 +1019,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1075,31 +1073,13 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		Context("tests for Shoot objects", func() {
-			It("should add the created-by annotation", func() {
-				Expect(gardenCoreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(gardenCoreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(gardenSecurityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBindingRefSecret)).To(Succeed())
-				Expect(kubeInformerFactory.Core().V1().ConfigMaps().Informer().GetStore().Add(&configMap)).To(Succeed())
-
-				user := &user.DefaultInfo{Name: allowedUser}
-				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
-
-				Expect(coreShoot.Annotations).NotTo(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, user.Name))
-
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(coreShoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, user.Name))
-			})
-
 			It("should accept because all referenced objects have been found", func() {
 				Expect(gardenCoreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
@@ -1110,7 +1090,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1126,7 +1106,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				coreShoot.Status.TechnicalID = "should-never-change"
 				attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1135,7 +1115,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				It("should reject because the referenced cloud profile does not exist (create)", func() {
 					attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 					Expect(err).To(HaveOccurred())
 				})
@@ -1146,7 +1126,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 					attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 					Expect(err).To(HaveOccurred())
 				})
@@ -1161,7 +1141,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 					attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 					Expect(err).To(HaveOccurred())
 				})
@@ -1178,7 +1158,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 					attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 					Expect(err).To(HaveOccurred())
 				})
@@ -1191,7 +1171,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -1203,7 +1183,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -1215,7 +1195,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -1230,7 +1210,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -1250,7 +1230,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				It("should reject because the referenced exposure class does not exists", func() {
 					attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 					Expect(err).To(HaveOccurred())
 				})
 
@@ -1264,7 +1244,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					Expect(gardenCoreInformerFactory.Core().V1beta1().ExposureClasses().Informer().GetStore().Add(&exposureClass)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -1276,7 +1256,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -1291,7 +1271,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(MatchError("shoots.core.gardener.cloud \"shoot-1\" is forbidden: cannot reference a resource you are not allowed to read"))
 			})
@@ -1318,7 +1298,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(MatchError("shoots.core.gardener.cloud \"shoot-1\" is forbidden: cannot reference a resource you are not allowed to read"))
 			})
@@ -1334,7 +1314,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
 			})
@@ -1351,7 +1331,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(MatchError(ContainSubstring("failed to resolve resource reference")))
 			})
@@ -1373,7 +1353,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					user := &user.DefaultInfo{Name: allowedUser}
 					attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(expectedErrorMessage)))
+					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(expectedErrorMessage)))
 				})
 
 				It("should reject because the referenced "+description+" does not exist (update)", func() {
@@ -1393,7 +1373,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					user := &user.DefaultInfo{Name: allowedUser}
 					attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, user)
 
-					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(expectedErrorMessage)))
+					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(expectedErrorMessage)))
 				})
 
 				It("should pass because the referenced "+description+" does not exist but shoot has deletion timestamp", func() {
@@ -1416,7 +1396,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					user := &user.DefaultInfo{Name: allowedUser}
 					attrs := admission.NewAttributesRecord(&coreShoot, oldShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, user)
 
-					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 				})
 
 				It("should pass because the referenced "+description+" exists", func() {
@@ -1435,7 +1415,7 @@ var _ = Describe("resourcereferencemanager", func() {
 					user := &user.DefaultInfo{Name: allowedUser}
 					attrs := admission.NewAttributesRecord(&coreShoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 				})
 			}
 
@@ -1509,7 +1489,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&coreSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", coreSeed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(MatchError("seeds.core.gardener.cloud \"seed-1\" is forbidden: cannot reference a resource you are not allowed to read"))
 			})
@@ -1520,7 +1500,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: "disallowed-user"}
 				attrs := admission.NewAttributesRecord(&coreSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", coreSeed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
 			})
@@ -1529,7 +1509,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&coreSeed, nil, core.Kind("Seed").WithVersion("version"), "", coreSeed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(MatchError(ContainSubstring("failed to resolve resource reference")))
 			})
@@ -1539,7 +1519,7 @@ var _ = Describe("resourcereferencemanager", func() {
 			It("should reject if the referred Seed is not found", func() {
 				attrs := admission.NewAttributesRecord(&coreBackupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), "", coreBackupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
 				Expect(err).To(MatchError(ContainSubstring("backupBuckets.core.gardener.cloud %q is forbidden: seed.core.gardener.cloud %q not found", coreBackupBucket.Name, seed.Name)))
@@ -1553,7 +1533,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreBackupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), "", coreBackupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
 				Expect(err).To(MatchError(ContainSubstring("secret not found")))
@@ -1572,7 +1552,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreBackupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), "", coreBackupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1583,7 +1563,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreBackupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), "", coreBackupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1598,7 +1578,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(nil, nil, core.Kind("BackupBucket").WithVersion("version"), "", coreBackupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1617,7 +1597,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(nil, nil, core.Kind("BackupBucket").WithVersion("version"), "", backupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
 				Expect(err).To(MatchError(ContainSubstring("backupBuckets.core.gardener.cloud %q is forbidden: cannot delete BackupBucket because BackupEntries are still referencing it, backupEntryNames: %s/%s,%s/%s", backupBucket.Name, backupEntry.Namespace, backupEntry.Name, backupEntry2.Namespace, backupEntry2.Name)))
@@ -1633,7 +1613,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(nil, nil, core.Kind("BackupBucket").WithVersion("version"), "", coreBackupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -1661,7 +1641,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(nil, nil, core.Kind("BackupBucket").WithVersion("version"), "", "", core.Resource("backupBuckets").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
 				Expect(err).To(MatchError(ContainSubstring("backupBuckets.core.gardener.cloud %q is forbidden: cannot delete BackupBucket because BackupEntries are still referencing it, backupEntryNames: %s/%s,%s/%s", backupBucket2.Name, backupEntry.Namespace, backupEntry.Name, backupEntry2.Namespace, backupEntry2.Name)))
@@ -1690,7 +1670,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(nil, nil, core.Kind("BackupBucket").WithVersion("version"), "", "", core.Resource("backupBuckets").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1700,7 +1680,7 @@ var _ = Describe("resourcereferencemanager", func() {
 			It("should reject if the referred Seed is not found", func() {
 				attrs := admission.NewAttributesRecord(&coreBackupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), coreBackupEntry.Namespace, coreBackupEntry.Name, core.Resource("backupEntries").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
 				Expect(err).To(MatchError(ContainSubstring("backupEntries.core.gardener.cloud %q is forbidden: seed.core.gardener.cloud %q not found", coreBackupEntry.Name, seed.Name)))
@@ -1710,7 +1690,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&coreBackupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), coreBackupEntry.Namespace, coreBackupEntry.Name, core.Resource("backupEntries").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
 				Expect(err).To(MatchError(ContainSubstring("backupEntries.core.gardener.cloud %q is forbidden: backupbucket.core.gardener.cloud %q not found", coreBackupEntry.Name, coreBackupBucket.Name)))
@@ -1721,102 +1701,13 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(gardenCoreInformerFactory.Core().V1beta1().BackupBuckets().Informer().GetStore().Add(&backupBucket)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&coreBackupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), coreBackupEntry.Namespace, coreBackupEntry.Name, core.Resource("backupEntries").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 
 		Context("tests for Project objects", func() {
-			It("should set the created-by field", func() {
-				Expect(gardenCoreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&coreProject, nil, core.Kind("Project").WithVersion("version"), coreProject.Namespace, coreProject.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
-
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(coreProject.Spec.CreatedBy).To(Equal(&rbacv1.Subject{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     rbacv1.UserKind,
-					Name:     defaultUserName,
-				}))
-			})
-
-			It("should set the owner field (member with owner role found)", func() {
-				projectCopy := project.DeepCopy()
-				coreProjectCopy := coreProject.DeepCopy()
-				ownerMember := &rbacv1.Subject{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     rbacv1.UserKind,
-					Name:     "owner",
-				}
-				projectCopy.Name = "foo"
-				projectCopy.Spec.Members = []gardencorev1beta1.ProjectMember{
-					{
-						Subject: *ownerMember,
-						Roles:   []string{core.ProjectMemberOwner},
-					},
-				}
-				coreProjectCopy.Name = "foo"
-				coreProjectCopy.Spec.Members = []core.ProjectMember{
-					{
-						Subject: *ownerMember,
-						Roles:   []string{core.ProjectMemberOwner},
-					},
-				}
-
-				Expect(gardenCoreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(projectCopy)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(coreProjectCopy, nil, core.Kind("Project").WithVersion("version"), coreProjectCopy.Namespace, coreProjectCopy.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
-
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(coreProjectCopy.Spec.Owner).To(Equal(ownerMember))
-				Expect(coreProjectCopy.Spec.CreatedBy).To(Equal(&rbacv1.Subject{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     rbacv1.UserKind,
-					Name:     defaultUserName,
-				}))
-			})
-
-			It("should set the owner field", func() {
-				Expect(gardenCoreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&coreProject, nil, core.Kind("Project").WithVersion("version"), coreProject.Namespace, coreProject.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
-
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(coreProject.Spec.Owner).To(Equal(&rbacv1.Subject{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     rbacv1.UserKind,
-					Name:     defaultUserName,
-				}))
-			})
-
-			It("should add the owner to members", func() {
-				Expect(gardenCoreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&coreProject, nil, core.Kind("Project").WithVersion("version"), coreProject.Namespace, coreProject.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
-
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(coreProject.Spec.Members).To(ContainElement(Equal(core.ProjectMember{
-					Subject: rbacv1.Subject{
-						APIGroup: "rbac.authorization.k8s.io",
-						Kind:     rbacv1.UserKind,
-						Name:     defaultUserName,
-					},
-					Roles: []string{
-						core.ProjectMemberAdmin,
-						core.ProjectMemberOwner,
-					},
-				})))
-			})
-
 			It("should allow specifying a namespace which is not in use (create)", func() {
 				project.Spec.Namespace = ptr.To("garden-foo")
 				projectCopy := project.DeepCopy()
@@ -1827,7 +1718,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				coreProject.Spec.Namespace = ptr.To("garden-foo")
 				attrs := admission.NewAttributesRecord(&coreProject, nil, core.Kind("Project").WithVersion("version"), coreProject.Namespace, coreProject.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
 			})
@@ -1845,7 +1736,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				coreProject.Spec.Namespace = ptr.To("garden-foo")
 				attrs := admission.NewAttributesRecord(&coreProject, coreProjectOld, core.Kind("Project").WithVersion("version"), coreProject.Namespace, coreProject.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
 			})
@@ -1857,7 +1748,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&coreProject, nil, core.Kind("Project").WithVersion("version"), coreProject.Namespace, coreProject.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
 			})
@@ -1871,7 +1762,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				coreProject.Spec.Namespace = ptr.To("garden-foo")
 				attrs := admission.NewAttributesRecord(&coreProject, nil, core.Kind("Project").WithVersion("version"), coreProject.Namespace, coreProject.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"ErrStatus": MatchFields(IgnoreExtras, Fields{
@@ -1893,7 +1784,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				coreProject.Spec.Namespace = ptr.To("garden-foo")
 				attrs := admission.NewAttributesRecord(&coreProject, &coreProjectOld, core.Kind("Project").WithVersion("version"), coreProject.Namespace, coreProject.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"ErrStatus": MatchFields(IgnoreExtras, Fields{
@@ -1935,7 +1826,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfile, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1956,7 +1847,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1976,7 +1867,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("1.24.1"))
@@ -2004,7 +1895,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(And(
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(And(
 					ContainSubstring("unable to delete Kubernetes version"),
 					ContainSubstring("1.24.1"),
 					ContainSubstring("still in use by NamespacedCloudProfile"),
@@ -2035,7 +1926,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(And(
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(And(
 					ContainSubstring("unable to delete Kubernetes version"),
 					ContainSubstring("1.24.1"),
 					ContainSubstring("still in use by shoot '/shoot-Two'"),
@@ -2064,7 +1955,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should accept removal of kubernetes versions that are used by shoots using another unrelated NamespacedCloudProfile of same name", func() {
@@ -2087,7 +1978,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should accept removal of kubernetes version that is still in use by a shoot that is being deleted", func() {
@@ -2109,7 +2000,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -2205,7 +2096,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfile, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -2248,7 +2139,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -2292,7 +2183,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("1.17.2"))
@@ -2344,7 +2235,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -2412,7 +2303,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("1.17.2"))
 				Expect(err.Error()).To(ContainSubstring(s.Spec.Provider.Workers[1].Name))
@@ -2463,7 +2354,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("1.17.2"))
@@ -2528,7 +2419,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should fail for removal of a machine version that is used by a NamespacedCloudProfile", func() {
@@ -2587,7 +2478,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(And(
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(And(
 					ContainSubstring("unable to delete MachineImage version"),
 					ContainSubstring("1.16.0"),
 					ContainSubstring("still in use by NamespacedCloudProfile"),
@@ -2634,7 +2525,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(And(
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(And(
 					ContainSubstring("unable to delete MachineImage version"),
 					ContainSubstring("1.16.0"),
 					ContainSubstring("still in use by NamespacedCloudProfile"),
@@ -2681,7 +2572,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(And(
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(And(
 					ContainSubstring("unable to delete MachineImage \"coreos\""),
 					ContainSubstring("still in use by NamespacedCloudProfile"),
 				)))
@@ -2734,7 +2625,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(&cloudProfileNew, &cloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(And(
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(And(
 					ContainSubstring("unable to add MachineImage \"gardenlinux\""),
 					ContainSubstring("already defined by NamespacedCloudProfile \"project-123/profile-42\""),
 				)))
@@ -2816,7 +2707,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(shootTwo)).To(Succeed())
 				attrs := admission.NewAttributesRecord(cloudProfile, oldCloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
+				err := admissionHandler.Validate(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -2834,7 +2725,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(shootTwo)).To(Succeed())
 				attrs := admission.NewAttributesRecord(cloudProfile, oldCloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
+				err := admissionHandler.Validate(ctx, attrs, nil)
 
 				Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"ErrStatus": MatchFields(IgnoreExtras, Fields{
@@ -2872,7 +2763,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(shootOne)).To(Succeed())
 				attrs := admission.NewAttributesRecord(cloudProfile, oldCloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("CloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
+				err := admissionHandler.Validate(ctx, attrs, nil)
 
 				Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"ErrStatus": MatchFields(IgnoreExtras, Fields{
@@ -2917,7 +2808,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should succeed for the complete Kubernetes section being removed without usages", func() {
@@ -2939,7 +2830,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should succeed if a used and already extended kubernetes version expiration is changed to another value still in the future", func() {
@@ -2967,7 +2858,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should succeed if a used and extended kubernetes version already expired is not modified", func() {
@@ -3003,7 +2894,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should succeed if an extended and used Kubernetes version is removed with the base version still being valid", func() {
@@ -3037,7 +2928,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should fail if an extended and used Kubernetes version is being removed with the base version being already expired", func() {
@@ -3072,7 +2963,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 				Expect(err).To(MatchError(And(
 					ContainSubstring("unable to delete Kubernetes version"),
 					ContainSubstring("1.29.0"),
@@ -3105,7 +2996,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(And(
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(And(
 					ContainSubstring("unable to delete Kubernetes version"),
 					ContainSubstring("1.29.0"),
 					ContainSubstring("still in use by shoot"),
@@ -3144,7 +3035,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 		})
 
@@ -3210,7 +3101,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should succeed if a used and extended MachineImage version already expired is not modified", func() {
@@ -3237,7 +3128,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should succeed if an extended and used MachineImage version is removed with the base version still being valid", func() {
@@ -3264,7 +3155,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should fail if an extended and used MachineImage version is being removed with the base version being already expired", func() {
@@ -3292,7 +3183,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 				Expect(err).To(MatchError(And(
 					ContainSubstring("unable to delete Machine image version"),
 					ContainSubstring("1.17.3"),
@@ -3336,7 +3227,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 				Expect(err).To(MatchError(And(
 					ContainSubstring("unable to delete Machine image version"),
 					ContainSubstring("'coreos/1.1.2'"),
@@ -3380,7 +3271,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 				Expect(err).To(MatchError(And(
 					ContainSubstring("unable to delete Machine image version"),
 					ContainSubstring("'custom-namespaced-image/1.1.2'"),
@@ -3413,7 +3304,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(And(
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(And(
 					ContainSubstring("unable to delete Machine image version"),
 					ContainSubstring("1.17.3"),
 					ContainSubstring("still in use by shoot"),
@@ -3444,7 +3335,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should succeed if a new but unused MachineImage version is removed", func() {
@@ -3471,7 +3362,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(updatedNamespacedCloudProfile, namespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 		})
 
@@ -3564,7 +3455,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(shootTwo)).To(Succeed())
 				attrs := admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
+				err := admissionHandler.Validate(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -3582,7 +3473,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Add(shootTwo)).To(Succeed())
 				attrs := admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, core.Kind("NamespacedCloudProfile").WithVersion("version"), namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, core.Resource("NamespacedCloudProfile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
+				err := admissionHandler.Validate(ctx, attrs, nil)
 
 				Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"ErrStatus": MatchFields(IgnoreExtras, Fields{
@@ -3611,7 +3502,7 @@ var _ = Describe("resourcereferencemanager", func() {
 			It("should accept because there is no managed seed with the same name", func() {
 				attrs := admission.NewAttributesRecord(gardenlet, nil, seedmanagement.Kind("Gardenlet").WithVersion("version"), gardenlet.Namespace, gardenlet.Name, seedmanagement.Resource("gardenlets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, &user.DefaultInfo{Name: allowedUser})
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should forbid because there is a managed seed with the same name", func() {
@@ -3619,7 +3510,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(gardenlet, nil, seedmanagement.Kind("Gardenlet").WithVersion("version"), gardenlet.Namespace, gardenlet.Name, seedmanagement.Resource("gardenlets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, &user.DefaultInfo{Name: allowedUser})
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("there is already a ManagedSeed object with the same name")))
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("there is already a ManagedSeed object with the same name")))
 			})
 		})
 
@@ -3637,7 +3528,7 @@ var _ = Describe("resourcereferencemanager", func() {
 			It("should accept because there is no gardenlet with the same name", func() {
 				attrs := admission.NewAttributesRecord(managedSeed, nil, seedmanagement.Kind("ManagedSeed").WithVersion("version"), gardenlet.Namespace, gardenlet.Name, seedmanagement.Resource("gardenlets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, &user.DefaultInfo{Name: allowedUser})
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should forbid because there is a gardenlet with the same name", func() {
@@ -3645,7 +3536,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				attrs := admission.NewAttributesRecord(managedSeed, nil, seedmanagement.Kind("ManagedSeed").WithVersion("version"), managedSeed.Namespace, managedSeed.Name, seedmanagement.Resource("managedseeds").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, &user.DefaultInfo{Name: allowedUser})
 
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("there is already a Gardenlet object with the same name")))
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("there is already a Gardenlet object with the same name")))
 			})
 		})
 	})

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -27,6 +27,8 @@ const (
 	PluginNameExtensionLabels = "ExtensionLabels"
 	// PluginNameExtensionValidator is the name of the ExtensionValidator admission plugin.
 	PluginNameExtensionValidator = "ExtensionValidator"
+	// PluginNameFinalizerRemoval is the name of the FinalizerRemoval admission plugin.
+	PluginNameFinalizerRemoval = "FinalizerRemoval"
 	// PluginNameResourceReferenceManager is the name of the ResourceReferenceManager admission plugin.
 	PluginNameResourceReferenceManager = "ResourceReferenceManager"
 	// PluginNameManagedSeedShoot is the name of the ManagedSeedShoot admission plugin.
@@ -88,6 +90,7 @@ func AllPluginNames() []string {
 		PluginNameNamespacedCloudProfileValidator,   // NamespacedCloudProfileValidator
 		PluginNameProjectValidator,                  // ProjectValidator
 		PluginNameDeletionConfirmation,              // DeletionConfirmation
+		PluginNameFinalizerRemoval,                  // FinalizerRemoval
 		PluginNameOpenIDConnectPreset,               // OpenIDConnectPreset
 		PluginNameClusterOpenIDConnectPreset,        // ClusterOpenIDConnectPreset
 		PluginNameCustomVerbAuthorizer,              // CustomVerbAuthorizer
@@ -131,6 +134,7 @@ func DefaultOnPlugins() sets.Set[string] {
 		PluginNameNamespacedCloudProfileValidator, // NamespacedCloudProfileValidator
 		PluginNameProjectValidator,                // ProjectValidator
 		PluginNameDeletionConfirmation,            // DeletionConfirmation
+		PluginNameFinalizerRemoval,                // FinalizerRemoval
 		PluginNameOpenIDConnectPreset,             // OpenIDConnectPreset
 		PluginNameClusterOpenIDConnectPreset,      // ClusterOpenIDConnectPreset
 		PluginNameCustomVerbAuthorizer,            // CustomVerbAuthorizer

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/admission"
 
@@ -17,6 +19,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	plugin "github.com/gardener/gardener/plugin/pkg"
+	"github.com/gardener/gardener/plugin/pkg/utils"
 )
 
 // Register registers a plugin.
@@ -33,13 +36,13 @@ type handler struct {
 // New creates a new handler admission plugin.
 func New() (*handler, error) {
 	return &handler{
-		Handler: admission.NewHandler(admission.Create),
+		Handler: admission.NewHandler(admission.Create, admission.Update),
 	}, nil
 }
 
-var _ admission.ValidationInterface = &handler{}
+var _ admission.MutationInterface = &handler{}
 
-func (v *handler) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+func (v *handler) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Ignore all kinds other than Project
 	if a.GetKind().GroupKind() != gardencore.Kind("Project") {
 		return nil
@@ -56,10 +59,65 @@ func (v *handler) Validate(_ context.Context, a admission.Attributes, _ admissio
 		return apierrors.NewBadRequest("could not convert object to Project")
 	}
 
-	// TODO: Remove this admission plugin in favor of static validation in a future release, see https://github.com/gardener/gardener/pull/4228.
+	// TODO: Remove this check in favor of static validation in a future release, see https://github.com/gardener/gardener/pull/4228.
 	if project.Spec.Namespace != nil && *project.Spec.Namespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(*project.Spec.Namespace, gardenerutils.ProjectNamespacePrefix) {
 		return admission.NewForbidden(a, fmt.Errorf(".spec.namespace must start with %s", gardenerutils.ProjectNamespacePrefix))
 	}
 
+	if utils.SkipVerification(a.GetOperation(), project.ObjectMeta) {
+		return nil
+	}
+
+	if a.GetOperation() == admission.Create {
+		ensureProjectOwner(project, a.GetUserInfo().GetName())
+	}
+
+	ensureOwnerIsMember(project)
+
 	return nil
+}
+
+func ensureProjectOwner(project *gardencore.Project, userName string) {
+	// Set createdBy field in Project
+	project.Spec.CreatedBy = &rbacv1.Subject{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     rbacv1.UserKind,
+		Name:     userName,
+	}
+
+	if project.Spec.Owner == nil {
+		owner := project.Spec.CreatedBy
+
+	outer:
+		for _, member := range project.Spec.Members {
+			for _, role := range member.Roles {
+				if role == gardencore.ProjectMemberOwner {
+					owner = member.Subject.DeepCopy()
+					break outer
+				}
+			}
+		}
+
+		project.Spec.Owner = owner
+	}
+}
+
+func ensureOwnerIsMember(project *gardencore.Project) {
+	if project.Spec.Owner == nil {
+		return
+	}
+
+	ownerIsMember := slices.ContainsFunc(project.Spec.Members, func(member gardencore.ProjectMember) bool {
+		return member.Subject == *project.Spec.Owner
+	})
+
+	if !ownerIsMember {
+		project.Spec.Members = append(project.Spec.Members, gardencore.ProjectMember{
+			Subject: *project.Spec.Owner,
+			Roles: []string{
+				gardencore.ProjectMemberAdmin,
+				gardencore.ProjectMemberOwner,
+			},
+		})
+	}
 }

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -86,19 +86,16 @@ func ensureProjectOwner(project *gardencore.Project, userName string) {
 	}
 
 	if project.Spec.Owner == nil {
-		owner := project.Spec.CreatedBy
-
-	outer:
-		for _, member := range project.Spec.Members {
-			for _, role := range member.Roles {
-				if role == gardencore.ProjectMemberOwner {
-					owner = member.Subject.DeepCopy()
-					break outer
+		project.Spec.Owner = func() *rbacv1.Subject {
+			for _, member := range project.Spec.Members {
+				for _, role := range member.Roles {
+					if role == gardencore.ProjectMemberOwner {
+						return member.Subject.DeepCopy()
+					}
 				}
 			}
-		}
-
-		project.Spec.Owner = owner
+			return project.Spec.CreatedBy
+		}()
 	}
 }
 

--- a/plugin/pkg/project/validator/admission_test.go
+++ b/plugin/pkg/project/validator/admission_test.go
@@ -9,8 +9,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -23,7 +25,8 @@ var _ = Describe("Admission", func() {
 		var (
 			err              error
 			project          core.Project
-			admissionHandler admission.ValidationInterface
+			admissionHandler admission.MutationInterface
+			attrs            admission.Attributes
 
 			namespaceName = "garden-my-project"
 			projectName   = "my-project"
@@ -33,6 +36,8 @@ var _ = Describe("Admission", func() {
 					Namespace: namespaceName,
 				},
 			}
+
+			userInfo user.Info
 		)
 
 		BeforeEach(func() {
@@ -40,36 +45,139 @@ var _ = Describe("Admission", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			project = projectBase
+
+			userInfo = &user.DefaultInfo{Name: "foo"}
 		})
 
-		It("should allow creating the project (namespace nil)", func() {
-			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+		When("project is created", func() {
+			BeforeEach(func() {
+				attrs = admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+			})
 
-			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			It("should allow creating the project (namespace nil)", func() {
+				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
+			It("should allow creating the project(namespace non-nil)", func() {
+				project.Spec.Namespace = &namespaceName
+
+				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
+			It("should allow creating the project (namespace is 'garden')", func() {
+				project.Spec.Namespace = ptr.To(v1beta1constants.GardenNamespace)
+
+				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
+			It("should prevent creating the project because namespace prefix is missing", func() {
+				project.Spec.Namespace = ptr.To("foo")
+
+				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(".spec.namespace must start with garden-")))
+			})
+
+			It("should maintain createdBy and project owner", func() {
+				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+
+				Expect(project.Spec.CreatedBy).To(Equal(&rbacv1.Subject{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "User",
+					Name:     userInfo.GetName(),
+				}))
+
+				Expect(project.Spec.Owner).To(Equal(&rbacv1.Subject{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "User",
+					Name:     userInfo.GetName(),
+				}))
+
+				Expect(project.Spec.Members).To(ConsistOf(core.ProjectMember{
+					Subject: rbacv1.Subject{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     userInfo.GetName(),
+					},
+					Roles: []string{
+						core.ProjectMemberAdmin,
+						core.ProjectMemberOwner,
+					},
+				}))
+			})
+
+			It("should not overwrite project owner", func() {
+				project.Spec.Owner = &rbacv1.Subject{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "User",
+					Name:     "bar",
+				}
+
+				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+
+				Expect(project.Spec.Owner).To(Equal(&rbacv1.Subject{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "User",
+					Name:     "bar",
+				}))
+			})
 		})
 
-		It("should allow creating the project(namespace non-nil)", func() {
-			project.Spec.Namespace = &namespaceName
+		When("project is updated", func() {
+			BeforeEach(func() {
+				attrs = admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+			})
 
-			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+			It("should add project owner to members", func() {
+				projectOwner := core.ProjectMember{
+					Subject: rbacv1.Subject{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "foo",
+					},
+					Roles: []string{
+						core.ProjectMemberAdmin,
+						core.ProjectMemberOwner,
+					},
+				}
 
-			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
-		})
+				projectMemberBar := core.ProjectMember{
+					Subject: rbacv1.Subject{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "bar",
+					},
+					Roles: []string{
+						core.ProjectMemberViewer,
+					},
+				}
 
-		It("should allow creating the project (namespace is 'garden')", func() {
-			project.Spec.Namespace = ptr.To(v1beta1constants.GardenNamespace)
+				project.Spec.Owner = &projectOwner.Subject
+				project.Spec.Members = []core.ProjectMember{projectMemberBar}
 
-			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 
-			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
-		})
+				Expect(project.Spec.Members).To(ConsistOf(projectMemberBar, projectOwner))
+			})
 
-		It("should prevent creating the project because namespace prefix is missing", func() {
-			project.Spec.Namespace = ptr.To("foo")
+			It("should not re-add owner as member", func() {
+				projectOwner := core.ProjectMember{
+					Subject: rbacv1.Subject{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "foo",
+					},
+					Roles: []string{
+						core.ProjectMemberAdmin,
+						core.ProjectMemberOwner,
+					},
+				}
 
-			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				project.Spec.Owner = &projectOwner.Subject
+				project.Spec.Members = []core.ProjectMember{projectOwner}
 
-			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(".spec.namespace must start with garden-")))
+				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+
+				Expect(project.Spec.Members).To(ConsistOf(projectOwner))
+			})
 		})
 	})
 
@@ -85,11 +193,11 @@ var _ = Describe("Admission", func() {
 	})
 
 	Describe("#New", func() {
-		It("should only handle CREATE operations", func() {
+		It("should handle CREATE and UPDATE operations", func() {
 			dr, err := New()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dr.Handles(admission.Create)).To(BeTrue())
-			Expect(dr.Handles(admission.Update)).To(BeFalse())
+			Expect(dr.Handles(admission.Update)).To(BeTrue())
 			Expect(dr.Handles(admission.Connect)).To(BeFalse())
 			Expect(dr.Handles(admission.Delete)).To(BeFalse())
 		})

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -253,13 +253,17 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, _ adm
 		}
 	}
 
+	if a.GetOperation() == admission.Create {
+		addCreatedByAnnotation(shoot, a.GetUserInfo().GetName())
+
+		if len(ptr.Deref(shoot.Spec.CloudProfileName, "")) > 0 && shoot.Spec.CloudProfile != nil {
+			return fmt.Errorf("new shoot can only specify either cloudProfileName or cloudProfile reference")
+		}
+	}
+
 	cloudProfileSpec, err := admissionutils.GetCloudProfileSpec(v.cloudProfileLister, v.namespacedCloudProfileLister, shoot)
 	if err != nil {
 		return apierrors.NewInternalError(fmt.Errorf("could not find referenced cloud profile: %+v", err.Error()))
-	}
-
-	if a.GetOperation() == admission.Create && len(ptr.Deref(shoot.Spec.CloudProfileName, "")) > 0 && shoot.Spec.CloudProfile != nil {
-		return fmt.Errorf("new shoot can only specify either cloudProfileName or cloudProfile reference")
 	}
 
 	if err := admissionutils.ValidateCloudProfileChanges(v.cloudProfileLister, v.namespacedCloudProfileLister, shoot, oldShoot); err != nil {
@@ -2146,4 +2150,13 @@ func validateMaxNodesTotal(workers []core.Worker, maxNodesTotal int32) field.Err
 	}
 
 	return allErrs
+}
+
+func addCreatedByAnnotation(shoot *core.Shoot, userName string) {
+	annotations := shoot.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[v1beta1constants.GardenCreatedBy] = userName
+	shoot.Annotations = annotations
 }

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -608,21 +608,6 @@ func (c *validationContext) validateDeletion(a admission.Attributes) error {
 		}
 	}
 
-	// Allow removal of `gardener` finalizer only if the Shoot deletion has completed successfully
-	if len(c.shoot.Status.TechnicalID) > 0 && c.shoot.Status.LastOperation != nil {
-		oldFinalizers := sets.New(c.oldShoot.Finalizers...)
-		newFinalizers := sets.New(c.shoot.Finalizers...)
-
-		if oldFinalizers.Has(core.GardenerName) && !newFinalizers.Has(core.GardenerName) {
-			lastOperation := c.shoot.Status.LastOperation
-			deletionSucceeded := lastOperation.Type == core.LastOperationTypeDelete && lastOperation.State == core.LastOperationStateSucceeded && lastOperation.Progress == 100
-
-			if !deletionSucceeded {
-				return admission.NewForbidden(a, fmt.Errorf("finalizer %q cannot be removed because shoot deletion has not completed successfully yet", core.GardenerName))
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -865,6 +865,7 @@ build:
             - pkg/admissioncontroller/webhook/admission/internaldomainsecret
             - pkg/admissioncontroller/webhook/admission/kubeconfigsecret
             - pkg/admissioncontroller/webhook/admission/namespacedeletion
+            - pkg/admissioncontroller/webhook/admission/providersecretlabels
             - pkg/admissioncontroller/webhook/admission/resourcesize
             - pkg/admissioncontroller/webhook/admission/seedrestriction
             - pkg/admissioncontroller/webhook/admission/shootkubeconfigsecretref

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -606,6 +606,7 @@ build:
             - plugin/pkg/global/deletionconfirmation
             - plugin/pkg/global/extensionlabels
             - plugin/pkg/global/extensionvalidation
+            - plugin/pkg/global/finalizerremoval
             - plugin/pkg/global/resourcereferencemanager
             - plugin/pkg/managedseed/shoot
             - plugin/pkg/managedseed/validator

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -203,6 +203,7 @@ build:
             - plugin/pkg/global/deletionconfirmation
             - plugin/pkg/global/extensionlabels
             - plugin/pkg/global/extensionvalidation
+            - plugin/pkg/global/finalizerremoval
             - plugin/pkg/global/resourcereferencemanager
             - plugin/pkg/managedseed/shoot
             - plugin/pkg/managedseed/validator

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -462,6 +462,7 @@ build:
             - pkg/admissioncontroller/webhook/admission/internaldomainsecret
             - pkg/admissioncontroller/webhook/admission/kubeconfigsecret
             - pkg/admissioncontroller/webhook/admission/namespacedeletion
+            - pkg/admissioncontroller/webhook/admission/providersecretlabels
             - pkg/admissioncontroller/webhook/admission/resourcesize
             - pkg/admissioncontroller/webhook/admission/seedrestriction
             - pkg/admissioncontroller/webhook/admission/shootkubeconfigsecretref

--- a/test/integration/envtest/environment_test.go
+++ b/test/integration/envtest/environment_test.go
@@ -44,6 +44,6 @@ var _ = Describe("GardenerTestEnvironment", func() {
 
 	It("should be able to manipulate resource from security.gardener.cloud/v1alpha1", func() {
 		credentialsBinding := &securityv1alpha1.CredentialsBinding{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-", Namespace: testNamespace.Name}}
-		Expect(testClient.Create(ctx, credentialsBinding)).To(MatchError(ContainSubstring("credentialsbindings.security.gardener.cloud \"test-\" is forbidden")))
+		Expect(testClient.Create(ctx, credentialsBinding)).To(MatchError(MatchRegexp("CredentialsBinding.security.gardener.cloud \"test-.+\" is invalid")))
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR makes sure that extension admission webhooks have validated `WorkloadIdentity`s and `Secret`s when used. In order to do so, it

- introduces a new webhook in `gardener-admission-controller` which syncs the `provider.gardener.cloud/*` labels on `Secret`s
- dry-runs `Secret` creation when referenced in a `CredentialsBinding` or `SecretBinding`
- introduces a new admission plugin that prevents finalzier removing for `*Binding` resources when still in-use by `Shoot`s
- ensures that the provider types in referenced `WorkloadIdentity`s and their `CredentialsBinding`s match
- ensures that the provider types in referenced `*Binding`s and `Shoot`s match

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11712
Fixes https://github.com/gardener/gardener/issues/12137

**Special notes for your reviewer**:
/cc @timuthy @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
It is now ensured that extension admission webhooks have validated `WorkloadIdentity`s/`Secret`s referenced in `Shoot`s.
```
