### PR TITLE
[GEP-28] Ensure `gardenadm` image is built for correct platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,9 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
+# build the images for the platform matching the nodes of the active kubernetes cluster,
+# even in `skaffold build`, which doesn't enable this by default
+export SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS = true
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug operator-seed-dev gardenadm%up: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug operator-seed-dev gardenadm%up: export SKAFFOLD_PUSH = true
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator%up operator-dev operator-debug operator-seed-dev gardenadm%up: export SOURCE_DATE_EPOCH = $(shell date -d $(BUILD_DATE) +%s)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind bug

**What this PR does / why we need it**:

`make gardenadm-medium-touch-up` uses `skaffold build` to prepare images for injection into the manifests.
However, this command doesn't detect the to-be-built platform (OS/arch) for images based on the targeted Kubernetes cluster by default:
```
    --check-cluster-node-platforms=true:
	When set to true, images are built for the target platforms matching the active kubernetes cluster node
	platforms. Enabled by default for `dev`, `debug` and `run`
```
This can lead to images built for `linux/amd64` even if the kind nodes run `linux/arm64`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
