### PR TITLE
[GEP-28] Deploy `druid.gardener.cloud/v1alpha1.Etcd` resources and replace bootstrap ETCD

### DIFF
--- a/pkg/component/etcd/etcd/constants/constants.go
+++ b/pkg/component/etcd/etcd/constants/constants.go
@@ -34,5 +34,5 @@ var (
 	StaticPodPortEtcdEventsBackupRestore int32 = 8081
 	// StaticPodPortEtcdEventsWrapper is the port exposed by the etcd-wrapper container in etcd-events when it runs as
 	// static pod.
-	StaticPodPortEtcdEventsWrapper int32 = 9095
+	StaticPodPortEtcdEventsWrapper int32 = 9096
 )

--- a/pkg/component/etcd/etcd/constants/constants.go
+++ b/pkg/component/etcd/etcd/constants/constants.go
@@ -20,8 +20,19 @@ var (
 	PortEtcdPeer int32 = 2380
 	// PortBackupRestore is the client port exposed by the backup-restore sidecar container.
 	PortBackupRestore int32 = 8080
+	// PortEtcdWrapper is the port exposed by etcd-wrapper.
+	PortEtcdWrapper int32 = 9095
 
 	// StaticPodPortEtcdEventsClient is the port exposed by etcd-events for client communication when it runs as static
 	// pod.
 	StaticPodPortEtcdEventsClient int32 = 2382
+	// StaticPodPortEtcdEventsPeer is the port exposed by etcd-events for server-to-server communication when it runs as
+	// static pod.
+	StaticPodPortEtcdEventsPeer int32 = 2383
+	// StaticPodPortEtcdEventsBackupRestore is the client port exposed by the backup-restore sidecar container when it
+	// runs as static pod.
+	StaticPodPortEtcdEventsBackupRestore int32 = 8081
+	// StaticPodPortEtcdEventsWrapper is the port exposed by the etcd-wrapper container in etcd-events when it runs as
+	// static pod.
+	StaticPodPortEtcdEventsWrapper int32 = 9095
 )

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -382,7 +382,7 @@ var _ = Describe("Etcd", func() {
 					obj.Spec.Backup.Port = ptr.To[int32](8081)
 					obj.Spec.Etcd.ClientPort = ptr.To[int32](2382)
 					obj.Spec.Etcd.ServerPort = ptr.To[int32](2383)
-					obj.Spec.Etcd.WrapperPort = ptr.To[int32](9095)
+					obj.Spec.Etcd.WrapperPort = ptr.To[int32](9096)
 				}
 			}
 

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -79,8 +79,8 @@ var _ = Describe("Etcd", func() {
 
 		secretNameCA         = "ca-etcd"
 		secretNamePeerCA     = "ca-etcd-peer"
-		secretNameServer     = "etcd-server-" + testRole
-		secretNameServerPeer = "etcd-peer-server-" + testRole
+		secretNameServer     string
+		secretNameServerPeer string
 		secretNameClient     = "etcd-client"
 
 		maintenanceTimeWindow = gardencorev1beta1.MaintenanceTimeWindow{
@@ -88,6 +88,8 @@ var _ = Describe("Etcd", func() {
 			End:   "5678",
 		}
 		highAvailabilityEnabled bool
+		runAsStaticPod          bool
+		role                    string
 		caRotationPhase         gardencorev1beta1.CredentialsRotationPhase
 		autoscalingConfig       AutoscalingConfig
 		backupConfig            *BackupConfig
@@ -110,11 +112,12 @@ var _ = Describe("Etcd", func() {
 		metricsBasic        = druidcorev1alpha1.Basic
 		metricsExtensive    = druidcorev1alpha1.Extensive
 
-		etcdName = "etcd-" + testRole
-		vpaName  = etcdName
+		etcdName string
+		vpaName  string
 
 		etcdObjFor = func(
 			class Class,
+			role string,
 			replicas int32,
 			backupConfig *BackupConfig,
 			existingDefragmentationSchedule,
@@ -128,6 +131,7 @@ var _ = Describe("Etcd", func() {
 			peerServerSecretName *string,
 			topologyAwareRoutingEnabled bool,
 			runtimeKubernetesVersion *semver.Version,
+			runAsStaticPod bool,
 		) *druidcorev1alpha1.Etcd {
 			defragSchedule := defragmentationSchedule
 			if existingDefragmentationSchedule != "" {
@@ -202,7 +206,7 @@ var _ = Describe("Etcd", func() {
 					},
 					Labels: map[string]string{
 						"gardener.cloud/role": "controlplane",
-						"role":                testRole,
+						"role":                role,
 					},
 				},
 				Spec: druidcorev1alpha1.EtcdSpec{
@@ -210,7 +214,7 @@ var _ = Describe("Etcd", func() {
 					PriorityClassName: &priorityClassName,
 					Labels: map[string]string{
 						"gardener.cloud/role":              "controlplane",
-						"role":                             testRole,
+						"role":                             role,
 						"app":                              "etcd-statefulset",
 						"networking.gardener.cloud/to-dns": "allowed",
 						"networking.gardener.cloud/to-public-networks":   "allowed",
@@ -220,7 +224,7 @@ var _ = Describe("Etcd", func() {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"gardener.cloud/role": "controlplane",
-							"role":                testRole,
+							"role":                role,
 							"app":                 "etcd-statefulset",
 						},
 					},
@@ -245,6 +249,7 @@ var _ = Describe("Etcd", func() {
 						},
 						ServerPort:              ptr.To[int32](2380),
 						ClientPort:              ptr.To[int32](2379),
+						WrapperPort:             ptr.To[int32](9095),
 						Metrics:                 &metricsBasic,
 						DefragmentationSchedule: &defragSchedule,
 						Quota:                   &quota,
@@ -297,16 +302,16 @@ var _ = Describe("Etcd", func() {
 					},
 				}
 				obj.Spec.Etcd.Metrics = &metricsExtensive
-				obj.Spec.VolumeClaimTemplate = ptr.To(testRole + "-etcd")
+				obj.Spec.VolumeClaimTemplate = ptr.To(role + "-etcd")
 			case ClassNormal:
 				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "resources.druid.gardener.cloud/allow-unhealthy-pod-eviction", "")
 			}
 
 			if replicas == 3 {
 				obj.Spec.Labels = utils.MergeStringMaps(obj.Spec.Labels, map[string]string{
-					"networking.resources.gardener.cloud/to-etcd-" + testRole + "-client-tcp-2379": "allowed",
-					"networking.resources.gardener.cloud/to-etcd-" + testRole + "-client-tcp-2380": "allowed",
-					"networking.resources.gardener.cloud/to-etcd-" + testRole + "-client-tcp-8080": "allowed",
+					"networking.resources.gardener.cloud/to-etcd-" + role + "-client-tcp-2379": "allowed",
+					"networking.resources.gardener.cloud/to-etcd-" + role + "-client-tcp-2380": "allowed",
+					"networking.resources.gardener.cloud/to-etcd-" + role + "-client-tcp-8080": "allowed",
 				})
 				obj.Spec.Etcd.PeerUrlTLS = &druidcorev1alpha1.TLSConfig{
 					ServerTLSSecretRef: corev1.SecretReference{
@@ -354,7 +359,7 @@ var _ = Describe("Etcd", func() {
 					SecretRef: &corev1.SecretReference{Name: backupConfig.SecretRefName},
 					Container: &backupConfig.Container,
 					Provider:  &provider,
-					Prefix:    backupConfig.Prefix + "/etcd-" + testRole,
+					Prefix:    backupConfig.Prefix + "/etcd-" + role,
 				}
 				obj.Spec.Backup.FullSnapshotSchedule = &fullSnapshotSchedule
 				obj.Spec.Backup.DeltaSnapshotPeriod = &deltaSnapshotPeriod
@@ -369,10 +374,22 @@ var _ = Describe("Etcd", func() {
 				}
 			}
 
+			if runAsStaticPod {
+				obj.Annotations["druid.gardener.cloud/disable-etcd-runtime-component-creation"] = ""
+				obj.Spec.RunAsRoot = ptr.To(true)
+
+				if role == "events" {
+					obj.Spec.Backup.Port = ptr.To[int32](8081)
+					obj.Spec.Etcd.ClientPort = ptr.To[int32](2382)
+					obj.Spec.Etcd.ServerPort = ptr.To[int32](2383)
+					obj.Spec.Etcd.WrapperPort = ptr.To[int32](9095)
+				}
+			}
+
 			return obj
 		}
 
-		expectedVPAFor = func(class Class, evictionRequirement string, minAllowed corev1.ResourceList) *vpaautoscalingv1.VerticalPodAutoscaler {
+		expectedVPAFor = func(class Class, role string, evictionRequirement string, minAllowed corev1.ResourceList) *vpaautoscalingv1.VerticalPodAutoscaler {
 			minAllowedConfig := minAllowed
 			if minAllowedConfig == nil {
 				minAllowedConfig = corev1.ResourceList{
@@ -384,7 +401,7 @@ var _ = Describe("Etcd", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      vpaName,
 					Namespace: testNamespace,
-					Labels:    map[string]string{v1beta1constants.LabelRole: "etcd-vpa-main"},
+					Labels:    map[string]string{v1beta1constants.LabelRole: "etcd-vpa-" + role},
 				},
 				Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 					TargetRef: &autoscalingv1.CrossVersionObjectReference{
@@ -704,6 +721,8 @@ var _ = Describe("Etcd", func() {
 		backupConfig = nil
 		replicas = ptr.To[int32](1)
 		highAvailabilityEnabled = false
+		runAsStaticPod = false
+		role = testRole
 	})
 
 	JustBeforeEach(func() {
@@ -711,10 +730,15 @@ var _ = Describe("Etcd", func() {
 		c = mockclient.NewMockClient(ctrl)
 		log = logr.Discard()
 
+		secretNameServer = "etcd-server-" + role
+		secretNameServerPeer = "etcd-peer-server-" + role
+		etcdName = "etcd-" + role
+		vpaName = etcdName
+
 		By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd", Namespace: testNamespace}})).To(Succeed())
 		etcd = New(log, c, testNamespace, sm, Values{
-			Role:                    testRole,
+			Role:                    role,
 			Class:                   class,
 			Replicas:                replicas,
 			Autoscaling:             autoscalingConfig,
@@ -726,6 +750,7 @@ var _ = Describe("Etcd", func() {
 			MaintenanceTimeWindow:   maintenanceTimeWindow,
 			HighAvailabilityEnabled: highAvailabilityEnabled,
 			BackupConfig:            backupConfig,
+			RunsAsStaticPod:         runAsStaticPod,
 		})
 	})
 
@@ -761,6 +786,7 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(etcdObjFor(
 						class,
+						role,
 						1,
 						nil,
 						"",
@@ -773,11 +799,13 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						false,
-						nil)))
+						nil,
+						runAsStaticPod,
+					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-					Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -833,6 +861,7 @@ var _ = Describe("Etcd", func() {
 
 					Expect(obj).To(DeepEqual(etcdObjFor(
 						class,
+						role,
 						existingReplicas,
 						nil,
 						"",
@@ -845,11 +874,13 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						false,
-						nil)))
+						nil,
+						runAsStaticPod,
+					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-					Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -910,6 +941,7 @@ var _ = Describe("Etcd", func() {
 
 					Expect(obj).To(DeepEqual(etcdObjFor(
 						class,
+						role,
 						existingReplicas,
 						nil,
 						"",
@@ -922,11 +954,13 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						false,
-						nil)))
+						nil,
+						runAsStaticPod,
+					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-					Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -971,6 +1005,7 @@ var _ = Describe("Etcd", func() {
 
 					expectedObj := etcdObjFor(
 						class,
+						role,
 						1,
 						nil,
 						"",
@@ -983,7 +1018,9 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						false,
-						nil)
+						nil,
+						runAsStaticPod,
+					)
 					expectedObj.Annotations = utils.MergeStringMaps(expectedObj.Annotations, map[string]string{
 						"foo": "bar",
 					})
@@ -992,7 +1029,7 @@ var _ = Describe("Etcd", func() {
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-					Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1041,6 +1078,7 @@ var _ = Describe("Etcd", func() {
 
 					Expect(obj).To(DeepEqual(etcdObjFor(
 						class,
+						role,
 						1,
 						nil,
 						existingDefragmentationSchedule,
@@ -1053,11 +1091,13 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						false,
-						nil)))
+						nil,
+						runAsStaticPod,
+					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-					Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1083,6 +1123,7 @@ var _ = Describe("Etcd", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(etcdObjFor(
 						class,
+						role,
 						1,
 						nil,
 						"",
@@ -1095,11 +1136,13 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						false,
-						nil)))
+						nil,
+						runAsStaticPod,
+					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 				c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-					Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+					Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1148,6 +1191,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
+							role,
 							1,
 							nil,
 							"",
@@ -1160,11 +1204,13 @@ var _ = Describe("Etcd", func() {
 							nil,
 							nil,
 							false,
-							nil)))
+							nil,
+							runAsStaticPod,
+						)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-						Expect(obj).To(DeepEqual(expectedVPAFor(class, evictionRequirement, nil)))
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, role, evictionRequirement, nil)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1205,6 +1251,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
+							role,
 							1,
 							backupConfig,
 							"",
@@ -1217,11 +1264,13 @@ var _ = Describe("Etcd", func() {
 							nil,
 							nil,
 							false,
-							nil)))
+							nil,
+							runAsStaticPod,
+						)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-						Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1267,6 +1316,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						expobj := etcdObjFor(
 							class,
+							role,
 							1,
 							backupConfig,
 							"",
@@ -1279,14 +1329,16 @@ var _ = Describe("Etcd", func() {
 							nil,
 							nil,
 							false,
-							nil)
+							nil,
+							runAsStaticPod,
+						)
 						expobj.Status.Etcd = &druidcorev1alpha1.CrossVersionObjectReference{}
 
 						Expect(obj).To(DeepEqual(expobj))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-						Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1299,6 +1351,105 @@ var _ = Describe("Etcd", func() {
 				)
 
 				Expect(etcd.Deploy(ctx)).To(Succeed())
+			})
+		})
+
+		When("etcd should run as static pod", func() {
+			BeforeEach(func() {
+				runAsStaticPod = true
+			})
+
+			Describe("main etcd", func() {
+				It("should successfully deploy the etcd", func() {
+					DeferCleanup(test.WithVar(&TimeNow, func() time.Time { return now }))
+
+					gomock.InOrder(
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(etcdObjFor(
+								class,
+								role,
+								1,
+								backupConfig,
+								"",
+								"",
+								nil,
+								nil,
+								secretNameCA,
+								secretNameClient,
+								secretNameServer,
+								nil,
+								nil,
+								false,
+								nil,
+								runAsStaticPod,
+							)))
+						}),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+							Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
+						}),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(serviceMonitor("shoot", "etcd-client")))
+						}),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(prometheusRule("shoot", class, *replicas, false)))
+						}),
+					)
+
+					Expect(etcd.Deploy(ctx)).To(Succeed())
+				})
+			})
+
+			Describe("events etcd", func() {
+				BeforeEach(func() {
+					class = ClassNormal
+					role = "events"
+
+					DeferCleanup(test.WithVar(&vpaName, "etcd-"+role))
+				})
+
+				It("should successfully deploy the etcd", func() {
+					DeferCleanup(test.WithVar(&TimeNow, func() time.Time { return now }))
+
+					gomock.InOrder(
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(etcdObjFor(
+								class,
+								role,
+								1,
+								backupConfig,
+								"",
+								"",
+								nil,
+								nil,
+								secretNameCA,
+								secretNameClient,
+								secretNameServer,
+								nil,
+								nil,
+								false,
+								nil,
+								runAsStaticPod,
+							)))
+						}),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+							Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
+						}),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + role}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()),
+						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + role}, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{}), gomock.Any()),
+					)
+
+					Expect(etcd.Deploy(ctx)).To(Succeed())
+				})
 			})
 		})
 
@@ -1327,6 +1478,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
+							role,
 							3,
 							nil,
 							"",
@@ -1340,11 +1492,12 @@ var _ = Describe("Etcd", func() {
 							&peerServerSecretName,
 							false,
 							nil,
+							runAsStaticPod,
 						)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-						Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1545,7 +1698,7 @@ var _ = Describe("Etcd", func() {
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-							Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+							Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1596,7 +1749,7 @@ var _ = Describe("Etcd", func() {
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-							Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+							Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1644,6 +1797,7 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(etcdObjFor(
 								class,
+								role,
 								1,
 								nil,
 								"",
@@ -1656,11 +1810,13 @@ var _ = Describe("Etcd", func() {
 								nil,
 								nil,
 								true,
-								runtimeKubernetesVersion)))
+								runtimeKubernetesVersion,
+								runAsStaticPod,
+							)))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-							Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+							Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1707,6 +1863,7 @@ var _ = Describe("Etcd", func() {
 
 				etcdObj := etcdObjFor(
 					class,
+					role,
 					1,
 					nil,
 					"",
@@ -1720,6 +1877,7 @@ var _ = Describe("Etcd", func() {
 					nil,
 					false,
 					nil,
+					runAsStaticPod,
 				)
 				etcdObj.Name = etcdName
 				etcdObj.Spec.VolumeClaimTemplate = ptr.To(testRole + "-virtual-garden-etcd")
@@ -1736,7 +1894,7 @@ var _ = Describe("Etcd", func() {
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-						Expect(obj).To(DeepEqual(expectedVPAFor(class, "", nil)))
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", nil)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "garden-virtual-garden-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1771,6 +1929,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidcorev1alpha1.Etcd{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
+							role,
 							1,
 							nil,
 							"",
@@ -1788,11 +1947,13 @@ var _ = Describe("Etcd", func() {
 							nil,
 							nil,
 							false,
-							nil)))
+							nil,
+							runAsStaticPod,
+						)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
-						Expect(obj).To(DeepEqual(expectedVPAFor(class, "", minAllowed)))
+						Expect(obj).To(DeepEqual(expectedVPAFor(class, role, "", minAllowed)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "shoot-etcd-" + testRole}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {

--- a/pkg/component/etcd/etcd/waiter.go
+++ b/pkg/component/etcd/etcd/waiter.go
@@ -73,10 +73,10 @@ func CheckEtcdObject(obj client.Object) error {
 		return fmt.Errorf("gardener operation %q is not yet picked up by etcd-druid", op)
 	}
 
-	// If etcd replicas are set to 0, then we can skip readiness and updation checks,
-	// because druid does not perform condition checks on hibernated etcd clusters,
-	// and readiness no longer makes sense for hibernated etcd clusters.
-	if e.Spec.Replicas == 0 {
+	// If etcd replicas are set to 0, then we can skip readiness and updation checks, because druid does not perform
+	// condition checks on hibernated etcd clusters, and readiness no longer makes sense for hibernated etcd clusters.
+	// The same is done when the etcd runtime component creation is disabled.
+	if e.Spec.Replicas == 0 || !druidcorev1alpha1.IsEtcdRuntimeComponentCreationEnabled(e.ObjectMeta) {
 		return nil
 	}
 

--- a/pkg/component/etcd/etcd/waiter_test.go
+++ b/pkg/component/etcd/etcd/waiter_test.go
@@ -370,9 +370,18 @@ var _ = Describe("#CheckEtcdObject", func() {
 		Expect(CheckEtcdObject(obj)).To(MatchError("gardener operation \"reconcile\" is not yet picked up by etcd-druid"))
 	})
 
-	It("should not return error if replicas is set to 0, even if AllMembersUpdated condition and readiness are not true ", func() {
+	It("should not return error if replicas is set to 0, even if AllMembersUpdated condition and readiness are not true", func() {
 		obj.SetGeneration(1)
 		obj.Spec.Replicas = 0
+		obj.Status.ObservedGeneration = ptr.To[int64](1)
+		obj.Status.Conditions = []druidcorev1alpha1.Condition{{Type: druidcorev1alpha1.ConditionTypeAllMembersUpdated, Status: druidcorev1alpha1.ConditionFalse}}
+		obj.Status.Ready = ptr.To(false)
+		Expect(CheckEtcdObject(obj)).To(Succeed())
+	})
+
+	It("should not return error if runtime component creation is disabled, even if AllMembersUpdated condition and readiness are not true", func() {
+		obj.SetGeneration(1)
+		obj.Annotations = map[string]string{"druid.gardener.cloud/disable-etcd-runtime-component-creation": ""}
 		obj.Status.ObservedGeneration = ptr.To[int64](1)
 		obj.Status.Conditions = []druidcorev1alpha1.Condition{{Type: druidcorev1alpha1.ConditionTypeAllMembersUpdated, Status: druidcorev1alpha1.ConditionFalse}}
 		obj.Status.Ready = ptr.To(false)

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -55,6 +55,7 @@ type AutonomousBotanist struct {
 	operatingSystemConfigSecret       *corev1.Secret
 	gardenerResourceManagerServiceIPs []string
 	staticPodNameToHash               map[string]string
+	useEtcdManagedByDruid             bool
 }
 
 // Extension contains the resources needed for an extension registration.

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -78,6 +78,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 			PriorityClassName:           v1beta1constants.PriorityClassNameShootControlPlane500,
 			HighAvailabilityEnabled:     v1beta1helper.IsHAControlPlaneConfigured(b.Shoot.GetInfo()),
 			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
+			RunsAsStaticPod:             b.Shoot.RunsControlPlane(),
 		},
 	)
 

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -121,8 +121,8 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace("kube-system"))).To(Succeed())
 				return podList.Items
 			}).Should(ContainElements(
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-bootstrap-events-machine-0")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-bootstrap-main-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-events-machine-0")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-main-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-apiserver-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-controller-manager-machine-0")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-scheduler-machine-0")})}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
- `gardenadm init` flow deploys the `druid.gardener.cloud/v1alpha1.Etcd` resources which result in a `StatefulSet` with `.spec.replicas=0` (due to explicit disablement of runtime component creation via annotation on these `Etcd` resources)
- The `StatefulSet` is translated into a static pod
- The static pod reuses the data directories of the bootstrap ETCDs - this way, it can safely replace them
- The bootstrap ETCDs are shut down and deleted/cleaned up (mostly automatically by `gardener-node-agent` since it removes the manifest file from `/etc/kubernetes/manifests`)
- The ETCD server certificate SANs now include `localhost` and alike

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ @timebertt 
FYI @shreyas-s-rao @ishan16696 

> [!NOTE]
> ~~- Depends on https://github.com/gardener/etcd-druid/pull/1117, a release of `etcd-druid@v0.31`, and https://github.com/gardener/gardener/pull/12551, hence, PR remains in draft state for now.~~
> ~~- The first commit needs to be dropped before this PR can be marked as "ready for review".~~
> ✅

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
