### PR TITLE
Fix operator not reconciling with disabled gardener dashboard

### DIFF
--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1172,18 +1172,13 @@ func (r *Reconciler) newGardenerDashboard(garden *operatorv1alpha1.Garden, secre
 		return nil, err
 	}
 
-	dashboardIngressEnabled := true
-	if garden.Spec.VirtualCluster.Gardener.Dashboard.Ingress != nil {
-		dashboardIngressEnabled = ptr.Deref(garden.Spec.VirtualCluster.Gardener.Dashboard.Ingress.Enabled, true)
-	}
-
 	values := gardenerdashboard.Values{
 		Image:            image.String(),
 		LogLevel:         logger.InfoLevel,
 		APIServerURL:     gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name),
 		EnableTokenLogin: true,
 		Ingress: gardenerdashboard.IngressValues{
-			Enabled:                dashboardIngressEnabled,
+			Enabled:                true,
 			Domains:                domainNames(garden.Spec.RuntimeCluster.Ingress.Domains),
 			WildcardCertSecretName: wildcardCertSecretName,
 		},
@@ -1231,6 +1226,10 @@ func (r *Reconciler) newGardenerDashboard(garden *operatorv1alpha1.Garden, secre
 		}
 		if config.AssetsConfigMapRef != nil {
 			values.AssetsConfigMapName = &config.AssetsConfigMapRef.Name
+		}
+
+		if config.Ingress != nil {
+			values.Ingress.Enabled = ptr.Deref(config.Ingress.Enabled, true)
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes a nil pointer dereference when `gardenerDashboard` is undefined in the `Garden` object.
Currently this causes the `Garden` controller within the operator to never be added to the manager, preventing reconciliation of the `Garden` object completely.

This bug was introduced with https://github.com/gardener/gardener/pull/12002,  really sorry about that 😢 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug that caused the gardener operator to never reconcile the `Garden` object, when there was no `gardenerDashboard` defined.
```
