### PR TITLE
[terminal] Remove obsolete permission

### DIFF
--- a/pkg/component/gardener/dashboard/terminal/rbac.go
+++ b/pkg/component/gardener/dashboard/terminal/rbac.go
@@ -33,11 +33,6 @@ func (t *terminal) clusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{corev1.GroupName},
-				Resources: []string{"secrets"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-			{
-				APIGroups: []string{corev1.GroupName},
 				Resources: []string{"serviceaccounts"},
 				Verbs:     []string{"get", "list", "watch", "patch", "update"},
 			},

--- a/pkg/component/gardener/dashboard/terminal/terminal_test.go
+++ b/pkg/component/gardener/dashboard/terminal/terminal_test.go
@@ -484,11 +484,6 @@ server:
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"secrets"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-				{
-					APIGroups: []string{""},
 					Resources: []string{"serviceaccounts"},
 					Verbs:     []string{"get", "list", "watch", "patch", "update"},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup

**What this PR does / why we need it**:
With the removal of `credential.secretRef` from the `Terminal` ([ref](https://github.com/gardener/terminal-controller-manager/pull/320)) resource, the permission to read `secrets` from the (virtual) garden cluster is not required anymore by the `terminal-controller-manager` and is therefore removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The terminal-controller-manager no longer needs to list Secrets from the (virtual) garden cluster.
```
