### PR TITLE
Make `.spec.cloudProfile` optional in mutating admission plugins

### DIFF
--- a/pkg/utils/gardener/cloudprofile.go
+++ b/pkg/utils/gardener/cloudprofile.go
@@ -90,7 +90,7 @@ func BuildV1beta1CloudProfileReference(shoot *gardencorev1beta1.Shoot) *gardenco
 func GetCloudProfileSpec(cloudProfileLister gardencorev1beta1listers.CloudProfileLister, namespacedCloudProfileLister gardencorev1beta1listers.NamespacedCloudProfileLister, shoot *core.Shoot) (*gardencorev1beta1.CloudProfileSpec, error) {
 	cloudProfileReference := BuildCoreCloudProfileReference(shoot)
 	if cloudProfileReference == nil {
-		return nil, fmt.Errorf("no cloudprofile reference has been provided")
+		return nil, nil
 	}
 	switch cloudProfileReference.Kind {
 	case v1beta1constants.CloudProfileReferenceKindNamespacedCloudProfile:

--- a/pkg/utils/gardener/cloudprofile_test.go
+++ b/pkg/utils/gardener/cloudprofile_test.go
@@ -184,11 +184,10 @@ var _ = Describe("CloudProfile", func() {
 			}
 		})
 		Describe("#GetCloudProfile", func() {
-			It("returns an error if CloudProfile is not found", func() {
-				shoot.Spec.CloudProfileName = &cloudProfileName
+			It("returns nil if CloudProfile is not found", func() {
 				res, err := gardenerutils.GetCloudProfileSpec(cloudProfileLister, namespacedCloudProfileLister, shoot)
 				Expect(res).To(BeNil())
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("returns CloudProfile if present, derived from cloudProfileName", func() {

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -409,6 +409,9 @@ func (q *QuotaValidator) getShootResources(shoot core.Shoot) (corev1.ResourceLis
 	if err != nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("could not find referenced cloud profile: %+v", err.Error()))
 	}
+	if cloudProfileSpec == nil {
+		return nil, fmt.Errorf("no cloudprofile reference has been provided")
+	}
 
 	var (
 		countLB      int64 = 1

--- a/plugin/pkg/shoot/resourcereservation/admission.go
+++ b/plugin/pkg/shoot/resourcereservation/admission.go
@@ -157,6 +157,9 @@ func (c *ResourceReservation) Admit(_ context.Context, a admission.Attributes, _
 	if err != nil {
 		return apierrors.NewInternalError(fmt.Errorf("could not find referenced cloud profile: %+v", err.Error()))
 	}
+	if cloudProfileSpec == nil {
+		return nil
+	}
 	machineTypeMap := buildMachineTypeMap(cloudProfileSpec)
 
 	allErrs := field.ErrorList{}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -265,6 +265,9 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, _ adm
 	if err != nil {
 		return apierrors.NewInternalError(fmt.Errorf("could not find referenced cloud profile: %+v", err.Error()))
 	}
+	if cloudProfileSpec == nil {
+		return nil
+	}
 
 	if err := gardenerutils.ValidateCloudProfileChanges(v.cloudProfileLister, v.namespacedCloudProfileLister, shoot, oldShoot); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Mutating admission plugins should fail if `.spec.cloudProfile{Name}` is empty - only validating plugins should. Hence, let's remove this at the few locations.

This enables webhooks to default the `.spec.cloudProfile{Name}` if not provided by the user. Without this, such webhooks wouldn't be called, because the in-tree admission plugins would already complain that the field isn't set.

All in-tree admission plugins are reinvoked after such webhook has set the field, i.e., we can be sure that potential defaulting in our in-tree mutating admission plugins is called/executed.

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
