### PR TITLE
Promote `CredentialsRotationWithoutWorkersRollout` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -29,6 +29,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | NodeAgentAuthorizer                      | `false` | `Alpha` | `1.109` | `1.115` |
 | NodeAgentAuthorizer                      | `true`  | `Beta`  | `1.116` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
+| CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
 | RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` | `1.118` |
 | RemoveAPIServerProxyLegacyPort           | `true`  | `Beta`  | `1.119` |         |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -62,6 +62,7 @@ const (
 	// later point in time of their convenience.
 	// owner: @rfranzke
 	// alpha: v1.112.0
+	// beta: v1.121.0
 	CredentialsRotationWithoutWorkersRollout featuregate.Feature = "CredentialsRotationWithoutWorkersRollout"
 
 	// InPlaceNodeUpdates enables setting the update strategy of worker pools to `AutoInPlaceUpdate` or `ManualInPlaceUpdate` in the Shoot API.
@@ -134,7 +135,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	NewWorkerPoolHash:                        {Default: false, PreRelease: featuregate.Alpha},
 	NewVPN:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	NodeAgentAuthorizer:                      {Default: true, PreRelease: featuregate.Beta},
-	CredentialsRotationWithoutWorkersRollout: {Default: false, PreRelease: featuregate.Alpha},
+	CredentialsRotationWithoutWorkersRollout: {Default: true, PreRelease: featuregate.Beta},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},
 	RemoveAPIServerProxyLegacyPort:           {Default: true, PreRelease: featuregate.Beta},
 	IstioTLSTermination:                      {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR promotes the `CredentialsRotationWithoutWorkersRollout` feature gate to beta.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10121
Follow-up of https://github.com/gardener/gardener/pull/11027

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `CredentialsRotationWithoutWorkersRollout` feature gate has been promoted to beta and is now enabled by default.
```
