### PR TITLE
Graduate `NodeAgentAuthorizer` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,8 +26,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
-| NodeAgentAuthorizer                      | `false` | `Alpha` | `1.109` | `1.115` |
-| NodeAgentAuthorizer                      | `true`  | `Beta`  | `1.116` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` | `1.120` |
 | CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
@@ -192,6 +190,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | RemoveAPIServerProxyLegacyPort               | `false` | `Alpha`      | `1.113` | `1.118` |
 | RemoveAPIServerProxyLegacyPort               | `true`  | `Beta`       | `1.119` | `1.121` |
 | RemoveAPIServerProxyLegacyPort               | `true`  | `GA`         | `1.122` |         |
+| NodeAgentAuthorizer                          | `false` | `Alpha`      | `1.109` | `1.115` |
+| NodeAgentAuthorizer                          | `true`  | `Beta`       | `1.116` | `1.122` |
+| NodeAgentAuthorizer                          | `true`  | `GA`         | `1.123` |         |
+
 
 ## Using a Feature
 

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -18,10 +18,8 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/nodeinit"
 	nodeagentcomponent "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
-	"github.com/gardener/gardener/pkg/features"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Init", func() {
@@ -217,49 +215,6 @@ server: {}
 
 				// best-effort check: ensure the node init configuration is not exceeding 4KB in size
 				Expect(utf8.RuneCountInString(writeFilesToDiskScript + writeUnitsToDiskScript)).To(BeNumerically("<", 4096))
-			})
-		})
-
-		When("NodeAgentAuthorizer feature gate is disabled", func() {
-			BeforeEach(func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, false))
-				config = nodeagentcomponent.ComponentConfig(oscSecretName, kubernetesVersion, apiServerURL, caBundle, nil)
-			})
-
-			It("should correctly configure the bootstrap configuration", func() {
-				_, files, err := Config(worker, image, config)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(files).To(ContainElement(extensionsv1alpha1.File{
-					Path:        "/var/lib/gardener-node-agent/config.yaml",
-					Permissions: ptr.To[uint32](0600),
-					Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiServer:
-  caBundle: ` + utils.EncodeBase64(caBundle) + `
-  server: ` + apiServerURL + `
-apiVersion: nodeagent.config.gardener.cloud/v1alpha1
-bootstrap: {}
-clientConnection:
-  acceptContentTypes: ""
-  burst: 0
-  contentType: ""
-  kubeconfig: ""
-  qps: 0
-controllers:
-  operatingSystemConfig:
-    kubernetesVersion: ` + kubernetesVersion.String() + `
-    secretName: ` + oscSecretName + `
-  token:
-    syncConfigs:
-    - path: /var/lib/gardener-node-agent/credentials/token
-      secretName: gardener-node-agent
-    syncPeriod: 12h0m0s
-featureGates:
-  NodeAgentAuthorizer: false
-kind: NodeAgentConfiguration
-logFormat: ""
-logLevel: ""
-server: {}
-`))}},
-				}))
 			})
 		})
 	})

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
@@ -27,190 +26,8 @@ var _ = Describe("RBAC", func() {
 			clusterRoleBindingSelfNodeClientYAML   string
 		)
 
-		When("NodeAgentAuthorizer feature gate is disabled", func() {
-			BeforeEach(func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, false))
-
-				clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: gardener-node-agent
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  - nodes/status
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-`
-
-				clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  name: gardener-node-agent
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: gardener-node-agent
-subjects:
-- kind: ServiceAccount
-  name: gardener-node-agent
-  namespace: kube-system
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: gardener.cloud:node-agents
-`
-
-				roleYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  name: gardener-node-agent
-  namespace: kube-system
-rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - gardener-node-agent
-  - gardener-valitail
-  - osc-secret1
-  - osc-secret2
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-`
-
-				roleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  name: gardener-node-agent
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: gardener-node-agent
-subjects:
-- kind: Group
-  name: system:bootstrappers
-- kind: ServiceAccount
-  name: gardener-node-agent
-  namespace: kube-system
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: gardener.cloud:node-agents
-`
-
-				clusterRoleBindingNodeBootstrapperYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  name: system:node-bootstrapper
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:node-bootstrapper
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:bootstrappers
-`
-
-				clusterRoleBindingNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:bootstrappers
-`
-				clusterRoleBindingSelfNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:nodes
-`
-			})
-
-			It("should generate the expected RBAC resources", func() {
-				dataMap, err := RBACResourcesData([]string{"osc-secret1", "osc-secret2"})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(dataMap).To(HaveKey("data.yaml.br"))
-				compressedData := dataMap["data.yaml.br"]
-				data, err := test.BrotliDecompression(compressedData)
-				Expect(err).NotTo(HaveOccurred())
-
-				manifests := strings.Split(string(data), "---\n")
-				Expect(manifests).To(ConsistOf(
-					clusterRoleYAML,
-					clusterRoleBindingYAML,
-					roleYAML,
-					roleBindingYAML,
-					clusterRoleBindingNodeBootstrapperYAML,
-					clusterRoleBindingNodeClientYAML,
-					clusterRoleBindingSelfNodeClientYAML,
-				))
-			})
-		})
-
-		When("NodeAgentAuthorizer feature gate is enabled", func() {
-			BeforeEach(func() {
-				clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
+		BeforeEach(func() {
+			clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
@@ -247,7 +64,7 @@ rules:
   - get
 `
 
-				clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+			clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
@@ -262,7 +79,39 @@ subjects:
   namespace: kube-system
 `
 
-				roleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+			roleYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: gardener-node-agent
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - gardener-node-agent
+  - gardener-valitail
+  - osc-secret1
+  - osc-secret2
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+`
+
+			roleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
@@ -279,28 +128,71 @@ subjects:
   name: gardener-node-agent
   namespace: kube-system
 `
-			})
 
-			It("should generate the expected RBAC resources", func() {
-				dataMap, err := RBACResourcesData([]string{"osc-secret1", "osc-secret2"})
-				Expect(err).NotTo(HaveOccurred())
+			clusterRoleBindingNodeBootstrapperYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: system:node-bootstrapper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-bootstrapper
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers
+`
 
-				Expect(dataMap).To(HaveKey("data.yaml.br"))
-				compressedData := dataMap["data.yaml.br"]
-				data, err := test.BrotliDecompression(compressedData)
-				Expect(err).NotTo(HaveOccurred())
+			clusterRoleBindingNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers
+`
+			clusterRoleBindingSelfNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+`
+		})
 
-				manifests := strings.Split(string(data), "---\n")
-				Expect(manifests).To(ConsistOf(
-					clusterRoleYAML,
-					clusterRoleBindingYAML,
-					roleYAML,
-					roleBindingYAML,
-					clusterRoleBindingNodeBootstrapperYAML,
-					clusterRoleBindingNodeClientYAML,
-					clusterRoleBindingSelfNodeClientYAML,
-				))
-			})
+		It("should generate the expected RBAC resources", func() {
+			dataMap, err := RBACResourcesData([]string{"osc-secret1", "osc-secret2"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dataMap).To(HaveKey("data.yaml.br"))
+			compressedData := dataMap["data.yaml.br"]
+			data, err := test.BrotliDecompression(compressedData)
+			Expect(err).NotTo(HaveOccurred())
+
+			manifests := strings.Split(string(data), "---\n")
+			Expect(manifests).To(ConsistOf(
+				clusterRoleYAML,
+				clusterRoleBindingYAML,
+				roleYAML,
+				roleBindingYAML,
+				clusterRoleBindingNodeBootstrapperYAML,
+				clusterRoleBindingNodeClientYAML,
+				clusterRoleBindingSelfNodeClientYAML,
+			))
 		})
 	})
 })

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -55,6 +55,7 @@ const (
 	// owner: @oliver-goetz
 	// alpha: v1.109.0
 	// beta: v1.116.0
+	// GA: v1.123.0
 	NodeAgentAuthorizer featuregate.Feature = "NodeAgentAuthorizer"
 
 	// CredentialsRotationWithoutWorkersRollout enables starting the credentials rotation without immediately causing
@@ -135,7 +136,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ShootCredentialsBinding:                  {Default: true, PreRelease: featuregate.Beta},
 	NewWorkerPoolHash:                        {Default: false, PreRelease: featuregate.Alpha},
 	NewVPN:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	NodeAgentAuthorizer:                      {Default: true, PreRelease: featuregate.Beta},
+	NodeAgentAuthorizer:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CredentialsRotationWithoutWorkersRollout: {Default: true, PreRelease: featuregate.Beta},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},
 	RemoveAPIServerProxyLegacyPort:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true},

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/gardener/gardener/pkg/api/indexer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
-	"github.com/gardener/gardener/pkg/features"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	healthcheckcontroller "github.com/gardener/gardener/pkg/nodeagent/controller/healthcheck"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
@@ -994,8 +993,6 @@ kind: NodeAgentConfiguration
 					return nil
 				},
 			))
-
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.NodeAgentAuthorizer, true))
 		})
 
 		JustBeforeEach(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
`NodeAgentAuthorizer` feature gate is beta since Gardener `v1.116.0` and now graduates to GA.

**Which issue(s) this PR fixes**:
Part of #10505

**Special notes for your reviewer**:
The migration code for this feature gate might be still required in case someone set the feature gate to false manually. Thus, all feature gate related (migration) code will be removed in Gardener release `v1.124.0`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `NodeAgentAuthorizer` feature gate has been graduated to GA and is locked to `true`. 
```
