### PR TITLE
Fix `CloudProfile` validation

### DIFF
--- a/pkg/apis/core/helper/cloudprofile.go
+++ b/pkg/apis/core/helper/cloudprofile.go
@@ -219,7 +219,9 @@ func GetMachineImageDiff(old, new []core.MachineImage) (removedMachineImages set
 func FilterVersionsWithClassification(versions []core.ExpirableVersion, classification core.VersionClassification) []core.ExpirableVersion {
 	var result []core.ExpirableVersion
 	for _, version := range versions {
-		if CurrentLifecycleClassification(version) != classification {
+		// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-32-PR.
+		//  The current behavior for nil classifications is treated differently across the codebase.
+		if version.Classification == nil || CurrentLifecycleClassification(version) != classification {
 			continue
 		}
 

--- a/pkg/apis/core/helper/cloudprofile_test.go
+++ b/pkg/apis/core/helper/cloudprofile_test.go
@@ -399,9 +399,9 @@ var _ = Describe("CloudProfile Helper", func() {
 	})
 
 	Describe("#FilterVersionsWithClassification", func() {
-		classification := core.ClassificationDeprecated
 		var (
-			versions = []core.ExpirableVersion{
+			classification = core.ClassificationSupported
+			versions       = []core.ExpirableVersion{
 				{
 					Version:        "1.0.2",
 					Classification: &classification,
@@ -415,6 +415,7 @@ var _ = Describe("CloudProfile Helper", func() {
 				},
 			}
 		)
+
 		It("should filter version", func() {
 			filteredVersions := FilterVersionsWithClassification(versions, classification)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind regression

**What this PR does / why we need it**:
The PR fixes a regression in the `CloudProfile` validation that led to errors when machine image versions didn't specify a `classification` (introduced by 2b37e9e6f17983db3d758f48cd3f2585da88708a).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @dimitar-kostadinov @ary1992 @LucaBernstein

The issue can be reproduced by applying a `CloudProfile` with the following images:
```
    - architectures:
      - amd64
      cri:
      - name: containerd
      inPlaceUpdates:
        supported: true
      version: 1.0.0
    - architectures:
      - amd64
      classification: supported
      cri:
      - name: containerd
      inPlaceUpdates:
        supported: true
      version: 1.0.0-custom
```

Thanks @ialidzhikov and @dimitar-kostadinov for reporting the issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A regression was fixed that previously prevented the creation or update of `CloudProfile`s without a specified machine image version `classification`.
```
