### PR TITLE
[GEP-28] Implement `Bastion` controller in provider-local

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -68,6 +68,7 @@ spec:
         - --service-zone-0-ip={{ .Values.controllers.service.zone0IP }}
         - --service-zone-1-ip={{ .Values.controllers.service.zone1IP }}
         - --service-zone-2-ip={{ .Values.controllers.service.zone2IP }}
+        - --service-bastion-ip={{ .Values.controllers.service.bastionIP }}
         - --backupbucket-local-dir={{ .Values.controllers.backupbucket.localDir }}
         - --backupbucket-container-mount-path={{ .Values.controllers.backupbucket.containerMountPath }}
         - --heartbeat-namespace={{ .Release.Namespace }}

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -55,6 +55,7 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         args:
+        - --bastion-max-concurrent-reconciles={{ .Values.controllers.bastion.concurrentSyncs }}
         - --controlplane-max-concurrent-reconciles={{ .Values.controllers.controlplane.concurrentSyncs }}
         - --dnsrecord-max-concurrent-reconciles={{ .Values.controllers.dnsrecord.concurrentSyncs }}
         - --healthcheck-max-concurrent-reconciles={{ .Values.controllers.healthcheck.concurrentSyncs }}

--- a/charts/gardener/provider-local/templates/rbac.yaml
+++ b/charts/gardener/provider-local/templates/rbac.yaml
@@ -13,6 +13,8 @@ rules:
   - backupbuckets/status
   - backupentries
   - backupentries/status
+  - bastions
+  - bastions/status
   - clusters
   - controlplanes
   - controlplanes/status

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -18,6 +18,8 @@ vpa:
     updateMode: "Auto"
 
 controllers:
+  bastion:
+    concurrentSyncs: 5
   controlplane:
     concurrentSyncs: 5
   dnsrecord:

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -38,7 +38,7 @@ controllers:
     zone0IP: "172.18.255.10"
     zone1IP: "172.18.255.11"
     zone2IP: "172.18.255.12"
-    bastionIP: "172.18.255.24"
+    bastionIP: "172.18.255.22"
   backupbucket:
     localDir: "/dev/local-backupbuckets"
     containerMountPath: "/etc/gardener/local-backupbuckets"

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -36,6 +36,7 @@ controllers:
     zone0IP: "172.18.255.10"
     zone1IP: "172.18.255.11"
     zone2IP: "172.18.255.12"
+    bastionIP: "172.18.255.24"
   backupbucket:
     localDir: "/dev/local-backupbuckets"
     containerMountPath: "/etc/gardener/local-backupbuckets"

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -45,6 +45,7 @@ import (
 	localbackupbucket "github.com/gardener/gardener/pkg/provider-local/controller/backupbucket"
 	localbackupentry "github.com/gardener/gardener/pkg/provider-local/controller/backupentry"
 	"github.com/gardener/gardener/pkg/provider-local/controller/backupoptions"
+	localbastion "github.com/gardener/gardener/pkg/provider-local/controller/bastion"
 	localcontrolplane "github.com/gardener/gardener/pkg/provider-local/controller/controlplane"
 	localdnsrecord "github.com/gardener/gardener/pkg/provider-local/controller/dnsrecord"
 	localextensionshootcontroller "github.com/gardener/gardener/pkg/provider-local/controller/extension/shoot"
@@ -92,6 +93,11 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 
 		// options for the health care controller
 		healthCheckCtrlOpts = &extensionscmdcontroller.ControllerOptions{
+			MaxConcurrentReconciles: 5,
+		}
+
+		// options for the bastion controller
+		bastionCtrlOpts = &extensionscmdcontroller.ControllerOptions{
 			MaxConcurrentReconciles: 5,
 		}
 
@@ -166,6 +172,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			restOpts,
 			mgrOpts,
 			generalOpts,
+			extensionscmdcontroller.PrefixOption("bastion-", bastionCtrlOpts),
 			extensionscmdcontroller.PrefixOption("controlplane-", controlPlaneCtrlOpts),
 			extensionscmdcontroller.PrefixOption("dnsrecord-", dnsRecordCtrlOpts),
 			extensionscmdcontroller.PrefixOption("infrastructure-", infraCtrlOpts),
@@ -263,6 +270,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 
 			log.Info("Adding controllers to manager")
+			bastionCtrlOpts.Completed().Apply(&localbastion.DefaultAddOptions.Controller)
 			controlPlaneCtrlOpts.Completed().Apply(&localcontrolplane.DefaultAddOptions.Controller)
 			dnsRecordCtrlOpts.Completed().Apply(&localdnsrecord.DefaultAddOptions)
 			healthCheckCtrlOpts.Completed().Apply(&localhealthcheck.DefaultAddOptions.Controller)
@@ -279,6 +287,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			prometheusWebhookOptions.Completed().Apply(&prometheuswebhook.DefaultAddOptions)
 
 			reconcileOpts.Completed().Apply(&localbackupbucket.DefaultAddOptions.IgnoreOperationAnnotation, &localbackupbucket.DefaultAddOptions.ExtensionClass)
+			reconcileOpts.Completed().Apply(&localbastion.DefaultAddOptions.IgnoreOperationAnnotation, &localbastion.DefaultAddOptions.ExtensionClass)
 			reconcileOpts.Completed().Apply(&localcontrolplane.DefaultAddOptions.IgnoreOperationAnnotation, &localcontrolplane.DefaultAddOptions.ExtensionClass)
 			reconcileOpts.Completed().Apply(&localdnsrecord.DefaultAddOptions.IgnoreOperationAnnotation, &localdnsrecord.DefaultAddOptions.ExtensionClass)
 			reconcileOpts.Completed().Apply(&localinfrastructure.DefaultAddOptions.IgnoreOperationAnnotation, &localinfrastructure.DefaultAddOptions.ExtensionClass)

--- a/cmd/gardener-extension-provider-local/app/options.go
+++ b/cmd/gardener-extension-provider-local/app/options.go
@@ -5,6 +5,7 @@
 package app
 
 import (
+	extensionsbastioncontroller "github.com/gardener/gardener/extensions/pkg/controller/bastion"
 	extensionscmdcontroller "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	extensionscontrolplanecontroller "github.com/gardener/gardener/extensions/pkg/controller/controlplane"
 	extensionsdnsrecordcontroller "github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
@@ -18,6 +19,7 @@ import (
 	extensionsshootwebhook "github.com/gardener/gardener/extensions/pkg/webhook/shoot"
 	backupbucketcontroller "github.com/gardener/gardener/pkg/provider-local/controller/backupbucket"
 	backupentrycontroller "github.com/gardener/gardener/pkg/provider-local/controller/backupentry"
+	bastioncontroller "github.com/gardener/gardener/pkg/provider-local/controller/bastion"
 	controlplanecontroller "github.com/gardener/gardener/pkg/provider-local/controller/controlplane"
 	dnsrecordcontroller "github.com/gardener/gardener/pkg/provider-local/controller/dnsrecord"
 	localextensionseedcontroller "github.com/gardener/gardener/pkg/provider-local/controller/extension/seed"
@@ -45,6 +47,7 @@ func ControllerSwitchOptions() *extensionscmdcontroller.SwitchOptions {
 	return extensionscmdcontroller.NewSwitchOptions(
 		extensionscmdcontroller.Switch(backupbucketcontroller.ControllerName, backupbucketcontroller.AddToManager),
 		extensionscmdcontroller.Switch(backupentrycontroller.ControllerName, backupentrycontroller.AddToManager),
+		extensionscmdcontroller.Switch(extensionsbastioncontroller.ControllerName, bastioncontroller.AddToManager),
 		extensionscmdcontroller.Switch(extensionscontrolplanecontroller.ControllerName, controlplanecontroller.AddToManager),
 		extensionscmdcontroller.Switch(extensionsdnsrecordcontroller.ControllerName, dnsrecordcontroller.AddToManager),
 		extensionscmdcontroller.Switch(extensionsinfrastructurecontroller.ControllerName, infrastructurecontroller.AddToManager),

--- a/dev-setup/extensions/provider-local/components/controllerregistration/controllerregistration.yaml
+++ b/dev-setup/extensions/provider-local/components/controllerregistration/controllerregistration.yaml
@@ -14,6 +14,8 @@ spec:
       type: local
     - kind: BackupEntry
       type: local
+    - kind: Bastion
+      type: local
     - kind: DNSRecord
       type: local
     - kind: ControlPlane

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -87,6 +87,7 @@ data:
 #### `Infrastructure`
 
 This controller generates a `NetworkPolicy` which allows the control plane pods (like `kube-apiserver`) to communicate with the worker machine pods (see [`Worker` section](#worker)).
+It also deploys a `NetworkPolicy` which allows the bastion pods to communicate with the worker machine pods (see [`Bastion` section](#bastion)).
 
 #### `Network`
 

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -118,9 +118,10 @@ This only happens for shoot namespaces (`gardener.cloud/role=shoot` label) to ma
 
 This controller reconciles `Services` of type `LoadBalancer` in the local `Seed` cluster.
 Since the local Kubernetes clusters used as Seed clusters typically don't support such services, this controller sets the `.status.ingress.loadBalancer.ip[0]` to the IP of the host.
-It makes important LoadBalancer Services (e.g. `istio-ingress/istio-ingressgateway` and `garden/nginx-ingress-controller`) available to the host by setting `spec.ports[].nodePort` to well-known ports that are mapped to `hostPorts` in the kind cluster configuration.
+It makes important LoadBalancer Services (e.g. `istio-ingress/istio-ingressgateway` and `shoot--*--*/bastion-*`) available to the host by setting `spec.ports[].nodePort` to well-known ports that are mapped to `hostPorts` in the kind cluster configuration.
 
 `istio-ingress/istio-ingressgateway` is set to be exposed on `nodePort` `30433` by this controller.
+The bastion services are exposed on `nodePort` `30022`.
 
 In case the seed has multiple availability zones (`.spec.provider.zones`) and it uses SNI, the different zone-specific `istio-ingressgateway` loadbalancers are exposed via different IP addresses. Per default, IP addresses `172.18.255.10`, `172.18.255.11`, and `172.18.255.12` are used for the zones `0`, `1`, and `2` respectively.
 

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -107,6 +107,12 @@ This controller leverages the standard [generic `Worker` actuator](../../extensi
 
 Additionally, it generates the [`MachineClass`es](https://github.com/gardener/machine-controller-manager-provider-local/blob/master/kubernetes/machine-class.yaml) and the `MachineDeployment`s based on the specification of the `Worker` resources.
 
+#### `Bastion`
+
+This controller implements the `Bastion.extensions.gardener.cloud` resource by deploying a pod with the local machine image along with a `LoadBalancer` service.
+
+Note that this controller does not respect the `Bastion.spec.ingress` configuration as there is no way to perform client IP restrictions in the local setup.
+
 #### `Ingress`
 
 The gardenlet creates a wildcard DNS record for the Seed's ingress domain pointing to the `nginx-ingress-controller`'s LoadBalancer.

--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -25,6 +25,16 @@
 {{- end }}
 {{- end }}
 
+{{- define "extraPortMappings.gardener.seed.bastion" -}}
+{{- if .Values.gardener.seed.deployed -}}
+{{- range $i, $listenAddress := (required ".Values.gardener.seed.bastion.listenAddresses is required" .Values.gardener.seed.bastion.listenAddresses) }}
+- containerPort: {{ add 30022 $i }}
+  hostPort: 22
+  listenAddress: {{ $listenAddress }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "extraPortMappings.gardener.operator.virtualGarden" -}}
 {{- if .Values.gardener.garden.deployed -}}
 - containerPort: 31443

--- a/example/gardener-local/kind/cluster/templates/cluster.yaml
+++ b/example/gardener-local/kind/cluster/templates/cluster.yaml
@@ -9,6 +9,7 @@ nodes:
 {{ include "extraPortMappings.gardener.operator.virtualGarden" . | indent 2 }}
 {{ include "extraPortMappings.gardener.controlPlane.etcd" . | indent 2 }}
 {{ include "extraPortMappings.gardener.seed.istio" . | indent 2 }}
+{{ include "extraPortMappings.gardener.seed.bastion" . | indent 2 }}
 {{ include "extraPortMappings.registry" . | indent 2 }}
 {{ include "extraPortMappings.gardener.seed.dns" . | indent 2 }}
   extraMounts:

--- a/example/gardener-local/kind/cluster/values-dual.yaml
+++ b/example/gardener-local/kind/cluster/values-dual.yaml
@@ -4,6 +4,10 @@ gardener:
       listenAddresses:
       - "::1"
       - "172.18.255.1"
+    bastion:
+      listenAddresses:
+      - "::24"
+      - "172.18.255.24"
 
 networking:
   ipFamily: dual

--- a/example/gardener-local/kind/cluster/values-dual.yaml
+++ b/example/gardener-local/kind/cluster/values-dual.yaml
@@ -6,8 +6,8 @@ gardener:
       - "172.18.255.1"
     bastion:
       listenAddresses:
-      - "::24"
-      - "172.18.255.24"
+      - "::22"
+      - "172.18.255.22"
 
 networking:
   ipFamily: dual

--- a/example/gardener-local/kind/cluster/values-ipv6.yaml
+++ b/example/gardener-local/kind/cluster/values-ipv6.yaml
@@ -3,6 +3,9 @@ gardener:
     istio:
       listenAddresses:
       - ::1
+    bastion:
+      listenAddresses:
+      - ::24
 
 networking:
   ipFamily: ipv6

--- a/example/gardener-local/kind/cluster/values-ipv6.yaml
+++ b/example/gardener-local/kind/cluster/values-ipv6.yaml
@@ -5,7 +5,7 @@ gardener:
       - ::1
     bastion:
       listenAddresses:
-      - ::24
+      - ::22
 
 networking:
   ipFamily: ipv6

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -16,7 +16,7 @@ gardener:
       - 172.18.255.1
     bastion:
       listenAddresses:
-      - 172.18.255.24
+      - 172.18.255.22
   repositoryRoot: "."
   garden:
     deployed: false

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -14,6 +14,9 @@ gardener:
     istio:
       listenAddresses:
       - 172.18.255.1
+    bastion:
+      listenAddresses:
+      - 172.18.255.24
   repositoryRoot: "."
   garden:
     deployed: false

--- a/example/gardener-local/kind/local2/values.yaml
+++ b/example/gardener-local/kind/local2/values.yaml
@@ -5,6 +5,8 @@ gardener:
     istio:
       listenAddresses:
       - 172.18.255.2
+    bastion:
+      listenAddresses: []
 
 registry:
   deployed: false

--- a/example/gardener-local/kind/multi-node2/values.yaml
+++ b/example/gardener-local/kind/multi-node2/values.yaml
@@ -5,6 +5,8 @@ gardener:
     istio:
       listenAddresses:
       - 172.18.255.2
+    bastion:
+      listenAddresses: []
 
 registry:
   deployed: false

--- a/example/provider-local/garden/dual/patch-controller-deployment.yaml
+++ b/example/provider-local/garden/dual/patch-controller-deployment.yaml
@@ -10,6 +10,7 @@ helm:
         zone0IP: "::10"
         zone1IP: "::11"
         zone2IP: "::12"
+        bastionIP: "::24"
     coredns:
       ipFamilies:
         - IPv6

--- a/example/provider-local/garden/dual/patch-controller-deployment.yaml
+++ b/example/provider-local/garden/dual/patch-controller-deployment.yaml
@@ -10,7 +10,7 @@ helm:
         zone0IP: "::10"
         zone1IP: "::11"
         zone2IP: "::12"
-        bastionIP: "::24"
+        bastionIP: "::22"
     coredns:
       ipFamilies:
         - IPv6

--- a/example/provider-local/garden/ipv6/patch-controller-deployment.yaml
+++ b/example/provider-local/garden/ipv6/patch-controller-deployment.yaml
@@ -10,4 +10,4 @@ helm:
         zone0IP: "::10"
         zone1IP: "::11"
         zone2IP: "::12"
-        bastionIP: "::24"
+        bastionIP: "::22"

--- a/example/provider-local/garden/ipv6/patch-controller-deployment.yaml
+++ b/example/provider-local/garden/ipv6/patch-controller-deployment.yaml
@@ -10,3 +10,4 @@ helm:
         zone0IP: "::10"
         zone1IP: "::11"
         zone2IP: "::12"
+        bastionIP: "::24"

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -294,6 +294,14 @@ if [[ "$MULTI_ZONAL" == "true" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::10 ::11 ::12)
   fi
 fi
+
+if [[ "$CLUSTER_NAME" != "*local2*" ]] ; then
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.24)
+  if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(::24)
+  fi
+fi
+
 if [[ "$CLUSTER_NAME" == "gardener-operator-local" ]]; then
   LOOPBACK_IP_ADDRESSES+=(172.18.255.3)
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -296,9 +296,9 @@ if [[ "$MULTI_ZONAL" == "true" ]]; then
 fi
 
 if [[ "$CLUSTER_NAME" != "*local2*" ]] ; then
-  LOOPBACK_IP_ADDRESSES+=(172.18.255.24)
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.22)
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
-    LOOPBACK_IP_ADDRESSES+=(::24)
+    LOOPBACK_IP_ADDRESSES+=(::22)
   fi
 fi
 

--- a/pkg/controller/service/add.go
+++ b/pkg/controller/service/add.go
@@ -23,6 +23,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, predicates ...predicate.P
 	if r.HostIP == "" {
 		r.HostIP = "172.18.255.1"
 	}
+	if r.BastionIP == "" {
+		r.BastionIP = "172.18.255.24"
+	}
 
 	return builder.
 		ControllerManagedBy(mgr).

--- a/pkg/controller/service/add.go
+++ b/pkg/controller/service/add.go
@@ -24,7 +24,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, predicates ...predicate.P
 		r.HostIP = "172.18.255.1"
 	}
 	if r.BastionIP == "" {
-		r.BastionIP = "172.18.255.24"
+		r.BastionIP = "172.18.255.22"
 	}
 
 	return builder.

--- a/pkg/provider-local/controller/bastion/actuator.go
+++ b/pkg/provider-local/controller/bastion/actuator.go
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bastion
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	extensionsbastion "github.com/gardener/gardener/extensions/pkg/bastion"
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
+	"github.com/gardener/gardener/pkg/provider-local/apis/local/helper"
+	"github.com/gardener/gardener/pkg/provider-local/local"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+// SSHPort is the default SSH port.
+const SSHPort = 22
+
+type actuator struct {
+	client client.Client
+}
+
+func newActuator(mgr manager.Manager) bastion.Actuator {
+	return &actuator{
+		client: mgr.GetClient(),
+	}
+}
+
+func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, bastion *extensionsv1alpha1.Bastion, cluster *extensionscontroller.Cluster) error {
+	image, err := bastionImage(cluster)
+	if err != nil {
+		return err
+	}
+
+	var (
+		userDataSecret = userDataSecretForBastion(bastion)
+		pod            = podForBastion(bastion, image, userDataSecret.Name)
+		service        = serviceForBastion(bastion)
+	)
+
+	for _, obj := range []client.Object{userDataSecret, pod, service} {
+		if err := controllerutil.SetControllerReference(bastion, obj, a.client.Scheme()); err != nil {
+			return fmt.Errorf("failed to set controller reference on %T %q: %w", obj, client.ObjectKeyFromObject(obj), err)
+		}
+		if err := a.client.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
+			return fmt.Errorf("failed to apply %T %q: %w", obj, client.ObjectKeyFromObject(obj), err)
+		}
+	}
+
+	// wait for LoadBalancer to be ready
+	if err := health.CheckService(service); err != nil {
+		return &reconcilerutils.RequeueAfterError{
+			RequeueAfter: 5 * time.Second,
+			Cause:        fmt.Errorf("waiting for Bastion LoadBalancer to get ready: %w", err),
+		}
+	}
+
+	// wait for Pod to be ready
+	if !health.IsPodReady(pod) {
+		return &reconcilerutils.RequeueAfterError{
+			RequeueAfter: 5 * time.Second,
+			Cause:        fmt.Errorf("waiting for Bastion Pod to get ready"),
+		}
+	}
+
+	patch := client.MergeFrom(bastion.DeepCopy())
+	bastion.Status.Ingress = service.Status.LoadBalancer.Ingress[0].DeepCopy()
+	return a.client.Status().Patch(ctx, bastion, patch)
+}
+
+func (a *actuator) Delete(ctx context.Context, log logr.Logger, bastion *extensionsv1alpha1.Bastion, _ *extensionscontroller.Cluster) error {
+	// Explicitly delete the Bastion Pod so that we can wait for it to terminate. The other objects will get cleaned up by
+	// the garbage collector (due to ownerReferences), but only after removing the Bastion's finalizer.
+	if err := a.client.Delete(ctx, podForBastion(bastion, "", "")); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Bastion Pod gone, releasing Bastion")
+			return nil
+		}
+		return err
+	}
+
+	return &reconcilerutils.RequeueAfterError{
+		RequeueAfter: 10 * time.Second,
+		Cause:        fmt.Errorf("waiting for Bastion Pod to terminate"),
+	}
+}
+
+func (a *actuator) ForceDelete(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.Bastion, _ *extensionscontroller.Cluster) error {
+	return nil
+}
+
+func bastionImage(cluster *extensionscontroller.Cluster) (string, error) {
+	machineSpec, err := extensionsbastion.GetMachineSpecFromCloudProfile(cluster.CloudProfile)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine machine spec for bastion from CloudProfile: %w", err)
+	}
+
+	cloudProfileConfig, err := helper.CloudProfileConfigFromCluster(cluster)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract CloudProfileConfig from cluster: %w", err)
+	}
+
+	image, err := helper.FindImageFromCloudProfile(cloudProfileConfig, machineSpec.ImageBaseName, machineSpec.ImageVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to find machine image in CloudProfileConfig: %w", err)
+	}
+
+	return image, nil
+}
+
+func objectMetaForBastion(bastion *extensionsv1alpha1.Bastion) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      "bastion-" + bastion.Name,
+		Namespace: bastion.Namespace,
+		Labels: map[string]string{
+			"app":     "bastion",
+			"bastion": bastion.Name,
+		},
+	}
+}
+
+func userDataSecretForBastion(bastion *extensionsv1alpha1.Bastion) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: objectMetaForBastion(bastion),
+		Data: map[string][]byte{
+			"userdata": bastion.Spec.UserData,
+		},
+	}
+}
+
+func podForBastion(bastion *extensionsv1alpha1.Bastion, image, userDataSecretName string) *corev1.Pod {
+	objectMeta := objectMetaForBastion(bastion)
+	metav1.SetMetaDataLabel(&objectMeta, gardenerutils.NetworkPolicyLabel("machines", SSHPort), v1beta1constants.LabelNetworkPolicyAllowed)
+
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+		},
+		ObjectMeta: objectMeta,
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "machine",
+					Image:           image,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: pointer.Bool(true),
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "userdata",
+							MountPath: "/etc/machine",
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: intstr.FromString("ssh"),
+							},
+						},
+					},
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: SSHPort,
+						Name:          "ssh",
+						Protocol:      corev1.ProtocolTCP,
+					}},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "userdata",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  userDataSecretName,
+							DefaultMode: pointer.Int32(0777),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func serviceForBastion(bastion *extensionsv1alpha1.Bastion) *corev1.Service {
+	objectMeta := objectMetaForBastion(bastion)
+	metav1.SetMetaDataAnnotation(&objectMeta, resourcesv1alpha1.NetworkingFromWorldToPorts, fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, SSHPort))
+
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Service",
+		},
+		ObjectMeta: objectMeta,
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeLoadBalancer,
+			Selector: objectMeta.DeepCopy().Labels,
+			Ports: []corev1.ServicePort{{
+				Name:        "ssh",
+				Port:        SSHPort,
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: ptr.To("ssh"),
+			}},
+		},
+	}
+}

--- a/pkg/provider-local/controller/bastion/add.go
+++ b/pkg/provider-local/controller/bastion/add.go
@@ -20,7 +20,7 @@ var (
 	DefaultAddOptions = AddOptions{}
 )
 
-// AddOptions are options to apply when adding the AWS bastion controller to the manager.
+// AddOptions are options to apply when adding the provider-local bastion controller to the manager.
 type AddOptions struct {
 	// Controller are the controller.Options.
 	Controller controller.Options

--- a/pkg/provider-local/controller/bastion/add.go
+++ b/pkg/provider-local/controller/bastion/add.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bastion
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/provider-local/local"
+)
+
+var (
+	// DefaultAddOptions are the default AddOptions for AddToManager.
+	DefaultAddOptions = AddOptions{}
+)
+
+// AddOptions are options to apply when adding the AWS bastion controller to the manager.
+type AddOptions struct {
+	// Controller are the controller.Options.
+	Controller controller.Options
+	// IgnoreOperationAnnotation specifies whether to ignore the operation annotation or not.
+	IgnoreOperationAnnotation bool
+	// ExtensionClass defines the extension class this extension is responsible for.
+	ExtensionClass extensionsv1alpha1.ExtensionClass
+}
+
+// AddToManagerWithOptions adds a controller with the given Options to the given manager.
+// The opts.Reconciler is being set with a newly instantiated actuator.
+func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
+	return bastion.Add(mgr, bastion.AddArgs{
+		Actuator:          newActuator(mgr),
+		ControllerOptions: opts.Controller,
+		Predicates:        bastion.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              local.Type,
+		ExtensionClass:    opts.ExtensionClass,
+	})
+}
+
+// AddToManager adds a controller with the default Options.
+func AddToManager(_ context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+}

--- a/pkg/provider-local/controller/operatingsystemconfig/actuator.go
+++ b/pkg/provider-local/controller/operatingsystemconfig/actuator.go
@@ -36,7 +36,6 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, osc *extensions
 
 	case extensionsv1alpha1.OperatingSystemConfigPurposeReconcile:
 		extensionUnits, inPlaceUpdates := a.handleReconcileOSC(osc)
-		// provider-local does not add any additional units or additional files
 		return nil, extensionUnits, nil, inPlaceUpdates, nil
 
 	default:

--- a/pkg/provider-local/controller/service/options.go
+++ b/pkg/provider-local/controller/service/options.go
@@ -22,6 +22,8 @@ type ControllerOptions struct {
 	Zone1IP string
 	// Zone2IP is the IP address to be used for the zone 2 istio ingress gateway.
 	Zone2IP string
+	// BastionIP is the bastion IP.
+	BastionIP string
 
 	config *ControllerConfig
 }
@@ -33,11 +35,12 @@ func (c *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Zone0IP, "zone-0-ip", c.Zone0IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 0")
 	fs.StringVar(&c.Zone1IP, "zone-1-ip", c.Zone1IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 1")
 	fs.StringVar(&c.Zone2IP, "zone-2-ip", c.Zone2IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 2")
+	fs.StringVar(&c.BastionIP, "bastion-ip", c.BastionIP, "Overwrite Bastion IP to use for Bastion service LoadBalancer")
 }
 
 // Complete implements Completer.Complete.
 func (c *ControllerOptions) Complete() error {
-	c.config = &ControllerConfig{c.MaxConcurrentReconciles, c.HostIP, c.Zone0IP, c.Zone1IP, c.Zone2IP}
+	c.config = &ControllerConfig{c.MaxConcurrentReconciles, c.HostIP, c.Zone0IP, c.Zone1IP, c.Zone2IP, c.BastionIP}
 	return nil
 }
 
@@ -58,6 +61,8 @@ type ControllerConfig struct {
 	Zone1IP string
 	// Zone2IP is the IP address to be used for the zone 2 istio ingress gateway.
 	Zone2IP string
+	// BastionIP is the bastion IP.
+	BastionIP string
 }
 
 // Apply sets the values of this ControllerConfig in the given AddOptions.
@@ -67,4 +72,5 @@ func (c *ControllerConfig) Apply(opts *AddOptions) {
 	opts.Zone0IP = c.Zone0IP
 	opts.Zone1IP = c.Zone1IP
 	opts.Zone2IP = c.Zone2IP
+	opts.BastionIP = c.BastionIP
 }

--- a/pkg/provider-local/node/Dockerfile
+++ b/pkg/provider-local/node/Dockerfile
@@ -1,7 +1,7 @@
 FROM kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d
 
 RUN apt-get update -yq && \
-    apt-get install -yq --no-install-recommends wget apparmor apparmor-utils jq openssh-server sudo
+    apt-get install -yq --no-install-recommends wget apparmor apparmor-utils jq openssh-server sudo logrotate
 
 # remove kind's kubelet unit
 RUN rm -f /etc/systemd/system/kubelet.service && \

--- a/pkg/utils/ssh/connection.go
+++ b/pkg/utils/ssh/connection.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var _ = io.Closer(&Connection{})
+
+// Connection simplifies working with SSH connections for standard command execution and connection proxying.
+// Use Dial to open a new Connection, and ensure to call Connection.Close() for cleanup.
+type Connection struct {
+	*ssh.Client
+}
+
+// Dial opens a new SSH Connection. Ensure to call Connection.Close() for cleanup.
+func Dial(ctx context.Context, addr string, opts ...Option) (*Connection, error) {
+	config := DefaultConfig()
+	for _, opt := range opts {
+		if err := opt(config); err != nil {
+			return nil, err
+		}
+	}
+
+	tcpConn, err := config.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, chans, reqs, err := ssh.NewClientConn(tcpConn, addr, &config.ClientConfig)
+	if err != nil {
+		_ = tcpConn.Close()
+		return nil, err
+	}
+
+	return &Connection{Client: ssh.NewClient(conn, chans, reqs)}, nil
+}
+
+// Run executes the given command on the remote host and returns stdout and stderr streams.
+func (c *Connection) Run(command string) (io.Reader, io.Reader, error) {
+	var stdout, stderr bytes.Buffer
+	return &stdout, &stderr, c.RunWithStreams(nil, &stdout, &stderr, command)
+}
+
+// RunWithStreams executes the given command on the remote host with the configured streams.
+func (c *Connection) RunWithStreams(stdin io.Reader, stdout, stderr io.Writer, command string) error {
+	session, err := c.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	session.Stdin = stdin
+	session.Stdout = stdout
+	session.Stderr = stderr
+
+	return session.Run(command)
+}

--- a/pkg/utils/ssh/knownhosts.go
+++ b/pkg/utils/ssh/knownhosts.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// SingleKnownHost is a simple HostKeyCallback that stores the host key in memory on the first callback.
+// Future callbacks verify that the host key hasn't changed.
+func SingleKnownHost() ssh.HostKeyCallback {
+	var knownKey []byte
+	return func(_ string, _ net.Addr, key ssh.PublicKey) error {
+		if len(knownKey) == 0 {
+			knownKey = key.Marshal()
+			return nil
+		}
+
+		if !bytes.Equal(knownKey, key.Marshal()) {
+			return fmt.Errorf("known host key does not match")
+		}
+		return nil
+	}
+}

--- a/pkg/utils/ssh/options.go
+++ b/pkg/utils/ssh/options.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"context"
+	"crypto/rsa"
+	"net"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Config contains configuration for connecting to remote hosts.
+type Config struct {
+	// ClientConfig is the standard SSH client config.
+	ssh.ClientConfig
+	// DialContext is used for opening TCP connections to the remote host. Defaults to a net.Dialer with 30s timeout.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+// DefaultConfig is the default SSH client Config used by Dial.
+func DefaultConfig() *Config {
+	return &Config{
+		ClientConfig: ssh.ClientConfig{
+			Timeout:         30 * time.Second,
+			HostKeyCallback: SingleKnownHost(),
+		},
+		DialContext: (&net.Dialer{Timeout: 30 * time.Second}).DialContext,
+	}
+}
+
+// Option is an option that can be passed to Dial for customizing the client Config.
+type Option func(opts *Config) error
+
+// WithUser configures the login user.
+func WithUser(user string) Option {
+	return func(opts *Config) error {
+		opts.User = user
+		return nil
+	}
+}
+
+// WithPrivateKey configures the client to authenticate using the given RSA private key.
+func WithPrivateKey(key *rsa.PrivateKey) Option {
+	return func(opts *Config) error {
+		signer, err := ssh.NewSignerFromKey(key)
+		if err != nil {
+			return err
+		}
+		opts.Auth = append(opts.Auth, ssh.PublicKeys(signer))
+		return nil
+	}
+}
+
+// WithPrivateKeyBytes configures the client to authenticate using the given PEM encoded private key.
+func WithPrivateKeyBytes(key []byte) Option {
+	return func(opts *Config) error {
+		signer, err := ssh.ParsePrivateKey(key)
+		if err != nil {
+			return err
+		}
+		opts.Auth = append(opts.Auth, ssh.PublicKeys(signer))
+		return nil
+	}
+}
+
+// WithProxyConnection configures the client to open the new TCP connection to the remote host via another open SSH
+// connection.
+func WithProxyConnection(conn *Connection) Option {
+	return func(opts *Config) error {
+		opts.DialContext = conn.DialContext
+		return nil
+	}
+}

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -625,10 +625,12 @@ build:
             - cmd/gardener-extension-provider-local/app
             - cmd/utils
             - extensions/pkg/apis/config/v1alpha1
+            - extensions/pkg/bastion
             - extensions/pkg/controller
             - extensions/pkg/controller/backupbucket
             - extensions/pkg/controller/backupentry
             - extensions/pkg/controller/backupentry/genericactuator
+            - extensions/pkg/controller/bastion
             - extensions/pkg/controller/cmd
             - extensions/pkg/controller/controlplane
             - extensions/pkg/controller/controlplane/genericactuator
@@ -742,6 +744,7 @@ build:
             - pkg/provider-local/controller/backupbucket
             - pkg/provider-local/controller/backupentry
             - pkg/provider-local/controller/backupoptions
+            - pkg/provider-local/controller/bastion
             - pkg/provider-local/controller/controlplane
             - pkg/provider-local/controller/dnsrecord
             - pkg/provider-local/controller/extension/seed

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1029,10 +1029,12 @@ build:
             - cmd/gardener-extension-provider-local/app
             - cmd/utils
             - extensions/pkg/apis/config/v1alpha1
+            - extensions/pkg/bastion
             - extensions/pkg/controller
             - extensions/pkg/controller/backupbucket
             - extensions/pkg/controller/backupentry
             - extensions/pkg/controller/backupentry/genericactuator
+            - extensions/pkg/controller/bastion
             - extensions/pkg/controller/cmd
             - extensions/pkg/controller/controlplane
             - extensions/pkg/controller/controlplane/genericactuator
@@ -1146,6 +1148,7 @@ build:
             - pkg/provider-local/controller/backupbucket
             - pkg/provider-local/controller/backupentry
             - pkg/provider-local/controller/backupoptions
+            - pkg/provider-local/controller/bastion
             - pkg/provider-local/controller/controlplane
             - pkg/provider-local/controller/dnsrecord
             - pkg/provider-local/controller/extension/seed

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -656,10 +656,12 @@ build:
             - cmd/gardener-extension-provider-local/app
             - cmd/utils
             - extensions/pkg/apis/config/v1alpha1
+            - extensions/pkg/bastion
             - extensions/pkg/controller
             - extensions/pkg/controller/backupbucket
             - extensions/pkg/controller/backupentry
             - extensions/pkg/controller/backupentry/genericactuator
+            - extensions/pkg/controller/bastion
             - extensions/pkg/controller/cmd
             - extensions/pkg/controller/controlplane
             - extensions/pkg/controller/controlplane/genericactuator
@@ -773,6 +775,7 @@ build:
             - pkg/provider-local/controller/backupbucket
             - pkg/provider-local/controller/backupentry
             - pkg/provider-local/controller/backupoptions
+            - pkg/provider-local/controller/bastion
             - pkg/provider-local/controller/controlplane
             - pkg/provider-local/controller/dnsrecord
             - pkg/provider-local/controller/extension/seed

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/gardener/gardener/test/e2e"
 	. "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/bastion"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/zerodowntimevalidator"
 	"github.com/gardener/gardener/test/utils/access"
@@ -95,6 +96,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				}, SpecTimeout(time.Minute))
 
 				inclusterclient.VerifyInClusterAccessToAPIServer(s)
+				bastion.VerifyBastion(s)
 			}
 
 			zeroDowntimeValidatorJob := &zerodowntimevalidator.Job{}

--- a/test/e2e/gardener/shoot/internal/bastion/bastion.go
+++ b/test/e2e/gardener/shoot/internal/bastion/bastion.go
@@ -117,7 +117,7 @@ func VerifyBastion(s *ShootContext) {
 			Eventually(ctx, s.GardenKomega.ObjectList(bastionList)).
 				WithPolling(5 * time.Second).
 				Should(HaveField("Items", BeEmpty()))
-		}, SpecTimeout(15*time.Minute))
+		}, SpecTimeout(5*time.Minute))
 
 		var bastionSSHKey *rsa.PrivateKey
 		It("should create the Bastion", func(ctx SpecContext) {

--- a/test/e2e/gardener/shoot/internal/bastion/bastion.go
+++ b/test/e2e/gardener/shoot/internal/bastion/bastion.go
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bastion
+
+import (
+	"crypto/rsa"
+	"io"
+	"net"
+	"slices"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	sshutils "github.com/gardener/gardener/pkg/utils/ssh"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+)
+
+const name = "e2e-test-bastion"
+
+// VerifyBastion tests the Bastion functionality of a shoot cluster.
+func VerifyBastion(s *ShootContext) {
+	GinkgoHelper()
+
+	Describe("Bastion", Label("bastion"), func() {
+		var (
+			bastion *operationsv1alpha1.Bastion
+			closers []io.Closer
+		)
+
+		BeforeAll(func() {
+			bastion = &operationsv1alpha1.Bastion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name + "-" + s.Shoot.Name,
+					Namespace: s.Shoot.Namespace,
+				},
+				Spec: operationsv1alpha1.BastionSpec{
+					ShootRef: corev1.LocalObjectReference{
+						Name: s.Shoot.Name,
+					},
+					Ingress: []operationsv1alpha1.BastionIngressPolicy{{
+						IPBlock: networkingv1.IPBlock{
+							CIDR: "0.0.0.0/0",
+						},
+					}},
+				},
+			}
+
+			DeferCleanup(func(ctx SpecContext) {
+				Eventually(ctx, func() error {
+					return s.GardenClient.Delete(ctx, bastion)
+				}).Should(Or(Succeed(), BeNotFoundError()))
+			}, NodeTimeout(time.Minute))
+
+			// Close the remaining open connections (if any) on best effort basis.
+			closers = nil
+			DeferCleanup(func() {
+				for _, closer := range closers {
+					// We ignore the error, as closing could result in "use of closed network connection".
+					_ = closer.Close()
+				}
+			})
+		})
+
+		var nodeSSHKey []byte
+		It("should fetch the shoot SSH key", func(ctx SpecContext) {
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      gardenerutils.ComputeShootProjectResourceName(s.Shoot.Name, gardenerutils.ShootProjectSecretSuffixSSHKeypair),
+				Namespace: s.Shoot.Namespace,
+			}}
+			Eventually(ctx, s.GardenKomega.Get(secret)).Should(Succeed())
+
+			nodeSSHKey = secret.Data[secretsutils.DataKeyRSAPrivateKey]
+		}, SpecTimeout(time.Minute))
+
+		var nodeName, nodeAddr string
+		It("should pick a shoot Node with InternalIP", func(ctx SpecContext) {
+			var nodes []corev1.Node
+			Eventually(ctx, s.ShootKomega.ObjectList(&corev1.NodeList{})).Should(
+				HaveField("Items", ContainElement(
+					HaveField("Status.Addresses", ContainElement(
+						HaveField("Type", corev1.NodeInternalIP),
+					)),
+					&nodes,
+				)),
+			)
+
+			nodeName = nodes[0].Name
+			AddReportEntry("node-name", nodeName)
+
+			nodeAddresses := nodes[0].Status.Addresses
+			nodeInternalIP := nodeAddresses[slices.IndexFunc(nodeAddresses, func(address corev1.NodeAddress) bool {
+				return address.Type == corev1.NodeInternalIP
+			})].Address
+			AddReportEntry("node-internal-ip", nodeInternalIP)
+
+			nodeAddr = net.JoinHostPort(nodeInternalIP, "22")
+		}, SpecTimeout(time.Minute))
+
+		It("should ensure there are no other Bastions", func(ctx SpecContext) {
+			// For now, the local setup supports only a single Bastion at a time because there is only one LoadBalancer IP.
+			// With this step, we try to avoid creating multiple Bastions at the same time that interfere with each other.
+			bastionList := &operationsv1alpha1.BastionList{}
+			Eventually(ctx, s.GardenKomega.ObjectList(bastionList)).
+				WithPolling(5 * time.Second).
+				Should(HaveField("Items", BeEmpty()))
+		}, SpecTimeout(15*time.Minute))
+
+		var bastionSSHKey *rsa.PrivateKey
+		It("should create the Bastion", func(ctx SpecContext) {
+			sshKeyInterface, err := (&secretsutils.RSASecretConfig{
+				Name:       name,
+				Bits:       4096,
+				UsedForSSH: true,
+			}).Generate()
+			Expect(err).NotTo(HaveOccurred())
+			sshKey := sshKeyInterface.(*secretsutils.RSAKeys)
+
+			bastionSSHKey = sshKey.PrivateKey
+
+			bastion.Spec.SSHPublicKey = string(sshKey.SecretData()[secretsutils.DataKeySSHAuthorizedKeys])
+
+			Eventually(ctx, func() error {
+				err := s.GardenClient.Create(ctx, bastion)
+				if apierrors.IsAlreadyExists(err) {
+					return StopTrying(err.Error())
+				}
+				return err
+			}).Should(Succeed())
+		}, SpecTimeout(time.Minute))
+
+		var bastionAddr string
+		It("should get ready", func(ctx SpecContext) {
+			Eventually(ctx, s.GardenKomega.Object(bastion)).Should(And(
+				HaveField("Status.Conditions", ConsistOf(And(
+					HaveField("Type", operationsv1alpha1.BastionReady),
+					HaveField("Status", gardencorev1beta1.ConditionTrue),
+				))),
+				HaveField("Status.Ingress", Not(BeNil())),
+			))
+
+			bastionHost := bastion.Status.Ingress.IP
+			if bastionHost == "" {
+				bastionHost = bastion.Status.Ingress.Hostname
+			}
+			AddReportEntry("bastion-host", bastionHost)
+			bastionAddr = net.JoinHostPort(bastionHost, "22")
+		}, SpecTimeout(5*time.Minute))
+
+		var bastionConnection *sshutils.Connection
+		It("should connect to the Bastion", func(ctx SpecContext) {
+			Eventually(ctx, func() error {
+				var err error
+				bastionConnection, err = sshutils.Dial(ctx, bastionAddr,
+					sshutils.WithUser("gardener"), sshutils.WithPrivateKey(bastionSSHKey),
+				)
+				return err
+			}).Should(Succeed())
+			closers = append(closers, bastionConnection)
+		}, SpecTimeout(time.Minute))
+
+		It("should connect to the Node via Bastion", func(ctx SpecContext) {
+			var nodeConnection *sshutils.Connection
+			Eventually(ctx, func() error {
+				var err error
+				nodeConnection, err = sshutils.Dial(ctx, nodeAddr,
+					sshutils.WithProxyConnection(bastionConnection),
+					sshutils.WithUser("gardener"), sshutils.WithPrivateKeyBytes(nodeSSHKey),
+				)
+				return err
+			}).Should(Succeed())
+			closers = append(closers, nodeConnection)
+
+			Eventually(ctx, execute(nodeConnection, "hostname")).Should(gbytes.Say(nodeName))
+		}, SpecTimeout(time.Minute))
+
+		It("should delete the Bastion", func(ctx SpecContext) {
+			Eventually(ctx, func() error {
+				return s.GardenClient.Delete(ctx, bastion)
+			}).Should(Or(Succeed(), BeNotFoundError()))
+		}, SpecTimeout(time.Minute))
+
+		It("should get deleted", func(ctx SpecContext) {
+			Eventually(ctx, s.GardenKomega.Get(bastion)).Should(BeNotFoundError())
+		}, SpecTimeout(time.Minute))
+	})
+}
+
+func execute(c *sshutils.Connection, command string) *gbytes.Buffer {
+	GinkgoHelper()
+
+	combinedBuffer := gbytes.NewBuffer()
+	Expect(c.RunWithStreams(
+		nil,
+		io.MultiWriter(combinedBuffer, gexec.NewPrefixedWriter("[out] ", GinkgoWriter)),
+		io.MultiWriter(combinedBuffer, gexec.NewPrefixedWriter("[err] ", GinkgoWriter)),
+		command,
+	)).To(Succeed())
+
+	return combinedBuffer
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind enhancement

**What this PR does / why we need it**:

This PR implements the `Bastion` controller in provider-local. For this, it deploys another pod with the local node image and a corresponding `LoadBalancer` service. As with other `LoadBalancer` services in the local setup, there is some network magic involved (see the provider-local `service` controller).
This PR also fixes user login sessions on local shoot nodes (required for SSH).

Finally, the PR adds e2e tests for the newly added `Bastion` functionality. With this, we extend the test coverage of local e2e tests to previously untested parts of the codebase.
The e2e tests use a newly introduced package (`pkg/utils/ssh`) that simplifies SSH connection handling for our use cases (e2e test and later on in `gardenadm bootstrap`).

This prepares the `Bastion` usage in `gardenadm bootstrap`, see [GEP-28](https://github.com/gardener/gardener/blob/master/docs/proposals/28-autonomous-shoot-clusters.md#gardenadm-bootstrap).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @ScheererJ @rfranzke @maboehm 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The provider-local extension implements the `Bastion` resource now. With this, you can use `gardenctl ssh` in the local setup.
```
