### PR TITLE
Deploy control plane chart through managed resource.

### DIFF
--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -410,6 +410,17 @@ func RenderChartAndCreate(ctx context.Context, namespace string, name string, se
 	return Create(ctx, client, namespace, name, nil, secretNameWithPrefix, "", map[string][]byte{chartName: data}, ptr.To(false), injectedLabels, &forceOverwriteAnnotations)
 }
 
+// RenderChartAndCreateForSeed renders a chart and creates a ManagedResource for the gardener-resource-manager
+// out of the results using the seed class.
+func RenderChartAndCreateForSeed(ctx context.Context, namespace string, name string, client client.Client, chartRenderer chartrenderer.Interface, chart chart.Interface, values map[string]any, imageVector imagevector.ImageVector, chartNamespace string, runtimeVersion, targetVersion string) error {
+	chartName, data, err := chart.Render(chartRenderer, chartNamespace, imageVector, runtimeVersion, targetVersion, values)
+	if err != nil {
+		return fmt.Errorf("could not render chart: %w", err)
+	}
+
+	return Create(ctx, client, namespace, name, nil, false, v1beta1constants.SeedResourceManagerClass, map[string][]byte{chartName: data}, nil, nil, nil)
+}
+
 // configurationProblemRegex is used to check if an error is caused by a bad managed resource configuration.
 var configurationProblemRegex = regexp.MustCompile(`(?i)(error during apply of object .* is invalid:)`)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/kind technical-debt

**What this PR does / why we need it**:

Currently, we deploy the seed control-plane components using the chart applier instead of directly deploying managed-resources. For the shoot parts of the control plane this was already implemented but for some reason this migration was not completed for the seed components. 

The current approach creates some issues where for example if we want to scale a seed component, we have to do it "manually", e.g. scaling a controller to 0 needs to be done imperatively. Removing objects from the chart is cumbersome, too, because the chart applier does not really maintain the state of existing objects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Implemented during Hackathon. 😻

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The generic actuator of the control plane now wraps seed-related charts into `ManagedResource`s . Any imperative logic in your provider extension that does not consider management through the gardener-resource-manager can potentially be cleaned up.
```
