### PR TITLE
[GEP-26] Do not default seed.spec.backup.secretRef/credentialsRef

### DIFF
--- a/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet.go
@@ -7,5 +7,5 @@ package v1alpha1
 // SetDefaults_Gardenlet sets default values for Gardenlet objects.
 func SetDefaults_Gardenlet(obj *Gardenlet) {
 	SetDefaults_GardenletDeployment(&obj.Spec.Deployment.GardenletDeployment)
-	setDefaultsGardenletConfig(&obj.Spec.Config, obj.Name, obj.Namespace)
+	setDefaultsGardenletConfig(&obj.Spec.Config)
 }

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Defaults", func() {
 				}}))
 		})
 
-		It("should default gardenlet configuration, and backup secret reference if backup is specified", func() {
+		It("should not default backup secret reference if backup is specified", func() {
 			obj.Spec.Config = runtime.RawExtension{
 				Raw: encode(&gardenletconfigv1alpha1.GardenletConfiguration{
 					TypeMeta: metav1.TypeMeta{
@@ -84,18 +84,7 @@ var _ = Describe("Defaults", func() {
 						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
-									Backup: &gardencorev1beta1.Backup{
-										SecretRef: corev1.SecretReference{
-											Name:      "backup-" + name,
-											Namespace: namespace,
-										},
-										CredentialsRef: &corev1.ObjectReference{
-											APIVersion: "v1",
-											Kind:       "Secret",
-											Name:       "backup-" + name,
-											Namespace:  namespace,
-										},
-									},
+									Backup: &gardencorev1beta1.Backup{},
 								},
 							},
 						},

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -18,7 +18,7 @@ import (
 
 // SetDefaults_ManagedSeed sets default values for ManagedSeed objects.
 func SetDefaults_ManagedSeed(obj *ManagedSeed) {
-	setDefaultsGardenlet(&obj.Spec.Gardenlet, obj.Name, obj.Namespace)
+	setDefaultsGardenlet(&obj.Spec.Gardenlet)
 }
 
 // SetDefaults_GardenletDeployment sets default values for GardenletDeployment objects.
@@ -54,13 +54,13 @@ func SetDefaults_Image(obj *Image) {
 	}
 }
 
-func setDefaultsGardenlet(obj *GardenletConfig, name, namespace string) {
+func setDefaultsGardenlet(obj *GardenletConfig) {
 	// Set deployment defaults
 	if obj.Deployment == nil {
 		obj.Deployment = &GardenletDeployment{}
 	}
 
-	setDefaultsGardenletConfig(&obj.Config, name, namespace)
+	setDefaultsGardenletConfig(&obj.Config)
 
 	// Set default garden connection bootstrap
 	if obj.Bootstrap == nil {
@@ -74,7 +74,7 @@ func setDefaultsGardenlet(obj *GardenletConfig, name, namespace string) {
 	}
 }
 
-func setDefaultsGardenletConfig(config *runtime.RawExtension, name, namespace string) {
+func setDefaultsGardenletConfig(config *runtime.RawExtension) {
 	if config == nil {
 		return
 	}
@@ -98,14 +98,14 @@ func setDefaultsGardenletConfig(config *runtime.RawExtension, name, namespace st
 	}
 
 	// Set gardenlet config defaults
-	setDefaultsGardenletConfiguration(gardenletConfig, name, namespace)
+	setDefaultsGardenletConfiguration(gardenletConfig)
 
 	// Set gardenlet config back to obj.Config
 	// Encoding back to bytes is not needed, it will be done by the custom conversion code
 	*config = runtime.RawExtension{Object: gardenletConfig}
 }
 
-func setDefaultsGardenletConfiguration(obj *gardenletconfigv1alpha1.GardenletConfiguration, name, namespace string) {
+func setDefaultsGardenletConfiguration(obj *gardenletconfigv1alpha1.GardenletConfiguration) {
 	// Initialize resources
 	if obj.Resources == nil {
 		obj.Resources = &gardenletconfigv1alpha1.ResourcesConfiguration{}

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -118,9 +118,6 @@ func setDefaultsGardenletConfiguration(obj *gardenletconfigv1alpha1.GardenletCon
 	if obj.SeedConfig == nil {
 		obj.SeedConfig = &gardenletconfigv1alpha1.SeedConfig{}
 	}
-
-	// Set seed spec defaults
-	setDefaultsSeedSpec(&obj.SeedConfig.Spec, name, namespace)
 }
 
 func setDefaultsResources(obj *gardenletconfigv1alpha1.ResourcesConfiguration) {
@@ -129,20 +126,5 @@ func setDefaultsResources(obj *gardenletconfigv1alpha1.ResourcesConfiguration) {
 			obj.Capacity = make(corev1.ResourceList)
 		}
 		obj.Capacity[gardencorev1beta1.ResourceShoots] = resource.MustParse("250")
-	}
-}
-
-func setDefaultsSeedSpec(spec *gardencorev1beta1.SeedSpec, name, namespace string) {
-	if spec.Backup != nil && spec.Backup.SecretRef == (corev1.SecretReference{}) && spec.Backup.CredentialsRef == nil {
-		spec.Backup.SecretRef = corev1.SecretReference{
-			Name:      "backup-" + name,
-			Namespace: namespace,
-		}
-		spec.Backup.CredentialsRef = &corev1.ObjectReference{
-			APIVersion: "v1",
-			Kind:       "Secret",
-			Name:       "backup-" + name,
-			Namespace:  namespace,
-		}
 	}
 }

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Gardenlet.MergeWithParent).To(PointTo(Equal(true)))
 		})
 
-		It("should default gardenlet configuration, and backup secret reference if backup is specified", func() {
+		It("should not default backup secret reference if backup is specified", func() {
 			obj.Spec.Gardenlet = GardenletConfig{
 				Config: runtime.RawExtension{
 					Raw: encode(&gardenletconfigv1alpha1.GardenletConfiguration{
@@ -98,18 +98,7 @@ var _ = Describe("Defaults", func() {
 						SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
-									Backup: &gardencorev1beta1.Backup{
-										SecretRef: corev1.SecretReference{
-											Name:      "backup-" + name,
-											Namespace: namespace,
-										},
-										CredentialsRef: &corev1.ObjectReference{
-											APIVersion: "v1",
-											Kind:       "Secret",
-											Name:       "backup-" + name,
-											Namespace:  namespace,
-										},
-									},
+									Backup: &gardencorev1beta1.Backup{},
 								},
 							},
 						},

--- a/test/integration/gardenlet/gardenlet/gardenlet_test.go
+++ b/test/integration/gardenlet/gardenlet/gardenlet_test.go
@@ -50,6 +50,12 @@ var _ = Describe("Gardenlet controller test", func() {
 						Backup: &gardencorev1beta1.Backup{
 							Provider: "test",
 							Region:   ptr.To("bar"),
+							CredentialsRef: &corev1.ObjectReference{
+								Kind:       "Secret",
+								APIVersion: "v1",
+								Name:       "backup-secret",
+								Namespace:  "garden",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind cleanup

**What this PR does / why we need it**:
With this PR seed backup secret and credentials reference will no longer be defaulted in GardenletConfiguration.

Related to https://github.com/gardener/gardener/pull/11950

In essence I want to remove the defaulting and copying shoot infrastructure credentials as backup credentials and require operators to explicitly set these if required.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

invite @vpnachev @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The field `.seedConfig.spec.backup.credentialsRef/secretRef` will no longer be defaulted in `GardenletConfiguration` when backup is configured but reference to credentials is not provided. Operators are responsible to provide a valid credentials reference when configuring backup for seeds. Please consult the [deploy gardenlet documentation](https://gardener.cloud/docs/gardener/deployment/deploy_gardenlet/) for more information.
```
