### PR TITLE
Flag error during conversion of `StructuredAuthentication` as user error

### DIFF
--- a/pkg/component/kubernetes/apiserver/authentication.go
+++ b/pkg/component/kubernetes/apiserver/authentication.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
@@ -61,7 +62,7 @@ func (k *kubeAPIServer) reconcileConfigMapAuthenticationConfig(ctx context.Conte
 
 	if len(authenticationConfig) > 0 {
 		if err := runtime.DecodeInto(ConfigCodec, []byte(authenticationConfig), authenticationConfiguration); err != nil {
-			return err
+			return v1beta1helper.NewErrorWithCodes(err, gardencorev1beta1.ErrorConfigurationProblem)
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
When met with the following error, it sounds like a pretty obvious user error in the configuration:
```
Last Error
task "Deploying Kubernetes API server" failed: retry failed with context deadline exceeded, last error: converting (v1alpha1.AuthenticationConfiguration) to (v1beta1.AuthenticationConfiguration): unknown conversion
```
This PR aims to mark the error as a user error.

How to reproduce locally:
Apply this breaking `ConfigMap`:
```
apiVersion: v1
data:
  config.yaml: |
    apiVersion: apiserver.config.k8s.io/v1alpha1
    kind: AuthenticationConfiguration
kind: ConfigMap
metadata:
  name: structured-auth-config
  namespace: garden-local
```
Then apply provider-local shoot with reference to ConfigMap:
```
...
    kubeAPIServer:
      structuredAuthentication:
        configMapName: structured-auth-config
```

Then it should be marked as a user error.
**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @dimityrmirchev @AleksandarSavchev @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
