### PR TITLE
[GEP-28] Compress `gardenadm` binaries during build

### DIFF
--- a/.ci/build-gardenadm
+++ b/.ci/build-gardenadm
@@ -17,12 +17,17 @@ ld_flags="$(hack/get-build-ld-flags.sh)"
 for os in linux darwin windows; do
   for arch in amd64 arm64; do
     out_file="${BINARY_PATH}/gardenadm-${os}-${arch}"
+    compress_command=(tar cvzf "${out_file}.tar.gz" -C $(dirname "${out_file}") $(basename "${out_file}"))
     if [[ "${os}" == "windows" ]]; then
+      compress_command=(zip -j "${out_file}.zip" "${out_file}.exe")
       out_file="${out_file}.exe"
     fi
 
     echo "Building gardenadm for ${os}-${arch} and writing output to ${out_file}..."
     GOOS="${os}" GOARCH="${arch}" LD_FLAGS="${ld_flags}" BUILD_OUTPUT_FILE="${out_file}" BUILD_PACKAGES="./cmd/gardenadm" make build
+
+    echo "Compressing ${out_file} to \"${compress_command[2]}\"..."
+    "${compress_command[@]}"
   done
 done
 

--- a/.ci/build-gardenadm
+++ b/.ci/build-gardenadm
@@ -28,6 +28,9 @@ for os in linux darwin windows; do
 
     echo "Compressing ${out_file} to \"${compress_command[2]}\"..."
     "${compress_command[@]}"
+
+    echo "Removing ${out_file}..."
+    rm "${out_file}"
   done
 done
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Compress `gardenadm` binaries during build.

The `gardenadm` binary has significantly grown in size from ~16 MB per architecture/platform in [v1.110.0](https://github.com/gardener/gardener/releases/tag/v1.110.0) to ~116 MB in [v1.119.0](https://github.com/gardener/gardener/releases/tag/v1.119.0).

Compression does not completely resolve the related issues, but can mitigate them. The reduction factor of ~2.5 seems good enough to achieve some benefits with limited effort.

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

This change requires a corresponding change in branch `refs/meta/ci` (see https://github.com/gardener/gardener/commit/52c3f5a3914da668416392186b6a1e06d1cda031).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardenadm artefacts uploaded as part of a release are now compressed.
```

/cc @timebertt @rfranzke 