### PR TITLE
Improve the doc string of the EnableAnonymousAuthentication field

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1469,12 +1469,13 @@ spec:
                             type: integer
                           enableAnonymousAuthentication:
                             description: |-
-                              Deprecated: This field is deprecated and will be removed in a future release.
-                              Please use anonymous authentication configuration instead.
-                              For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
                               EnableAnonymousAuthentication defines whether anonymous requests to the secure port
                               of the API server should be allowed (flag `--anonymous-auth`).
                               See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+
+                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Please use anonymous authentication configuration instead.
+                              For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
                             type: boolean
                           encryptionConfig:
                             description: EncryptionConfig contains customizable encryption

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -6636,13 +6636,13 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
+<p>EnableAnonymousAuthentication defines whether anonymous requests to the secure port
+of the API server should be allowed (flag <code>--anonymous-auth</code>).
+See: <a href="https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/">https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/</a></p>
 <p>Deprecated: This field is deprecated and will be removed in a future release.
 Please use anonymous authentication configuration instead.
 For more information see: <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration">https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration</a>
-TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
-EnableAnonymousAuthentication defines whether anonymous requests to the secure port
-of the API server should be allowed (flag <code>--anonymous-auth</code>).
-See: <a href="https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/">https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/</a></p>
+TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.</p>
 </td>
 </tr>
 <tr>

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1469,12 +1469,13 @@ spec:
                             type: integer
                           enableAnonymousAuthentication:
                             description: |-
-                              Deprecated: This field is deprecated and will be removed in a future release.
-                              Please use anonymous authentication configuration instead.
-                              For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
                               EnableAnonymousAuthentication defines whether anonymous requests to the secure port
                               of the API server should be allowed (flag `--anonymous-auth`).
                               See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+
+                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Please use anonymous authentication configuration instead.
+                              For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
                             type: boolean
                           encryptionConfig:
                             description: EncryptionConfig contains customizable encryption

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -682,13 +682,14 @@ type KubeAPIServerConfig struct {
 	WatchCacheSizes *WatchCacheSizes
 	// Requests contains configuration for request-specific settings for the kube-apiserver.
 	Requests *APIServerRequests
+	// EnableAnonymousAuthentication defines whether anonymous requests to the secure port
+	// of the API server should be allowed (flag `--anonymous-auth`).
+	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// Please use anonymous authentication configuration instead.
 	// For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
 	// TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
-	// EnableAnonymousAuthentication defines whether anonymous requests to the secure port
-	// of the API server should be allowed (flag `--anonymous-auth`).
-	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 	EnableAnonymousAuthentication *bool
 	// EventTTL controls the amount of time to retain events.
 	EventTTL *metav1.Duration

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1364,13 +1364,14 @@ message KubeAPIServerConfig {
   // +optional
   optional APIServerRequests requests = 10;
 
+  // EnableAnonymousAuthentication defines whether anonymous requests to the secure port
+  // of the API server should be allowed (flag `--anonymous-auth`).
+  // See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+  //
   // Deprecated: This field is deprecated and will be removed in a future release.
   // Please use anonymous authentication configuration instead.
   // For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
   // TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
-  // EnableAnonymousAuthentication defines whether anonymous requests to the secure port
-  // of the API server should be allowed (flag `--anonymous-auth`).
-  // See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
   // +optional
   optional bool enableAnonymousAuthentication = 11;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -902,13 +902,14 @@ type KubeAPIServerConfig struct {
 	// Requests contains configuration for request-specific settings for the kube-apiserver.
 	// +optional
 	Requests *APIServerRequests `json:"requests,omitempty" protobuf:"bytes,10,opt,name=requests"`
+	// EnableAnonymousAuthentication defines whether anonymous requests to the secure port
+	// of the API server should be allowed (flag `--anonymous-auth`).
+	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// Please use anonymous authentication configuration instead.
 	// For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
 	// TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
-	// EnableAnonymousAuthentication defines whether anonymous requests to the secure port
-	// of the API server should be allowed (flag `--anonymous-auth`).
-	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 	// +optional
 	EnableAnonymousAuthentication *bool `json:"enableAnonymousAuthentication,omitempty" protobuf:"varint,11,opt,name=enableAnonymousAuthentication"`
 	// EventTTL controls the amount of time to retain events.

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -4651,7 +4651,7 @@ func schema_pkg_apis_core_v1beta1_KubeAPIServerConfig(ref common.ReferenceCallba
 					},
 					"enableAnonymousAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated: This field is deprecated and will be removed in a future release. Please use anonymous authentication configuration instead. For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration EnableAnonymousAuthentication defines whether anonymous requests to the secure port of the API server should be allowed (flag `--anonymous-auth`). See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/",
+							Description: "EnableAnonymousAuthentication defines whether anonymous requests to the secure port of the API server should be allowed (flag `--anonymous-auth`). See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/\n\nDeprecated: This field is deprecated and will be removed in a future release. Please use anonymous authentication configuration instead. For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
N/A

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/11984

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
