### PR TITLE
Resolve conflict when configuring anonymous authentication

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
@@ -410,7 +410,7 @@ anonymous:
 					return nil
 				})
 				newShoot := shootv1beta1.DeepCopy()
-				newShoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(true)
+				newShoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(false)
 				test(admissionv1.Create, shootv1beta1, newShoot, false, statusCodeInvalid, "cannot use anonymous authentication configuration when the following shoots have the legacy configuration enabled: fake-shoot-name", "")
 			})
 		})
@@ -466,16 +466,6 @@ anonymous:
 
 					test(admissionv1.Update, cm, newCm, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
 				})
-
-				It("should allow anonymous authentication when the legacy kube-apiserver setting is disabled", func() {
-					shootv1beta1.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(false)
-					Expect(fakeClient.Create(ctx, shootv1beta1)).To(Succeed())
-
-					newCm := cm.DeepCopy()
-					newCm.Data["config.yaml"] = anonymousAuthenticationConfiguration
-
-					test(admissionv1.Update, cm, newCm, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
-				})
 			})
 
 			Context("Deny", func() {
@@ -518,6 +508,16 @@ anonymous:
 
 				It("uses anonymous authentication and has the legacy kube-apiserver setting already enabled", func() {
 					shootv1beta1.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(true)
+					Expect(fakeClient.Update(ctx, shootv1beta1)).To(Succeed())
+
+					newCm := cm.DeepCopy()
+					newCm.Data["config.yaml"] = anonymousAuthenticationConfiguration
+
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "cannot use anonymous authentication configuration when the following shoots have the legacy configuration enabled: fake-shoot-name", "")
+				})
+
+				It("uses anonymous authentication and has the legacy kube-apiserver setting already enabled", func() {
+					shootv1beta1.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(false)
 					Expect(fakeClient.Update(ctx, shootv1beta1)).To(Succeed())
 
 					newCm := cm.DeepCopy()

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -41,7 +41,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 		warnings = append(warnings, "you are setting the spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field. The field has been deprecated and will not be supported by gardener from Kubernetes 1.33. Instead, use the spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism field.")
 	}
 
-	if helper.IsLegacyAnonymousAuthenticationEnabled(shoot.Spec.Kubernetes.KubeAPIServer) {
+	if helper.IsLegacyAnonymousAuthenticationSet(shoot.Spec.Kubernetes.KubeAPIServer) {
 		warnings = append(warnings, "you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")
 	}
 

--- a/pkg/apis/core/helper/shoot.go
+++ b/pkg/apis/core/helper/shoot.go
@@ -285,9 +285,7 @@ func IsUpdateStrategyInPlace(updateStrategy *core.MachineUpdateStrategy) bool {
 	return *updateStrategy == core.AutoInPlaceUpdate || *updateStrategy == core.ManualInPlaceUpdate
 }
 
-// IsLegacyAnonymousAuthenticationEnabled checks if the legacy anonymous authentication is enabled in the given kubeAPIServerConfig.
-func IsLegacyAnonymousAuthenticationEnabled(kubeAPIServerConfig *core.KubeAPIServerConfig) bool {
-	return kubeAPIServerConfig != nil &&
-		kubeAPIServerConfig.EnableAnonymousAuthentication != nil &&
-		*kubeAPIServerConfig.EnableAnonymousAuthentication
+// IsLegacyAnonymousAuthenticationSet checks if the legacy anonymous authentication is set in the given kubeAPIServerConfig.
+func IsLegacyAnonymousAuthenticationSet(kubeAPIServerConfig *core.KubeAPIServerConfig) bool {
+	return kubeAPIServerConfig != nil && kubeAPIServerConfig.EnableAnonymousAuthentication != nil
 }

--- a/pkg/apis/core/helper/shoot_test.go
+++ b/pkg/apis/core/helper/shoot_test.go
@@ -595,14 +595,14 @@ var _ = Describe("Helper", func() {
 		Entry("with ManualInPlaceUpdate  update strategy", ptr.To(core.ManualInPlaceUpdate), true),
 	)
 
-	DescribeTable("#IsLegacyAnonymousAuthenticationEnabled",
+	DescribeTable("#IsLegacyAnonymousAuthenticationSet",
 		func(kubeAPIServerConfig *core.KubeAPIServerConfig, expected bool) {
-			Expect(IsLegacyAnonymousAuthenticationEnabled(kubeAPIServerConfig)).To(Equal(expected))
+			Expect(IsLegacyAnonymousAuthenticationSet(kubeAPIServerConfig)).To(Equal(expected))
 		},
 		Entry("kubeAPIServerConfig is nil", nil, false),
 		Entry("kubeAPIServerConfig is empty", &core.KubeAPIServerConfig{}, false),
 		Entry("EnableAnonymousAuthentication is nil", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: nil}, false),
-		Entry("EnableAnonymousAuthentication is false", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(false)}, false),
+		Entry("EnableAnonymousAuthentication is false", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(false)}, true),
 		Entry("EnableAnonymousAuthentication is true", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}, true),
 	)
 })

--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -204,9 +204,6 @@ func SetDefaults_KubeAPIServerConfig(obj *KubeAPIServerConfig) {
 	if obj.Requests.MaxMutatingInflight == nil {
 		obj.Requests.MaxMutatingInflight = ptr.To[int32](200)
 	}
-	if obj.EnableAnonymousAuthentication == nil {
-		obj.EnableAnonymousAuthentication = ptr.To(false)
-	}
 	if obj.EventTTL == nil {
 		obj.EventTTL = &metav1.Duration{Duration: time.Hour}
 	}

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -637,20 +637,6 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Kubernetes.KubeAPIServer.Requests.MaxMutatingInflight).To(Equal(&maxMutatingRequestsInflight))
 		})
 
-		It("should default anonymous authentication field", func() {
-			SetObjectDefaults_Shoot(obj)
-
-			Expect(obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(PointTo(BeFalse()))
-		})
-
-		It("should not overwrite the already set values for anonymous authentication field", func() {
-			obj.Spec.Kubernetes.KubeAPIServer = &KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}
-
-			SetObjectDefaults_Shoot(obj)
-
-			Expect(obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(PointTo(BeTrue()))
-		})
-
 		It("should default the event ttl field", func() {
 			SetObjectDefaults_Shoot(obj)
 

--- a/pkg/apis/core/v1beta1/helper/shoot.go
+++ b/pkg/apis/core/v1beta1/helper/shoot.go
@@ -360,17 +360,6 @@ func GetShootAuthorizationConfiguration(apiServerConfig *gardencorev1beta1.KubeA
 	return nil
 }
 
-// AnonymousAuthenticationEnabled returns true if anonymous authentication is set explicitly to 'true' and false otherwise.
-func AnonymousAuthenticationEnabled(kubeAPIServerConfig *gardencorev1beta1.KubeAPIServerConfig) bool {
-	if kubeAPIServerConfig == nil {
-		return false
-	}
-	if kubeAPIServerConfig.EnableAnonymousAuthentication == nil {
-		return false
-	}
-	return *kubeAPIServerConfig.EnableAnonymousAuthentication
-}
-
 // KubeAPIServerFeatureGateDisabled returns whether the given feature gate is explicitly disabled for the kube-apiserver for the given Shoot spec.
 func KubeAPIServerFeatureGateDisabled(shoot *gardencorev1beta1.Shoot, featureGate string) bool {
 	kubeAPIServer := shoot.Spec.Kubernetes.KubeAPIServer

--- a/pkg/apis/core/v1beta1/helper/shoot_test.go
+++ b/pkg/apis/core/v1beta1/helper/shoot_test.go
@@ -762,18 +762,6 @@ var _ = Describe("Helper", func() {
 		Entry("StructuredAuthorization set", &gardencorev1beta1.KubeAPIServerConfig{StructuredAuthorization: &gardencorev1beta1.StructuredAuthorization{}}, &gardencorev1beta1.StructuredAuthorization{}),
 	)
 
-	DescribeTable("#AnonymousAuthenticationEnabled",
-		func(kubeAPIServerConfig *gardencorev1beta1.KubeAPIServerConfig, wantsAnonymousAuth bool) {
-			actualWantsAnonymousAuth := AnonymousAuthenticationEnabled(kubeAPIServerConfig)
-			Expect(actualWantsAnonymousAuth).To(Equal(wantsAnonymousAuth))
-		},
-
-		Entry("no kubeapiserver configuration", nil, false),
-		Entry("field not set", &gardencorev1beta1.KubeAPIServerConfig{}, false),
-		Entry("explicitly enabled", &gardencorev1beta1.KubeAPIServerConfig{EnableAnonymousAuthentication: &trueVar}, true),
-		Entry("explicitly disabled", &gardencorev1beta1.KubeAPIServerConfig{EnableAnonymousAuthentication: &falseVar}, false),
-	)
-
 	DescribeTable("#KubeAPIServerFeatureGateDisabled",
 		func(shoot *gardencorev1beta1.Shoot, featureGate string, expected bool) {
 			actual := KubeAPIServerFeatureGateDisabled(shoot, featureGate)

--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -86,7 +86,7 @@ type Interface interface {
 type Values struct {
 	apiserver.Values
 	// AnonymousAuthenticationEnabled states whether anonymous authentication is enabled.
-	AnonymousAuthenticationEnabled bool
+	AnonymousAuthenticationEnabled *bool
 	// APIAudiences are identifiers of the API. The service account token authenticator will validate that tokens used
 	// against the API are bound to at least one of these audiences.
 	APIAudiences []string

--- a/pkg/component/kubernetes/apiserver/authentication.go
+++ b/pkg/component/kubernetes/apiserver/authentication.go
@@ -255,13 +255,18 @@ func (k *kubeAPIServer) structuredAuthenticationFeatureGateEnabled() bool {
 }
 
 func (k *kubeAPIServer) anonymousAuthConfigurableEndpointsFeatureGateEnabled() bool {
-	if !versionutils.ConstraintK8sGreaterEqual132.Check(k.values.Version) {
+	if versionutils.ConstraintK8sLess131.Check(k.values.Version) {
 		return false
 	}
 
 	featureGateEnabled, featureGateSet := k.values.FeatureGates["AnonymousAuthConfigurableEndpoints"]
 	if featureGateSet {
 		return featureGateEnabled
+	}
+
+	if versionutils.ConstraintK8sEqual131.Check(k.values.Version) {
+		// the feature is not enabled by default in v1.31
+		return false
 	}
 
 	return true

--- a/pkg/component/kubernetes/apiserver/authentication.go
+++ b/pkg/component/kubernetes/apiserver/authentication.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,51 +45,71 @@ func (k *kubeAPIServer) reconcileConfigMapAuthenticationConfig(ctx context.Conte
 		return errors.New("oidc configuration is incompatible with structured authentication")
 	}
 
-	if value, ok := k.values.FeatureGates["StructuredAuthenticationConfiguration"]; (ok && !value) ||
-		(k.values.AuthenticationConfiguration == nil && k.values.OIDC == nil) ||
+	var (
+		structAuthGateEnabled, structAuthGateSet  = k.values.FeatureGates["StructuredAuthenticationConfiguration"]
+		anonymousGateEnabled, anonymousGateSet    = k.values.FeatureGates["AnonymousAuthConfigurableEndpoints"]
+		shouldConfigureAnonymousViaStructuredAuth = (!anonymousGateSet || (anonymousGateSet && anonymousGateEnabled)) && versionutils.ConstraintK8sGreaterEqual132.Check(k.values.Version)
+	)
+
+	if (structAuthGateSet && !structAuthGateEnabled) ||
+		(k.values.AuthenticationConfiguration == nil && k.values.OIDC == nil && !shouldConfigureAnonymousViaStructuredAuth) ||
 		versionutils.ConstraintK8sLess130.Check(k.values.Version) {
 		return nil
 	}
 
 	authenticationConfig := ptr.Deref(k.values.AuthenticationConfiguration, "")
-	if k.values.OIDC != nil {
-		oidcAuthenticationConfig, err := ComputeAuthenticationConfigRawConfig(k.values.OIDC)
-		if err != nil {
-			return err
-		}
 
-		authenticationConfig = oidcAuthenticationConfig
-	}
-
-	configMap.Data = map[string]string{DataKeyConfigMapAuthenticationConfig: authenticationConfig}
-	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
-	return client.IgnoreAlreadyExists(k.client.Client().Create(ctx, configMap))
-}
-
-// ComputeAuthenticationConfigRawConfig computes a AuthenticationConfiguration from oidcConfiguration.
-// TODO(AleksandarSavchev): Remove this functionality as soon as v1.32 is the least supported Kubernetes version in Gardener.
-func ComputeAuthenticationConfigRawConfig(oidc *gardencorev1beta1.OIDCConfig) (string, error) {
 	authenticationConfiguration := &apiserverv1beta1.AuthenticationConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: apiserverv1beta1.ConfigSchemeGroupVersion.String(),
 			Kind:       "AuthenticationConfiguration",
 		},
-		JWT: []apiserverv1beta1.JWTAuthenticator{{}},
 	}
 
+	if len(authenticationConfig) > 0 {
+		if err := runtime.DecodeInto(ConfigCodec, []byte(authenticationConfig), authenticationConfiguration); err != nil {
+			return err
+		}
+	}
+
+	if k.values.OIDC != nil {
+		authenticationConfiguration.JWT = ConfigureJWTAuthenticators(k.values.OIDC)
+	}
+
+	if shouldConfigureAnonymousViaStructuredAuth && authenticationConfiguration.Anonymous == nil {
+		authenticationConfiguration.Anonymous = &apiserverv1beta1.AnonymousAuthConfig{
+			Enabled: ptr.Deref(k.values.AnonymousAuthenticationEnabled, false),
+		}
+	}
+
+	data, err := runtime.Encode(ConfigCodec, authenticationConfiguration)
+	if err != nil {
+		return fmt.Errorf("unable to encode authentication configuration: %w", err)
+	}
+
+	configMap.Data = map[string]string{DataKeyConfigMapAuthenticationConfig: string(data)}
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+	return client.IgnoreAlreadyExists(k.client.Client().Create(ctx, configMap))
+}
+
+// ConfigureJWTAuthenticators computes JWTAuthenticator configuration from oidcConfiguration.
+// TODO(AleksandarSavchev): Remove this functionality as soon as v1.32 is the least supported Kubernetes version in Gardener.
+func ConfigureJWTAuthenticators(oidc *gardencorev1beta1.OIDCConfig) []apiserverv1beta1.JWTAuthenticator {
+	jwts := []apiserverv1beta1.JWTAuthenticator{{}}
+
 	if v := oidc.CABundle; v != nil {
-		authenticationConfiguration.JWT[0].Issuer.CertificateAuthority = *v
+		jwts[0].Issuer.CertificateAuthority = *v
 	}
 
 	if v := oidc.IssuerURL; v != nil {
-		authenticationConfiguration.JWT[0].Issuer.URL = *v
+		jwts[0].Issuer.URL = *v
 	}
 
 	if v := oidc.ClientID; v != nil {
-		authenticationConfiguration.JWT[0].Issuer.Audiences = append(authenticationConfiguration.JWT[0].Issuer.Audiences, *v)
+		jwts[0].Issuer.Audiences = append(jwts[0].Issuer.Audiences, *v)
 	}
 
-	authenticationConfiguration.JWT[0].ClaimMappings.Username.Claim = ptr.Deref(oidc.UsernameClaim, "sub")
+	jwts[0].ClaimMappings.Username.Claim = ptr.Deref(oidc.UsernameClaim, "sub")
 
 	usernamePrefix := ptr.Deref(oidc.UsernamePrefix, "")
 
@@ -96,16 +117,16 @@ func ComputeAuthenticationConfigRawConfig(oidc *gardencorev1beta1.OIDCConfig) (s
 	// We use the defaulting suggested in kubernetes https://github.com/kubernetes/kubernetes/blob/a2106b5f73fe9352f7bc0520788855d57fc301e1/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go#L357-L366
 	switch {
 	case usernamePrefix == "-":
-		authenticationConfiguration.JWT[0].ClaimMappings.Username.Prefix = ptr.To("")
-	case len(usernamePrefix) == 0 && authenticationConfiguration.JWT[0].ClaimMappings.Username.Claim != "email":
-		authenticationConfiguration.JWT[0].ClaimMappings.Username.Prefix = ptr.To(fmt.Sprintf("%s#", authenticationConfiguration.JWT[0].Issuer.URL))
+		jwts[0].ClaimMappings.Username.Prefix = ptr.To("")
+	case len(usernamePrefix) == 0 && jwts[0].ClaimMappings.Username.Claim != "email":
+		jwts[0].ClaimMappings.Username.Prefix = ptr.To(fmt.Sprintf("%s#", jwts[0].Issuer.URL))
 	default:
-		authenticationConfiguration.JWT[0].ClaimMappings.Username.Prefix = ptr.To(usernamePrefix)
+		jwts[0].ClaimMappings.Username.Prefix = ptr.To(usernamePrefix)
 	}
 
 	if v := oidc.GroupsClaim; v != nil {
-		authenticationConfiguration.JWT[0].ClaimMappings.Groups.Claim = *v
-		authenticationConfiguration.JWT[0].ClaimMappings.Groups.Prefix = ptr.To(ptr.Deref(oidc.GroupsPrefix, ""))
+		jwts[0].ClaimMappings.Groups.Claim = *v
+		jwts[0].ClaimMappings.Groups.Prefix = ptr.To(ptr.Deref(oidc.GroupsPrefix, ""))
 	}
 
 	for key, value := range oidc.RequiredClaims {
@@ -113,21 +134,24 @@ func ComputeAuthenticationConfigRawConfig(oidc *gardencorev1beta1.OIDCConfig) (s
 			Claim:         key,
 			RequiredValue: value,
 		}
-		authenticationConfiguration.JWT[0].ClaimValidationRules = append(authenticationConfiguration.JWT[0].ClaimValidationRules, claimValidationRule)
+		jwts[0].ClaimValidationRules = append(jwts[0].ClaimValidationRules, claimValidationRule)
 	}
 
-	data, err := runtime.Encode(ConfigCodec, authenticationConfiguration)
-	if err != nil {
-		return "", fmt.Errorf("unable to encode authentication configuration: %w", err)
-	}
-
-	return string(data), nil
+	return jwts
 }
 
 func (k *kubeAPIServer) handleAuthenticationSettings(deployment *appsv1.Deployment, configMapAuthenticationConfig *corev1.ConfigMap, secretOIDCCABundle *corev1.Secret) {
 	if value, ok := k.values.FeatureGates["StructuredAuthenticationConfiguration"]; versionutils.ConstraintK8sLess130.Check(k.values.Version) || (ok && !value) {
 		k.handleOIDCSettings(deployment, secretOIDCCABundle)
-		return
+	}
+
+	var (
+		anonymousGateEnabled, anonymousGateSet    = k.values.FeatureGates["AnonymousAuthConfigurableEndpoints"]
+		shouldConfigureAnonymousViaStructuredAuth = (!anonymousGateSet || (anonymousGateSet && anonymousGateEnabled)) && versionutils.ConstraintK8sGreaterEqual132.Check(k.values.Version)
+	)
+
+	if !shouldConfigureAnonymousViaStructuredAuth {
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--anonymous-auth="+strconv.FormatBool(ptr.Deref(k.values.AnonymousAuthenticationEnabled, false)))
 	}
 
 	if _, ok := configMapAuthenticationConfig.Data[DataKeyConfigMapAuthenticationConfig]; !ok {

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -389,8 +389,6 @@ func (k *kubeAPIServer) reconcileDeployment(
 func (k *kubeAPIServer) computeKubeAPIServerArgs() []string {
 	var out []string
 
-	out = append(out, "--anonymous-auth="+strconv.FormatBool(k.values.AnonymousAuthenticationEnabled))
-
 	if len(k.values.APIAudiences) > 0 {
 		out = append(out, "--api-audiences="+strings.Join(k.values.APIAudiences, ","))
 	}

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -370,7 +370,9 @@ func (k *kubeAPIServer) reconcileDeployment(
 		k.handleSNISettings(deployment)
 		k.handleTLSSNISettings(deployment, tlsSNISecrets)
 		k.handleServiceAccountSigningKeySettings(deployment)
-		k.handleAuthenticationSettings(deployment, configMapAuthenticationConfig, secretOIDCCABundle)
+		if err := k.handleAuthenticationSettings(deployment, configMapAuthenticationConfig, secretOIDCCABundle); err != nil {
+			return err
+		}
 		k.handleAuthenticationWebhookSettings(deployment, secretAuthenticationWebhookKubeconfig)
 		k.handleAuthorizationSettings(deployment, configMapAuthorizationConfig, secretAuthorizationWebhooksKubeconfigs)
 		if err := k.handleVPNSettings(deployment, serviceAccount, configMapEgressSelector, secretHTTPProxy, secretHAVPNSeedClient, secretHAVPNSeedClientSeedTLSAuth); err != nil {

--- a/pkg/component/kubernetes/apiserver/secrets.go
+++ b/pkg/component/kubernetes/apiserver/secrets.go
@@ -25,7 +25,6 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 const (
@@ -52,9 +51,9 @@ func (k *kubeAPIServer) emptySecret(name string) *corev1.Secret {
 }
 
 func (k *kubeAPIServer) reconcileSecretOIDCCABundle(ctx context.Context, secret *corev1.Secret) error {
-	if value, ok := k.values.FeatureGates["StructuredAuthenticationConfiguration"]; k.values.OIDC == nil ||
-		(versionutils.ConstraintK8sGreaterEqual130.Check(k.values.Version) && (!ok || value)) ||
-		k.values.OIDC.CABundle == nil {
+	if k.values.OIDC == nil ||
+		k.values.OIDC.CABundle == nil ||
+		k.structuredAuthenticationFeatureGateEnabled() {
 		// We don't delete the secret here as we don't know its name (as it's unique). Instead, we rely on the usual
 		// garbage collection for unique secrets/configmaps.
 		return nil

--- a/pkg/component/shared/kubeapiserver.go
+++ b/pkg/component/shared/kubeapiserver.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/imagevector"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/apiserver"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
@@ -115,6 +114,7 @@ func NewKubeAPIServer(
 		runtimeConfig                            map[string]bool
 		watchCacheSizes                          *gardencorev1beta1.WatchCacheSizes
 		logging                                  *gardencorev1beta1.APIServerLogging
+		enableAnonymousAuthentication            *bool
 	)
 
 	if apiServerConfig != nil {
@@ -157,6 +157,7 @@ func NewKubeAPIServer(
 		requests = apiServerConfig.Requests
 		runtimeConfig = apiServerConfig.RuntimeConfig
 		watchCacheSizes = apiServerConfig.WatchCacheSizes
+		enableAnonymousAuthentication = apiServerConfig.EnableAnonymousAuthentication
 	}
 
 	enabledAdmissionPluginConfigs, err := convertToAdmissionPluginConfigs(ctx, resourceConfigClient, objectMeta.Namespace, enabledAdmissionPlugins)
@@ -180,7 +181,7 @@ func NewKubeAPIServer(
 				RuntimeVersion:           runtimeVersion,
 				WatchCacheSizes:          watchCacheSizes,
 			},
-			AnonymousAuthenticationEnabled:      v1beta1helper.AnonymousAuthenticationEnabled(apiServerConfig),
+			AnonymousAuthenticationEnabled:      enableAnonymousAuthentication,
 			APIAudiences:                        apiAudiences,
 			AuthenticationConfiguration:         authenticationConfigurationFromConfigMap,
 			AuthenticationWebhook:               authenticationWebhookConfig,

--- a/pkg/component/shared/kubeapiserver_test.go
+++ b/pkg/component/shared/kubeapiserver_test.go
@@ -115,10 +115,10 @@ var _ = Describe("KubeAPIServer", func() {
 		})
 
 		Describe("AnonymousAuthenticationEnabled", func() {
-			It("should set the field to false by default", func() {
+			It("should not set the field by default", func() {
 				kubeAPIServer, err := NewKubeAPIServer(ctx, runtimeClientSet, resourceConfigClient, namespace, objectMeta, runtimeVersion, targetVersion, sm, namePrefix, apiServerConfig, autoscalingConfig, vpnConfig, priorityClassName, isWorkerless, runsAsStaticPod, auditWebhookConfig, authenticationWebhookConfig, authorizationWebhookConfigs, resourcesToStoreInETCDEvents)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(kubeAPIServer.GetValues().AnonymousAuthenticationEnabled).To(BeFalse())
+				Expect(kubeAPIServer.GetValues().AnonymousAuthenticationEnabled).To(BeNil())
 			})
 
 			It("should set the field to true if explicitly enabled", func() {
@@ -126,7 +126,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 				kubeAPIServer, err := NewKubeAPIServer(ctx, runtimeClientSet, resourceConfigClient, namespace, objectMeta, runtimeVersion, targetVersion, sm, namePrefix, apiServerConfig, autoscalingConfig, vpnConfig, priorityClassName, isWorkerless, runsAsStaticPod, auditWebhookConfig, authenticationWebhookConfig, authorizationWebhookConfigs, resourcesToStoreInETCDEvents)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(kubeAPIServer.GetValues().AnonymousAuthenticationEnabled).To(BeTrue())
+				Expect(kubeAPIServer.GetValues().AnonymousAuthenticationEnabled).To(PointTo(BeTrue()))
 			})
 		})
 

--- a/pkg/operator/webhook/defaulting/garden/handler_test.go
+++ b/pkg/operator/webhook/defaulting/garden/handler_test.go
@@ -41,8 +41,7 @@ var _ = Describe("Handler", func() {
 						MaxNonMutatingInflight: ptr.To[int32](400),
 						MaxMutatingInflight:    ptr.To[int32](200),
 					},
-					EnableAnonymousAuthentication: ptr.To(false),
-					EventTTL:                      &metav1.Duration{Duration: time.Hour},
+					EventTTL: &metav1.Duration{Duration: time.Hour},
 					Logging: &gardencorev1beta1.APIServerLogging{
 						Verbosity: ptr.To[int32](2),
 					},
@@ -86,9 +85,8 @@ var _ = Describe("Handler", func() {
 						Kubernetes: operatorv1alpha1.Kubernetes{
 							KubeAPIServer: &operatorv1alpha1.KubeAPIServerConfig{
 								KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{
-									Requests:                      customRequests,
-									EnableAnonymousAuthentication: ptr.To(false),
-									EventTTL:                      &metav1.Duration{Duration: time.Hour},
+									Requests: customRequests,
+									EventTTL: &metav1.Duration{Duration: time.Hour},
 									Logging: &gardencorev1beta1.APIServerLogging{
 										Verbosity: ptr.To[int32](2),
 									},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #12191

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing the `kube-apiserver` to crash when anonymous authentication is configured via `StructuredAuthentication` was fixed.
```
