### PR TITLE
Update dependency-watchdog to v1.5.0 (minor) and consume the new DWD annotation

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -83,6 +83,10 @@ linters:
           alias: druidcorecrds
         - pkg: github.com/gardener/cert-management/pkg/apis/cert/v1alpha1
           alias: certv1alpha1
+        - pkg: github.com/gardener/dependency-watchdog/api/prober
+          alias: proberapi
+        - pkg: github.com/gardener/dependency-watchdog/api/weeder
+          alias: weederapi
         # Gardener extension package
         - pkg: github.com/gardener/gardener/extensions/.*/(\w+)/mock$
           alias: extensionsmock${1}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/docker/cli v28.2.2+incompatible
 	github.com/fluent/fluent-operator/v3 v3.3.0
 	github.com/gardener/cert-management v0.17.5
-	github.com/gardener/dependency-watchdog v1.4.0
+	github.com/gardener/dependency-watchdog v1.5.0
 	github.com/gardener/etcd-druid/api v0.30.1
 	github.com/gardener/machine-controller-manager v0.58.0
 	github.com/gardener/terminal-controller-manager v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vt
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gardener/cert-management v0.17.5 h1:feqNpdgkF2RJP5xPidbkUx2MS15m4mBWGNE5mo3sg34=
 github.com/gardener/cert-management v0.17.5/go.mod h1:jazLDc7bcJ0T8axC96A52X7AqeIYsEyALpYsuTFuhbw=
-github.com/gardener/dependency-watchdog v1.4.0 h1:RKsjOSS41cR2kjbacWsrVlyhpV71PZhAiaB49D821UM=
-github.com/gardener/dependency-watchdog v1.4.0/go.mod h1:B5OYoELKMn8D28OFU4ZMSQFv+RD4mSLV0rvXMEhp4KI=
+github.com/gardener/dependency-watchdog v1.5.0 h1:MORMbQ8IJgISPWEhN8LROOUl9y2TnvWAH0bRuo8RDTY=
+github.com/gardener/dependency-watchdog v1.5.0/go.mod h1:gsHy1P7QPTXzzBOEMQKhUXH8pv2YecYf9PwhLkLnYQQ=
 github.com/gardener/etcd-druid/api v0.30.1 h1:g1XKFi6OFotrQmj/ZppTacuUKq3rGVYBQDhRBc//Y98=
 github.com/gardener/etcd-druid/api v0.30.1/go.mod h1:R9by0d9G/kT8/yA6nY21h4GffQ8j8Uj8hA7mM8JgCmM=
 github.com/gardener/machine-controller-manager v0.58.0 h1:JLMpuD+omliu/RwK0mA9Ce+MLObJq421Du1qmaAHmAU=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -74,7 +74,7 @@ images:
   - name: dependency-watchdog
     sourceRepository: github.com/gardener/dependency-watchdog
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog
-    tag: "v1.4.0"
+    tag: "v1.5.0"
   - name: nginx-ingress-controller
     sourceRepository: github.com/kubernetes/ingress-nginx
     repository: registry.k8s.io/ingress-nginx/controller-chroot

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -62,6 +62,8 @@ type Interface interface {
 	SetMachineDeployments([]extensionsv1alpha1.MachineDeployment)
 	// SetMaxNodesTotal sets the maximum number of nodes that can be created in the cluster. 0 means unlimited.
 	SetMaxNodesTotal(int64)
+	// SetReplicas sets the replicas
+	SetReplicas(int32)
 }
 
 // New creates a new instance of DeployWaiter for the cluster-autoscaler.
@@ -390,6 +392,9 @@ func (c *clusterAutoscaler) SetMachineDeployments(machineDeployments []extension
 
 func (c *clusterAutoscaler) SetMaxNodesTotal(maxNodesTotal int64) {
 	c.maxNodesTotal = maxNodesTotal
+}
+func (c *clusterAutoscaler) SetReplicas(replicas int32) {
+	c.replicas = replicas
 }
 
 func (c *clusterAutoscaler) emptyClusterRoleBinding() *rbacv1.ClusterRoleBinding {

--- a/pkg/component/autoscaling/clusterautoscaler/mock/mocks.go
+++ b/pkg/component/autoscaling/clusterautoscaler/mock/mocks.go
@@ -106,6 +106,17 @@ func (mr *MockInterfaceMockRecorder) SetNamespaceUID(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNamespaceUID", reflect.TypeOf((*MockInterface)(nil).SetNamespaceUID), arg0)
 }
 
+// SetReplicas mocks base method.
+func (m *MockInterface) SetReplicas(arg0 int32) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetReplicas", arg0)
+}
+// SetReplicas indicates an expected call of SetReplicas.
+func (mr *MockInterfaceMockRecorder) SetReplicas(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReplicas", reflect.TypeOf((*MockInterface)(nil).SetReplicas), arg0)
+}
+
 // Wait mocks base method.
 func (m *MockInterface) Wait(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/component/autoscaling/clusterautoscaler/mock/mocks.go
+++ b/pkg/component/autoscaling/clusterautoscaler/mock/mocks.go
@@ -111,6 +111,7 @@ func (m *MockInterface) SetReplicas(arg0 int32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetReplicas", arg0)
 }
+
 // SetReplicas indicates an expected call of SetReplicas.
 func (mr *MockInterfaceMockRecorder) SetReplicas(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler.go
@@ -43,6 +43,11 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 // DeployClusterAutoscaler deploys the Kubernetes cluster-autoscaler.
 func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 	if b.Shoot.WantsClusterAutoscaler {
+		repl, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameClusterAutoscaler, 1)
+		if err != nil {
+			return err
+		}
+		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetReplicas(repl)
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetNamespaceUID(b.SeedNamespaceObject.UID)
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetMachineDeployments(b.Shoot.Components.Extensions.Worker.MachineDeployments())
 

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler.go
@@ -43,11 +43,11 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 // DeployClusterAutoscaler deploys the Kubernetes cluster-autoscaler.
 func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 	if b.Shoot.WantsClusterAutoscaler {
-		repl, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameClusterAutoscaler, 1)
+		replicas, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameClusterAutoscaler, 1)
 		if err != nil {
 			return err
 		}
-		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetReplicas(repl)
+		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetReplicas(replicas)
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetNamespaceUID(b.SeedNamespaceObject.UID)
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetMachineDeployments(b.Shoot.Components.Extensions.Worker.MachineDeployments())
 

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
@@ -122,7 +122,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 				clusterAutoscaler.EXPECT().SetMaxNodesTotal(int64(0))
 				clusterAutoscaler.EXPECT().SetReplicas(int32(1))
 				kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1)).AnyTimes()
-
 			})
 
 			It("should set the secrets, namespace uid, machine deployments, and deploy", func() {

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
@@ -108,7 +108,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 			}
 			botanist.Shoot.ControlPlaneNamespace = namespace
 			c = mockclient.NewMockClient(ctrl)
-			kubernetesClient.EXPECT().Client().Return(c).AnyTimes()
+			kubernetesClient.EXPECT().Client().Return(c).MaxTimes(3)
 		})
 
 		Context("CA wanted", func() {
@@ -121,11 +121,11 @@ var _ = Describe("ClusterAutoscaler", func() {
 				clusterAutoscaler.EXPECT().SetMachineDeployments(machineDeployments)
 				clusterAutoscaler.EXPECT().SetMaxNodesTotal(int64(0))
 				clusterAutoscaler.EXPECT().SetReplicas(int32(1))
-				kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1)).AnyTimes()
+				kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1))
 			})
 
 			It("should set the secrets, namespace uid, machine deployments, and deploy", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "cluster-autoscaler"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "cluster-autoscaler"}, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
 
 				clusterAutoscaler.EXPECT().Deploy(ctx)
 				Expect(botanist.DeployClusterAutoscaler(ctx)).To(Succeed())
@@ -133,7 +133,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 
 			It("should fail when the deploy function fails", func() {
 				clusterAutoscaler.EXPECT().Deploy(ctx).Return(fakeErr)
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "cluster-autoscaler"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "cluster-autoscaler"}, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
 				Expect(botanist.DeployClusterAutoscaler(ctx)).To(Equal(fakeErr))
 			})
 		})

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler_test.go
@@ -25,6 +25,7 @@ import (
 	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	mockclusterautoscaler "github.com/gardener/gardener/pkg/component/autoscaling/clusterautoscaler/mock"
 	mockworker "github.com/gardener/gardener/pkg/component/extensions/worker/mock"
+	mockkubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/mock"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
@@ -34,9 +35,9 @@ import (
 
 var _ = Describe("ClusterAutoscaler", func() {
 	var (
-		ctx     = context.TODO()
-		fakeErr = errors.New("fake err")
-
+		ctx              = context.TODO()
+		fakeErr          = errors.New("fake err")
+		namespace        = "shoot--foo--bar"
 		ctrl             *gomock.Controller
 		botanist         *Botanist
 		kubernetesClient *kubernetesmock.MockInterface
@@ -65,6 +66,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 			kubernetesClient.EXPECT().Client()
 			kubernetesClient.EXPECT().Version().Return("1.28.0")
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{Version: "1.28.0"}}})
+			botanist.Shoot.ControlPlaneNamespace = namespace
 		})
 
 		It("should successfully create a cluster-autoscaler interface", func() {
@@ -81,9 +83,12 @@ var _ = Describe("ClusterAutoscaler", func() {
 
 			namespaceUID       = types.UID("5678")
 			machineDeployments = []extensionsv1alpha1.MachineDeployment{{}}
+			c                  *mockclient.MockClient
+			kubeAPIServer      *mockkubeapiserver.MockInterface
 		)
 
 		BeforeEach(func() {
+			kubeAPIServer = mockkubeapiserver.NewMockInterface(ctrl)
 			clusterAutoscaler = mockclusterautoscaler.NewMockInterface(ctrl)
 			worker = mockworker.NewMockInterface(ctrl)
 
@@ -95,11 +100,15 @@ var _ = Describe("ClusterAutoscaler", func() {
 			botanist.Shoot.Components = &shootpkg.Components{
 				ControlPlane: &shootpkg.ControlPlane{
 					ClusterAutoscaler: clusterAutoscaler,
+					KubeAPIServer:     kubeAPIServer,
 				},
 				Extensions: &shootpkg.Extensions{
 					Worker: worker,
 				},
 			}
+			botanist.Shoot.ControlPlaneNamespace = namespace
+			c = mockclient.NewMockClient(ctrl)
+			kubernetesClient.EXPECT().Client().Return(c).AnyTimes()
 		})
 
 		Context("CA wanted", func() {
@@ -111,15 +120,21 @@ var _ = Describe("ClusterAutoscaler", func() {
 				worker.EXPECT().MachineDeployments().Return(machineDeployments)
 				clusterAutoscaler.EXPECT().SetMachineDeployments(machineDeployments)
 				clusterAutoscaler.EXPECT().SetMaxNodesTotal(int64(0))
+				clusterAutoscaler.EXPECT().SetReplicas(int32(1))
+				kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1)).AnyTimes()
+
 			})
 
 			It("should set the secrets, namespace uid, machine deployments, and deploy", func() {
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "cluster-autoscaler"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+
 				clusterAutoscaler.EXPECT().Deploy(ctx)
 				Expect(botanist.DeployClusterAutoscaler(ctx)).To(Succeed())
 			})
 
 			It("should fail when the deploy function fails", func() {
 				clusterAutoscaler.EXPECT().Deploy(ctx).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "cluster-autoscaler"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
 				Expect(botanist.DeployClusterAutoscaler(ctx)).To(Equal(fakeErr))
 			})
 		})

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -67,9 +67,6 @@ func (b *Botanist) isControlledByDependencyWatchdog(ctx context.Context, deploym
 	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: deploymentName}, deployment); err != nil && !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("failed to get deployment %q: %w", deploymentName, err)
 	}
-	if deployment.Annotations == nil {
-		return false, nil
-	}
 
 	return metav1.HasAnnotation(deployment.ObjectMeta, dwdapi.MeltdownProtectionActive), nil
 }

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -71,8 +71,7 @@ func (b *Botanist) isControlledByDependencyWatchdog(ctx context.Context, deploym
 		return false, nil
 	}
 
-	_, ok := deployment.Annotations[dwdapi.MeltdownProtectionActive]
-	return ok, nil
+	return metav1.HasAnnotation(deployment.ObjectMeta, dwdapi.MeltdownProtectionActive), nil
 }
 
 // HibernateControlPlane hibernates the entire control plane if the shoot shall be hibernated.

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	dwdapi "github.com/gardener/dependency-watchdog/api/prober"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dwdapi "github.com/gardener/dependency-watchdog/api/prober"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	dwdapi "github.com/gardener/dependency-watchdog/api/prober"
+	proberapi "github.com/gardener/dependency-watchdog/api/prober"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,7 +41,7 @@ func (b *Botanist) determineControllerReplicas(ctx context.Context, deploymentNa
 
 	isControlledByDWD, err := b.isControlledByDependencyWatchdog(ctx, deploymentName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to check if deployment %q is controlled by dependency-watchdog: %w", deploymentName, err)
+		return 0, fmt.Errorf("failed to check if deployment %q is controlled by dependency-watchdog: %w", client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: deploymentName}, err)
 	}
 	if isControlledByDWD && !isCreateOrRestoreOperation && !b.Shoot.HibernationEnabled && !b.Shoot.GetInfo().Status.IsHibernated {
 		// The replicas of the component are controlled by dependency-watchdog and
@@ -63,12 +63,12 @@ func (b *Botanist) determineControllerReplicas(ctx context.Context, deploymentNa
 
 // If the deployment is controlled by dependency-watchdog, then it has the annotation dependency-watchdog.gardener.cloud/meltdown-protection set.
 func (b *Botanist) isControlledByDependencyWatchdog(ctx context.Context, deploymentName string) (bool, error) {
-	deployment := &appsv1.Deployment{}
-	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: deploymentName}, deployment); err != nil && !apierrors.IsNotFound(err) {
-		return false, fmt.Errorf("failed to get deployment %q: %w", deploymentName, err)
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deploymentName, Namespace: b.Shoot.ControlPlaneNamespace}}
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKeyFromObject(deployment), deployment); err != nil && !apierrors.IsNotFound(err) {
+		return false, err
 	}
 
-	return metav1.HasAnnotation(deployment.ObjectMeta, dwdapi.MeltdownProtectionActive), nil
+	return metav1.HasAnnotation(deployment.ObjectMeta, proberapi.MeltdownProtectionActive), nil
 }
 
 // HibernateControlPlane hibernates the entire control plane if the shoot shall be hibernated.

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -41,7 +41,6 @@ func (b *Botanist) determineControllerReplicas(ctx context.Context, deploymentNa
 	if err != nil {
 		return 0, err
 	}
-
 	if isControlledByDWD && !isCreateOrRestoreOperation && !b.Shoot.HibernationEnabled && !b.Shoot.GetInfo().Status.IsHibernated {
 		// The replicas of the component are controlled by dependency-watchdog and
 		// Shoot is being reconciled with .spec.hibernation.enabled=.status.isHibernated=false,

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
@@ -39,7 +39,7 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interfa
 
 // DeployKubeControllerManager deploys the Kubernetes Controller Manager.
 func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
-	replicaCount, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameKubeControllerManager, 1, true)
+	replicaCount, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameKubeControllerManager, 1)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
@@ -7,6 +7,7 @@ package botanist_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 
 	"github.com/Masterminds/semver/v3"
@@ -298,10 +299,11 @@ var _ = Describe("KubeControllerManager", func() {
 		})
 
 		It("should fail when the replicas cannot be determined", func() {
+			formattedFakeErr := fmt.Errorf("failed to check if deployment \"kube-controller-manager\" is controlled by dependency-watchdog: failed to get deployment \"kube-controller-manager\": fake err")
 			kubernetesClient.EXPECT().Client().Return(c)
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(fakeErr)
 
-			Expect(botanist.DeployKubeControllerManager(ctx)).To(Equal(fakeErr))
+			Expect(botanist.DeployKubeControllerManager(ctx).Error()).To(Equal(formattedFakeErr.Error()))
 		})
 
 		It("should fail when the deploy function fails", func() {

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 
 	"github.com/Masterminds/semver/v3"
+	proberapi "github.com/gardener/dependency-watchdog/api/prober"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,7 +21,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	proberapi "github.com/gardener/dependency-watchdog/api/prober"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 
 	"github.com/Masterminds/semver/v3"
+	dwdapi "github.com/gardener/dependency-watchdog/api/prober"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,7 +21,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dwdapi "github.com/gardener/dependency-watchdog/api/prober"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
@@ -133,7 +133,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 			Context("last operation is nil or neither of type 'create' nor 'restore'", func() {
 				BeforeEach(func() {
-					kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1)).AnyTimes()
+					kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1)).MaxTimes(1)
 					botanist.Shoot.GetInfo().Status.LastOperation = nil
 				})
 
@@ -143,8 +143,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 					kubeControllerManager.EXPECT().SetReplicaCount(int32(1))
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
-
+					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
 					Expect(botanist.DeployKubeControllerManager(ctx)).To(Succeed())
 				})
 
@@ -154,7 +153,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 					kubeControllerManager.EXPECT().SetReplicaCount(int32(1))
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
 
 					Expect(botanist.DeployKubeControllerManager(ctx)).To(Succeed())
 				})
@@ -168,7 +167,7 @@ var _ = Describe("KubeControllerManager", func() {
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
 						obj.Spec.Replicas = ptr.To(replicas)
 						return nil
-					}).AnyTimes()
+					})
 
 					kubeControllerManager.EXPECT().SetReplicaCount(replicas)
 
@@ -183,13 +182,13 @@ var _ = Describe("KubeControllerManager", func() {
 					var dwdMeltdownProtectionActive = map[string]string{
 						dwdapi.MeltdownProtectionActive: "",
 					}
-					kubernetesClient.EXPECT().Client().Return(c).AnyTimes()
+					kubernetesClient.EXPECT().Client().Return(c).MaxTimes(2)
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...client.GetOption) error {
 						obj.Spec.Replicas = ptr.To(replicas)
 						obj.Annotations = dwdMeltdownProtectionActive
 						return nil
-					}).AnyTimes()
-					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+					}).MaxTimes(2)
+					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).MaxTimes(2)
 
 					kubeControllerManager.EXPECT().SetReplicaCount(replicas)
 
@@ -210,7 +209,7 @@ var _ = Describe("KubeControllerManager", func() {
 						return nil
 					})
 					kubeControllerManager.EXPECT().SetReplicaCount(int32(0))
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).MaxTimes(2)
 					Expect(botanist.DeployKubeControllerManager(ctx)).To(Succeed())
 				})
 
@@ -241,7 +240,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 					kubeControllerManager.EXPECT().SetReplicaCount(int32(1))
 					kubernetesClient.EXPECT().Client().Return(c)
-					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
 					Expect(botanist.DeployKubeControllerManager(ctx)).To(Succeed())
 				})
 			})
@@ -304,8 +303,8 @@ var _ = Describe("KubeControllerManager", func() {
 		})
 
 		It("should fail when the deploy function fails", func() {
-			kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](0)).AnyTimes()
-			kubeAPIServer.EXPECT().GetValues().Return(kubeapiserver.Values{RuntimeConfig: map[string]bool{"foo": true}}).AnyTimes()
+			kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](0))
+			kubeAPIServer.EXPECT().GetValues().Return(kubeapiserver.Values{RuntimeConfig: map[string]bool{"foo": true}})
 			kubeControllerManager.EXPECT().SetReplicaCount(int32(0))
 			kubeControllerManager.EXPECT().SetRuntimeConfig(map[string]bool{"foo": true})
 			kubeControllerManager.EXPECT().SetServiceNetworks(botanist.Shoot.Networks.Services)
@@ -313,7 +312,7 @@ var _ = Describe("KubeControllerManager", func() {
 			kubeControllerManager.EXPECT().Deploy(ctx).Return(fakeErr)
 
 			kubernetesClient.EXPECT().Client().Return(c)
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
 
 			Expect(botanist.DeployKubeControllerManager(ctx)).To(Equal(fakeErr))
 		})

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
@@ -7,7 +7,6 @@ package botanist_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 
 	"github.com/Masterminds/semver/v3"
@@ -299,15 +298,12 @@ var _ = Describe("KubeControllerManager", func() {
 		})
 
 		It("should fail when the replicas cannot be determined", func() {
-			formattedFakeErr := fmt.Errorf("failed to check if deployment \"kube-controller-manager\" is controlled by dependency-watchdog: failed to get deployment \"kube-controller-manager\": fake err")
 			kubernetesClient.EXPECT().Client().Return(c)
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "kube-controller-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(fakeErr)
-
-			Expect(botanist.DeployKubeControllerManager(ctx).Error()).To(Equal(formattedFakeErr.Error()))
+			Expect(botanist.DeployKubeControllerManager(ctx).Error()).To(Equal(`failed to check if deployment "kube-controller-manager" is controlled by dependency-watchdog: failed to get deployment "kube-controller-manager": fake err`))
 		})
 
 		It("should fail when the deploy function fails", func() {
-
 			kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](0)).AnyTimes()
 			kubeAPIServer.EXPECT().GetValues().Return(kubeapiserver.Values{RuntimeConfig: map[string]bool{"foo": true}}).AnyTimes()
 			kubeControllerManager.EXPECT().SetReplicaCount(int32(0))

--- a/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
@@ -50,7 +50,11 @@ func (b *Botanist) DeployMachineControllerManager(ctx context.Context) error {
 		replicas = 1
 	// if there are any existing machine deployments present with a positive replica count then MCM is needed.
 	case machineDeploymentWithPositiveReplicaCountExist(machineDeploymentList):
-		replicas = 1
+		repl, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameMachineControllerManager, 1)
+		if err != nil {
+			return err
+		}
+		replicas = repl
 	// If the cluster is hibernated then there is no further need of MCM and therefore its desired replicas is 0
 	case b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated:
 		replicas = 0
@@ -68,7 +72,6 @@ func (b *Botanist) DeployMachineControllerManager(ctx context.Context) error {
 	case b.IsRestorePhase():
 		replicas = 0
 	}
-
 	b.Shoot.Components.ControlPlane.MachineControllerManager.SetReplicas(replicas)
 
 	return b.Shoot.Components.ControlPlane.MachineControllerManager.Deploy(ctx)

--- a/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
@@ -50,11 +50,11 @@ func (b *Botanist) DeployMachineControllerManager(ctx context.Context) error {
 		replicas = 1
 	// if there are any existing machine deployments present with a positive replica count then MCM is needed.
 	case machineDeploymentWithPositiveReplicaCountExist(machineDeploymentList):
-		repl, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameMachineControllerManager, 1)
+		replicaCount, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameMachineControllerManager, 1)
 		if err != nil {
 			return err
 		}
-		replicas = repl
+		replicas = replicaCount
 	// If the cluster is hibernated then there is no further need of MCM and therefore its desired replicas is 0
 	case b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated:
 		replicas = 0

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -82,7 +82,7 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 		b.Shoot.Components.ControlPlane.ResourceManager,
 		b.Shoot.ControlPlaneNamespace,
 		func(ctx context.Context) (int32, error) {
-			return b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameGardenerResourceManager, 2, false)
+			return b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameGardenerResourceManager, 2)
 		},
 		func() string { return b.Shoot.ComputeInClusterAPIServerAddress(true) })
 }

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -252,7 +252,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes(),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})
@@ -292,7 +292,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes(),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
@@ -173,6 +174,8 @@ var _ = Describe("ResourceManager", func() {
 
 			By("Ensure secrets managed outside of this function for which secretsmanager.Get() will be called")
 			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: "ca"}, gomock.AssignableToTypeOf(&corev1.Secret{})).AnyTimes()
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
+			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, gomock.AssignableToTypeOf(&metav1.ObjectMeta{})).AnyTimes()
 
 			botanist.SeedClientSet = k8sSeedClient
 			botanist.SecretsManager = sm
@@ -251,7 +254,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes(),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})
@@ -290,7 +293,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes(),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})
@@ -313,7 +316,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes(),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -174,8 +174,6 @@ var _ = Describe("ResourceManager", func() {
 
 			By("Ensure secrets managed outside of this function for which secretsmanager.Get() will be called")
 			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: "ca"}, gomock.AssignableToTypeOf(&corev1.Secret{})).AnyTimes()
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes()
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, gomock.AssignableToTypeOf(&metav1.ObjectMeta{})).AnyTimes()
 
 			botanist.SeedClientSet = k8sSeedClient
 			botanist.SecretsManager = sm
@@ -270,6 +268,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
+						c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](0)),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
@@ -316,7 +315,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).AnyTimes(),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](0)),
 					)
 				})
@@ -326,6 +325,7 @@ var _ = Describe("ResourceManager", func() {
 				BeforeEach(func() {
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
+						c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1)),
 						resourceManager.EXPECT().SetReplicas(ptr.To[int32](2)),
 						resourceManager.EXPECT().GetReplicas().Return(ptr.To[int32](2)),
@@ -462,6 +462,7 @@ var _ = Describe("ResourceManager", func() {
 
 						gomock.InOrder(
 							resourceManager.EXPECT().GetReplicas(),
+							c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 							kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1)),
 							resourceManager.EXPECT().SetReplicas(ptr.To[int32](2)),
 							resourceManager.EXPECT().GetReplicas().Return(ptr.To[int32](2)),
@@ -478,6 +479,7 @@ var _ = Describe("ResourceManager", func() {
 
 						gomock.InOrder(
 							resourceManager.EXPECT().GetReplicas(),
+							c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 							kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(ptr.To[int32](1)),
 							resourceManager.EXPECT().SetReplicas(ptr.To[int32](2)),
 							resourceManager.EXPECT().GetReplicas().Return(ptr.To[int32](2)),

--- a/pkg/utils/kubernetes/deployment.go
+++ b/pkg/utils/kubernetes/deployment.go
@@ -99,3 +99,17 @@ func WaitUntilDeploymentRolloutIsComplete(ctx context.Context, client client.Cli
 		return HasDeploymentRolloutCompleted(ctx, client, namespace, name)
 	})
 }
+
+// GetAnnotationsForDeployment retrieves the annotations for a deployment.
+// If the deployment does not exist or has no annotations, it returns nil.
+func GetAnnotationsForDeployment(ctx context.Context, c client.Client, namespace, name string) (map[string]string, error) {
+	deployment := &appsv1.Deployment{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, deployment); err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if deployment.Annotations == nil {
+		return nil, nil
+	}
+	return deployment.Annotations, nil
+
+}

--- a/pkg/utils/kubernetes/deployment.go
+++ b/pkg/utils/kubernetes/deployment.go
@@ -99,17 +99,3 @@ func WaitUntilDeploymentRolloutIsComplete(ctx context.Context, client client.Cli
 		return HasDeploymentRolloutCompleted(ctx, client, namespace, name)
 	})
 }
-
-// GetAnnotationsForDeployment retrieves the annotations for a deployment.
-// If the deployment does not exist or has no annotations, it returns nil.
-func GetAnnotationsForDeployment(ctx context.Context, c client.Client, namespace, name string) (map[string]string, error) {
-	deployment := &appsv1.Deployment{}
-	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, deployment); err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-	if deployment.Annotations == nil {
-		return nil, nil
-	}
-	return deployment.Annotations, nil
-
-}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
- This PR vendors the release DWD [v1.5.0](https://github.com/gardener/dependency-watchdog/releases/tag/v1.5.0).
- With the release of DWD [v1.5.0](https://github.com/gardener/dependency-watchdog/releases/tag/v1.5.0) a new annotation `dependency-watchdog.gardener.cloud/meltdown-protection-active` is now put on every deployment scaled down by DWD. 
  This is done to ensure that it is not acted upon during shoot reconciliation.
   This PR introduces corresponding changes in g/g to consume this new annotation during checks to determineControllerReplicas for a deployment during shoot reconciliation. 
   If the deployment is scaled down by DWD then it will return the current replicas to ensure the deployment is not scaled up mistakenly. 


**Which issue(s) this PR fixes**:
Fixes # 
 As part of its functionality, during a Infra degradation where the nodes are not able to update their leases, Dependency Watchdog enables meltdown protection by bringing down KCM/MCM/CA.
However if a shoot reconciliation is triggered while the meltdown proection is active, we have observed MCM/CA being scaled up.  
This happens as currently gardener only has a hardcoded check for KCM as being managed by DWD, but not for MCM/CA. This leads to shoot reconciliation bringing up MCM/CA. 
It can so happen that before DWD can act during its next reconcilation to bring MCM/CA down again, MCM might pick up mcahines which are in unknown state and trigger their deletion. This leads to breaking out from meltdown protection. 

As a solution DWD now annotates every deployment it scales down with `dependency-watchdog.gardener.cloud/meltdown-protection-active` to allow higher level controllers like shoot or any other controller to ensure they consider this annotation before scaling up the respective deployments. 

**Special notes for your reviewer**:
Kindly check if the release notes have the right category and target group as I'm not well verse with the norm. 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```other dependency
The following dependencies have been updated:
- `gardener/dependency-watchdog` from `v1.4.0` to `v1.5.0`. [Release Notes](https://redirect.github.com/gardener/dependency-watchdog/releases/tag/v1.5.0)
- `github.com/gardener/dependency-watchdog` from `v1.4.0` to `v1.5.0`. 
```
```feature operator
`gardenlet` now doesn't scale up deployments during `Shoot` reconciliation if they have `dependency-watchdog.gardener.cloud/meltdown-protection-active` annotation on them.
```
