### PR TITLE
Use mirrored Perses images from Gardener mirror instead of quay.io

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -383,7 +383,7 @@ images:
             teamname: 'gardener/monitoring-maintainers'
   - name: perses
     sourceRepository: github.com/perses/perses
-    repository: quay.io/persesdev/perses
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/persesdev/perses
     tag: "v0.51.0"
     labels:
       - name: gardener.cloud/cve-categorisation
@@ -400,7 +400,7 @@ images:
             teamname: 'gardener/monitoring-maintainers'
   - name: perses-operator
     sourceRepository: github.com/perses/perses-operator
-    repository: quay.io/persesdev/perses-operator
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/persesdev/perses-operator
     tag: v0.1.12
     labels:
       - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind impediment

**What this PR does / why we need it**:
Use mirrored Perses images from docker hub instead of `quay.io` images.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
See also: https://github.com/gardener/ci-infra/pull/3982
cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Perses container images are switched from upstream `quay.io` images to Gardener AR images (mirror from upstream `docker.io` images). The upstream `quay.io` images are 200MB larger compared to the `docker.io` ones and include binary with Sleepycat license (Berkeley DB).
```
