### PR TITLE
Forbid setting anonymous auth simultaneously in both shoot spec and auth config

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
@@ -410,7 +410,7 @@ anonymous:
 					return nil
 				})
 				newShoot := shootv1beta1.DeepCopy()
-				newShoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(true)
+				newShoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(false)
 				test(admissionv1.Create, shootv1beta1, newShoot, false, statusCodeInvalid, "cannot use anonymous authentication configuration when the following shoots have the legacy configuration enabled: fake-shoot-name", "")
 			})
 		})
@@ -466,16 +466,6 @@ anonymous:
 
 					test(admissionv1.Update, cm, newCm, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
 				})
-
-				It("should allow anonymous authentication when the legacy kube-apiserver setting is disabled", func() {
-					shootv1beta1.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(false)
-					Expect(fakeClient.Create(ctx, shootv1beta1)).To(Succeed())
-
-					newCm := cm.DeepCopy()
-					newCm.Data["config.yaml"] = anonymousAuthenticationConfiguration
-
-					test(admissionv1.Update, cm, newCm, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
-				})
 			})
 
 			Context("Deny", func() {
@@ -518,6 +508,16 @@ anonymous:
 
 				It("uses anonymous authentication and has the legacy kube-apiserver setting already enabled", func() {
 					shootv1beta1.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(true)
+					Expect(fakeClient.Update(ctx, shootv1beta1)).To(Succeed())
+
+					newCm := cm.DeepCopy()
+					newCm.Data["config.yaml"] = anonymousAuthenticationConfiguration
+
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "cannot use anonymous authentication configuration when the following shoots have the legacy configuration enabled: fake-shoot-name", "")
+				})
+
+				It("uses anonymous authentication and has the legacy kube-apiserver setting already enabled", func() {
+					shootv1beta1.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(false)
 					Expect(fakeClient.Update(ctx, shootv1beta1)).To(Succeed())
 
 					newCm := cm.DeepCopy()

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -41,7 +41,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 		warnings = append(warnings, "you are setting the spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field. The field has been deprecated and will not be supported by gardener from Kubernetes 1.33. Instead, use the spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism field.")
 	}
 
-	if helper.IsLegacyAnonymousAuthenticationEnabled(shoot.Spec.Kubernetes.KubeAPIServer) {
+	if helper.IsLegacyAnonymousAuthenticationSet(shoot.Spec.Kubernetes.KubeAPIServer) {
 		warnings = append(warnings, "you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")
 	}
 

--- a/pkg/apis/core/helper/shoot.go
+++ b/pkg/apis/core/helper/shoot.go
@@ -285,9 +285,7 @@ func IsUpdateStrategyInPlace(updateStrategy *core.MachineUpdateStrategy) bool {
 	return *updateStrategy == core.AutoInPlaceUpdate || *updateStrategy == core.ManualInPlaceUpdate
 }
 
-// IsLegacyAnonymousAuthenticationEnabled checks if the legacy anonymous authentication is enabled in the given kubeAPIServerConfig.
-func IsLegacyAnonymousAuthenticationEnabled(kubeAPIServerConfig *core.KubeAPIServerConfig) bool {
-	return kubeAPIServerConfig != nil &&
-		kubeAPIServerConfig.EnableAnonymousAuthentication != nil &&
-		*kubeAPIServerConfig.EnableAnonymousAuthentication
+// IsLegacyAnonymousAuthenticationSet checks if the legacy anonymous authentication is set in the given kubeAPIServerConfig.
+func IsLegacyAnonymousAuthenticationSet(kubeAPIServerConfig *core.KubeAPIServerConfig) bool {
+	return kubeAPIServerConfig != nil && kubeAPIServerConfig.EnableAnonymousAuthentication != nil
 }

--- a/pkg/apis/core/helper/shoot_test.go
+++ b/pkg/apis/core/helper/shoot_test.go
@@ -595,14 +595,14 @@ var _ = Describe("Helper", func() {
 		Entry("with ManualInPlaceUpdate  update strategy", ptr.To(core.ManualInPlaceUpdate), true),
 	)
 
-	DescribeTable("#IsLegacyAnonymousAuthenticationEnabled",
+	DescribeTable("#IsLegacyAnonymousAuthenticationSet",
 		func(kubeAPIServerConfig *core.KubeAPIServerConfig, expected bool) {
-			Expect(IsLegacyAnonymousAuthenticationEnabled(kubeAPIServerConfig)).To(Equal(expected))
+			Expect(IsLegacyAnonymousAuthenticationSet(kubeAPIServerConfig)).To(Equal(expected))
 		},
 		Entry("kubeAPIServerConfig is nil", nil, false),
 		Entry("kubeAPIServerConfig is empty", &core.KubeAPIServerConfig{}, false),
 		Entry("EnableAnonymousAuthentication is nil", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: nil}, false),
-		Entry("EnableAnonymousAuthentication is false", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(false)}, false),
+		Entry("EnableAnonymousAuthentication is false", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(false)}, true),
 		Entry("EnableAnonymousAuthentication is true", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}, true),
 	)
 })

--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -204,9 +204,6 @@ func SetDefaults_KubeAPIServerConfig(obj *KubeAPIServerConfig) {
 	if obj.Requests.MaxMutatingInflight == nil {
 		obj.Requests.MaxMutatingInflight = ptr.To[int32](200)
 	}
-	if obj.EnableAnonymousAuthentication == nil {
-		obj.EnableAnonymousAuthentication = ptr.To(false)
-	}
 	if obj.EventTTL == nil {
 		obj.EventTTL = &metav1.Duration{Duration: time.Hour}
 	}

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -637,20 +637,6 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Kubernetes.KubeAPIServer.Requests.MaxMutatingInflight).To(Equal(&maxMutatingRequestsInflight))
 		})
 
-		It("should default anonymous authentication field", func() {
-			SetObjectDefaults_Shoot(obj)
-
-			Expect(obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(PointTo(BeFalse()))
-		})
-
-		It("should not overwrite the already set values for anonymous authentication field", func() {
-			obj.Spec.Kubernetes.KubeAPIServer = &KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}
-
-			SetObjectDefaults_Shoot(obj)
-
-			Expect(obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(PointTo(BeTrue()))
-		})
-
 		It("should default the event ttl field", func() {
 			SetObjectDefaults_Shoot(obj)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
Setting both `shoot.spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication` and anonymous authentication via `AuthenticationConfiguration` leads to ambiguity and should be forbidden.

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: auth
  namespace: garden-local
data:
  config.yaml: |
    apiVersion: apiserver.config.k8s.io/v1beta1
    kind: AuthenticationConfiguration
    anonymous:
      enabled: false
---
apiVersion: core.gardener.cloud/v1beta1
kind: Shoot
metadata:
  name: local
  namespace: garden-local
spec:
...
  kubernetes:
    version: 1.32.0
    kubeAPIServer:
      enableAnonymousAuthentication: false
      structuredAuthentication:
        configMapName: auth
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
It is now forbidden to set anonymous authentication via both the `Shoot` specification and `AuthenticationConfiguration` simultaneously.
```
