### PR TITLE
Allow gardener admins to manage services and endpoints in the virtual cluster

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -49,6 +49,8 @@ rules:
   - events
   - namespaces
   - resourcequotas
+  - services
+  - endpoints
   verbs:
   - create
   - delete
@@ -227,6 +229,8 @@ rules:
   - events
   - namespaces
   - resourcequotas
+  - services
+  - endpoints
   verbs:
   - get
   - list

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -166,7 +166,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"events", "namespaces", "resourcequotas"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
 					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
@@ -272,7 +272,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"events", "namespaces", "resourcequotas"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Virtual", func() {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"events", "namespaces", "resourcequotas"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
 					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
@@ -293,7 +293,7 @@ var _ = Describe("Virtual", func() {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"events", "namespaces", "resourcequotas"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
gardener-operator creates `kube-system/gardener-apiserver` Service and `kube-system/gardener-apiserver` Endpoint in the virtual cluster:
- https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/component/gardener/apiserver/service.go#L42-L59
- https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/component/gardener/apiserver/endpoints.go#L12-L29
- https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/component/gardener/apiserver/apiserver.go#L193-L206

However, gardener admins currently don't have permissions to inspect or mutate these resources.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
~~I don't know at all what is the use case of these Service and Endpoint. Let me know if they are not used. Let me know also what is their use case - it would be interesting to learn this.~~
_EDIT_: The APIService points to the kube-system/gardener-apiserver Service. The underlying Endpoint resolves to the clusterIP of the garden/gardener-apiserver Service in the runtime cluster.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener administrators are now allowed to inspect and manage Services and Endpoints in the garden cluster.
```
