### PR TITLE
allow callers to set full output-path for reports

### DIFF
--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -7,6 +7,7 @@
 set -e
 
 report_dir="$(git rev-parse --show-toplevel)"
+report_fname='gosec-report.sarif'
 
 gosec_report="false"
 gosec_report_parse_flags=""
@@ -20,6 +21,9 @@ parse_flags() {
         ;;
       --report-dir)
         shift; report_dir="$1"
+        ;;
+      --report-fname)
+        shift; report_fname="$1"
         ;;
       --exclude-dirs)
         shift; exclude_dirs="$1"
@@ -35,11 +39,13 @@ parse_flags() {
 
 parse_flags "$@"
 
+report_path="${report_dir}/${report_fname}"
+
 echo "> Running gosec"
 gosec --version
 if [[ "$gosec_report" != "false" ]]; then
-  echo "Exporting report to ${report_dir}/gosec-report.sarif"
-  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=${report_dir}/gosec-report.sarif -stdout"
+  echo "Exporting report to ${report_path}"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=${report_path} -stdout"
 fi
 
 # Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf


### PR DESCRIPTION
If collecting created gosec-reports from Scripts, it is preferable to have control over the created report-file to avoid having to hard-code the default fname.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind robustness

**What this PR does / why we need it**

Allows callers of `sast.sh` to control the path of the generated report-file. This will allow collecting of such reports from scripts (mainly in our release-pipelines), without having to hardcode the default output-path.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
