### PR TITLE
Update remote local setup `/etc/hosts` entries

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -92,9 +92,9 @@ spec:
           bash -c "
             echo {{p,g}-seed,{gu,p,v}-local--local}.ingress.local.seed.local.gardener.cloud \
                  api.{e2e-managedseed.garden,local.local}.{internal,external}.local.gardener.cloud \
-                 api.e2e-{hib,upg-hib,wake-up,wake-up-ncp,migrate,rotate,default,upd-node,upgrade}{,-wl}.local.{internal,external}.local.gardener.cloud \
-                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib,e2e-auth-{one,two},layer4-lb}.local.{internal,external}.local.gardener.cloud \
-                 gu-local--e2e-rotate{,-wl}.ingress.local.seed.local.gardener.cloud
+                 api.e2e-{hib,upg-hib,wake-up,wake-up-ncp,migrate,rotate,default,upd-node,upgrade,upg-ha}{,-wl}.local.{internal,external}.local.gardener.cloud \
+                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib,auth-{one,two},layer4-lb,default-ip,rot-{ip,noroll}}.local.{internal,external}.local.gardener.cloud \
+                 gu-local--e2e-{rotate{,-wl},rot-{ip,noroll}}.ingress.local.seed.local.gardener.cloud
             " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort      >> /etc/hosts
           echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
           echo "127.0.0.1 garden.local.gardener.cloud"                >> /etc/hosts


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Occasionally, when new tests are introduced, the remote local setup (RLS) needs additional hostnames. This PR adapts the script that generates the RLS's  `/etc/hosts` file.

**Which issue(s) this PR fixes**:
Fixes e2e tests failing to start on the remote local setup

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
