### PR TITLE
Deprecate the `.spec.purpose` field in the ControlPlane resource

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -727,7 +727,9 @@ Purpose
 <td>
 <em>(Optional)</em>
 <p>Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
-This field is immutable.</p>
+This field is immutable.
+Deprecated: This field will be removed in a future release.
+The value &ldquo;exposure&rdquo; is no longer used since the enablement of SNI, and the value &ldquo;normal&rdquo; is redundant.</p>
 </td>
 </tr>
 <tr>
@@ -2548,7 +2550,9 @@ Purpose
 <td>
 <em>(Optional)</em>
 <p>Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
-This field is immutable.</p>
+This field is immutable.
+Deprecated: This field will be removed in a future release.
+The value &ldquo;exposure&rdquo; is no longer used since the enablement of SNI, and the value &ldquo;normal&rdquo; is redundant.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -727,9 +727,10 @@ Purpose
 <td>
 <em>(Optional)</em>
 <p>Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
-This field is immutable.
-Deprecated: This field will be removed in a future release.
-The value &ldquo;exposure&rdquo; is no longer used since the enablement of SNI, and the value &ldquo;normal&rdquo; is redundant.</p>
+This field is immutable.</p>
+<p>Deprecated: This field will be removed in gardener v1.123.0.
+The value &ldquo;exposure&rdquo; is no longer used since the enablement of SNI, and the value &ldquo;normal&rdquo; is redundant.
+TODO(theoddora): Remove this field in v1.123.0.</p>
 </td>
 </tr>
 <tr>
@@ -2550,9 +2551,10 @@ Purpose
 <td>
 <em>(Optional)</em>
 <p>Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
-This field is immutable.
-Deprecated: This field will be removed in a future release.
-The value &ldquo;exposure&rdquo; is no longer used since the enablement of SNI, and the value &ldquo;normal&rdquo; is redundant.</p>
+This field is immutable.</p>
+<p>Deprecated: This field will be removed in gardener v1.123.0.
+The value &ldquo;exposure&rdquo; is no longer used since the enablement of SNI, and the value &ldquo;normal&rdquo; is redundant.
+TODO(theoddora): Remove this field in v1.123.0.</p>
 </td>
 </tr>
 <tr>
@@ -4429,6 +4431,9 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
 </p>
 <p>
 <p>Purpose is a string alias.</p>
+<p>Deprecated: This type will be removed in gardener v1.123.0.
+The value &ldquo;exposure&rdquo; is no longer used since the enablement of SNI, and the value &ldquo;normal&rdquo; is redundant.
+TODO(theoddora): Remove this type.</p>
 </p>
 <h3 id="extensions.gardener.cloud/v1alpha1.RegistryCapability">RegistryCapability
 (<code>string</code> alias)</p></h3>

--- a/docs/extensions/resources/controlplane-exposure.md
+++ b/docs/extensions/resources/controlplane-exposure.md
@@ -2,7 +2,8 @@
 title: ControlPlane Exposure
 ---
 
-> **⚠️ Disclaimer:** The `ControlPlane` resource with purpose `exposure` is deprecated and will be removed in a future Gardener release. Since the enablement of SNI, the `exposure` purpose is no longer used.
+> [!WARNING]
+> The `ControlPlane` resource with purpose `exposure` is deprecated and will be removed in Gardener v1.123. Since the enablement of SNI, the `exposure` purpose is no longer used.
 
 # Contract: `ControlPlane` Resource with Purpose `exposure`
 

--- a/docs/extensions/resources/controlplane-exposure.md
+++ b/docs/extensions/resources/controlplane-exposure.md
@@ -2,6 +2,8 @@
 title: ControlPlane Exposure
 ---
 
+> **⚠️ Disclaimer:** The `ControlPlane` resource with purpose `exposure` is deprecated and will be removed in a future Gardener release. Since the enablement of SNI, the `exposure` purpose is no longer used.
+
 # Contract: `ControlPlane` Resource with Purpose `exposure`
 
 Some Kubernetes clusters require an additional deployments required by the seed cloud provider in order to work properly, e.g. AWS Load Balancer Readvertiser.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
@@ -81,7 +81,8 @@ spec:
                 description: |-
                   Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
                   This field is immutable.
-                  Deprecated: This field will be removed in a future release.
+
+                  Deprecated: This field will be removed in gardener v1.123.0.
                   The value "exposure" is no longer used since the enablement of SNI, and the value "normal" is redundant.
                 type: string
               region:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
@@ -81,6 +81,8 @@ spec:
                 description: |-
                   Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
                   This field is immutable.
+                  Deprecated: This field will be removed in a future release.
+                  The value "exposure" is no longer used since the enablement of SNI, and the value "normal" is redundant.
                 type: string
               region:
                 description: Region is the region of this control plane. This field

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -49,6 +49,9 @@ type ValuesProvider interface {
 	// GetStorageClassesChartValues returns the values for the storage classes chart applied by this actuator.
 	GetStorageClassesChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]any, error)
 	// GetControlPlaneExposureChartValues returns the values for the control plane exposure chart applied by this actuator.
+	//
+	// Deprecated: Control plane with purpose `exposure` is being deprecated and will be removed in gardener v1.123.0.
+	// TODO(theoddora): Remove this function in v1.123.0 when the Purpose field is removed.
 	GetControlPlaneExposureChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, secretsReader secretsmanager.Reader, checksums map[string]string) (map[string]any, error)
 }
 

--- a/extensions/pkg/controller/controlplane/genericactuator/noopvaluesprovider.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/noopvaluesprovider.go
@@ -43,6 +43,9 @@ func (vp NoopValuesProvider) GetStorageClassesChartValues(context.Context, *exte
 }
 
 // GetControlPlaneExposureChartValues returns the values for the control plane exposure chart applied by this actuator.
+//
+// Deprecated: Control plane with purpose `exposure` is being deprecated and will be removed in gardener v1.123.0.
+// TODO(theoddora): Remove this function in v1.123.0 when the Purpose field is removed.
 func (vp NoopValuesProvider) GetControlPlaneExposureChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, secretsmanager.Reader, map[string]string) (map[string]any, error) {
 	return nil, nil
 }

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -80,6 +80,10 @@ func HasClass(extensionClasses ...extensionsv1alpha1.ExtensionClass) predicate.P
 }
 
 // HasPurpose filters the incoming ControlPlanes for the given spec.purpose.
+//
+// Deprecated: Purpose field is being deprecated and will be removed in gardener v1.123.0.
+// The value "exposure" is no longer used since the enablement of SNI, and the value "normal" is redundant.
+// TODO(theoddora): Remove this function in v1.123.0 when the Purpose field is removed.
 func HasPurpose(purpose extensionsv1alpha1.Purpose) predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		controlPlane, ok := obj.(*extensionsv1alpha1.ControlPlane)

--- a/pkg/apis/extensions/v1alpha1/types_controlplane.go
+++ b/pkg/apis/extensions/v1alpha1/types_controlplane.go
@@ -67,6 +67,8 @@ type ControlPlaneSpec struct {
 	DefaultSpec `json:",inline"`
 	// Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
 	// This field is immutable.
+	// Deprecated: This field will be removed in a future release.
+	// The value "exposure" is no longer used since the enablement of SNI, and the value "normal" is redundant.
 	// +optional
 	Purpose *Purpose `json:"purpose,omitempty"`
 	// InfrastructureProviderStatus contains the provider status that has
@@ -92,7 +94,9 @@ type Purpose string
 
 const (
 	// Normal triggers the ControlPlane controllers for the shoot provider.
+	// Deprecated: This value is no longer necessary and will be removed in a future release.
 	Normal Purpose = "normal"
 	// Exposure triggers the ControlPlane controllers for the exposure settings.
+	// Deprecated: ControlPlane with purpose "exposure" is not deployed since the enablement of SNI.
 	Exposure Purpose = "exposure"
 )

--- a/pkg/apis/extensions/v1alpha1/types_controlplane.go
+++ b/pkg/apis/extensions/v1alpha1/types_controlplane.go
@@ -67,8 +67,10 @@ type ControlPlaneSpec struct {
 	DefaultSpec `json:",inline"`
 	// Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
 	// This field is immutable.
-	// Deprecated: This field will be removed in a future release.
+	//
+	// Deprecated: This field will be removed in gardener v1.123.0.
 	// The value "exposure" is no longer used since the enablement of SNI, and the value "normal" is redundant.
+	// TODO(theoddora): Remove this field in v1.123.0.
 	// +optional
 	Purpose *Purpose `json:"purpose,omitempty"`
 	// InfrastructureProviderStatus contains the provider status that has
@@ -90,13 +92,20 @@ type ControlPlaneStatus struct {
 }
 
 // Purpose is a string alias.
+//
+// Deprecated: This type will be removed in gardener v1.123.0.
+// The value "exposure" is no longer used since the enablement of SNI, and the value "normal" is redundant.
+// TODO(theoddora): Remove this type.
 type Purpose string
 
 const (
 	// Normal triggers the ControlPlane controllers for the shoot provider.
-	// Deprecated: This value is no longer necessary and will be removed in a future release.
+	//
+	// Deprecated: This value is no longer necessary and will be removed in gardener v1.123.0.
 	Normal Purpose = "normal"
 	// Exposure triggers the ControlPlane controllers for the exposure settings.
-	// Deprecated: ControlPlane with purpose "exposure" is not deployed since the enablement of SNI.
+	//
+	// Deprecated: ControlPlane with purpose "exposure" has not been deployed since the enablement of SNI.
+	// The value will be removed in gardener v1.123.0.
 	Exposure Purpose = "exposure"
 )

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_controlplanes.yaml
@@ -83,7 +83,8 @@ spec:
                 description: |-
                   Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
                   This field is immutable.
-                  Deprecated: This field will be removed in a future release.
+
+                  Deprecated: This field will be removed in gardener v1.123.0.
                   The value "exposure" is no longer used since the enablement of SNI, and the value "normal" is redundant.
                 type: string
               region:

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_controlplanes.yaml
@@ -83,6 +83,8 @@ spec:
                 description: |-
                   Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
                   This field is immutable.
+                  Deprecated: This field will be removed in a future release.
+                  The value "exposure" is no longer used since the enablement of SNI, and the value "normal" is redundant.
                 type: string
               region:
                 description: Region is the region of this control plane. This field


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
Dropping ControlPlane with purpose=exposure logic #10018
Plan for dropping support for ControlPlane resources with purpose=exposure:

1. Mark the purpose field in the ControlPlane type as deprecated.
2. Clean up the logic in gardenlet for Deployment for ControlPlane resources with purpose=exposure.
3. Remove related logic
    - in the extensions library (actuator).
    - remove the purpose (tombstone it).
    - gardenlet destroy logic for ControlPlane with purpose=exposure.


**Which issue(s) this PR fixes**:
[1/3] First step of dropping `purpose=exposure`: #10018

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The `.spec.purpose` field in the ControlPlane resource is now deprecated and will be removed in Gardener v1.123. In the times before SNI was introduced and unconditionally enabled it was previously used to manage control plane exposure.
```
