### PR TITLE
docs: Update the `Until` version for feature gates where it is missing

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,7 +28,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
 | NodeAgentAuthorizer                      | `false` | `Alpha` | `1.109` | `1.115` |
 | NodeAgentAuthorizer                      | `true`  | `Beta`  | `1.116` |         |
-| CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` |         |
+| CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` | `1.120` |
 | CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
@@ -45,7 +45,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | KonnectivityTunnel                           |         | `Removed`    | `1.27`  |         |
 | MountHostCADirectories                       | `false` | `Alpha`      | `1.11`  | `1.25`  |
 | MountHostCADirectories                       | `true`  | `Beta`       | `1.26`  | `1.27`  |
-| MountHostCADirectories                       | `true`  | `GA`         | `1.27`  |         |
+| MountHostCADirectories                       | `true`  | `GA`         | `1.27`  | `1.29`  |
 | MountHostCADirectories                       |         | `Removed`    | `1.30`  |         |
 | DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha`      | `1.28`  | `1.31`  |
 | DisallowKubeconfigRotationForShootInDeletion | `true`  | `Beta`       | `1.32`  | `1.35`  |
@@ -122,11 +122,11 @@ The following tables are a summary of the feature gates that you can set on diff
 | CopyEtcdBackupsDuringControlPlaneMigration   | `true`  | `GA`         | `1.69`  | `1.72`  |
 | CopyEtcdBackupsDuringControlPlaneMigration   |         | `Removed`    | `1.73`  |         |
 | ManagedIstio                                 | `false` | `Alpha`      | `1.5`   | `1.18`  |
-| ManagedIstio                                 | `true`  | `Beta`       | `1.19`  |         |
+| ManagedIstio                                 | `true`  | `Beta`       | `1.19`  | `1.47`  |
 | ManagedIstio                                 | `true`  | `Deprecated` | `1.48`  | `1.69`  |
 | ManagedIstio                                 |         | `Removed`    | `1.70`  |         |
 | APIServerSNI                                 | `false` | `Alpha`      | `1.7`   | `1.18`  |
-| APIServerSNI                                 | `true`  | `Beta`       | `1.19`  |         |
+| APIServerSNI                                 | `true`  | `Beta`       | `1.19`  | `1.47`  |
 | APIServerSNI                                 | `true`  | `Deprecated` | `1.48`  | `1.72`  |
 | APIServerSNI                                 |         | `Removed`    | `1.73`  |         |
 | HAControlPlanes                              | `false` | `Alpha`      | `1.49`  | `1.70`  |
@@ -149,7 +149,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | WorkerlessShoots                             | `true`  | `Beta`       | `1.79`  | `1.85`  |
 | WorkerlessShoots                             | `true`  | `GA`         | `1.86`  | `1.87`  |
 | WorkerlessShoots                             |         | `Removed`    | `1.88`  |         |
-| MachineControllerManagerDeployment           | `false` | `Alpha`      | `1.73`  |         |
+| MachineControllerManagerDeployment           | `false` | `Alpha`      | `1.73`  | `1.80`  |
 | MachineControllerManagerDeployment           | `true`  | `Beta`       | `1.81`  | `1.81`  |
 | MachineControllerManagerDeployment           | `true`  | `GA`         | `1.82`  | `1.91`  |
 | MachineControllerManagerDeployment           |         | `Removed`    | `1.92`  |         |
@@ -182,7 +182,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | HVPAForShootedSeed                           | `false` | `Alpha`      | `0.32`  | `1.105` |
 | HVPAForShootedSeed                           | `false` | `Deprecated` | `1.106` | `1.108` |
 | HVPAForShootedSeed                           |         | `Removed`    | `1.109` |         |
-| IPv6SingleStack                              | `false` | `Alpha`      | `1.63`  |         |
+| IPv6SingleStack                              | `false` | `Alpha`      | `1.63`  | `1.106` |
 | IPv6SingleStack                              |         | `Removed`    | `1.107` |         |
 | ShootManagedIssuer                           | `false` | `Alpha`      | `1.93`  | `1.110` |
 | ShootManagedIssuer                           |         | `Removed`    | `1.111` |         |


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Update the `Until` version for feature gates where it can be missing and it is not set.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
