### PR TITLE
Support docs generation with repo outside of gopath

### DIFF
--- a/pkg/apis/authentication/v1alpha1/doc.go
+++ b/pkg/apis/authentication/v1alpha1/doc.go
@@ -9,7 +9,7 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:protobuf-gen=package
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/authentication-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/authentication.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/authentication/v1alpha1 -config ../../../../hack/api-reference/authentication-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/authentication.md
 
 // Package v1alpha1 is a version of the API.
 // "authentication.gardener.cloud/v1alpha1" API is already used for CRD registration and must not be served by the API server.

--- a/pkg/apis/core/v1beta1/doc.go
+++ b/pkg/apis/core/v1beta1/doc.go
@@ -9,7 +9,7 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:protobuf-gen=package
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/core-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/core.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/core/v1beta1 -config ../../../../hack/api-reference/core-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/core.md
 
 // Package v1beta1 is a version of the API.
 // +groupName=core.gardener.cloud

--- a/pkg/apis/extensions/v1alpha1/doc.go
+++ b/pkg/apis/extensions/v1alpha1/doc.go
@@ -4,7 +4,7 @@
 
 // +k8s:deepcopy-gen=package
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/extensions-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/extensions.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/extensions/v1alpha1 -config ../../../../hack/api-reference/extensions-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/extensions.md
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 // +groupName=extensions.gardener.cloud

--- a/pkg/apis/operations/v1alpha1/doc.go
+++ b/pkg/apis/operations/v1alpha1/doc.go
@@ -9,7 +9,7 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:protobuf-gen=package
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/operations-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/operations.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/operations/v1alpha1 -config ../../../../hack/api-reference/operations-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/operations.md
 
 // Package v1alpha1 is a version of the API.
 // +groupName=operations.gardener.cloud

--- a/pkg/apis/operator/v1alpha1/doc.go
+++ b/pkg/apis/operator/v1alpha1/doc.go
@@ -5,7 +5,7 @@
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/operator-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/operator.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/operator/v1alpha1 -config ../../../../hack/api-reference/operator-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/operator.md
 
 // Package v1alpha1 contains the configuration of the Gardener Operator.
 // +groupName=operator.gardener.cloud

--- a/pkg/apis/resources/v1alpha1/doc.go
+++ b/pkg/apis/resources/v1alpha1/doc.go
@@ -5,7 +5,7 @@
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/resources-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/resources.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/resources/v1alpha1 -config ../../../../hack/api-reference/resources-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/resources.md
 
 // Package v1alpha1 contains the configuration of the Gardener Resource Manager.
 // +groupName=resources.gardener.cloud

--- a/pkg/apis/security/v1alpha1/doc.go
+++ b/pkg/apis/security/v1alpha1/doc.go
@@ -9,7 +9,7 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:protobuf-gen=package
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/security-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/security.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/security/v1alpha1 -config ../../../../hack/api-reference/security-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/security.md
 
 // Package v1alpha1 is a version of the API.
 // +groupName=security.gardener.cloud

--- a/pkg/apis/seedmanagement/v1alpha1/doc.go
+++ b/pkg/apis/seedmanagement/v1alpha1/doc.go
@@ -9,7 +9,7 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:protobuf-gen=package
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/seedmanagement-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/seedmanagement.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1 -config ../../../../hack/api-reference/seedmanagement-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/seedmanagement.md
 
 // Package v1alpha1 is a version of the API.
 // +groupName=seedmanagement.gardener.cloud

--- a/pkg/apis/settings/v1alpha1/doc.go
+++ b/pkg/apis/settings/v1alpha1/doc.go
@@ -9,7 +9,7 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:protobuf-gen=package
 
-//go:generate gen-crd-api-reference-docs -api-dir . -config ../../../../hack/api-reference/settings-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/settings.md
+//go:generate gen-crd-api-reference-docs -api-dir github.com/gardener/gardener/pkg/apis/settings/v1alpha1 -config ../../../../hack/api-reference/settings-config.json -template-dir ../../../../hack/api-reference/template -out-file ../../../../docs/api-reference/settings.md
 
 // Package v1alpha1 is a version of the API.
 // +groupName=settings.gardener.cloud


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Unfortunately, the docs generator seems to not work well if the repo is outside of the gopath.
In those cases, a `make generate` led to unintended docs modifications:
```
docs/api-reference/core.md
   @@ -3565,7 +3565,7 @@ CRIName
   <p>CRIName is a type alias for the CRI name string.</p>
   </p>
   <h3 id="core.gardener.cloud/v1beta1.Capabilities">Capabilities
   (<code>map[string]github.com/gardener/gardener/pkg/apis/core/v1beta1.CapabilityValues</code> alias)</p></h3>
   (<code>map[string]..CapabilityValues</code> alias)</p></h3>
```

https://github.com/ahmetb/gen-crd-api-reference-docs/issues/12 states that this is an issue of `gengo`. This workaround fixes the undesired diff on docs generation if the repo is outside of the gopath.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
