### PR TITLE
Make `configure-admission.sh` use the tag configured in the files under `controllerregistrations`

### DIFF
--- a/example/provider-extensions/garden/configure-admission.sh
+++ b/example/provider-extensions/garden/configure-admission.sh
@@ -33,12 +33,26 @@ shift 2
 for p in $(yq '. | select(.kind == "ControllerDeployment") | select(.metadata.name == "provider-*" or .metadata.name == "networking-*") | .metadata.name' "$REPO_ROOT_DIR"/example/provider-extensions/garden/controllerregistrations/* | grep -v -E "^---$"); do
   echo "Found \"$p\" in $REPO_ROOT_DIR/example/provider-extensions/garden/controllerregistrations. Trying to configure its admission controller..."
   if PROVIDER_RELEASES=$(curl --fail -s -L -H "Accept: application/vnd.github+json" "https://api.github.com/repos/gardener/gardener-extension-$p/releases"); then
-    LATEST_RELEASE=$(jq -r '.[].tag_name' <<< "$PROVIDER_RELEASES" | head -n 1)
     ADMISSION_NAME=$(sed -E 's/(provider|networking)/admission/g' <<< $p)
-    echo "Identified $LATEST_RELEASE as latest release of $ADMISSION_NAME. Trying to $command it..."
+    RELEASE=$(jq -r '.[].tag_name' <<< "$PROVIDER_RELEASES" | head -n 1)
+    echo "Identified \"$RELEASE\" as latest release of $ADMISSION_NAME."
+    IMAGE=$(yq ". | select(.kind == \"ControllerDeployment\") | select(.metadata.name == \"$p\") | .helm.values.image" "$REPO_ROOT_DIR"/example/provider-extensions/garden/controllerregistrations/*)
+    if [ -n "$(yq '.tag' <<< "$IMAGE")" ]; then
+      CONTROLLER_DEPLOYMENT_RELEASE=$(yq '.tag' <<< "$IMAGE")
+    else
+      CONTROLLER_DEPLOYMENT_RELEASE=${IMAGE#*:}
+    fi
+    echo "Identified \"$CONTROLLER_DEPLOYMENT_RELEASE\" as currently used release of \"$p\" ControllerDeployment from its '.providerConfig.values.image.tag' field."
+    if [[ $(jq -r "any(.[].tag_name; . == \"$CONTROLLER_DEPLOYMENT_RELEASE\")" <<< "$PROVIDER_RELEASES") == "true" ]]; then
+      RELEASE=$CONTROLLER_DEPLOYMENT_RELEASE
+    else
+      echo "Could not find \"$CONTROLLER_DEPLOYMENT_RELEASE\" release in the set of github repository releases of \"$p\"."
+      echo "Using latest release instead."
+    fi
+    echo "Trying to deploy $ADMISSION_NAME with $RELEASE ..."
     ADMISSION_GIT_ROOT=$(mktemp -d)
     ADMISSION_FILE=$(mktemp)
-    curl --fail -L -o "$ADMISSION_FILE" "https://github.com/gardener/gardener-extension-$p/archive/refs/tags/$LATEST_RELEASE.tar.gz"
+    curl --fail -L -o "$ADMISSION_FILE" "https://github.com/gardener/gardener-extension-$p/archive/refs/tags/$RELEASE.tar.gz"
     tar xfz "$ADMISSION_FILE" -C "$ADMISSION_GIT_ROOT" --strip-components 1
     ADMISSION_CHARTS_DIR="$ADMISSION_GIT_ROOT/charts/gardener-extension-$ADMISSION_NAME/charts"
     set +e
@@ -48,13 +62,13 @@ for p in $(yq '. | select(.kind == "ControllerDeployment") | select(.metadata.na
     if [ $NEW_VALUES == 0 ]; then
       # Found .Values.global.* in the chart. Deploy it with "global" values...
       echo "Deploying $ADMISSION_NAME with deprecated global values..."
-      helm template --namespace garden --set global.image.tag="$LATEST_RELEASE" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_CHARTS_DIR"/application > "$ADMISSION_GIT_ROOT"/virtual-resources.yaml
-      helm template --namespace garden --set global.image.tag="$LATEST_RELEASE" --set global.kubeconfig="$(cat "$garden_kubeconfig" | sed 's/127.0.0.1:.*$/kubernetes.default.svc.cluster.local/g')" --set global.vpa.enabled="false" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_CHARTS_DIR"/runtime > "$ADMISSION_GIT_ROOT"/runtime-resources.yaml
+      helm template --namespace garden --set global.image.tag="$RELEASE" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_CHARTS_DIR"/application > "$ADMISSION_GIT_ROOT"/virtual-resources.yaml
+      helm template --namespace garden --set global.image.tag="$RELEASE" --set global.kubeconfig="$(cat "$garden_kubeconfig" | sed 's/127.0.0.1:.*$/kubernetes.default.svc.cluster.local/g')" --set global.vpa.enabled="false" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_CHARTS_DIR"/runtime > "$ADMISSION_GIT_ROOT"/runtime-resources.yaml
     else
       # No .Values.global.* found in the chart. Deploy it with new values...
       echo "Deploying $ADMISSION_NAME with new values..."
-      helm template --namespace garden --set image.tag="$LATEST_RELEASE" --set gardener.virtualCluster.enabled="false" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_CHARTS_DIR"/application > "$ADMISSION_GIT_ROOT"/virtual-resources.yaml
-      helm template --namespace garden --set image.tag="$LATEST_RELEASE" --set gardener.virtualCluster.enabled="false" --set kubeconfig="$(cat "$garden_kubeconfig" | sed 's/127.0.0.1:.*$/kubernetes.default.svc.cluster.local/g')" --set vpa.enabled="false" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_CHARTS_DIR"/runtime > "$ADMISSION_GIT_ROOT"/runtime-resources.yaml
+      helm template --namespace garden --set image.tag="$RELEASE" --set gardener.virtualCluster.enabled="false" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_CHARTS_DIR"/application > "$ADMISSION_GIT_ROOT"/virtual-resources.yaml
+      helm template --namespace garden --set image.tag="$RELEASE" --set gardener.virtualCluster.enabled="false" --set kubeconfig="$(cat "$garden_kubeconfig" | sed 's/127.0.0.1:.*$/kubernetes.default.svc.cluster.local/g')" --set vpa.enabled="false" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_CHARTS_DIR"/runtime > "$ADMISSION_GIT_ROOT"/runtime-resources.yaml
     fi
     kubectl --kubeconfig "$garden_kubeconfig" "$command" "$@" -f "$ADMISSION_GIT_ROOT/virtual-resources.yaml"
     kubectl --kubeconfig "$garden_kubeconfig" "$command" "$@" -f "$ADMISSION_GIT_ROOT/runtime-resources.yaml"
@@ -62,7 +76,7 @@ for p in $(yq '. | select(.kind == "ControllerDeployment") | select(.metadata.na
       kubectl --kubeconfig "$garden_kubeconfig" wait --for=condition=available deployment -l app.kubernetes.io/name=gardener-extension-"$ADMISSION_NAME" -n garden --timeout 5m
     fi
     rm -rf "$ADMISSION_FILE" "$ADMISSION_GIT_ROOT"
-    echo "Successfully deployed $ADMISSION_NAME:$LATEST_RELEASE."
+    echo "Successfully deployed $ADMISSION_NAME:$RELEASE."
   else
     echo "Github repository releases of \"$p\" not found."
   fi

--- a/example/provider-extensions/garden/configure-admission.sh
+++ b/example/provider-extensions/garden/configure-admission.sh
@@ -49,7 +49,7 @@ for p in $(yq '. | select(.kind == "ControllerDeployment") | select(.metadata.na
       echo "Could not find \"$CONTROLLER_DEPLOYMENT_RELEASE\" release in the set of github repository releases of \"$p\"."
       echo "Using latest release \"$RELEASE\" instead."
     fi
-    echo "Trying to deploy $ADMISSION_NAME with $RELEASE..."
+    echo "Trying to $command $ADMISSION_NAME with $RELEASE..."
     ADMISSION_GIT_ROOT=$(mktemp -d)
     ADMISSION_FILE=$(mktemp)
     curl --fail -L -o "$ADMISSION_FILE" "https://github.com/gardener/gardener-extension-$p/archive/refs/tags/$RELEASE.tar.gz"
@@ -76,7 +76,7 @@ for p in $(yq '. | select(.kind == "ControllerDeployment") | select(.metadata.na
       kubectl --kubeconfig "$garden_kubeconfig" wait --for=condition=available deployment -l app.kubernetes.io/name=gardener-extension-"$ADMISSION_NAME" -n garden --timeout 5m
     fi
     rm -rf "$ADMISSION_FILE" "$ADMISSION_GIT_ROOT"
-    echo "Successfully deployed $ADMISSION_NAME:$RELEASE."
+    echo "Successful execution of '$command' operation for $ADMISSION_NAME:$RELEASE."
   else
     echo "Github repository releases of \"$p\" not found."
   fi

--- a/example/provider-extensions/garden/configure-admission.sh
+++ b/example/provider-extensions/garden/configure-admission.sh
@@ -47,9 +47,9 @@ for p in $(yq '. | select(.kind == "ControllerDeployment") | select(.metadata.na
       RELEASE=$CONTROLLER_DEPLOYMENT_RELEASE
     else
       echo "Could not find \"$CONTROLLER_DEPLOYMENT_RELEASE\" release in the set of github repository releases of \"$p\"."
-      echo "Using latest release instead."
+      echo "Using latest release \"$RELEASE\" instead."
     fi
-    echo "Trying to deploy $ADMISSION_NAME with $RELEASE ..."
+    echo "Trying to deploy $ADMISSION_NAME with $RELEASE..."
     ADMISSION_GIT_ROOT=$(mktemp -d)
     ADMISSION_FILE=$(mktemp)
     curl --fail -L -o "$ADMISSION_FILE" "https://github.com/gardener/gardener-extension-$p/archive/refs/tags/$RELEASE.tar.gz"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Makes script `configure-admission.sh` use the tag configured in the files under `controllerregistrations` or else fall back to latest release tag.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @plkokanov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
