### PR TITLE
[GEP-26] Use WorkloadIdentity for ETCD backup - part 3

### DIFF
--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -7,6 +7,7 @@ package genericactuator
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -19,6 +20,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -27,6 +29,9 @@ type actuator struct {
 	backupEntryDelegate BackupEntryDelegate
 	client              client.Client
 }
+
+// Ensure actuator implements backupentry.Actuator interface
+var _ backupentry.Actuator = (*actuator)(nil)
 
 // AnnotationKeyCreatedByBackupEntry is a constant for the key of an annotation on the etcd-backup Secret whose value contains
 // the name of the BackupEntry object that created the Secret.
@@ -62,18 +67,32 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, log logr.Logger, 
 		return nil
 	}
 
-	backupSecret, err := kubernetesutils.GetSecretByReference(ctx, a.client, &be.Spec.SecretRef)
+	backupEntrySecret, err := kubernetesutils.GetSecretByReference(ctx, a.client, &be.Spec.SecretRef)
 	if err != nil {
 		log.Error(err, "Failed to read backup extension secret")
 		return err
 	}
 
-	backupSecretData := backupSecret.DeepCopy().Data
-	if backupSecretData == nil {
-		backupSecretData = map[string][]byte{}
+	var (
+		backupEntrySecretData = backupEntrySecret.DeepCopy().Data
+		withWorkloadIdentity  = false
+	)
+
+	if purpose, ok := backupEntrySecret.Labels[securityv1alpha1constants.LabelPurpose]; ok && purpose == securityv1alpha1constants.LabelPurposeWorkloadIdentityTokenRequestor {
+		withWorkloadIdentity = true
 	}
-	backupSecretData[v1beta1constants.DataKeyBackupBucketName] = []byte(be.Spec.BucketName)
-	etcdSecretData, err := a.backupEntryDelegate.GetETCDSecretData(ctx, log, be, backupSecretData)
+
+	if withWorkloadIdentity {
+		maps.DeleteFunc(backupEntrySecretData, func(k string, _ []byte) bool {
+			return k != securityv1alpha1constants.DataKeyConfig
+		})
+	}
+
+	if backupEntrySecretData == nil {
+		backupEntrySecretData = map[string][]byte{}
+	}
+	backupEntrySecretData[v1beta1constants.DataKeyBackupBucketName] = []byte(be.Spec.BucketName)
+	etcdSecretData, err := a.backupEntryDelegate.GetETCDSecretData(ctx, log, be, backupEntrySecretData)
 	if err != nil {
 		return err
 	}
@@ -81,6 +100,40 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, log logr.Logger, 
 	etcdSecret := emptyEtcdBackupSecret(be.Name)
 
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, a.client, etcdSecret, func() error {
+		if withWorkloadIdentity {
+			maps.DeleteFunc(etcdSecret.Annotations, func(k, _ string) bool {
+				return k != securityv1alpha1constants.AnnotationWorkloadIdentityTokenRenewTimestamp
+			})
+
+			if workloadIdentityName, ok := backupEntrySecret.Annotations[securityv1alpha1constants.AnnotationWorkloadIdentityName]; !ok {
+				return fmt.Errorf("BackupEntry is set to use workload identity but WorkloadIdentity's name is missing")
+			} else {
+				metav1.SetMetaDataAnnotation(&etcdSecret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityName, workloadIdentityName)
+			}
+
+			if workloadIdentityNamespace, ok := backupEntrySecret.Annotations[securityv1alpha1constants.AnnotationWorkloadIdentityNamespace]; !ok {
+				return fmt.Errorf("BackupEntry is set to use workload identity but WorkloadIdentity's namespace is missing")
+			} else {
+				metav1.SetMetaDataAnnotation(&etcdSecret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityNamespace, workloadIdentityNamespace)
+			}
+
+			if contextObj, ok := backupEntrySecret.Annotations[securityv1alpha1constants.AnnotationWorkloadIdentityContextObject]; ok {
+				metav1.SetMetaDataAnnotation(&etcdSecret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityContextObject, contextObj)
+			}
+
+			etcdSecret.Labels = map[string]string{securityv1alpha1constants.LabelPurpose: securityv1alpha1constants.LabelPurposeWorkloadIdentityTokenRequestor}
+
+			if provider, ok := backupEntrySecret.Labels[securityv1alpha1constants.LabelWorkloadIdentityProvider]; !ok {
+				return fmt.Errorf("BackupEntry is set to use workload identity but WorkloadIdentity's provider type missing")
+			} else {
+				etcdSecret.Labels[securityv1alpha1constants.LabelWorkloadIdentityProvider] = provider
+			}
+
+			if token, ok := etcdSecret.Data[securityv1alpha1constants.DataKeyToken]; ok {
+				etcdSecretData[securityv1alpha1constants.DataKeyToken] = token
+			}
+		}
+
 		metav1.SetMetaDataAnnotation(&etcdSecret.ObjectMeta, AnnotationKeyCreatedByBackupEntry, be.Name)
 		etcdSecret.Data = etcdSecretData
 		return nil

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -59,8 +59,7 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, log logr.Logger, 
 			log.Info("SeedNamespace for shoot not found. Avoiding etcd backup secret deployment")
 			return nil
 		}
-		log.Error(err, "Failed to get seed namespace")
-		return err
+		return fmt.Errorf("failed to get seed namespace: %w", err)
 	}
 	if namespace.DeletionTimestamp != nil {
 		log.Info("SeedNamespace for shoot is being terminated. Avoiding etcd backup secret deployment")

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -74,12 +74,8 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, log logr.Logger, 
 
 	var (
 		backupEntrySecretData = backupEntrySecret.DeepCopy().Data
-		withWorkloadIdentity  = false
+		withWorkloadIdentity  = backupEntrySecret.Labels[securityv1alpha1constants.LabelPurpose] == securityv1alpha1constants.LabelPurposeWorkloadIdentityTokenRequestor
 	)
-
-	if purpose, ok := backupEntrySecret.Labels[securityv1alpha1constants.LabelPurpose]; ok && purpose == securityv1alpha1constants.LabelPurposeWorkloadIdentityTokenRequestor {
-		withWorkloadIdentity = true
-	}
 
 	if withWorkloadIdentity {
 		maps.DeleteFunc(backupEntrySecretData, func(k string, _ []byte) bool {

--- a/extensions/pkg/controller/backupentry/genericactuator/types.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/types.go
@@ -12,9 +12,9 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// BackupEntryDelegate preforms provider specific operation with BackupBucket resources.
+// BackupEntryDelegate preforms provider specific operation with BackupEntry resources.
 type BackupEntryDelegate interface {
-	// Delete deletes the BackupBucket.
+	// Delete deletes the BackupEntry.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.BackupEntry) error
 	// GetETCDSecretData returns the updated secret data as per provider requirement.
 	GetETCDSecretData(context.Context, logr.Logger, *extensionsv1alpha1.BackupEntry, map[string][]byte) (map[string][]byte, error)

--- a/extensions/pkg/controller/backupentry/mapper_test.go
+++ b/extensions/pkg/controller/backupentry/mapper_test.go
@@ -134,6 +134,14 @@ var _ = Describe("Controller Mapper", func() {
 		It("should find no objects because the passed object is not secret", func() {
 			Expect(mapper(ctx, configMap)).To(BeEmpty())
 		})
+
+		It("should return empty request array because the secret is not referred by the backupentry", func() {
+			backupEntry.Spec.SecretRef.Name = "another" + secret.Name
+
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, backupEntry)).To(Succeed())
+			Expect(mapper(ctx, secret)).To(BeEmpty())
+		})
 	})
 
 	Describe("#NamespaceToBackupEntryMapper", func() {

--- a/extensions/pkg/controller/backupentry/util.go
+++ b/extensions/pkg/controller/backupentry/util.go
@@ -5,15 +5,14 @@
 package backupentry
 
 import (
-	"fmt"
 	"strings"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
-// ExtractShootDetailsFromBackupEntryName returns Shoot resource technicalID its UID from provided <backupEntryName>.
+// ExtractShootDetailsFromBackupEntryName returns Shoot resource technicalID and UID from provided <backupEntryName>.
 func ExtractShootDetailsFromBackupEntryName(backupEntryName string) (shootTechnicalID, shootUID string) {
-	backupEntryName = strings.TrimPrefix(backupEntryName, fmt.Sprintf("%s-", v1beta1constants.BackupSourcePrefix))
+	backupEntryName = strings.TrimPrefix(backupEntryName, v1beta1constants.BackupSourcePrefix+"-")
 	tokens := strings.Split(backupEntryName, "--")
 	shootUID = tokens[len(tokens)-1]
 	shootTechnicalID = strings.TrimSuffix(backupEntryName, "--"+shootUID)

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -192,7 +192,7 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorizeSecret(requestLog, seedName, attrs)
 		case workloadIdentityResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeWorkloadIdentity, attrs,
-				[]string{"get", "list", "watch", "create"},
+				[]string{"get", "list", "watch", "create", "patch"},
 				nil,
 				[]string{"token"},
 			)

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -526,6 +526,7 @@ var _ = Describe("Seed", func() {
 					Entry("list", "list"),
 					Entry("watch", "watch"),
 					Entry("create", "create"),
+					Entry("patch", "patch"),
 				)
 
 				It("should allow the request when the request is for 'token' subresource and path exists", func() {
@@ -549,10 +550,9 @@ var _ = Describe("Seed", func() {
 
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch create]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch create patch]"))
 					},
 
-					Entry("patch", "patch"),
 					Entry("update", "update"),
 					Entry("delete", "delete"),
 					Entry("deletecollection", "deletecollection"),

--- a/pkg/apiserver/registry/security/rest/storage_security.go
+++ b/pkg/apiserver/registry/security/rest/storage_security.go
@@ -43,10 +43,15 @@ func (p StorageProvider) v1alpha1Storage(restOptionsGetter generic.RESTOptionsGe
 	credentialsBindingStorage := credentialsbindingstore.NewStorage(restOptionsGetter)
 	storage["credentialsbindings"] = credentialsBindingStorage.CredentialsBinding
 
+	sharedInformer := p.CoreInformerFactory.Core().V1beta1()
 	workloadIdentityStorage := workloadidentitystore.NewStorage(
 		restOptionsGetter,
 		p.TokenIssuer,
-		p.CoreInformerFactory,
+		sharedInformer.Shoots().Lister(),
+		sharedInformer.Seeds().Lister(),
+		sharedInformer.Projects().Lister(),
+		sharedInformer.BackupBuckets().Lister(),
+		sharedInformer.BackupEntries().Lister(),
 	)
 	storage["workloadidentities"] = workloadIdentityStorage.WorkloadIdentity
 	storage["workloadidentities/token"] = workloadIdentityStorage.TokenRequest

--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
@@ -153,7 +153,7 @@ func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *security
 		ctxObjects.shoot = shoot.GetObjectMeta()
 
 		if shoot.UID != ctxObj.UID {
-			return nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, shoot.UID)
+			return nil, fmt.Errorf("uid of contextObject (%s) and real world Shoot resource (%s) differ", ctxObj.UID, shoot.UID)
 		}
 
 		if shoot.Spec.SeedName != nil {
@@ -175,7 +175,7 @@ func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *security
 		}
 
 		if seed.UID != ctxObj.UID {
-			return nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, seed.UID)
+			return nil, fmt.Errorf("uid of contextObject (%s) and real world Seed resource (%s) differ", ctxObj.UID, seed.UID)
 		}
 		ctxObjects.seed = seed.GetObjectMeta()
 
@@ -185,7 +185,7 @@ func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *security
 		}
 
 		if backupBucket.UID != ctxObj.UID {
-			return nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupBucket.UID)
+			return nil, fmt.Errorf("uid of contextObject (%s) and real world BackupBucket resource (%s) differ", ctxObj.UID, backupBucket.UID)
 		}
 		ctxObjects.backupBucket = backupBucket.GetObjectMeta()
 
@@ -203,7 +203,7 @@ func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *security
 		}
 
 		if backupEntry.UID != ctxObj.UID {
-			return nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupEntry.UID)
+			return nil, fmt.Errorf("uid of contextObject (%s) and real world BackupEntry resource (%s) differ", ctxObj.UID, backupEntry.UID)
 		}
 		ctxObjects.backupEntry = backupEntry.GetObjectMeta()
 

--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
@@ -40,9 +40,19 @@ type ref struct {
 	UID       string  `json:"uid"`
 }
 
+// contextObjects contains metadata information about the objects
+// which are in the context of given WorkloadIdentity
+type contextObjects struct {
+	shoot        metav1.Object
+	seed         metav1.Object
+	project      metav1.Object
+	backupBucket metav1.Object
+	backupEntry  metav1.Object
+}
+
 // issueToken generates the JSON Web Token based on the provided configurations.
 func (r *TokenRequestREST) issueToken(user user.Info, tokenRequest *securityapi.TokenRequest, workloadIdentity *securityapi.WorkloadIdentity) (string, *time.Time, error) {
-	shoot, seed, project, backupBucket, backupEntry, err := r.resolveContextObject(user, tokenRequest.Spec.ContextObject)
+	contextObjects, err := r.resolveContextObject(user, tokenRequest.Spec.ContextObject)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to resolve context object: %w", err)
 	}
@@ -51,7 +61,7 @@ func (r *TokenRequestREST) issueToken(user user.Info, tokenRequest *securityapi.
 		workloadIdentity.Status.Sub,
 		workloadIdentity.Spec.Audiences,
 		tokenRequest.Spec.ExpirationSeconds,
-		r.getGardenerClaims(workloadIdentity, shoot, seed, project, backupBucket, backupEntry),
+		r.getGardenerClaims(workloadIdentity, contextObjects),
 	)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to issue JSON Web Token: %w", err)
@@ -60,7 +70,7 @@ func (r *TokenRequestREST) issueToken(user user.Info, tokenRequest *securityapi.
 	return token, exp, nil
 }
 
-func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.WorkloadIdentity, shoot, seed, project, backupBucket, backupEntry metav1.Object) *gardenerClaims {
+func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.WorkloadIdentity, ctxObjects *contextObjects) *gardenerClaims {
 	gardenerClaims := &gardenerClaims{
 		Gardener: gardener{
 			WorkloadIdentity: ref{
@@ -71,161 +81,165 @@ func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.Workl
 		},
 	}
 
-	if shoot != nil {
+	if ctxObjects == nil {
+		return gardenerClaims
+	}
+
+	if ctxObjects.shoot != nil {
 		gardenerClaims.Gardener.Shoot = &ref{
-			Name:      shoot.GetName(),
-			Namespace: ptr.To(shoot.GetNamespace()),
-			UID:       string(shoot.GetUID()),
+			Name:      ctxObjects.shoot.GetName(),
+			Namespace: ptr.To(ctxObjects.shoot.GetNamespace()),
+			UID:       string(ctxObjects.shoot.GetUID()),
 		}
 	}
 
-	if seed != nil {
+	if ctxObjects.seed != nil {
 		gardenerClaims.Gardener.Seed = &ref{
-			Name: seed.GetName(),
-			UID:  string(seed.GetUID()),
+			Name: ctxObjects.seed.GetName(),
+			UID:  string(ctxObjects.seed.GetUID()),
 		}
 	}
 
-	if project != nil {
+	if ctxObjects.project != nil {
 		gardenerClaims.Gardener.Project = &ref{
-			Name: project.GetName(),
-			UID:  string(project.GetUID()),
+			Name: ctxObjects.project.GetName(),
+			UID:  string(ctxObjects.project.GetUID()),
 		}
 	}
 
-	if backupBucket != nil {
+	if ctxObjects.backupBucket != nil {
 		gardenerClaims.Gardener.BackupBucket = &ref{
-			Name: backupBucket.GetName(),
-			UID:  string(backupBucket.GetUID()),
+			Name: ctxObjects.backupBucket.GetName(),
+			UID:  string(ctxObjects.backupBucket.GetUID()),
 		}
 	}
 
-	if backupEntry != nil {
+	if ctxObjects.backupEntry != nil {
 		gardenerClaims.Gardener.BackupEntry = &ref{
-			Name:      backupEntry.GetName(),
-			Namespace: ptr.To(backupEntry.GetNamespace()),
-			UID:       string(backupEntry.GetUID()),
+			Name:      ctxObjects.backupEntry.GetName(),
+			Namespace: ptr.To(ctxObjects.backupEntry.GetNamespace()),
+			UID:       string(ctxObjects.backupEntry.GetUID()),
 		}
 	}
 
 	return gardenerClaims
 }
 
-func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *securityapi.ContextObject) (metav1.Object, metav1.Object, metav1.Object, metav1.Object, metav1.Object, error) {
+func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *securityapi.ContextObject) (*contextObjects, error) {
 	if ctxObj == nil {
-		return nil, nil, nil, nil, nil, nil
+		return nil, nil
 	}
 
 	if !slices.Contains(user.GetGroups(), v1beta1constants.SeedsGroup) {
-		return nil, nil, nil, nil, nil, nil
+		return nil, nil
 	}
 
 	var (
+		ctxObjects   = &contextObjects{}
 		shoot        *gardencorev1beta1.Shoot
 		seed         *gardencorev1beta1.Seed
 		project      *gardencorev1beta1.Project
 		backupBucket *gardencorev1beta1.BackupBucket
 		backupEntry  *gardencorev1beta1.BackupEntry
 
-		shootMeta, seedMeta, projectMeta, backupBucketMeta, backupEntryMeta metav1.Object
-		err                                                                 error
+		err error
 	)
 
 	switch gvk := schema.FromAPIVersionAndKind(ctxObj.APIVersion, ctxObj.Kind); {
 	case gvk.Group == gardencorev1beta1.SchemeGroupVersion.Group && gvk.Kind == "Shoot":
 		if shoot, err = r.shootListers.Shoots(*ctxObj.Namespace).Get(ctxObj.Name); err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, err
 		}
-		shootMeta = shoot.GetObjectMeta()
+		ctxObjects.shoot = shoot.GetObjectMeta()
 
 		if shoot.UID != ctxObj.UID {
-			return nil, nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, shoot.UID)
+			return nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, shoot.UID)
 		}
 
 		if shoot.Spec.SeedName != nil {
 			seedName := *shoot.Spec.SeedName
 			if seed, err = r.seedLister.Get(seedName); err != nil {
-				return nil, nil, nil, nil, nil, err
+				return nil, err
 			}
-			seedMeta = seed.GetObjectMeta()
+			ctxObjects.seed = seed.GetObjectMeta()
 		}
 
 		if project, err = admissionutils.ProjectForNamespaceFromLister(r.projectLister, shoot.Namespace); err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, err
 		}
-		projectMeta = project.GetObjectMeta()
+		ctxObjects.project = project.GetObjectMeta()
 
 	case gvk.Group == gardencorev1beta1.SchemeGroupVersion.Group && gvk.Kind == "Seed":
 		if seed, err = r.seedLister.Get(ctxObj.Name); err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, err
 		}
 
 		if seed.UID != ctxObj.UID {
-			return nil, nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, seed.UID)
+			return nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, seed.UID)
 		}
-		seedMeta = seed.GetObjectMeta()
+		ctxObjects.seed = seed.GetObjectMeta()
 
 	case gvk.Group == gardencorev1beta1.SchemeGroupVersion.Group && gvk.Kind == "BackupBucket":
 		if backupBucket, err = r.backupBucketLister.Get(ctxObj.Name); err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, err
 		}
 
 		if backupBucket.UID != ctxObj.UID {
-			return nil, nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupBucket.UID)
+			return nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupBucket.UID)
 		}
-		backupBucketMeta = backupBucket.GetObjectMeta()
+		ctxObjects.backupBucket = backupBucket.GetObjectMeta()
 
 		if backupBucket.Spec.SeedName != nil {
 			seedName := *backupBucket.Spec.SeedName
 			if seed, err = r.seedLister.Get(seedName); err != nil {
-				return nil, nil, nil, nil, nil, err
+				return nil, err
 			}
-			seedMeta = seed.GetObjectMeta()
+			ctxObjects.seed = seed.GetObjectMeta()
 		}
 
 	case gvk.Group == gardencorev1beta1.SchemeGroupVersion.Group && gvk.Kind == "BackupEntry":
 		if backupEntry, err = r.backupEntryLister.BackupEntries(*ctxObj.Namespace).Get(ctxObj.Name); err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, err
 		}
 
 		if backupEntry.UID != ctxObj.UID {
-			return nil, nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupEntry.UID)
+			return nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupEntry.UID)
 		}
-		backupEntryMeta = backupEntry.GetObjectMeta()
+		ctxObjects.backupEntry = backupEntry.GetObjectMeta()
 
 		if backupBucket, err = r.backupBucketLister.Get(backupEntry.Spec.BucketName); err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, err
 		}
-		backupBucketMeta = backupBucket.GetObjectMeta()
+		ctxObjects.backupBucket = backupBucket.GetObjectMeta()
 
 		if backupEntry.Spec.SeedName != nil {
 			seedName := *backupEntry.Spec.SeedName
 			if seed, err = r.seedLister.Get(seedName); err != nil {
-				return nil, nil, nil, nil, nil, err
+				return nil, err
 			}
-			seedMeta = seed.GetObjectMeta()
+			ctxObjects.seed = seed.GetObjectMeta()
 		}
 
 		if shootName := gardenerutils.GetShootNameFromOwnerReferences(backupEntry); shootName != "" {
 			shoot, err := r.shootListers.Shoots(backupEntry.GetNamespace()).Get(shootName)
 			if err != nil {
-				return nil, nil, nil, nil, nil, err
+				return nil, err
 			}
 
 			shootTechnicalID, shootUID := gardenerutils.ExtractShootDetailsFromBackupEntryName(ctxObj.Name)
 			if shootTechnicalID == shoot.Status.TechnicalID && shootUID == shoot.GetUID() {
-				shootMeta = shoot.GetObjectMeta()
+				ctxObjects.shoot = shoot.GetObjectMeta()
 
 				if project, err = admissionutils.ProjectForNamespaceFromLister(r.projectLister, shoot.Namespace); err != nil {
-					return nil, nil, nil, nil, nil, err
+					return nil, err
 				}
-				projectMeta = project.GetObjectMeta()
+				ctxObjects.project = project.GetObjectMeta()
 			}
 		}
 
 	default:
-		return nil, nil, nil, nil, nil, fmt.Errorf("unsupported GVK for context object: %s", gvk.String())
+		return nil, fmt.Errorf("unsupported GVK for context object: %s", gvk.String())
 	}
 
-	return shootMeta, seedMeta, projectMeta, backupBucketMeta, backupEntryMeta, nil
+	return ctxObjects, nil
 }

--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
@@ -17,6 +17,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	securityapi "github.com/gardener/gardener/pkg/apis/security"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 )
 
@@ -30,6 +31,7 @@ type gardener struct {
 	Project          *ref `json:"project,omitempty"`
 	Seed             *ref `json:"seed,omitempty"`
 	BackupBucket     *ref `json:"backupBucket,omitempty"`
+	BackupEntry      *ref `json:"backupEntry,omitempty"`
 }
 
 type ref struct {
@@ -40,7 +42,7 @@ type ref struct {
 
 // issueToken generates the JSON Web Token based on the provided configurations.
 func (r *TokenRequestREST) issueToken(user user.Info, tokenRequest *securityapi.TokenRequest, workloadIdentity *securityapi.WorkloadIdentity) (string, *time.Time, error) {
-	shoot, seed, project, backupBucket, err := r.resolveContextObject(user, tokenRequest.Spec.ContextObject)
+	shoot, seed, project, backupBucket, backupEntry, err := r.resolveContextObject(user, tokenRequest.Spec.ContextObject)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to resolve context object: %w", err)
 	}
@@ -49,7 +51,7 @@ func (r *TokenRequestREST) issueToken(user user.Info, tokenRequest *securityapi.
 		workloadIdentity.Status.Sub,
 		workloadIdentity.Spec.Audiences,
 		tokenRequest.Spec.ExpirationSeconds,
-		r.getGardenerClaims(workloadIdentity, shoot, seed, project, backupBucket),
+		r.getGardenerClaims(workloadIdentity, shoot, seed, project, backupBucket, backupEntry),
 	)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to issue JSON Web Token: %w", err)
@@ -58,7 +60,7 @@ func (r *TokenRequestREST) issueToken(user user.Info, tokenRequest *securityapi.
 	return token, exp, nil
 }
 
-func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.WorkloadIdentity, shoot, seed, project, backupBucket metav1.Object) *gardenerClaims {
+func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.WorkloadIdentity, shoot, seed, project, backupBucket, backupEntry metav1.Object) *gardenerClaims {
 	gardenerClaims := &gardenerClaims{
 		Gardener: gardener{
 			WorkloadIdentity: ref{
@@ -98,16 +100,24 @@ func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.Workl
 		}
 	}
 
+	if backupEntry != nil {
+		gardenerClaims.Gardener.BackupEntry = &ref{
+			Name:      backupEntry.GetName(),
+			Namespace: ptr.To(backupEntry.GetNamespace()),
+			UID:       string(backupEntry.GetUID()),
+		}
+	}
+
 	return gardenerClaims
 }
 
-func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *securityapi.ContextObject) (metav1.Object, metav1.Object, metav1.Object, metav1.Object, error) {
+func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *securityapi.ContextObject) (metav1.Object, metav1.Object, metav1.Object, metav1.Object, metav1.Object, error) {
 	if ctxObj == nil {
-		return nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil
 	}
 
 	if !slices.Contains(user.GetGroups(), v1beta1constants.SeedsGroup) {
-		return nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil
 	}
 
 	var (
@@ -115,67 +125,108 @@ func (r *TokenRequestREST) resolveContextObject(user user.Info, ctxObj *security
 		seed         *gardencorev1beta1.Seed
 		project      *gardencorev1beta1.Project
 		backupBucket *gardencorev1beta1.BackupBucket
+		backupEntry  *gardencorev1beta1.BackupEntry
 
-		shootMeta, seedMeta, projectMeta, backupMeta metav1.Object
-		err                                          error
-		coreInformers                                = r.coreInformerFactory.Core().V1beta1()
+		shootMeta, seedMeta, projectMeta, backupBucketMeta, backupEntryMeta metav1.Object
+		err                                                                 error
+		coreInformers                                                       = r.coreInformerFactory.Core().V1beta1()
 	)
 
 	switch gvk := schema.FromAPIVersionAndKind(ctxObj.APIVersion, ctxObj.Kind); {
 	case gvk.Group == gardencorev1beta1.SchemeGroupVersion.Group && gvk.Kind == "Shoot":
 		if shoot, err = coreInformers.Shoots().Lister().Shoots(*ctxObj.Namespace).Get(ctxObj.Name); err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 		shootMeta = shoot.GetObjectMeta()
 
 		if shoot.UID != ctxObj.UID {
-			return nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, shoot.UID)
+			return nil, nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, shoot.UID)
 		}
 
 		if shoot.Spec.SeedName != nil {
 			seedName := *shoot.Spec.SeedName
 			if seed, err = coreInformers.Seeds().Lister().Get(seedName); err != nil {
-				return nil, nil, nil, nil, err
+				return nil, nil, nil, nil, nil, err
 			}
 			seedMeta = seed.GetObjectMeta()
 		}
 
 		if project, err = admissionutils.ProjectForNamespaceFromLister(coreInformers.Projects().Lister(), shoot.Namespace); err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 		projectMeta = project.GetObjectMeta()
 
 	case gvk.Group == gardencorev1beta1.SchemeGroupVersion.Group && gvk.Kind == "Seed":
 		if seed, err = coreInformers.Seeds().Lister().Get(ctxObj.Name); err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 
 		if seed.UID != ctxObj.UID {
-			return nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, seed.UID)
+			return nil, nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, seed.UID)
 		}
 		seedMeta = seed.GetObjectMeta()
 
 	case gvk.Group == gardencorev1beta1.SchemeGroupVersion.Group && gvk.Kind == "BackupBucket":
 		if backupBucket, err = coreInformers.BackupBuckets().Lister().Get(ctxObj.Name); err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 
 		if backupBucket.UID != ctxObj.UID {
-			return nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupBucket.UID)
+			return nil, nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupBucket.UID)
 		}
-		backupMeta = backupBucket.GetObjectMeta()
+		backupBucketMeta = backupBucket.GetObjectMeta()
 
 		if backupBucket.Spec.SeedName != nil {
 			seedName := *backupBucket.Spec.SeedName
 			if seed, err = coreInformers.Seeds().Lister().Get(seedName); err != nil {
-				return nil, nil, nil, nil, err
+				return nil, nil, nil, nil, nil, err
 			}
 			seedMeta = seed.GetObjectMeta()
 		}
 
+	case gvk.Group == gardencorev1beta1.SchemeGroupVersion.Group && gvk.Kind == "BackupEntry":
+		if backupEntry, err = coreInformers.BackupEntries().Lister().BackupEntries(*ctxObj.Namespace).Get(ctxObj.Name); err != nil {
+			return nil, nil, nil, nil, nil, err
+		}
+
+		if backupEntry.UID != ctxObj.UID {
+			return nil, nil, nil, nil, nil, fmt.Errorf("uid of contextObject (%s) and real world resource(%s) differ", ctxObj.UID, backupEntry.UID)
+		}
+		backupEntryMeta = backupEntry.GetObjectMeta()
+
+		if backupBucket, err = coreInformers.BackupBuckets().Lister().Get(backupEntry.Spec.BucketName); err != nil {
+			return nil, nil, nil, nil, nil, err
+		}
+		backupBucketMeta = backupBucket.GetObjectMeta()
+
+		if backupEntry.Spec.SeedName != nil {
+			seedName := *backupEntry.Spec.SeedName
+			if seed, err = coreInformers.Seeds().Lister().Get(seedName); err != nil {
+				return nil, nil, nil, nil, nil, err
+			}
+			seedMeta = seed.GetObjectMeta()
+		}
+
+		if shootName := gardenerutils.GetShootNameFromOwnerReferences(backupEntry); shootName != "" {
+			shoot, err := coreInformers.Shoots().Lister().Shoots(backupEntry.GetNamespace()).Get(shootName)
+			if err != nil {
+				return nil, nil, nil, nil, nil, err
+			}
+
+			shootTechnicalID, shootUID := gardenerutils.ExtractShootDetailsFromBackupEntryName(ctxObj.Name)
+			if shootTechnicalID == shoot.Status.TechnicalID && shootUID == shoot.GetUID() {
+				shootMeta = shoot.GetObjectMeta()
+
+				if project, err = admissionutils.ProjectForNamespaceFromLister(coreInformers.Projects().Lister(), shoot.Namespace); err != nil {
+					return nil, nil, nil, nil, nil, err
+				}
+				projectMeta = project.GetObjectMeta()
+			}
+		}
+
 	default:
-		return nil, nil, nil, nil, fmt.Errorf("unsupported GVK for context object: %s", gvk.String())
+		return nil, nil, nil, nil, nil, fmt.Errorf("unsupported GVK for context object: %s", gvk.String())
 	}
 
-	return shootMeta, seedMeta, projectMeta, backupMeta, nil
+	return shootMeta, seedMeta, projectMeta, backupBucketMeta, backupEntryMeta, nil
 }

--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt_test.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt_test.go
@@ -390,7 +390,7 @@ var _ = Describe("#TokenRequest", func() {
 
 			ctxObjects, err = r.resolveContextObject(&seedUser, uidMismatchContext)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(BeEquivalentTo("uid of contextObject (" + uidMismatch + ") and real world resource(" + shootUID + ") differ"))
+			Expect(err.Error()).To(BeEquivalentTo("uid of contextObject (" + uidMismatch + ") and real world Shoot resource (" + shootUID + ") differ"))
 			Expect(ctxObjects).To(BeNil())
 
 			By("seed does not exist")
@@ -464,7 +464,7 @@ var _ = Describe("#TokenRequest", func() {
 			uidMismatchContext.UID = uidMismatch
 			ctxObjects, err = r.resolveContextObject(&seedUser, uidMismatchContext)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(BeEquivalentTo("uid of contextObject (" + uidMismatch + ") and real world resource(" + seedUID + ") differ"))
+			Expect(err.Error()).To(BeEquivalentTo("uid of contextObject (" + uidMismatch + ") and real world Seed resource (" + seedUID + ") differ"))
 			Expect(ctxObjects).To(BeNil())
 		})
 
@@ -539,7 +539,7 @@ var _ = Describe("#TokenRequest", func() {
 
 			ctxObjects, err = r.resolveContextObject(&seedUser, uidMismatchContext)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(BeEquivalentTo("uid of contextObject (" + uidMismatch + ") and real world resource(" + backupBucketUID + ") differ"))
+			Expect(err.Error()).To(BeEquivalentTo("uid of contextObject (" + uidMismatch + ") and real world BackupBucket resource (" + backupBucketUID + ") differ"))
 			Expect(ctxObjects).To(BeNil())
 
 			By("bind the backupBucket to the seed")
@@ -675,7 +675,7 @@ var _ = Describe("#TokenRequest", func() {
 
 			ctxObjects, err = r.resolveContextObject(&seedUser, uidMismatchContext)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(BeEquivalentTo("uid of contextObject (" + uidMismatch + ") and real world resource(" + backupEntryUID + ") differ"))
+			Expect(err.Error()).To(BeEquivalentTo("uid of contextObject (" + uidMismatch + ") and real world BackupEntry resource (" + backupEntryUID + ") differ"))
 			Expect(ctxObjects).To(BeNil())
 
 			By("backupBucket does not exist")

--- a/pkg/apiserver/registry/security/workloadidentity/storage/storage.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/storage.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/security"
 	"github.com/gardener/gardener/pkg/apiserver/registry/security/workloadidentity"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	workloadidentityutils "github.com/gardener/gardener/pkg/utils/workloadidentity"
 )
 
@@ -31,13 +31,17 @@ type WorkloadIdentityStorage struct {
 func NewStorage(
 	optsGetter generic.RESTOptionsGetter,
 	tokenIssuer workloadidentityutils.TokenIssuer,
-	coreInformerFactory gardencoreinformers.SharedInformerFactory,
+	shootListers gardencorev1beta1listers.ShootLister,
+	seedLister gardencorev1beta1listers.SeedLister,
+	projectLister gardencorev1beta1listers.ProjectLister,
+	backupBucketLister gardencorev1beta1listers.BackupBucketLister,
+	backupEntryLister gardencorev1beta1listers.BackupEntryLister,
 ) WorkloadIdentityStorage {
 	workloadIdentityRest := NewREST(optsGetter)
 
 	return WorkloadIdentityStorage{
 		WorkloadIdentity: workloadIdentityRest,
-		TokenRequest:     NewTokenRequestREST(workloadIdentityRest, tokenIssuer, coreInformerFactory),
+		TokenRequest:     NewTokenRequestREST(workloadIdentityRest, tokenIssuer, shootListers, seedLister, projectLister, backupBucketLister, backupEntryLister),
 	}
 }
 

--- a/pkg/apiserver/registry/security/workloadidentity/storage/tokenrequest.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/tokenrequest.go
@@ -22,13 +22,17 @@ import (
 	securityapi "github.com/gardener/gardener/pkg/apis/security"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	securityvalidation "github.com/gardener/gardener/pkg/apis/security/validation"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/workloadidentity"
 )
 
 // TokenRequestREST implements a RESTStorage for a token request.
 type TokenRequestREST struct {
-	coreInformerFactory gardencoreinformers.SharedInformerFactory
+	shootListers       gardencorev1beta1listers.ShootLister
+	seedLister         gardencorev1beta1listers.SeedLister
+	projectLister      gardencorev1beta1listers.ProjectLister
+	backupBucketLister gardencorev1beta1listers.BackupBucketLister
+	backupEntryLister  gardencorev1beta1listers.BackupEntryLister
 
 	workloadIdentityGetter getter
 	tokenIssuer            workloadidentity.TokenIssuer
@@ -166,12 +170,20 @@ func (r *TokenRequestREST) GroupVersionKind(schema.GroupVersion) schema.GroupVer
 func NewTokenRequestREST(
 	storage getter,
 	tokenIssuer workloadidentity.TokenIssuer,
-	coreInformerFactory gardencoreinformers.SharedInformerFactory,
+	shootListers gardencorev1beta1listers.ShootLister,
+	seedLister gardencorev1beta1listers.SeedLister,
+	projectLister gardencorev1beta1listers.ProjectLister,
+	backupBucketLister gardencorev1beta1listers.BackupBucketLister,
+	backupEntryLister gardencorev1beta1listers.BackupEntryLister,
 ) *TokenRequestREST {
 	return &TokenRequestREST{
 		workloadIdentityGetter: storage,
 
-		tokenIssuer:         tokenIssuer,
-		coreInformerFactory: coreInformerFactory,
+		tokenIssuer:        tokenIssuer,
+		shootListers:       shootListers,
+		seedLister:         seedLister,
+		projectLister:      projectLister,
+		backupBucketLister: backupBucketLister,
+		backupEntryLister:  backupEntryLister,
 	}
 }

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -80,10 +80,7 @@ func setTaskAnnotations(annotations map[string]string, tasks []string) {
 // GetMainReconciliationContext returns a context with timeout for the controller's main client. The resulting context has a timeout equal to the timeout passed in the argument but
 // not more than DefaultReconciliationTimeout.
 func GetMainReconciliationContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	t := timeout
-	if timeout > DefaultReconciliationTimeout {
-		t = DefaultReconciliationTimeout
-	}
+	t := min(timeout, DefaultReconciliationTimeout)
 
 	return context.WithTimeout(ctx, t)
 }
@@ -91,10 +88,7 @@ func GetMainReconciliationContext(ctx context.Context, timeout time.Duration) (c
 // GetChildReconciliationContext returns context with timeout for the controller's secondary client. The resulting context has a timeout equal to half of the timeout
 // for the controller's main client.
 func GetChildReconciliationContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	t := timeout
-	if timeout > DefaultReconciliationTimeout {
-		t = DefaultReconciliationTimeout
-	}
+	t := min(timeout, DefaultReconciliationTimeout)
 
 	return context.WithTimeout(ctx, t/2)
 }

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -330,15 +330,9 @@ func (r *Reconciler) deleteBackupBucket(
 
 	log.Info("Successfully deleted")
 
-	credentials, err := kubernetesutils.GetCredentialsByObjectReference(gardenCtx, r.GardenClient, *backupBucket.Spec.CredentialsRef)
-	if err != nil {
-		log.Error(err, "Failed to get backup credentials", "credentialsRef", backupBucket.Spec.CredentialsRef)
-		return reconcile.Result{}, err
-	}
-
-	if controllerutil.ContainsFinalizer(credentials, gardencorev1beta1.ExternalGardenerName) {
-		log.Info("Removing finalizer from credentials", "credentials", client.ObjectKeyFromObject(credentials))
-		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, credentials, gardencorev1beta1.ExternalGardenerName); err != nil {
+	if controllerutil.ContainsFinalizer(backupCredentials, gardencorev1beta1.ExternalGardenerName) {
+		log.Info("Removing finalizer from credentials", "kind", backupCredentials.GetObjectKind().GroupVersionKind().Kind, "credentials", client.ObjectKeyFromObject(backupCredentials))
+		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, backupCredentials, gardencorev1beta1.ExternalGardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from credentials: %w", err)
 		}
 	}

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -115,7 +115,7 @@ func (r *Reconciler) reconcileBackupBucket(
 	}
 
 	if !controllerutil.ContainsFinalizer(backupCredentials, gardencorev1beta1.ExternalGardenerName) {
-		log.Info("Adding finalizer to backup credentials", "kind", backupCredentials.GetObjectKind().GroupVersionKind().Kind, "key", client.ObjectKeyFromObject(backupCredentials))
+		log.Info("Adding finalizer to backup credentials", "gvk", backupCredentials.GetObjectKind().GroupVersionKind().String(), "key", client.ObjectKeyFromObject(backupCredentials))
 		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, backupCredentials, gardencorev1beta1.ExternalGardenerName); err != nil {
 			return fmt.Errorf("failed to add finalizer to backup credentials: %w", err)
 		}
@@ -331,7 +331,7 @@ func (r *Reconciler) deleteBackupBucket(
 	log.Info("Successfully deleted")
 
 	if controllerutil.ContainsFinalizer(backupCredentials, gardencorev1beta1.ExternalGardenerName) {
-		log.Info("Removing finalizer from credentials", "kind", backupCredentials.GetObjectKind().GroupVersionKind().Kind, "credentials", client.ObjectKeyFromObject(backupCredentials))
+		log.Info("Removing finalizer from credentials", "gvk", backupCredentials.GetObjectKind().GroupVersionKind().String(), "credentials", client.ObjectKeyFromObject(backupCredentials))
 		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, backupCredentials, gardencorev1beta1.ExternalGardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from credentials: %w", err)
 		}
@@ -380,7 +380,7 @@ func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, e
 		}
 		return s.Reconcile(ctx, r.SeedClient)
 	default:
-		return fmt.Errorf("unsupported credentials type GVK: %q", backupCredentials.GetObjectKind().GroupVersionKind())
+		return fmt.Errorf("unsupported credentials type GVK: %q", backupCredentials.GetObjectKind().GroupVersionKind().String())
 	}
 }
 

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -28,10 +28,12 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/workloadidentity"
 )
 
 // finalizerName is the backupbucket controller finalizer.
@@ -105,17 +107,17 @@ func (r *Reconciler) reconcileBackupBucket(
 		return fmt.Errorf("could not update status after reconciliation start: %w", updateErr)
 	}
 
-	gardenSecret, err := kubernetesutils.GetSecretByObjectReference(gardenCtx, r.GardenClient, backupBucket.Spec.CredentialsRef) // TODO(vpnachev): Add support for WorkloadIdentity
+	backupCredentials, err := kubernetesutils.GetCredentialsByObjectReference(gardenCtx, r.GardenClient, *backupBucket.Spec.CredentialsRef)
 	if err != nil {
-		log.Error(err, "Failed to get backup secret", "credentialsRef", backupBucket.Spec.CredentialsRef)
-		r.Recorder.Eventf(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, "Failed to get backup secret from credentials reference %v: %w", backupBucket.Spec.CredentialsRef, err)
+		log.Error(err, "Failed to get backup credentials", "credentialsRef", backupBucket.Spec.CredentialsRef)
+		r.Recorder.Eventf(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, "Failed to get backup credentials from reference %v: %w", backupBucket.Spec.CredentialsRef, err)
 		return err
 	}
 
-	if !controllerutil.ContainsFinalizer(gardenSecret, gardencorev1beta1.ExternalGardenerName) {
-		log.Info("Adding finalizer to secret", "secret", client.ObjectKeyFromObject(gardenSecret))
-		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, gardenSecret, gardencorev1beta1.ExternalGardenerName); err != nil {
-			return fmt.Errorf("failed to add finalizer to backup secret: %w", err)
+	if !controllerutil.ContainsFinalizer(backupCredentials, gardencorev1beta1.ExternalGardenerName) {
+		log.Info("Adding finalizer to backup credentials", "kind", backupCredentials.GetObjectKind().GroupVersionKind().Kind, "key", client.ObjectKeyFromObject(backupCredentials))
+		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, backupCredentials, gardencorev1beta1.ExternalGardenerName); err != nil {
+			return fmt.Errorf("failed to add finalizer to backup credentials: %w", err)
 		}
 	}
 
@@ -147,11 +149,22 @@ func (r *Reconciler) reconcileBackupBucket(
 		// if the extension secret doesn't exist yet, create it
 		mustReconcileExtensionSecret = true
 	} else {
-		// if the backupBucket secret data has changed, reconcile extension backupBucket and extension secret
-		if !reflect.DeepEqual(extensionSecret.Data, gardenSecret.Data) {
-			mustReconcileExtensionBackupBucket = true
-			mustReconcileExtensionSecret = true
+		switch credentials := backupCredentials.(type) {
+		case *corev1.Secret:
+			// if the backupBucket secret data has changed, reconcile extension backupBucket and extension secret
+			if !reflect.DeepEqual(extensionSecret.Data, credentials.Data) {
+				mustReconcileExtensionBackupBucket = true
+				mustReconcileExtensionSecret = true
+			}
+		case *securityv1alpha1.WorkloadIdentity:
+			if secretChanged, err := workloadIdentitySecretChanged(backupBucket, extensionSecret, credentials); err != nil {
+				return err
+			} else if secretChanged {
+				mustReconcileExtensionBackupBucket = true
+				mustReconcileExtensionSecret = true
+			}
 		}
+
 		// if the timestamp is not present yet (needed for existing secrets), reconcile the secret
 		if _, timestampPresent := extensionSecret.Annotations[v1beta1constants.GardenerTimestamp]; !timestampPresent {
 			mustReconcileExtensionSecret = true
@@ -159,14 +172,16 @@ func (r *Reconciler) reconcileBackupBucket(
 	}
 
 	if mustReconcileExtensionSecret {
-		if err := r.reconcileBackupBucketExtensionSecret(seedCtx, extensionSecret, gardenSecret); err != nil {
+		if err := r.reconcileBackupBucketExtensionSecret(seedCtx, extensionSecret, backupCredentials, backupBucket); err != nil {
 			return err
 		}
 	}
 
-	secretLastUpdateTime, err := time.Parse(time.RFC3339Nano, extensionSecret.Annotations[v1beta1constants.GardenerTimestamp])
-	if err != nil {
-		return err
+	secretLastUpdateTime := time.Time{}
+	if lastUpdateTime, ok := extensionSecret.Annotations[v1beta1constants.GardenerTimestamp]; ok {
+		if secretLastUpdateTime, err = time.Parse(time.RFC3339Nano, lastUpdateTime); err != nil {
+			return err
+		}
 	}
 
 	// truncate the secret timestamp because extension.Status.LastOperation.LastUpdateTime
@@ -180,8 +195,9 @@ func (r *Reconciler) reconcileBackupBucket(
 		// if the extension BackupBucket doesn't exist yet, create it
 		mustReconcileExtensionBackupBucket = true
 	} else if !reflect.DeepEqual(extensionBackupBucket.Spec, extensionBackupBucketSpec) ||
-		(extensionBackupBucket.Status.LastOperation != nil && extensionBackupBucket.Status.LastOperation.LastUpdateTime.Time.UTC().Before(secretLastUpdateTime)) {
-		// if the spec of the extensionBackupBucket has changed or it has not been reconciled after the last updation of secret, reconcile it
+		(extensionBackupBucket.Status.LastOperation != nil && extensionBackupBucket.Status.LastOperation.LastUpdateTime.Time.UTC().Before(secretLastUpdateTime)) ||
+		secretLastUpdateTime.IsZero() {
+		// if the spec of the extensionBackupBucket has changed, or it has not been reconciled after the last update of secret, or secret last update timestamp is zero - reconcile it
 		mustReconcileExtensionBackupBucket = true
 	} else if extensionBackupBucket.Status.LastOperation == nil {
 		// if the extension did not record a lastOperation yet, record it as error in the backupbucket status
@@ -273,13 +289,13 @@ func (r *Reconciler) deleteBackupBucket(
 		return reconcile.Result{}, err
 	}
 
-	gardenSecret, err := kubernetesutils.GetSecretByObjectReference(gardenCtx, r.GardenClient, backupBucket.Spec.CredentialsRef) // TODO(vpnachev): Add support for WorkloadIdentity
+	backupCredentials, err := kubernetesutils.GetCredentialsByObjectReference(gardenCtx, r.GardenClient, *backupBucket.Spec.CredentialsRef)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	extensionSecret := r.emptyExtensionSecret(backupBucket.Name)
-	if err := r.reconcileBackupBucketExtensionSecret(seedCtx, extensionSecret, gardenSecret); err != nil {
+	if err := r.reconcileBackupBucketExtensionSecret(seedCtx, extensionSecret, backupCredentials, backupBucket); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -314,16 +330,16 @@ func (r *Reconciler) deleteBackupBucket(
 
 	log.Info("Successfully deleted")
 
-	secret, err := kubernetesutils.GetSecretByObjectReference(gardenCtx, r.GardenClient, backupBucket.Spec.CredentialsRef)
+	credentials, err := kubernetesutils.GetCredentialsByObjectReference(gardenCtx, r.GardenClient, *backupBucket.Spec.CredentialsRef)
 	if err != nil {
-		log.Error(err, "Failed to get backup secret", "credentialsRef", backupBucket.Spec.CredentialsRef)
+		log.Error(err, "Failed to get backup credentials", "credentialsRef", backupBucket.Spec.CredentialsRef)
 		return reconcile.Result{}, err
 	}
 
-	if controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
-		log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secret))
-		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)
+	if controllerutil.ContainsFinalizer(credentials, gardencorev1beta1.ExternalGardenerName) {
+		log.Info("Removing finalizer from credentials", "credentials", client.ObjectKeyFromObject(credentials))
+		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, credentials, gardencorev1beta1.ExternalGardenerName); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from credentials: %w", err)
 		}
 	}
 
@@ -346,13 +362,32 @@ func (r *Reconciler) emptyExtensionSecret(backupBucketName string) *corev1.Secre
 	}
 }
 
-func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, extensionSecret, gardenSecret *corev1.Secret) error {
-	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
-		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339Nano))
-		extensionSecret.Data = gardenSecret.Data
-		return nil
-	})
-	return err
+func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, extensionSecret *corev1.Secret, backupCredentials client.Object, backupBucket *gardencorev1beta1.BackupBucket) error {
+	now := r.Clock.Now().UTC().Format(time.RFC3339Nano)
+	switch credentials := backupCredentials.(type) {
+	case *corev1.Secret:
+		_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
+			metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, now)
+			extensionSecret.Data = credentials.Data
+			return nil
+		})
+		return err
+	case *securityv1alpha1.WorkloadIdentity:
+		s, err := workloadidentity.NewSecret(
+			extensionSecret.Name,
+			extensionSecret.Namespace,
+			workloadidentity.For(credentials.GetName(), credentials.GetNamespace(), credentials.Spec.TargetSystem.Type),
+			workloadidentity.WithProviderConfig(credentials.Spec.TargetSystem.ProviderConfig),
+			workloadidentity.WithContextObject(securityv1alpha1.ContextObject{APIVersion: backupBucket.APIVersion, Kind: backupBucket.Kind, Name: backupBucket.GetName(), UID: backupBucket.GetUID()}),
+			workloadidentity.WithAnnotations(map[string]string{v1beta1constants.GardenerTimestamp: now}),
+		)
+		if err != nil {
+			return err
+		}
+		return s.Reconcile(ctx, r.SeedClient)
+	default:
+		return fmt.Errorf("unsupported credentials type GVK: %q", backupCredentials.GetObjectKind().GroupVersionKind())
+	}
 }
 
 func (r *Reconciler) syncGeneratedSecretToGarden(gardenCtx context.Context, seedCtx context.Context, backupBucket *gardencorev1beta1.BackupBucket, extensionBackupBucket *extensionsv1alpha1.BackupBucket) error {
@@ -490,4 +525,21 @@ func generateBackupBucketSecretName(backupBucketName string) string {
 
 func generateGeneratedBackupBucketSecretName(backupBucketName string) string {
 	return v1beta1constants.SecretPrefixGeneratedBackupBucket + backupBucketName
+}
+
+func workloadIdentitySecretChanged(backupBucket *gardencorev1beta1.BackupBucket, secretToCompareTo *corev1.Secret, workloadIdentity *securityv1alpha1.WorkloadIdentity) (bool, error) {
+	opts := []workloadidentity.SecretOption{
+		workloadidentity.For(workloadIdentity.GetName(), workloadIdentity.GetNamespace(), workloadIdentity.Spec.TargetSystem.Type),
+		workloadidentity.WithProviderConfig(workloadIdentity.Spec.TargetSystem.ProviderConfig),
+		workloadidentity.WithContextObject(securityv1alpha1.ContextObject{APIVersion: backupBucket.APIVersion, Kind: backupBucket.Kind, Name: backupBucket.GetName(), UID: backupBucket.GetUID()}),
+	}
+	if val, ok := secretToCompareTo.Annotations[v1beta1constants.GardenerTimestamp]; ok {
+		opts = append(opts, workloadidentity.WithAnnotations(map[string]string{v1beta1constants.GardenerTimestamp: val}))
+	}
+	s, err := workloadidentity.NewSecret(secretToCompareTo.Name, secretToCompareTo.Namespace, opts...)
+	if err != nil {
+		return false, err
+	}
+
+	return !s.Equal(secretToCompareTo), nil
 }

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -336,7 +336,6 @@ var _ = Describe("Controller", func() {
 				"security.gardener.cloud/purpose":                   "workload-identity-token-requestor",
 				"workloadidentity.security.gardener.cloud/provider": "local",
 			}
-			extensionSecret.Data = map[string][]byte{"config": []byte("null")}
 			extensionSecret.Type = "Opaque"
 		})
 
@@ -346,7 +345,7 @@ var _ = Describe("Controller", func() {
 			Expect(result).To(Equal(reconcile.Result{}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
-			Expect(extensionSecret.Data).To(Equal(map[string][]byte{"config": []byte("null")}))
+			Expect(extensionSecret.Data).To(BeEmpty())
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
 			Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{
@@ -393,7 +392,8 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should reconcile the extension BackupBucket if the secret data has changed", func() {
-			extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+			// the workloadIdentity.spec.targetSystem.providerConfig=nil will cause the `config` data key to be removed from the secret
+			extensionSecret.Data = map[string][]byte{"config": []byte("null")}
 			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
 			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
 

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Controller", func() {
 			extensionSecret.Data = gardenSecret.Data
 		})
 
-		It("should create the extension secret and extension BackupBucket if then do not exist yet", func() {
+		It("should create the extension secret and extension BackupBucket if they do not exist yet", func() {
 			result, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -326,6 +326,7 @@ var _ = Describe("Controller", func() {
 			}
 			Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
 			Expect(gardenClient.Create(ctx, workloadIdentity)).To(Succeed())
+
 			extensionSecret.Annotations = map[string]string{
 				"gardener.cloud/timestamp":                                now.Format(time.RFC3339Nano),
 				"workloadidentity.security.gardener.cloud/context-object": `{"kind":"BackupBucket","apiVersion":"core.gardener.cloud/v1beta1","name":"foo","uid":""}`,
@@ -410,7 +411,7 @@ var _ = Describe("Controller", func() {
 			// the workloadIdentity.spec.targetSystem.providerConfig=nil will cause the `config` data key to be removed from the secret
 			extensionSecret.Data = map[string][]byte{"config": []byte("null")}
 			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
-			delete(extensionBackupBucket.Annotations, "gardener.cloud/operation")
+			Expect(extensionBackupBucket.Annotations).ToNot(HaveKey("gardener.cloud/operation"))
 			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, request)

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -24,9 +24,11 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/backupbucket"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 const (
@@ -44,11 +46,13 @@ var _ = Describe("Controller", func() {
 		fakeClock *testclock.FakeClock
 
 		gardenSecret          *corev1.Secret
+		workloadIdentity      *securityv1alpha1.WorkloadIdentity
 		backupBucket          *gardencorev1beta1.BackupBucket
 		extensionBackupBucket *extensionsv1alpha1.BackupBucket
 		extensionSecret       *corev1.Secret
 		providerConfig        = &runtime.RawExtension{Raw: []byte(`{"dash":"baz"}`)}
 		providerStatus        = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
+		now                   time.Time
 
 		request reconcile.Request
 	)
@@ -63,7 +67,18 @@ var _ = Describe("Controller", func() {
 				"foo": []byte("bar"),
 			},
 		}
-
+		workloadIdentity = &securityv1alpha1.WorkloadIdentity{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-workload-identity",
+				Namespace: gardenNamespaceName,
+			},
+			Spec: securityv1alpha1.WorkloadIdentitySpec{
+				Audiences: []string{"test"},
+				TargetSystem: securityv1alpha1.TargetSystem{
+					Type: "local",
+				},
+			},
+		}
 		backupBucket = &gardencorev1beta1.BackupBucket{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "foo",
@@ -75,13 +90,7 @@ var _ = Describe("Controller", func() {
 					Region: "some-region",
 				},
 				ProviderConfig: providerConfig,
-				CredentialsRef: &corev1.ObjectReference{
-					APIVersion: "v1",
-					Kind:       "Secret",
-					Namespace:  gardenSecret.Namespace,
-					Name:       gardenSecret.Name,
-				},
-				SeedName: ptr.To(seedName),
+				SeedName:       ptr.To(seedName),
 			},
 			Status: gardencorev1beta1.BackupBucketStatus{
 				ObservedGeneration: 1,
@@ -118,19 +127,12 @@ var _ = Describe("Controller", func() {
 			SeedName:        seedName,
 		}
 
-		Expect(gardenClient.Create(ctx, gardenSecret)).To(Succeed())
-		Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
-
-		now := fakeClock.Now().UTC()
+		now = fakeClock.Now().UTC()
 		extensionSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      generateBackupBucketSecretName(backupBucket.Name),
 				Namespace: gardenNamespaceName,
-				Annotations: map[string]string{
-					v1beta1constants.GardenerTimestamp: now.Format(time.RFC3339Nano),
-				},
 			},
-			Data: gardenSecret.Data,
 		}
 
 		extensionBackupBucket = &extensionsv1alpha1.BackupBucket{
@@ -166,100 +168,273 @@ var _ = Describe("Controller", func() {
 		}
 	})
 
-	It("should create the extension secret and extension BackupBucket if it doesn't exist yet", func() {
-		result, err := reconciler.Reconcile(ctx, request)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{}))
+	Describe("#Invalid Credentials", func() {
+		It("should fail to reconcile with non-existing credentials", func() {
+			backupBucket.Spec.CredentialsRef = &corev1.ObjectReference{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Secret",
+				Namespace:  "non-existing",
+				Name:       "non-existing",
+			}
+			Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+			gardenSecret := corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: backupBucket.Spec.CredentialsRef.Namespace, Name: backupBucket.Spec.CredentialsRef.Name}}
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(&gardenSecret), &gardenSecret)).To(BeNotFoundError())
 
-		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
-		Expect(extensionSecret.Data).To(Equal(gardenSecret.Data))
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeNotFoundError())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
 
-		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
-		Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{
-			DefaultSpec: extensionsv1alpha1.DefaultSpec{
-				Type:           backupBucket.Spec.Provider.Type,
-				ProviderConfig: backupBucket.Spec.ProviderConfig,
-			},
-			Region: backupBucket.Spec.Provider.Region,
-			SecretRef: corev1.SecretReference{
-				Name:      extensionSecret.Name,
-				Namespace: extensionSecret.Namespace,
-			},
-		}))
+		It("should fail to reconcile with unsupported credentials", func() {
+			backupBucket.Spec.CredentialsRef = &corev1.ObjectReference{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "ConfigMap",
+				Namespace:  "garden",
+				Name:       "backup-cm",
+			}
+			Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+			gardenConfigMap := corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: backupBucket.Spec.CredentialsRef.Namespace, Name: backupBucket.Spec.CredentialsRef.Name}}
+			Expect(gardenClient.Create(ctx, &gardenConfigMap)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("unsupported credentials reference: garden/backup-cm, /v1, Kind=ConfigMap"))
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
 	})
 
-	It("should not reconcile the extension BackupBucket if the secret data or extension spec hasn't changed", func() {
-		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
-		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+	Describe("#Secrets Credentials", func() {
+		BeforeEach(func() {
+			backupBucket.Spec.CredentialsRef = &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Namespace:  gardenSecret.Namespace,
+				Name:       gardenSecret.Name,
+			}
+			Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+			Expect(gardenClient.Create(ctx, gardenSecret)).To(Succeed())
+			extensionSecret.Annotations = map[string]string{v1beta1constants.GardenerTimestamp: now.Format(time.RFC3339Nano)}
+			extensionSecret.Data = gardenSecret.Data
+		})
 
-		result, err := reconciler.Reconcile(ctx, request)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{}))
+		It("should create the extension secret and extension BackupBucket if it doesn't exist yet", func() {
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
 
-		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
-		Expect(extensionBackupBucket.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+			Expect(extensionSecret.Data).To(Equal(gardenSecret.Data))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           backupBucket.Spec.Provider.Type,
+					ProviderConfig: backupBucket.Spec.ProviderConfig,
+				},
+				Region: backupBucket.Spec.Provider.Region,
+				SecretRef: corev1.SecretReference{
+					Name:      extensionSecret.Name,
+					Namespace: extensionSecret.Namespace,
+				},
+			}))
+		})
+
+		It("should not reconcile the extension BackupBucket if the secret data or extension spec hasn't changed", func() {
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+		})
+
+		It("should reconcile the extension secret and extension BackupBucket if the secret currently doesn't have a timestamp", func() {
+			extensionSecret.Annotations = nil
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+			// step the clock so that the updated timestamp of the secret is greater than the extensionSecret lastUpdate time.
+			fakeClock.Step(time.Minute)
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+			Expect(extensionSecret.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339Nano)))
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+		})
+
+		It("should reconcile the extension BackupBucket if the secret data has changed", func() {
+			extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		})
+
+		It("should reconcile the extension BackupBucket if the secret update timestamp is after the extension last update time", func() {
+			time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339Nano)
+			metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		})
+
+		It("should reconcile the extension BackupBucket if it's been 12hrs after the extension's last reconciliation", func() {
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			extensionBackupBucket.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				Type:           gardencorev1beta1.LastOperationTypeReconcile,
+				LastUpdateTime: metav1.NewTime(now.Add(-13 * time.Hour)),
+			}
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+		})
 	})
 
-	It("should reconcile the extension secret and extension BackupBucket if the secret currently doesn't have a timestamp", func() {
-		extensionSecret.Annotations = nil
-		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
-		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+	Describe("#WorkloadIdentity Credentials", func() {
+		BeforeEach(func() {
+			backupBucket.TypeMeta = metav1.TypeMeta{APIVersion: "core.gardener.cloud/v1beta1", Kind: "BackupBucket"}
+			backupBucket.Spec.CredentialsRef = &corev1.ObjectReference{
+				APIVersion: securityv1alpha1.SchemeGroupVersion.String(),
+				Kind:       "WorkloadIdentity",
+				Namespace:  workloadIdentity.Namespace,
+				Name:       workloadIdentity.Name,
+			}
+			Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+			Expect(gardenClient.Create(ctx, workloadIdentity)).To(Succeed())
+			extensionSecret.Annotations = map[string]string{
+				"gardener.cloud/timestamp":                                now.Format(time.RFC3339Nano),
+				"workloadidentity.security.gardener.cloud/context-object": `{"kind":"BackupBucket","apiVersion":"core.gardener.cloud/v1beta1","name":"foo","uid":""}`,
+				"workloadidentity.security.gardener.cloud/name":           workloadIdentity.Name,
+				"workloadidentity.security.gardener.cloud/namespace":      workloadIdentity.Namespace,
+			}
+			extensionSecret.Labels = map[string]string{
+				"security.gardener.cloud/purpose":                   "workload-identity-token-requestor",
+				"workloadidentity.security.gardener.cloud/provider": "local",
+			}
+			extensionSecret.Data = map[string][]byte{"config": []byte("null")}
+			extensionSecret.Type = "Opaque"
+		})
 
-		// step the clock so that the updated timestamp of the secret is greater than the extensionSecret lastUpdate time.
-		fakeClock.Step(time.Minute)
+		It("should create the extension secret and extension BackupBucket if it doesn't exist yet", func() {
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
 
-		result, err := reconciler.Reconcile(ctx, request)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{}))
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+			Expect(extensionSecret.Data).To(Equal(map[string][]byte{"config": []byte("null")}))
 
-		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
-		Expect(extensionSecret.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339Nano)))
-		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
-		Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
-	})
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           backupBucket.Spec.Provider.Type,
+					ProviderConfig: backupBucket.Spec.ProviderConfig,
+				},
+				Region: backupBucket.Spec.Provider.Region,
+				SecretRef: corev1.SecretReference{
+					Name:      extensionSecret.Name,
+					Namespace: extensionSecret.Namespace,
+				},
+			}))
+		})
 
-	It("should reconcile the extension BackupBucket if the secret data has changed", func() {
-		extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
-		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
-		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+		It("should not reconcile the extension BackupBucket if the secret data or extension spec hasn't changed", func() {
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
 
-		result, err := reconciler.Reconcile(ctx, request)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{}))
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
 
-		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
-		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
-	})
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+		})
 
-	It("should reconcile the extension BackupBucket if the secret update timestamp is after the extension last update time", func() {
-		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339Nano)
-		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
-		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
-		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+		It("should reconcile the extension secret and extension BackupBucket if the secret currently doesn't have a timestamp", func() {
+			delete(extensionSecret.Annotations, "gardener.cloud/timestamp")
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
 
-		result, err := reconciler.Reconcile(ctx, request)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{}))
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
 
-		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
-		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
-	})
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+			Expect(extensionSecret.Annotations).To(HaveKeyWithValue("workloadidentity.security.gardener.cloud/context-object", `{"kind":"BackupBucket","apiVersion":"core.gardener.cloud/v1beta1","name":"foo","uid":""}`))
+			Expect(extensionSecret.Annotations).To(HaveKeyWithValue("workloadidentity.security.gardener.cloud/name", workloadIdentity.Name))
+			Expect(extensionSecret.Annotations).To(HaveKeyWithValue("workloadidentity.security.gardener.cloud/namespace", workloadIdentity.Namespace))
 
-	It("should reconcile the extension BackupBucket if it's been 12hrs after the extension's last reconciliation", func() {
-		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
-		extensionBackupBucket.Status.LastOperation = &gardencorev1beta1.LastOperation{
-			State:          gardencorev1beta1.LastOperationStateSucceeded,
-			Type:           gardencorev1beta1.LastOperationTypeReconcile,
-			LastUpdateTime: metav1.NewTime(fakeClock.Now().Add(-13 * time.Hour)),
-		}
-		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+		})
 
-		result, err := reconciler.Reconcile(ctx, request)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{}))
+		It("should reconcile the extension BackupBucket if the secret data has changed", func() {
+			extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
 
-		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
-		Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		})
+
+		It("should reconcile the extension BackupBucket if the secret update timestamp is after the extension last update time", func() {
+			time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339Nano)
+			metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, "gardener.cloud/timestamp", time)
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		})
+
+		It("should reconcile the extension BackupBucket if it's been 12hrs after the extension's last reconciliation", func() {
+			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+			extensionBackupBucket.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				Type:           gardencorev1beta1.LastOperationTypeReconcile,
+				LastUpdateTime: metav1.NewTime(now.Add(-13 * time.Hour)),
+			}
+			Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+			Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+		})
 	})
 })
 

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -678,7 +678,7 @@ func (r *Reconciler) reconcileBackupEntryExtensionSecret(ctx context.Context, ex
 		}
 		return s.Reconcile(ctx, r.SeedClient)
 	default:
-		return fmt.Errorf("unsupported credentials type GVK: %q", backupCredentials.GetObjectKind().GroupVersionKind())
+		return fmt.Errorf("unsupported credentials type GVK: %q", backupCredentials.GetObjectKind().GroupVersionKind().String())
 	}
 }
 

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -35,6 +36,7 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/workloadidentity"
 )
 
 var (
@@ -155,7 +157,7 @@ func (r *Reconciler) reconcileBackupEntry(
 		return nil
 	}
 
-	gardenSecret, err := r.getGardenSecret(gardenCtx, backupBucket)
+	gardenCredentials, err := kubernetesutils.GetCredentialsByObjectReference(gardenCtx, r.GardenClient, *backupBucket.Spec.CredentialsRef)
 	if err != nil {
 		return err
 	}
@@ -167,11 +169,22 @@ func (r *Reconciler) reconcileBackupEntry(
 		// if the extension secret doesn't exist yet, create it
 		mustReconcileExtensionSecret = true
 	} else {
-		// if the backupBucket secret data has changed, reconcile extension backupEntry and extension secret
-		if !reflect.DeepEqual(extensionSecret.Data, gardenSecret.Data) {
-			mustReconcileExtensionBackupEntry = true
-			mustReconcileExtensionSecret = true
+		switch credentials := gardenCredentials.(type) {
+		case *corev1.Secret:
+			// if the backupBucket secret data has changed, reconcile extension backupEntry and extension secret
+			if !reflect.DeepEqual(extensionSecret.Data, credentials.Data) {
+				mustReconcileExtensionBackupEntry = true
+				mustReconcileExtensionSecret = true
+			}
+		case *securityv1alpha1.WorkloadIdentity:
+			if secretChanged, err := workloadIdentitySecretChanged(backupEntry, extensionSecret, credentials); err != nil {
+				return err
+			} else if secretChanged {
+				mustReconcileExtensionBackupEntry = true
+				mustReconcileExtensionSecret = true
+			}
 		}
+
 		// if the timestamp is not present yet (needed for existing secrets), reconcile the secret
 		if _, timestampPresent := extensionSecret.Annotations[v1beta1constants.GardenerTimestamp]; !timestampPresent {
 			mustReconcileExtensionSecret = true
@@ -179,7 +192,7 @@ func (r *Reconciler) reconcileBackupEntry(
 	}
 
 	if mustReconcileExtensionSecret {
-		if err := r.reconcileBackupEntryExtensionSecret(seedCtx, extensionSecret, gardenSecret); err != nil {
+		if err := r.reconcileBackupEntryExtensionSecret(seedCtx, extensionSecret, gardenCredentials, backupEntry); err != nil {
 			return err
 		}
 	}
@@ -198,9 +211,11 @@ func (r *Reconciler) reconcileBackupEntry(
 		BackupBucketProviderStatus: backupBucket.Status.ProviderStatus,
 	}
 
-	secretLastUpdateTime, err := time.Parse(time.RFC3339Nano, extensionSecret.Annotations[v1beta1constants.GardenerTimestamp])
-	if err != nil {
-		return err
+	secretLastUpdateTime := time.Time{}
+	if lastUpdateTime, ok := extensionSecret.Annotations[v1beta1constants.GardenerTimestamp]; ok {
+		if secretLastUpdateTime, err = time.Parse(time.RFC3339Nano, lastUpdateTime); err != nil {
+			return err
+		}
 	}
 
 	// truncate the secret timestamp because extension.Status.LastOperation.LastUpdateTime
@@ -214,8 +229,9 @@ func (r *Reconciler) reconcileBackupEntry(
 		// if the extension BackupEntry doesn't exist yet, create it
 		mustReconcileExtensionBackupEntry = true
 	} else if !reflect.DeepEqual(extensionBackupEntry.Spec, extensionBackupEntrySpec) ||
-		(extensionBackupEntry.Status.LastOperation != nil && extensionBackupEntry.Status.LastOperation.LastUpdateTime.Time.UTC().Before(secretLastUpdateTime)) {
-		// if the spec of the extensionBackupEntry has changed or it has not been reconciled after the last updation of secret, reconcile it
+		(extensionBackupEntry.Status.LastOperation != nil && extensionBackupEntry.Status.LastOperation.LastUpdateTime.Time.UTC().Before(secretLastUpdateTime)) ||
+		secretLastUpdateTime.IsZero() {
+		// if the spec of the extensionBackupEntry has changed or it has not been reconciled after the last update of secret, , or secret last update timestamp is zero - reconcile it
 		mustReconcileExtensionBackupEntry = true
 	} else if extensionBackupEntry.Status.LastOperation == nil {
 		// if the extension did not record a lastOperation yet, record it as error in the backupentry status
@@ -321,12 +337,12 @@ func (r *Reconciler) deleteBackupEntry(
 			return reconcile.Result{}, nil
 		}
 
-		gardenSecret, err := r.getGardenSecret(gardenCtx, backupBucket)
+		gardenCredentials, err := kubernetesutils.GetCredentialsByObjectReference(gardenCtx, r.GardenClient, *backupBucket.Spec.CredentialsRef)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 
-		if err := r.reconcileBackupEntryExtensionSecret(seedCtx, extensionSecret, gardenSecret); err != nil {
+		if err := r.reconcileBackupEntryExtensionSecret(seedCtx, extensionSecret, gardenCredentials, backupEntry); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -638,34 +654,32 @@ func (r *Reconciler) checkIfBackupBucketIsHealthy(ctx context.Context, backupBuc
 	return nil
 }
 
-func (r *Reconciler) getGardenSecret(ctx context.Context, backupBucket *gardencorev1beta1.BackupBucket) (*corev1.Secret, error) {
-	if backupBucket.Spec.CredentialsRef.APIVersion == securityv1alpha1.SchemeGroupVersion.String() && backupBucket.Spec.CredentialsRef.Kind == "WorkloadIdentity" {
-		return nil, errors.New("WorkloadIdentity is not yet supported for backup credentials") // TODO(vpnachev): Add support for Workload Identity.
+func (r *Reconciler) reconcileBackupEntryExtensionSecret(ctx context.Context, extensionSecret *corev1.Secret, backupCredentials client.Object, backupEntry *gardencorev1beta1.BackupEntry) error {
+	now := r.Clock.Now().UTC().Format(time.RFC3339Nano)
+	switch credentials := backupCredentials.(type) {
+	case *corev1.Secret:
+		_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
+			metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, now)
+			extensionSecret.Data = credentials.Data
+			return nil
+		})
+		return err
+	case *securityv1alpha1.WorkloadIdentity:
+		s, err := workloadidentity.NewSecret(
+			extensionSecret.Name,
+			extensionSecret.Namespace,
+			workloadidentity.For(credentials.GetName(), credentials.GetNamespace(), credentials.Spec.TargetSystem.Type),
+			workloadidentity.WithProviderConfig(credentials.Spec.TargetSystem.ProviderConfig),
+			workloadidentity.WithContextObject(securityv1alpha1.ContextObject{APIVersion: backupEntry.APIVersion, Kind: backupEntry.Kind, Namespace: ptr.To(backupEntry.GetNamespace()), Name: backupEntry.GetName(), UID: backupEntry.GetUID()}),
+			workloadidentity.WithAnnotations(map[string]string{v1beta1constants.GardenerTimestamp: now}),
+		)
+		if err != nil {
+			return err
+		}
+		return s.Reconcile(ctx, r.SeedClient)
+	default:
+		return fmt.Errorf("unsupported credentials type GVK: %q", backupCredentials.GetObjectKind().GroupVersionKind())
 	}
-
-	gardenSecretRef := &corev1.SecretReference{Namespace: backupBucket.Spec.CredentialsRef.Namespace, Name: backupBucket.Spec.CredentialsRef.Name}
-	if backupBucket.Status.GeneratedSecretRef != nil {
-		gardenSecretRef = backupBucket.Status.GeneratedSecretRef
-	}
-
-	gardenSecret, err := kubernetesutils.GetSecretByReference(ctx, r.GardenClient, gardenSecretRef)
-	if err != nil {
-		return nil, fmt.Errorf("could not get secret referred in core backup bucket: %w", err)
-	}
-
-	return gardenSecret, nil
-}
-
-func (r *Reconciler) reconcileBackupEntryExtensionSecret(ctx context.Context, extensionSecret, gardenSecret *corev1.Secret) error {
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
-		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339Nano))
-		extensionSecret.Data = gardenSecret.DeepCopy().Data
-		return nil
-	}); err != nil {
-		return fmt.Errorf("could not reconcile extension secret in seed: %w", err)
-	}
-
-	return nil
 }
 
 // reconcileBackupEntryExtension deploys the BackupEntry extension resource in Seed with the required secret.
@@ -719,4 +733,21 @@ func removeGardenerOperationAnnotation(ctx context.Context, c client.Client, be 
 	patch := client.MergeFrom(be.DeepCopy())
 	delete(be.GetAnnotations(), v1beta1constants.GardenerOperation)
 	return c.Patch(ctx, be, patch)
+}
+
+func workloadIdentitySecretChanged(backupEntry *gardencorev1beta1.BackupEntry, secretToCompareTo *corev1.Secret, workloadIdentity *securityv1alpha1.WorkloadIdentity) (bool, error) {
+	opts := []workloadidentity.SecretOption{
+		workloadidentity.For(workloadIdentity.GetName(), workloadIdentity.GetNamespace(), workloadIdentity.Spec.TargetSystem.Type),
+		workloadidentity.WithProviderConfig(workloadIdentity.Spec.TargetSystem.ProviderConfig),
+		workloadidentity.WithContextObject(securityv1alpha1.ContextObject{APIVersion: backupEntry.APIVersion, Kind: backupEntry.Kind, Namespace: ptr.To(backupEntry.GetNamespace()), Name: backupEntry.GetName(), UID: backupEntry.GetUID()}),
+	}
+	if val, ok := secretToCompareTo.Annotations[v1beta1constants.GardenerTimestamp]; ok {
+		opts = append(opts, workloadidentity.WithAnnotations(map[string]string{v1beta1constants.GardenerTimestamp: val}))
+	}
+	s, err := workloadidentity.NewSecret(secretToCompareTo.Name, secretToCompareTo.Namespace, opts...)
+	if err != nil {
+		return false, err
+	}
+
+	return !s.Equal(secretToCompareTo), nil
 }

--- a/pkg/gardenlet/controller/backupentry/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler_test.go
@@ -345,7 +345,6 @@ var _ = Describe("Controller", func() {
 				"security.gardener.cloud/purpose":                   "workload-identity-token-requestor",
 				"workloadidentity.security.gardener.cloud/provider": "local",
 			}
-			extensionSecret.Data = map[string][]byte{"config": []byte("null")}
 			extensionSecret.Type = "Opaque"
 		})
 
@@ -355,7 +354,7 @@ var _ = Describe("Controller", func() {
 			Expect(result).To(Equal(reconcile.Result{}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
-			Expect(extensionSecret.Data).To(Equal(map[string][]byte{"config": []byte("null")}))
+			Expect(extensionSecret.Data).To(BeEmpty())
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
 			Expect(extensionBackupEntry.Spec).To(MatchFields(IgnoreExtras, Fields{
@@ -403,7 +402,8 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should reconcile the extension BackupEntry if the secret data has changed", func() {
-			extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+			// the workloadIdentity.spec.targetSystem.providerConfig=nil will cause the `config` data key to be removed from the secret
+			extensionSecret.Data = map[string][]byte{"config": []byte("null")}
 			Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
 			Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
 

--- a/pkg/gardenlet/controller/backupentry/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Controller", func() {
 			extensionSecret.Data = gardenSecret.Data
 		})
 
-		It("should create the extension secret and extension BackupEntry if it doesn't exist yet", func() {
+		It("should create the extension secret and extension BackupEntry if they do not exist yet", func() {
 			result, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -377,7 +377,7 @@ var _ = Describe("Controller", func() {
 			extensionSecret.Type = "Opaque"
 		})
 
-		It("should create the extension secret and extension BackupEntry if it doesn't exist yet", func() {
+		It("should create the extension secret and extension BackupEntry if they do not exist yet", func() {
 			result, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(reconcile.Result{}))

--- a/pkg/utils/workloadidentity/secret.go
+++ b/pkg/utils/workloadidentity/secret.go
@@ -9,9 +9,9 @@ import (
 	"encoding/json"
 	"errors"
 	"maps"
-	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -207,5 +207,5 @@ func (s *Secret) Reconcile(ctx context.Context, c client.Client) error {
 func (s *Secret) Equal(other *corev1.Secret) bool {
 	copySecret := other.DeepCopy()
 	s.reconcileSecret(copySecret, false)
-	return reflect.DeepEqual(other, copySecret)
+	return apiequality.Semantic.DeepEqual(other, copySecret)
 }

--- a/pkg/utils/workloadidentity/secret.go
+++ b/pkg/utils/workloadidentity/secret.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"maps"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,54 +141,71 @@ func WithContextObject(contextObject securityv1alpha1.ContextObject) SecretOptio
 	}
 }
 
+// reconcileSecret applies in-place the required modifications on the provided
+// <secret>. If <cleanDataKeys> is set, it deletes all data keys from the secret
+// except <token>, otherwise all data keys are preserved.
+func (s *Secret) reconcileSecret(secret *corev1.Secret, cleanDataKeys bool) {
+	secret.Type = corev1.SecretTypeOpaque
+
+	// preserve the renew timestamp if present but overwrite all other annotations
+	if v, ok := secret.Annotations[securityv1alpha1constants.AnnotationWorkloadIdentityTokenRenewTimestamp]; ok {
+		secret.Annotations = utils.MergeStringMaps(s.annotations, map[string]string{
+			securityv1alpha1constants.AnnotationWorkloadIdentityTokenRenewTimestamp: v,
+		})
+	} else {
+		secret.Annotations = s.annotations
+	}
+
+	metav1.SetMetaDataAnnotation(&secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityNamespace, s.workloadIdentityNamespace)
+	metav1.SetMetaDataAnnotation(&secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityName, s.workloadIdentityName)
+	if len(s.workloadIdentityContextObject) > 0 {
+		metav1.SetMetaDataAnnotation(&secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityContextObject, string(s.workloadIdentityContextObject))
+	} else {
+		delete(secret.Annotations, securityv1alpha1constants.AnnotationWorkloadIdentityContextObject)
+	}
+
+	secret.Labels = utils.MergeStringMaps(s.labels, map[string]string{
+		securityv1alpha1constants.LabelPurpose:                  securityv1alpha1constants.LabelPurposeWorkloadIdentityTokenRequestor,
+		securityv1alpha1constants.LabelWorkloadIdentityProvider: s.workloadIdentityProviderType,
+	})
+
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+
+	if cleanDataKeys {
+		// preserve the data token key if present but overwrite all other data keys
+		maps.DeleteFunc(secret.Data, func(k string, _ []byte) bool {
+			return k != securityv1alpha1constants.DataKeyToken
+		})
+	}
+
+	if len(s.workloadIdentityProviderConfig) > 0 {
+		secret.Data[securityv1alpha1constants.DataKeyConfig] = s.workloadIdentityProviderConfig
+	} else {
+		delete(secret.Data, securityv1alpha1constants.DataKeyConfig)
+	}
+}
+
 // Reconcile creates or patches the workload identity secret. Based on the struct configuration, it adds
 // annotations and labels that are recognized by the token requestor controller for workload identities.
 func (s *Secret) Reconcile(ctx context.Context, c client.Client) error {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c, s.secret, func() error {
-		s.secret.Type = corev1.SecretTypeOpaque
-
-		// preserve the renew timestamp if present but overwrite all other annotations
-		if v, ok := s.secret.Annotations[securityv1alpha1constants.AnnotationWorkloadIdentityTokenRenewTimestamp]; ok {
-			s.secret.Annotations = utils.MergeStringMaps(s.annotations, map[string]string{
-				securityv1alpha1constants.AnnotationWorkloadIdentityTokenRenewTimestamp: v,
-			})
-		} else {
-			s.secret.Annotations = s.annotations
-		}
-
-		metav1.SetMetaDataAnnotation(&s.secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityNamespace, s.workloadIdentityNamespace)
-		metav1.SetMetaDataAnnotation(&s.secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityName, s.workloadIdentityName)
-		if len(s.workloadIdentityContextObject) > 0 {
-			metav1.SetMetaDataAnnotation(&s.secret.ObjectMeta, securityv1alpha1constants.AnnotationWorkloadIdentityContextObject, string(s.workloadIdentityContextObject))
-		} else {
-			delete(s.secret.Annotations, securityv1alpha1constants.AnnotationWorkloadIdentityContextObject)
-		}
-
-		s.secret.Labels = utils.MergeStringMaps(s.labels, map[string]string{
-			securityv1alpha1constants.LabelPurpose:                  securityv1alpha1constants.LabelPurposeWorkloadIdentityTokenRequestor,
-			securityv1alpha1constants.LabelWorkloadIdentityProvider: s.workloadIdentityProviderType,
-		})
-
-		if s.secret.Data == nil {
-			s.secret.Data = make(map[string][]byte)
-		}
-
-		// preserve the data token key if present but overwrite all other data keys
-		maps.DeleteFunc(s.secret.Data, func(k string, _ []byte) bool {
-			return k != securityv1alpha1constants.DataKeyToken
-		})
-
-		if len(s.workloadIdentityProviderConfig) > 0 {
-			s.secret.Data[securityv1alpha1constants.DataKeyConfig] = s.workloadIdentityProviderConfig
-		} else {
-			delete(s.secret.Data, securityv1alpha1constants.DataKeyConfig)
-		}
-
+		s.reconcileSecret(s.secret, true)
 		return nil
 	},
 		// The token-requestor might concurrently update the secret token key to populate the token.
 		// Hence, we need to use optimistic locking here to ensure we don't accidentally overwrite the concurrent update.
 		// ref https://github.com/gardener/gardener/issues/6092#issuecomment-1156244514
-		controllerutils.MergeFromOption{MergeFromOption: client.MergeFromWithOptimisticLock{}})
+		controllerutils.MergeFromOption{MergeFromOption: client.MergeFromWithOptimisticLock{}},
+	)
 	return err
+}
+
+// Equal generates a workload identity secret based on the <other> Secret
+// and compare them if they are deeply equal.
+func (s *Secret) Equal(other *corev1.Secret) bool {
+	copySecret := other.DeepCopy()
+	s.reconcileSecret(copySecret, false)
+	return reflect.DeepEqual(other, copySecret)
 }

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -682,6 +682,7 @@ build:
             - pkg/apis/security
             - pkg/apis/security/install
             - pkg/apis/security/v1alpha1
+            - pkg/apis/security/v1alpha1/constants
             - pkg/apis/seedmanagement
             - pkg/apis/seedmanagement/encoding
             - pkg/apis/seedmanagement/install

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1084,6 +1084,7 @@ build:
             - pkg/apis/security
             - pkg/apis/security/install
             - pkg/apis/security/v1alpha1
+            - pkg/apis/security/v1alpha1/constants
             - pkg/apis/seedmanagement
             - pkg/apis/seedmanagement/encoding
             - pkg/apis/seedmanagement/install

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -713,6 +713,7 @@ build:
             - pkg/apis/security
             - pkg/apis/security/install
             - pkg/apis/security/v1alpha1
+            - pkg/apis/security/v1alpha1/constants
             - pkg/apis/seedmanagement
             - pkg/apis/seedmanagement/encoding
             - pkg/apis/seedmanagement/install


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement
/label ipcei/workload-identity 

**What this PR does / why we need it**:
Enables gardenlet.backupbucket, gardenlet.backupentry, and extensions.backupentry controllers with support for credentials of type WorkloadIdentity  

**Which issue(s) this PR fixes**:
Part of #9586 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
BackupBucket/BackupEntry controllers now support WorkloadIdentity type of credentials, provider extensions may need to adjust the respective controllers or to explicitly disallow BackupBuckets of their type to configure WorkloadIdentity. 
```


