### PR TITLE
Increase timeout for `gardenadm init` to `10m`

### DIFF
--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -69,7 +69,7 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(ctx, stdOut).Should(gbytes.Say("Your Shoot cluster control-plane has initialized successfully!"))
-		}, SpecTimeout(5*time.Minute))
+		}, SpecTimeout(10*time.Minute))
 
 		It("copy admin kubeconfig and create client", func(ctx SpecContext) {
 			tempDir, err := os.MkdirTemp("", "tmp")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/12169, there is another restart of the control plane to activate the NodeAgentAuthorizer webhook (this changes configuration in `kube-apiserver`). Additionally, we have to ensure that `gardener-node-agent` is still running afterwards, and this can take some additional time.

In some e2e runs, the current `5m` timeout is simply too short, see for example:

- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12344/pull-gardener-e2e-kind-gardenadm/1934980463915438080
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12335/pull-gardener-e2e-kind-gardenadm/1934970509573754880
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12318/pull-gardener-e2e-kind-gardenadm/1934964955145048064

or generally
https://prow.gardener.cloud/?repo=gardener%2Fgardener&job=pull-gardener-e2e-kind-gardenadm&state=failure, if you are fast enough

**Special notes for your reviewer**:
found w/ @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
