### PR TITLE
[release-v1.119] Fix network policy for `admission-local`

### DIFF
--- a/charts/gardener/admission-local/charts/runtime/templates/service.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
+    networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
     {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
     service.kubernetes.io/topology-mode: "auto"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
`from-all-webhook-targets-allowed-ports` does not work in non-operator based KinD setups (blocked ingress connection). Hence, use `from-world-to-ports` in addition.

This fixes the failing upgrade e2e tests in multi-node clusters (see [example](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12109/pull-gardener-e2e-kind-ha-multi-zone-upgrade/1923106463111188480)).

**Special notes for your reviewer**:
The change is first pushed against the `release-v1.119` branch to verify the upgrade tests succeed again on `master`.

/cc @LucaBernstein @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
