### PR TITLE
Revert "Use `Role/RoleBinding` to provide RBAC permissions to MCM/CA pod instead of `ClusterRole/ClusterRoleBinding` (#11923)"

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -11,20 +11,13 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/component/autoscaling/clusterautoscaler"
-	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
 func (g *garden) runMigrations(ctx context.Context, log logr.Logger, gardenClient client.Client) error {
@@ -37,16 +30,6 @@ func (g *garden) runMigrations(ctx context.Context, log logr.Logger, gardenClien
 		if err := verifyRemoveAPIServerProxyLegacyPortFeatureGate(ctx, gardenClient, g.config.SeedConfig.Name); err != nil {
 			return err
 		}
-	}
-
-	log.Info("Migrating RBAC resources for machine-controller-manager")
-	if err := migrateMCMRBAC(ctx, g.mgr.GetClient()); err != nil {
-		return err
-	}
-
-	log.Info("Migrating RBAC resources for cluster-autoscaler")
-	if err := migrateAutoscalerRBAC(ctx, g.mgr.GetClient()); err != nil {
-		return err
 	}
 
 	return nil
@@ -181,80 +164,4 @@ func syncBackupSecretRefAndCredentialsRef(backup *gardencorev1beta1.SeedBackup) 
 	// - both fields are unset -> we have nothing to sync
 	// - both fields are set -> let the validation check if they are correct
 	// - credentialsRef refer to WorkloadIdentity -> secretRef should stay unset
-}
-
-// TODO(@aaronfern): Remove this after v1.120 is released
-func migrateMCMRBAC(ctx context.Context, seedClient client.Client) error {
-	namespaceList := &corev1.NamespaceList{}
-	if err := seedClient.List(ctx, namespaceList, client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot})); err != nil {
-		return err
-	}
-
-	var tasks []flow.TaskFn
-
-	for _, namespace := range namespaceList.Items {
-		if namespace.DeletionTimestamp != nil || namespace.Status.Phase == corev1.NamespaceTerminating {
-			continue
-		}
-		tasks = append(tasks, func(ctx context.Context) error {
-			clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			if err := seedClient.Get(ctx, client.ObjectKey{Name: "machine-controller-manager-" + namespace.Name}, clusterRoleBinding); err != nil {
-				//If MCM clusterRoleBinding does not exist, nothing to do
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}
-
-			return machinecontrollermanager.New(seedClient, namespace.Name, nil, machinecontrollermanager.Values{}).DeployMigrate(ctx)
-		})
-	}
-
-	if err := flow.Parallel(tasks...)(ctx); err != nil {
-		return err
-	}
-	if err := managedresources.DeleteForSeed(ctx, seedClient, "garden", "machine-controller-manager"); err != nil {
-		if !meta.IsNoMatchError(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-// TODO(@aaronfern): Remove this after v1.120 is released
-func migrateAutoscalerRBAC(ctx context.Context, seedClient client.Client) error {
-	namespaceList := &corev1.NamespaceList{}
-	if err := seedClient.List(ctx, namespaceList, client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot})); err != nil {
-		return err
-	}
-
-	var tasks []flow.TaskFn
-
-	for _, namespace := range namespaceList.Items {
-		if namespace.DeletionTimestamp != nil || namespace.Status.Phase == corev1.NamespaceTerminating {
-			continue
-		}
-		tasks = append(tasks, func(ctx context.Context) error {
-			clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			if err := seedClient.Get(ctx, client.ObjectKey{Name: "cluster-autoscaler-" + namespace.Name}, clusterRoleBinding); err != nil {
-				//If autoscaler clusterRoleBinding does not exist, nothing to do
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}
-
-			return clusterautoscaler.New(seedClient, namespace.Name, nil, "", 0, nil, []gardencorev1beta1.Worker{}, nil).DeployMigrate(ctx)
-		})
-	}
-
-	if err := flow.Parallel(tasks...)(ctx); err != nil {
-		return err
-	}
-	if err := managedresources.DeleteForSeed(ctx, seedClient, "garden", "cluster-autoscaler"); err != nil {
-		if !meta.IsNoMatchError(err) {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/component/autoscaling/clusterautoscaler/bootstrap.go
+++ b/pkg/component/autoscaling/clusterautoscaler/bootstrap.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterautoscaler
+
+import (
+	"context"
+	"time"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+const (
+	clusterRoleControlName     = "system:cluster-autoscaler-seed"
+	managedResourceControlName = "cluster-autoscaler"
+)
+
+// NewBootstrapper creates a new instance of DeployWaiter for the cluster-autoscaler bootstrapper.
+func NewBootstrapper(client client.Client, namespace string) component.DeployWaiter {
+	return &bootstrapper{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+type bootstrapper struct {
+	client    client.Client
+	namespace string
+}
+
+func (b *bootstrapper) Deploy(ctx context.Context) error {
+	var (
+		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+
+		clusterRole = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterRoleControlName,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{machinev1alpha1.GroupName},
+					Resources: []string{"machineclasses", "machinedeployments", "machines", "machinesets"},
+					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"deployments"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			},
+		}
+	)
+
+	resources, err := registry.AddAllAndSerialize(clusterRole)
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForSeed(ctx, b.client, b.namespace, managedResourceControlName, false, resources)
+}
+
+func (b *bootstrapper) Destroy(ctx context.Context) error {
+	return managedresources.DeleteForSeed(ctx, b.client, b.namespace, managedResourceControlName)
+}
+
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
+// or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
+
+func (b *bootstrapper) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilHealthy(timeoutCtx, b.client, b.namespace, managedResourceControlName)
+}
+
+func (b *bootstrapper) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilDeleted(timeoutCtx, b.client, b.namespace, managedResourceControlName)
+}

--- a/pkg/component/autoscaling/clusterautoscaler/bootstrap_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/bootstrap_test.go
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterautoscaler_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/autoscaling/clusterautoscaler"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("ClusterAutoscaler", func() {
+	var (
+		c client.Client
+
+		bootstrapper component.DeployWaiter
+
+		ctx       = context.Background()
+		namespace = "shoot--foo--bar"
+
+		consistOf                 func(...client.Object) types.GomegaMatcher
+		managedResourceName       = "cluster-autoscaler"
+		managedResourceSecretName = "managedresource-" + managedResourceName
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(c)
+		bootstrapper = NewBootstrapper(c, namespace)
+	})
+
+	Describe("#Deploy", func() {
+		var (
+			clusterRole = &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "system:cluster-autoscaler-seed",
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"machine.sapcloud.io"},
+						Resources: []string{"machineclasses", "machinedeployments", "machines", "machinesets"},
+						Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+					},
+					{
+						APIGroups: []string{"apps"},
+						Resources: []string{"deployments"},
+						Verbs:     []string{"get", "list", "watch"},
+					},
+				},
+			}
+
+			expectedMr = &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            managedResourceName,
+					Namespace:       namespace,
+					ResourceVersion: "1",
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					SecretRefs:  []corev1.LocalObjectReference{},
+					Class:       ptr.To("seed"),
+					KeepObjects: ptr.To(false),
+				},
+			}
+		)
+
+		It("should successfully deploy all the resources", func() {
+			Expect(bootstrapper.Deploy(ctx)).To(Succeed())
+
+			actualMr := &resourcesv1alpha1.ManagedResource{}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(expectedMr), actualMr)).To(Succeed())
+
+			expectedMr.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: actualMr.Spec.SecretRefs[0].Name}}
+			utilruntime.Must(references.InjectAnnotations(expectedMr))
+			Expect(actualMr).To(DeepEqual(expectedMr))
+			Expect(actualMr).To(consistOf(clusterRole))
+		})
+	})
+
+	Context("waiting functions", func() {
+		var (
+			fakeOps   *retryfake.Ops
+			resetVars func()
+		)
+
+		BeforeEach(func() {
+			fakeOps = &retryfake.Ops{MaxAttempts: 1}
+			resetVars = test.WithVars(
+				&retry.Until, fakeOps.Until,
+				&retry.UntilTimeout, fakeOps.UntilTimeout,
+			)
+		})
+
+		AfterEach(func() {
+			resetVars()
+		})
+
+		Describe("#Wait", func() {
+			It("should fail because reading the ManagedResource fails", func() {
+				Expect(bootstrapper.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the managed resource doesn't become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(bootstrapper.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should successfully wait for all resources to be ready", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(bootstrapper.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe("#WaitCleanup", func() {
+			It("should fail when the wait for the managed resource deletion times out", func() {
+				fakeOps.MaxAttempts = 2
+
+				managedResource := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      managedResourceName,
+						Namespace: namespace,
+					},
+				}
+				Expect(c.Create(ctx, managedResource)).To(Succeed())
+
+				Expect(bootstrapper.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when it's already removed", func() {
+				Expect(bootstrapper.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should successfully destroy all resources", func() {
+			managedResource := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedResourceName,
+					Namespace: namespace,
+				},
+			}
+			managedResourceSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedResourceSecretName,
+					Namespace: namespace,
+				},
+			}
+			Expect(c.Create(ctx, managedResource)).To(Succeed())
+			Expect(c.Create(ctx, managedResourceSecret)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+
+			Expect(bootstrapper.Destroy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
+		})
+	})
+})

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -157,8 +156,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 		serviceAccountName               = "cluster-autoscaler"
 		secretName                       = "shoot-access-cluster-autoscaler"
 		clusterRoleBindingName           = "cluster-autoscaler-" + namespace
-		roleName                         = "cluster-autoscaler"
-		roleBindingName                  = "cluster-autoscaler"
 		vpaName                          = "cluster-autoscaler-vpa"
 		pdbName                          = "cluster-autoscaler"
 		serviceName                      = "cluster-autoscaler"
@@ -229,43 +226,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 				Name:      serviceAccountName,
 				Namespace: namespace,
 			}},
-		}
-		roleBinding = &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "cluster-autoscaler",
-				Namespace:       namespace,
-				ResourceVersion: "1",
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "Role",
-				Name:     "cluster-autoscaler",
-			},
-			Subjects: []rbacv1.Subject{{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "cluster-autoscaler",
-				Namespace: namespace,
-			}},
-		}
-
-		role = &rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "cluster-autoscaler",
-				Namespace:       namespace,
-				ResourceVersion: "1",
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{machinev1alpha1.GroupName},
-					Resources: []string{"machineclasses", "machinedeployments", "machines", "machinesets"},
-					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
-				},
-				{
-					APIGroups: []string{"apps"},
-					Resources: []string{"deployments"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-			},
 		}
 		serviceAccount = &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
@@ -691,6 +651,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
 
 		clusterAutoscaler = New(c, namespace, sm, image, replicas, nil, workerConfig, nil)
+		clusterAutoscaler.SetNamespaceUID(namespaceUID)
 		clusterAutoscaler.SetMachineDeployments(machineDeployments)
 	})
 
@@ -716,6 +677,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 				}
 
 				clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, config, shootWorkerConfig, semver.MustParse("1.28.1"))
+				clusterAutoscaler.SetNamespaceUID(namespaceUID)
 				clusterAutoscaler.SetMachineDeployments(machineDeployments)
 
 				Expect(clusterAutoscaler.Deploy(ctx)).To(Succeed())
@@ -737,17 +699,9 @@ var _ = Describe("ClusterAutoscaler", func() {
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), actualServiceAccount)).To(Succeed())
 				Expect(actualServiceAccount).To(DeepEqual(serviceAccount))
 
-				//TODO(@aaronfern): Remove this after v1.120 is released
 				actualClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), actualClusterRoleBinding)).ToNot(Succeed())
-
-				actualRoleBinding := &rbacv1.RoleBinding{}
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(roleBinding), actualRoleBinding)).To(Succeed())
-				Expect(actualRoleBinding).To(DeepEqual(roleBinding))
-
-				actualRole := &rbacv1.Role{}
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(role), actualRole)).To(Succeed())
-				Expect(actualRole).To(DeepEqual(role))
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), actualClusterRoleBinding)).To(Succeed())
+				Expect(actualClusterRoleBinding).To(DeepEqual(clusterRoleBinding))
 
 				actualService := &corev1.Service{}
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), actualService)).To(Succeed())
@@ -783,28 +737,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 			It("w/ config", func() { test(true, false, false) })
 			It("w/ config, w/ workerConfig", func() { test(true, true, false) })
 			It("w/ config, w/ workerConfig, w/ 'priority' expander already configured", func() { test(true, true, true) })
-		})
-	})
-
-	Describe("#DeployMigrate", func() {
-		It("should delete existing cluster role binding object", func() {
-			clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, nil, nil, semver.MustParse("1.28.1"))
-
-			Expect(fakeClient.Create(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBinding.Name}})).To(Succeed())
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), &rbacv1.ClusterRoleBinding{})).To(Succeed())
-
-			Expect(clusterAutoscaler.DeployMigrate(ctx)).To(Succeed())
-
-			actualRoleBinding := &rbacv1.RoleBinding{}
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(roleBinding), actualRoleBinding)).To(Succeed())
-			Expect(actualRoleBinding).To(DeepEqual(roleBinding))
-
-			actualRole := &rbacv1.Role{}
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(role), actualRole)).To(Succeed())
-			Expect(actualRole).To(DeepEqual(role))
-
-			actualClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), actualClusterRoleBinding)).ToNot(Succeed())
 		})
 	})
 
@@ -859,33 +791,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 			Expect(clusterAutoscaler.Destroy(ctx)).To(MatchError(fakeErr))
 		})
 
-		It("should fail because the role cannot be deleted", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
-				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
-				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespace}}).Return(fakeErr),
-			)
-
-			Expect(clusterAutoscaler.Destroy(ctx)).To(MatchError(fakeErr))
-		})
-
-		It("should fail because the role binding cannot be deleted", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
-				c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName}}),
-				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
-				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespace}}),
-				c.EXPECT().Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: namespace}}).Return(fakeErr),
-			)
-
-			Expect(clusterAutoscaler.Destroy(ctx)).To(MatchError(fakeErr))
-		})
-
 		It("should fail because the secret cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: managedResourceName}}),
@@ -893,8 +798,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
 				c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespace}}),
-				c.EXPECT().Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: namespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: secretName}}).Return(fakeErr),
 			)
 
@@ -908,8 +811,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
 				c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespace}}),
-				c.EXPECT().Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: namespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: secretName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName}}).Return(fakeErr),
 			)
@@ -924,8 +825,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
 				c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespace}}),
-				c.EXPECT().Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: namespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: secretName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName}}),
 				c.EXPECT().Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceAccountName}}).Return(fakeErr),
@@ -941,8 +840,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
 				c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespace}}),
-				c.EXPECT().Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: namespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: secretName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName}}),
 				c.EXPECT().Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceAccountName}}),
@@ -959,8 +856,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
 				c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespace}}),
-				c.EXPECT().Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: namespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: secretName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName}}),
 				c.EXPECT().Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceAccountName}}),
@@ -978,8 +873,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 				c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pdbName}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}}),
 				c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName}}),
-				c.EXPECT().Delete(ctx, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespace}}),
-				c.EXPECT().Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: namespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: secretName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName}}),
 				c.EXPECT().Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceAccountName}}),

--- a/pkg/component/autoscaling/clusterautoscaler/mock/mocks.go
+++ b/pkg/component/autoscaling/clusterautoscaler/mock/mocks.go
@@ -15,6 +15,7 @@ import (
 
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gomock "go.uber.org/mock/gomock"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -55,20 +56,6 @@ func (mr *MockInterfaceMockRecorder) Deploy(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockInterface)(nil).Deploy), ctx)
 }
 
-// DeployMigrate mocks base method.
-func (m *MockInterface) DeployMigrate(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployMigrate", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeployMigrate indicates an expected call of DeployMigrate.
-func (mr *MockInterfaceMockRecorder) DeployMigrate(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployMigrate", reflect.TypeOf((*MockInterface)(nil).DeployMigrate), ctx)
-}
-
 // Destroy mocks base method.
 func (m *MockInterface) Destroy(ctx context.Context) error {
 	m.ctrl.T.Helper()
@@ -105,6 +92,18 @@ func (m *MockInterface) SetMaxNodesTotal(arg0 int64) {
 func (mr *MockInterfaceMockRecorder) SetMaxNodesTotal(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxNodesTotal", reflect.TypeOf((*MockInterface)(nil).SetMaxNodesTotal), arg0)
+}
+
+// SetNamespaceUID mocks base method.
+func (m *MockInterface) SetNamespaceUID(arg0 types.UID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNamespaceUID", arg0)
+}
+
+// SetNamespaceUID indicates an expected call of SetNamespaceUID.
+func (mr *MockInterfaceMockRecorder) SetNamespaceUID(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNamespaceUID", reflect.TypeOf((*MockInterface)(nil).SetNamespaceUID), arg0)
 }
 
 // Wait mocks base method.

--- a/pkg/component/networking/vpn/seedserver/mock/mocks.go
+++ b/pkg/component/networking/vpn/seedserver/mock/mocks.go
@@ -16,6 +16,7 @@ import (
 
 	seedserver "github.com/gardener/gardener/pkg/component/networking/vpn/seedserver"
 	gomock "go.uber.org/mock/gomock"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -106,6 +107,18 @@ func (m *MockInterface) SetPodNetworkCIDRs(pods []net.IPNet) {
 func (mr *MockInterfaceMockRecorder) SetPodNetworkCIDRs(pods any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPodNetworkCIDRs", reflect.TypeOf((*MockInterface)(nil).SetPodNetworkCIDRs), pods)
+}
+
+// SetSeedNamespaceObjectUID mocks base method.
+func (m *MockInterface) SetSeedNamespaceObjectUID(namespaceUID types.UID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSeedNamespaceObjectUID", namespaceUID)
+}
+
+// SetSeedNamespaceObjectUID indicates an expected call of SetSeedNamespaceObjectUID.
+func (mr *MockInterfaceMockRecorder) SetSeedNamespaceObjectUID(namespaceUID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSeedNamespaceObjectUID", reflect.TypeOf((*MockInterface)(nil).SetSeedNamespaceObjectUID), namespaceUID)
 }
 
 // SetServiceNetworkCIDRs mocks base method.

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -28,6 +28,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -109,6 +110,8 @@ type Interface interface {
 	SetNodeNetworkCIDRs(nodes []net.IPNet)
 	SetServiceNetworkCIDRs(services []net.IPNet)
 	SetPodNetworkCIDRs(pods []net.IPNet)
+	// SetSeedNamespaceObjectUID sets UID for the namespace
+	SetSeedNamespaceObjectUID(namespaceUID types.UID)
 
 	// GetValues returns the current configuration values of the deployer.
 	GetValues() Values
@@ -171,6 +174,7 @@ type vpnSeedServer struct {
 	client             client.Client
 	namespace          string
 	secretsManager     secretsmanager.Interface
+	namespaceUID       types.UID
 	values             Values
 	istioNamespaceFunc func() string
 }
@@ -981,6 +985,10 @@ func (v *vpnSeedServer) Destroy(ctx context.Context) error {
 
 func (v *vpnSeedServer) Wait(_ context.Context) error        { return nil }
 func (v *vpnSeedServer) WaitCleanup(_ context.Context) error { return nil }
+
+func (v *vpnSeedServer) SetSeedNamespaceObjectUID(namespaceUID types.UID) {
+	v.namespaceUID = namespaceUID
+}
 
 func (v *vpnSeedServer) SetNodeNetworkCIDRs(nodes []net.IPNet) {
 	v.values.Network.NodeCIDRs = nodes

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -28,6 +28,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -80,6 +81,7 @@ var _ = Describe("VpnSeedServer", func() {
 		istioNamespaceFunc = func() string { return istioNamespace }
 
 		vpaUpdateMode = vpaautoscalingv1.UpdateModeAuto
+		namespaceUID  = types.UID("123456")
 
 		secretNameTLSAuth = "vpn-seed-server-tlsauth-a1d0aa00"
 
@@ -824,6 +826,7 @@ var _ = Describe("VpnSeedServer", func() {
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-vpn", Namespace: namespace}})).To(Succeed())
 
 		vpnSeedServer = New(c, namespace, sm, istioNamespaceFunc, values)
+		vpnSeedServer.SetSeedNamespaceObjectUID(namespaceUID)
 	})
 
 	Describe("#Deploy", func() {

--- a/pkg/component/nodemanagement/machinecontrollermanager/bootstrap.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/bootstrap.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package machinecontrollermanager
+
+import (
+	"context"
+	"time"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+const (
+	managedResourceControlName = "machine-controller-manager"
+	clusterRoleName            = "system:machine-controller-manager-runtime"
+)
+
+// NewBootstrapper creates a new instance of DeployWaiter for the machine-controller-manager bootstrapper.
+func NewBootstrapper(client client.Client, namespace string) component.DeployWaiter {
+	return &bootstrapper{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+type bootstrapper struct {
+	client    client.Client
+	namespace string
+}
+
+func (b *bootstrapper) Deploy(ctx context.Context) error {
+	var (
+		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+
+		clusterRole = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterRoleName,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{machinev1alpha1.GroupName},
+					Resources: []string{
+						"machineclasses",
+						"machineclasses/status",
+						"machinedeployments",
+						"machinedeployments/status",
+						"machines",
+						"machines/status",
+						"machinesets",
+						"machinesets/status",
+					},
+					Verbs: []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
+				},
+				{
+					APIGroups: []string{corev1.GroupName},
+					Resources: []string{"configmaps", "secrets", "endpoints", "events", "pods"},
+					Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
+				},
+				{
+					APIGroups: []string{coordinationv1.GroupName},
+					Resources: []string{"leases"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups:     []string{coordinationv1.GroupName},
+					Resources:     []string{"leases"},
+					Verbs:         []string{"get", "watch", "update"},
+					ResourceNames: []string{"machine-controller", "machine-controller-manager"},
+				},
+			},
+		}
+	)
+
+	resources, err := registry.AddAllAndSerialize(clusterRole)
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForSeed(ctx, b.client, b.namespace, managedResourceControlName, false, resources)
+}
+
+func (b *bootstrapper) Destroy(ctx context.Context) error {
+	return managedresources.DeleteForSeed(ctx, b.client, b.namespace, managedResourceControlName)
+}
+
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
+// or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
+
+func (b *bootstrapper) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilHealthy(timeoutCtx, b.client, b.namespace, managedResourceControlName)
+}
+
+func (b *bootstrapper) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilDeleted(timeoutCtx, b.client, b.namespace, managedResourceControlName)
+}

--- a/pkg/component/nodemanagement/machinecontrollermanager/bootstrap_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/bootstrap_test.go
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package machinecontrollermanager_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("Bootstrap", func() {
+	var (
+		ctx = context.TODO()
+
+		managedResourceName = "machine-controller-manager"
+		namespace           = "some-namespace"
+
+		fakeClient client.Client
+		mcm        component.DeployWaiter
+
+		managedResource       *resourcesv1alpha1.ManagedResource
+		managedResourceSecret *corev1.Secret
+
+		clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: system:machine-controller-manager-runtime
+rules:
+- apiGroups:
+  - machine.sapcloud.io
+  resources:
+  - machineclasses
+  - machineclasses/status
+  - machinedeployments
+  - machinedeployments/status
+  - machines
+  - machines/status
+  - machinesets
+  - machinesets/status
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - delete
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - endpoints
+  - events
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - delete
+  - deletecollection
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - machine-controller
+  - machine-controller-manager
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - update
+`
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		mcm = NewBootstrapper(fakeClient, namespace)
+
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceName,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResource.Name,
+				Namespace: namespace,
+			},
+		}
+	})
+
+	Describe("#Deploy", func() {
+		It("should successfully deploy all resources", func() {
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+
+			Expect(mcm.Deploy(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+			expectedMr := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            managedResource.Name,
+					Namespace:       managedResource.Namespace,
+					ResourceVersion: "1",
+					Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class:       ptr.To("seed"),
+					SecretRefs:  []corev1.LocalObjectReference{{Name: managedResource.Spec.SecretRefs[0].Name}},
+					KeepObjects: ptr.To(false),
+				},
+			}
+			utilruntime.Must(references.InjectAnnotations(expectedMr))
+			Expect(managedResource).To(Equal(expectedMr))
+
+			managedResourceSecret.Name = managedResource.Spec.SecretRefs[0].Name
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+			Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
+			Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
+			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
+
+			manifests, err := test.ExtractManifestsFromManagedResourceData(managedResourceSecret.Data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(manifests).To(ConsistOf(clusterRoleYAML))
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should successfully destroy all resources", func() {
+			Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecret)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+
+			Expect(mcm.Destroy(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
+		})
+	})
+
+	Context("waiting functions", func() {
+		var fakeOps *retryfake.Ops
+
+		BeforeEach(func() {
+			fakeOps = &retryfake.Ops{MaxAttempts: 1}
+			DeferCleanup(test.WithVars(
+				&retry.Until, fakeOps.Until,
+				&retry.UntilTimeout, fakeOps.UntilTimeout,
+			))
+		})
+
+		Describe("#Wait", func() {
+			It("should fail because reading the ManagedResource fails", func() {
+				Expect(mcm.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the ManagedResource doesn't become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(mcm.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should successfully wait for the managed resource to become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(mcm.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe("#WaitCleanup", func() {
+			It("should fail when the wait for the managed resource deletion times out", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
+
+				Expect(mcm.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when it's already removed", func() {
+				Expect(mcm.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+})

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -8,13 +8,11 @@ import (
 	"context"
 	"time"
 
-	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -60,8 +58,6 @@ var _ = Describe("MachineControllerManager", func() {
 
 		serviceAccount        *corev1.ServiceAccount
 		clusterRoleBinding    *rbacv1.ClusterRoleBinding
-		roleBinding           *rbacv1.RoleBinding
-		role                  *rbacv1.Role
 		service               *corev1.Service
 		shootAccessSecret     *corev1.Secret
 		deployment            *appsv1.Deployment
@@ -81,6 +77,7 @@ var _ = Describe("MachineControllerManager", func() {
 			Replicas: replicas,
 		}
 		mcm = New(fakeClient, namespace, sm, values)
+		mcm.SetNamespaceUID(namespaceUID)
 
 		By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
@@ -115,62 +112,6 @@ var _ = Describe("MachineControllerManager", func() {
 				Name:      "machine-controller-manager",
 				Namespace: namespace,
 			}},
-		}
-
-		roleBinding = &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "machine-controller-manager",
-				Namespace: namespace,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     "machine-controller-manager",
-			},
-			Subjects: []rbacv1.Subject{{
-				Kind:      "ServiceAccount",
-				Name:      "machine-controller-manager",
-				Namespace: namespace,
-			}},
-		}
-
-		role = &rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "machine-controller-manager",
-				Namespace: namespace,
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{machinev1alpha1.GroupName},
-					Resources: []string{
-						"machineclasses",
-						"machineclasses/status",
-						"machinedeployments",
-						"machinedeployments/status",
-						"machines",
-						"machines/status",
-						"machinesets",
-						"machinesets/status",
-					},
-					Verbs: []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
-				},
-				{
-					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"configmaps", "secrets", "endpoints", "events", "pods"},
-					Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
-				},
-				{
-					APIGroups: []string{coordinationv1.GroupName},
-					Resources: []string{"leases"},
-					Verbs:     []string{"create"},
-				},
-				{
-					APIGroups:     []string{coordinationv1.GroupName},
-					Resources:     []string{"leases"},
-					Verbs:         []string{"get", "watch", "update"},
-					ResourceNames: []string{"machine-controller", "machine-controller-manager"},
-				},
-			},
 		}
 
 		service = &corev1.Service{
@@ -583,19 +524,10 @@ subjects:
 			serviceAccount.ResourceVersion = "1"
 			Expect(actualServiceAccount).To(Equal(serviceAccount))
 
-			//TODO(@aaronfern): Remove this after v1.120 is released
 			actualClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), actualClusterRoleBinding)).ToNot(Succeed())
-
-			actualRoleBinding := &rbacv1.RoleBinding{}
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(roleBinding), actualRoleBinding)).To(Succeed())
-			roleBinding.ResourceVersion = "1"
-			Expect(actualRoleBinding).To(Equal(roleBinding))
-
-			actualRole := &rbacv1.Role{}
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(role), actualRole)).To(Succeed())
-			role.ResourceVersion = "1"
-			Expect(actualRole).To(Equal(role))
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), actualClusterRoleBinding)).To(Succeed())
+			clusterRoleBinding.ResourceVersion = "1"
+			Expect(actualClusterRoleBinding).To(Equal(clusterRoleBinding))
 
 			actualService := &corev1.Service{}
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), actualService)).To(Succeed())
@@ -657,22 +589,10 @@ subjects:
 		})
 	})
 
-	Describe("#DeployMigrate", func() {
-		It("should successfully delete existing clusterRoleBinding when deployMigrate is called", func() {
-			Expect(fakeClient.Create(ctx, clusterRoleBinding)).To(Succeed())
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), &rbacv1.ClusterRoleBinding{})).To(Succeed())
-
-			Expect(mcm.DeployMigrate(ctx)).To(Succeed())
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), &rbacv1.ClusterRoleBinding{})).ToNot(Succeed())
-		})
-	})
-
 	Describe("#Destroy", func() {
 		It("should successfully destroy all resources", func() {
 			Expect(fakeClient.Create(ctx, serviceAccount)).To(Succeed())
 			Expect(fakeClient.Create(ctx, clusterRoleBinding)).To(Succeed())
-			Expect(fakeClient.Create(ctx, role)).To(Succeed())
-			Expect(fakeClient.Create(ctx, roleBinding)).To(Succeed())
 			Expect(fakeClient.Create(ctx, service)).To(Succeed())
 			Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
@@ -693,8 +613,6 @@ subjects:
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(shootAccessSecret), &corev1.Secret{})).To(BeNotFoundError())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &corev1.Service{})).To(BeNotFoundError())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), &rbacv1.ClusterRoleBinding{})).To(BeNotFoundError())
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(role), &rbacv1.ClusterRoleBinding{})).To(BeNotFoundError())
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(roleBinding), &rbacv1.ClusterRoleBinding{})).To(BeNotFoundError())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), &corev1.ServiceAccount{})).To(BeNotFoundError())
 		})
 	})

--- a/pkg/component/nodemanagement/machinecontrollermanager/mock/mocks.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/mock/mocks.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -54,20 +55,6 @@ func (mr *MockInterfaceMockRecorder) Deploy(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockInterface)(nil).Deploy), ctx)
 }
 
-// DeployMigrate mocks base method.
-func (m *MockInterface) DeployMigrate(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployMigrate", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeployMigrate indicates an expected call of DeployMigrate.
-func (mr *MockInterfaceMockRecorder) DeployMigrate(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployMigrate", reflect.TypeOf((*MockInterface)(nil).DeployMigrate), ctx)
-}
-
 // Destroy mocks base method.
 func (m *MockInterface) Destroy(ctx context.Context) error {
 	m.ctrl.T.Helper()
@@ -80,6 +67,18 @@ func (m *MockInterface) Destroy(ctx context.Context) error {
 func (mr *MockInterfaceMockRecorder) Destroy(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), ctx)
+}
+
+// SetNamespaceUID mocks base method.
+func (m *MockInterface) SetNamespaceUID(arg0 types.UID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNamespaceUID", arg0)
+}
+
+// SetNamespaceUID indicates an expected call of SetNamespaceUID.
+func (mr *MockInterfaceMockRecorder) SetNamespaceUID(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNamespaceUID", reflect.TypeOf((*MockInterface)(nil).SetNamespaceUID), arg0)
 }
 
 // SetReplicas mocks base method.

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -144,6 +144,14 @@ func (r *Reconciler) runDeleteSeedFlow(
 			Name: "Destroying AlertManager",
 			Fn:   c.alertManager.Destroy,
 		})
+		destroyClusterAutoscaler = g.Add(flow.Task{
+			Name: "Destroying cluster-autoscaler resources",
+			Fn:   component.OpDestroyAndWait(c.clusterAutoscaler).Destroy,
+		})
+		destroyMachineControllerManager = g.Add(flow.Task{
+			Name: "Destroying machine-controller-manager resources",
+			Fn:   component.OpDestroyAndWait(c.machineControllerManager).Destroy,
+		})
 		destroyNginxIngress = g.Add(flow.Task{
 			Name:   "Destroying nginx-ingress",
 			Fn:     component.OpDestroyAndWait(c.nginxIngressController).Destroy,
@@ -240,6 +248,8 @@ func (r *Reconciler) runDeleteSeedFlow(
 			destroyAggregatePrometheus,
 			destroyAlertManager,
 			destroyNginxIngress,
+			destroyClusterAutoscaler,
+			destroyMachineControllerManager,
 			destroyDWDWeeder,
 			destroyDWDProber,
 			destroyKubeAPIServerIngress,

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -334,6 +334,16 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Dependencies: flow.NewTaskIDs(deployIstio),
 		})
 		_ = g.Add(flow.Task{
+			Name:         "Deploying cluster-autoscaler resources",
+			Fn:           c.clusterAutoscaler.Deploy,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying machine-controller-manager resources",
+			Fn:           c.machineControllerManager.Deploy,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
+		})
+		_ = g.Add(flow.Task{
 			Name:         "Deploying dependency-watchdog-weeder",
 			Fn:           c.dwdWeeder.Deploy,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler.go
@@ -43,6 +43,7 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 // DeployClusterAutoscaler deploys the Kubernetes cluster-autoscaler.
 func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 	if b.Shoot.WantsClusterAutoscaler {
+		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetNamespaceUID(b.SeedNamespaceObject.UID)
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetMachineDeployments(b.Shoot.Components.Extensions.Worker.MachineDeployments())
 
 		maxNodesTotal, err := b.CalculateMaxNodesTotal(b.Shoot.GetInfo())

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
@@ -107,6 +107,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 				botanist.Shoot.WantsClusterAutoscaler = true
 				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 
+				clusterAutoscaler.EXPECT().SetNamespaceUID(namespaceUID)
 				worker.EXPECT().MachineDeployments().Return(machineDeployments)
 				clusterAutoscaler.EXPECT().SetMachineDeployments(machineDeployments)
 				clusterAutoscaler.EXPECT().SetMaxNodesTotal(int64(0))

--- a/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
@@ -69,6 +69,7 @@ func (b *Botanist) DeployMachineControllerManager(ctx context.Context) error {
 	}
 
 	b.Shoot.Components.ControlPlane.MachineControllerManager.SetReplicas(replicas)
+	b.Shoot.Components.ControlPlane.MachineControllerManager.SetNamespaceUID(b.SeedNamespaceObject.UID)
 
 	return b.Shoot.Components.ControlPlane.MachineControllerManager.Deploy(ctx)
 }

--- a/pkg/gardenlet/operation/botanist/vpnseedserver.go
+++ b/pkg/gardenlet/operation/botanist/vpnseedserver.go
@@ -64,6 +64,7 @@ func (b *Botanist) DeployVPNServer(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetNodeNetworkCIDRs(b.Shoot.Networks.Nodes)
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetServiceNetworkCIDRs(b.Shoot.Networks.Services)
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetPodNetworkCIDRs(b.Shoot.Networks.Pods)
+	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSeedNamespaceObjectUID(b.SeedNamespaceObject.UID)
 
 	return b.Shoot.Components.ControlPlane.VPNSeedServer.Deploy(ctx)
 }

--- a/pkg/gardenlet/operation/botanist/vpnseedserver_test.go
+++ b/pkg/gardenlet/operation/botanist/vpnseedserver_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -115,6 +116,8 @@ var _ = Describe("VPNSeedServer", func() {
 
 			ctx     = context.TODO()
 			fakeErr = errors.New("fake err")
+
+			namespaceUID = types.UID("1234")
 		)
 
 		BeforeEach(func() {
@@ -153,6 +156,7 @@ var _ = Describe("VPNSeedServer", func() {
 			vpnSeedServer.EXPECT().SetNodeNetworkCIDRs(botanist.Shoot.Networks.Nodes)
 			vpnSeedServer.EXPECT().SetServiceNetworkCIDRs(botanist.Shoot.Networks.Services)
 			vpnSeedServer.EXPECT().SetPodNetworkCIDRs(botanist.Shoot.Networks.Pods)
+			vpnSeedServer.EXPECT().SetSeedNamespaceObjectUID(namespaceUID)
 		})
 
 		It("should set the secrets and SNI config and deploy", func() {

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -674,8 +674,10 @@ var _ = Describe("Seed controller tests", func() {
 
 					By("Verify that the seed system components have been deployed")
 					expectedManagedResources := []string{
+						"cluster-autoscaler",
 						"dependency-watchdog-weeder",
 						"dependency-watchdog-prober",
+						"machine-controller-manager",
 						"system",
 						"prometheus-cache",
 						"prometheus-seed",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement bug

**What this PR does / why we need it**:
This reverts commit 426de097 (https://github.com/gardener/gardener/pull/11923)

**Which issue(s) this PR fixes**:
> A shared informer is created for all namespaces which ties with the error of not being able to list resources at the cluster scope
```
W0515 08:59:08.756493       1 reflector.go:569] pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:shoot--xxx--aws-local-ext:cluster-autoscaler" cannot list resource "deployments" in API group "apps" at the cluster scope
```

**Special notes for your reviewer**:
/cc @aaronfern @rfranzke @timuthy 

/hold for clarification

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
