### PR TITLE
Enable `local-ext-seed` extension in local setup

### DIFF
--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -80,9 +80,8 @@ config:
           secretRef:
             name: internal-domain-internal-local-gardener-cloud
             namespace: garden
-#      TODO(timuthy): Enable extension after Gardener v1.120 was released.
-#      extensions:
-#      - type: local-ext-seed
+      extensions:
+      - type: local-ext-seed
       ingress:
         domain: ingress.local.seed.local.gardener.cloud
         controller:

--- a/example/provider-local/garden/local/controllerregistration.yaml
+++ b/example/provider-local/garden/local/controllerregistration.yaml
@@ -26,10 +26,9 @@ spec:
       type: local
     - kind: Extension
       type: local-ext-seed
-#     TODO(timuthy): Enable clusterCompatibility after Gardener v1.120 was released.
-#     clusterCompatibility:
-#     - shoot
-#     - seed
+      clusterCompatibility:
+      - shoot
+      - seed
       lifecycle:
         reconcile: BeforeKubeAPIServer
         delete: AfterKubeAPIServer


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
This PR activates the `local-ext-seed` extension again after #11982 was released.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
