### PR TITLE
[GEP-28] Persist shell profile of high-touch machines

### DIFF
--- a/example/gardenadm-local/high-touch/machine.yaml
+++ b/example/gardenadm-local/high-touch/machine.yaml
@@ -35,6 +35,9 @@ spec:
           mountPath: /etc/gardener/local-backupbuckets
         - name: gardenadm
           mountPath: /gardenadm
+        - name: bashrc
+          mountPath: /root/.bashrc
+          subPath: bashrc
       # we don't want components of the autonomous shoot cluster to communicate with the kind API server
       automountServiceAccountToken: false
       hostAliases:
@@ -53,6 +56,9 @@ spec:
       - name: etcd-backup
         hostPath:
           path: /etc/gardener/local-backupbuckets
+      - name: bashrc
+        configMap:
+          name: machine-bashrc
   volumeClaimTemplates:
   - metadata:
       name: gardenadm
@@ -61,3 +67,14 @@ spec:
       resources:
         requests:
           storage: 1Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: machine-bashrc
+  labels:
+    app: high-touch-machine
+data:
+  bashrc: |
+    export KUBECONFIG=/etc/kubernetes/admin.conf
+    alias k=kubectl

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -890,15 +890,5 @@ deploy:
                 mkdir -p "/gardenadm"
                 cp -f "$tmp_dir/ko-app/gardenadm" "/gardenadm"
                 chmod +x "/gardenadm/gardenadm"
-
-                echo "> Prepare shell profile"
-                if ! grep 'kubectl environment' ~/.bashrc >/dev/null ; then
-                  cat <<EOF >> ~/.bashrc
-                # BEGIN kubectl environment
-                export KUBECONFIG=/etc/kubernetes/admin.conf
-                alias k=kubectl
-                # END kubectl environment
-                EOF
-                fi
             podName: machine-*
             containerName: node


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

When restarting high-touch machine pods, we lose the shell profile as only the `/gardenadm` directory is persisted in the mounted PV, but not the home directory.
When developing gardenadm, you might find yourself frequently restarting the pods, even by running the e2e tests.
This PR ensures that the shell profile is always configured in high-touch machines to improve the development flow.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
