### PR TITLE
Improve error message of `CleanKubernetesResources`

### DIFF
--- a/pkg/gardenlet/operation/botanist/cleanup.go
+++ b/pkg/gardenlet/operation/botanist/cleanup.go
@@ -139,7 +139,7 @@ func cleanResourceFn(cleanOps utilclient.CleanOps, c client.Client, list client.
 				if utilclient.AreObjectsRemaining(err) {
 					return retry.MinorError(helper.NewErrorWithCodes(err, gardencorev1beta1.ErrorCleanupClusterResources))
 				}
-				return retry.SevereError(fmt.Errorf("failed cleanup of resource kind %s : %w", list.GetObjectKind(), err))
+				return retry.SevereError(fmt.Errorf("failed cleanup of resource kind %s : %w", list.GetObjectKind().GroupVersionKind().Kind, err))
 			}
 			return retry.Ok()
 		})

--- a/pkg/gardenlet/operation/botanist/cleanup.go
+++ b/pkg/gardenlet/operation/botanist/cleanup.go
@@ -139,7 +139,7 @@ func cleanResourceFn(cleanOps utilclient.CleanOps, c client.Client, list client.
 				if utilclient.AreObjectsRemaining(err) {
 					return retry.MinorError(helper.NewErrorWithCodes(err, gardencorev1beta1.ErrorCleanupClusterResources))
 				}
-				return retry.SevereError(fmt.Errorf("failed cleanup of resource kind %s : %w", list.GetObjectKind().GroupVersionKind().Kind, err))
+				return retry.SevereError(fmt.Errorf("failed to clean up resources with kind %s : %w", list.GetObjectKind().GroupVersionKind().Kind, err))
 			}
 			return retry.Ok()
 		})

--- a/pkg/gardenlet/operation/botanist/cleanup.go
+++ b/pkg/gardenlet/operation/botanist/cleanup.go
@@ -6,6 +6,7 @@ package botanist
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -138,7 +139,7 @@ func cleanResourceFn(cleanOps utilclient.CleanOps, c client.Client, list client.
 				if utilclient.AreObjectsRemaining(err) {
 					return retry.MinorError(helper.NewErrorWithCodes(err, gardencorev1beta1.ErrorCleanupClusterResources))
 				}
-				return retry.SevereError(err)
+				return retry.SevereError(fmt.Errorf("failed cleanup of resource kind %s : %w", list.GetObjectKind(), err))
 			}
 			return retry.Ok()
 		})

--- a/pkg/gardenlet/operation/botanist/cleanup.go
+++ b/pkg/gardenlet/operation/botanist/cleanup.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -23,6 +24,7 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/controllers/autoregister"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -139,7 +141,14 @@ func cleanResourceFn(cleanOps utilclient.CleanOps, c client.Client, list client.
 				if utilclient.AreObjectsRemaining(err) {
 					return retry.MinorError(helper.NewErrorWithCodes(err, gardencorev1beta1.ErrorCleanupClusterResources))
 				}
-				return retry.SevereError(fmt.Errorf("failed to clean up resources with kind %s: %w", list.GetObjectKind().GroupVersionKind().Kind, err))
+
+				gvk, gvkErr := apiutil.GVKForObject(list, c.Scheme())
+				if gvkErr != nil {
+					return retry.SevereError(fmt.Errorf("could not get GroupVersionKind from object %v: %w", list, gvkErr))
+				}
+				gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+				return retry.SevereError(fmt.Errorf("failed to clean up resources with kind %s: %w", gvk.Kind, err))
 			}
 			return retry.Ok()
 		})

--- a/pkg/gardenlet/operation/botanist/cleanup.go
+++ b/pkg/gardenlet/operation/botanist/cleanup.go
@@ -139,7 +139,7 @@ func cleanResourceFn(cleanOps utilclient.CleanOps, c client.Client, list client.
 				if utilclient.AreObjectsRemaining(err) {
 					return retry.MinorError(helper.NewErrorWithCodes(err, gardencorev1beta1.ErrorCleanupClusterResources))
 				}
-				return retry.SevereError(fmt.Errorf("failed to clean up resources with kind %s : %w", list.GetObjectKind().GroupVersionKind().Kind, err))
+				return retry.SevereError(fmt.Errorf("failed to clean up resources with kind %s: %w", list.GetObjectKind().GroupVersionKind().Kind, err))
 			}
 			return retry.Ok()
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR improves error message when `CleanKubernetesResources` fails to pin-point what resource failed cleaning up 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
