### PR TITLE
Restrict project owner change

### DIFF
--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -166,6 +166,10 @@ func (c *CustomVerbAuthorizer) admitProjects(ctx context.Context, a admission.At
 		return c.authorize(ctx, a, CustomVerbProjectManageMembers, "manage human users or groups in .spec.members")
 	}
 
+	if mustCheckProjectOwner(oldObj.Spec.Owner, obj.Spec.Owner, a.GetUserInfo()) {
+		return c.authorize(ctx, a, CustomVerbProjectManageMembers, "manage owner in .spec.owner")
+	}
+
 	return nil
 }
 
@@ -263,6 +267,20 @@ func mustCheckProjectTolerationsWhitelist(oldTolerations, tolerations *core.Proj
 		return !apiequality.Semantic.DeepEqual(oldTolerations.Whitelist, nil)
 	}
 	return !apiequality.Semantic.DeepEqual(oldTolerations.Whitelist, tolerations.Whitelist)
+}
+
+func mustCheckProjectOwner(oldOwner *rbacv1.Subject, owner *rbacv1.Subject, userInfo user.Info) bool {
+	// allow to set owner initially
+	if oldOwner == nil && owner != nil {
+		return false
+	}
+
+	// allow owner to change owner
+	if userIsOwner(userInfo, oldOwner) {
+		return false
+	}
+
+	return !apiequality.Semantic.DeepEqual(oldOwner, owner)
 }
 
 func mustCheckProjectMembers(oldMembers, members []core.ProjectMember, owner *rbacv1.Subject, userInfo user.Info) bool {

--- a/plugin/pkg/global/customverbauthorizer/admission_test.go
+++ b/plugin/pkg/global/customverbauthorizer/admission_test.go
@@ -359,6 +359,72 @@ var _ = Describe("customverbauthorizer", func() {
 					})
 				})
 			})
+
+			Context("owner configuration", func() {
+				Context("CREATE", func() {
+					It("should allow setting the owner", func() {
+						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
+						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+					})
+				})
+
+				Context("UPDATE", func() {
+					BeforeEach(func() {
+						authorizeAttributes.Verb = CustomVerbProjectManageMembers
+					})
+
+					It("should succeed without owner change", func() {
+						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
+						oldProject := project.DeepCopy()
+
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+					})
+
+					It("should allow changing the owner for owner", func() {
+						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
+						oldProject := project.DeepCopy()
+						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "new-owner"}
+
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+					})
+
+					It("should allow changing the owner for uam user", func() {
+						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionAllow, "", nil)
+
+						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "old-owner"}
+						oldProject := project.DeepCopy()
+						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "new-owner"}
+
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+					})
+
+					It("should deny changing the owner", func() {
+						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
+
+						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "old-owner"}
+						oldProject := project.DeepCopy()
+						project.Spec.Owner.Name = "new-owner"
+
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("not allowed to manage owner")))
+					})
+
+					It("should deny unsetting the owner", func() {
+						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
+
+						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "owner"}
+						oldProject := project.DeepCopy()
+						project.Spec.Owner = nil
+
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("not allowed to manage owner")))
+					})
+				})
+			})
 		})
 
 		Context("NamespacedCloudProfiles", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Only allow the owner itself or users with UAM role to change the owner of a project.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A new check ensures that only owners and project members with a UAM role are allowed to modify the project owner.
```
