### PR TITLE
Avoid unnecessary VPA eviction for several Shoot control plane components

### DIFF
--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -225,7 +225,7 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 								corev1.ResourceMemory: resource.MustParse("30M"),
 							},
 						},

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -410,7 +410,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("5m"),
+											corev1.ResourceCPU:    resource.MustParse("10m"),
 											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -903,7 +903,7 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 						Env: env,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 								corev1.ResourceMemory: resource.MustParse("30M"),
 							},
 						},

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -594,7 +594,7 @@ var _ = Describe("ResourceManager", func() {
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("5m"),
+											corev1.ResourceCPU:    resource.MustParse("10m"),
 											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -346,7 +346,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 								corev1.ResourceMemory: resource.MustParse("30M"),
 							},
 						},

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -378,7 +378,7 @@ var _ = Describe("KubeControllerManager", func() {
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("5m"),
+											corev1.ResourceCPU:    resource.MustParse("10m"),
 											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},

--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -256,7 +256,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 						Env: env,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 								corev1.ResourceMemory: resource.MustParse("30M"),
 							},
 						},

--- a/pkg/component/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/component/kubernetes/scheduler/scheduler_test.go
@@ -261,7 +261,7 @@ var _ = Describe("KubeScheduler", func() {
 									Env: env,
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("5m"),
+											corev1.ResourceCPU:    resource.MustParse("10m"),
 											corev1.ResourceMemory: resource.MustParse("30M"),
 										},
 									},

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -243,7 +243,7 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 					}},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
 							corev1.ResourceMemory: resource.MustParse("20M"),
 						},
 					},

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -237,7 +237,7 @@ var _ = Describe("MachineControllerManager", func() {
 							}},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("5m"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
 									corev1.ResourceMemory: resource.MustParse("20M"),
 								},
 							},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR adapts part of the Shoot control plane components which are not in line with the new Pod autoscaling recommendations from https://github.com/gardener/gardener/pull/12030.

In particular, no container under VPA should define initial resource recommendations less than vpa-recommender's Pod minimum recommendation (`10m` and `10Mi`). Otherwise, the corresponding Pod will be evicted (guaranteed) after the initial recommendation by vpa-recommender so that the vpa-recommender's minimum recommendation is applied.

**Which issue(s) this PR fixes**:
N/A
but part of issue on investigating many VPA evictions during (or shortly after) Shoot creation

**Special notes for your reviewer**:
Have in mind that this PR does not guarantee that the corresponding components won't be evicted at all on Shoot creation.
I see that compared to the master branch the evictions of the corresponding components gets reduced and but it can still happen due to upscaling and downscaling later on by VPA. 
This PR makes sure that there won't be a guaranteed eviction by VPA for applying the vpa-recommender's minimums (`10m` and `10Mi`).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The cpu resource requests for cluster-autoscaler, gardener-resource-manager, kube-controller-manager, kube-scheduler and machine-controller-manager is increased from `5m` to `10m` in order to avoid unnecessary VPA eviction for these components after the first VPA recommendation.
```
