### PR TITLE
Add gardener upgrade tests for in-place update strategy

### DIFF
--- a/test/e2e/gardener/shoot/create_force-delete.go
+++ b/test/e2e/gardener/shoot/create_force-delete.go
@@ -68,6 +68,6 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	})
 
 	Context("Workerless Shoot", Ordered, func() {
-		test(NewTestContext().ForShoot(DefaultWorkerlessShoot("e2e-fd-wl")))
+		test(NewTestContext().ForShoot(DefaultWorkerlessShoot("e2e-fd")))
 	})
 })

--- a/test/e2e/gardener/shoot/gardenerupgrade/create_upgrade_delete.go
+++ b/test/e2e/gardener/shoot/gardenerupgrade/create_upgrade_delete.go
@@ -6,7 +6,9 @@ package gardenerupgrade
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/utils/ptr"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/test/e2e/gardener"
 	. "github.com/gardener/gardener/test/e2e/gardener/shoot"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/zerodowntimevalidator"
@@ -42,7 +44,15 @@ var _ = Describe("Gardener Upgrade Tests", func() {
 		}
 
 		Context("Shoot with workers", Ordered, func() {
-			test(NewTestContext().ForShoot(DefaultShoot("e2e-upgrade")))
+			shoot := DefaultShoot("e2e-upgrade")
+
+			// add two more worker pools with in-place update strategies
+			shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers,
+				DefaultWorker("auto", ptr.To(gardencorev1beta1.AutoInPlaceUpdate)),
+				DefaultWorker("manual", ptr.To(gardencorev1beta1.ManualInPlaceUpdate)),
+			)
+
+			test(NewTestContext().ForShoot(shoot))
 		})
 
 		Context("Workerless Shoot", Label("workerless"), Ordered, func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Let's include worker pools with in-place update strategy as well in the upgrade test Shoot.

**Which issue(s) this PR fixes**:
Part of #10219 

**Special notes for your reviewer**:
/cc @acumino @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
