### PR TITLE
[GEP-26] Set the JTI claim in the WorkloadIdentity tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/gnostic-models v0.6.9
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.20.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ironcore-dev/vgopath v0.1.5
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
@@ -150,7 +151,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.25.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect

--- a/pkg/utils/workloadidentity/export_test.go
+++ b/pkg/utils/workloadidentity/export_test.go
@@ -4,7 +4,11 @@
 
 package workloadidentity
 
-import "time"
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+)
 
 // Functions exported for testing.
 
@@ -22,6 +26,10 @@ func SetNow(n func() time.Time) {
 
 func Now() func() time.Time {
 	return now
+}
+
+func SetUID(u func() types.UID) {
+	uid = u
 }
 
 // Types exported for testing.

--- a/pkg/utils/workloadidentity/export_test.go
+++ b/pkg/utils/workloadidentity/export_test.go
@@ -7,7 +7,7 @@ package workloadidentity
 import (
 	"time"
 
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/google/uuid"
 )
 
 // Functions exported for testing.
@@ -28,8 +28,8 @@ func Now() func() time.Time {
 	return now
 }
 
-func SetUID(u func() types.UID) {
-	uid = u
+func SetNewUUID(u func() (uuid.UUID, error)) {
+	newUUID = u
 }
 
 // Types exported for testing.

--- a/pkg/utils/workloadidentity/jwt.go
+++ b/pkg/utils/workloadidentity/jwt.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 const (
@@ -27,6 +28,7 @@ const (
 
 var (
 	now = time.Now
+	uid = uuid.NewUUID
 )
 
 // TokenIssuer is an interface for JSON Web Token issuers.
@@ -98,6 +100,7 @@ func (t *tokenIssuer) IssueToken(sub string, aud []string, duration int64, claim
 		NotBefore: jwt.NewNumericDate(iat),
 		Subject:   sub,
 		Audience:  aud,
+		ID:        string(uid()),
 	}
 
 	token, err := builder.Claims(c).Serialize()

--- a/pkg/utils/workloadidentity/jwt.go
+++ b/pkg/utils/workloadidentity/jwt.go
@@ -95,7 +95,7 @@ func (t *tokenIssuer) IssueToken(sub string, aud []string, duration int64, claim
 
 	jti, err := newUUID()
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to generated UUID for the jti claim: %w", err)
+		return "", nil, fmt.Errorf("failed to generate UUID for the jti claim: %w", err)
 	}
 
 	c := jwt.Claims{

--- a/pkg/utils/workloadidentity/jwt.go
+++ b/pkg/utils/workloadidentity/jwt.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
-	"k8s.io/apimachinery/pkg/util/uuid"
+	"github.com/google/uuid"
 )
 
 const (
@@ -27,8 +27,8 @@ const (
 )
 
 var (
-	now = time.Now
-	uid = uuid.NewUUID
+	now     = time.Now
+	newUUID = uuid.NewRandom
 )
 
 // TokenIssuer is an interface for JSON Web Token issuers.
@@ -93,6 +93,11 @@ func (t *tokenIssuer) IssueToken(sub string, aud []string, duration int64, claim
 	iat := now()
 	exp := iat.Add(time.Second * time.Duration(duration))
 
+	jti, err := newUUID()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generated UUID for the jti claim: %w", err)
+	}
+
 	c := jwt.Claims{
 		Issuer:    t.issuer,
 		IssuedAt:  jwt.NewNumericDate(iat),
@@ -100,7 +105,7 @@ func (t *tokenIssuer) IssueToken(sub string, aud []string, duration int64, claim
 		NotBefore: jwt.NewNumericDate(iat),
 		Subject:   sub,
 		Audience:  aud,
-		ID:        string(uid()),
+		ID:        jti.String(),
 	}
 
 	token, err := builder.Claims(c).Serialize()

--- a/pkg/utils/workloadidentity/jwt_test.go
+++ b/pkg/utils/workloadidentity/jwt_test.go
@@ -400,12 +400,12 @@ wQIDAQAB
 
 		It("should fail to issue token when uuid generation fails", func() {
 			workloadidentity.SetNewUUID(func() (uuid.UUID, error) {
-				return uuid.UUID{}, fmt.Errorf("failed to generated uuid")
+				return uuid.UUID{}, fmt.Errorf("failed to generate uuid")
 			})
 
 			token, exp, err := t.IssueToken(sub, audiences, int64(time.Hour.Seconds())*2)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError("failed to generated UUID for the jti claim: failed to generated uuid"))
+			Expect(err).To(MatchError("failed to generate UUID for the jti claim: failed to generate uuid"))
 			Expect(exp).To(BeNil())
 			Expect(token).To(BeEmpty())
 		})


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement

**What this PR does / why we need it**:
Set the JTI claim in the WorkloadIdentity tokens.
This ensures that two tokens issued on behalf of the same input parameters at the same time rounded to the second are different. 

**Which issue(s) this PR fixes**:
Part of #9586 

/cc @dimityrmirchev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
While implementing #12321 it happens the `garden/entry-<uid>` and `<shoot-namespace>/etcd-backup` secrets to contain exactly the same token - the reason was that both have the same input parameters (WorkloadIdentity and ContextObject) and the tokens were issued at the same time, their iat, exp, and nbf claims had the same value. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The JWTs issued on behalf of WorkloadIdentity now have the `jti` claim set. Already issued tokens will get the `jti` claim next time when they are renewed.
```
