### PR TITLE
Clean up `kubelet-monitor` ClusterInput and ClusterFilter

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/logging.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/logging.go
@@ -38,19 +38,6 @@ func generateClusterInputs() []*fluentbitv1alpha2.ClusterInput {
 				},
 			},
 		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   journaldServiceName + "-monitor",
-				Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
-			},
-			Spec: fluentbitv1alpha2.InputSpec{
-				Systemd: &fluentbitv1alpha2input.Systemd{
-					Tag:           "journald.kubelet-monitor",
-					ReadFromTail:  "on",
-					SystemdFilter: []string{"_SYSTEMD_UNIT=kubelet-monitor.service"},
-				},
-			},
-		},
 	}
 }
 
@@ -67,22 +54,6 @@ func generateClusterFilters() []*fluentbitv1alpha2.ClusterFilter {
 					{
 						RecordModifier: &fluentbitv1alpha2filter.RecordModifier{
 							Records: []string{"hostname ${NODE_NAME}", "unit kubelet"},
-						},
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   journaldServiceName + "-monitor",
-				Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
-			},
-			Spec: fluentbitv1alpha2.FilterSpec{
-				Match: "journald.kubelet-monitor",
-				FilterItems: []fluentbitv1alpha2.FilterItem{
-					{
-						RecordModifier: &fluentbitv1alpha2filter.RecordModifier{
-							Records: []string{"hostname ${NODE_NAME}", "unit kubelet-monitor"},
 						},
 					},
 				},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/logging_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/logging_test.go
@@ -36,19 +36,6 @@ var _ = Describe("Logging", func() {
 							},
 						},
 					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "journald-kubelet-monitor",
-							Labels: map[string]string{"fluentbit.gardener/type": "seed"},
-						},
-						Spec: fluentbitv1alpha2.InputSpec{
-							Systemd: &fluentbitv1alpha2input.Systemd{
-								Tag:           "journald.kubelet-monitor",
-								ReadFromTail:  "on",
-								SystemdFilter: []string{"_SYSTEMD_UNIT=kubelet-monitor.service"},
-							},
-						},
-					},
 				}))
 
 			Expect(loggingConfig.Filters).To(Equal(
@@ -64,22 +51,6 @@ var _ = Describe("Logging", func() {
 								{
 									RecordModifier: &fluentbitv1alpha2filter.RecordModifier{
 										Records: []string{"hostname ${NODE_NAME}", "unit kubelet"},
-									},
-								},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "journald-kubelet-monitor",
-							Labels: map[string]string{"fluentbit.gardener/type": "seed"},
-						},
-						Spec: fluentbitv1alpha2.FilterSpec{
-							Match: "journald.kubelet-monitor",
-							FilterItems: []fluentbitv1alpha2.FilterItem{
-								{
-									RecordModifier: &fluentbitv1alpha2filter.RecordModifier{
-										Records: []string{"hostname ${NODE_NAME}", "unit kubelet-monitor"},
 									},
 								},
 							},

--- a/pkg/component/observability/logging/fluentcustomresources/custom_resources_test.go
+++ b/pkg/component/observability/logging/fluentcustomresources/custom_resources_test.go
@@ -55,19 +55,6 @@ var _ = Describe("Custom Resources", func() {
 						},
 					},
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "journald-kubelet-monitor",
-						Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
-					},
-					Spec: fluentbitv1alpha2.InputSpec{
-						Systemd: &fluentbitv1alpha2input.Systemd{
-							Tag:           "journald.kubelet-monitor",
-							ReadFromTail:  "on",
-							SystemdFilter: []string{"_SYSTEMD_UNIT=kubelet-monitor.service"},
-						},
-					},
-				},
 			},
 			Filters: []*fluentbitv1alpha2.ClusterFilter{
 				{
@@ -200,7 +187,6 @@ var _ = Describe("Custom Resources", func() {
 			manifests, err := test.ExtractManifestsFromManagedResourceData(customResourcesManagedResourceSecret.Data)
 			Expect(err).NotTo(HaveOccurred())
 			test.ExpectKindWithNameAndNamespace(manifests, "ClusterInput", "journald-kubelet", "")
-			test.ExpectKindWithNameAndNamespace(manifests, "ClusterInput", "journald-kubelet-monitor", "")
 			test.ExpectKindWithNameAndNamespace(manifests, "ClusterFilter", "gardener-extension", "")
 			test.ExpectKindWithNameAndNamespace(manifests, "ClusterParser", "extensions-parser", "")
 			test.ExpectKindWithNameAndNamespace(manifests, "ClusterOutput", "journald2", "")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/8786 replaces the `kubelet-monitor` systemd unit with a healthcheck controller in GNA.
This PR cleans up logging ClusterInput and ClusterFilter resources for the `kubelet-monitor` unit. There is no need of them when there is no longer such unit anymore.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/8786

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Obsolete `journald-kubelet-monitor` ClusterFilter and ClusterInput resources are now deleted. The systemd unit `kubelet-monitor` was replaced by a healthcheck controller in the gardener-node-agent in Gardener v1.87.0.
```
