### PR TITLE
Allow communication from `local-path-provisioner` to `kube-apiserver`

### DIFF
--- a/pkg/provider-local/charts/shoot-system-components/charts/local-path-provisioner/templates/deployment.yaml
+++ b/pkg/provider-local/charts/shoot-system-components/charts/local-path-provisioner/templates/deployment.yaml
@@ -18,7 +18,8 @@ spec:
     metadata:
       labels:
         app: local-path-provisioner
-        networking.gardener.cloud/to-runtime-apiserver: allowed
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: local-path-provisioner-service-account


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/11502, the `kube-system` namespace has a `deny-all` Network Policy, so in [this part](https://github.com/gardener/gardener/pull/11502/files#diff-7dbf10c6ffc2d5550cb7e4716f439fe349ecd9faa4b0f68ac57fbd438842c6aa) of the change the Network Policy is applied for versions >= 1.33. During local testing for the integration of Kubernetes v1.33, this became an issue since the `local-path-provisioner` couldn't make calls to the `kube-apiserver`. With the added labels, it's now allowed.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11933

**Special notes for your reviewer**:
This change has been tested locally during the integration of Kubernetes v1.33.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
