### PR TITLE
Install typos tool on linux/arm64 nodes

### DIFF
--- a/hack/tools/install-protoc.sh
+++ b/hack/tools/install-protoc.sh
@@ -8,6 +8,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo "> Installing protoc"
+
 TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname "$0")/bin}
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/hack/tools/install-typos.sh
+++ b/hack/tools/install-typos.sh
@@ -8,19 +8,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo "> Installing typos"
+
 TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname "$0")/bin}
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
-arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+arch=$(uname -m | sed 's/amd64/x86_64/;s/arm64/aarch64/')
 typos_tar=typos-"$TYPOS_VERSION"-"$os"-"$arch".zip
 
 if [[ $os == "darwin" ]]; then
-  url="https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/typos-${TYPOS_VERSION}-aarch64-apple-darwin.tar.gz"
-elif [[ $os == "linux" && $arch == "amd64" ]]; then
-  url="https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/typos-${TYPOS_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+  url="https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/typos-${TYPOS_VERSION}-${arch}-apple-darwin.tar.gz"
+elif [[ $os == "linux" ]]; then
+  url="https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/typos-${TYPOS_VERSION}-${arch}-unknown-linux-musl.tar.gz"
 else
   if ! command -v typos &>/dev/null; then
-    echo "Unable to automatically install typos for ${os}/${arch}. Please install it yourself and retry."
+    echo "Unable to automatically install typos(https://github.com/crate-ci/typos) for ${os}/${arch}. Please install it yourself and retry."
     exit 1
   fi
 fi


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity 
/kind enhancement

**What this PR does / why we need it**:
Install typos tool on linux/arm64 nodes

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Since https://github.com/crate-ci/typos/commit/4b96e0d5fe137c0073d5c14632a8c9f50f891a24 (https://github.com/crate-ci/typos/releases/tag/v1.29.8) have added support for linux arm64 nodes.
 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
