### PR TITLE
[GEP-28] Prevent flaky e2e tests

### DIFF
--- a/example/gardenadm-local/high-touch/machine.yaml
+++ b/example/gardenadm-local/high-touch/machine.yaml
@@ -3,17 +3,17 @@ kind: StatefulSet
 metadata:
   name: machine
   labels:
-    app: machine
+    app: high-touch-machine
 spec:
   replicas: 2
   serviceName: "machine"
   selector:
     matchLabels:
-      app: machine
+      app: high-touch-machine
   template:
     metadata:
       labels:
-        app: machine
+        app: high-touch-machine
     spec:
       containers:
       - name: node

--- a/example/gardenadm-local/high-touch/namespace.yaml
+++ b/example/gardenadm-local/high-touch/namespace.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   name: gardenadm-high-touch
   labels:
-    # Use shoot label so that machine pods are considered in the export_artifacts() helper function during test runs in Prow.
+    # Use label so that machine pods are considered in the export_artifacts() helper function during test runs in Prow.
     # This makes sure that the usual systemd and pod logs get exported for each machine pod in this namespace.
-    gardener.cloud/role: shoot
+    export-artifacts: "true"

--- a/example/gardenadm-local/high-touch/service.yaml
+++ b/example/gardenadm-local/high-touch/service.yaml
@@ -8,7 +8,7 @@ spec:
     protocol: TCP
     targetPort: 443
   selector:
-    app: machine
+    app: high-touch-machine
     apps.kubernetes.io/pod-index: "0"
   sessionAffinity: None
   type: ClusterIP

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -37,7 +37,7 @@ export_artifacts() {
       # container logs
       kubectl cp "$namespace/$node":/var/log "$node_dir" || true
     done < <(kubectl -n "$namespace" get po -l app=machine -oname | cut -d/ -f2; kubectl -n "$namespace" get po -l app=high-touch-machine -oname | cut -d/ -f2)
-  done < <(kubectl get ns -l gardener.cloud/role=shoot -oname | cut -d/ -f2)
+  done < <(kubectl get ns -l gardener.cloud/role=shoot -oname | cut -d/ -f2; kubectl get ns -l export-artifacts=true -oname | cut -d/ -f2)
 
   echo "> Exporting /etc/hosts"
   cp /etc/hosts $ARTIFACTS/$cluster_name/hosts

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -36,7 +36,7 @@ export_artifacts() {
 
       # container logs
       kubectl cp "$namespace/$node":/var/log "$node_dir" || true
-    done < <(kubectl -n "$namespace" get po -l app=machine -oname | cut -d/ -f2)
+    done < <(kubectl -n "$namespace" get po -l app=machine -oname | cut -d/ -f2; kubectl -n "$namespace" get po -l app=high-touch-machine -oname | cut -d/ -f2)
   done < <(kubectl get ns -l gardener.cloud/role=shoot -oname | cut -d/ -f2)
 
   echo "> Exporting /etc/hosts"

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "medium-touch"), func() {
 	BeforeEach(OncePerOrdered, func(SpecContext) {
 		PrepareBinary()
-	}, NodeTimeout(time.Minute))
+	}, NodeTimeout(5*time.Minute))
 
 	Describe("Prepare infrastructure and machines", Ordered, func() {
 		It("should bootstrap the machine pods", func(ctx SpecContext) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind flake

**What this PR does / why we need it**:
1. **Do not label `machine` `StatefulSet` with `app=machine`**
   After https://github.com/gardener/gardener/pull/12052, `provider-local` is deployed into the kind cluster. It runs the `dnsconfig` webhook which reacts on `app=machine` pods: https://github.com/gardener/gardener/blob/f3efe83358ef0a6182d63c759b290bd392d7260f/pkg/provider-local/webhook/dnsconfig/add.go#L63-L64
   This `provider-local` is responsible for the medium-touch scenario of `gardenadm`.

   Hence, we actually don't want it to react on the pods related to the `machine` `StatefulSet` since these are relevant for the high-touch scenario of `gardenadm`. Let's simply change the labels here to prevent the webhook from interfering.

   Example flake: https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-gardenadm/1922295612275953664
   Here, the `kube-controller-manager` of the kind cluster fails to rollout
the new `machine` pods.

   From https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/logs/ci-gardener-e2e-kind-gardenadm/1922295612275953664/artifacts/gardener-local/gardener-local-control-plane/pods/kube-system_kube-controller-manager-gardener-local-control-plane_e4d0c8f9c71fba7c8d1b9da5e2da23b7/kube-controller-manager/0.log

   ```text
   2025-05-13T14:26:54.433492015Z stderr F E0513 14:26:54.433359       1 stateful_set.go:438] "Unhandled Error" err="error syncing StatefulSet gardenadm-high-touch/machine, requeuing: admission webhook \"dnsconfig.local.extensions.gardener.cloud\" denied the request: Service \"coredns\" not found" logger="UnhandledError"
   2025-05-13T14:26:54.440101864Z stderr F E0513 14:26:54.439984       1 stateful_set.go:438] "Unhandled Error" err="error syncing StatefulSet gardenadm-high-touch/machine, requeuing: admission webhook \"dnsconfig.local.extensions.gardener.cloud\" denied the request: Service \"coredns\" not found" logger="UnhandledError"
   2025-05-13T14:26:54.444946334Z stderr F E0513 14:26:54.444823       1 stateful_set.go:438] "Unhandled Error" err="error syncing StatefulSet gardenadm-high-touch/machine, requeuing: admission webhook \"dnsconfig.local.extensions.gardener.cloud\" denied the request: Service \"coredns\" not found" logger="UnhandledError"
   ...
   ```
2. **Increase timeout for building `gardenadm` binary**
   Since the complexity of the binary has increased in the past weeks, and since running many e2e in the Prow cluster can lead to CPU shortage, let's better increase the timeout a bit to prevent running into flakes.

   Example flake: https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-gardenadm/1922537540246573056

3. **Remove `gardener.cloud/role=shoot` label from `gardenadm-high-touch` namespace**
   To prevent NetworkPolicies to be applied

   Example flake: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12085/pull-gardener-e2e-kind-gardenadm/1922568377612636160

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
