### PR TITLE
[GEP-32] Introduce helper functions for version classifications

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -5666,7 +5666,8 @@ VersionClassification
 </td>
 <td>
 <em>(Optional)</em>
-<p>Classification defines the state of a version (preview, supported, deprecated)</p>
+<p>Classification defines the state of a version (preview, supported, deprecated).
+To get the currently valid classification, use CurrentLifecycleClassification().</p>
 </td>
 </tr>
 </tbody>

--- a/extensions/pkg/bastion/machine.go
+++ b/extensions/pkg/bastion/machine.go
@@ -85,6 +85,8 @@ func findSupportedArchitectures(images []gardencorev1beta1.MachineImage, machine
 				// Skip versions that are not the specified one.
 				continue
 			}
+			// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-32-PR.
+			//  The current behavior for nil classifications is treated differently across the codebase.
 			if version.Classification != nil && v1beta1helper.CurrentLifecycleClassification(version.ExpirableVersion) == gardencorev1beta1.ClassificationSupported {
 				architectures.Insert(v1beta1helper.GetArchitecturesFromImageVersion(version)...)
 			}
@@ -161,6 +163,8 @@ func getImageVersion(bastion *gardencorev1beta1.Bastion, imageName, machineArch 
 			return "", fmt.Errorf("image version %s not found not found in cloudProfile", *bastion.MachineImage.Version)
 		}
 
+		// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-32-PR.
+		//  The current behavior for nil classifications is treated differently across the codebase.
 		if image.Versions[versionIndex].Classification != nil && v1beta1helper.CurrentLifecycleClassification(image.Versions[versionIndex].ExpirableVersion) != gardencorev1beta1.ClassificationSupported {
 			return "", fmt.Errorf("specified image %s in version %s is not classified supported", imageName, *bastion.MachineImage.Version)
 		}

--- a/extensions/pkg/bastion/machine.go
+++ b/extensions/pkg/bastion/machine.go
@@ -85,7 +85,7 @@ func findSupportedArchitectures(images []gardencorev1beta1.MachineImage, machine
 				// Skip versions that are not the specified one.
 				continue
 			}
-			if version.Classification != nil && *version.Classification == gardencorev1beta1.ClassificationSupported {
+			if version.Classification != nil && v1beta1helper.CurrentLifecycleClassification(version.ExpirableVersion) == gardencorev1beta1.ClassificationSupported {
 				architectures.Insert(v1beta1helper.GetArchitecturesFromImageVersion(version)...)
 			}
 			if machineImageVersion != "" {
@@ -132,7 +132,7 @@ func getImageName(bastion *gardencorev1beta1.Bastion, images []gardencorev1beta1
 	// take the first image from cloud profile that is supported and arch compatible
 	for _, image := range images {
 		for _, version := range image.Versions {
-			if version.Classification == nil || *version.Classification != gardencorev1beta1.ClassificationSupported {
+			if v1beta1helper.CurrentLifecycleClassification(version.ExpirableVersion) != gardencorev1beta1.ClassificationSupported {
 				continue
 			}
 			if !slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(version), arch) {
@@ -161,7 +161,7 @@ func getImageVersion(bastion *gardencorev1beta1.Bastion, imageName, machineArch 
 			return "", fmt.Errorf("image version %s not found not found in cloudProfile", *bastion.MachineImage.Version)
 		}
 
-		if image.Versions[versionIndex].Classification != nil && *image.Versions[versionIndex].Classification != gardencorev1beta1.ClassificationSupported {
+		if image.Versions[versionIndex].Classification != nil && v1beta1helper.CurrentLifecycleClassification(image.Versions[versionIndex].ExpirableVersion) != gardencorev1beta1.ClassificationSupported {
 			return "", fmt.Errorf("specified image %s in version %s is not classified supported", imageName, *bastion.MachineImage.Version)
 		}
 
@@ -170,7 +170,7 @@ func getImageVersion(bastion *gardencorev1beta1.Bastion, imageName, machineArch 
 
 	var greatest *semver.Version
 	for _, version := range image.Versions {
-		if version.Classification == nil || *version.Classification != gardencorev1beta1.ClassificationSupported {
+		if v1beta1helper.CurrentLifecycleClassification(version.ExpirableVersion) != gardencorev1beta1.ClassificationSupported {
 			continue
 		}
 

--- a/pkg/apis/core/helper/cloudprofile.go
+++ b/pkg/apis/core/helper/cloudprofile.go
@@ -7,14 +7,28 @@ package helper
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 )
+
+// CurrentLifecycleClassification returns the current lifecycle classification of the given version.
+// An empty classification is interpreted as supported. If the version is expired, it returns ClassificationExpired.
+func CurrentLifecycleClassification(version core.ExpirableVersion) core.VersionClassification {
+	var currentTime = time.Now()
+
+	if version.ExpirationDate != nil && !currentTime.Before(version.ExpirationDate.Time) {
+		return core.ClassificationExpired
+	}
+
+	return ptr.Deref(version.Classification, core.ClassificationSupported)
+}
 
 // FindMachineImageVersion finds the machine image version in the <cloudProfile> for the given <name> and <version>.
 // In case no machine image version can be found with the given <name> or <version>, false is being returned.

--- a/pkg/apis/core/helper/cloudprofile.go
+++ b/pkg/apis/core/helper/cloudprofile.go
@@ -106,7 +106,7 @@ func DetermineLatestExpirableVersion(versions []core.ExpirableVersion, filterPre
 			return core.ExpirableVersion{}, core.ExpirableVersion{}, fmt.Errorf("error while parsing expirable version '%s': %s", version.Version, err.Error())
 		}
 
-		if filterPreviewVersions && version.Classification != nil && *version.Classification == core.ClassificationPreview {
+		if filterPreviewVersions && CurrentLifecycleClassification(version) == core.ClassificationPreview {
 			continue
 		}
 
@@ -115,7 +115,7 @@ func DetermineLatestExpirableVersion(versions []core.ExpirableVersion, filterPre
 			latestExpirableVersion = version
 		}
 
-		if version.Classification != nil && *version.Classification != core.ClassificationDeprecated {
+		if CurrentLifecycleClassification(version) != core.ClassificationDeprecated {
 			if latestNonDeprecatedSemVerVersion == nil || v.GreaterThan(latestNonDeprecatedSemVerVersion) {
 				latestNonDeprecatedSemVerVersion = v
 				latestNonDeprecatedExpirableVersion = version
@@ -219,7 +219,7 @@ func GetMachineImageDiff(old, new []core.MachineImage) (removedMachineImages set
 func FilterVersionsWithClassification(versions []core.ExpirableVersion, classification core.VersionClassification) []core.ExpirableVersion {
 	var result []core.ExpirableVersion
 	for _, version := range versions {
-		if version.Classification == nil || *version.Classification != classification {
+		if CurrentLifecycleClassification(version) != classification {
 			continue
 		}
 

--- a/pkg/apis/core/helper/cloudprofile_test.go
+++ b/pkg/apis/core/helper/cloudprofile_test.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/gardener/gardener/pkg/apis/core/helper"
 )
 
-var _ = Describe("Helper", func() {
+var _ = Describe("CloudProfile Helper", func() {
 	Describe("#FindMachineImageVersion", func() {
 		var machineImages []core.MachineImage
 

--- a/pkg/apis/core/helper/cloudprofile_test.go
+++ b/pkg/apis/core/helper/cloudprofile_test.go
@@ -6,18 +6,72 @@ package helper_test
 
 import (
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/gardener/gardener/pkg/apis/core/helper"
 )
 
 var _ = Describe("CloudProfile Helper", func() {
+	Describe("#CurrentLifecycleClassification", func() {
+		It("version is implicitly supported", func() {
+			classification := CurrentLifecycleClassification(core.ExpirableVersion{
+				Version: "1.28.0",
+			})
+			Expect(classification).To(Equal(core.ClassificationSupported))
+		})
+
+		It("version is explicitly supported", func() {
+			classification := CurrentLifecycleClassification(core.ExpirableVersion{
+				Version:        "1.28.0",
+				Classification: ptr.To(core.ClassificationSupported),
+			})
+			Expect(classification).To(Equal(core.ClassificationSupported))
+		})
+
+		It("version is in preview stage", func() {
+			classification := CurrentLifecycleClassification(core.ExpirableVersion{
+				Version:        "1.28.0",
+				Classification: ptr.To(core.ClassificationPreview),
+			})
+			Expect(classification).To(Equal(core.ClassificationPreview))
+		})
+
+		It("version is deprecated ", func() {
+			classification := CurrentLifecycleClassification(core.ExpirableVersion{
+				Version:        "1.28.0",
+				Classification: ptr.To(core.ClassificationDeprecated),
+			})
+			Expect(classification).To(Equal(core.ClassificationDeprecated))
+		})
+
+		It("supported version will expire in the future", func() {
+			classification := CurrentLifecycleClassification(core.ExpirableVersion{
+				Version:        "1.28.0",
+				Classification: ptr.To(core.ClassificationSupported),
+				ExpirationDate: ptr.To(metav1.NewTime(time.Now().Add(2 * time.Hour))),
+			})
+			Expect(classification).To(Equal(core.ClassificationSupported))
+		})
+
+		It("supported version has already expired", func() {
+			classification := CurrentLifecycleClassification(core.ExpirableVersion{
+				Version:        "1.28.0",
+				Classification: ptr.To(core.ClassificationSupported),
+				ExpirationDate: ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Hour))),
+			})
+			Expect(classification).To(Equal(core.ClassificationExpired))
+		})
+	})
+
 	Describe("#FindMachineImageVersion", func() {
 		var machineImages []core.MachineImage
 

--- a/pkg/apis/core/types_cloudprofile.go
+++ b/pkg/apis/core/types_cloudprofile.go
@@ -144,7 +144,8 @@ type ExpirableVersion struct {
 	Version string
 	// ExpirationDate defines the time at which this version expires.
 	ExpirationDate *metav1.Time
-	// Classification defines the state of a version (preview, supported, deprecated)
+	// Classification defines the state of a version (preview, supported, deprecated).
+	// To get the currently valid classification, use CurrentLifecycleClassification().
 	Classification *VersionClassification
 }
 
@@ -264,7 +265,14 @@ const (
 // VersionClassification is the logical state of a version.
 type VersionClassification string
 
+// IsActive returns whether the version can be used.
+func (v VersionClassification) IsActive() bool {
+	return v != ClassificationExpired && v != ClassificationUnavailable
+}
+
 const (
+	// ClassificationUnavailable indicates that a version is currently not available and is planned to become available depending on the classification lifecycle.
+	ClassificationUnavailable VersionClassification = "unavailable"
 	// ClassificationPreview indicates that a version has recently been added and not promoted to "Supported" yet.
 	// ClassificationPreview versions will not be considered for automatic Kubernetes and Machine Image patch version updates.
 	ClassificationPreview VersionClassification = "preview"
@@ -275,6 +283,9 @@ const (
 	// ClassificationDeprecated indicates that a patch version should not be used anymore, should be updated to a new version
 	// and will eventually expire.
 	ClassificationDeprecated VersionClassification = "deprecated"
+	// ClassificationExpired indicates that a version has expired.
+	// New entities with that version cannot be created and existing entities are forcefully migrated to a higher version during the maintenance time.
+	ClassificationExpired VersionClassification = "expired"
 )
 
 // MachineImageUpdateStrategy is the update strategy to use for a machine image

--- a/pkg/apis/core/types_test.go
+++ b/pkg/apis/core/types_test.go
@@ -43,4 +43,14 @@ var _ = Describe("API Types", func() {
 			Expect(IsIPv6SingleStack([]IPFamily{IPFamilyIPv6})).To(BeTrue())
 		})
 	})
+
+	DescribeTable("#VersionClassification.IsActive", func(v VersionClassification, want bool) {
+		Expect(v.IsActive()).To(Equal(want))
+	},
+		Entry("#ClassificationUnavailable is not active", ClassificationUnavailable, false),
+		Entry("#ClassificationPreview is active", ClassificationPreview, true),
+		Entry("#ClassificationSupported is active", ClassificationSupported, true),
+		Entry("#ClassificationDeprecated is active", ClassificationDeprecated, true),
+		Entry("#ClassificationExpired is not active", ClassificationExpired, false),
+	)
 })

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1030,7 +1030,8 @@ message ExpirableVersion {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time expirationDate = 2;
 
-  // Classification defines the state of a version (preview, supported, deprecated)
+  // Classification defines the state of a version (preview, supported, deprecated).
+  // To get the currently valid classification, use CurrentLifecycleClassification().
   // +optional
   optional string classification = 3;
 }

--- a/pkg/apis/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile.go
@@ -335,7 +335,7 @@ func GetLatestQualifyingVersion(versions []gardencorev1beta1.ExpirableVersion, p
 	)
 OUTER:
 	for _, v := range versions {
-		if v.Classification != nil && *v.Classification == gardencorev1beta1.ClassificationPreview {
+		if CurrentLifecycleClassification(v) == gardencorev1beta1.ClassificationPreview {
 			continue
 		}
 
@@ -411,7 +411,7 @@ OUTER:
 		}
 
 		// never update to preview versions
-		if v.Classification != nil && *v.Classification == gardencorev1beta1.ClassificationPreview {
+		if CurrentLifecycleClassification(v) == gardencorev1beta1.ClassificationPreview {
 			continue
 		}
 

--- a/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 )
 
-var _ = Describe("Helper", func() {
+var _ = Describe("CloudProfile Helper", func() {
 	var (
 		trueVar                 = true
 		expirationDateInThePast = metav1.Time{Time: time.Now().AddDate(0, 0, -1)}

--- a/pkg/apis/core/v1beta1/types_cloudprofile.go
+++ b/pkg/apis/core/v1beta1/types_cloudprofile.go
@@ -162,7 +162,8 @@ type ExpirableVersion struct {
 	// ExpirationDate defines the time at which this version expires.
 	// +optional
 	ExpirationDate *metav1.Time `json:"expirationDate,omitempty" protobuf:"bytes,2,opt,name=expirationDate"`
-	// Classification defines the state of a version (preview, supported, deprecated)
+	// Classification defines the state of a version (preview, supported, deprecated).
+	// To get the currently valid classification, use CurrentLifecycleClassification().
 	// +optional
 	Classification *VersionClassification `json:"classification,omitempty" protobuf:"bytes,3,opt,name=classification,casttype=VersionClassification"`
 }
@@ -302,7 +303,14 @@ const (
 // VersionClassification is the logical state of a version.
 type VersionClassification string
 
+// IsActive returns whether the version can be used.
+func (v VersionClassification) IsActive() bool {
+	return v != ClassificationExpired && v != ClassificationUnavailable
+}
+
 const (
+	// ClassificationUnavailable indicates that a version is currently not available and is planned to become available depending on the classification lifecycle.
+	ClassificationUnavailable VersionClassification = "unavailable"
 	// ClassificationPreview indicates that a version has recently been added and not promoted to "Supported" yet.
 	// ClassificationPreview versions will not be considered for automatic Kubernetes and Machine Image patch version updates.
 	ClassificationPreview VersionClassification = "preview"
@@ -313,6 +321,9 @@ const (
 	// ClassificationDeprecated indicates that a patch version should not be used anymore, should be updated to a new version
 	// and will eventually expire.
 	ClassificationDeprecated VersionClassification = "deprecated"
+	// ClassificationExpired indicates that a version has expired.
+	// New entities with that version cannot be created and existing entities are forcefully migrated to a higher version during the maintenance time.
+	ClassificationExpired VersionClassification = "expired"
 )
 
 // MachineImageUpdateStrategy is the update strategy to use for a machine image

--- a/pkg/apis/core/v1beta1/types_test.go
+++ b/pkg/apis/core/v1beta1/types_test.go
@@ -43,4 +43,14 @@ var _ = Describe("Types", func() {
 			Expect(IsIPv6SingleStack([]IPFamily{IPFamilyIPv6})).To(BeTrue())
 		})
 	})
+
+	DescribeTable("#VersionClassification.IsActive", func(v VersionClassification, want bool) {
+		Expect(v.IsActive()).To(Equal(want))
+	},
+		Entry("#ClassificationUnavailable is not active", ClassificationUnavailable, false),
+		Entry("#ClassificationPreview is active", ClassificationPreview, true),
+		Entry("#ClassificationSupported is active", ClassificationSupported, true),
+		Entry("#ClassificationDeprecated is active", ClassificationDeprecated, true),
+		Entry("#ClassificationExpired is not active", ClassificationExpired, false),
+	)
 })

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -121,6 +121,8 @@ func validateCloudProfileKubernetesSettings(kubernetes core.KubernetesSettings, 
 func validateSupportedVersionsConfiguration(version core.ExpirableVersion, allVersions []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-32-PR.
+	//  The current behavior for nil classifications is treated differently across the codebase.
 	if version.Classification != nil && helper.CurrentLifecycleClassification(version) == core.ClassificationSupported {
 		currentSemVer, err := semver.NewVersion(version.Version)
 		if err != nil {
@@ -363,6 +365,8 @@ func checkImageSupport(bastionImageName string, imageVersions []core.MachineImag
 			archSupported = true
 		}
 
+		// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-32-PR.
+		//  The current behavior for nil classifications is treated differently across the codebase.
 		if version.Classification != nil && helper.CurrentLifecycleClassification(version.ExpirableVersion) == core.ClassificationSupported {
 			validClassification = true
 		}

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -121,7 +121,7 @@ func validateCloudProfileKubernetesSettings(kubernetes core.KubernetesSettings, 
 func validateSupportedVersionsConfiguration(version core.ExpirableVersion, allVersions []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if version.Classification != nil && *version.Classification == core.ClassificationSupported {
+	if version.Classification != nil && helper.CurrentLifecycleClassification(version) == core.ClassificationSupported {
 		currentSemVer, err := semver.NewVersion(version.Version)
 		if err != nil {
 			// check is already performed by caller, avoid duplicate error
@@ -363,7 +363,7 @@ func checkImageSupport(bastionImageName string, imageVersions []core.MachineImag
 			archSupported = true
 		}
 
-		if version.Classification != nil && *version.Classification == core.ClassificationSupported {
+		if version.Classification != nil && helper.CurrentLifecycleClassification(version.ExpirableVersion) == core.ClassificationSupported {
 			validClassification = true
 		}
 		if archSupported && validClassification {

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -3763,7 +3763,7 @@ func schema_pkg_apis_core_v1beta1_ExpirableVersion(ref common.ReferenceCallback)
 					},
 					"classification": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Classification defines the state of a version (preview, supported, deprecated)",
+							Description: "Classification defines the state of a version (preview, supported, deprecated). To get the currently valid classification, use CurrentLifecycleClassification().",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5783,7 +5783,7 @@ func schema_pkg_apis_core_v1beta1_MachineImageVersion(ref common.ReferenceCallba
 					},
 					"classification": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Classification defines the state of a version (preview, supported, deprecated)",
+							Description: "Classification defines the state of a version (preview, supported, deprecated). To get the currently valid classification, use CurrentLifecycleClassification().",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apiserver/registry/core/cloudprofile/strategy.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy.go
@@ -6,7 +6,6 @@ package cloudprofile
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -33,7 +33,7 @@ func (cloudProfileStrategy) NamespaceScoped() bool {
 func (cloudProfileStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	cloudProfile := obj.(*core.CloudProfile)
 
-	dropExpiredVersions(cloudProfile)
+	dropInactiveVersions(cloudProfile)
 }
 
 func (cloudProfileStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
@@ -77,11 +77,11 @@ func (cloudProfileStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Obj
 	return nil
 }
 
-func dropExpiredVersions(cloudProfile *core.CloudProfile) {
+func dropInactiveVersions(cloudProfile *core.CloudProfile) {
 	var validKubernetesVersions []core.ExpirableVersion
 
 	for _, version := range cloudProfile.Spec.Kubernetes.Versions {
-		if version.ExpirationDate != nil && version.ExpirationDate.Time.Before(time.Now()) {
+		if !gardencorehelper.CurrentLifecycleClassification(version).IsActive() {
 			continue
 		}
 		validKubernetesVersions = append(validKubernetesVersions, version)
@@ -93,7 +93,7 @@ func dropExpiredVersions(cloudProfile *core.CloudProfile) {
 		var validMachineImageVersions []core.MachineImageVersion
 
 		for _, version := range machineImage.Versions {
-			if version.ExpirationDate != nil && version.ExpirationDate.Time.Before(time.Now()) {
+			if gardencorehelper.CurrentLifecycleClassification(version.ExpirableVersion) == core.ClassificationExpired {
 				continue
 			}
 			validMachineImageVersions = append(validMachineImageVersions, version)

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -626,7 +626,7 @@ func shouldKubernetesVersionBeUpdated(kubernetesVersion string, autoUpdate bool,
 		return true, updateReason, true, nil
 	}
 
-	if ExpirationDateExpired(version.ExpirationDate) {
+	if v1beta1helper.CurrentLifecycleClassification(version) == gardencorev1beta1.ClassificationExpired {
 		updateReason = "Kubernetes version expired - force update required"
 		return true, updateReason, true, nil
 	}
@@ -784,7 +784,7 @@ func shouldMachineImageVersionBeUpdated(shootMachineImage *gardencorev1beta1.Sho
 		return true, updateReason, true
 	}
 
-	if ExpirationDateExpired(machineImage.Versions[versionIndex].ExpirationDate) {
+	if v1beta1helper.CurrentLifecycleClassification(machineImage.Versions[versionIndex].ExpirableVersion) == gardencorev1beta1.ClassificationExpired {
 		updateReason = fmt.Sprintf("Machine image version expired - force update required (image update strategy: %s)", *machineImage.UpdateStrategy)
 		return true, updateReason, true
 	}
@@ -869,14 +869,6 @@ func determineVersionForStrategy(expirableVersions []gardencorev1beta1.Expirable
 	}
 
 	return versionForForceUpdate, nil
-}
-
-// ExpirationDateExpired returns if now is equal or after the given expirationDate
-func ExpirationDateExpired(timestamp *metav1.Time) bool {
-	if timestamp == nil {
-		return false
-	}
-	return time.Now().UTC().After(timestamp.Time) || time.Now().UTC().Equal(timestamp.Time)
 }
 
 // setLimitedSwap sets the swap behavior to `LimitedSwap` if it's currently set to `UnlimitedSwap`

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -36,20 +36,6 @@ var _ = Describe("Shoot Maintenance", func() {
 		expirationDateInThePast = metav1.Time{Time: now.AddDate(0, 0, -1)}
 	})
 
-	Context("Shoot Maintenance", func() {
-		Describe("#ExpirationDateExpired", func() {
-			It("should determine that expirationDate applies", func() {
-				applies := ExpirationDateExpired(&expirationDateInThePast)
-				Expect(applies).To(BeTrue())
-			})
-
-			It("should determine that expirationDate not applies", func() {
-				applies := ExpirationDateExpired(&expirationDateInTheFuture)
-				Expect(applies).To(BeFalse())
-			})
-		})
-	})
-
 	Describe("#maintainMachineImages", func() {
 		var (
 			shootCurrentImage        *gardencorev1beta1.ShootMachineImage

--- a/pkg/utils/gardener/cloudprofile_test.go
+++ b/pkg/utils/gardener/cloudprofile_test.go
@@ -404,7 +404,7 @@ var _ = Describe("CloudProfile", func() {
 			})
 		})
 
-		Describe("#BuildCloudProfileReference", func() {
+		Describe("#BuildCoreCloudProfileReference", func() {
 			It("should return nil for nil shoot", func() {
 				Expect(gardenerutils.BuildCoreCloudProfileReference(nil)).To(BeNil())
 			})

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -14,7 +14,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
@@ -1391,7 +1390,7 @@ func defaultKubernetesVersion(constraints []gardencorev1beta1.ExpirableVersion, 
 		shootVersionMajor = ptr.To(v)
 	}
 
-	if latestVersion := findLatestVersion(constraints, shootVersionMajor, shootVersionMinor); latestVersion != nil {
+	if latestVersion := findLatestSupportedVersion(constraints, shootVersionMajor, shootVersionMinor); latestVersion != nil {
 		return ptr.To(latestVersion.String()), nil
 	}
 
@@ -1399,16 +1398,10 @@ func defaultKubernetesVersion(constraints []gardencorev1beta1.ExpirableVersion, 
 	return nil, allErrs
 }
 
-func findLatestVersion(constraints []gardencorev1beta1.ExpirableVersion, major, minor *uint64) *semver.Version {
+func findLatestSupportedVersion(constraints []gardencorev1beta1.ExpirableVersion, major, minor *uint64) *semver.Version {
 	var latestVersion *semver.Version
 	for _, versionConstraint := range constraints {
-		// ignore expired versions
-		if versionConstraint.ExpirationDate != nil && versionConstraint.ExpirationDate.Time.UTC().Before(time.Now().UTC()) {
-			continue
-		}
-
-		// filter preview versions for defaulting
-		if ptr.Deref(versionConstraint.Classification, "") == gardencorev1beta1.ClassificationPreview {
+		if v1beta1helper.CurrentLifecycleClassification(versionConstraint) != gardencorev1beta1.ClassificationSupported {
 			continue
 		}
 
@@ -1444,7 +1437,7 @@ func validateKubernetesVersionConstraints(a admission.Attributes, constraints []
 		// Disallow usage of an expired Kubernetes version on Shoot creation and new worker pool creation
 		// Updating an existing worker to a higher (ensured by validation) expired Kubernetes version is necessary for consecutive maintenance force updates
 		if a.GetOperation() == admission.Create || isNewWorkerPool {
-			if versionConstraint.ExpirationDate != nil && versionConstraint.ExpirationDate.Time.UTC().Before(time.Now().UTC()) {
+			if !v1beta1helper.CurrentLifecycleClassification(versionConstraint).IsActive() {
 				continue
 			}
 		}
@@ -1853,9 +1846,9 @@ func validateMachineImagesConstraints(a admission.Attributes, constraints []gard
 			for _, machineVersion := range machineImage.Versions {
 				machineImageVersion := fmt.Sprintf("%s:%s", machineImage.Name, machineVersion.Version)
 
-				if machineVersion.ExpirationDate == nil || machineVersion.ExpirationDate.Time.UTC().After(time.Now().UTC()) {
+				if v1beta1helper.CurrentLifecycleClassification(machineVersion.ExpirableVersion).IsActive() {
 					activeMachineImageVersions.Insert(machineImageVersion)
-				} else if machineVersion.ExpirationDate != nil && machineVersion.ExpirationDate.Time.UTC().Before(time.Now().UTC()) && a.GetOperation() == admission.Update && !isNewWorkerPool {
+				} else if a.GetOperation() == admission.Update && !isNewWorkerPool && v1beta1helper.CurrentLifecycleClassification(machineVersion.ExpirableVersion) == gardencorev1beta1.ClassificationExpired {
 					// An already expired machine image version is a viable machine image version for the worker pool if-and-only-if:
 					//  - this is an update call (no new Shoot creation)
 					//  - updates an existing worker pool (not for a new worker pool)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity usability
/kind cleanup

**What this PR does / why we need it**:
Introduce helper functions (signatures) for upcoming type-changes and the implementation of the version classification lifecycles as proposed in [GEP-32](https://github.com/gardener/gardener/blob/master/docs/proposals/32-version-classification-lifecycles.md).

**Which issue(s) this PR fixes**:
Part of #12256.

**Special notes for your reviewer**:
Co-authored by @vknabel @Gerrit91 @crigertg.
Part of hackathon instances [2024-12](https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen#-version-classification-lifecycle-in-cloudprofiles) and [2025-06](https://github.com/gardener-community/hackathon/blob/main/2025-06_Schelklingen/README.md).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Introduced new version classifications `unavailable` and `expired`. They are not meant to be set manually but should act as computed classification states.
```
```other developer
Added the helper function `CurrentLifecycleClassification(version)` to evaluate the current classification of a given `ExpirableVersion`.
```