### PR TITLE
Promote feature gate `RemoveAPIServerProxyLegacyPort` to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -31,8 +31,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
 | CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
-| RemoveAPIServerProxyLegacyPort           | `false` | `Alpha` | `1.113` | `1.118` |
-| RemoveAPIServerProxyLegacyPort           | `true`  | `Beta`  | `1.119` |         |
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
 | CloudProfileCapabilities                 | `false` | `Alpha` | `1.117` |         |
 | DoNotCopyBackupCredentials               | `false` | `Alpha` | `1.121` |         |
@@ -191,6 +189,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | NewVPN                                       | `false` | `Alpha`      | `1.104` | `1.114` |
 | NewVPN                                       | `true`  | `Beta`       | `1.115` | `1.115` |
 | NewVPN                                       | `true`  | `GA`         | `1.116` |         |
+| RemoveAPIServerProxyLegacyPort               | `false` | `Alpha`      | `1.113` | `1.118` |
+| RemoveAPIServerProxyLegacyPort               | `true`  | `Beta`       | `1.119` | `1.121` |
+| RemoveAPIServerProxyLegacyPort               | `true`  | `GA`         | `1.122` |         |
 
 ## Using a Feature
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -81,6 +81,7 @@ const (
 	// owner: @Wieneo @timebertt
 	// alpha: v1.113.0
 	// beta: v1.119.0
+	// GA: v1.122.0
 	RemoveAPIServerProxyLegacyPort featuregate.Feature = "RemoveAPIServerProxyLegacyPort"
 
 	// IstioTLSTermination enables TLS termination for the Istio Ingress Gateway instead of TLS termination at the kube-apiserver.
@@ -137,7 +138,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	NodeAgentAuthorizer:                      {Default: true, PreRelease: featuregate.Beta},
 	CredentialsRotationWithoutWorkersRollout: {Default: true, PreRelease: featuregate.Beta},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},
-	RemoveAPIServerProxyLegacyPort:           {Default: true, PreRelease: featuregate.Beta},
+	RemoveAPIServerProxyLegacyPort:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	IstioTLSTermination:                      {Default: false, PreRelease: featuregate.Alpha},
 	CloudProfileCapabilities:                 {Default: false, PreRelease: featuregate.Alpha},
 	DoNotCopyBackupCredentials:               {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR promotes the feature gate `RemoveAPIServerProxyLegacyPort` to GA status.
Now that we had the feature gate in beta for 3 versions, we are confident this can go GA.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `RemoveAPIServerProxyLegacyPort` feature gate has been promoted to GA and is now unconditionally enabled.
```
