### PR TITLE
[release-v1.119] Fix credentials rotation without workers rollout for in-place update

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -266,6 +266,8 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 api.e2e-rot-noroll.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-rot-ip.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-rot-ip.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-rot-nr-ip.local.external.local.gardener.cloud
+172.18.255.1 api.e2e-rot-nr-ip.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-default.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-default.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-default-wl.local.external.local.gardener.cloud
@@ -296,6 +298,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 gu-local--e2e-rotate-wl.ingress.local.seed.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rot-noroll.ingress.local.seed.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rot-ip.ingress.local.seed.local.gardener.cloud
+172.18.255.1 gu-local--e2e-rot-nr-ip.ingress.local.seed.local.gardener.cloud
 # End of Gardener local setup section
 EOF
 ```

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -94,6 +94,7 @@ case $TYPE in
       e2e-rotate-wl.local
       e2e-rot-noroll.local
       e2e-rot-ip.local
+      e2e-rot-nr-ip.local
       e2e-default.local
       e2e-default-wl.local
       e2e-default-ip.local

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -724,12 +724,13 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 
 	var caRotationLastInitiationTime, serviceAccountKeyRotationLastInitiationTime *metav1.Time
 
-	if o.values.CredentialsRotationStatus != nil {
-		if o.values.CredentialsRotationStatus.CertificateAuthorities != nil {
-			caRotationLastInitiationTime = o.values.CredentialsRotationStatus.CertificateAuthorities.LastInitiationTime
+	if credentialsRotation := o.values.CredentialsRotationStatus; credentialsRotation != nil {
+		if caRotation := credentialsRotation.CertificateAuthorities; caRotation != nil {
+			caRotationLastInitiationTime = v1beta1helper.LastInitiationTimeForWorkerPool(worker.Name, caRotation.PendingWorkersRollouts, caRotation.LastInitiationTime)
 		}
-		if o.values.CredentialsRotationStatus.ServiceAccountKey != nil {
-			serviceAccountKeyRotationLastInitiationTime = o.values.CredentialsRotationStatus.ServiceAccountKey.LastInitiationTime
+
+		if serviceAccountKeyRotation := credentialsRotation.ServiceAccountKey; serviceAccountKeyRotation != nil {
+			serviceAccountKeyRotationLastInitiationTime = v1beta1helper.LastInitiationTimeForWorkerPool(worker.Name, serviceAccountKeyRotation.PendingWorkersRollouts, serviceAccountKeyRotation.LastInitiationTime)
 		}
 	}
 

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -130,7 +130,7 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		}, SpecTimeout(5*time.Minute))
 	}
 
-	nodesOfInPlaceWorkersBeforeTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
+	machinePodNamesBeforeTest := ItShouldFindAllMachinePodsBefore(s)
 
 	ItShouldAnnotateShoot(s, map[string]string{
 		v1beta1constants.GardenerOperation: v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout,
@@ -154,8 +154,7 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		}).Should(Succeed())
 	}, SpecTimeout(time.Minute))
 
-	nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
-	Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
+	ItShouldCompareMachinePodNamesAfter(s, machinePodNamesBeforeTest)
 
 	It("Ensure all worker pools are marked as 'pending for roll out'", func() {
 		for _, worker := range s.Shoot.Spec.Provider.Workers {

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -75,6 +75,11 @@ func testCredentialRotation(s *ShootContext, shootVerifiers, utilsverifiers rota
 		}
 
 		ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+		if inPlaceUpdate {
+			inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+		}
+
 		shootVerifiers.AfterPrepared(context.TODO())
 		for _, k := range utilsverifiers {
 			It(fmt.Sprintf("Verify after prepared for %T", k), func(ctx SpecContext) {
@@ -122,7 +127,7 @@ func testCredentialRotationComplete(s *ShootContext, shootVerifiers, utilsverifi
 	}
 }
 
-func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers rotationutils.Verifiers, utilsverifiers rotationutils.Verifiers) {
+func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers rotationutils.Verifiers, utilsverifiers rotationutils.Verifiers, inPlaceUpdate bool) {
 	shootVerifiers.Before(context.TODO())
 	for _, k := range utilsverifiers {
 		It(fmt.Sprintf("Verify before for %T", k), func(ctx SpecContext) {
@@ -206,7 +211,16 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 		})).Should(Succeed())
 	}, SpecTimeout(time.Minute))
 
+	// In case of rotation without workers rollout, the in-place update status in only populated when the rollout for that worker pool is triggered
+	if inPlaceUpdate {
+		inplace.ItShouldVerifyInPlaceUpdateStart(s.GardenClient, s.Shoot, true, true)
+	}
+
 	ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+	if inPlaceUpdate {
+		inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+	}
 
 	It("Credential rotation in status prepared", func() {
 		Expect(s.Shoot.Status.Credentials.Rotation.CertificateAuthorities.Phase).To(Equal(gardencorev1beta1.RotationPrepared))
@@ -322,7 +336,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				// test rotation for every rotation type
 				testCredentialRotation(s, shootVerifiers, utilsVerifiers, v1beta1constants.OperationRotateCredentialsStart, v1beta1constants.OperationRotateCredentialsComplete, inPlaceUpdate)
 			} else {
-				testCredentialRotationWithoutWorkersRollout(s, shootVerifiers, utilsVerifiers)
+				testCredentialRotationWithoutWorkersRollout(s, shootVerifiers, utilsVerifiers, inPlaceUpdate)
 			}
 
 			if !v1beta1helper.IsWorkerless(s.Shoot) {
@@ -333,7 +347,6 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				if inPlaceUpdate {
 					nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 					Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
-					inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
 				}
 			}
 
@@ -390,6 +403,38 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				test(s, true, false)
 			})
 
+			Context("without workers rollout, in-place update strategy", Label("without-workers-rollout", "in-place"), Ordered, func() {
+				var s *ShootContext
+				BeforeTestSetup(func() {
+					shoot := DefaultShoot("e2e-rot-nr-ip")
+
+					worker1 := DefaultWorker("auto", ptr.To(gardencorev1beta1.AutoInPlaceUpdate))
+					worker1.Minimum = 2
+					worker1.Maximum = 2
+					worker1.MaxUnavailable = ptr.To(intstr.FromInt(1))
+					worker1.MaxSurge = ptr.To(intstr.FromInt(0))
+
+					worker2 := DefaultWorker("manual", ptr.To(gardencorev1beta1.ManualInPlaceUpdate))
+
+					// Add a third worker pool when worker rollout should not be performed such that we can make proper
+					// assertions of the shoot status
+					worker3 := DefaultWorker("rolling", nil)
+
+					shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{worker1, worker2, worker3}
+
+					s = NewTestContext().ForShoot(shoot)
+				})
+
+				// Skip the test for IPv6 single-stack Shoot as it is extremely flaky (success rate < 30%).
+				//
+				// TODO(shafeeqes, acumino, ary1992): Debug and fix the flaky test for ipv6.
+				if os.Getenv("IPFAMILY") == "ipv6" {
+					s.Log.Info("Skip the flaky credentials rotation with in-place update strategy e2e test for ipv6")
+					return
+				}
+
+				test(s, true, true)
+			})
 		})
 
 		Context("Workerless Shoot", Label("workerless"), Ordered, func() {

--- a/test/integration/gardenlet/shoot/status/status_test.go
+++ b/test/integration/gardenlet/shoot/status/status_test.go
@@ -512,4 +512,109 @@ var _ = Describe("Shoot Status controller tests", func() {
 			g.Expect(shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
 		}).Should(Succeed())
 	})
+
+	It("should annotate the shoot with operation Reconcile if manual in-place update workers are empty and credentials rotation phases are in WaitingForWorkersRollout and pendingWorkersRollouts is empty", func() {
+		shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{
+			Rotation: &gardencorev1beta1.ShootCredentialsRotation{
+				CertificateAuthorities: &gardencorev1beta1.CARotation{
+					Phase: gardencorev1beta1.RotationWaitingForWorkersRollout,
+				},
+				ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+					Phase: gardencorev1beta1.RotationWaitingForWorkersRollout,
+				},
+			},
+		}
+		Expect(testClient.Status().Update(ctx, shoot)).To(Succeed())
+
+		waitForManagerToObserveUpdatedShootStatus(shoot)
+
+		workerPoolHashMap := map[string]string{
+			"worker1": "ef492a9674e2778a",
+			"worker3": "981b8e740cbbf058",
+			"worker5": "2c12ce1fbb06b184",
+		}
+
+		patchAndWaitForManagerToObserveUpdatedWorkerStatus(worker, workerPoolHashMap)
+
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+			g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
+			// No change for auto in-place update workers
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).To(ConsistOf("worker2"))
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).To(BeEmpty())
+			g.Expect(shoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		}).Should(Succeed())
+	})
+
+	It("should not annotate the shoot with operation Reconcile if manual in-place update workers are empty and credentials rotation phases are in WaitingForWorkersRollout and pendingWorkersRollouts is not empty", func() {
+		shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{
+			Rotation: &gardencorev1beta1.ShootCredentialsRotation{
+				CertificateAuthorities: &gardencorev1beta1.CARotation{
+					Phase: gardencorev1beta1.RotationWaitingForWorkersRollout,
+					PendingWorkersRollouts: []gardencorev1beta1.PendingWorkersRollout{
+						{
+							Name: "worker1",
+						},
+					},
+				},
+				ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+					Phase: gardencorev1beta1.RotationWaitingForWorkersRollout,
+					PendingWorkersRollouts: []gardencorev1beta1.PendingWorkersRollout{
+						{
+							Name: "worker1",
+						},
+					},
+				},
+			},
+		}
+		Expect(testClient.Status().Update(ctx, shoot)).To(Succeed())
+
+		waitForManagerToObserveUpdatedShootStatus(shoot)
+
+		workerPoolHashMap := map[string]string{
+			"worker1": "ef492a9674e2778a",
+			"worker3": "981b8e740cbbf058",
+			"worker5": "2c12ce1fbb06b184",
+		}
+
+		patchAndWaitForManagerToObserveUpdatedWorkerStatus(worker, workerPoolHashMap)
+
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+			g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
+			// No change for auto in-place update workers
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).To(ConsistOf("worker2"))
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).To(BeEmpty())
+			g.Expect(shoot.Annotations).NotTo(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		}).Should(Succeed())
+	})
+
 })
+
+func waitForManagerToObserveUpdatedShootStatus(shoot *gardencorev1beta1.Shoot) {
+	By("Wait until the manager cache has observed the Shoot status")
+	EventuallyWithOffset(1, func(g Gomega) gardencorev1beta1.ShootStatus {
+		updatedShoot := &gardencorev1beta1.Shoot{}
+		g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(shoot), updatedShoot)).To(Succeed())
+		return updatedShoot.Status
+	}).Should(Equal(shoot.Status))
+}
+
+func patchAndWaitForManagerToObserveUpdatedWorkerStatus(worker *extensionsv1alpha1.Worker, workerPoolHashMap map[string]string) {
+	patch := client.MergeFrom(worker.DeepCopy())
+	worker.Status = extensionsv1alpha1.WorkerStatus{
+		InPlaceUpdates: &extensionsv1alpha1.InPlaceUpdatesWorkerStatus{
+			WorkerPoolToHashMap: workerPoolHashMap,
+		},
+	}
+	Expect(testClient.Status().Patch(ctx, worker, patch)).To(Succeed())
+	By("Wait until the manager cache has observed the worker status")
+	EventuallyWithOffset(1, func(g Gomega) map[string]string {
+		updatedWorker := &extensionsv1alpha1.Worker{}
+		g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(worker), updatedWorker)).To(Succeed())
+		g.Expect(updatedWorker.Status.InPlaceUpdates).NotTo(BeNil())
+		return updatedWorker.Status.InPlaceUpdates.WorkerPoolToHashMap
+	}).Should(Equal(workerPoolHashMap))
+}

--- a/test/utils/shoots/update/inplace/shoot.go
+++ b/test/utils/shoots/update/inplace/shoot.go
@@ -55,5 +55,5 @@ func ItShouldVerifyInPlaceUpdateCompletion(gardenClient client.Client, shoot *ga
 				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
 			))
 		}).Should(Succeed())
-	}, SpecTimeout(2*time.Minute))
+	}, SpecTimeout(5*time.Minute))
 }


### PR DESCRIPTION
This is a cherry-pick of #12241

/assign shafeeqes

```bugfix user github.com/gardener/gardener #12249 @shafeeqes
An issue causing the in-place update to fail during credentials rotation without workers rollout is now fixed.
```