### PR TITLE
Remove the deprecated `ReconcileTopologyAwareRoutingMetadata` func

### DIFF
--- a/pkg/utils/gardener/topology_aware_routing.go
+++ b/pkg/utils/gardener/topology_aware_routing.go
@@ -43,9 +43,3 @@ func ReconcileTopologyAwareRoutingSettings(service *corev1.Service, topologyAwar
 		metav1.SetMetaDataLabel(&service.ObjectMeta, resourcesv1alpha1.EndpointSliceHintsConsider, "true")
 	}
 }
-
-// ReconcileTopologyAwareRoutingMetadata adds or removes the required annotation, label and spec field to make a Service topology-aware.
-//
-// TODO(ialidzhikov): Remove this function after Gardener v1.119 has been released.
-// Deprecated: Use ReconcileTopologyAwareRoutingSettings instead.
-var ReconcileTopologyAwareRoutingMetadata = ReconcileTopologyAwareRoutingSettings


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking high-availability
/kind cleanup

**What this PR does / why we need it**:
Clean up a TODO introduced with https://github.com/gardener/gardener/pull/11178.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/11178

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The already deprecated `github.com/gardener/gardener/pkg/utils/gardener.ReconcileTopologyAwareRoutingMetadata` func is now removed. Instead, use `github.com/gardener/gardener/pkg/utils/gardener.ReconcileTopologyAwareRoutingSettings`. 
```
