### PR TITLE
Add Perses images to renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -388,7 +388,7 @@
       ],
     },
     {
-      // Do not use docker for images from gardener registry except those which do not work with github-releases.
+      // Use Docker only for images from the Gardener registry that don't work with GitHub releases.
       matchDatasources: [
         'docker',
       ],
@@ -403,7 +403,7 @@
       ],
     },
     {
-      // Do not use github-releases for external dependencies except those we copy.
+      // Use GitHub releases only for external dependencies we mirror.
       matchDatasources: [
         'github-releases',
       ],
@@ -416,6 +416,7 @@
         '!/credativ/.+/',
         '!/envoyproxy/.+/',
         '!/fluent/.+/',
+        '!/perses/.+/',
       ],
     },
     {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With #12371 we need to add the perses images to the renovate config so that the renovate bot picks up on the new github releases and creates a Docker image update PR.
I also struggled to wrap my head around the comments because of all the negations, so I reworded them slightly.

**Special notes for your reviewer**:
cc @marc1404 @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
NONE
```
