### PR TITLE
Fix `admission-local` deployment

### DIFF
--- a/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
@@ -32,8 +32,10 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         args:
         - --webhook-config-server-port={{ .Values.webhookConfig.serverPort }}
-        - --webhook-config-mode=url
+        - --webhook-config-mode={{ .Values.webhookConfig.mode }}
+{{- if eq .Values.webhookConfig.mode "url" }}
         - --webhook-config-url={{ printf "%s.%s" (include "name" .) (.Release.Namespace) }}
+{{- end }}
         - --webhook-config-namespace={{ .Release.Namespace }}
 {{- if .Values.gardener.virtualCluster.namespace }}
         - --webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}

--- a/charts/gardener/admission-local/charts/runtime/values.yaml
+++ b/charts/gardener/admission-local/charts/runtime/values.yaml
@@ -16,6 +16,7 @@ vpa:
   updatePolicy:
     updateMode: "Auto"
 webhookConfig:
+  mode: url
   serverPort: 10250
 service:
   topologyAwareRouting:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1840,6 +1840,7 @@ deploy:
         namespace: garden
         setValueTemplates:
           gardener.runtimeCluster.priorityClassName: gardener-system-400
+          webhookConfig.mode: service
         createNamespace: true
         wait: true
 profiles:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
For non-operator setups, the `admission-local` webhook needs to be registered as a `service` to be reachable from the KinD's Kube API Server.

The bug was introduced with #12061.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The change fixes the errors happening in all upgrade e2e tests ([example](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12088/pull-gardener-e2e-kind-upgrade/1922920175741440000)), but probably only after it was cherry-picked to branch `release-v1.119`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `admission-local` deployment was fixed to work with KinD based test setup.
```
