### PR TITLE
Clean up migration for ko-built node-agent images

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -6,7 +6,6 @@ package nodeagent
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -79,7 +78,10 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		Path:        PathBinary,
 		Permissions: ptr.To[uint32](0755),
 		Content: extensionsv1alpha1.FileContent{
-			ImageRef: fileContentImageRef(ctx.Images[imagevector.ContainerImageNameGardenerNodeAgent].String()),
+			ImageRef: &extensionsv1alpha1.FileContentImageRef{
+				Image:           ctx.Images[imagevector.ContainerImageNameGardenerNodeAgent].String(),
+				FilePathInImage: "/gardener-node-agent",
+			},
 		},
 	})
 
@@ -159,22 +161,4 @@ func Files(config *nodeagentconfigv1alpha1.NodeAgentConfiguration) ([]extensions
 		Permissions: ptr.To[uint32](0600),
 		Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(configRaw)}},
 	}}, nil
-}
-
-func fileContentImageRef(image string) *extensionsv1alpha1.FileContentImageRef {
-	return &extensionsv1alpha1.FileContentImageRef{
-		Image:           image,
-		FilePathInImage: FilePathInImage(image),
-	}
-}
-
-// FilePathInImage returns the path of the gardener-node-agent binary file in its container image.
-func FilePathInImage(image string) string {
-	// TODO(timebertt): drop this workaround after https://github.com/gardener/gardener/pull/12021 has been released
-	var prefix string
-	if strings.HasPrefix(image, "garden.local.gardener.cloud:5001") {
-		prefix = "/ko-app"
-	}
-
-	return prefix + "/gardener-node-agent"
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -87,23 +87,6 @@ WantedBy=multi-user.target`),
 				},
 			})))
 		})
-
-		It("should return the expected binary prefix when image is from local registry", func() {
-			_, files, err := component.Config(components.Context{
-				Images: map[string]*imagevectorutils.Image{"gardener-node-agent": {Repository: ptr.To("garden.local.gardener.cloud:5001/gardener-node-agent"), Tag: ptr.To("v1")}},
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(files).To(ContainElement(extensionsv1alpha1.File{
-				Path:        "/opt/bin/gardener-node-agent",
-				Permissions: ptr.To[uint32](0755),
-				Content: extensionsv1alpha1.FileContent{
-					ImageRef: &extensionsv1alpha1.FileContentImageRef{
-						Image:           "garden.local.gardener.cloud:5001/gardener-node-agent:v1",
-						FilePathInImage: "/ko-app/gardener-node-agent",
-					},
-				},
-			}))
-		})
 	})
 
 	Describe("#UnitContent", func() {
@@ -252,16 +235,6 @@ logLevel: ""
 server: {}
 `))}},
 			}))
-		})
-	})
-
-	Describe("#FilePathInImage", func() {
-		It("should return the path when registry is not local", func() {
-			Expect(FilePathInImage("some-registry/gna:v1.0")).To(Equal("/gardener-node-agent"))
-		})
-
-		It("should return the path when registry is local", func() {
-			Expect(FilePathInImage("garden.local.gardener.cloud:5001/gna:v1.0")).To(Equal("/ko-app/gardener-node-agent"))
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:

This PR cleans up the migration code left in https://github.com/gardener/gardener/pull/12021 (basically reverts 3f7458db0d37fb542cf9d7ae75e6271dc1e3b3ac). 
We had to leave the `/ko-app` prefix in the `FileContentImageRef` for one more release. Otherwise, the upgrade tests would have failed, because the old node-agent is not able to extract its new binary from a ko-built image.
Now, that the latest version of node-agent (present on existing nodes in the upgrade tests) have the fallback to `/ko-app` in the `FileContentImageRef` handling, we no longer need to set `/ko-app` in the OSC.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
