### PR TITLE
Speed-up bring-up of Gardener and a seed using `gardener-operator`-based setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,7 @@ operator-seed-up operator-seed-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) operator-up
 	$(SKAFFOLD) $(SKAFFOLD_MODE) -m gardenlet -p $(SKAFFOLD_PROFILE) -f=skaffold.yaml --kubeconfig=$(VIRTUAL_GARDEN_KUBECONFIG) \
 		--cache-artifacts=$(shell ./hack/get-skaffold-cache-artifacts.sh) \
 		--status-check=false --platform="linux/$(SYSTEM_ARCH)" 	# deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
+	TIMEOUT=900 ./hack/usage/wait-for.sh garden local VirtualGardenAPIServerAvailable RuntimeComponentsHealthy VirtualComponentsHealthy
 
 operator-seed-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/operator-seed-down.sh --path-kind-kubeconfig $(KUBECONFIG) --path-garden-kubeconfig $(VIRTUAL_GARDEN_KUBECONFIG)

--- a/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
@@ -9,8 +9,12 @@ metadata:
     high-availability-config.resources.gardener.cloud/type: server
     {{- end }}
 spec:
-  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
 {{ include "labels" . | indent 6 }}
@@ -62,8 +66,8 @@ spec:
             path: /healthz
             port: {{ .Values.healthPort }}
             scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          initialDelaySeconds: 3
+          periodSeconds: 5
         {{- end }}
         {{- if .Values.readinessProbe.enable }}
         readinessProbe:
@@ -71,7 +75,8 @@ spec:
             path: /readyz
             port: {{ .Values.healthPort }}
             scheme: HTTP
-          initialDelaySeconds: 5
+          initialDelaySeconds: 3
+          periodSeconds: 5
           {{- end }}
 {{- if .Values.resources }}
         resources:

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -11,6 +11,10 @@ metadata:
 {{ include "labels" . | indent 4 }}
     high-availability-config.resources.gardener.cloud/type: server
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 2
   selector:
@@ -69,13 +73,11 @@ spec:
         - --heartbeat-namespace={{ .Release.Namespace }}
         - --heartbeat-renew-interval-seconds={{ .Values.controllers.heartbeat.renewIntervalSeconds }}
         {{- if .Values.gardener.runtimeCluster.enabled }}
-        - --disable-webhooks="*"
+        - --disable-webhooks=controlplane,dnsconfig,networkpolicy,prometheus,shoot
         - --controllers=backupbucket,dnsrecord,local-ext-shoot
         - --extension-class=garden
         {{- else }}
-        - --webhook-config-namespace={{ .Release.Namespace }}
-        - --webhook-config-service-port={{ .Values.webhookConfig.servicePort }}
-        - --webhook-config-server-port={{ tpl .Values.webhookConfig.serverPort . }}
+        - --disable-webhooks="rollout-speedup"
         {{- range .Values.webhooks.prometheus.remoteWriteURLs }}
         - --prometheus-remote-write-url={{ . }}
         {{- end }}
@@ -85,6 +87,9 @@ spec:
         - --disable-controllers={{ .Values.disableControllers | join "," }}
         - --disable-webhooks={{ .Values.disableWebhooks | join "," }}
         {{- end }}
+        - --webhook-config-namespace={{ .Release.Namespace }}
+        - --webhook-config-service-port={{ .Values.webhookConfig.servicePort }}
+        - --webhook-config-server-port={{ tpl .Values.webhookConfig.serverPort . }}
         - --metrics-bind-address=:{{ tpl .Values.metricsPort . }}
         - --health-bind-address=:{{ tpl .Values.healthPort . }}
         {{- if .Values.gardener.version }}
@@ -109,13 +114,15 @@ spec:
             path: /healthz
             port: {{ tpl .Values.healthPort . }}
             scheme: HTTP
-          initialDelaySeconds: 10
+          initialDelaySeconds: 3
+          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: /readyz
             port: {{ tpl .Values.healthPort . }}
             scheme: HTTP
-          initialDelaySeconds: 5
+          initialDelaySeconds: 3
+          periodSeconds: 5
         ports:
         - name: webhook-server
           containerPort: {{ tpl .Values.webhookConfig.serverPort . }}

--- a/charts/gardener/provider-local/templates/service.yaml
+++ b/charts/gardener/provider-local/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "name" . }}
+  name: gardener-extension-provider-local
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":{{ tpl .Values.webhookConfig.serverPort . }}}]'

--- a/cmd/gardener-extension-provider-local/app/options.go
+++ b/cmd/gardener-extension-provider-local/app/options.go
@@ -35,6 +35,7 @@ import (
 	networkpolicywebhook "github.com/gardener/gardener/pkg/provider-local/webhook/networkpolicy"
 	nodewebhook "github.com/gardener/gardener/pkg/provider-local/webhook/node"
 	prometheuswebhook "github.com/gardener/gardener/pkg/provider-local/webhook/prometheus"
+	rolloutspeedupwebhook "github.com/gardener/gardener/pkg/provider-local/webhook/rolloutspeedup"
 	shootwebhook "github.com/gardener/gardener/pkg/provider-local/webhook/shoot"
 )
 
@@ -65,6 +66,7 @@ func WebhookSwitchOptions() *extensionscmdwebhook.SwitchOptions {
 		extensionscmdwebhook.Switch(extensionscontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
 		extensionscmdwebhook.Switch(extensionsshootwebhook.WebhookName, shootwebhook.AddToManager),
 		extensionscmdwebhook.Switch(dnsconfigwebhook.WebhookName, dnsconfigwebhook.AddToManager),
+		extensionscmdwebhook.Switch(rolloutspeedupwebhook.WebhookName, rolloutspeedupwebhook.AddToManager),
 		extensionscmdwebhook.Switch(networkpolicywebhook.WebhookName, networkpolicywebhook.AddToManager),
 		extensionscmdwebhook.Switch(nodewebhook.WebhookName, nodewebhook.AddToManager),
 		extensionscmdwebhook.Switch(nodewebhook.WebhookNameShoot, nodewebhook.AddShootWebhookToManager),

--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -9,7 +9,7 @@
 # It takes the resource type, object name, and a list of conditions as arguments
 set -euo pipefail
 
-if [ "$#" -lt 3 ]; then
+if [ "$#" -lt 2 ]; then
   echo "Usage: $0 <resource_type> <object_name> <condition_1> <condition_2> ... <condition_n>
 Note: Namespace/Timeout will be used from the 'NAMESPACE'/'TIMEOUT' environment variable if set, otherwise it is optional.
       TIMEOUT: The operation will be retried until the timeout[default 600 seconds] is reached, with a 5 second sleep interval between each retry.

--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -22,6 +22,7 @@ OBJECT_NAME=$2
 shift 2
 CONDITIONS=("$@")
 NAMESPACE=${NAMESPACE:-}
+SKIP_LAST_OPERATION_CHECK=${SKIP_LAST_OPERATION_CHECK:-false}
 
 # The number of retries before failing
 TIMEOUT=${TIMEOUT:-600}
@@ -48,7 +49,7 @@ while [ "${retries}" -lt "${TIMEOUT}" ]; do
   fi
 
   # Check last operation state
-  if [ "$LAST_OPERATION_STATE" != "Succeeded" ]; then
+  if [ "$SKIP_LAST_OPERATION_CHECK" != "true" ] && [ "$LAST_OPERATION_STATE" != "Succeeded" ]; then
     LAST_OPERATION_SUCCEEDED=false
   fi
 

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -125,7 +125,7 @@ func (r *Reconciler) reconcile(
 	}
 
 	log.Info("Instantiating component deployers")
-	enableSeedAuthorizer, err := r.enableSeedAuthorizer(ctx)
+	enableSeedAuthorizer, err := r.enableSeedAuthorizer(ctx, targetVersion)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -646,7 +646,7 @@ func (r *Reconciler) runRuntimeSetupFlow(ctx context.Context, log logr.Logger, g
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name:         "Deploying gardener-resource-manager",
-			Fn:           component.OpWait(c.gardenerResourceManager).Deploy,
+			Fn:           c.gardenerResourceManager.Deploy,
 			Dependencies: flow.NewTaskIDs(deployEtcdCRD, deployVPACRD, deployIstioCRD),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/provider-local/webhook/rolloutspeedup/add.go
+++ b/pkg/provider-local/webhook/rolloutspeedup/add.go
@@ -18,7 +18,8 @@ import (
 	"github.com/gardener/gardener/pkg/provider-local/local"
 )
 
-// WebhookName is the name of the DNS config webhook.
+// WebhookName is the name of the rollout-speedup webhook. It modifies the API server deployments (kube-apiserver and
+// garden-apiserver) to make sure that a rolling update happens faster.
 const WebhookName = "rollout-speedup"
 
 var (

--- a/pkg/provider-local/webhook/rolloutspeedup/add.go
+++ b/pkg/provider-local/webhook/rolloutspeedup/add.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rolloutspeedup
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/provider-local/local"
+)
+
+// WebhookName is the name of the DNS config webhook.
+const WebhookName = "rollout-speedup"
+
+var (
+	logger = log.Log.WithName("local-rollout-speedup-webhook")
+
+	// DefaultAddOptions are the default AddOptions for AddToManager.
+	DefaultAddOptions = AddOptions{}
+)
+
+// AddOptions are options to apply when adding the local exposure webhook to the manager.
+type AddOptions struct{}
+
+// AddToManagerWithOptions creates a webhook with the given options and adds it to the manager.
+func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebhook.Webhook, error) {
+	logger.Info("Adding webhook to manager")
+
+	var (
+		name     = "rollout-speedup"
+		provider = local.Type
+		types    = []extensionswebhook.Type{
+			{Obj: &appsv1.Deployment{}},
+		}
+	)
+
+	logger = logger.WithValues("provider", provider)
+
+	handler, err := extensionswebhook.NewBuilder(mgr, logger).WithMutator(&mutator{client: mgr.GetClient()}, types...).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("Creating webhook", "name", name)
+
+	return &extensionswebhook.Webhook{
+		Name:              name,
+		Provider:          provider,
+		Types:             types,
+		Target:            extensionswebhook.TargetSeed,
+		Path:              name,
+		Webhook:           &admission.Webhook{Handler: handler, RecoverPanic: ptr.To(true)},
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: v1beta1constants.GardenNamespace}},
+		ObjectSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: v1beta1constants.LabelRole, Operator: metav1.LabelSelectorOpIn, Values: []string{v1beta1constants.LabelAPIServer}},
+		}},
+	}, nil
+}
+
+// AddToManager creates a webhook with the default options and adds it to the manager.
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+}

--- a/pkg/provider-local/webhook/rolloutspeedup/mutator.go
+++ b/pkg/provider-local/webhook/rolloutspeedup/mutator.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rolloutspeedup
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mutator struct {
+	client client.Client
+}
+
+func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
+	if newObj.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
+	deployment, ok := newObj.(*appsv1.Deployment)
+	if !ok {
+		return fmt.Errorf("expected deployment, got %T", newObj)
+	}
+
+	// 3 and 5 are the magic numbers 🪄
+	if deployment.Spec.MinReadySeconds > 5 {
+		deployment.Spec.MinReadySeconds = 5
+	}
+	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To[int64](3)
+
+	for i, container := range deployment.Spec.Template.Spec.Containers {
+		if container.ReadinessProbe != nil {
+			deployment.Spec.Template.Spec.Containers[i].ReadinessProbe.InitialDelaySeconds = 3
+			deployment.Spec.Template.Spec.Containers[i].ReadinessProbe.PeriodSeconds = 5
+		}
+	}
+
+	return nil
+}

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -739,6 +739,7 @@ build:
             - pkg/provider-local/webhook/networkpolicy
             - pkg/provider-local/webhook/node
             - pkg/provider-local/webhook/prometheus
+            - pkg/provider-local/webhook/rolloutspeedup
             - pkg/provider-local/webhook/shoot
             - pkg/resourcemanager/controller/garbagecollector/references
             - pkg/utils

--- a/skaffold-operator-garden.yaml
+++ b/skaffold-operator-garden.yaml
@@ -13,7 +13,9 @@ deploy:
             command:
               - bash
               - -ec
-              - TIMEOUT=900 hack/usage/wait-for.sh garden local VirtualGardenAPIServerAvailable RuntimeComponentsHealthy VirtualComponentsHealthy
+              # We deliberately only wait for the last operation to be 'Reconcile Succeeded' in order to be able to
+              # faster deploy the gardenlet.
+              - TIMEOUT=900 hack/usage/wait-for.sh garden local
         - host:
             command:
               - bash

--- a/skaffold-operator-garden.yaml
+++ b/skaffold-operator-garden.yaml
@@ -20,6 +20,14 @@ deploy:
             command:
               - bash
               - -ec
+              # Check that the admission component of provider-local extension is healthy - it may run webhooks for the
+              # resources that we are about to create in below 'garden-config' Skaffold config. This will fail in case
+              # the webhook server is down or not yet available.
+              - TIMEOUT=60 SKIP_LAST_OPERATION_CHECK=true ./hack/usage/wait-for.sh extop provider-local AdmissionHealthy
+        - host:
+            command:
+              - bash
+              - -ec
               - kubectl -n garden get secret gardener -o jsonpath={.data.kubeconfig} | base64 -d > $VIRTUAL_GARDEN_KUBECONFIG
   statusCheck: false # enabled status check would watch all deployments in the garden namespace
 ---

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1139,6 +1139,7 @@ build:
             - pkg/provider-local/webhook/networkpolicy
             - pkg/provider-local/webhook/node
             - pkg/provider-local/webhook/prometheus
+            - pkg/provider-local/webhook/rolloutspeedup
             - pkg/provider-local/webhook/shoot
             - pkg/resourcemanager/controller/garbagecollector/references
             - pkg/utils

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -781,6 +781,7 @@ build:
             - pkg/provider-local/webhook/networkpolicy
             - pkg/provider-local/webhook/node
             - pkg/provider-local/webhook/prometheus
+            - pkg/provider-local/webhook/rolloutspeedup
             - pkg/provider-local/webhook/shoot
             - pkg/resourcemanager/controller/garbagecollector/references
             - pkg/utils

--- a/test/integration/operator/extension/extension/extension_test.go
+++ b/test/integration/operator/extension/extension/extension_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -193,6 +194,12 @@ var _ = Describe("Extension controller tests", func() {
 				Namespace: testNamespace.Name,
 			},
 		}
+
+		priorityClass := &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardener-garden-system-200"}}
+		Expect(testClient.Create(ctx, priorityClass)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(testClient.Delete(ctx, priorityClass)).To(Succeed())
+		})
 	})
 
 	It("should reconcile all required cluster resources in the virtual and runtime garden cluster", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR speeds up the bring-up of Gardener and a seed (i.e., `make kind-operator-up operator-seed-up`) significantly. This will soon replace the default `gardener*-up` rules based on the deprecated `controlplane` Helm chart.

Benchmarks:
- `master` branch: `12m40s` for `operator-seed-up` on M3 Max (48Gi, 1Ti)
- this branch: `7m15s` for `operator-seed-up` on M1 Max (64Gi, 1Ti)
- `master` branch: `4m57s` for make gardener-up on M3 Max (48Gi, 1Ti)

Naturally, `make gardener-up` is still a bit faster, but the difference to `operator-seed-up` is much smaller now. There might be more opportunity to even tune it further in the future.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11958

**Special notes for your reviewer**:
/cc @oliver-goetz @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
