### PR TITLE
Allow `Etcd` backup `providerConfig` in `VirtualCluster` when `bucketName` is set

### DIFF
--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -264,15 +264,7 @@ func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster 
 	allErrs = validateDomains(dns, virtualCluster.DNS.Domains, fldPath.Child("dns", "domains"), allErrs)
 
 	if virtualCluster.ETCD != nil && virtualCluster.ETCD.Main != nil {
-		etcdMainFldPath := fldPath.Child("etcd", "main")
-
-		if virtualCluster.ETCD.Main.Backup != nil {
-			if virtualCluster.ETCD.Main.Backup.BucketName != nil && virtualCluster.ETCD.Main.Backup.ProviderConfig != nil {
-				allErrs = append(allErrs, field.Forbidden(etcdMainFldPath.Child("backup", "providerConfig"), "provider must not be set when bucket name is set"))
-			}
-		}
-
-		allErrs = append(allErrs, validateETCDAutoscaling(virtualCluster.ETCD.Main.Autoscaling, corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("300M")}, etcdMainFldPath.Child("autoscaling"))...)
+		allErrs = append(allErrs, validateETCDAutoscaling(virtualCluster.ETCD.Main.Autoscaling, corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("300M")}, fldPath.Child("etcd", "main", "autoscaling"))...)
 	}
 
 	if virtualCluster.ETCD != nil && virtualCluster.ETCD.Events != nil {

--- a/pkg/apis/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden_test.go
@@ -1300,7 +1300,7 @@ var _ = Describe("Validation Tests", func() {
 			})
 
 			Context("ETCD", func() {
-				It("should complain if both bucket name and provider config are set", func() {
+				It("should allow provider config even if bucket name is set", func() {
 					garden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
 						Main: &operatorv1alpha1.ETCDMain{
 							Backup: &operatorv1alpha1.Backup{
@@ -1313,12 +1313,8 @@ var _ = Describe("Validation Tests", func() {
 						},
 					}
 
-					Expect(ValidateGarden(garden, extensions)).To(ContainElements(
-						PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":  Equal(field.ErrorTypeForbidden),
-							"Field": Equal("spec.virtualCluster.etcd.main.backup.providerConfig"),
-						})),
-					))
+					Expect(ValidateGarden(garden, extensions)).To(BeEmpty())
+
 				})
 
 				It("should complain if invalid autoscaling resource is configured", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR removes the validation that previously prevented setting both `bucketName` and `providerConfig` in the ETCD backup configuration of a `VirtualCluster` within the `Garden` resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @timuthy 
/invite @MartinWeindel 
/invite @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `Garden` resource validation no longer forbids setting both `bucketName` and `providerConfig` in the ETCD backup configuration under the `.spec.virtualCluster` field.
```
