### PR TITLE
ETCD Encryption Config: improve validation

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1134,6 +1134,9 @@ func validateEncryptionConfig(encryptionConfig *core.EncryptionConfig, defaultEn
 		if resource == "apiserveripinfo" || resource == "serviceipallocations" || resource == "servicenodeportallocations" {
 			allErrs = append(allErrs, field.Invalid(idxPath, resource, "resources which do not have REST API/s cannot be encrypted"))
 		}
+		if strings.HasSuffix(resource, ".") {
+			allErrs = append(allErrs, field.Invalid(idxPath, resource, "resource should not end with '.'"))
+		}
 		if strings.Contains(resource, "*") {
 			allErrs = append(allErrs, field.Invalid(idxPath, resource, "wildcards are not supported"))
 		}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1134,7 +1134,7 @@ func validateEncryptionConfig(encryptionConfig *core.EncryptionConfig, defaultEn
 		}
 
 		if gr.Group == "events.k8s.io" {
-			allErrs = append(allErrs, field.Invalid(idxPath, resource, "'*.events.k8s.io' objects are stored using the 'events' API group in etcd"))
+			allErrs = append(allErrs, field.Invalid(idxPath, resource, "'*.events.k8s.io' objects are stored using the 'events' API group in etcd. Use 'events' instead in the config file"))
 		}
 		if gr.Group == "extensions" {
 			allErrs = append(allErrs, field.Invalid(idxPath, resource, "group cannot be used for encryption"))

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2053,7 +2053,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[1]"),
-							"Detail": Equal("'*.events.k8s.io' objects are stored using the 'events' API group in etcd"),
+							"Detail": Equal("'*.events.k8s.io' objects are stored using the 'events' API group in etcd. Use 'events' instead in the config file"),
 						})),
 					))
 				})

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2024,17 +2024,17 @@ var _ = Describe("Shoot Validation Tests", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[0]"),
-							"Detail": Equal("resource cannot be encrypted"),
+							"Detail": Equal("resources which do not have REST API/s cannot be encrypted"),
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[1]"),
-							"Detail": Equal("resource cannot be encrypted"),
+							"Detail": Equal("resources which do not have REST API/s cannot be encrypted"),
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[2]"),
-							"Detail": Equal("resource cannot be encrypted"),
+							"Detail": Equal("resources which do not have REST API/s cannot be encrypted"),
 						})),
 					))
 				})
@@ -2048,12 +2048,12 @@ var _ = Describe("Shoot Validation Tests", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[0]"),
-							"Detail": Equal("group cannot be used for encryption"),
+							"Detail": Equal("'extensions' group has been removed and cannot be used for encryption"),
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[1]"),
-							"Detail": Equal("'*.events.k8s.io' objects are stored using the 'events' API group in etcd. Use 'events' instead in the config file"),
+							"Detail": Equal("'*.events.k8s.io' objects are stored using the 'events' API group in etcd. Use 'events' instead"),
 						})),
 					))
 				})
@@ -2118,7 +2118,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				It("should deny specifying wildcard resources", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
-						Resources: []string{"*.apps", "*.*", "pods.*"},
+						Resources: []string{"*.apps", "*.*", "pods.*", "foo.*.bar"},
 					}
 
 					Expect(ValidateShoot(shoot)).To(ConsistOf(
@@ -2135,6 +2135,11 @@ var _ = Describe("Shoot Validation Tests", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[2]"),
+							"Detail": Equal("wildcards are not supported"),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[3]"),
 							"Detail": Equal("wildcards are not supported"),
 						})),
 					))

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2015,7 +2015,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					))
 				})
 
-				It("should deny using none encryptable resources", func() {
+				It("should deny using non-encryptable resources", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: []string{"apiserveripinfo", "serviceipallocations", "servicenodeportallocations"},
 					}
@@ -2039,7 +2039,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					))
 				})
 
-				It("should deny using specific group", func() {
+				It("should deny using specific groups", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: []string{"foo.extensions", "events.events.k8s.io"},
 					}
@@ -2075,7 +2075,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					))
 				})
 
-				It("should deny resoureces with '.' suffix", func() {
+				It("should deny resources with '.' suffix", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: []string{"configmaps.", "deployment.apps.", "services"},
 					}

--- a/pkg/apis/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden_test.go
@@ -860,9 +860,9 @@ var _ = Describe("Validation Tests", func() {
 				),
 				Entry("when spec encrypted resources and status encrypted resources are equal", true,
 					operatorv1alpha1.GardenStatus{
-						EncryptedResources: []string{"configmaps", "daemonsets.apps", "projects.core.gardener.cloud", "shoots.core.gardener.cloud"},
+						EncryptedResources: []string{"configmaps.", "daemonsets.apps", "projects.core.gardener.cloud", "shoots.core.gardener.cloud"},
 					},
-					&gardencorev1beta1.EncryptionConfig{Resources: []string{"daemonsets.apps", "configmaps."}},
+					&gardencorev1beta1.EncryptionConfig{Resources: []string{"daemonsets.apps", "configmaps"}},
 					&gardencorev1beta1.EncryptionConfig{Resources: []string{"shoots.core.gardener.cloud", "projects.core.gardener.cloud"}},
 				),
 			)
@@ -1590,7 +1590,7 @@ var _ = Describe("Validation Tests", func() {
 						It("should deny specifying resources which are not served by gardener-apiserver", func() {
 							garden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
 								Resources: []string{"shoots.core.gardener.cloud",
-									"bastions.operations.gardener.cloud",
+									"bastions.operations.gardener.cloud.",
 									"ingresses.networking.io",
 									"foo.gardener.cloud",
 									"configmaps",
@@ -1598,6 +1598,12 @@ var _ = Describe("Validation Tests", func() {
 							}
 
 							Expect(ValidateGarden(garden, extensions)).To(ConsistOf(
+								PointTo(MatchFields(IgnoreExtras, Fields{
+									"Type":     Equal(field.ErrorTypeInvalid),
+									"Field":    Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[1]"),
+									"BadValue": Equal("bastions.operations.gardener.cloud."),
+									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {authentication,core,operations,security,settings,seedmanagement}.gardener.cloud"),
+								})),
 								PointTo(MatchFields(IgnoreExtras, Fields{
 									"Type":     Equal(field.ErrorTypeInvalid),
 									"Field":    Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[2]"),
@@ -2724,7 +2730,7 @@ var _ = Describe("Validation Tests", func() {
 						}
 						newGarden.Status.EncryptedResources = append(oldResources, oldGardenerResources...)
 
-						newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig.Resources = []string{"configmaps.", "resource.custom.io"}
+						newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig.Resources = []string{"configmaps", "resource.custom.io"}
 						newGarden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig.Resources = []string{"shoots.core.gardener.cloud", "bastions.operations.gardener.cloud"}
 
 						newGarden.Status.Credentials = &operatorv1alpha1.Credentials{

--- a/pkg/apis/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden_test.go
@@ -1621,7 +1621,7 @@ var _ = Describe("Validation Tests", func() {
 
 						It("should deny specifying wildcard resources", func() {
 							garden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
-								Resources: []string{"*.core.gardener.cloud", "*.operations.gardener.cloud", "*.*", "shoots.*"},
+								Resources: []string{"shoots.*.gardener.cloud", "*.operations.gardener.cloud", "*.*", "shoots.*"},
 							}
 
 							Expect(ValidateGarden(garden, extensions)).To(ConsistOf(
@@ -1644,6 +1644,24 @@ var _ = Describe("Validation Tests", func() {
 									"Type":   Equal(field.ErrorTypeInvalid),
 									"Field":  Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[3]"),
 									"Detail": Equal("wildcards are not supported"),
+								})),
+								PointTo(MatchFields(IgnoreExtras, Fields{
+									"Type":     Equal(field.ErrorTypeInvalid),
+									"Field":    Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[0]"),
+									"BadValue": Equal("shoots.*.gardener.cloud"),
+									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {authentication,core,operations,security,settings,seedmanagement}.gardener.cloud"),
+								})),
+								PointTo(MatchFields(IgnoreExtras, Fields{
+									"Type":     Equal(field.ErrorTypeInvalid),
+									"Field":    Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[2]"),
+									"BadValue": Equal("*.*"),
+									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {authentication,core,operations,security,settings,seedmanagement}.gardener.cloud"),
+								})),
+								PointTo(MatchFields(IgnoreExtras, Fields{
+									"Type":     Equal(field.ErrorTypeInvalid),
+									"Field":    Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources[3]"),
+									"BadValue": Equal("shoots.*"),
+									"Detail":   Equal("should be a resource served by gardener-apiserver. ie; should have any of the suffixes {authentication,core,operations,security,settings,seedmanagement}.gardener.cloud"),
 								})),
 							))
 						})

--- a/pkg/component/shared/apiserver.go
+++ b/pkg/component/shared/apiserver.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -345,7 +346,8 @@ func StringifyGroupResources(resources []schema.GroupResource) []string {
 		out = append(out, r.String())
 	}
 
-	return out
+	// We use NormalizeResources for backwards compatibility
+	return NormalizeResources(out)
 }
 
 // NormalizeResources returns the list of resources after trimming the suffix '.' if present.
@@ -354,7 +356,8 @@ func NormalizeResources(resources []string) []string {
 	var out []string
 
 	for _, resource := range resources {
-		out = append(out, schema.ParseGroupResource(resource).String())
+		// For backwards compatibility we always remove the suffix '.'
+		out = append(out, strings.TrimSuffix(resource, "."))
 	}
 
 	return out

--- a/pkg/component/shared/apiserver.go
+++ b/pkg/component/shared/apiserver.go
@@ -352,11 +352,12 @@ func StringifyGroupResources(resources []schema.GroupResource) []string {
 
 // NormalizeResources returns the list of resources after trimming the suffix '.' if present.
 // This is needed for core resources which can be specified as '<resource>.' as well.
+// TODO: With https://github.com/gardener/gardener/pull/12355 we no longer allow resources with '.' suffix.
+// This function is kept for backwards compatibility and should be removed in the future.
 func NormalizeResources(resources []string) []string {
 	var out []string
 
 	for _, resource := range resources {
-		// For backwards compatibility we always remove the suffix '.'
 		out = append(out, strings.TrimSuffix(resource, "."))
 	}
 

--- a/pkg/component/shared/apiserver_test.go
+++ b/pkg/component/shared/apiserver_test.go
@@ -41,11 +41,11 @@ var _ = Describe("APIServer", func() {
 
 		It("should return the correct list of resources when resources are not nil", func() {
 			resources := []schema.GroupResource{
-				schema.GroupResource{Resource: "deployments", Group: "apps"},
-				schema.GroupResource{Resource: "fancyresource", Group: "customoperator.io"},
-				schema.GroupResource{Resource: "configmaps", Group: ""},
-				schema.GroupResource{Resource: "services", Group: ""},
-				schema.GroupResource{Resource: "daemonsets", Group: "apps"},
+				{Resource: "deployments", Group: "apps"},
+				{Resource: "fancyresource", Group: "customoperator.io"},
+				{Resource: "configmaps", Group: ""},
+				{Resource: "services", Group: ""},
+				{Resource: "daemonsets", Group: "apps"},
 			}
 
 			Expect(StringifyGroupResources(resources)).To(ConsistOf(

--- a/pkg/component/shared/apiserver_test.go
+++ b/pkg/component/shared/apiserver_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/component/shared"
 )
@@ -20,13 +22,38 @@ var _ = Describe("APIServer", func() {
 
 		It("should return the correct list of resources when encryptionConfig is not nil", func() {
 			encryptionConfig := &gardencorev1beta1.EncryptionConfig{
-				Resources: []string{"deployments.apps", "fancyresource.customoperator.io", "configmaps", "daemonsets.apps"},
+				Resources: []string{"deployments.apps", "fancyresource.customoperator.io", "configmaps", "services.", "daemonsets.apps"},
 			}
 
 			Expect(GetResourcesForEncryptionFromConfig(encryptionConfig)).To(ConsistOf(
+				schema.GroupResource{Resource: "deployments", Group: "apps"},
+				schema.GroupResource{Resource: "fancyresource", Group: "customoperator.io"},
+				schema.GroupResource{Resource: "configmaps", Group: ""},
+				schema.GroupResource{Resource: "services", Group: ""},
+				schema.GroupResource{Resource: "daemonsets", Group: "apps"},
+			))
+		})
+	})
+
+	Describe("#StringifyGroupResources", func() {
+		It("should return nil when resources are nil", func() {
+			Expect(StringifyGroupResources(nil)).To(BeNil())
+		})
+
+		It("should return the correct list of resources when resources are not nil", func() {
+			resources := []schema.GroupResource{
+				schema.GroupResource{Resource: "deployments", Group: "apps"},
+				schema.GroupResource{Resource: "fancyresource", Group: "customoperator.io"},
+				schema.GroupResource{Resource: "configmaps", Group: ""},
+				schema.GroupResource{Resource: "services", Group: ""},
+				schema.GroupResource{Resource: "daemonsets", Group: "apps"},
+			}
+
+			Expect(StringifyGroupResources(resources)).To(ConsistOf(
 				"deployments.apps",
 				"fancyresource.customoperator.io",
 				"configmaps",
+				"services",
 				"daemonsets.apps",
 			))
 		})

--- a/pkg/component/shared/apiserver_test.go
+++ b/pkg/component/shared/apiserver_test.go
@@ -7,7 +7,6 @@ package shared_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"

--- a/pkg/component/shared/apiserver_test.go
+++ b/pkg/component/shared/apiserver_test.go
@@ -45,7 +45,7 @@ var _ = Describe("APIServer", func() {
 				{Resource: "fancyresource", Group: "customoperator.io"},
 				{Resource: "configmaps", Group: ""},
 				{Resource: "services", Group: ""},
-				{Resource: "daemonsets", Group: "apps"},
+				{Resource: "daemonsets", Group: "apps."},
 			}
 
 			Expect(StringifyGroupResources(resources)).To(ConsistOf(
@@ -64,7 +64,7 @@ var _ = Describe("APIServer", func() {
 		})
 
 		It("should return the correct list of resources when encryptionConfig is not nil", func() {
-			resources := []string{"deployments.apps", "fancyresource.customoperator.io", "endpoints.", "configmaps", "services."}
+			resources := []string{"deployments.apps.", "fancyresource.customoperator.io", "endpoints.", "configmaps", "services."}
 
 			Expect(NormalizeResources(resources)).To(ConsistOf(
 				"deployments.apps",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -511,7 +511,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 					if err := o.Shoot.UpdateInfoStatus(ctx, o.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
 						var encryptedResources []string
 						if o.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer != nil {
-							encryptedResources = shared.GetResourcesForEncryptionFromConfig(o.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig)
+							encryptedResources = shared.StringifyGroupResources(shared.GetResourcesForEncryptionFromConfig(o.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig))
 						}
 
 						shoot.Status.EncryptedResources = encryptedResources

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -284,7 +284,7 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	shoot.Purpose = v1beta1helper.GetPurpose(shootObject)
 
 	if shoot.GetInfo().Spec.Kubernetes.KubeAPIServer != nil {
-		shoot.ResourcesToEncrypt = sharedcomponent.NormalizeResources(sharedcomponent.GetResourcesForEncryptionFromConfig(shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig))
+		shoot.ResourcesToEncrypt = sharedcomponent.StringifyGroupResources(sharedcomponent.GetResourcesForEncryptionFromConfig(shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig))
 	}
 	if len(shoot.GetInfo().Status.EncryptedResources) > 0 {
 		shoot.EncryptedResources = sharedcomponent.NormalizeResources(shoot.GetInfo().Status.EncryptedResources)

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -169,7 +169,7 @@ func (r *Reconciler) reconcile(
 		virtualClusterClientSet kubernetes.Interface
 		virtualClusterClient    client.Client
 		defaultEncryptedGVKs    = append(gardenerutils.DefaultGardenerGVKsForEncryption(), gardenerutils.DefaultGVKsForEncryption()...)
-		resourcesToEncrypt      = append(shared.NormalizeResources(getKubernetesResourcesForEncryption(garden)), getGardenerResourcesForEncryption(garden)...)
+		resourcesToEncrypt      = append(shared.StringifyGroupResources(getKubernetesResourcesForEncryption(garden)), shared.StringifyGroupResources(getGardenerResourcesForEncryption(garden))...)
 		encryptedResources      = shared.NormalizeResources(garden.Status.EncryptedResources)
 
 		g                              = flow.NewGraph("Garden reconciliation")
@@ -519,7 +519,7 @@ func (r *Reconciler) reconcile(
 					encryptedResources := append(getKubernetesResourcesForEncryption(garden), getGardenerResourcesForEncryption(garden)...)
 
 					patch := client.MergeFrom(garden.DeepCopy())
-					garden.Status.EncryptedResources = encryptedResources
+					garden.Status.EncryptedResources = shared.StringifyGroupResources(encryptedResources)
 					if err := r.RuntimeClientSet.Client().Status().Patch(ctx, garden, patch); err != nil {
 						return fmt.Errorf("error patching Garden status after snapshotting ETCD: %w", err)
 					}
@@ -860,7 +860,7 @@ func (r *Reconciler) deployKubeAPIServerFunc(garden *operatorv1alpha1.Garden, ku
 			nil,
 			services,
 			nil,
-			shared.NormalizeResources(getKubernetesResourcesForEncryption(garden)),
+			shared.StringifyGroupResources(getKubernetesResourcesForEncryption(garden)),
 			utils.FilterEntriesByFilterFn(shared.NormalizeResources(garden.Status.EncryptedResources), operator.IsServedByKubeAPIServer),
 			helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials),
 			false,
@@ -897,7 +897,7 @@ func (r *Reconciler) deployGardenerAPIServerFunc(garden *operatorv1alpha1.Garden
 			r.RuntimeClientSet.Client(),
 			r.GardenNamespace,
 			gardenerAPIServer,
-			getGardenerResourcesForEncryption(garden),
+			shared.StringifyGroupResources(getGardenerResourcesForEncryption(garden)),
 			utils.FilterEntriesByFilterFn(garden.Status.EncryptedResources, operator.IsServedByGardenerAPIServer),
 			helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials),
 			helper.GetWorkloadIdentityKeyRotationPhase(garden.Status.Credentials),
@@ -1140,7 +1140,7 @@ func (r *Reconciler) listManagedDNSRecords(ctx context.Context, dnsRecordList *e
 	return nil
 }
 
-func getKubernetesResourcesForEncryption(garden *operatorv1alpha1.Garden) []string {
+func getKubernetesResourcesForEncryption(garden *operatorv1alpha1.Garden) []schema.GroupResource {
 	var encryptionConfig *gardencorev1beta1.EncryptionConfig
 
 	if apiServer := garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer; apiServer != nil && apiServer.KubeAPIServerConfig != nil {
@@ -1150,7 +1150,7 @@ func getKubernetesResourcesForEncryption(garden *operatorv1alpha1.Garden) []stri
 	return shared.GetResourcesForEncryptionFromConfig(encryptionConfig)
 }
 
-func getGardenerResourcesForEncryption(garden *operatorv1alpha1.Garden) []string {
+func getGardenerResourcesForEncryption(garden *operatorv1alpha1.Garden) []schema.GroupResource {
 	var encryptionConfig *gardencorev1beta1.EncryptionConfig
 
 	if garden.Spec.VirtualCluster.Gardener.APIServer != nil {

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -329,7 +329,7 @@ func DefaultGardenerGVKsForEncryption() []schema.GroupVersionKind {
 	}
 }
 
-// DefaultGardenerGRSsForEncryption returns the list of [schema.GroupResource] served by Gardener API Server which are encrypted by default.
+// DefaultGardenerGRsForEncryption returns the list of [schema.GroupResource] served by Gardener API Server which are encrypted by default.
 func DefaultGardenerGRsForEncryption() []schema.GroupResource {
 	return []schema.GroupResource{
 		gardencorev1beta1.Resource("controllerdeployments"),

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -319,13 +319,23 @@ func PrepareGardenClientRestConfig(baseConfig *rest.Config, address *string, caC
 	return gardenClientRestConfig
 }
 
-// DefaultGardenerGVKsForEncryption returns the list of GroupVersionKinds served by Gardener API Server which are encrypted by default.
+// DefaultGardenerGVKsForEncryption returns the list of [schema.GroupVersionKind] served by Gardener API Server which are encrypted by default.
 func DefaultGardenerGVKsForEncryption() []schema.GroupVersionKind {
 	return []schema.GroupVersionKind{
 		gardencorev1beta1.SchemeGroupVersion.WithKind("ControllerDeployment"),
 		gardencorev1beta1.SchemeGroupVersion.WithKind("ControllerRegistration"),
 		gardencorev1beta1.SchemeGroupVersion.WithKind("InternalSecret"),
 		gardencorev1beta1.SchemeGroupVersion.WithKind("ShootState"),
+	}
+}
+
+// DefaultGardenerGRSsForEncryption returns the list of [schema.GroupResource] served by Gardener API Server which are encrypted by default.
+func DefaultGardenerGRsForEncryption() []schema.GroupResource {
+	return []schema.GroupResource{
+		gardencorev1beta1.Resource("controllerdeployments"),
+		gardencorev1beta1.Resource("controllerregistrations"),
+		gardencorev1beta1.Resource("internalsecrets"),
+		gardencorev1beta1.Resource("shootstates"),
 	}
 }
 

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -329,8 +329,8 @@ func DefaultGardenerGVKsForEncryption() []schema.GroupVersionKind {
 	}
 }
 
-// DefaultGardenerGRsForEncryption returns the list of [schema.GroupResource] served by Gardener API Server which are encrypted by default.
-func DefaultGardenerGRsForEncryption() []schema.GroupResource {
+// DefaultGardenerGroupResourcesForEncryption returns the list of [schema.GroupResource] served by Gardener API Server which are encrypted by default.
+func DefaultGardenerGroupResourcesForEncryption() []schema.GroupResource {
 	return []schema.GroupResource{
 		gardencorev1beta1.Resource("controllerdeployments"),
 		gardencorev1beta1.Resource("controllerregistrations"),

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -330,7 +330,7 @@ var _ = Describe("Garden", func() {
 
 	Describe("#DefaultGardenerGRsForEncryption", func() {
 		It("should return all default GroupVersionKinds", func() {
-			Expect(DefaultGardenerGRsForEncryption()).To(ConsistOf(
+			Expect(DefaultGardenerGroupResourcesForEncryption()).To(ConsistOf(
 				schema.GroupResource{Group: "core.gardener.cloud", Resource: "controllerdeployments"},
 				schema.GroupResource{Group: "core.gardener.cloud", Resource: "controllerregistrations"},
 				schema.GroupResource{Group: "core.gardener.cloud", Resource: "internalsecrets"},

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -328,7 +328,7 @@ var _ = Describe("Garden", func() {
 		})
 	})
 
-	Describe("#DefaultGardenerGRsForEncryption", func() {
+	Describe("#DefaultGardenerGroupResourcesForEncryption", func() {
 		It("should return all default GroupVersionKinds", func() {
 			Expect(DefaultGardenerGroupResourcesForEncryption()).To(ConsistOf(
 				schema.GroupResource{Group: "core.gardener.cloud", Resource: "controllerdeployments"},

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -328,6 +328,17 @@ var _ = Describe("Garden", func() {
 		})
 	})
 
+	Describe("#DefaultGardenerGRsForEncryption", func() {
+		It("should return all default GroupVersionKinds", func() {
+			Expect(DefaultGardenerGRsForEncryption()).To(ConsistOf(
+				schema.GroupResource{Group: "core.gardener.cloud", Resource: "controllerdeployments"},
+				schema.GroupResource{Group: "core.gardener.cloud", Resource: "controllerregistrations"},
+				schema.GroupResource{Group: "core.gardener.cloud", Resource: "internalsecrets"},
+				schema.GroupResource{Group: "core.gardener.cloud", Resource: "shootstates"},
+			))
+		})
+	})
+
 	Describe("#DefaultGardenerResourcesForEncryption", func() {
 		It("should return all default resources", func() {
 			Expect(DefaultGardenerResourcesForEncryption().UnsortedList()).To(ConsistOf(

--- a/pkg/utils/gardener/operator/garden.go
+++ b/pkg/utils/gardener/operator/garden.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,6 +32,8 @@ import (
 
 // IsServedByGardenerAPIServer returns true if the passed resources is served by the Gardener API Server.
 func IsServedByGardenerAPIServer(resource string) bool {
+	groupResource := schema.ParseGroupResource(resource)
+
 	for _, groupName := range []string{
 		authentication.GroupName,
 		gardencore.GroupName,
@@ -40,7 +42,7 @@ func IsServedByGardenerAPIServer(resource string) bool {
 		settings.GroupName,
 		seedmanagement.GroupName,
 	} {
-		if strings.HasSuffix(resource, groupName) {
+		if groupName == groupResource.Group {
 			return true
 		}
 	}

--- a/pkg/utils/gardener/operator/garden_test.go
+++ b/pkg/utils/gardener/operator/garden_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Garden", func() {
 		Entry("authentication resource", authenticationv1alpha1.Resource("adminkubeconfigrequests").String(), true),
 		Entry("security resource", securityv1alpha1.Resource("workloadidentities").String(), true),
 		Entry("any other resource", "foo", false),
+		Entry("not served with suffix of served", "workloadidentities.foo.security.gardener.cloud", false),
 	)
 
 	DescribeTable("#IsServedByKubeAPIServer",

--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -239,8 +239,7 @@ func GetResourcesForRewrite(
 	error,
 ) {
 	var (
-		resourcesForRewrite = resourcesToEncrypt
-		// encryptionConfigHasChanged = !apiequality.Semantic.DeepEqual(resourcesToEncrypt, encryptedResources)
+		resourcesForRewrite        = resourcesToEncrypt
 		encryptionConfigHasChanged = !sets.New(resourcesToEncrypt...).Equal(sets.New(encryptedResources...))
 		encryptedGVKs              = sets.New[schema.GroupVersionKind]()
 		groupResourcesToEncrypt    = []schema.GroupResource{}
@@ -292,11 +291,9 @@ func GetResourcesForRewrite(
 				version = apiResource.Version
 			}
 
-			shouldEncrypt := slices.ContainsFunc(groupResourcesToEncrypt, func(gr schema.GroupResource) bool {
+			if shouldEncrypt := slices.ContainsFunc(groupResourcesToEncrypt, func(gr schema.GroupResource) bool {
 				return gr.Group == group && gr.Resource == apiResource.Name
-			})
-
-			if shouldEncrypt {
+			}); shouldEncrypt {
 				encryptedGVKs.Insert(schema.GroupVersionKind{Group: group, Version: version, Kind: apiResource.Kind})
 			}
 		}

--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -291,9 +291,9 @@ func GetResourcesForRewrite(
 				version = apiResource.Version
 			}
 
-			if shouldEncrypt := slices.ContainsFunc(groupResourcesToEncrypt, func(gr schema.GroupResource) bool {
+			if slices.ContainsFunc(groupResourcesToEncrypt, func(gr schema.GroupResource) bool {
 				return gr.Group == group && gr.Resource == apiResource.Name
-			}); shouldEncrypt {
+			}) {
 				encryptedGVKs.Insert(schema.GroupVersionKind{Group: group, Version: version, Kind: apiResource.Kind})
 			}
 		}

--- a/pkg/utils/gardener/secretsrotation/etcd_test.go
+++ b/pkg/utils/gardener/secretsrotation/etcd_test.go
@@ -331,7 +331,7 @@ var _ = Describe("ETCD", func() {
 			))
 		})
 
-		It("should return the correct GVK list when not all resources are part from resourece list", func() {
+		It("should return the correct GVK list when not all resources are part from the discovered resources list", func() {
 			var (
 				resourcesToEncrypt = []string{
 					"crontabs.stable.example.com",

--- a/pkg/utils/gardener/secretsrotation/etcd_test.go
+++ b/pkg/utils/gardener/secretsrotation/etcd_test.go
@@ -331,6 +331,35 @@ var _ = Describe("ETCD", func() {
 			))
 		})
 
+		It("should return the correct GVK list when not all resources are part from resourece list", func() {
+			var (
+				resourcesToEncrypt = []string{
+					"crontabs.stable.example.com",
+					"baz",
+					"configmaps",
+					"foo.bar",
+				}
+
+				encryptedResources = []string{
+					"baz",
+					"foo.bar",
+					"crontabs.stable.example.com",
+					"configmaps",
+				}
+
+				defaultGVKs = []schema.GroupVersionKind{corev1.SchemeGroupVersion.WithKind("Secret")}
+			)
+
+			list, message, err := GetResourcesForRewrite(fakeDiscoveryClient, resourcesToEncrypt, encryptedResources, defaultGVKs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(message).To(Equal("Objects requiring to be rewritten after ETCD encryption key rotation"))
+			Expect(list).To(ConsistOf(
+				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
+				schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "CronTab"},
+			))
+		})
+
 		It("should return the correct GVK list for the modified resources when the resources to encrypt and encrypted resources are not equal", func() {
 			var (
 				resourcesToEncrypt = []string{

--- a/pkg/utils/gardener/secretsrotation/etcd_test.go
+++ b/pkg/utils/gardener/secretsrotation/etcd_test.go
@@ -331,7 +331,7 @@ var _ = Describe("ETCD", func() {
 			))
 		})
 
-		It("should return the correct GVK list when not all resources are part from the discovered resources list", func() {
+		It("should return the correct GVK list when not all resources are part of the discovered resources list", func() {
 			var (
 				resourcesToEncrypt = []string{
 					"crontabs.stable.example.com",

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -788,6 +788,13 @@ func DefaultGVKsForEncryption() []schema.GroupVersionKind {
 	}
 }
 
+// DefaultGRsForEncryption returns the list of GroupResources which are encrypted by default.
+func DefaultGRsForEncryption() []schema.GroupResource {
+	return []schema.GroupResource{
+		corev1.Resource("secrets"),
+	}
+}
+
 // DefaultResourcesForEncryption returns the list of resources which are encrypted by default.
 func DefaultResourcesForEncryption() sets.Set[string] {
 	return sets.New(corev1.Resource("secrets").String())

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -788,8 +788,8 @@ func DefaultGVKsForEncryption() []schema.GroupVersionKind {
 	}
 }
 
-// DefaultGRsForEncryption returns the list of GroupResources which are encrypted by default.
-func DefaultGRsForEncryption() []schema.GroupResource {
+// DefaultGroupResourcesForEncryption returns the list of GroupResources which are encrypted by default.
+func DefaultGroupResourcesForEncryption() []schema.GroupResource {
 	return []schema.GroupResource{
 		corev1.Resource("secrets"),
 	}

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1425,7 +1425,7 @@ var _ = Describe("Shoot", func() {
 
 	Describe("#DefaultGRForEncryption", func() {
 		It("should return all default resources", func() {
-			Expect(DefaultGRsForEncryption()).To(ConsistOf(
+			Expect(DefaultGroupResourcesForEncryption()).To(ConsistOf(
 				schema.GroupResource{Group: "", Resource: "secrets"},
 			))
 		})

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1423,6 +1423,14 @@ var _ = Describe("Shoot", func() {
 		})
 	})
 
+	Describe("#DefaultGRForEncryption", func() {
+		It("should return all default resources", func() {
+			Expect(DefaultGRsForEncryption()).To(ConsistOf(
+				schema.GroupResource{Group: "", Resource: "secrets"},
+			))
+		})
+	})
+
 	Describe("#DefaultResourcesForEncryption", func() {
 		It("should return all default resources", func() {
 			Expect(DefaultResourcesForEncryption().UnsortedList()).To(ConsistOf(

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1423,7 +1423,7 @@ var _ = Describe("Shoot", func() {
 		})
 	})
 
-	Describe("#DefaultGRForEncryption", func() {
+	Describe("#DefaultGroupResourcesForEncryption", func() {
 		It("should return all default resources", func() {
 			Expect(DefaultGroupResourcesForEncryption()).To(ConsistOf(
 				schema.GroupResource{Group: "", Resource: "secrets"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR adopts validation from [Kubernetes](https://github.com/kubernetes/kubernetes/blob/8adc0f041b8e7ad1d30e29cc59c6ae7a15e19828/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_encryption.go#L122-L284) for the encryption config. It also takes advantage of [schema.GroupResource](https://github.com/kubernetes/kubernetes/blob/8adc0f041b8e7ad1d30e29cc59c6ae7a15e19828/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go#L54-L59) for more reliable comparisons between encryption configs.

**Which issue(s) this PR fixes**:
Fixes #12338

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Setting resources with `.` suffix in the `spec.kubernetes.kubeAPIServer.encryptionConfig.resources` field is now forbidden.
```
```bugfix user
A bug causing the `kube-apiserver` to crash due to invalid resources in the `spec.kubernetes.kubeAPIServer.encryptionConfig.resources` was fixed.
```
```bugfix user
A bug forbidding the update of `spec.kubernetes.kubeAPIServer.encryptionConfig.resources` due to use of `.` suffix in resources was fixed.
```
