### PR TITLE
[GEP-28] `gardenadm bootstrap`:  Wait for `Worker`

### DIFF
--- a/dev-setup/gardenadm/resources/overlays/medium-touch/kustomization.yaml
+++ b/dev-setup/gardenadm/resources/overlays/medium-touch/kustomization.yaml
@@ -22,8 +22,3 @@ patches:
       value:
         name: local
         version: 1.0.0
-    # TODO(timebertt): remove this once machine-controller-manager no longer waits for the Node object to be created
-    - op: add
-      path: /spec/provider/workers/0/machineControllerManager
-      value:
-        machineCreationTimeout: 24h

--- a/pkg/component/nodemanagement/machinecontrollermanager/provider_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/provider_test.go
@@ -108,17 +108,17 @@ var _ = Describe("Provider", func() {
 			})
 		})
 
-		JustBeforeEach(func() {
-			for i, s := range container.Args {
-				if strings.HasPrefix(s, "--target-kubeconfig=") {
-					container.Args[i] = "--target-kubeconfig="
-				}
-			}
-		})
-
 		When("running the control plane (gardenadm init)", func() {
 			BeforeEach(func() {
 				namespace = "kube-system"
+			})
+
+			JustBeforeEach(func() {
+				for i, s := range container.Args {
+					if strings.HasPrefix(s, "--target-kubeconfig=") {
+						container.Args[i] = "--target-kubeconfig="
+					}
+				}
 			})
 
 			It("should return the provider sidecar container", func() {
@@ -127,6 +127,14 @@ var _ = Describe("Provider", func() {
 		})
 
 		When("not running the control plane (gardenadm bootstrap)", func() {
+			JustBeforeEach(func() {
+				for i, s := range container.Args {
+					if strings.HasPrefix(s, "--target-kubeconfig=") {
+						container.Args[i] = "--target-kubeconfig=none"
+					}
+				}
+			})
+
 			It("should return the provider sidecar container", func() {
 				Expect(ProviderSidecarContainer(shoot, namespace, provider, image)).To(DeepEqual(container))
 			})

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -83,6 +83,11 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 			), "should be healthy and not have default (open) ingress CIDRs")
 		}, SpecTimeout(time.Minute))
 
+		It("should deploy the worker", func(ctx SpecContext) {
+			worker := &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: technicalID}}
+			Eventually(ctx, Object(worker)).Should(BeHealthy(health.CheckExtensionObject))
+		}, SpecTimeout(5*time.Minute))
+
 		It("should deploy a control plane machine", func(ctx SpecContext) {
 			podList := &corev1.PodList{}
 			Eventually(ctx, ObjectList(podList, client.InNamespace(technicalID), client.MatchingLabels{"app": "machine"})).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR continues https://github.com/gardener/gardener/pull/12196 and waits for the `Worker` object to be reconciled successfully in `gardenadm bootstrap`.
It uses https://github.com/gardener/machine-controller-manager/pull/1004 to disable machine-controller-manager's interaction with the target cluster. With this, the `Machines` transition to `Available` and the `Worker` is reconciled successfully.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ @maboehm 

- [x] in draft until https://github.com/gardener/machine-controller-manager/pull/1004 has been merged and released (dependency updated in https://github.com/gardener/gardener/pull/12482)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
