### PR TITLE
[GEP-28] `gardenadm bootstrap`: Deploy and wait for `Infrastructure`

### DIFF
--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -177,6 +177,10 @@ func (b *AutonomousBotanist) initializeFakeGardenResources(ctx context.Context) 
 		return fmt.Errorf("failed creating Seed %s: %w", b.Seed.GetInfo().Name, err)
 	}
 
+	if err := b.GardenClient.Create(ctx, b.Shoot.GetInfo().DeepCopy()); client.IgnoreAlreadyExists(err) != nil {
+		return fmt.Errorf("failed creating Shoot %s: %w", client.ObjectKeyFromObject(b.Shoot.GetInfo()), err)
+	}
+
 	for _, extension := range b.Extensions {
 		if err := b.GardenClient.Create(ctx, extension.ControllerRegistration.DeepCopy()); client.IgnoreAlreadyExists(err) != nil {
 			return fmt.Errorf("failed creating ControllerRegistration %s: %w", extension.ControllerRegistration.Name, err)
@@ -269,7 +273,10 @@ func newFakeGardenClient() client.Client {
 	return fakeclient.
 		NewClientBuilder().
 		WithScheme(kubernetes.GardenScheme).
-		WithStatusSubresource(&gardencorev1beta1.ControllerInstallation{}).
+		WithStatusSubresource(
+			&gardencorev1beta1.ControllerInstallation{},
+			&gardencorev1beta1.Shoot{},
+		).
 		Build()
 }
 

--- a/pkg/utils/test/matchers/health.go
+++ b/pkg/utils/test/matchers/health.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	gomegatypes "github.com/onsi/gomega/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BeHealthy wraps a function (e.g., health.CheckDeployment) in a gomega matcher.
+// If the given health function returns nil for the actual value, the matcher succeeds.
+// If the health function returns an error, the matcher fails with the returned health check details.
+// For example:
+//
+//	Expect(deployment).To(BeHealthy(health.CheckDeployment))
+func BeHealthy[T client.Object](healthFunc func(T) error) gomegatypes.GomegaMatcher {
+	return &healthMatcher[T]{
+		healthFunc: healthFunc,
+	}
+}
+
+type healthMatcher[T client.Object] struct {
+	healthFunc func(T) error
+
+	failure error
+}
+
+func (h *healthMatcher[T]) Match(actual any) (success bool, err error) {
+	obj, ok := actual.(T)
+	if !ok {
+		return false, fmt.Errorf("expected %T but got %T", obj, actual)
+	}
+
+	h.failure = h.healthFunc(obj)
+	return h.failure == nil, nil
+}
+
+func (h *healthMatcher[T]) FailureMessage(actual any) string {
+	return h.expectedString(actual) +
+		fmt.Sprintf("to be healthy but the health check returned the following error:\n%s", format.IndentString(h.failure.Error(), 1))
+}
+
+func (h *healthMatcher[T]) NegatedFailureMessage(actual any) (message string) {
+	return h.expectedString(actual) + "not to be healthy but the health check did not return any error"
+}
+
+func (h *healthMatcher[T]) expectedString(actual any) string {
+	obj := actual.(T)
+	return fmt.Sprintf("Expected\n%s%T %s\n", format.Indent, obj, client.ObjectKeyFromObject(obj))
+}

--- a/pkg/utils/test/matchers/health_test.go
+++ b/pkg/utils/test/matchers/health_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("BeHealthy", func() {
+	var (
+		matcher gomegatypes.GomegaMatcher
+
+		pod *corev1.Pod
+	)
+
+	BeforeEach(func() {
+		matcher = BeHealthy(health.CheckPod)
+
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		}
+	})
+
+	When("the object is healthy", func() {
+		It("should succeed", func() {
+			Expect(pod).To(matcher)
+		})
+
+		It("return the correct negated failure message", func() {
+			Expect(matcher.Match(pod)).To(BeTrue())
+			Expect(matcher.NegatedFailureMessage(pod)).To(Equal(`Expected
+    *v1.Pod bar/foo
+not to be healthy but the health check did not return any error`))
+		})
+	})
+
+	When("the object is not healthy", func() {
+		BeforeEach(func() {
+			pod.Status.Phase = corev1.PodFailed
+		})
+
+		It("should fail", func() {
+			Expect(pod).NotTo(matcher)
+		})
+
+		It("return the correct failure message", func() {
+			Expect(matcher.Match(pod)).To(BeFalse())
+			Expect(matcher.FailureMessage(pod)).To(ContainSubstring(`Expected
+    *v1.Pod bar/foo
+to be healthy but the health check returned the following error:
+    pod is in invalid phase "Failed"`))
+		})
+	})
+
+	When("an unexpected object is passed", func() {
+		It("should return an error", func() {
+			Expect(matcher.Match(&appsv1.Deployment{})).Error().To(MatchError("expected *v1.Pod but got *v1.Deployment"))
+		})
+	})
+})

--- a/test/e2e/gardenadm/common/client.go
+++ b/test/e2e/gardenadm/common/client.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/gomega"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
@@ -24,6 +26,12 @@ func SetupRuntimeClient() {
 	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&componentbaseconfigv1alpha1.ClientConnectionConfiguration{Kubeconfig: os.Getenv("KUBECONFIG")}, nil, kubernetes.AuthTokenFile)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	RuntimeClient, err = kubernetes.NewWithConfig(kubernetes.WithRESTConfig(restConfig), kubernetes.WithDisabledCachedClient())
+	RuntimeClient, err = kubernetes.NewWithConfig(
+		kubernetes.WithRESTConfig(restConfig),
+		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
+		kubernetes.WithDisabledCachedClient(),
+	)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	komega.SetClient(RuntimeClient.Client())
 }

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -10,6 +10,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/provider-local/local"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "medium-touch"), func() {
@@ -18,10 +28,41 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 	}, NodeTimeout(5*time.Minute))
 
 	Describe("Prepare infrastructure and machines", Ordered, func() {
-		It("should bootstrap the machine pods", func(ctx SpecContext) {
-			Eventually(RunAndWait(ctx,
-				"bootstrap", "-d", "../../../example/gardenadm-local/medium-touch",
-			).Err).Should(gbytes.Say("work in progress"))
+		const (
+			shootName   = "root"
+			technicalID = "shoot--garden--" + shootName
+		)
+
+		var session *gexec.Session
+
+		It("should start the bootstrap flow", func() {
+			// Start the gardenadm process but don't wait for it to complete so that we can asynchronously perform assertions
+			// on individual steps in the test specs below.
+			session = Run("bootstrap", "-d", "../../../example/gardenadm-local/medium-touch")
+		})
+
+		It("should deploy gardener-resource-manager", func(ctx SpecContext) {
+			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameGardenerResourceManager, Namespace: technicalID}}
+			Eventually(ctx, Object(deployment)).Should(BeHealthy(health.CheckDeployment))
+		}, SpecTimeout(time.Minute))
+
+		It("should deploy the provider extension", func(ctx SpecContext) {
+			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardener-extension-" + local.Name, Namespace: "extension-" + local.Name}}
+			Eventually(ctx, Object(deployment)).Should(BeHealthy(health.CheckDeployment))
+		}, SpecTimeout(time.Minute))
+
+		It("should deploy the infrastructure", func(ctx SpecContext) {
+			infra := &extensionsv1alpha1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: technicalID}}
+			Eventually(ctx, Object(infra)).Should(BeHealthy(health.CheckExtensionObject))
+		}, SpecTimeout(time.Minute))
+
+		It("should finish successfully", func(ctx SpecContext) {
+			Wait(ctx, session)
+			Eventually(ctx, session.Err).Should(gbytes.Say("work in progress"))
+		}, SpecTimeout(time.Minute))
+
+		It("should run successfully a second time (should be idempotent)", func(ctx SpecContext) {
+			RunAndWait(ctx, "bootstrap", "-d", "../../../example/gardenadm-local/medium-touch")
 		}, SpecTimeout(2*time.Minute))
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR continues https://github.com/gardener/gardener/pull/12052 and deploys the shoot `Infrastructure` object.
The PR also reworks the e2e tests to check individual steps of `gardenadm bootstrap` asynchronously.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
