### PR TITLE
Forbid setting the Shoot's `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` field for Kubernetes versions >= 1.33

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -4063,9 +4063,10 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set).
-Deprecated: This field is deprecated and will be removed once gardener drops support for Kubernetes v1.32.
-This cluster-autoscaler field is deprecated upstream, use &ndash;max-scale-down-parallelism instead.</p>
+<p>MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set).</p>
+<p>Deprecated: This field is deprecated. Setting this field will be forbidden starting from Kubernetes 1.33 and will be removed once gardener drops support for kubernetes v1.32.
+This cluster-autoscaler field is deprecated upstream, use &ndash;max-scale-down-parallelism instead.
+TODO(Kostov6): Drop this field after support for Kubernetes 1.32 is dropped.</p>
 </td>
 </tr>
 <tr>

--- a/docs/usage/shoot/shoot_kubernetes_versions.md
+++ b/docs/usage/shoot/shoot_kubernetes_versions.md
@@ -13,6 +13,7 @@ For Kubernetes specific upgrade notes the upstream Kubernetes release notes, [ch
 
 - A new `deny-all` `NetworkPolicy` is deployed into the `kube-system` namespace of the `Shoot` cluster. `Shoot` owners that run workloads in the `kube-system` namespace are required to explicitly allow their expected `Ingress` and `Egress` traffic in `kube-system` via `NetworkPolicies`.
 - The `Shoot`'s field `.spec.kubernetes.kubeControllerManager.podEvictionTimeout` is forbidden. `Shoot` owners should use the `.spec.kubernetes.kubeAPIServer.defaultNotReadyTolerationSeconds` and `.spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds` fields.
+- The `Shoot`'s field `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` is forbidden. `Shoot` owners should use the `.spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism` field.
 
 ## Upgrading to Kubernetes `v1.32`
 

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -333,7 +333,7 @@ spec:
   #   statusTaints:
   #     - "reservedForTenant"
   #   newPodScaleUpDelay: 0s
-  #   maxEmptyBulkDelete: 10 # Deprecated, will be removed once gardener drops support for Kubernetes v1.32. Use maxScaleDownParallelism instead.
+  #   maxEmptyBulkDelete: 10 # Deprecated and forbidden to be set starting from Kubernetes 1.33. Will be removed once gardener drops support for Kubernetes v1.32. Use maxScaleDownParallelism instead.
   #   maxScaleDownParallelism: 10
   #   maxDrainParallelism: 1
   #   ignoreDaemonsetsUtilization: false

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -37,7 +37,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	}
 
 	if supportedVersion, _ := versionutils.CompareVersions(shoot.Spec.Kubernetes.Version, "<", "1.33"); supportedVersion && shoot.Spec.Kubernetes.ClusterAutoscaler != nil && shoot.Spec.Kubernetes.ClusterAutoscaler.MaxEmptyBulkDelete != nil {
-		warnings = append(warnings, "you are setting the spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field. The field has been deprecated and will not be supported by gardener from Kubernetes 1.33. Instead, use the spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism field.")
+		warnings = append(warnings, "you are setting the spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.33. Instead, use the spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism field.")
 	}
 
 	if helper.IsLegacyAnonymousAuthenticationSet(shoot.Spec.Kubernetes.KubeAPIServer) {

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Warnings", func() {
 			shoot.Spec.Kubernetes.ClusterAutoscaler = &core.ClusterAutoscaler{
 				MaxEmptyBulkDelete: ptr.To(int32(5)),
 			}
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field. The field has been deprecated and will not be supported by gardener from Kubernetes 1.33. Instead, use the spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism field.")))
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.33. Instead, use the spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism field.")))
 		})
 
 		It("should return a warning when enableAnonymousAuthentication is set", func() {

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -543,6 +543,7 @@ type ClusterAutoscaler struct {
 	// NewPodScaleUpDelay specifies how long CA should ignore newly created pods before they have to be considered for scale-up.
 	NewPodScaleUpDelay *metav1.Duration
 	// MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set).
+	//
 	// Deprecated: This field is deprecated. Setting this field will be forbidden starting from Kubernetes 1.33 and will be removed once gardener drops support for kubernetes v1.32.
 	// This cluster-autoscaler field is deprecated upstream, use --max-scale-down-parallelism instead.
 	// TODO(Kostov6): Drop this field after support for Kubernetes 1.32 is dropped.

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -543,8 +543,9 @@ type ClusterAutoscaler struct {
 	// NewPodScaleUpDelay specifies how long CA should ignore newly created pods before they have to be considered for scale-up.
 	NewPodScaleUpDelay *metav1.Duration
 	// MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set).
-	// Deprecated: This field is deprecated and will be removed once gardener drops support for kubernetes v1.32.
+	// Deprecated: This field is deprecated. Setting this field will be forbidden starting from Kubernetes 1.33 and will be removed once gardener drops support for kubernetes v1.32.
 	// This cluster-autoscaler field is deprecated upstream, use --max-scale-down-parallelism instead.
+	// TODO(Kostov6): Drop this field after support for Kubernetes 1.32 is dropped.
 	MaxEmptyBulkDelete *int32
 	// MaxScaleDownParallelism specifies the maximum number of nodes (both empty and needing drain) that can be deleted in parallel.
 	// Default: 10 or MaxEmptyBulkDelete when that is set

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -544,8 +544,10 @@ message ClusterAutoscaler {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration newPodScaleUpDelay = 11;
 
   // MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set).
-  // Deprecated: This field is deprecated and will be removed once gardener drops support for Kubernetes v1.32.
+  //
+  // Deprecated: This field is deprecated. Setting this field will be forbidden starting from Kubernetes 1.33 and will be removed once gardener drops support for kubernetes v1.32.
   // This cluster-autoscaler field is deprecated upstream, use --max-scale-down-parallelism instead.
+  // TODO(Kostov6): Drop this field after support for Kubernetes 1.32 is dropped.
   // +optional
   optional int32 maxEmptyBulkDelete = 12;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -680,6 +680,7 @@ type ClusterAutoscaler struct {
 	// +optional
 	NewPodScaleUpDelay *metav1.Duration `json:"newPodScaleUpDelay,omitempty" protobuf:"bytes,11,opt,name=newPodScaleUpDelay"`
 	// MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set).
+	//
 	// Deprecated: This field is deprecated. Setting this field will be forbidden starting from Kubernetes 1.33 and will be removed once gardener drops support for kubernetes v1.32.
 	// This cluster-autoscaler field is deprecated upstream, use --max-scale-down-parallelism instead.
 	// TODO(Kostov6): Drop this field after support for Kubernetes 1.32 is dropped.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -680,8 +680,9 @@ type ClusterAutoscaler struct {
 	// +optional
 	NewPodScaleUpDelay *metav1.Duration `json:"newPodScaleUpDelay,omitempty" protobuf:"bytes,11,opt,name=newPodScaleUpDelay"`
 	// MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set).
-	// Deprecated: This field is deprecated and will be removed once gardener drops support for Kubernetes v1.32.
+	// Deprecated: This field is deprecated. Setting this field will be forbidden starting from Kubernetes 1.33 and will be removed once gardener drops support for kubernetes v1.32.
 	// This cluster-autoscaler field is deprecated upstream, use --max-scale-down-parallelism instead.
+	// TODO(Kostov6): Drop this field after support for Kubernetes 1.32 is dropped.
 	// +optional
 	MaxEmptyBulkDelete *int32 `json:"maxEmptyBulkDelete,omitempty" protobuf:"varint,12,opt,name=maxEmptyBulkDelete"`
 	// IgnoreDaemonsetsUtilization allows CA to ignore DaemonSet pods when calculating resource utilization for scaling down (default: false).

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2449,7 +2449,7 @@ func schema_pkg_apis_core_v1beta1_ClusterAutoscaler(ref common.ReferenceCallback
 					},
 					"maxEmptyBulkDelete": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set). Deprecated: This field is deprecated and will be removed once gardener drops support for Kubernetes v1.32. This cluster-autoscaler field is deprecated upstream, use --max-scale-down-parallelism instead.",
+							Description: "MaxEmptyBulkDelete specifies the maximum number of empty nodes that can be deleted at the same time (default: MaxScaleDownParallelism when that is set).\n\nDeprecated: This field is deprecated. Setting this field will be forbidden starting from Kubernetes 1.33 and will be removed once gardener drops support for kubernetes v1.32. This cluster-autoscaler field is deprecated upstream, use --max-scale-down-parallelism instead.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -190,7 +190,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 	}
 
 	// Set the .spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field to nil, when Shoot cluster is being forcefully updated to K8s >= 1.33.
-	// Gardener forbids setting the field for Shoots with K8s 1.33+. See <TODO: Add link to PR after it is opened>
+	// Gardener forbids setting the field for Shoots with K8s 1.33+. See https://github.com/gardener/gardener/pull/12413
 	{
 		oldK8sLess133, _ := versionutils.CheckVersionMeetsConstraint(oldShootKubernetesVersion.String(), "< 1.33")
 		newK8sGreaterEqual133, _ := versionutils.CheckVersionMeetsConstraint(shootKubernetesVersion.String(), ">= 1.33")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This PR forbids users to set the previously deprecated `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` shoot field for Kubernetes versions >= 1.33. In this way, once support for Kubernetes 1.32 is dropped, the field can be safely removed from the shoot spec.
Shoot owners should already be relying on the `.spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism` field instead of the deprecated one

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11933

**Special notes for your reviewer**:
Related PRs:
- https://github.com/gardener/gardener/pull/12115
- https://github.com/gardener/gardener/pull/12343

/cc @takoverflow

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` field in the `Shoot` API is forbidden to be set for Kubernetes versions >= 1.33 and will be removed after support for Kubernetes 1.32 is dropped.
```
