### PR TITLE
Specify initial resource requests for the MCM provider sidecar container

### DIFF
--- a/pkg/component/nodemanagement/machinecontrollermanager/provider.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/provider.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
@@ -60,6 +61,12 @@ func ProviderSidecarContainer(namespace, providerName, image string) corev1.Cont
 			ContainerPort: portProviderMetrics,
 			Protocol:      corev1.ProtocolTCP,
 		}},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
 		},

--- a/pkg/component/nodemanagement/machinecontrollermanager/provider_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/provider_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
@@ -60,6 +61,12 @@ var _ = Describe("Provider", func() {
 				ContainerPort: 10259,
 				Protocol:      corev1.ProtocolTCP,
 			}},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("20Mi"),
+				},
+			},
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.To(false),
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
From https://github.com/gardener/gardener/pull/12030:
> - As a rule of thumb, for a container under VPA always specify initial resource requests for the resources which are controlled by VPA (the `controlledResources` field; by default both cpu and memory are controlled). vpa-updater evicts immediately if a container does not specify initial resource requests for a resource controlled by VPA (see [code](https://github.com/kubernetes/autoscaler/blob/00f627fbb9f4dfba952601d1e8c4c781eb423772/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go#L79-L86)).

**Which issue(s) this PR fixes**:
N/A
but part of issue on investigating many VPA evictions during (or shortly after) Shoot creation

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager.ProviderSidecarContainer` func does now set initial resource requests for the machine-controller-manager provider sidecar container in order to avoid unnecessary VPA eviction for the machine-controller-manager Pod after the first VPA recommendation.
```
