### PR TITLE
Clean up obsolete `prometheus-` folder from Prometheus volumes

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -428,6 +428,8 @@ rules:
   - servicemonitors
   - scrapeconfigs
   - prometheusrules
+  # TODO(vicwicker): Remove this after v1.125 has been released.
+  - prometheuses
   verbs:
   - list
   - watch

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -341,7 +341,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"monitoring.coreos.com"},
-				Resources: []string{"servicemonitors", "scrapeconfigs", "prometheusrules"},
+				Resources: []string{"servicemonitors", "scrapeconfigs", "prometheusrules", "prometheuses"},
 				Verbs:     []string{"list", "watch", "get", "create", "patch", "update", "delete"},
 			},
 		},

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -16,6 +16,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -368,6 +369,7 @@ func cleanupPrometheusObsoleteFolders(ctx context.Context, log logr.Logger, seed
 				})
 			}
 
+			prometheus.Spec.Replicas = ptr.To(int32(1))
 			if err := seedClient.Patch(ctx, prometheus, prometheusPatch); err != nil {
 				log.Error(err, "Failed to patch Prometheus resource", "cluster", cluster.Name)
 				return nil

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -383,5 +383,7 @@ func cleanupPrometheusObsoleteFolders(ctx context.Context, log logr.Logger, seed
 		})
 	}
 
-	_ = flow.Parallel(tasks...)(ctx)
+	go func() {
+		_ = flow.Parallel(tasks...)(ctx)
+	}()
 }

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -189,6 +189,10 @@ const (
 	// NetworkingServiceNamespace is a constant for a label on a NetworkPolicy which contains the namespace of the
 	// Service is has been created for.
 	NetworkingServiceNamespace = "networking.resources.gardener.cloud/service-namespace"
+
+	// PrometheusObsoleteFolderCleanedUp is a temporal annotation to indicate that the obsolete "prometheus-" data folder
+	// from Prometheus has been cleaned up. This is used to mark the clean up as complete and avoid repeated attempts to clean up
+	PrometheusObsoleteFolderCleanedUp = "monitoring.resources.gardener.cloud/prometheus-obsolete-folder-cleaned-up"
 )
 
 // +kubebuilder:resource:shortName="mr"

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -227,6 +227,11 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		cortexConfigMap = p.cortexConfigMap()
 	}
 
+	prometheus, err := p.prometheus(ctx, cortexConfigMap)
+	if err != nil {
+		return err
+	}
+
 	resources, err := registry.AddAllAndSerialize(
 		p.serviceAccount(),
 		p.service(),
@@ -235,7 +240,7 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		p.secretAdditionalAlertmanagerConfigs(),
 		p.secretRemoteWriteBasicAuth(),
 		cortexConfigMap,
-		p.prometheus(cortexConfigMap),
+		prometheus,
 		p.vpa(),
 		p.podDisruptionBudget(),
 		ingress,

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -83,6 +83,17 @@ func (p *prometheus) prometheus(cortexConfigMap *corev1.ConfigMap) *monitoringv1
 				Web: &monitoringv1.PrometheusWebSpec{
 					MaxConnections: ptr.To[int32](1024),
 				},
+				// TODO(vicwicker): Remove this after v1.125 has been released.
+				InitContainers: []corev1.Container{{
+					Name:            "cleanup-obsolete-folder",
+					Image:           p.values.Image,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"sh", "-c", "rm -rf /prometheus/prometheus-; rm -rf /prometheus/prometheus-db/prometheus-"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      "prometheus-db",
+						MountPath: "/prometheus",
+					}},
+				}},
 			},
 			RuleSelector:          &metav1.LabelSelector{MatchLabels: monitoringutils.Labels(p.values.Name)},
 			RuleNamespaceSelector: &metav1.LabelSelector{},

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -172,6 +172,7 @@ func (p *prometheus) prometheus(ctx context.Context, cortexConfigMap *corev1.Con
 	case "shoot":
 		var (
 			isNew      bool
+			isMarked   bool
 			prometheus monitoringv1.Prometheus
 		)
 
@@ -182,7 +183,11 @@ func (p *prometheus) prometheus(ctx context.Context, cortexConfigMap *corev1.Con
 			isNew = true
 		}
 
-		if isNew {
+		if value, ok := prometheus.Annotations[resourcesv1alpha1.PrometheusObsoleteFolderCleanedUp]; ok && value == "true" {
+			isMarked = true
+		}
+
+		if isNew || isMarked {
 			if obj.Annotations == nil {
 				obj.Annotations = map[string]string{}
 			}


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

We have recently discovered that some Prometheus volumes still contain the `prometheus-` folder with old Prometheus data. This folder was used for storage before [GEP-19](https://github.com/gardener/gardener/issues/9065), when the Prometheus operator was introduced. With the operator, the storage folder is now `prometheus-db`:

```bash
> k get pods prometheus-shoot-0 -o json | jq -r '
    (.spec.volumes[] | select(.name == "prometheus-db")),
    (.spec.containers[].volumeMounts[] | select(.name == "prometheus-db"))'
{
  "name": "prometheus-db",
  "persistentVolumeClaim": {
    "claimName": "prometheus-db-prometheus-shoot-0"
  }
}
{
  "mountPath": "/prometheus",
  "name": "prometheus-db",
  "subPath": "prometheus-db"
}
```

In the past, the `prometheus-` subpath was mounted instead. For example, in the [seed](https://github.com/gardener/gardener/blob/96335a6487944f05322ac8f182f46c1e738ee2ff/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml#L134-L135).

GEP-19 included a [migration](https://github.com/gardener/gardener/pull/9128/commits/ca0a1863fca24146d6689bdb6b8d9017a44441d9#diff-c6e1ff35f50162ec0f10e92c7b5a3407c6d314b2cde196661c0d5253120d9c71R101-R106) to transfer data from the old folder to the new one. However, it appears there are remnants where the `prometheus-` folder is either a sibling of the new `prometheus-db` or a subfolder. Unfortunately, pinpointing the exact sequence of steps that led to this situation is now very challenging.

In some cases, the old `prometheus-` folder has been observed consuming up to 7GB of data. This poses a risk of Prometheus running out of disk space, as it operates, for example, in a control plane Prometheus, on a 20GB volume with a disk retention setting of 15GB.

This PR introduces an init container to Prometheus to remove the obsolete `prometheus-` folder. However, this init container is injected differently based on the Prometheus type:

- In shoot Prometheus instances, where reconciliation cannot be guaranteed to successfully occur, such init containers are injected during the startup of the `gardenlet`. Hibernated shoot Prometheus instances are accordingly woken up to ensure the cleanup runs. The `gardenlet` patches Prometheus custom resources on-the-fly, bypassing the previously ignored ManagedResource. The GRM reverts these patches once the ManagedResource is unignored upon completion. Finally, an annotation marks those shoot Prometheus instances successfully cleaned up:

```
monitoring.resources.gardener.cloud/prometheus-obsolete-folder-cleaned-up: "true"
```

- Other Prometheus instances include the aforementioned init container as part of their reconciliation.

These cleanup steps will be undone in upcoming releases.

**Special notes for your reviewer**:

/cc @istvanballok @rickardsjp @chrkl @rfranzke 

**Release note**:

```other operator
Clean up obsolete `prometheus-` folder from Prometheus volumes. This might be a leftover of GEP-19
```
