### PR TITLE
[GEP-26] Use `string` instead of `*string` for namespace in the private WorkloadIdentity claims

### DIFF
--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
@@ -36,7 +36,7 @@ type gardener struct {
 
 type ref struct {
 	Name      string `json:"name"`
-	Namespace string `json:"namespace,omitempty"`
+	Namespace string `json:"namespace,omitempty,omitzero"`
 	UID       string `json:"uid"`
 }
 

--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
-	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -36,9 +35,9 @@ type gardener struct {
 }
 
 type ref struct {
-	Name      string  `json:"name"`
-	Namespace *string `json:"namespace,omitempty"`
-	UID       string  `json:"uid"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	UID       string `json:"uid"`
 }
 
 // contextObjects contains metadata information about the objects
@@ -76,7 +75,7 @@ func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.Workl
 		Gardener: gardener{
 			WorkloadIdentity: ref{
 				Name:      workloadIdentity.Name,
-				Namespace: ptr.To(workloadIdentity.Namespace),
+				Namespace: workloadIdentity.Namespace,
 				UID:       string(workloadIdentity.UID),
 			},
 		},
@@ -89,7 +88,7 @@ func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.Workl
 	if ctxObjects.shoot != nil {
 		gardenerClaims.Gardener.Shoot = &ref{
 			Name:      ctxObjects.shoot.GetName(),
-			Namespace: ptr.To(ctxObjects.shoot.GetNamespace()),
+			Namespace: ctxObjects.shoot.GetNamespace(),
 			UID:       string(ctxObjects.shoot.GetUID()),
 		}
 	}
@@ -118,7 +117,7 @@ func (r *TokenRequestREST) getGardenerClaims(workloadIdentity *securityapi.Workl
 	if ctxObjects.backupEntry != nil {
 		gardenerClaims.Gardener.BackupEntry = &ref{
 			Name:      ctxObjects.backupEntry.GetName(),
-			Namespace: ptr.To(ctxObjects.backupEntry.GetNamespace()),
+			Namespace: ctxObjects.backupEntry.GetNamespace(),
 			UID:       string(ctxObjects.backupEntry.GetUID()),
 		}
 	}

--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt_test.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt_test.go
@@ -912,18 +912,28 @@ var _ = Describe("#TokenRequest", func() {
 			payload, err := base64.RawURLEncoding.DecodeString(encodedPayload)
 			Expect(err).ToNot(HaveOccurred())
 
-			gardenerClaims := map[string](map[string](map[string]string)){}
+			gardenerClaims := map[string]any{}
 			Expect(json.Unmarshal(payload, &gardenerClaims)).To(Succeed())
 			Expect(gardenerClaims).To(HaveKey("gardener.cloud"))
-			Expect(gardenerClaims["gardener.cloud"]).To(HaveKey("seed"))
 
-			seedClaims := gardenerClaims["gardener.cloud"]["seed"]
+			gardenerCloud, ok := (gardenerClaims["gardener.cloud"]).(map[string]any)
+			Expect(ok).To(BeTrue())
+
+			Expect(gardenerCloud).To(HaveKey("seed"))
+			seedClaims, ok := (gardenerCloud["seed"]).(map[string]any)
+			Expect(ok).To(BeTrue())
+
 			Expect(seedClaims).To(HaveLen(2))
 			Expect(seedClaims).To(Not(HaveKey("namespace")))
-			Expect(seedClaims).To(And(
-				HaveKeyWithValue("name", seedName),
-				HaveKeyWithValue("uid", string(seedUID)),
-			))
+			Expect(seedClaims).To(And(HaveKey("name"), HaveKey("uid")))
+
+			name, ok := (seedClaims["name"]).(string)
+			Expect(ok).To(BeTrue())
+			Expect(name).To(Equal(seedName))
+
+			uid, ok := (seedClaims["uid"]).(string)
+			Expect(ok).To(BeTrue())
+			Expect(uid).To(Equal(string(seedUID)))
 		})
 	})
 })

--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt_test.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt_test.go
@@ -938,28 +938,31 @@ var _ = Describe("#TokenRequest", func() {
 	})
 })
 
-type fakeShootLister struct {
-	err error
-}
-type fakeShootNamespaceLister struct {
-	err error
-}
-
 var (
 	_ gardencorev1beta1listers.ShootLister          = (*fakeShootLister)(nil)
 	_ gardencorev1beta1listers.ShootNamespaceLister = (*fakeShootNamespaceLister)(nil)
 )
 
+type fakeShootLister struct {
+	err error
+}
+
 func (*fakeShootLister) List(_ labels.Selector) (ret []*gardencorev1beta1.Shoot, err error) {
 	return []*gardencorev1beta1.Shoot{}, nil
 }
+
 func (f *fakeShootLister) Shoots(_ string) gardencorev1beta1listers.ShootNamespaceLister {
 	return &fakeShootNamespaceLister{err: f.err}
+}
+
+type fakeShootNamespaceLister struct {
+	err error
 }
 
 func (*fakeShootNamespaceLister) List(_ labels.Selector) (ret []*gardencorev1beta1.Shoot, err error) {
 	return []*gardencorev1beta1.Shoot{}, nil
 }
+
 func (f *fakeShootNamespaceLister) Get(_ string) (*gardencorev1beta1.Shoot, error) {
 	return nil, f.err
 }

--- a/pkg/apiserver/registry/security/workloadidentity/storage/jwt_test.go
+++ b/pkg/apiserver/registry/security/workloadidentity/storage/jwt_test.go
@@ -116,8 +116,7 @@ var _ = Describe("#TokenRequest", func() {
 
 				Expect(g).ToNot(BeNil())
 				Expect(g.Gardener.WorkloadIdentity.Name).To(Equal(workloadName))
-				Expect(g.Gardener.WorkloadIdentity.Namespace).ToNot(BeNil())
-				Expect(*g.Gardener.WorkloadIdentity.Namespace).To(Equal(workloadNamespace))
+				Expect(g.Gardener.WorkloadIdentity.Namespace).To(Equal(workloadNamespace))
 				Expect(g.Gardener.WorkloadIdentity.UID).To(Equal(workloadUID))
 
 				if objType == "none" {
@@ -131,8 +130,7 @@ var _ = Describe("#TokenRequest", func() {
 					Expect(ctxObjects.shoot).ToNot(BeNil())
 					Expect(g.Gardener.Shoot).ToNot(BeNil())
 					Expect(g.Gardener.Shoot.Name).To(Equal(ctxObjects.shoot.GetName()))
-					Expect(g.Gardener.Shoot.Namespace).ToNot(BeNil())
-					Expect(*g.Gardener.Shoot.Namespace).To(Equal(ctxObjects.shoot.GetNamespace()))
+					Expect(g.Gardener.Shoot.Namespace).To(Equal(ctxObjects.shoot.GetNamespace()))
 					Expect(g.Gardener.Shoot.UID).To(BeEquivalentTo(ctxObjects.shoot.GetUID()))
 				} else {
 					Expect(ctxObjects.shoot).To(BeNil())
@@ -144,7 +142,7 @@ var _ = Describe("#TokenRequest", func() {
 					Expect(g.Gardener.Seed).ToNot(BeNil())
 					Expect(g.Gardener.Seed.Name).To(Equal(ctxObjects.seed.GetName()))
 					Expect(g.Gardener.Seed.UID).To(BeEquivalentTo(ctxObjects.seed.GetUID()))
-					Expect(g.Gardener.Seed.Namespace).To(BeNil())
+					Expect(g.Gardener.Seed.Namespace).To(BeZero())
 				} else {
 					Expect(ctxObjects.seed).To(BeNil())
 					Expect(g.Gardener.Seed).To(BeNil())
@@ -155,7 +153,7 @@ var _ = Describe("#TokenRequest", func() {
 					Expect(g.Gardener.Project).ToNot(BeNil())
 					Expect(g.Gardener.Project.Name).To(Equal(ctxObjects.project.GetName()))
 					Expect(g.Gardener.Project.UID).To(BeEquivalentTo(ctxObjects.project.GetUID()))
-					Expect(g.Gardener.Project.Namespace).To(BeNil())
+					Expect(g.Gardener.Project.Namespace).To(BeZero())
 				} else {
 					Expect(ctxObjects.project).To(BeNil())
 					Expect(g.Gardener.Project).To(BeNil())
@@ -166,7 +164,7 @@ var _ = Describe("#TokenRequest", func() {
 					Expect(g.Gardener.BackupBucket).ToNot(BeNil())
 					Expect(g.Gardener.BackupBucket.Name).To(Equal(ctxObjects.backupBucket.GetName()))
 					Expect(g.Gardener.BackupBucket.UID).To(BeEquivalentTo(ctxObjects.backupBucket.GetUID()))
-					Expect(g.Gardener.BackupBucket.Namespace).To(BeNil())
+					Expect(g.Gardener.BackupBucket.Namespace).To(BeZero())
 				} else {
 					Expect(ctxObjects.backupBucket).To(BeNil())
 					Expect(g.Gardener.BackupBucket).To(BeNil())
@@ -177,8 +175,7 @@ var _ = Describe("#TokenRequest", func() {
 					Expect(g.Gardener.BackupEntry).ToNot(BeNil())
 					Expect(g.Gardener.BackupEntry.Name).To(Equal(ctxObjects.backupEntry.GetName()))
 					Expect(g.Gardener.BackupEntry.UID).To(BeEquivalentTo(ctxObjects.backupEntry.GetUID()))
-					Expect(g.Gardener.BackupEntry.Namespace).ToNot(BeNil())
-					Expect(*g.Gardener.BackupEntry.Namespace).To(Equal(ctxObjects.backupEntry.GetNamespace()))
+					Expect(g.Gardener.BackupEntry.Namespace).To(Equal(ctxObjects.backupEntry.GetNamespace()))
 				} else {
 					Expect(ctxObjects.backupEntry).To(BeNil())
 					Expect(g.Gardener.BackupEntry).To(BeNil())


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement
/label ipcei/workload-identity 

**What this PR does / why we need it**:
Use `string` instead of `*string` for namespace in the private WorkloadIdentity claims

**Which issue(s) this PR fixes**:
Part of #9586 

**Special notes for your reviewer**:
~~Only the last two commits 28468f6c9c and a565f5738e are relevant~~
To be merged after https://github.com/gardener/gardener/pull/12321

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
```


/cc @dimityrmirchev 