### PR TITLE
Fix `NamespacedCloudProfile` deletion

### DIFF
--- a/pkg/controllerutils/associations.go
+++ b/pkg/controllerutils/associations.go
@@ -42,7 +42,8 @@ func DetermineShootsAssociatedTo(ctx context.Context, gardenClient client.Reader
 		case *gardencorev1beta1.NamespacedCloudProfile:
 			namespacedCloudProfile := obj.(*gardencorev1beta1.NamespacedCloudProfile)
 			if shoot.Spec.CloudProfile != nil && shoot.Spec.CloudProfile.Kind == constants.CloudProfileReferenceKindNamespacedCloudProfile &&
-				shoot.Spec.CloudProfile.Name == namespacedCloudProfile.Name {
+				shoot.Spec.CloudProfile.Name == namespacedCloudProfile.Name &&
+				shoot.Namespace == namespacedCloudProfile.Namespace {
 				associatedShoots = append(associatedShoots, fmt.Sprintf("%s/%s", shoot.Namespace, shoot.Name))
 			}
 		case *gardencorev1beta1.Seed:

--- a/pkg/controllerutils/associations_test.go
+++ b/pkg/controllerutils/associations_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Associations", func() {
 				s.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{Kind: "CloudProfile", Name: obj.GetName()}
 			}, BeNil()),
 		Entry("should return shoots associated to namespacedcloudprofile by cloudprofile reference",
-			&gardencorev1beta1.NamespacedCloudProfile{ObjectMeta: metav1.ObjectMeta{Name: "namespacedcloudprofile"}, Spec: gardencorev1beta1.NamespacedCloudProfileSpec{Parent: gardencorev1beta1.CloudProfileReference{Kind: "CloudProfile", Name: "cloudprofile"}}}, func(s *gardencorev1beta1.Shoot, obj client.Object) {
+			&gardencorev1beta1.NamespacedCloudProfile{ObjectMeta: metav1.ObjectMeta{Name: "namespacedcloudprofile", Namespace: namespace}, Spec: gardencorev1beta1.NamespacedCloudProfileSpec{Parent: gardencorev1beta1.CloudProfileReference{Kind: "CloudProfile", Name: "cloudprofile"}}}, func(s *gardencorev1beta1.Shoot, obj client.Object) {
 				s.Spec.CloudProfileName = nil
 				s.Spec.CloudProfile = &gardencorev1beta1.CloudProfileReference{Kind: "NamespacedCloudProfile", Name: obj.GetName()}
 			}, BeNil()),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
Fixes the `NamespacedCloudProfile` deletion.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@dguendisch thanks for reporting 🙏 

/cc @LucaBernstein

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The deletion of `NamespacedCloudProfile`s has been fixed. Previously, users could not delete these resources if objects with the same name but in different namespaces existed in the landscape. Gardener incorrectly reported them as still being referenced by shoot clusters.
```
