### PR TITLE
🧹 Cleanup nginx-ingress controller resource lock configmaps

### DIFF
--- a/pkg/component/networking/nginxingress/nginxingress.go
+++ b/pkg/component/networking/nginxingress/nginxingress.go
@@ -217,7 +217,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 	}
 
 	if n.values.ClusterType == component.ClusterTypeShoot {
-		serviceAccount.Labels = utils.MergeStringMaps[string](serviceAccount.Labels, map[string]string{
+		serviceAccount.Labels = utils.MergeStringMaps(serviceAccount.Labels, map[string]string{
 			labelKeyRelease: labelValueAddons,
 		})
 		serviceAnnotations = map[string]string{"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "*"}
@@ -485,13 +485,13 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 				Replicas:             ptr.To[int32](2),
 				RevisionHistoryLimit: ptr.To[int32](2),
 				Selector: &metav1.LabelSelector{
-					MatchLabels: utils.MergeStringMaps[string](n.getLabels(LabelValueController, false), map[string]string{
+					MatchLabels: utils.MergeStringMaps(n.getLabels(LabelValueController, false), map[string]string{
 						labelKeyRelease: labelValueAddons,
 					}),
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: utils.MergeStringMaps[string](n.getLabels(LabelValueController, true), map[string]string{
+						Labels: utils.MergeStringMaps(n.getLabels(LabelValueController, true), map[string]string{
 							labelKeyRelease: labelValueAddons,
 						}),
 					},

--- a/pkg/component/networking/nginxingress/nginxingress_test.go
+++ b/pkg/component/networking/nginxingress/nginxingress_test.go
@@ -653,6 +653,17 @@ spec:
 status: {}
 `
 				}
+
+				leaseYAML = `apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  annotations:
+    resources.gardener.cloud/ignore: "true"
+  creationTimestamp: null
+  name: ingress-controller-seed-leader
+  namespace: ` + namespace + `
+spec: {}
+`
 			)
 
 			It("should successfully deploy all resources", func() {
@@ -709,6 +720,7 @@ status: {}
 					podDisruptionBudgetYAML,
 					virtualServiceYAML(0),
 					virtualServiceYAML(1),
+					leaseYAML,
 				}
 
 				Expect(manifests).To(ConsistOf(expectedManifests))
@@ -1241,6 +1253,17 @@ spec:
     updateMode: Auto
 status: {}
 `
+
+			leaseYAML = `apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  annotations:
+    resources.gardener.cloud/ignore: "true"
+  creationTimestamp: null
+  name: ingress-controller-leader
+  namespace: kube-system
+spec: {}
+`
 		)
 
 		BeforeEach(func() {
@@ -1314,6 +1337,7 @@ status: {}
 					networkPolicyYAML,
 					ingressClassYAML,
 					deploymentControllerYAMLFor(configMapData),
+					leaseYAML,
 				}
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
The nginx-ingress controller moved from using configmaps to leases for resource lock way back, but these old configmaps were never cleaned up.
This PR adds code to clean these up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- The two configmap names are due to gardener switching the `electionID` sometime back, I guess. This `electionID` is used as the CM name by the controller.
- We might need to keep the cleanup code of Shoot for longer because care controller will not run garbage collection for hibernated shoots.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
