### PR TITLE
gardenlet: Prevent CA bundle on the Nodes to contain wrong certificates when worker pool specifies custom CA bundle

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/mock/mocks.go
+++ b/pkg/component/extensions/operatingsystemconfig/mock/mocks.go
@@ -125,7 +125,7 @@ func (mr *MockInterfaceMockRecorder) SetAPIServerURL(arg0 any) *gomock.Call {
 }
 
 // SetCABundle mocks base method.
-func (m *MockInterface) SetCABundle(arg0 *string) {
+func (m *MockInterface) SetCABundle(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCABundle", arg0)
 }

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -671,12 +671,15 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 		criName = extensionsv1alpha1.CRIName(worker.CRI.Name)
 	}
 
-	caBundle := o.values.CABundle
+	var caBundle *string
+	if o.values.CABundle != nil {
+		caBundle = ptr.To(*o.values.CABundle)
+	}
 	if worker.CABundle != nil {
 		if caBundle == nil {
-			caBundle = worker.CABundle
+			caBundle = ptr.To(*worker.CABundle)
 		} else {
-			*caBundle = fmt.Sprintf("%s\n%s", *caBundle, *worker.CABundle)
+			caBundle = ptr.To(fmt.Sprintf("%s\n%s", *caBundle, *worker.CABundle))
 		}
 	}
 

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -84,7 +84,7 @@ type Interface interface {
 	// SetAPIServerURL sets the APIServerURL value.
 	SetAPIServerURL(string)
 	// SetCABundle sets the CABundle value.
-	SetCABundle(*string)
+	SetCABundle(string)
 	// SetCredentialsRotationStatus sets the credentials rotation status
 	SetCredentialsRotationStatus(*gardencorev1beta1.ShootCredentialsRotation)
 	// SetSSHPublicKeys sets the SSHPublicKeys value.
@@ -123,7 +123,7 @@ type InitValues struct {
 // OriginalValues are configuration values required for the 'reconcile' OperatingSystemConfigPurpose.
 type OriginalValues struct {
 	// CABundle is the bundle of certificate authorities that will be added as root certificates.
-	CABundle *string
+	CABundle string
 	// ClusterDNSAddresses are the addresses for in-cluster DNS.
 	ClusterDNSAddresses []string
 	// ClusterDomain is the Kubernetes cluster domain.
@@ -642,7 +642,7 @@ func (o *operatingSystemConfig) SetAPIServerURL(apiServerURL string) {
 }
 
 // SetCABundle sets the CABundle value.
-func (o *operatingSystemConfig) SetCABundle(val *string) {
+func (o *operatingSystemConfig) SetCABundle(val string) {
 	o.values.CABundle = val
 }
 
@@ -671,16 +671,9 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 		criName = extensionsv1alpha1.CRIName(worker.CRI.Name)
 	}
 
-	var caBundle *string
-	if o.values.CABundle != nil {
-		caBundle = ptr.To(*o.values.CABundle)
-	}
+	caBundle := o.values.CABundle
 	if worker.CABundle != nil {
-		if caBundle == nil {
-			caBundle = ptr.To(*worker.CABundle)
-		} else {
-			caBundle = ptr.To(fmt.Sprintf("%s\n%s", *caBundle, *worker.CABundle))
-		}
+		caBundle = fmt.Sprintf("%s\n%s", caBundle, *worker.CABundle)
 	}
 
 	clusterCASecret, found := o.secretsManager.Get(v1beta1constants.SecretNameCACluster)
@@ -819,7 +812,7 @@ type deployer struct {
 	apiServerURL string
 
 	// original values
-	caBundle                                    *string
+	caBundle                                    string
 	clusterCASecretName                         string
 	clusterCABundle                             []byte
 	clusterDNSAddresses                         []string

--- a/pkg/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/components.go
@@ -24,7 +24,7 @@ type Component interface {
 // Context contains configuration for the components.
 type Context struct {
 	Key                     string
-	CABundle                *string
+	CABundle                string
 	ClusterDNSAddresses     []string
 	ClusterDomain           string
 	CRIName                 extensionsv1alpha1.CRIName

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -57,10 +57,7 @@ func (component) Name() string {
 }
 
 func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
-	var caBundle []byte
-	if ctx.CABundle != nil {
-		caBundle = []byte(*ctx.CABundle)
-	}
+	caBundle := []byte(ctx.CABundle)
 
 	var additionalTokenSyncConfigs []nodeagentconfigv1alpha1.TokenSecretSyncConfig
 	if ctx.ValitailEnabled {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Component", func() {
 				Key:               key,
 				KubernetesVersion: kubernetesVersion,
 				APIServerURL:      apiServerURL,
-				CABundle:          ptr.To(string(caBundle)),
+				CABundle:          string(caBundle),
 				Images:            map[string]*imagevectorutils.Image{"gardener-node-agent": {Repository: ptr.To("gardener-node-agent"), Tag: ptr.To("v1")}},
 			})
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -56,17 +56,13 @@ func (component) Name() string {
 }
 
 func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
-	if ctx.CABundle == nil {
-		return nil, nil, nil
-	}
-
 	updateLocalCaCertificatesScriptFile, err := updateLocalCACertificatesScriptFile()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	const pathEtcSSLCerts = "/etc/ssl/certs"
-	var caBundleBase64 = utils.EncodeBase64([]byte(*ctx.CABundle))
+	var caBundleBase64 = utils.EncodeBase64([]byte(ctx.CABundle))
 
 	updateCACertsFiles := []extensionsv1alpha1.File{
 		updateLocalCaCertificatesScriptFile,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -27,17 +27,7 @@ var _ = Describe("Component", func() {
 
 		BeforeEach(func() {
 			component = New()
-			ctx = components.Context{CABundle: &caBundle}
-		})
-
-		It("should return nothing because the CABundle is empty", func() {
-			ctx.CABundle = nil
-
-			units, files, err := component.Config(ctx)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(units).To(BeNil())
-			Expect(files).To(BeNil())
+			ctx = components.Context{CABundle: caBundle}
 		})
 
 		It("should return the expected units and files", func() {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -69,10 +69,7 @@ func getValitailConfigurationFile(ctx components.Context) (extensionsv1alpha1.Fi
 }
 
 func getValitailCAFile(ctx components.Context) extensionsv1alpha1.File {
-	var cABundle []byte
-	if ctx.CABundle != nil {
-		cABundle = []byte(*ctx.CABundle)
-	}
+	caBundleBase64 := utils.EncodeBase64([]byte(ctx.CABundle))
 
 	return extensionsv1alpha1.File{
 		Path:        PathCACert,
@@ -80,7 +77,7 @@ func getValitailCAFile(ctx components.Context) extensionsv1alpha1.File {
 		Content: extensionsv1alpha1.FileContent{
 			Inline: &extensionsv1alpha1.FileContentInline{
 				Encoding: "b64",
-				Data:     utils.EncodeBase64(cABundle),
+				Data:     caBundleBase64,
 			},
 		},
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Valitail", func() {
 		testConfig := func() {
 			It("should return the expected units and files when shoot logging is enabled", func() {
 				ctx := components.Context{
-					CABundle:      &cABundle,
+					CABundle:      cABundle,
 					ClusterDomain: clusterDomain,
 					Images: map[string]*imagevector.Image{
 						"valitail": valitailImage,
@@ -264,7 +264,7 @@ scrape_configs:
 
 			It("should return the expected units and files when shoot logging is not enabled", func() {
 				ctx := components.Context{
-					CABundle:      &cABundle,
+					CABundle:      cABundle,
 					ClusterDomain: clusterDomain,
 					Images: map[string]*imagevector.Image{
 						"valitail": valitailImage,
@@ -282,7 +282,7 @@ scrape_configs:
 
 			It("should return error when vali ingress is not specified", func() {
 				ctx := components.Context{
-					CABundle:      &cABundle,
+					CABundle:      cABundle,
 					ClusterDomain: clusterDomain,
 					Images: map[string]*imagevector.Image{
 						"valitail": valitailImage,

--- a/pkg/component/extensions/operatingsystemconfig/original/original_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/original_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Original", func() {
 
 	Describe("#Config", func() {
 		var (
-			caBundle                = ptr.To("cabundle")
+			caBundle                = "cabundle"
 			criName                 = extensionsv1alpha1.CRIName("foo")
 			images                  = map[string]*imagevector.Image{}
 			kubeletCABundle         = []byte("kubelet-ca-bundle")

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -92,7 +92,6 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 	if !found {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
 	}
-
 	clusterCABundle, found := clusterCASecret.Data[secretsutils.DataKeyCertificateBundle]
 	if !found {
 		return fmt.Errorf("key %q not found in secret %q", secretsutils.DataKeyCertificateBundle, v1beta1constants.SecretNameCACluster)

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -146,13 +146,11 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 }
 
 func (b *Botanist) getOperatingSystemConfigCABundle(clusterCABundle []byte) string {
-	var caBundle string
+	caBundle := string(clusterCABundle)
 
 	if cloudProfileCaBundle := b.Shoot.CloudProfile.Spec.CABundle; cloudProfileCaBundle != nil {
-		caBundle = *cloudProfileCaBundle
+		caBundle = fmt.Sprintf("%s\n%s", *cloudProfileCaBundle, caBundle)
 	}
-
-	caBundle = fmt.Sprintf("%s\n%s", caBundle, clusterCABundle)
 
 	return caBundle
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
If the [Worker.CABundle](https://github.com/gardener/gardener/blob/5cfbb5b1b195e60f9080c9eb09811764f1810bc4/pkg/apis/core/v1beta1/types_shoot.go#L1595)  is set in the Shoot spec, the generation of the `CABundle` in the `operatingsystemconfig` is incorrect. This PR solves the problem by using a new local variable, so concurrent modifications are no longer possible.

**Which issue(s) this PR fixes**:
Fixes #12140 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
gardenlet: An issue causing the CA bundle on the Nodes to contain wrong certificates when a worker specifies a custom CA bundle (`spec.provider.workers[].caBundle`) is now fixed.
```
