### PR TITLE
Deflake `e2e-kind-operator-seed` e2e test by fixing `service` controller auto-remediation

### DIFF
--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -215,11 +215,11 @@ func (r *Reconciler) remediateAllocatedNodePorts(ctx context.Context, log logr.L
 				service.Spec.Ports[i].NodePort = newNodePort
 				mustUpdate = true
 			}
+		}
 
-			if mustUpdate {
-				if err := r.Client.Patch(ctx, &service, patch); err != nil {
-					return err
-				}
+		if mustUpdate {
+			if err := r.Client.Patch(ctx, &service, patch); err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -145,7 +146,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			// for some reason this error is not of type "Invalid"
 			strings.Contains(err.Error(), "duplicate nodePort") {
 			log.Info("Patching nodePort failed because it is already allocated, enabling auto-remediation", "err", err.Error())
-			return reconcile.Result{Requeue: true}, r.remediateAllocatedNodePorts(ctx, log, key, nodePort, nodePortTunnel)
+			return reconcile.Result{RequeueAfter: 2 * time.Second}, r.remediateAllocatedNodePorts(ctx, log, key, nodePort, nodePortTunnel)
 		}
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Only patch the `service`(s) that block the required node ports. Earlier, the controller re-allocated ports that were correctly assigned to Istio Ingress services. More details can be found in the linked issue.

**Which issue(s) this PR fixes**:
Fixes #12370

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
