### PR TITLE
Add information for upgrading from OIDC to Structured Authentication config

### DIFF
--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -165,6 +165,62 @@ The user is responsible for the validity of the configured `JWTAuthenticator`s.
 Be aware that changing the configuration in the `ConfigMap` will be applied in the next `Shoot` reconciliation, but this is not automatically triggered.
 If you want the changes to roll out immediately, [trigger a reconciliation explicitly](../shoot-operations/shoot_operations.md#immediate-reconciliation).
 
+### Upgrading from `OpenIDConnect` to Structured Authentication Config
+
+If you would like to migrate from `OpenIDConnect` to Structured Authentication Config and your `shoot.yaml` has `spec.kubernetes.kubeAPIServer.oidcConfig` set, for example:
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+spec:
+  kubernetes:
+    kubeAPIServer:
+      oidcConfig:
+        clientID: <client-ID>
+        groupsClaim: groups
+        issuerURL: <issuer-url>
+        usernameClaim: username
+```
+
+1. Create a `ConfigMap` in your project namespaces containing an equivalent `AuthenticationConfiguration` to your current `oidcConfig`. It should look similar to:
+
+    ```yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: structured-authentication-config
+    data:
+      config.yaml: |
+        apiVersion: apiserver.config.k8s.io/v1beta1
+        kind: AuthenticationConfiguration
+        jwt:
+        - issuer:
+            url: <issuer-url>
+            audiences:
+            - <client-ID>
+          claimMappings:
+            groups:
+              claim: groups
+              prefix: ""
+            username:
+              claim: username
+              prefix: ""
+    ```
+
+    You can also follow the steps in the [Kubernetes 1.30: Structured Authentication Configuration Moves to Beta](https://kubernetes.io/blog/2024/04/25/structured-authentication-moves-to-beta/#migration-from-command-line-arguments-to-configuration-file) blog post.
+
+1. Remove the `spec.kubernetes.kubeAPIServer.oidcConfig` section from the `shoot.yaml` file and replace it a reference to the newly created `ConfigMap` in `spec.kubernetes.kubeAPIServer.structuredAuthentication.configMapName`:
+
+    ```yaml
+    apiVersion: core.gardener.cloud/v1beta1
+    kind: Shoot
+    spec:
+      kubernetes:
+        kubeAPIServer:
+          structuredAuthentication:
+            configMapName: structured-authentication-config
+    ```
+
 ## Structured Authorization
 
 For shoots with Kubernetes version `>= 1.30`, which have `StructuredAuthorizationConfiguration` feature gate enabled (enabled by default), `kube-apiserver` of shoot clusters can be provided with [Structured Authorization configuration](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#using-configuration-file-for-authorization) via the Shoot spec:

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -165,9 +165,9 @@ The user is responsible for the validity of the configured `JWTAuthenticator`s.
 Be aware that changing the configuration in the `ConfigMap` will be applied in the next `Shoot` reconciliation, but this is not automatically triggered.
 If you want the changes to roll out immediately, [trigger a reconciliation explicitly](../shoot-operations/shoot_operations.md#immediate-reconciliation).
 
-### Upgrading from `OpenIDConnect` to Structured Authentication Config
+### Migrating from `OpenIDConnect` to Structured Authentication Config
 
-If you would like to migrate from `OpenIDConnect` to Structured Authentication Config and your `shoot.yaml` has `spec.kubernetes.kubeAPIServer.oidcConfig` set, for example:
+If you would like to migrate from `OpenIDConnect` to Structured Authentication Config and your `Shoot` spec has the `spec.kubernetes.kubeAPIServer.oidcConfig` field set, for example:
 
 ```yaml
 apiVersion: core.gardener.cloud/v1beta1
@@ -209,7 +209,7 @@ spec:
 
     You can also follow the steps in the [Kubernetes 1.30: Structured Authentication Configuration Moves to Beta](https://kubernetes.io/blog/2024/04/25/structured-authentication-moves-to-beta/#migration-from-command-line-arguments-to-configuration-file) blog post.
 
-1. Remove the `spec.kubernetes.kubeAPIServer.oidcConfig` section from the `shoot.yaml` file and replace it a reference to the newly created `ConfigMap` in `spec.kubernetes.kubeAPIServer.structuredAuthentication.configMapName`:
+1. Remove the `spec.kubernetes.kubeAPIServer.oidcConfig` field from the Shoot spec and replace it with a reference to the newly created `ConfigMap` in `spec.kubernetes.kubeAPIServer.structuredAuthentication.configMapName`:
 
     ```yaml
     apiVersion: core.gardener.cloud/v1beta1

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -183,7 +183,21 @@ spec:
         usernameClaim: username
 ```
 
-1. Create a `ConfigMap` in your project namespaces containing an equivalent `AuthenticationConfiguration` to your current `oidcConfig`. It should look similar to:
+Or you have configured OIDC using a `(Cluster)OpenIDConnectPreset` resource, for example:
+
+``` yaml
+apiVersion: settings.gardener.cloud/v1alpha1
+kind: (Cluster)OpenIDConnectPreset
+spec:
+  server:
+    clientID: <client-ID>
+    groupsClaim: groups
+    groupsPrefix: "<groups-prefix>"
+    issuerURL: <issuer-url>
+    usernameClaim: username
+```
+
+1. Create a `ConfigMap` in your project namespace containing an equivalent `AuthenticationConfiguration` to your current OIDC config. It should look similar to:
 
     ```yaml
     apiVersion: v1
@@ -210,7 +224,7 @@ spec:
 
     You can also follow the steps in the [Kubernetes 1.30: Structured Authentication Configuration Moves to Beta](https://kubernetes.io/blog/2024/04/25/structured-authentication-moves-to-beta/#migration-from-command-line-arguments-to-configuration-file) blog post.
 
-1. Remove the `spec.kubernetes.kubeAPIServer.oidcConfig` field from the Shoot spec and replace it with a reference to the newly created `ConfigMap` in `spec.kubernetes.kubeAPIServer.structuredAuthentication.configMapName`:
+1. Remove the `spec.kubernetes.kubeAPIServer.oidcConfig` field from the Shoot spec (or the `(Cluster)OpenIDConnectPreset` resources if it does not target any other Shoot cluster) and replace it with a reference to the newly created `ConfigMap` in `spec.kubernetes.kubeAPIServer.structuredAuthentication.configMapName`:
 
     ```yaml
     apiVersion: core.gardener.cloud/v1beta1
@@ -295,7 +309,7 @@ Hence, if RBAC already allows a request, your webhook authorizer might not get c
 ## OpenID Connect
 
 > [!WARNING]
-> OpenID Connect is deprecated in favor of [Structured Authentication configuration](#structured-authentication). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`.
+> OpenID Connect is deprecated in favor of [Structured Authentication configuration](#structured-authentication). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`. The configuration and the related CRDs `(Cluster)OpenIDConnectPreset` will be removed when the oldest supported version of Kubernetes is `v1.32` in Gardener.
 
 The `kube-apiserver` of shoot clusters can be provided with [OpenID Connect configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) via the Shoot spec:
 
@@ -318,5 +332,6 @@ Shoots have to "opt-in" for such defaulting by using the `oidc=enable` label.
 
 For further information on `(Cluster)OpenIDConnectPreset`, refer to [ClusterOpenIDConnectPreset and OpenIDConnectPreset](../security/openidconnect-presets.md).
 
-For shoots with Kubernetes version `>= 1.30`, which have `StructuredAuthenticationConfiguration` feature gate enabled (enabled by default), it is advised to use Structured Authentication instead of configuring `.spec.kubernetes.kubeAPIServer.oidcConfig`.
+For shoots with Kubernetes version `>= 1.30`, which have `StructuredAuthenticationConfiguration` feature gate enabled (enabled by default), it is advised to use Structured Authentication instead of configuring `.spec.kubernetes.kubeAPIServer.oidcConfig` and/or `(Cluster)OpenIDConnectPreset`.
+
 If `oidcConfig` is configured, it is translated into an `AuthenticationConfiguration` file to use for [Structured Authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration).

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -309,7 +309,7 @@ Hence, if RBAC already allows a request, your webhook authorizer might not get c
 ## OpenID Connect
 
 > [!WARNING]
-> OpenID Connect is deprecated in favor of [Structured Authentication configuration](#structured-authentication). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`. The configuration and the related CRDs `(Cluster)OpenIDConnectPreset` will be removed when the oldest supported version of Kubernetes is `v1.32` in Gardener.
+> OpenID Connect is deprecated in favor of [Structured Authentication configuration](#structured-authentication). Setting OpenID Connect configurations is forbidden for clusters with Kubernetes version `>= 1.32`. The configuration and the related API resources `(Cluster)OpenIDConnectPreset` will be removed when Gardener no longer supports clusters with Kubernetes version `< 1.32`.
 
 The `kube-apiserver` of shoot clusters can be provided with [OpenID Connect configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) via the Shoot spec:
 

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -165,9 +165,9 @@ The user is responsible for the validity of the configured `JWTAuthenticator`s.
 Be aware that changing the configuration in the `ConfigMap` will be applied in the next `Shoot` reconciliation, but this is not automatically triggered.
 If you want the changes to roll out immediately, [trigger a reconciliation explicitly](../shoot-operations/shoot_operations.md#immediate-reconciliation).
 
-### Migrating from `OpenIDConnect` to Structured Authentication Config
+### Migrating from OIDC to Structured Authentication Config
 
-If you would like to migrate from `OpenIDConnect` to Structured Authentication Config and your `Shoot` spec has the `spec.kubernetes.kubeAPIServer.oidcConfig` field set, for example:
+If you would like to migrate from OIDC to Structured Authentication Config and your `Shoot` spec has the `spec.kubernetes.kubeAPIServer.oidcConfig` field set, for example:
 
 ```yaml
 apiVersion: core.gardener.cloud/v1beta1
@@ -178,6 +178,7 @@ spec:
       oidcConfig:
         clientID: <client-ID>
         groupsClaim: groups
+        groupsPrefix: "<groups-prefix>"
         issuerURL: <issuer-url>
         usernameClaim: username
 ```
@@ -201,7 +202,7 @@ spec:
           claimMappings:
             groups:
               claim: groups
-              prefix: ""
+              prefix: "<groups-prefix>"
             username:
               claim: username
               prefix: ""

--- a/docs/usage/shoot/shoot_kubernetes_versions.md
+++ b/docs/usage/shoot/shoot_kubernetes_versions.md
@@ -16,12 +16,16 @@ For Kubernetes specific upgrade notes the upstream Kubernetes release notes, [ch
 
 ## Upgrading to Kubernetes `v1.32`
 
-- The `Shoot`'s field `.spec.kubernetes.kubeAPIServer.oidcConfig` is forbidden. `Shoot` owners that have used `oidcConfig` are recommended to configure `StructuredAuthentication`. More information about `StructuredAuthentication` can be found [here](./shoot_access.md#structured-authentication)
+> [!TIP]
+> It is recommended to [migrate from OIDC to `StructuredAuthentication`](shoot_access.md#migrating-from-oidc-to-structured-authentication-config) before updating to Kubernetes v1.32 in order to avoid not being able to revert the change.
+
+- The `Shoot`'s `spec.kubernetes.kubeAPIServer.oidcConfig` field is forbidden.
+  - `Shoot` owners that have used `oidcConfig` are required to [migrate to `StructuredAuthentication`](shoot_access.md#migrating-from-oidc-to-structured-authentication-config). More information about `StructuredAuthentication` can be found in the [Structured Authentication documentation](./shoot_access.md#structured-authentication).
 
 ## Upgrading to Kubernetes `v1.31`
 
-- The `Shoot`'s field `.spec.kubernetes.kubeAPIServer.oidcConfig.clientAuthentication` is forbidden.
-- The `Shoot`'s fields `.spec.kubernetes.kubelet.systemReserved` and `.spec.provider.workers[].kubernetes.kubelet.systemReserved` are forbidden. `Shoot` owners should use the `.spec.kubernetes.kubelet.kubeReserved` and `.spec.provider.workers[].kubernetes.kubelet.kubeReserved` fields.
+- The `Shoot`'s `spec.kubernetes.kubeAPIServer.oidcConfig.clientAuthentication` field is forbidden.
+- The `Shoot`'s `.spec.kubernetes.kubelet.systemReserved` and `.spec.provider.workers[].kubernetes.kubelet.systemReserved` fields are forbidden. `Shoot` owners should use the `.spec.kubernetes.kubelet.kubeReserved` and `.spec.provider.workers[].kubernetes.kubelet.kubeReserved` fields.
 
 ## Upgrading to Kubernetes `v1.30`
 

--- a/docs/usage/shoot/shoot_kubernetes_versions.md
+++ b/docs/usage/shoot/shoot_kubernetes_versions.md
@@ -20,7 +20,7 @@ For Kubernetes specific upgrade notes the upstream Kubernetes release notes, [ch
 > It is recommended to [migrate from OIDC to `StructuredAuthentication`](shoot_access.md#migrating-from-oidc-to-structured-authentication-config) before updating to Kubernetes v1.32 in order to avoid not being able to revert the change.
 
 - The `Shoot`'s `spec.kubernetes.kubeAPIServer.oidcConfig` field is forbidden.
-  - `Shoot` owners that have used `oidcConfig` are required to [migrate to `StructuredAuthentication`](shoot_access.md#migrating-from-oidc-to-structured-authentication-config). More information about `StructuredAuthentication` can be found in the [Structured Authentication documentation](./shoot_access.md#structured-authentication).
+  - `Shoot` owners that have used `oidcConfig` or a `(Cluster)OpenIDConnectPreset` resource are recommended to [migrate to `StructuredAuthentication`](shoot_access.md#migrating-from-oidc-to-structured-authentication-config). More information about `StructuredAuthentication` can be found in the [Structured Authentication documentation](./shoot_access.md#structured-authentication).
 
 ## Upgrading to Kubernetes `v1.31`
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR updates the Shoot Access topic with information for upgrading from `OpenIDConnect` to Structured Authentication config.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
