### PR TITLE
[release-v1.121] Fix `provider-local` webhook conflict

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -86,7 +86,6 @@ spec:
         - --disable-controllers={{ .Values.disableControllers | join "," }}
         - --disable-webhooks={{ .Values.disableWebhooks | join "," }}
         {{- end }}
-        - --webhook-config-namespace={{ .Release.Namespace }}
         - --webhook-config-service-port={{ .Values.webhookConfig.servicePort }}
         - --webhook-config-server-port={{ tpl .Values.webhookConfig.serverPort . }}
         - --metrics-bind-address=:{{ tpl .Values.metricsPort . }}
@@ -104,6 +103,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WEBHOOK_CONFIG_NAMESPACE
+          value: {{ .Release.Namespace }}
         {{- if .Values.imageVectorOverwrite }}
         - name: IMAGEVECTOR_OVERWRITE
           value: /imagevector_overwrite/images_overwrite.yaml

--- a/charts/gardener/provider-local/templates/service.yaml
+++ b/charts/gardener/provider-local/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: gardener-extension-provider-local
+  name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":{{ tpl .Values.webhookConfig.serverPort . }}}]'

--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/webhook/certificates"
 	extensionsshootwebhook "github.com/gardener/gardener/extensions/pkg/webhook/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/gardener/operator"
 )
 
 const (
@@ -203,8 +205,13 @@ func NewAddToManagerOptions(
 	serverOpts *ServerOptions,
 	switchOpts *SwitchOptions,
 ) *AddToManagerOptions {
+	name := extensionName
+	if strings.HasPrefix(os.Getenv("WEBHOOK_CONFIG_NAMESPACE"), operator.ExtensionRuntimeNamespacePrefix) {
+		name += extensionswebhook.NameSuffixRuntime
+	}
+
 	return &AddToManagerOptions{
-		extensionName:                   extensionName,
+		extensionName:                   name,
 		shootWebhookManagedResourceName: shootWebhookManagedResourceName,
 		shootNamespaceSelector:          shootNamespaceSelector,
 		Server:                          *serverOpts,

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -27,6 +27,9 @@ const (
 	NamePrefix = "gardener-extension-"
 	// NameSuffixShoot is the suffix used for {Valida,Muta}tingWebhookConfigurations of extensions targeting a shoot.
 	NameSuffixShoot = "-shoot"
+	// NameSuffixRuntime is the suffix used for {Valida,Muta}tingWebhookConfigurations of extensions targeting a garden
+	// runtime cluster.
+	NameSuffixRuntime = "-runtime"
 	// ModeService is a constant for the webhook mode indicating that the controller is running inside of the Kubernetes cluster it
 	// is serving.
 	ModeService = "service"

--- a/pkg/utils/gardener/operator/extension.go
+++ b/pkg/utils/gardener/operator/extension.go
@@ -5,7 +5,6 @@
 package operator
 
 import (
-	"fmt"
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -52,9 +51,12 @@ func ExtensionForManagedResourceName(managedResourceName string) (string, bool) 
 	return "", false
 }
 
+// ExtensionRuntimeNamespacePrefix is the prefix for the namespace hosting resources for the Garden runtime cluster.
+const ExtensionRuntimeNamespacePrefix = "runtime-extension-"
+
 // ExtensionRuntimeNamespaceName returns the name of the namespace hosting resources for the Garden runtime cluster.
 func ExtensionRuntimeNamespaceName(extensionName string) string {
-	return fmt.Sprintf("runtime-extension-%s", extensionName)
+	return ExtensionRuntimeNamespacePrefix + extensionName
 }
 
 // IsControllerInstallationInVirtualRequired returns true if the extension requires a controller installation in the virtual cluster.

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -674,6 +674,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -772,6 +773,7 @@ build:
             - pkg/utils/errors
             - pkg/utils/flow
             - pkg/utils/gardener
+            - pkg/utils/gardener/operator
             - pkg/utils/gardener/shootstate
             - pkg/utils/imagevector
             - pkg/utils/kubernetes

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1079,6 +1079,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -1177,6 +1178,7 @@ build:
             - pkg/utils/errors
             - pkg/utils/flow
             - pkg/utils/gardener
+            - pkg/utils/gardener/operator
             - pkg/utils/gardener/shootstate
             - pkg/utils/imagevector
             - pkg/utils/kubernetes
@@ -1233,6 +1235,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -1270,6 +1273,7 @@ build:
             - pkg/utils/errors
             - pkg/utils/flow
             - pkg/utils/gardener
+            - pkg/utils/gardener/operator
             - pkg/utils/imagevector
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/health

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -707,6 +707,7 @@ build:
             - pkg/apis/operations/v1alpha1
             - pkg/apis/operator
             - pkg/apis/operator/v1alpha1
+            - pkg/apis/operator/v1alpha1/helper
             - pkg/apis/resources
             - pkg/apis/resources/v1alpha1
             - pkg/apis/security
@@ -805,6 +806,7 @@ build:
             - pkg/utils/errors
             - pkg/utils/flow
             - pkg/utils/gardener
+            - pkg/utils/gardener/operator
             - pkg/utils/gardener/shootstate
             - pkg/utils/imagevector
             - pkg/utils/kubernetes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Runtime webhook config must have different name otherwise, if another instance `gardener-extension-provider-local` comes up later when a `Seed` is registered (i.e., when the garden runtime cluster is a seed at the same time), they will both fight over the same `MutatingWebhookConfiguration/gardener-extension-provider-local`. Concretely, they both try to write their CA bundle into it. The CA bundles are different, hence, this can lead to errors like this:

```
  - lastTransitionTime: "2025-05-26T11:49:09Z"
    lastUpdateTime: "2025-05-26T11:49:09Z"
    message: 'error during apply of object "monitoring.coreos.com/v1/Prometheus/garden/seed":
      Internal error occurred: failed calling webhook "prometheus.local.extensions.gardener.cloud":
      failed to call webhook: Post "https://gardener-extension-provider-local.extension-provider-local-rq9gk.svc:443/prometheus?timeout=10s":
      tls: failed to verify certificate: x509: certificate signed by unknown authority
      (possibly because of "crypto/rsa: verification error" while trying to verify
      candidate authority certificate "ca-provider-local-webhook-f0e82f96")'
    reason: ApplyFailed
    status: Progressing
    type: ObservabilityComponentsHealthy
```

Cherry-pick from https://github.com/gardener/gardener/pull/12213.

**Which issue(s) this PR fixes**:
See #12243

**Special notes for your reviewer**:
/cc @ary1992 @plkokanov @ialidzhikov @rfranzke @oliver-goetz

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
