### PR TITLE
[GEP-31] Support enablement of `NewWorkerPoolHash` feature gate for Shoots with InPlace updates

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -442,6 +442,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					Labels: map[string]string{
 						"persist": "true",
 					},
+					Finalizers: []string{"gardener.cloud/gardener"},
 				},
 				Type: corev1.SecretTypeOpaque,
 				Data: map[string][]byte{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery open-source scalability
/kind enhancement

**What this PR does / why we need it**:
When the feature gate `NewWorkerPoolHash` is enabled, the worker pool is expected to use the `GNA` secret with a new name calculated using `KeyV2`. This works with rolling updates, as new nodes can use the updated GNA configuration, which refers to the new secret. However, with in-place updates, the nodes are not recreated, so changing the secret name is not possible. Doing so would put GNA into a failing state, as it would not have access to the secret with the new name.

To prevent this, this PR stops recalculating the hash for in-place update shoots if it has already been calculated. Additionally, a finalizer is added to the secret `worker-pools-operatingsystemconfig-hashes` to prevent it from being accidentally deleted, which would cause the hash to be recalculated—something that is not expected.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:
/cc @rfranzke @shafeeqes @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
