### PR TITLE
Support defaulting machine image version from provided prefix on spec update

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -2015,7 +2015,7 @@ func ensureMachineImage(oldWorkers []core.Worker, worker core.Worker, images []g
 		if oldWorker.Machine.Image.Name == worker.Machine.Image.Name {
 			// image name was not changed -> keep version from the new worker if specified, otherwise use the old worker image version
 			if len(worker.Machine.Image.Version) != 0 {
-				return worker.Machine.Image, nil
+				return getDefaultMachineImage(images, worker.Machine.Image, worker.Machine.Architecture, helper.IsUpdateStrategyInPlace(worker.UpdateStrategy), fldPath)
 			}
 			return oldWorker.Machine.Image, nil
 		} else if len(worker.Machine.Image.Version) != 0 {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -2020,7 +2020,7 @@ func ensureMachineImage(oldWorkers []core.Worker, worker core.Worker, images []g
 			return oldWorker.Machine.Image, nil
 		} else if len(worker.Machine.Image.Version) != 0 {
 			// image name was changed -> keep version from new worker if specified, otherwise default the image version
-			return worker.Machine.Image, nil
+			return getDefaultMachineImage(images, worker.Machine.Image, worker.Machine.Architecture, helper.IsUpdateStrategyInPlace(worker.UpdateStrategy), fldPath)
 		}
 	}
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -4903,6 +4903,20 @@ var _ = Describe("validator", func() {
 						}))
 					})
 
+					It("should default a version prefix of an existing worker pool to the latest non-preview version", func() {
+						newShoot := shoot.DeepCopy()
+						newShoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+							Name:    imageName1,
+							Version: "2",
+						}
+
+						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(Not(HaveOccurred()))
+						Expect(newShoot.Spec.Provider.Workers[0].Machine.Image.Version).To(Equal(latestNonExpiredVersion))
+					})
+
 					It("should default version of new worker pool to latest non-preview version", func() {
 						newShoot := shoot.DeepCopy()
 						newWorker := newShoot.Spec.Provider.Workers[0].DeepCopy()

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -4917,6 +4917,20 @@ var _ = Describe("validator", func() {
 						Expect(newShoot.Spec.Provider.Workers[0].Machine.Image.Version).To(Equal(latestNonExpiredVersion))
 					})
 
+					It("should default a version prefix of a new image of an existing worker pool to the latest non-preview version", func() {
+						newShoot := shoot.DeepCopy()
+						newShoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+							Name:    imageName2,
+							Version: "2.0",
+						}
+
+						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(Not(HaveOccurred()))
+						Expect(newShoot.Spec.Provider.Workers[0].Machine.Image.Version).To(Equal(nonExpiredVersion2))
+					})
+
 					It("should default version of new worker pool to latest non-preview version", func() {
 						newShoot := shoot.DeepCopy()
 						newWorker := newShoot.Spec.Provider.Workers[0].DeepCopy()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability os
/kind bug

**What this PR does / why we need it**:
Support defaulting machine image versions from version prefix on Shoot spec update

- When a machine image version is specified as a prefix in the Shoot spec during a spec update, it is now also defaulted to the latest matching non-preview version (just like it was on creation).

**Which issue(s) this PR fixes**:
Fixes #12320 

**Special notes for your reviewer**:
/cc @marc1404 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support defaulting machine image versions from version prefix on Shoot spec update.
```
