### PR TITLE
utils/gardener: Remove `GetOwnerDomain` function

### DIFF
--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -30,10 +30,6 @@ const (
 	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the apiserver domain would be
 	// 'api.cluster.example.com'.
 	APIServerFQDNPrefix = "api"
-	// OwnerFQDNPrefix is the part of a FQDN which will be used to construct the domain name for the owner of
-	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the owner domain would be
-	// 'owner.cluster.example.com'.
-	OwnerFQDNPrefix = "owner"
 	// IngressPrefix is the part of a FQDN which will be used to construct the domain name for an ingress controller of
 	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the ingress domain would be
 	// '*.<IngressPrefix>.cluster.example.com'.

--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -88,12 +88,6 @@ func GetAPIServerDomain(domain string) string {
 	return fmt.Sprintf("%s.%s", APIServerFQDNPrefix, domain)
 }
 
-// GetOwnerDomain returns the fully qualified domain name for the owner of the Shoot cluster. The
-// end result is 'owner.<domain>'.
-func GetOwnerDomain(domain string) string {
-	return fmt.Sprintf("%s.%s", OwnerFQDNPrefix, domain)
-}
-
 // GenerateDNSProviderName creates a name for the dns provider out of the passed `secretName` and `providerType`.
 func GenerateDNSProviderName(secretName, providerType string) string {
 	switch {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Function is unused. Probably a leftover after https://github.com/gardener/gardener/issues/6302

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
fyi @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
