### PR TITLE
Make `gardener-operator` and `Garden` scenario work on single-node kind cluster

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -408,6 +408,13 @@ make operator-seed-up
 You find the kubeconfig for the KinD cluster at `./example/gardener-local/kind/operator/kubeconfig`.
 The one for the virtual garden is accessible at `./example/operator/virtual-garden/kubeconfig`.
 
+[!NOTE]
+To create a local dev landscape using gardener-operator and with a single node only, you can use the following command:
+
+```shell
+make kind-operator-single-up operator-up operator-seed-single-up
+```
+
 > [!IMPORTANT]
 > When you create non-HA shoot clusters (i.e., `Shoot`s with `.spec.controlPlane.highAvailability.failureTolerance != zone`), then they are not exposed via `172.18.255.1` ([ref](#accessing-the-shoot-cluster)).
 > Instead, you need to find out under which Istio instance they got exposed, and put the corresponding IP address into your `/etc/hosts` file:

--- a/example/gardener-local/gardenlet/operator-single/kustomization.yaml
+++ b/example/gardener-local/gardenlet/operator-single/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../operator
+
+patches:
+  - path: patch-gardenlet.yaml

--- a/example/gardener-local/gardenlet/operator-single/patch-gardenlet.yaml
+++ b/example/gardener-local/gardenlet/operator-single/patch-gardenlet.yaml
@@ -1,0 +1,12 @@
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: Gardenlet
+metadata:
+  name: local
+  namespace: garden
+spec:
+  config:
+    seedConfig:
+      spec:
+        provider:
+          zones:
+            - "0"

--- a/example/gardener-local/kind/operator-single/.gitignore
+++ b/example/gardener-local/kind/operator-single/.gitignore
@@ -1,0 +1,1 @@
+kubeconfig

--- a/example/gardener-local/kind/operator-single/values.yaml
+++ b/example/gardener-local/kind/operator-single/values.yaml
@@ -1,0 +1,14 @@
+gardener:
+  controlPlane:
+    deployed: true
+    kindIsGardenCluster: false
+    customEtcdStatefulSet: false
+  seed:
+    istio:
+      # Add one 'global' address and one per zone, see https://github.com/gardener/gardener/pull/6997
+      listenAddresses:
+      - 172.18.255.1
+  nginxIngress:
+    deployed: true
+  garden:
+    deployed: true

--- a/example/operator-single/kustomization.yaml
+++ b/example/operator-single/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../operator
+
+patches:
+- path: patch-garden.yaml

--- a/example/operator-single/patch-garden.yaml
+++ b/example/operator-single/patch-garden.yaml
@@ -1,0 +1,9 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Garden
+metadata:
+  name: local
+spec:
+  runtimeCluster:
+    provider:
+      zones:
+        - "0"

--- a/example/operator/kustomization.yaml
+++ b/example/operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - 20-garden.yaml

--- a/skaffold-operator-garden.yaml
+++ b/skaffold-operator-garden.yaml
@@ -3,8 +3,9 @@ kind: Config
 metadata:
   name: garden
 manifests:
-  rawYaml:
-    - example/operator/20-garden.yaml
+  kustomize:
+    paths:
+      - example/operator
 deploy:
   kubectl:
     hooks:
@@ -30,6 +31,12 @@ deploy:
               - -ec
               - kubectl -n garden get secret gardener -o jsonpath={.data.kubeconfig} | base64 -d > $VIRTUAL_GARDEN_KUBECONFIG
   statusCheck: false # enabled status check would watch all deployments in the garden namespace
+profiles:
+  - name: single
+    patches:
+      - op: replace
+        path: /manifests/kustomize/paths/0
+        value: example/operator-single
 ---
 apiVersion: skaffold/v4beta12
 kind: Config

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1687,7 +1687,7 @@ profiles:
     manifests:
       kustomize:
         paths:
-          - example/gardener-local/gardenlet/operator
+          - example/gardener-local/gardenlet/{{.SKAFFOLD_OPERATOR_DIR}}
     deploy:
       kubectl:
         hooks:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Addresses 'Make `gardener-operator` and `Garden` scenario work on single-node kind cluster' of #11958 
with
```shell
make kind-operator-single-up operator-up operator-seed-single-up
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11958

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
