### PR TITLE
[release-v1.118] Update dependency gardener/dashboard to v1.80.2

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -47,7 +47,7 @@ images:
 - name: gardener-dashboard
   sourceRepository: github.com/gardener/dashboard
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
-  tag: "1.80.1"
+  tag: "1.80.2"
 - name: terminal-controller-manager
   sourceRepository: github.com/gardener/terminal-controller-manager
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...
"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This is a cherry-pick of #12103

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency github.com/gardener/gardener #12120 @gardener-ci-robot
The following dependencies have been updated:
- `gardener/dashboard` from `1.80.1` to `1.80.2`. [Release Notes](https://redirect.github.com/gardener/dashboard/releases/tag/1.80.2)
```
