### PR TITLE
Add list of acceptable tls cipher suites to kubelet configuration

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -126,6 +126,16 @@ shutdownGracePeriod: 0s
 shutdownGracePeriodCriticalPods: 0s
 streamingConnectionIdleTimeout: 5m0s
 syncFrequency: 1m0s
+tlsCipherSuites:
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_AES_128_GCM_SHA256
+- TLS_AES_256_GCM_SHA384
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_CHACHA20_POLY1305_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 volumePluginDir: /var/lib/kubelet/volumeplugins
 volumeStatsAggPeriod: 1m0s
 `

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -16,6 +16,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/version"
 )
 
@@ -102,6 +103,7 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddresses []string, clu
 		RegistryBurst:                    ptr.Deref(params.RegistryBurst, 0),
 		SyncFrequency:                    metav1.Duration{Duration: time.Minute},
 		SystemReserved:                   params.SystemReserved,
+		TLSCipherSuites:                  kubernetesutils.TLSCipherSuites,
 		VolumeStatsAggPeriod:             metav1.Duration{Duration: time.Minute},
 		VolumePluginDir:                  pathVolumePluginDirectory,
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -152,6 +153,7 @@ var _ = Describe("Config", func() {
 			ServerTLSBootstrap:             true,
 			StreamingConnectionIdleTimeout: metav1.Duration{Duration: time.Hour * 4},
 			SyncFrequency:                  metav1.Duration{Duration: time.Minute},
+			TLSCipherSuites:                kubernetesutils.TLSCipherSuites,
 			VolumeStatsAggPeriod:           metav1.Duration{Duration: time.Minute},
 		}
 
@@ -256,6 +258,7 @@ var _ = Describe("Config", func() {
 			SyncFrequency:                  metav1.Duration{Duration: time.Minute},
 			SystemReserved:                 params.SystemReserved,
 			StreamingConnectionIdleTimeout: metav1.Duration{Duration: time.Minute * 12},
+			TLSCipherSuites:                kubernetesutils.TLSCipherSuites,
 			VolumeStatsAggPeriod:           metav1.Duration{Duration: time.Minute},
 		}
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind enhancement

**What this PR does / why we need it**:

Our security audit complained about the missing definition of allowed cipher suites for the kubelet. The kube-apiserver already sets this flag, which was part of resolving https://github.com/gardener/gardener/issues/4300.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
