### PR TITLE
Add backup region to `Garden`

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -438,6 +438,13 @@ spec:
                                   configuration passed to BackupBucket resource.
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              region:
+                                description: Region is a region name. If undefined
+                                  the provider region is used. This field is immutable.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: Region is immutable
+                                  rule: self == oldSelf
                               secretRef:
                                 description: |-
                                   SecretRef is a reference to a Secret object containing the cloud provider credentials for the object store where

--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -439,7 +439,7 @@ spec:
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
                               region:
-                                description: Region is a region name. If undefined
+                                description: Region is a region name. If undefined,
                                   the provider region is used. This field is immutable.
                                 type: string
                                 x-kubernetes-validations:

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -271,6 +271,18 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 </tr>
 <tr>
 <td>
+<code>region</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Region is a region name. If undefined the provider region is used. This field is immutable.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>secretRef</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#localobjectreference-v1-core">

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -278,7 +278,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Region is a region name. If undefined the provider region is used. This field is immutable.</p>
+<p>Region is a region name. If undefined, the provider region is used. This field is immutable.</p>
 </td>
 </tr>
 <tr>

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -438,6 +438,13 @@ spec:
                                   configuration passed to BackupBucket resource.
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              region:
+                                description: Region is a region name. If undefined
+                                  the provider region is used. This field is immutable.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: Region is immutable
+                                  rule: self == oldSelf
                               secretRef:
                                 description: |-
                                   SecretRef is a reference to a Secret object containing the cloud provider credentials for the object store where

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -439,7 +439,7 @@ spec:
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
                               region:
-                                description: Region is a region name. If undefined
+                                description: Region is a region name. If undefined,
                                   the provider region is used. This field is immutable.
                                 type: string
                                 x-kubernetes-validations:

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -77,6 +77,7 @@ spec:
       main:
         backup:
           provider: local
+    #     region: local
     #     bucketName: gardener-operator # if not provided, gardener-operator generates a name
     #     providerConfig:
     #       <some-provider-specific-config-for-the-backup-buckets>

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -290,7 +290,7 @@ type Backup struct {
 	// ProviderConfig is the provider-specific configuration passed to BackupBucket resource.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty"`
-	// Region is a region name. If undefined the provider region is used. This field is immutable.
+	// Region is a region name. If undefined, the provider region is used. This field is immutable.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Region is immutable"
 	// +optional
 	Region *string `json:"region,omitempty"`

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -290,6 +290,10 @@ type Backup struct {
 	// ProviderConfig is the provider-specific configuration passed to BackupBucket resource.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty"`
+	// Region is a region name. If undefined the provider region is used. This field is immutable.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Region is immutable"
+	// +optional
+	Region *string `json:"region,omitempty"`
 	// SecretRef is a reference to a Secret object containing the cloud provider credentials for the object store where
 	// backups should be stored. It should have enough privileges to manipulate the objects as well as buckets.
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -136,6 +136,11 @@ func (in *Backup) DeepCopyInto(out *Backup) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Region != nil {
+		in, out := &in.Region, &out.Region
+		*out = new(string)
+		**out = **in
+	}
 	out.SecretRef = in.SecretRef
 	return
 }

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -699,7 +699,7 @@ func (r *Reconciler) deployEtcdMainBackupBucket(ctx context.Context, garden *ope
 	} else if garden.Spec.RuntimeCluster.Provider.Region != nil {
 		bucketRegion = *garden.Spec.RuntimeCluster.Provider.Region
 	} else {
-		return fmt.Errorf("no region found in spec.VirtualCluster.ETCD.Main.Backup.Region of spec.runtimeCluster.provider.region in Garden resource")
+		return fmt.Errorf("no region found in spec.virtualCluster.etcd.main.backup.region of spec.runtimeCluster.provider.region in Garden resource")
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.RuntimeClientSet.Client(), backupBucket, func() error {

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -692,8 +692,14 @@ func (r *Reconciler) deployEtcdMainBackupBucket(ctx context.Context, garden *ope
 	if backup == nil {
 		return fmt.Errorf("no ETCD main backup configuration found in Garden resource")
 	}
-	if garden.Spec.RuntimeCluster.Provider.Region == nil {
-		return fmt.Errorf("no region found in spec.runtimeCluster.provider.region in Garden resource")
+
+	var bucketRegion string
+	if backup.Region != nil {
+		bucketRegion = *backup.Region
+	} else if garden.Spec.RuntimeCluster.Provider.Region != nil {
+		bucketRegion = *garden.Spec.RuntimeCluster.Provider.Region
+	} else {
+		return fmt.Errorf("no region found in spec.VirtualCluster.ETCD.Main.Backup.Region of spec.runtimeCluster.provider.region in Garden resource")
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.RuntimeClientSet.Client(), backupBucket, func() error {
@@ -706,7 +712,7 @@ func (r *Reconciler) deployEtcdMainBackupBucket(ctx context.Context, garden *ope
 				ProviderConfig: backup.ProviderConfig,
 				Class:          ptr.To(extensionsv1alpha1.ExtensionClassGarden),
 			},
-			Region: *garden.Spec.RuntimeCluster.Provider.Region,
+			Region: bucketRegion,
 			SecretRef: corev1.SecretReference{
 				Name:      backup.SecretRef.Name,
 				Namespace: r.GardenNamespace,

--- a/test/e2e/operator/garden/common.go
+++ b/test/e2e/operator/garden/common.go
@@ -80,6 +80,7 @@ func defaultGarden(backupSecret *corev1.Secret, specifyBackupBucket bool) *opera
 					Main: &operatorv1alpha1.ETCDMain{
 						Backup: &operatorv1alpha1.Backup{
 							Provider:   "local",
+							Region:     ptr.To("local"),
 							BucketName: bucketName,
 							SecretRef: corev1.LocalObjectReference{
 								Name: backupSecret.Name,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement

**What this PR does / why we need it**:
This PR updates the Garden API to allow independent configuration of the backup region from the provider region. A similar handling is already in place for `Seed`s.

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `Garden` resource has been enhanced with a new field, `spec.VirtualCluster.ETCD.Main.Backup.Region`, which enables the configuration of the backup bucket region. Previously, the region was derived from the provider (`spec.runtimeCluster.provider.region`). This behavior remains as a fallback if the backup region is not explicitly specified.
```
