### PR TITLE
Draft: Signing of GRM secrets

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -6,7 +6,6 @@ package resourcemanager
 
 import (
 	"context"
-	"crypto/rand"
 	_ "embed"
 	"fmt"
 	"slices"
@@ -29,7 +28,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -369,7 +367,7 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 
 	fns := []flow.TaskFn{
 		r.ensureServiceAccount,
-		r.ensureSigningSecret,
+		r.ensureSigningSecrets,
 		func(ctx context.Context) error {
 			return r.ensureConfigMap(ctx, configMap)
 		},
@@ -1107,28 +1105,8 @@ func (r *resourceManager) ensureServiceAccount(ctx context.Context) error {
 	return err
 }
 
-func (r *resourceManager) ensureSigningSecret(ctx context.Context) error {
-	saltSecret := &corev1.Secret{}
-	err := r.client.Get(ctx, client.ObjectKey{
-		Name:      managedresources.SigningSaltSecretName,
-		Namespace: managedresources.SigningSaltSecretNamespace,
-	}, saltSecret)
-
-	if !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	saltSecret = &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      managedresources.SigningSaltSecretName,
-			Namespace: managedresources.SigningSaltSecretNamespace,
-		},
-		Data: map[string][]byte{
-			managedresources.SigningSaltSecretKey: []byte(rand.Text()),
-		},
-	}
-
-	return r.client.Create(ctx, saltSecret)
+func (r *resourceManager) ensureSigningSecrets(ctx context.Context) error {
+	return managedresources.EnsureSigningKeys(ctx, r.client)
 }
 
 func (r *resourceManager) emptyServiceAccount() *corev1.ServiceAccount {

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -183,6 +183,10 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 
 		err := managedresourcesutils.VerifySecretSignature(ctx, r.SourceClient, secret)
 		if err != nil {
+			conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionFalse, "SignatureVerificationFailed", err.Error())
+			if err := updateConditions(ctx, r.SourceClient, mr, conditionResourcesApplied); err != nil {
+				return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
+			}
 			return reconcile.Result{}, fmt.Errorf("could not verify signature of secret '%s': %w", secret.Name, err)
 		}
 

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -58,14 +58,14 @@ const (
 	LabelValueOperator = "gardener-operator"
 	// SignatureSecretNamespace is the namespace in which the signing secret is located.
 	SignatureSecretNamespace = v1beta1constants.GardenNamespace
-	// SignatureVerificationSecretName is the name of the secret containing the salt used for verifying managed resource secret signatures.
-	SignatureVerificationSecretName = "gardener-resource-manager-signing-secret-verify"
-	// SignatureSigningSecretName is the name of the secret containing the salt used for signing managed resources secrets.
-	SignatureSigningSecretName = "gardener-resource-manager-signing-secret-sign"
+	// SignatureVerificationSecretName is the name of the secret containing the public key used for verifying managed resource secret signatures.
+	SignatureVerificationSecretName = "gardener-resource-manager-signature-verify"
+	// SignatureSigningSecretName is the name of the secret containing the private key used for signing managed resources secrets.
+	SignatureSigningSecretName = "gardener-resource-manager-signature-sign"
 	// SignaturePublicSecretKey is the key for the public key in the secret used for verifying managed resource secret signatures.
-	SignaturePublicSecretKey = "public-key"
+	SignaturePublicSecretKey = "public-key.pem"
 	// SignaturePrivateSecretKey is the key for the private key in the secret used for signing managed resource secrets.
-	SignaturePrivateSecretKey = "private-key"
+	SignaturePrivateSecretKey = "private-key.pem"
 	// SignatureAnnotationKey is the key for the annotation on the secret containing the signature of managed resource secrets.
 	SignatureAnnotationKey = "gardener.cloud/managed-resource-signature"
 )

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -160,9 +160,18 @@ func Update(
 	forceOverwriteAnnotations *bool,
 ) error {
 	var (
+		signature, err     = calculateSignature(ctx, client, data)
 		secretName, secret = NewSecret(client, namespace, name, data, secretNameWithPrefix)
 		managedResource    = New(client, namespace, name, class, keepObjects, labels, injectedLabels, forceOverwriteAnnotations).WithSecretRef(secretName).CreateIfNotExists(false)
 	)
+
+	if err != nil {
+		return err
+	}
+
+	secret.WithAnnotations(map[string]string{
+		SignatureAnnotationKey: signature,
+	})
 
 	return deployManagedResource(ctx, secret, managedResource)
 }

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -355,7 +355,6 @@ func EnsureSigningKeys(ctx context.Context, c client.Client) error {
 	err = errors.Join(privateErr, publicErr)
 	if err != nil {
 		return fmt.Errorf("failed to create matching signing secrets, manual intervention needed: %w", err)
-
 	}
 
 	return nil

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -139,24 +139,14 @@ var _ = Describe("Certificates tests", func() {
 		By("Create garden Namespace")
 		gardenNamespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: managedresources.SigningSaltSecretNamespace,
+				Name: managedresources.SignatureSecretNamespace,
 			},
 		}
 		err := testClient.Create(ctx, gardenNamespace)
 		Expect(err).To(Or(Succeed(), BeAlreadyExistsError()), "Failed to create garden Namespace")
 
 		By("Create resource manager signing secret")
-		signingSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      managedresources.SigningSaltSecretName,
-				Namespace: managedresources.SigningSaltSecretNamespace,
-			},
-			Data: map[string][]byte{
-				managedresources.SigningSaltSecretKey: []byte("test-salt"),
-			},
-		}
-		err = testClient.Create(ctx, signingSecret)
-		Expect(err).To(Or(Succeed(), BeAlreadyExistsError()), "Failed to create resource manager signing secret")
+		Expect(managedresources.EnsureSigningKeys(ctx, testClient)).To(Succeed())
 
 		// use unique extension name for each test,for unique webhook config name
 		extensionName = "provider-test-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -48,25 +48,11 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 	BeforeEach(func() {
 		gardenNs := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: managedresources.SigningSaltSecretNamespace,
+				Name: managedresources.SignatureSecretNamespace,
 			},
 		}
 		Expect(testClient.Create(ctx, gardenNs)).To(Or(Succeed(), BeAlreadyExistsError()))
-
-		signingSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      managedresources.SigningSaltSecretName,
-				Namespace: managedresources.SigningSaltSecretNamespace,
-			},
-			Data: map[string][]byte{
-				managedresources.SigningSaltSecretKey: []byte("test-salt"),
-			},
-		}
-		err := testClient.Create(ctx, signingSecret)
-		Expect(err).To(Or(BeNil(), BeAlreadyExistsError()))
-		DeferCleanup(func() {
-			Expect(client.IgnoreNotFound(testClient.Delete(ctx, signingSecret))).To(Succeed())
-		})
+		Expect(managedresources.EnsureSigningKeys(ctx, testClient)).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -70,25 +70,11 @@ var _ = Describe("Seed controller tests", func() {
 		By("Prepare managed resources")
 		gardenNs := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: managedresources.SigningSaltSecretNamespace,
+				Name: managedresources.SignatureSecretNamespace,
 			},
 		}
 		Expect(testClient.Create(ctx, gardenNs)).To(Or(Succeed(), BeAlreadyExistsError()))
-
-		signingSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      managedresources.SigningSaltSecretName,
-				Namespace: managedresources.SigningSaltSecretNamespace,
-			},
-			Data: map[string][]byte{
-				managedresources.SigningSaltSecretKey: []byte("test-salt"),
-			},
-		}
-		err := testClient.Create(ctx, signingSecret)
-		Expect(err).To(Or(BeNil(), BeAlreadyExistsError()))
-		DeferCleanup(func() {
-			Expect(client.IgnoreNotFound(testClient.Delete(ctx, signingSecret))).To(Succeed())
-		})
+		Expect(managedresources.EnsureSigningKeys(ctx, testClient)).To(Succeed())
 
 		By("Create test Namespace")
 		testNamespace = &corev1.Namespace{

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -119,6 +119,14 @@ var _ = Describe("Garden controller tests", func() {
 		log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 		testRunID = testNamespace.Name
 
+		By("Create garden Namespace")
+		gardenNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "garden",
+			},
+		}
+		Expect(testClient.Create(ctx, gardenNamespace)).To(Succeed())
+
 		DeferCleanup(func() {
 			By("Delete test Namespace")
 			Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -98,7 +98,7 @@ var _ = BeforeSuite(func() {
 	By("Create garden Namespace")
 	gardenNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: managedresourcesutils.SigningSaltSecretNamespace,
+			Name: managedresourcesutils.SignatureSecretNamespace,
 		},
 	}
 	Expect(testClient.Create(ctx, gardenNs)).To(Or(Succeed(), BeAlreadyExistsError()))

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -73,16 +73,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 			Data: map[string]string{"abc": "xyz"},
 		}
 
-		signatureSecret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      managedresourcesutils.SigningSaltSecretName,
-				Namespace: managedresourcesutils.SigningSaltSecretNamespace,
-			},
-			Data: map[string][]byte{
-				managedresourcesutils.SigningSaltSecretKey: []byte("test-salt"),
-			},
-		}
-		Expect(testClient.Create(ctx, signatureSecret)).To(Succeed())
+		Expect(managedresourcesutils.EnsureSigningKeys(ctx, testClient)).To(Succeed())
 
 		secretForManagedResource = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -110,7 +101,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 		if secretForManagedResource != nil {
 			By("Create Secret for test")
 			log.Info("Create Secret for test", "secret", objectKey)
-			signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+			signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 			Expect(err).ToNot(HaveOccurred())
 			secretForManagedResource.Annotations = map[string]string{
 				managedresourcesutils.SignatureAnnotationKey: signature,
@@ -207,7 +198,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				newConfigMap := &corev1.ConfigMap{}
 				secretForManagedResource.Data = secretDataForObject(newConfigMap, dataKey)
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -292,7 +283,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 
 				patch := client.MergeFrom(secretForManagedResource.DeepCopy())
 				secretForManagedResource.Data = secretDataForObject(newConfigMap, dataKey)
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -322,7 +313,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				patch := client.MergeFrom(secretForManagedResource.DeepCopy())
 				configMap.Data = map[string]string{"foo": "bar"}
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -354,7 +345,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				patch := client.MergeFrom(secretForManagedResource.DeepCopy())
 				secretForManagedResource.Data[newDataKey] = secretDataForObject(newResource, newDataKey)[newDataKey]
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -384,7 +375,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				patch := client.MergeFrom(secretForManagedResource.DeepCopy())
 				secretForManagedResource.Data[newDataKey] = secretDataForObject(newResource, newDataKey)[newDataKey]
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -414,7 +405,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					Data: secretDataForObject(newResource, dataKey),
 				}
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, newSecretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, newSecretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				newSecretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -552,7 +543,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				patch := client.MergeFrom(secretForManagedResource.DeepCopy())
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -572,7 +563,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				patch := client.MergeFrom(secretForManagedResource.DeepCopy())
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -593,7 +584,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				configMap.SetAnnotations(map[string]string{resourcesv1alpha1.KeepObject: "true"})
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -651,7 +642,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				configMap.Finalizers = []string{"some.finalizer.to/make-the-deletion-stuck"}
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -718,7 +709,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				}
 				secretForManagedResource.Data["node.yaml"] = jsonDataForObject(node)
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -779,7 +770,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				configMap.SetAnnotations(map[string]string{resourcesv1alpha1.Ignore: "true"})
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -887,7 +878,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 
 				secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -1026,7 +1017,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 
 				secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
 
-				signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+				signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 				Expect(err).To(BeNil())
 				secretForManagedResource.Annotations = map[string]string{
 					managedresourcesutils.SignatureAnnotationKey: signature,
@@ -1084,7 +1075,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 						deployment.SetAnnotations(map[string]string{resourcesv1alpha1.PreserveReplicas: "true"})
 						secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
 
-						signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+						signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 						Expect(err).To(BeNil())
 						secretForManagedResource.Annotations = map[string]string{
 							managedresourcesutils.SignatureAnnotationKey: signature,
@@ -1158,7 +1149,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 						deployment.SetAnnotations(map[string]string{resourcesv1alpha1.PreserveResources: "true"})
 						secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
 
-						signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+						signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 						Expect(err).To(BeNil())
 						secretForManagedResource.Annotations = map[string]string{
 							managedresourcesutils.SignatureAnnotationKey: signature,
@@ -1198,7 +1189,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				Data: secretDataForObject(configMap, dataKey),
 			}
 
-			signature, err := managedresourcesutils.CalculateSignature(ctx, testClient, secretForManagedResource.Data)
+			signature, err := managedresourcesutils.SignSecret(ctx, testClient, secretForManagedResource.Data)
 			Expect(err).ToNot(HaveOccurred())
 			secretForManagedResource.Annotations = map[string]string{
 				managedresourcesutils.SignatureAnnotationKey: signature,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
In case a potential attacker already gained access to a shoot namespace (editing secrets and/or managed resources), they could deploy malicious code and RBACs to escalate their privileges to `*`.

ToDo ⚙️: (_probably after the Hackathon_)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Proper RBAC configuration for components that create MRs
- [ ] _probably_ fix e2e tests
- [ ] Documentation
- [ ] ...
- [ ] Profit
 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Hackathon topic, early WIP with @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
