### PR TITLE
Remove rolling update exception from docu

### DIFF
--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -86,7 +86,7 @@ The complete list of fields that trigger a rolling update:
 * `.spec.provider.workers[].machine.type`
 * `.spec.provider.workers[].volume.type`
 * `.spec.provider.workers[].volume.size`
-* `.spec.provider.workers[].providerConfig` (except if feature gate `NewWorkerPoolHash`)
+* `.spec.provider.workers[].providerConfig`
 * `.spec.provider.workers[].cri.name`
 * `.spec.provider.workers[].kubernetes.version` (except for patch version changes)
 * `.spec.systemComponents.nodeLocalDNS.enabled`

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -86,7 +86,7 @@ The complete list of fields that trigger a rolling update:
 * `.spec.provider.workers[].machine.type`
 * `.spec.provider.workers[].volume.type`
 * `.spec.provider.workers[].volume.size`
-* `.spec.provider.workers[].providerConfig`
+* `.spec.provider.workers[].providerConfig` (provider extension dependent with feature gate `NewWorkerPoolHash`)
 * `.spec.provider.workers[].cri.name`
 * `.spec.provider.workers[].kubernetes.version` (except for patch version changes)
 * `.spec.systemComponents.nodeLocalDNS.enabled`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
Currently, the NewWorkerPoolHash does not affect updates to the `.spec.provider.workers[].providerConfig` field.
This behaviour may change once MCM supports in-place updates for certain operations, such as volume updates.
See also https://github.com/gardener/gardener-extension-provider-aws/pull/1198.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
