### PR TITLE
Shoot creation test supports using CredentialsBindings

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -20,6 +20,7 @@ spec:
     -cloud-profile-name=$CLOUDPROFILE
     -seed=$SEED
     -secret-binding=$SECRET_BINDING
+    -credentials-binding=$CREDENTIALS_BINDING
     -provider-type=$PROVIDER_TYPE
     -k8s-version=$K8S_VERSION
     -region=$REGION

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -244,6 +244,10 @@ func setShootGeneralSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreationC
 		shoot.Spec.SecretBindingName = ptr.To(cfg.secretBinding)
 	}
 
+	if StringSet(cfg.credentialsBinding) {
+		shoot.Spec.CredentialsBindingName = ptr.To(cfg.credentialsBinding)
+	}
+
 	if StringSet(cfg.shootProviderType) {
 		shoot.Spec.Provider.Type = cfg.shootProviderType
 	}

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -39,6 +39,7 @@ type ShootCreationConfig struct {
 	seedName                      string
 	shootRegion                   string
 	secretBinding                 string
+	credentialsBinding            string
 	shootProviderType             string
 	shootK8sVersion               string
 	externalDomain                string
@@ -125,6 +126,10 @@ func validateShootCreationConfig(cfg *ShootCreationConfig) {
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("annotations could not be parsed: %+v", err))
 		}
+	}
+
+	if StringSet(cfg.credentialsBinding) && StringSet(cfg.secretBinding) {
+		ginkgo.Fail("you cannot specify both credentialsBinding and secretBinding for the shoot, please use only one of them")
 	}
 
 	if !StringSet(cfg.shootProviderType) {
@@ -232,6 +237,10 @@ func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreati
 		base.secretBinding = overwrite.secretBinding
 	}
 
+	if StringSet(overwrite.credentialsBinding) {
+		base.credentialsBinding = overwrite.credentialsBinding
+	}
+
 	if StringSet(overwrite.shootProviderType) {
 		base.shootProviderType = overwrite.shootProviderType
 	}
@@ -337,6 +346,7 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	flag.StringVar(&newCfg.seedName, "seed", "", "Name of the seed to use for the shoot.")
 	flag.StringVar(&newCfg.shootRegion, "region", "", "region to use for the shoot. Must be compatible with the infrastructureProvider.Zone.")
 	flag.StringVar(&newCfg.secretBinding, "secret-binding", "", "the secretBinding for the provider account of the shoot.")
+	flag.StringVar(&newCfg.credentialsBinding, "credentials-binding", "", "the credentialsBinding for the provider account of the shoot.")
 	flag.StringVar(&newCfg.shootProviderType, "provider-type", "", "the type of the cloud provider where the shoot is deployed to. e.g gcp, aws,azure,alicloud.")
 	flag.StringVar(&newCfg.shootK8sVersion, "k8s-version", "", "kubernetes version to use for the shoot.")
 	flag.StringVar(&newCfg.externalDomain, "external-domain", "", "external domain to use for the shoot. If not set, will use the default domain.")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:

Expand the shoot creation framework to support `credentialsBinding` as an alternative to `secretBindings`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @dguendisch @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Shoot creation test supports using CredentialsBindings.
```
