### PR TITLE
cleanup: Drop unused codepath from component-descriptor-callback

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -17,35 +17,7 @@
 set -e
 
 repo_root_dir="$1"
-repo_name="${2:-github.com/gardener/gardener}"
 descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
-
-resources_file="$repo_root_dir/.ci/resources.yaml"
-if [[ -f ${resources_file} ]]; then
-  echo "Adding additional resources from ${resources_file}"
-
-  # component-cli expects a directory where the component descriptor file is named component-descriptor.yaml.
-  # however the pre-rendered component descriptors of the pipeline have different filenames.
-  # therefore create a tempdir and copy the pre-rendered component descriptor to it with the correct filename.
-  tmp_dir="$(mktemp -d)"
-  tmp_cd="${tmp_dir}/component-descriptor.yaml"
-  cp "${BASE_DEFINITION_PATH}" "${tmp_cd}"
-  echo "${tmp_cd}"
-
-  # read the component version.
-  if [[ -z ${EFFECTIVE_VERSION} ]]; then
-    echo "The env variable EFFECTIVE_VERSION must be set"
-    exit 1
-  fi
-
-  # adds all resources defined in the resources file to the component descriptor.
-  component-cli component-archive resources add ${tmp_dir} ${resources_file} -v=3 -- COMPONENT_VERSION=${EFFECTIVE_VERSION}
-
-  # move modified component descriptor back to the original file.
-  mv "${tmp_cd}" "${BASE_DEFINITION_PATH}"
-else
-  echo "Resources file ${resources_file} not found. Skip adding additional resources."
-fi
 
 echo "Enriching component descriptor from ${BASE_DEFINITION_PATH}"
 


### PR DESCRIPTION
As of today, none of current heads of gardener-repositories' trees (on default branches) contain a file `.ci/resources.yaml`. Hence, drop unused codepath.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind cleanup

**What this PR does / why we need it**:

Drop unused codepath from component-descriptor-callback.

This will make ongoing [migration to GitHub-Actions](https://gardener.github.io/cc-utils/github_actions.html) slightly easier, as there will be one codepath less to consider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Probably, the release-note will not be of interest for most users, as this cleanup will have _no_ actual effect. I am fine w/ removing it.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Remove unused codepath from the `hack/.ci/component_descriptor` script.
```
