### PR TITLE
Add egress CIDRs to shoot-info config map.

### DIFF
--- a/pkg/component/shoot/system/mock/mocks.go
+++ b/pkg/component/shoot/system/mock/mocks.go
@@ -82,6 +82,18 @@ func (mr *MockInterfaceMockRecorder) SetAPIResourceList(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIResourceList", reflect.TypeOf((*MockInterface)(nil).SetAPIResourceList), arg0)
 }
 
+// SetEgressCIDRs mocks base method.
+func (m *MockInterface) SetEgressCIDRs(arg0 []net.IPNet) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetEgressCIDRs", arg0)
+}
+
+// SetEgressCIDRs indicates an expected call of SetEgressCIDRs.
+func (mr *MockInterfaceMockRecorder) SetEgressCIDRs(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEgressCIDRs", reflect.TypeOf((*MockInterface)(nil).SetEgressCIDRs), arg0)
+}
+
 // SetNodeNetworkCIDRs mocks base method.
 func (m *MockInterface) SetNodeNetworkCIDRs(arg0 []net.IPNet) {
 	m.ctrl.T.Helper()

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -44,6 +44,7 @@ type Interface interface {
 	SetPodNetworkCIDRs([]net.IPNet)
 	SetServiceNetworkCIDRs([]net.IPNet)
 	SetNodeNetworkCIDRs([]net.IPNet)
+	SetEgressCIDRs([]net.IPNet)
 }
 
 // Values is a set of configuration values for the system resources.
@@ -70,6 +71,8 @@ type Values struct {
 	ServiceNetworkCIDRs []net.IPNet
 	// NodeNetworkCIDRs are the CIDRs of the node network.
 	NodeNetworkCIDRs []net.IPNet
+	// EgressCIDRs are the egress CIDRs of the cluster, actual presence of this field depends on the implementation of the provider extension.
+	EgressCIDRs []net.IPNet
 }
 
 // New creates a new instance of DeployWaiter for shoot system resources.
@@ -118,6 +121,10 @@ func (s *shootSystem) SetServiceNetworkCIDRs(services []net.IPNet) {
 
 func (s *shootSystem) SetNodeNetworkCIDRs(nodes []net.IPNet) {
 	s.values.NodeNetworkCIDRs = nodes
+}
+
+func (s *shootSystem) SetEgressCIDRs(cidrs []net.IPNet) {
+	s.values.EgressCIDRs = cidrs
 }
 
 // TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
@@ -370,6 +377,7 @@ func (s *shootSystem) shootInfoData() map[string]string {
 	addNetworkToMap("podNetworks", s.values.PodNetworkCIDRs, data)
 	addNetworkToMap("serviceNetworks", s.values.ServiceNetworkCIDRs, data)
 	addNetworkToMap("nodeNetworks", s.values.NodeNetworkCIDRs, data)
+	addNetworkToMap("egressCIDRs", s.values.EgressCIDRs, data)
 
 	return data
 }

--- a/pkg/gardenlet/operation/botanist/shootsystem.go
+++ b/pkg/gardenlet/operation/botanist/shootsystem.go
@@ -56,5 +56,6 @@ func (b *Botanist) DeployShootSystem(ctx context.Context) error {
 	b.Shoot.Components.SystemComponents.Resources.SetPodNetworkCIDRs(b.Shoot.Networks.Pods)
 	b.Shoot.Components.SystemComponents.Resources.SetServiceNetworkCIDRs(b.Shoot.Networks.Services)
 	b.Shoot.Components.SystemComponents.Resources.SetNodeNetworkCIDRs(b.Shoot.Networks.Nodes)
+	b.Shoot.Components.SystemComponents.Resources.SetEgressCIDRs(b.Shoot.Networks.EgressCIDRs)
 	return b.Shoot.Components.SystemComponents.Resources.Deploy(ctx)
 }

--- a/pkg/gardenlet/operation/botanist/shootsystem_test.go
+++ b/pkg/gardenlet/operation/botanist/shootsystem_test.go
@@ -31,6 +31,8 @@ var _ = Describe("ShootSystem", func() {
 		serviceCIDR = "2001:db8:1::/64"
 		podCIDR1    = "2001:db8:2::/64"
 		podCIDR2    = "2001:db8:3::/64"
+		egressCIDR1 = "100.64.0.1/32"
+		egressCIDR2 = "100.64.0.2/32"
 	)
 
 	BeforeEach(func() {
@@ -82,6 +84,10 @@ var _ = Describe("ShootSystem", func() {
 			Expect(err).ToNot(HaveOccurred())
 			_, pods2, err := net.ParseCIDR(podCIDR2)
 			Expect(err).ToNot(HaveOccurred())
+			_, egress1, err := net.ParseCIDR(egressCIDR1)
+			Expect(err).ToNot(HaveOccurred())
+			_, egress2, err := net.ParseCIDR(egressCIDR2)
+			Expect(err).ToNot(HaveOccurred())
 
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -90,9 +96,10 @@ var _ = Describe("ShootSystem", func() {
 					},
 				},
 				Networks: &shootpkg.Networks{
-					Nodes:    []net.IPNet{*nodes},
-					Pods:     []net.IPNet{*pods1, *pods2},
-					Services: []net.IPNet{*services},
+					Nodes:       []net.IPNet{*nodes},
+					Pods:        []net.IPNet{*pods1, *pods2},
+					Services:    []net.IPNet{*services},
+					EgressCIDRs: []net.IPNet{*egress1, *egress2},
 				},
 			}
 
@@ -100,6 +107,7 @@ var _ = Describe("ShootSystem", func() {
 			shootSystem.EXPECT().SetNodeNetworkCIDRs(botanist.Shoot.Networks.Nodes)
 			shootSystem.EXPECT().SetServiceNetworkCIDRs(botanist.Shoot.Networks.Services)
 			shootSystem.EXPECT().SetPodNetworkCIDRs(botanist.Shoot.Networks.Pods)
+			shootSystem.EXPECT().SetEgressCIDRs(botanist.Shoot.Networks.EgressCIDRs)
 		})
 
 		It("should discover the API and deploy", func() {

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -188,6 +188,8 @@ type Networks struct {
 	Services []net.IPNet
 	// Nodes subnets
 	Nodes []net.IPNet
+	// EgressCIDRs contains the outgoing IP address ranges used by the cluster if known.
+	EgressCIDRs []net.IPNet
 	// APIServer are the ClusterIPs of default/kubernetes Service
 	APIServer []net.IP
 	// CoreDNS are the ClusterIPs of kube-system/coredns Service


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

For some controllers (e.g. crossplane) that run on the shoot it would be great to have the egress CIDRs information available directly in the cluster.

We were also considering adding more information about the shoot to the `shoot-info` `ConfigMap` but the purpose of it was not really clear. Thus, we reduced this PR to the bare minimum.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Implemented during Hackathon. 😻

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
