### PR TITLE
Match external hostname to service account issuer

### DIFF
--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -82,7 +82,7 @@ func GetDomainInfoFromAnnotations(annotations map[string]string) (provider strin
 	return
 }
 
-// GetAPIServerDomain returns the fully qualified domain name for the api-server of the Shoot cluster. The
+// GetAPIServerDomain returns the fully qualified domain name for the api-server of a Shoot or Virtual Garden cluster. The
 // end result is 'api.<domain>'.
 func GetAPIServerDomain(domain string) string {
 	return fmt.Sprintf("%s.%s", APIServerFQDNPrefix, domain)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
I was trying to do a PoC for https://github.com/gardener/gardener/issues/12189 without involving the Gardener Discovery Server, but directly expose the discovery documents of the virtual kube-apiserver directly using [Anonymous Authenticator Configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration).

My setup:
- Gardener deployed via `gardener-operator`
- Two configured `kube-apiserver` domains in the `garden` resource
   ```yaml
   virtualCluster:
    dns:
      domains:
      - name: example.domain1
        provider: example
      - name: example.domain2
        provider: example
   ```
- The `garden` resource also configures service account issuer
   ```yaml
   virtualCluster:
     kubernetes:
       kubeAPIServer:
         serviceAccountConfig:
           issuer: https://api.example.domain2
   ```

The problem occurs when I query `https://api.example.domain2/.well-known/openid-configuration` which returns `jwks_uri` using the `api.example.domain1` hostname as `api.example.domain1` is set for the `--external-hostname` flag. If `api.example.domain2` is served using certificate issued by a publicly trusted CA, e.g. using `virtualCluster.kubernetes.kubeAPIServer.sni`, but `api.example.domain2` is served with a self-signed certificate this creates the issue that discovery clients cannot fetch the JWKS without having the CA bundle of the `kube-apiserver`.

I propose that if there is a custom `issuer` configured for the virtual `kube-apiserver` and that issuer's hostname is a hostname of the `kube-apiserver` then set the external hostname to that hostname and not always to the first mentioned domain.
 
 /cc @vpnachev 
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I do not expect this change to cause much friction, but as the behaviour changes I wrote a "breaking" release note.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
If an operator configures `serviceAccountConfig.issuer` for the virtual cluster in a Garden resource and that issuer matches a hostname of the virtual `kube-apiserver` then the `--external-hostname` flag of the virtual `kube-apiserver` will be set to that hostname instead of the first domain set in the `virtualCluster.dns.domains[]` field.
```
