### PR TITLE
node-problem-detector: enable `readonly-monitor` for detecting read-only filesystems

### DIFF
--- a/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector.go
@@ -206,7 +206,7 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 								Command: []string{
 									"/bin/sh",
 									"-c",
-									"exec /node-problem-detector --logtostderr --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json .. --config.custom-plugin-monitor=/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json .. --config.system-stats-monitor=/config/system-stats-monitor.json --prometheus-port=" + strconv.Itoa(daemonSetPrometheusPort),
+									"exec /node-problem-detector --logtostderr --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json,/config/readonly-monitor.json .. --config.custom-plugin-monitor=/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json .. --config.system-stats-monitor=/config/system-stats-monitor.json --prometheus-port=" + strconv.Itoa(daemonSetPrometheusPort),
 								},
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: ptr.To(true),

--- a/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/component/nodemanagement/nodeproblemdetector/node_problem_detector_test.go
@@ -194,7 +194,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - exec /node-problem-detector --logtostderr --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json
+        - exec /node-problem-detector --logtostderr --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json,/config/readonly-monitor.json
           .. --config.custom-plugin-monitor=/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json
           .. --config.system-stats-monitor=/config/system-stats-monitor.json --prometheus-port=` + strconv.Itoa(daemonSetPrometheusPort) + `
         env:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR enables the `readonly-monitor` for the `node-problem-detector` by adding the config path to the `--config.system-log-monitor` argument.

It allows to detect read-only filesystems on nodes and report them both as `NodeCondition` and Prometheus metric exported by the agent.

This will, when properly configured, make the `machine-controller-manager` aware of affected `Nodes` and mark them as `Unknown`, and eventually delete them when not resolved in time.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`node-problem-detector`: the `readonly-monitor` is now enabled as part of the `system-log-monitor`.
This monitor detects read-only filesystems and reports them as a `nodeCondition` on the `Node` object.
```
