### PR TITLE
Restrict Shoot Prometheus RBAC to control-plane namespace

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -234,8 +234,7 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		clusterRoleBinding *rbacv1.ClusterRoleBinding
 	)
 
-	if p.values.TargetCluster != nil {
-		// Restrict Prometheus instances with a target cluster to the corresponding control-plane namespace of the Seed.
+	if p.values.ClusterType == component.ClusterTypeShoot {
 		role = p.role()
 		roleBinding = p.roleBinding()
 	} else {

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -228,9 +228,12 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		cortexConfigMap = p.cortexConfigMap()
 	}
 
-	var role *rbacv1.Role
-	var roleBinding *rbacv1.RoleBinding
-	var clusterRoleBinding *rbacv1.ClusterRoleBinding
+	var (
+		role               *rbacv1.Role
+		roleBinding        *rbacv1.RoleBinding
+		clusterRoleBinding *rbacv1.ClusterRoleBinding
+	)
+
 	if p.values.TargetCluster != nil {
 		// Restrict Prometheus instances with a target cluster to the corresponding control-plane namespace of the Seed.
 		role = p.role()

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -231,12 +231,14 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 	var (
 		role               *rbacv1.Role
 		roleBinding        *rbacv1.RoleBinding
+		gardenRoleBinding  *rbacv1.RoleBinding
 		clusterRoleBinding *rbacv1.ClusterRoleBinding
 	)
 
 	if p.values.ClusterType == component.ClusterTypeShoot {
 		role = p.role()
 		roleBinding = p.roleBinding()
+		gardenRoleBinding = p.gardenRoleBinding()
 	} else {
 		clusterRoleBinding = p.clusterRoleBinding()
 	}
@@ -252,6 +254,7 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		clusterRoleBinding,
 		role,
 		roleBinding,
+		gardenRoleBinding,
 		p.secretAdditionalScrapeConfigs(),
 		p.secretAdditionalAlertmanagerConfigs(),
 		p.secretRemoteWriteBasicAuth(),

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -708,7 +708,8 @@ honor_labels: true`
 					Expect(managedResource).To(consistOf(
 						serviceAccount,
 						service,
-						clusterRoleBinding,
+						role,
+						roleBinding,
 						prometheusFor(nil, true),
 						vpa,
 						prometheusRule,
@@ -1373,8 +1374,7 @@ query_range:
 					Expect(managedResource).To(consistOf(
 						serviceAccount,
 						service,
-						role,
-						roleBinding,
+						clusterRoleBinding,
 						prometheusFor(nil, false),
 						vpa,
 						prometheusRule,
@@ -1419,8 +1419,7 @@ query_range:
 						Expect(managedResource).To(consistOf(
 							serviceAccount,
 							service,
-							role,
-							roleBinding,
+							clusterRoleBinding,
 							prometheusFor(nil, false),
 							vpa,
 							prometheusRule,

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -96,6 +96,7 @@ honor_labels: true`
 		clusterRoleBinding                  *rbacv1.ClusterRoleBinding
 		role                                *rbacv1.Role
 		roleBinding                         *rbacv1.RoleBinding
+		gardenRoleBinding                   *rbacv1.RoleBinding
 		prometheusFor                       func([]alertmanager, bool) *monitoringv1.Prometheus
 		vpa                                 *vpaautoscalingv1.VerticalPodAutoscaler
 		ingress                             *networkingv1.Ingress
@@ -247,6 +248,27 @@ honor_labels: true`
 				APIGroup: rbacv1.GroupName,
 				Kind:     "Role",
 				Name:     "prometheus-" + name,
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "prometheus-" + name,
+				Namespace: namespace,
+			}},
+		}
+		gardenRoleBinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prometheus-" + namespace,
+				Namespace: v1beta1constants.GardenNamespace,
+				Labels: map[string]string{
+					"role": "monitoring",
+					"name": name,
+					"app":  "prometheus",
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "Role",
+				Name:     "prometheus-shoot",
 			},
 			Subjects: []rbacv1.Subject{{
 				Kind:      rbacv1.ServiceAccountKind,
@@ -710,6 +732,7 @@ honor_labels: true`
 						service,
 						role,
 						roleBinding,
+						gardenRoleBinding,
 						prometheusFor(nil, true),
 						vpa,
 						prometheusRule,

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -224,7 +224,7 @@ honor_labels: true`
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups: []string{corev1.GroupName},
+					APIGroups: []string{""},
 					Resources: []string{
 						"services",
 						"endpoints",
@@ -245,12 +245,12 @@ honor_labels: true`
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
+				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "Role",
 				Name:     "prometheus-" + name,
 			},
 			Subjects: []rbacv1.Subject{{
-				Kind:      rbacv1.ServiceAccountKind,
+				Kind:      "ServiceAccount",
 				Name:      "prometheus-" + name,
 				Namespace: namespace,
 			}},
@@ -258,7 +258,7 @@ honor_labels: true`
 		gardenRoleBinding = &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "prometheus-" + namespace,
-				Namespace: v1beta1constants.GardenNamespace,
+				Namespace: "garden",
 				Labels: map[string]string{
 					"role": "monitoring",
 					"name": name,
@@ -266,12 +266,12 @@ honor_labels: true`
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
+				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "Role",
 				Name:     "prometheus-shoot",
 			},
 			Subjects: []rbacv1.Subject{{
-				Kind:      rbacv1.ServiceAccountKind,
+				Kind:      "ServiceAccount",
 				Name:      "prometheus-" + name,
 				Namespace: namespace,
 			}},

--- a/pkg/component/observability/monitoring/prometheus/rbac.go
+++ b/pkg/component/observability/monitoring/prometheus/rbac.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
@@ -126,6 +127,26 @@ func (p *prometheus) roleBinding() *rbacv1.RoleBinding {
 			APIGroup: rbacv1.GroupName,
 			Kind:     "Role",
 			Name:     "prometheus-" + p.values.Name,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      p.name(),
+			Namespace: p.namespace,
+		}},
+	}
+}
+
+func (p *prometheus) gardenRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-" + p.namespace,
+			Namespace: v1beta1constants.GardenNamespace,
+			Labels:    p.getLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     "prometheus-shoot",
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      rbacv1.ServiceAccountKind,

--- a/pkg/component/observability/monitoring/prometheus/rbac.go
+++ b/pkg/component/observability/monitoring/prometheus/rbac.go
@@ -93,3 +93,46 @@ func (p *prometheus) clusterRoleBindingTarget() *rbacv1.ClusterRoleBinding {
 		}},
 	}
 }
+
+func (p *prometheus) role() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-" + p.values.Name,
+			Namespace: p.namespace,
+			Labels:    p.getLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{corev1.GroupName},
+				Resources: []string{
+					"services",
+					"endpoints",
+					"pods",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+		},
+	}
+}
+
+func (p *prometheus) roleBinding() *rbacv1.RoleBinding {
+	obj := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-" + p.values.Name,
+			Namespace: p.namespace,
+			Labels:    p.getLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     "prometheus-" + p.values.Name,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      p.name(),
+			Namespace: p.namespace,
+		}},
+	}
+
+	return obj
+}

--- a/pkg/component/observability/monitoring/prometheus/rbac.go
+++ b/pkg/component/observability/monitoring/prometheus/rbac.go
@@ -116,7 +116,7 @@ func (p *prometheus) role() *rbacv1.Role {
 }
 
 func (p *prometheus) roleBinding() *rbacv1.RoleBinding {
-	obj := &rbacv1.RoleBinding{
+	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "prometheus-" + p.values.Name,
 			Namespace: p.namespace,
@@ -133,6 +133,4 @@ func (p *prometheus) roleBinding() *rbacv1.RoleBinding {
 			Namespace: p.namespace,
 		}},
 	}
-
-	return obj
 }

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
@@ -63,6 +63,7 @@ func (p *prometheusOperator) Deploy(ctx context.Context) error {
 		p.clusterRole(),
 		p.clusterRoleBinding(),
 		p.clusterRolePrometheus(),
+		p.rolePrometheusShoot(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -63,6 +63,7 @@ var _ = Describe("PrometheusOperator", func() {
 		clusterRole           *rbacv1.ClusterRole
 		clusterRoleBinding    *rbacv1.ClusterRoleBinding
 		clusterRolePrometheus *rbacv1.ClusterRole
+		rolePrometheusShoot   *rbacv1.Role
 	)
 
 	BeforeEach(func() {
@@ -345,6 +346,23 @@ var _ = Describe("PrometheusOperator", func() {
 				},
 			},
 		}
+		rolePrometheusShoot = &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prometheus-shoot",
+				Namespace: namespace,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{corev1.GroupName},
+					Resources: []string{
+						"services",
+						"endpoints",
+						"pods",
+					},
+					Verbs: []string{"get", "list", "watch"},
+				},
+			},
+		}
 	})
 
 	JustBeforeEach(func() {
@@ -410,6 +428,7 @@ var _ = Describe("PrometheusOperator", func() {
 					clusterRole,
 					clusterRoleBinding,
 					clusterRolePrometheus,
+					rolePrometheusShoot,
 				))
 			})
 		})

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -353,7 +353,7 @@ var _ = Describe("PrometheusOperator", func() {
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups: []string{corev1.GroupName},
+					APIGroups: []string{""},
 					Resources: []string{
 						"services",
 						"endpoints",

--- a/pkg/component/observability/monitoring/prometheusoperator/rbac.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/rbac.go
@@ -155,3 +155,23 @@ func (p *prometheusOperator) clusterRolePrometheus() *rbacv1.ClusterRole {
 		},
 	}
 }
+
+func (p *prometheusOperator) rolePrometheusShoot() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-shoot",
+			Namespace: p.namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{corev1.GroupName},
+				Resources: []string{
+					"services",
+					"endpoints",
+					"pods",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/prometheusoperator/rbac.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/rbac.go
@@ -160,7 +160,7 @@ func (p *prometheusOperator) rolePrometheusShoot() *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "prometheus-shoot",
-			Namespace: p.namespace,
+			Namespace: p.namespace, // This is set to the garden namespace when instantiated by the shared component.
 		},
 		Rules: []rbacv1.PolicyRule{
 			{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
All Prometheus instances were bound to a [ClusterRole](https://prometheus-operator.dev/docs/platform/rbac/#prometheus-rbac) that grants read access to all Nodes, Services, Endpoints, and Pods. The Shoot specific Prometheus instances do not need access to all namespaces but only the shoot specific and the garden namespace in the Seed cluster. This PR introduces a namespace scoped Role and RoleBinding for the Shoot Prometheus instances. 


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/monitoring/issues/50

**Special notes for your reviewer**:
/cc @vicwicker @istvanballok @rickardsjp

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Shoot Prometheus RBAC is now restricted to the control-plane and the garden namespace.
```
