### PR TITLE
[E2E] Adapt testing docs after refactoring e2e tests

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -478,6 +478,7 @@ gsutil cp -r gs://gardener-prow/pr-logs/pull/gardener_gardener/6136/pull-gardene
   - At this point, we are pretty much working with a distributed system and failures can happen anytime.
   - Wrapping calls in `Eventually` makes tests more stable and more realistic (usually, you wouldn't call the system broken if a single API call fails because of a short connectivity issue).
   - Calculate patches before entering the `Eventually` block
+    - If the first try of `Eventually` fails, the patch could become empty as the targeted resource was already modified in the first run
 - Most of the points from [writing integration tests](#writing-integration-tests) are relevant for e2e tests as well (especially the points about asynchronous assertions).
 - In contrast to integration tests, in e2e tests, it might make sense to specify higher timeouts for `Eventually` calls, e.g., when waiting for a `Shoot` to be reconciled.
   - Generally, try to use the default settings for `Eventually` specified via the environment variables.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -477,8 +477,6 @@ gsutil cp -r gs://gardener-prow/pr-logs/pull/gardener_gardener/6136/pull-gardene
 - Always wrap API calls and similar things in `Eventually` blocks: [example test](https://github.com/gardener/gardener/blob/3206df77c64b3a7d4c899bce184b532a5bad6c96/test/e2e/gardener/shoot/create_delete_unprivileged.go#L76)
   - At this point, we are pretty much working with a distributed system and failures can happen anytime.
   - Wrapping calls in `Eventually` makes tests more stable and more realistic (usually, you wouldn't call the system broken if a single API call fails because of a short connectivity issue).
-  - Calculate patches before entering the `Eventually` block
-    - If the first try of `Eventually` fails, the patch could become empty as the targeted resource was already modified in the first run
 - Most of the points from [writing integration tests](#writing-integration-tests) are relevant for e2e tests as well (especially the points about asynchronous assertions).
 - In contrast to integration tests, in e2e tests, it might make sense to specify higher timeouts for `Eventually` calls, e.g., when waiting for a `Shoot` to be reconciled.
   - Generally, try to use the default settings for `Eventually` specified via the environment variables.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adapts `testing.md` to include learnings from the e2e refactoring.

Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
