### PR TITLE
[release-v1.121] Automated cherry pick of #12371: Use mirrored Perses images from Gardener mirror instead of quay.io

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -378,7 +378,7 @@ images:
             teamname: 'gardener/monitoring-maintainers'
   - name: perses
     sourceRepository: github.com/perses/perses
-    repository: quay.io/persesdev/perses
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/persesdev/perses
     tag: "v0.50.3"
     labels:
       - name: gardener.cloud/cve-categorisation
@@ -395,7 +395,7 @@ images:
             teamname: 'gardener/monitoring-maintainers'
   - name: perses-operator
     sourceRepository: github.com/perses/perses-operator
-    repository: quay.io/persesdev/perses-operator
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/persesdev/perses-operator
     tag: v0.1.10
     labels:
       - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
/area monitoring
/kind impediment

Cherry pick of #12371 on release-v1.121.

#12371: Use mirrored Perses images from Gardener mirror instead of quay.io

**Release Notes:**
```other dependency
Perses container images are switched from upstream `quay.io` images to Gardener AR images (mirror from upstream `docker.io` images). The upstream `quay.io` images are 200MB larger compared to the `docker.io` ones and include binary with Sleepycat license (Berkeley DB).
```