### PR TITLE
Revert "Update etcd-druid to v0.30.0 (minor) (#12111)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fluent/fluent-operator/v3 v3.3.0
 	github.com/gardener/cert-management v0.17.5
 	github.com/gardener/dependency-watchdog v1.4.0
-	github.com/gardener/etcd-druid/api v0.30.0
+	github.com/gardener/etcd-druid/api v0.29.1
 	github.com/gardener/machine-controller-manager v0.58.0
 	github.com/gardener/terminal-controller-manager v0.34.0
 	github.com/go-jose/go-jose/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/gardener/cert-management v0.17.5 h1:feqNpdgkF2RJP5xPidbkUx2MS15m4mBWG
 github.com/gardener/cert-management v0.17.5/go.mod h1:jazLDc7bcJ0T8axC96A52X7AqeIYsEyALpYsuTFuhbw=
 github.com/gardener/dependency-watchdog v1.4.0 h1:RKsjOSS41cR2kjbacWsrVlyhpV71PZhAiaB49D821UM=
 github.com/gardener/dependency-watchdog v1.4.0/go.mod h1:B5OYoELKMn8D28OFU4ZMSQFv+RD4mSLV0rvXMEhp4KI=
-github.com/gardener/etcd-druid/api v0.30.0 h1:Vxyt57Ynutqn1b8DCoXRm2xf+F9au+ZdJ0A/e00h4rI=
-github.com/gardener/etcd-druid/api v0.30.0/go.mod h1:R9by0d9G/kT8/yA6nY21h4GffQ8j8Uj8hA7mM8JgCmM=
+github.com/gardener/etcd-druid/api v0.29.1 h1:PKit1++grtPhXrBb6zScIAyfrXxbBJ5gkCKzvmTBFWs=
+github.com/gardener/etcd-druid/api v0.29.1/go.mod h1:70xxFBajCoQd+ZwreEbMKORVGj0a0nrj4KeB5coPM9U=
 github.com/gardener/machine-controller-manager v0.58.0 h1:JLMpuD+omliu/RwK0mA9Ce+MLObJq421Du1qmaAHmAU=
 github.com/gardener/machine-controller-manager v0.58.0/go.mod h1:TCU/KoudCMt2eV0Jnrq2D1TwgsrBCuhIVgV3j1el6Og=
 github.com/gardener/terminal-controller-manager v0.34.0 h1:qE8xIKsOFnVr1yZ2meesRR0q65uZ1Nyf5oSluAiLTeM=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -66,7 +66,7 @@ images:
   - name: etcd-druid
     sourceRepository: github.com/gardener/etcd-druid
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
-    tag: "v0.30.0"
+    tag: "v0.29.1"
   - name: etcd
     sourceRepository: github.com/etcd-io/etcd
     repository: quay.io/coreos/etcd


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind regression

**What this PR does / why we need it**:
This reverts commit 9af9b02b4ad17ff98d8661d65f796790297fd009.

See the discussion in https://github.com/gardener/gardener/pull/12111. The `targetRef` of the etcd VPAs should be changed from the etcd StatefulSet to the Etcd resource.

With the current master branch:
```
% k -n shoot--local--local get vpa etcd-main -o yaml

status:
  conditions:
  - lastTransitionTime: "2025-05-16T09:48:28Z"
    message: The targetRef controller has a parent but it should point to a topmost
      well-known or scalable controller
    status: "True"
    type: ConfigUnsupported
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
