### PR TITLE
tm tests: Wake up Shoot in case the `HibernateShoot` fails

### DIFF
--- a/test/testmachinery/shoots/operations/operations.go
+++ b/test/testmachinery/shoots/operations/operations.go
@@ -57,8 +57,9 @@ import (
 )
 
 const (
-	hibernationTestTimeout = 1 * time.Hour
-	reconcileTimeout       = 40 * time.Minute
+	hibernationTestTimeout        = 1 * time.Hour
+	hibernationTestCleanupTimeout = 25 * time.Minute
+	reconcileTimeout              = 40 * time.Minute
 )
 
 var _ = ginkgo.Describe("Shoot operation testing", func() {
@@ -97,7 +98,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 			err := f.WakeUpShoot(ctx)
 			framework.ExpectNoError(err)
 		}
-	}, 25*time.Minute))
+	}, hibernationTestCleanupTimeout))
 
 	f.Default().Serial().CIt("should fully maintain and reconcile a shoot cluster", func(ctx context.Context) {
 		ginkgo.By("Maintain shoot")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

Wake up Shoot in case the `HibernateShoot` fails. We need this to prevent failures of subsequent tests executed within the same test run. For example if the Shoot hibernation fails with:
```
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697387103Z stdout F Shoot operation testing [It] [DEFAULT] [SERIAL] [SHOOT] Testing if Shoot can be hibernated successfully
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697392968Z stdout F /src/test/framework/gingko_utils.go:16
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697397512Z stdout F
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697402568Z stdout F   [FAILED] Expected
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697406707Z stdout F       <*retry.Error \| 0xc000ebc740>:
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697411553Z stdout F       retry failed with context deadline exceeded, last error: failed to verify no running pods after hibernation: found pods in namespace shoot--it--tmk4z-dpq: [aws-custom-route-controller-58cc469644-9pwqt cloud-controller-manager-66d59f8759-fcjhz csi-driver-controller-67d6d579d7-6brdh csi-snapshot-controller-9b8cd7c96-bw9wj]
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697432528Z stdout F       {
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697445224Z stdout F           ctxError: <context.deadlineExceededError>{},
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697449104Z stdout F           err: <*errors.errorString \| 0xc00096d070>{
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697453348Z stdout F               s: "failed to verify no running pods after hibernation: found pods in namespace shoot--it--tmk4z-dpq: [aws-custom-route-controller-58cc469644-9pwqt cloud-controller-manager-66d59f8759-fcjhz csi-driver-controller-67d6d579d7-6brdh csi-snapshot-controller-9b8cd7c96-bw9wj]",
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697457309Z stdout F           },
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697461112Z stdout F       }
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697464294Z stdout F   to be nil
  |   | 2025-05-23 12:59:42 | 2025-05-23T12:59:42.697467679Z stdout F   In [It] at: /src/test/testmachinery/shoots/operations/operations.go:79 @ 05/23/25 12:59:41.49
```
The subsequent `registry-cache-serial-test-suite` and `shoot-rsyslog-relp-serial-test-suite` test suites fail due to `nil` Shoot client, as Shoot is hibernated:

![image](https://github.com/user-attachments/assets/f5082291-b73c-4fe7-b737-51ace94a2fdf)

```
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778539625Z stdout F FAIL! -- 0 Passed \| 3 Failed \| 0 Pending \| 0 Skipped
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.7784897Z stdout F Ran 3 of 3 Specs in 8.688 seconds
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778485604Z stdout F
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778481099Z stdout F   /src/test/testmachinery/shoot/enable_disable_test.go:34
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778476647Z stdout F   [FAIL] Shoot registry cache testing  [It] [SERIAL] [SHOOT] should enable and disable the registry-cache extension
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778472045Z stdout F   /src/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go:36
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778467912Z stdout F   [FAIL] Shoot registry cache testing  [It] [SERIAL] [SHOOT] should enable extension, hibernate Shoot, reconcile Shoot, wake up Shoot, disable extension
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778463509Z stdout F   /src/test/testmachinery/shoot/enable_rotate_ca_disable_test.go:36
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778458512Z stdout F   [FAIL] Registry Cache Extension Tests  [It] [SERIAL] [SHOOT] should enable extension, rotate CA, disable extension [cache]
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778454052Z stdout F Summarizing 3 Failures:
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778449118Z stdout F
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778437933Z stdout F ------------------------------
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778433073Z stdout F   In [It] at: /src/test/testmachinery/shoot/enable_disable_test.go:34 @ 05/23/25 13:15:04.835
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778428448Z stdout F   not to be nil
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778424557Z stdout F       <nil>: nil
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778420354Z stdout F   Expected
  |   | 2025-05-23 13:15:07 | 2025-05-23T13:15:07.778416209Z stdout F   [FAILED] Shoot client should not be nil. If it is the Shoot might be hibernated
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
