### PR TITLE
Fix shoot reconciliation after credentials rotation if manual in-place pending workers are updated

### DIFF
--- a/pkg/gardenlet/controller/shoot/status/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/status/reconciler.go
@@ -194,10 +194,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func needsReconcile(shoot *gardencorev1beta1.Shoot) bool {
-	if kubernetesutils.HasMetaDataAnnotation(shoot, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile) {
-		return false
-	}
-
 	caRotationPhase := v1beta1helper.GetShootCARotationPhase(shoot.Status.Credentials)
 	serviceAccountKeyRotationPhase := v1beta1helper.GetShootServiceAccountKeyRotationPhase(shoot.Status.Credentials)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
In the Shoot reconciliation flow, we don't set the `credentialsRotation` status to `Prepared` if there are manual in-place workers pending update. When they are updated, shoot status reconciler will annotate the shoot with `gardener.cloud/operation=reconcile`,
https://github.com/gardener/gardener/blob/4c7ae4aa50b2223c319cd3741b58c2941703b5e9/pkg/gardenlet/controller/shoot/status/reconciler.go#L163-L175
so that the reconcile flow is run again and the status is set to `Prepared`. However if the shoot status is updated with zero manual in place update pending workers, https://github.com/gardener/gardener/blob/4c7ae4aa50b2223c319cd3741b58c2941703b5e9/pkg/gardenlet/controller/shoot/status/reconciler.go#L153-L156
and the above patching of shoot with operation annotation fails, the next time the reconciliation is retried, we exit early:
https://github.com/gardener/gardener/blob/4c7ae4aa50b2223c319cd3741b58c2941703b5e9/pkg/gardenlet/controller/shoot/status/reconciler.go#L79-L82

This is not ideal and can cause failures like the one below.
This PR fixes this behaviour.

Thanks @rfranzke for reporting.

**Which issue(s) this PR fixes**:
Fixes failures like: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12213/pull-gardener-e2e-kind-ha-multi-zone/1932519479678341120

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the Shoot credentials rotation status not to correctly get updated, after all the manual in-place pending workers are updated, is now fixed.
```
