### PR TITLE
Fix bug with `AuthenticationConfiguration` conversion to `v1beta1`

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	k8sapiserver "k8s.io/apiserver/pkg/apis/apiserver"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
@@ -690,6 +691,7 @@ func init() {
 	utilruntime.Must(apiserverv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(apiserverv1beta1.AddToScheme(scheme))
 	utilruntime.Must(apiserverv1.AddToScheme(scheme))
+	utilruntime.Must(k8sapiserver.AddToScheme(scheme))
 
 	var (
 		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{
@@ -698,6 +700,7 @@ func init() {
 			Strict: false,
 		})
 		versions = schema.GroupVersions([]schema.GroupVersion{
+			k8sapiserver.SchemeGroupVersion,
 			apiserverv1alpha1.SchemeGroupVersion,
 			apiserverv1alpha1.ConfigSchemeGroupVersion,
 			apiserverv1beta1.SchemeGroupVersion,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR addresses the error from https://github.com/gardener/gardener/pull/12365. The error is a regression coming from https://github.com/gardener/gardener/pull/12198, where it is expected `AuthenticationConfiguration` to be of version `v1beta1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @dimityrmirchev @ialidzhikov @RadaBDimitrova @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A regression causing the gardenlet to fail to decode the referenced `AuthenticationConfiguration` while deploying the kube-apiserver when the API version is not `apiserver.config.k8s.io/v1beta1` is now fixed.
```
