### PR TITLE
Fix credentials rotation without workers rollout for in-place update

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -266,6 +266,8 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 api.e2e-rot-noroll.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-rot-ip.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-rot-ip.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-rot-nr-ip.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-rot-nr-ip.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-default.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-default.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-default-wl.local.external.local.gardener.cloud
@@ -296,6 +298,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 gu-local--e2e-rotate-wl.ingress.local.seed.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rot-noroll.ingress.local.seed.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rot-ip.ingress.local.seed.local.gardener.cloud
+172.18.255.1 gu-local--e2e-rot-nr-ip.ingress.local.seed.local.gardener.cloud
 # End of Gardener local setup section
 EOF
 ```

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -94,6 +94,7 @@ case $TYPE in
       e2e-rotate-wl.local
       e2e-rot-noroll.local
       e2e-rot-ip.local
+      e2e-rot-nr-ip.local
       e2e-default.local
       e2e-default-wl.local
       e2e-default-ip.local

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -731,12 +731,13 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 
 	var caRotationLastInitiationTime, serviceAccountKeyRotationLastInitiationTime *metav1.Time
 
-	if o.values.CredentialsRotationStatus != nil {
-		if o.values.CredentialsRotationStatus.CertificateAuthorities != nil {
-			caRotationLastInitiationTime = o.values.CredentialsRotationStatus.CertificateAuthorities.LastInitiationTime
+	if credentialsRotation := o.values.CredentialsRotationStatus; credentialsRotation != nil {
+		if caRotation := credentialsRotation.CertificateAuthorities; caRotation != nil {
+			caRotationLastInitiationTime = v1beta1helper.LastInitiationTimeForWorkerPool(worker.Name, caRotation.PendingWorkersRollouts, caRotation.LastInitiationTime)
 		}
-		if o.values.CredentialsRotationStatus.ServiceAccountKey != nil {
-			serviceAccountKeyRotationLastInitiationTime = o.values.CredentialsRotationStatus.ServiceAccountKey.LastInitiationTime
+
+		if serviceAccountKeyRotation := credentialsRotation.ServiceAccountKey; serviceAccountKeyRotation != nil {
+			serviceAccountKeyRotationLastInitiationTime = v1beta1helper.LastInitiationTimeForWorkerPool(worker.Name, serviceAccountKeyRotation.PendingWorkersRollouts, serviceAccountKeyRotation.LastInitiationTime)
 		}
 	}
 

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -130,7 +130,7 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		}, SpecTimeout(5*time.Minute))
 	}
 
-	nodesOfInPlaceWorkersBeforeTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
+	machinePodNamesBeforeTest := ItShouldFindAllMachinePodsBefore(s)
 
 	ItShouldAnnotateShoot(s, map[string]string{
 		v1beta1constants.GardenerOperation: v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout,
@@ -154,8 +154,7 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		}).Should(Succeed())
 	}, SpecTimeout(time.Minute))
 
-	nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
-	Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
+	ItShouldCompareMachinePodNamesAfter(s, machinePodNamesBeforeTest)
 
 	It("Ensure all worker pools are marked as 'pending for roll out'", func() {
 		for _, worker := range s.Shoot.Spec.Provider.Workers {

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -75,6 +75,11 @@ func testCredentialRotation(s *ShootContext, shootVerifiers, utilsverifiers rota
 		}
 
 		ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+		if inPlaceUpdate {
+			inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+		}
+
 		shootVerifiers.AfterPrepared(context.TODO())
 		for _, k := range utilsverifiers {
 			It(fmt.Sprintf("Verify after prepared for %T", k), func(ctx SpecContext) {
@@ -122,7 +127,7 @@ func testCredentialRotationComplete(s *ShootContext, shootVerifiers, utilsverifi
 	}
 }
 
-func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers rotationutils.Verifiers, utilsverifiers rotationutils.Verifiers) {
+func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers rotationutils.Verifiers, utilsverifiers rotationutils.Verifiers, inPlaceUpdate bool) {
 	shootVerifiers.Before(context.TODO())
 	for _, k := range utilsverifiers {
 		It(fmt.Sprintf("Verify before for %T", k), func(ctx SpecContext) {
@@ -206,7 +211,16 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		})).Should(Succeed())
 	}, SpecTimeout(time.Minute))
 
+	// In case of rotation without workers rollout, the in-place update status in only populated when the rollout for that worker pool is triggered
+	if inPlaceUpdate {
+		inplace.ItShouldVerifyInPlaceUpdateStart(s.GardenClient, s.Shoot, true, true)
+	}
+
 	ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+	if inPlaceUpdate {
+		inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+	}
 
 	It("Credential rotation in status prepared", func() {
 		Expect(s.Shoot.Status.Credentials.Rotation.CertificateAuthorities.Phase).To(Equal(gardencorev1beta1.RotationPrepared))
@@ -322,7 +336,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				// test rotation for every rotation type
 				testCredentialRotation(s, shootVerifiers, utilsVerifiers, v1beta1constants.OperationRotateCredentialsStart, v1beta1constants.OperationRotateCredentialsComplete, inPlaceUpdate)
 			} else {
-				testCredentialRotationWithoutWorkersRollout(s, shootVerifiers, utilsVerifiers)
+				testCredentialRotationWithoutWorkersRollout(s, shootVerifiers, utilsVerifiers, inPlaceUpdate)
 			}
 
 			if !v1beta1helper.IsWorkerless(s.Shoot) {
@@ -333,7 +347,6 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				if inPlaceUpdate {
 					nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 					Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
-					inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
 				}
 			}
 
@@ -390,6 +403,38 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				test(s, true, false)
 			})
 
+			Context("without workers rollout, in-place update strategy", Label("without-workers-rollout", "in-place"), Ordered, func() {
+				var s *ShootContext
+				BeforeTestSetup(func() {
+					shoot := DefaultShoot("e2e-rot-nr-ip")
+
+					worker1 := DefaultWorker("auto", ptr.To(gardencorev1beta1.AutoInPlaceUpdate))
+					worker1.Minimum = 2
+					worker1.Maximum = 2
+					worker1.MaxUnavailable = ptr.To(intstr.FromInt(1))
+					worker1.MaxSurge = ptr.To(intstr.FromInt(0))
+
+					worker2 := DefaultWorker("manual", ptr.To(gardencorev1beta1.ManualInPlaceUpdate))
+
+					// Add a third worker pool when worker rollout should not be performed such that we can make proper
+					// assertions of the shoot status
+					worker3 := DefaultWorker("rolling", nil)
+
+					shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{worker1, worker2, worker3}
+
+					s = NewTestContext().ForShoot(shoot)
+				})
+
+				// Skip the test for IPv6 single-stack Shoot as it is extremely flaky (success rate < 30%).
+				//
+				// TODO(shafeeqes, acumino, ary1992): Debug and fix the flaky test for ipv6.
+				if os.Getenv("IPFAMILY") == "ipv6" {
+					s.Log.Info("Skip the flaky credentials rotation with in-place update strategy e2e test for ipv6")
+					return
+				}
+
+				test(s, true, true)
+			})
 		})
 
 		Context("Workerless Shoot", Label("workerless"), Ordered, func() {

--- a/test/integration/gardenlet/shoot/status/status_test.go
+++ b/test/integration/gardenlet/shoot/status/status_test.go
@@ -445,6 +445,85 @@ var _ = Describe("Shoot Status controller tests", func() {
 			g.Expect(shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
 		}).Should(Succeed())
 	})
+
+	It("should annotate the shoot with operation Reconcile if manual in-place update workers are empty and credentials rotation phases are in WaitingForWorkersRollout and pendingWorkersRollouts is empty", func() {
+		shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{
+			Rotation: &gardencorev1beta1.ShootCredentialsRotation{
+				CertificateAuthorities: &gardencorev1beta1.CARotation{
+					Phase: gardencorev1beta1.RotationWaitingForWorkersRollout,
+				},
+				ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+					Phase: gardencorev1beta1.RotationWaitingForWorkersRollout,
+				},
+			},
+		}
+		Expect(testClient.Status().Update(ctx, shoot)).To(Succeed())
+
+		waitForManagerToObserveUpdatedShootStatus(shoot)
+
+		workerPoolHashMap := map[string]string{
+			"worker1": "ef492a9674e2778a",
+			"worker3": "981b8e740cbbf058",
+			"worker5": "2c12ce1fbb06b184",
+		}
+
+		patchAndWaitForManagerToObserveUpdatedWorkerStatus(worker, workerPoolHashMap)
+
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+			g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
+			// No change for auto in-place update workers
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).To(ConsistOf("worker2"))
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).To(BeEmpty())
+			g.Expect(shoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		}).Should(Succeed())
+	})
+
+	It("should not annotate the shoot with operation Reconcile if manual in-place update workers are empty and credentials rotation phases are in WaitingForWorkersRollout and pendingWorkersRollouts is not empty", func() {
+		shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{
+			Rotation: &gardencorev1beta1.ShootCredentialsRotation{
+				CertificateAuthorities: &gardencorev1beta1.CARotation{
+					Phase: gardencorev1beta1.RotationWaitingForWorkersRollout,
+					PendingWorkersRollouts: []gardencorev1beta1.PendingWorkersRollout{
+						{
+							Name: "worker1",
+						},
+					},
+				},
+				ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+					Phase: gardencorev1beta1.RotationWaitingForWorkersRollout,
+					PendingWorkersRollouts: []gardencorev1beta1.PendingWorkersRollout{
+						{
+							Name: "worker1",
+						},
+					},
+				},
+			},
+		}
+		Expect(testClient.Status().Update(ctx, shoot)).To(Succeed())
+
+		waitForManagerToObserveUpdatedShootStatus(shoot)
+
+		workerPoolHashMap := map[string]string{
+			"worker1": "ef492a9674e2778a",
+			"worker3": "981b8e740cbbf058",
+			"worker5": "2c12ce1fbb06b184",
+		}
+
+		patchAndWaitForManagerToObserveUpdatedWorkerStatus(worker, workerPoolHashMap)
+
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+			g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
+			// No change for auto in-place update workers
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).To(ConsistOf("worker2"))
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).To(BeEmpty())
+			g.Expect(shoot.Annotations).NotTo(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		}).Should(Succeed())
+	})
+
 })
 
 func waitForManagerToObserveUpdatedShootStatus(shoot *gardencorev1beta1.Shoot) {

--- a/test/utils/shoots/update/inplace/shoot.go
+++ b/test/utils/shoots/update/inplace/shoot.go
@@ -55,5 +55,5 @@ func ItShouldVerifyInPlaceUpdateCompletion(gardenClient client.Client, shoot *ga
 				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
 			))
 		}).Should(Succeed())
-	}, SpecTimeout(2*time.Minute))
+	}, SpecTimeout(5*time.Minute))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
The credentialsRotation in the `OperatingSystemConfig` was not correctly calculated in case of credentials-rotation without workers rollout.

This PR fixes this issue and adds an e2e test for the same.
It also replaces a function wrongly changed in https://github.com/gardener/gardener/pull/11990.

**Which issue(s) this PR fixes**:
Part of #10219 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing the in-place update to fail during credentials rotation without workers rollout is now fixed.
```
