### PR TITLE
Deflake 1 flake in the Seed integration test

### DIFF
--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -707,6 +707,10 @@ var _ = Describe("Seed controller tests", func() {
 							"prometheus-operator",
 							"perses-operator",
 						)
+					} else {
+						expectedManagedResources = append(expectedManagedResources,
+							"nginx-ingress-seed",
+						)
 					}
 
 					Eventually(func(g Gomega) []string {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/12213/commits/6dd8a556881a0ce2e214077b1a8af65e8609b9ea#diff-a3bc9d8bf428d542a1668556adcba0143538e5af8dad225753b26953049ceb18 deploys a new ManagedResource when the Seed cluster is Garden: `nginx-ingress-seed`. 

The test flakes that this MR `nginx-ingress-seed` is not present when Seed is Garden. See the error message in https://github.com/gardener/gardener/issues/12333.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/12333

**Special notes for your reviewer**:
Against the master branch (c1b54bdcf1cf5f2163e990f5f4735dd028ccd1d1):
```
% stress -p 8 ./hack/test-integration.sh ./test/integration/gardenlet/seed/seed -test.count=1 -ginkgo.v -v

30m30s: 242 runs so far, 35 failures (14.46%)
30m35s: 242 runs so far, 35 failures (14.46%)
30m40s: 242 runs so far, 35 failures (14.46%)
30m45s: 242 runs so far, 35 failures (14.46%)
30m50s: 242 runs so far, 35 failures (14.46%)
```

Against this PR:
```
% stress -p 8 ./hack/test-integration.sh ./test/integration/gardenlet/seed/seed -test.count=1 -ginkgo.v -v

38m40s: 327 runs so far, 36 failures (11.01%)
38m45s: 327 runs so far, 36 failures (11.01%)
38m50s: 327 runs so far, 36 failures (11.01%)
38m55s: 328 runs so far, 36 failures (10.98%)
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
