### PR TITLE
Align "allow all" network policy with k8s documentation

### DIFF
--- a/charts/gardener/gardenlet/templates/networkpolicy.yaml
+++ b/charts/gardener/gardenlet/templates/networkpolicy.yaml
@@ -16,12 +16,6 @@ spec:
       role: gardenlet
       release: {{ .Release.Name }}
   egress:
-  - to:
-    - namespaceSelector: {}
-      podSelector: {}
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    - ipBlock:
-        cidr: ::/0
+  - {}
   policyTypes:
   - Egress

--- a/charts/gardener/operator/templates/networkpolicy.yaml
+++ b/charts/gardener/operator/templates/networkpolicy.yaml
@@ -16,21 +16,9 @@ spec:
       role: operator
       release: {{ .Release.Name }}
   ingress:
-  - from:
-    - namespaceSelector: {}
-      podSelector: {}
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    - ipBlock:
-        cidr: ::/0
+  - {}
   egress:
-  - to:
-    - namespaceSelector: {}
-      podSelector: {}
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    - ipBlock:
-        cidr: ::/0
+  - {}
   policyTypes:
   - Ingress
   - Egress

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -738,14 +738,7 @@ metadata:
   namespace: a
 spec:
   ingress:
-  - from:
-    - namespaceSelector: {}
-      podSelector: {}
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    - ipBlock:
-        cidr: ::/0
-    ports:
+  - ports:
     - port: 10250
       protocol: TCP
   podSelector:

--- a/example/gardener-local/controlplane/networkpolicy.yaml
+++ b/example/gardener-local/controlplane/networkpolicy.yaml
@@ -18,21 +18,9 @@ spec:
       - controller-manager
       - scheduler
   ingress:
-  - from:
-    - namespaceSelector: {}
-      podSelector: {}
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    - ipBlock:
-        cidr: ::/0
+  - {}
   egress:
-  - to:
-    - namespaceSelector: {}
-      podSelector: {}
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    - ipBlock:
-        cidr: ::/0
+  - {}
   policyTypes:
   - Egress
   - Ingress


### PR DESCRIPTION
This policy is meant to serve as an allow-all configuration - as its name indicates. According to the Kubernetes network policies documentation
(https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-policies), the default policy should be completely empty. Adapting the policy to this standard ensures that Cilium v1.17.x works as expected. Although the Cilium v1.17.0 release notes
(https://github.com/cilium/cilium/releases/tag/v1.17.0) do not detail the changes related to policy evaluation, aligning with the Kubernetes documentation addresses the issues observed.

**How to categorize this PR?**
/area networking
/kind api-change
/kind bug

**Special notes for your reviewer**:
this should not change anything, especially not for other networking solutions, although this is untested