### PR TITLE
Deflake `kind-ha-multi-zone` e2e test

### DIFF
--- a/hack/ci-e2e-kind-ha-multi-zone.sh
+++ b/hack/ci-e2e-kind-ha-multi-zone.sh
@@ -7,7 +7,6 @@
 set -o nounset
 set -o pipefail
 set -o errexit
-set -x
 
 source $(dirname "${0}")/ci-common.sh
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -167,4 +167,4 @@ case $TYPE in
     ;;
 esac
 
-GO111MODULE=on ginkgo run --timeout=90m $ginkgo_flags --v --show-node-events "$@"
+GO111MODULE=on ginkgo run --timeout=105m $ginkgo_flags --v --show-node-events "$@"

--- a/test/utils/shoots/update/inplace/nodes.go
+++ b/test/utils/shoots/update/inplace/nodes.go
@@ -42,9 +42,11 @@ func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, shootClie
 				continue
 			}
 
+			patch := client.MergeFrom(node.DeepCopy())
 			metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate, "true")
+
 			Eventually(ctx, func(g Gomega) {
-				g.Expect(shootClient.Update(ctx, &node)).To(Succeed())
+				g.Expect(shootClient.Patch(ctx, &node, patch)).To(Succeed())
 			}).Should(Succeed(), "node %s should be labeled", node.Name)
 		}
 	}

--- a/test/utils/shoots/update/inplace/nodes.go
+++ b/test/utils/shoots/update/inplace/nodes.go
@@ -33,8 +33,8 @@ func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, shootClie
 		}
 
 		nodeList := &corev1.NodeList{}
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(shootClient.List(ctx, nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})).To(Succeed())
+		Eventually(ctx, func() error {
+			return shootClient.List(ctx, nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})
 		}).Should(Succeed())
 
 		for _, node := range nodeList.Items {
@@ -64,8 +64,8 @@ func FindNodesOfInPlaceWorkers(ctx context.Context, shootClient client.Client, s
 		}
 
 		nodeList := &corev1.NodeList{}
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(shootClient.List(context.Background(), nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})).To(Succeed())
+		Eventually(ctx, func() error {
+			return shootClient.List(ctx, nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})
 		}).Should(Succeed())
 
 		for _, node := range nodeList.Items {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
After the addition of e2e tests https://github.com/gardener/gardener/pull/11953, https://github.com/gardener/gardener/pull/12241, the timeout of `90m` is not enough for the `kind-ha-multi-zone` tests. This PR increases the timeout by 15m.

https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12325/pull-gardener-e2e-kind-ha-multi-zone/1934519415227813888
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12326/pull-gardener-e2e-kind-ha-multi-zone/1934538852752429056
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/batch/pull-gardener-e2e-kind-ha-multi-zone/1934565854347792384
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12326/pull-gardener-e2e-kind-ha-multi-zone/1934616421631791104

The node `Update` call is replaced with `Patch` call in the `LabelManualInPlaceNodesWithSelectedForUpdate` function to prevent conflict errors like the ones in:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12216/pull-gardener-e2e-kind-ha-multi-zone/1934868595590828032
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12353/pull-gardener-e2e-kind-ha-multi-zone/1935586713267081216

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Multiple flakes are happening due to different causes, will continue investigating. Opened this PR to improve the current situation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
