### PR TITLE
[GEP-26] Promote `DoNotCopyBackupCredentials` feature gate to Beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -36,7 +36,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
 | CloudProfileCapabilities                 | `false` | `Alpha` | `1.117` |         |
 | DoNotCopyBackupCredentials               | `false` | `Alpha` | `1.121` | `1.122` |
-| DoNotCopyBackupCredentials               | `false` | `Beta`  | `1.123` |         |
+| DoNotCopyBackupCredentials               | `true`  | `Beta`  | `1.123` |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -35,7 +35,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | RemoveAPIServerProxyLegacyPort           | `true`  | `Beta`  | `1.119` |         |
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
 | CloudProfileCapabilities                 | `false` | `Alpha` | `1.117` |         |
-| DoNotCopyBackupCredentials               | `false` | `Alpha` | `1.121` |         |
+| DoNotCopyBackupCredentials               | `false` | `Alpha` | `1.121` | `1.122` |
+| DoNotCopyBackupCredentials               | `false` | `Beta`  | `1.123` |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -39,7 +39,6 @@ config:
     DefaultSeccompProfile: true
     NewWorkerPoolHash: true
     IstioTLSTermination: true
-    DoNotCopyBackupCredentials: true
   logging:
     enabled: true
     vali:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -101,6 +101,7 @@ const (
 	// Credentials that were already copied will be labeled with "secret.backup.gardener.cloud/status=previously-managed" and would have to be cleaned up by operators.
 	// owner: @dimityrmirchev
 	// alpha: v1.121.0
+	// beta: v1.123.0
 	DoNotCopyBackupCredentials featuregate.Feature = "DoNotCopyBackupCredentials"
 )
 
@@ -140,7 +141,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RemoveAPIServerProxyLegacyPort:           {Default: true, PreRelease: featuregate.Beta},
 	IstioTLSTermination:                      {Default: false, PreRelease: featuregate.Alpha},
 	CloudProfileCapabilities:                 {Default: false, PreRelease: featuregate.Alpha},
-	DoNotCopyBackupCredentials:               {Default: false, PreRelease: featuregate.Alpha},
+	DoNotCopyBackupCredentials:               {Default: true, PreRelease: featuregate.Beta},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
/invite @ialidzhikov 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `DoNotCopyBackupCredentials` feature gate has been promoted to beta and is now enabled by default. When the feature is enabled the `Seed` backup secret is no longer copied from the `Shoot` infrastructure credentials in case an operator does not provide an existing backup secret. If you configure `seed.spec.backup.credentialsRef`, make sure that the referred credential already exists. For production setups, it is advised that operators configure a separate set of credentials for `Seed` backup and `Shoot` infrastructure.
```
