### PR TITLE
Change permissions of /host/etc/sysctl.d/ to fix local-setup with Cilium

### DIFF
--- a/pkg/provider-local/node/Dockerfile
+++ b/pkg/provider-local/node/Dockerfile
@@ -19,4 +19,6 @@ RUN systemctl enable run-userdata.service
 
 RUN runc --version ; containerd --version
 
+RUN chmod 755 /etc/sysctl.d/
+
 ENTRYPOINT ["/usr/local/bin/entrypoint", "/sbin/init"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/12151 the local setup with Cilium breaks.
Using the image `kindest/node:v1.32.5` results in the following error running an init container:
`cannot create /host/etc/sysctl.d/99-cilium-rp-filter.conf: Permission denied`
With kindest/node image before v1.32.5 `/host/etc/sysctl.d/` have the permissions `drwxr-xr-x`. Starting with v1.32.5 the permissions changed to `drw-r--r--`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fixed the local-setup for Cilium shoots.
```
