### PR TITLE
Add `TODO` for follow-up regarding authorizer decision caches

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -189,6 +189,9 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context, enableNodeAgentAutho
 				WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
 					// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
 					// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
+					// TODO(rfranzke): Use `Cache{Una,A}uthorizedRequests` instead of `AuthorizedTTL` and
+					//  `UnauthorizedTTL` once Kubernetes 1.34 is the lowest supported version.
+					//  More info: https://github.com/kubernetes/kubernetes/pull/129237
 					AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
 					UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
 					Timeout:                                  metav1.Duration{Duration: 10 * time.Second},

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -624,6 +624,9 @@ func (r *Reconciler) newKubeAPIServer(
 			WebhookConfiguration: apiserverv1beta1.WebhookConfiguration{
 				// Set TTL to a very low value since it cannot be set to 0 because of defaulting.
 				// See https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/apis/apiserver/v1beta1/defaults.go#L29-L36
+				// TODO(rfranzke): Use `Cache{Una,A}uthorizedRequests` instead of `AuthorizedTTL` and
+				//  `UnauthorizedTTL` once Kubernetes 1.34 is the lowest supported version.
+				//  More info: https://github.com/kubernetes/kubernetes/pull/129237
 				AuthorizedTTL:                            metav1.Duration{Duration: 1 * time.Nanosecond},
 				UnauthorizedTTL:                          metav1.Duration{Duration: 1 * time.Nanosecond},
 				Timeout:                                  metav1.Duration{Duration: 10 * time.Second},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind task

**What this PR does / why we need it**:
Add a follow-up `TODO` for https://github.com/kubernetes/website/pull/50717 (see https://github.com/kubernetes/kubernetes/pull/129237 and https://github.com/kubernetes/kubernetes/issues/129233)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
