### PR TITLE
[GEP-26] Do not set "null" as config data in workloadidentity secret

### DIFF
--- a/pkg/utils/workloadidentity/secret.go
+++ b/pkg/utils/workloadidentity/secret.go
@@ -114,6 +114,9 @@ func For(workloadIdentityName, workloadIdentityNamespace, workloadIdentityProvid
 // provider specific information in the workload identity secret.
 func WithProviderConfig(providerConfig *runtime.RawExtension) SecretOption {
 	return func(s *Secret) error {
+		if providerConfig == nil {
+			return nil
+		}
 		data, err := json.Marshal(providerConfig)
 		if err != nil {
 			return err

--- a/pkg/utils/workloadidentity/secret_test.go
+++ b/pkg/utils/workloadidentity/secret_test.go
@@ -245,4 +245,23 @@ var _ = Describe("#Secret", func() {
 			},
 		}))
 	})
+
+	It("should not set the `config` data key when provider config is nil", func() {
+		secret, err := workloadidentity.NewSecret(secretName, secretNamespace,
+			workloadidentity.For("wi-foo", "wi-ns", "provider"),
+			workloadidentity.WithProviderConfig(nil),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(secret.Reconcile(ctx, fakeClient)).To(Succeed())
+		got := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+			},
+		}
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+		Expect(got.Data).ToNot(HaveKey("config"))
+	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement
/label ipcei/workload-identity 

**What this PR does / why we need it**:
Do not set "null" as config data in workloadidentity secret

**Which issue(s) this PR fixes**:
Part of #9586 

**Special notes for your reviewer**:
The known extensions that have support for Workload Identity have validation ensuring the `workloadIdentity.spec.targetSystem.providerConfig` is not set to nil:
- [provider-aws](https://github.com/gardener/gardener-extension-provider-aws/blob/ecbe6387b790fa60179f08fc43370eb9c2cf31b3/pkg/admission/validator/workloadidentity.go#L40-L42)
- [provider-azure](https://github.com/gardener/gardener-extension-provider-azure/blob/3c320e0c5c9b089d27f369ebf8db95e3df76e214/pkg/admission/validator/workloadidentity.go#L40-L42)
- [provider-gcp](https://github.com/gardener/gardener-extension-provider-gcp/blob/e612d64325651410556f82dcafe18d1a082f8fbe/pkg/admission/validator/workloadidentity.go#L45-L47)

therefore, they are actually not affected by this change. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The Workload Identity secrets will no longer set the `config` data key (with value `"null"`) when the `workloadIdentity.spec.targetSystem.providerConfig` is `nil`.
```


/cc @dimityrmirchev 