### PR TITLE
enable/disable node-local-dns without rolling nodes

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3519,7 +3519,7 @@ CRIName
 <p>CRIName is a type alias for the CRI name string.</p>
 </p>
 <h3 id="core.gardener.cloud/v1beta1.Capabilities">Capabilities
-(<code>map[string]github.com/gardener/gardener/pkg/apis/core/v1beta1.CapabilityValues</code> alias)</p></h3>
+(<code>map[string]..CapabilityValues</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
 <a href="#core.gardener.cloud/v1beta1.CapabilitySet">CapabilitySet</a>, 

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3519,7 +3519,7 @@ CRIName
 <p>CRIName is a type alias for the CRI name string.</p>
 </p>
 <h3 id="core.gardener.cloud/v1beta1.Capabilities">Capabilities
-(<code>map[string]..CapabilityValues</code> alias)</p></h3>
+(<code>map[string]github.com/gardener/gardener/pkg/apis/core/v1beta1.CapabilityValues</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
 <a href="#core.gardener.cloud/v1beta1.CapabilitySet">CapabilitySet</a>, 

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -110,7 +110,7 @@ The complete list of fields that trigger a rolling update:
 * `.spec.provider.workers[].providerConfig` (provider extension dependent with feature gate `NewWorkerPoolHash`)
 * `.spec.provider.workers[].cri.name`
 * `.spec.provider.workers[].kubernetes.version` (except for patch version changes)
-* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34)
+* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34 or if `kube-proxy` runs in `IPVS` mode)
 * `.status.credentials.rotation.certificateAuthorities.lastInitiationTime` (changed by Gardener when a shoot CA rotation is initiated) when worker pool is not part of `.status.credentials.rotation.certificateAuthorities.pendingWorkersRollouts[]`
 * `.status.credentials.rotation.serviceAccountKey.lastInitiationTime` (changed by Gardener when a shoot service account signing key rotation is initiated) when worker pool is not part of `.status.credentials.rotation.serviceAccountKey.pendingWorkersRollouts[]`
 
@@ -169,7 +169,7 @@ An in-place update of the shoot worker nodes is triggered for rolling update tri
 * `.spec.provider.workers[].volume.type`
 * `.spec.provider.workers[].volume.size`
 * `.spec.provider.workers[].cri.name`
-* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34)
+* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34 or if `kube-proxy` runs in `IPVS` mode)
 
 > There are validations which restricts changing the above mentioned exception fields when `in-place` updates strategy is configured.
 

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -109,8 +109,8 @@ The complete list of fields that trigger a rolling update:
 * `.spec.provider.workers[].volume.size`
 * `.spec.provider.workers[].providerConfig` (provider extension dependent with feature gate `NewWorkerPoolHash`)
 * `.spec.provider.workers[].cri.name`
+* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34)
 * `.spec.provider.workers[].kubernetes.version` (except for patch version changes)
-* `.spec.systemComponents.nodeLocalDNS.enabled`
 * `.status.credentials.rotation.certificateAuthorities.lastInitiationTime` (changed by Gardener when a shoot CA rotation is initiated) when worker pool is not part of `.status.credentials.rotation.certificateAuthorities.pendingWorkersRollouts[]`
 * `.status.credentials.rotation.serviceAccountKey.lastInitiationTime` (changed by Gardener when a shoot service account signing key rotation is initiated) when worker pool is not part of `.status.credentials.rotation.serviceAccountKey.pendingWorkersRollouts[]`
 
@@ -169,7 +169,7 @@ An in-place update of the shoot worker nodes is triggered for rolling update tri
 * `.spec.provider.workers[].volume.type`
 * `.spec.provider.workers[].volume.size`
 * `.spec.provider.workers[].cri.name`
-* `.spec.systemComponents.nodeLocalDNS.enabled`
+* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34)
 
 > There are validations which restricts changing the above mentioned exception fields when `in-place` updates strategy is configured.
 

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -109,8 +109,8 @@ The complete list of fields that trigger a rolling update:
 * `.spec.provider.workers[].volume.size`
 * `.spec.provider.workers[].providerConfig` (provider extension dependent with feature gate `NewWorkerPoolHash`)
 * `.spec.provider.workers[].cri.name`
-* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34)
 * `.spec.provider.workers[].kubernetes.version` (except for patch version changes)
+* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34)
 * `.status.credentials.rotation.certificateAuthorities.lastInitiationTime` (changed by Gardener when a shoot CA rotation is initiated) when worker pool is not part of `.status.credentials.rotation.certificateAuthorities.pendingWorkersRollouts[]`
 * `.status.credentials.rotation.serviceAccountKey.lastInitiationTime` (changed by Gardener when a shoot service account signing key rotation is initiated) when worker pool is not part of `.status.credentials.rotation.serviceAccountKey.pendingWorkersRollouts[]`
 

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -110,7 +110,7 @@ The complete list of fields that trigger a rolling update:
 * `.spec.provider.workers[].providerConfig` (provider extension dependent with feature gate `NewWorkerPoolHash`)
 * `.spec.provider.workers[].cri.name`
 * `.spec.provider.workers[].kubernetes.version` (except for patch version changes)
-* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34 or if `kube-proxy` runs in `IPVS` mode)
+* `.spec.systemComponents.nodeLocalDNS.enabled` (for Kubernetes version < 1.34 or if `kube-proxy` runs in `IPVS` mode)
 * `.status.credentials.rotation.certificateAuthorities.lastInitiationTime` (changed by Gardener when a shoot CA rotation is initiated) when worker pool is not part of `.status.credentials.rotation.certificateAuthorities.pendingWorkersRollouts[]`
 * `.status.credentials.rotation.serviceAccountKey.lastInitiationTime` (changed by Gardener when a shoot service account signing key rotation is initiated) when worker pool is not part of `.status.credentials.rotation.serviceAccountKey.pendingWorkersRollouts[]`
 
@@ -169,7 +169,7 @@ An in-place update of the shoot worker nodes is triggered for rolling update tri
 * `.spec.provider.workers[].volume.type`
 * `.spec.provider.workers[].volume.size`
 * `.spec.provider.workers[].cri.name`
-* `.spec.systemComponents.nodeLocalDNS.enabled` (for kubernetes version < 1.34 or if `kube-proxy` runs in `IPVS` mode)
+* `.spec.systemComponents.nodeLocalDNS.enabled` (for Kubernetes version < 1.34 or if `kube-proxy` runs in `IPVS` mode)
 
 > There are validations which restricts changing the above mentioned exception fields when `in-place` updates strategy is configured.
 

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -21,6 +21,7 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
@@ -160,7 +161,9 @@ func WorkerPoolHashV1(pool extensionsv1alpha1.WorkerPool, cluster *extensionscon
 		return "", fmt.Errorf("failed to parse Kubernetes version %q: %w", kubernetesVersion, err)
 	}
 
-	if versionutils.ConstraintK8sLess134.Check(parsedVersion) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
+	if versionutils.ConstraintK8sLess134.Check(parsedVersion) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) ||
+		cluster.Shoot.Spec.Kubernetes.KubeProxy != nil && cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled != nil && *cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled &&
+			cluster.Shoot.Spec.Kubernetes.KubeProxy.Mode != nil && *cluster.Shoot.Spec.Kubernetes.KubeProxy.Mode == gardencorev1beta1.ProxyModeIPVS && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
 		data = append(data, "node-local-dns")
 	}
 

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 var diskSizeRegex = regexp.MustCompile(`^(\d+)`)
@@ -159,10 +160,8 @@ func WorkerPoolHashV1(pool extensionsv1alpha1.WorkerPool, cluster *extensionscon
 		return "", fmt.Errorf("failed to parse Kubernetes version %q: %w", kubernetesVersion, err)
 	}
 
-	if parsedVersion.LessThan(semver.MustParse("1.34.0")) {
-		if v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
-			data = append(data, "node-local-dns")
-		}
+	if versionutils.ConstraintK8sLess134.Check(parsedVersion) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
+		data = append(data, "node-local-dns")
 	}
 
 	var result string

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -160,8 +160,8 @@ func WorkerPoolHashV1(pool extensionsv1alpha1.WorkerPool, cluster *extensionscon
 		return "", fmt.Errorf("failed to parse Kubernetes version %q: %w", kubernetesVersion, err)
 	}
 
-	if versionutils.ConstraintK8sLess134.Check(parsedVersion) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) ||
-		v1beta1helper.IsKubeProxyIPVSMode(cluster.Shoot.Spec.Kubernetes.KubeProxy) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
+	if (versionutils.ConstraintK8sLess134.Check(parsedVersion) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents)) ||
+		(v1beta1helper.IsKubeProxyIPVSMode(cluster.Shoot.Spec.Kubernetes.KubeProxy) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents)) {
 		data = append(data, "node-local-dns")
 	}
 

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -21,7 +21,6 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
@@ -162,8 +161,7 @@ func WorkerPoolHashV1(pool extensionsv1alpha1.WorkerPool, cluster *extensionscon
 	}
 
 	if versionutils.ConstraintK8sLess134.Check(parsedVersion) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) ||
-		cluster.Shoot.Spec.Kubernetes.KubeProxy != nil && cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled != nil && *cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled &&
-			cluster.Shoot.Spec.Kubernetes.KubeProxy.Mode != nil && *cluster.Shoot.Spec.Kubernetes.KubeProxy.Mode == gardencorev1beta1.ProxyModeIPVS && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
+		v1beta1helper.IsKubeProxyIPVSMode(cluster.Shoot.Spec.Kubernetes.KubeProxy) && v1beta1helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
 		data = append(data, "node-local-dns")
 	}
 

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -559,6 +559,19 @@ var _ = Describe("Machines", func() {
 
 				c.Shoot.Status.Credentials.Rotation.ServiceAccountKey = credentialStatusWithInitiatedRotation
 			})
+			It("when kubernetes version is updated to 1.34 and node local dns is enabled", func() {
+				c.Shoot.Spec.Kubernetes.Version = "1.30.0"
+				p.KubernetesVersion = ptr.To("1.30.0")
+				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{
+					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true},
+				}
+				hash1, err := WorkerPoolHashV1(p, c)
+				Expect(err).NotTo(HaveOccurred())
+				p.KubernetesVersion = ptr.To("1.34.0")
+				hash2, err := WorkerPoolHashV1(p, c)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hash1).NotTo(Equal(hash2))
+			})
 		})
 	})
 

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -559,17 +559,34 @@ var _ = Describe("Machines", func() {
 
 				c.Shoot.Status.Credentials.Rotation.ServiceAccountKey = credentialStatusWithInitiatedRotation
 			})
-			It("when kubernetes version is updated to 1.34 and node local dns is enabled", func() {
-				c.Shoot.Spec.Kubernetes.Version = "1.30.0"
-				p.KubernetesVersion = ptr.To("1.30.0")
+			It("when node-local-dns gets enabled and kubernetes version is equal or larger than 1.34", func() {
+				c.Shoot.Spec.Kubernetes.Version = "1.34.0"
+				p.KubernetesVersion = ptr.To("1.34.0")
 				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{
-					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true},
+					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false},
 				}
 				hash1, err := WorkerPoolHashV1(p, c)
 				Expect(err).NotTo(HaveOccurred())
-				p.KubernetesVersion = ptr.To("1.34.0")
+				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{
+					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true},
+				}
 				hash2, err := WorkerPoolHashV1(p, c)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(hash1).To(Equal(hash2))
+			})
+			It("when node-local-dns gets enabled and kubernetes version is lower than 1.34", func() {
+				c.Shoot.Spec.Kubernetes.Version = "1.31.0"
+				p.KubernetesVersion = ptr.To("1.31.0")
+				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{
+					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false},
+				}
+				hash1, err := WorkerPoolHashV1(p, c)
+				Expect(err).NotTo(HaveOccurred())
+				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{
+					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true},
+				}
+				hash2, err := WorkerPoolHashV1(p, c)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(hash1).NotTo(Equal(hash2))
 			})
 		})

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -559,6 +559,7 @@ var _ = Describe("Machines", func() {
 
 				c.Shoot.Status.Credentials.Rotation.ServiceAccountKey = credentialStatusWithInitiatedRotation
 			})
+
 			It("when node-local-dns gets enabled and kubernetes version is equal or larger than 1.34", func() {
 				c.Shoot.Spec.Kubernetes.Version = "1.34.0"
 				p.KubernetesVersion = ptr.To("1.34.0")
@@ -574,6 +575,7 @@ var _ = Describe("Machines", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hash1).To(Equal(hash2))
 			})
+
 			It("when node-local-dns gets disabled and kube-proxy runs in ipvs mode", func() {
 				c.Shoot.Spec.Kubernetes.Version = "1.34.0"
 				p.KubernetesVersion = ptr.To("1.34.0")
@@ -593,6 +595,7 @@ var _ = Describe("Machines", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hash1).ToNot(Equal(hash2))
 			})
+
 			It("when node-local-dns gets enabled and kubernetes version is lower than 1.34", func() {
 				c.Shoot.Spec.Kubernetes.Version = "1.31.0"
 				p.KubernetesVersion = ptr.To("1.31.0")

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -574,6 +574,25 @@ var _ = Describe("Machines", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hash1).To(Equal(hash2))
 			})
+			It("when node-local-dns gets disabled and kube-proxy runs in ipvs mode", func() {
+				c.Shoot.Spec.Kubernetes.Version = "1.34.0"
+				p.KubernetesVersion = ptr.To("1.34.0")
+				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{
+					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true},
+				}
+				c.Shoot.Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{
+					Mode:    ptr.To(gardencorev1beta1.ProxyModeIPVS),
+					Enabled: ptr.To(true),
+				}
+				hash1, err := WorkerPoolHashV1(p, c)
+				Expect(err).NotTo(HaveOccurred())
+				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{
+					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false},
+				}
+				hash2, err := WorkerPoolHashV1(p, c)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hash1).ToNot(Equal(hash2))
+			})
 			It("when node-local-dns gets enabled and kubernetes version is lower than 1.34", func() {
 				c.Shoot.Spec.Kubernetes.Version = "1.31.0"
 				p.KubernetesVersion = ptr.To("1.31.0")

--- a/imagevector/containers.go
+++ b/imagevector/containers.go
@@ -11,6 +11,10 @@ const (
 	ContainerImageNameAlertmanager = "alertmanager"
 	// ContainerImageNameAlpineConntrack is a constant for an image in the image vector with name 'alpine-conntrack'.
 	ContainerImageNameAlpineConntrack = "alpine-conntrack"
+	// ContainerImageNameAlpineIptables is a constant for an image in the image vector with name 'alpine-iptables'.
+	ContainerImageNameAlpineIptables = "alpine-iptables"
+	// ContainerImageNameApiserverProxy is a constant for an image in the image vector with name 'apiserver-proxy'.
+	ContainerImageNameApiserverProxy = "apiserver-proxy"
 	// ContainerImageNameApiserverProxySidecar is a constant for an image in the image vector with name 'apiserver-proxy-sidecar'.
 	ContainerImageNameApiserverProxySidecar = "apiserver-proxy-sidecar"
 	// ContainerImageNameBlackboxExporter is a constant for an image in the image vector with name 'blackbox-exporter'.

--- a/imagevector/containers.go
+++ b/imagevector/containers.go
@@ -13,8 +13,6 @@ const (
 	ContainerImageNameAlpineConntrack = "alpine-conntrack"
 	// ContainerImageNameAlpineIptables is a constant for an image in the image vector with name 'alpine-iptables'.
 	ContainerImageNameAlpineIptables = "alpine-iptables"
-	// ContainerImageNameApiserverProxy is a constant for an image in the image vector with name 'apiserver-proxy'.
-	ContainerImageNameApiserverProxy = "apiserver-proxy"
 	// ContainerImageNameApiserverProxySidecar is a constant for an image in the image vector with name 'apiserver-proxy-sidecar'.
 	ContainerImageNameApiserverProxySidecar = "apiserver-proxy-sidecar"
 	// ContainerImageNameBlackboxExporter is a constant for an image in the image vector with name 'blackbox-exporter'.

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -556,6 +556,10 @@ images:
     sourceRepository: github.com/gardener/alpine-conntrack
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/alpine-conntrack
     tag: "3.21.3"
+  - name: alpine-iptables
+    sourceRepository: github.com/gardener/alpine-iptables
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/alpine-iptables
+    tag: "3.21.3"
   # Logging
   - name: fluent-operator
     sourceRepository: github.com/fluent/fluent-operator

--- a/pkg/apis/core/helper/shoot.go
+++ b/pkg/apis/core/helper/shoot.go
@@ -289,3 +289,12 @@ func IsUpdateStrategyInPlace(updateStrategy *core.MachineUpdateStrategy) bool {
 func IsLegacyAnonymousAuthenticationSet(kubeAPIServerConfig *core.KubeAPIServerConfig) bool {
 	return kubeAPIServerConfig != nil && kubeAPIServerConfig.EnableAnonymousAuthentication != nil
 }
+
+// IsKubeProxyIPVSMode checks if the shoot is running with kube-proxy in IPVS mode.
+func IsKubeProxyIPVSMode(kubeProxyConfig *core.KubeProxyConfig) bool {
+	if kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
+		kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == core.ProxyModeIPVS {
+		return true
+	}
+	return false
+}

--- a/pkg/apis/core/helper/shoot.go
+++ b/pkg/apis/core/helper/shoot.go
@@ -292,9 +292,6 @@ func IsLegacyAnonymousAuthenticationSet(kubeAPIServerConfig *core.KubeAPIServerC
 
 // IsKubeProxyIPVSMode checks if the shoot is running with kube-proxy in IPVS mode.
 func IsKubeProxyIPVSMode(kubeProxyConfig *core.KubeProxyConfig) bool {
-	if kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
-		kubeProxyConfig.Mode != nil {
-		return *kubeProxyConfig.Mode == core.ProxyModeIPVS
-	}
-	return false
+	return kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
+		kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == core.ProxyModeIPVS
 }

--- a/pkg/apis/core/helper/shoot.go
+++ b/pkg/apis/core/helper/shoot.go
@@ -293,8 +293,8 @@ func IsLegacyAnonymousAuthenticationSet(kubeAPIServerConfig *core.KubeAPIServerC
 // IsKubeProxyIPVSMode checks if the shoot is running with kube-proxy in IPVS mode.
 func IsKubeProxyIPVSMode(kubeProxyConfig *core.KubeProxyConfig) bool {
 	if kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
-		kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == core.ProxyModeIPVS {
-		return true
+		kubeProxyConfig.Mode != nil {
+		return *kubeProxyConfig.Mode == core.ProxyModeIPVS
 	}
 	return false
 }

--- a/pkg/apis/core/helper/shoot_test.go
+++ b/pkg/apis/core/helper/shoot_test.go
@@ -605,4 +605,12 @@ var _ = Describe("Helper", func() {
 		Entry("EnableAnonymousAuthentication is false", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(false)}, true),
 		Entry("EnableAnonymousAuthentication is true", &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}, true),
 	)
+
+	DescribeTable("#IsKubeProxyIPVSMode",
+		func(kubeProxyConfig *core.KubeProxyConfig, expected bool) {
+			Expect(IsKubeProxyIPVSMode(kubeProxyConfig)).To(Equal(expected))
+		},
+		Entry("with KubeProxy in IPVS mode", &core.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(core.ProxyModeIPVS)}, true),
+		Entry("with KubeProxy in IPTables mode", &core.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(core.ProxyModeIPTables)}, false),
+	)
 })

--- a/pkg/apis/core/helper/shoot_test.go
+++ b/pkg/apis/core/helper/shoot_test.go
@@ -610,6 +610,9 @@ var _ = Describe("Helper", func() {
 		func(kubeProxyConfig *core.KubeProxyConfig, expected bool) {
 			Expect(IsKubeProxyIPVSMode(kubeProxyConfig)).To(Equal(expected))
 		},
+		Entry("with KubeProxy in IPVS mode", nil, false),
+		Entry("with KubeProxy in IPVS mode", &core.KubeProxyConfig{}, false),
+		Entry("with KubeProxy in IPVS mode", &core.KubeProxyConfig{Enabled: ptr.To(false), Mode: ptr.To(core.ProxyModeIPVS)}, false),
 		Entry("with KubeProxy in IPVS mode", &core.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(core.ProxyModeIPVS)}, true),
 		Entry("with KubeProxy in IPTables mode", &core.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(core.ProxyModeIPTables)}, false),
 	)

--- a/pkg/apis/core/v1beta1/helper/shoot.go
+++ b/pkg/apis/core/v1beta1/helper/shoot.go
@@ -696,3 +696,12 @@ func GetBackupConfigForShoot(shoot *gardencorev1beta1.Shoot, seed *gardencorev1b
 func GetAPIServerDomain(domain string) string {
 	return fmt.Sprintf("%s.%s", v1beta1constants.APIServerFQDNPrefix, domain)
 }
+
+// IsKubeProxyIPVSMode checks if the shoot is running with kube-proxy in IPVS mode.
+func IsKubeProxyIPVSMode(kubeProxyConfig *gardencorev1beta1.KubeProxyConfig) bool {
+	if kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
+		kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS {
+		return true
+	}
+	return false
+}

--- a/pkg/apis/core/v1beta1/helper/shoot.go
+++ b/pkg/apis/core/v1beta1/helper/shoot.go
@@ -18,6 +18,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // HibernationIsEnabled checks if the given shoot's desired state is hibernated.
@@ -701,4 +702,21 @@ func GetAPIServerDomain(domain string) string {
 func IsKubeProxyIPVSMode(kubeProxyConfig *gardencorev1beta1.KubeProxyConfig) bool {
 	return kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
 		kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS
+}
+
+// IsOneWorkerPoolLowerKubernetes134 checks if at least one worker pool has a Kubernetes version lower than 1.34.
+func IsOneWorkerPoolLowerKubernetes134(controlPlaneVersion *semver.Version, workers []gardencorev1beta1.Worker) (bool, error) {
+	atLeastOnePoolLowerKubernetes134 := false
+	for _, worker := range workers {
+		kubernetesVersion, err := CalculateEffectiveKubernetesVersion(controlPlaneVersion, worker.Kubernetes)
+		if err != nil {
+			return false, fmt.Errorf("failed to calculate effective Kubernetes version for worker %q: %w", worker.Name, err)
+		}
+
+		if versionutils.ConstraintK8sLess134.Check(kubernetesVersion) {
+			atLeastOnePoolLowerKubernetes134 = true
+			break
+		}
+	}
+	return atLeastOnePoolLowerKubernetes134, nil
 }

--- a/pkg/apis/core/v1beta1/helper/shoot.go
+++ b/pkg/apis/core/v1beta1/helper/shoot.go
@@ -700,8 +700,8 @@ func GetAPIServerDomain(domain string) string {
 // IsKubeProxyIPVSMode checks if the shoot is running with kube-proxy in IPVS mode.
 func IsKubeProxyIPVSMode(kubeProxyConfig *gardencorev1beta1.KubeProxyConfig) bool {
 	if kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
-		kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS {
-		return true
+		kubeProxyConfig.Mode != nil {
+		return *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS
 	}
 	return false
 }

--- a/pkg/apis/core/v1beta1/helper/shoot.go
+++ b/pkg/apis/core/v1beta1/helper/shoot.go
@@ -699,9 +699,6 @@ func GetAPIServerDomain(domain string) string {
 
 // IsKubeProxyIPVSMode checks if the shoot is running with kube-proxy in IPVS mode.
 func IsKubeProxyIPVSMode(kubeProxyConfig *gardencorev1beta1.KubeProxyConfig) bool {
-	if kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
-		kubeProxyConfig.Mode != nil {
-		return *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS
-	}
-	return false
+	return kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled &&
+		kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS
 }

--- a/pkg/apis/core/v1beta1/helper/shoot_test.go
+++ b/pkg/apis/core/v1beta1/helper/shoot_test.go
@@ -1545,4 +1545,21 @@ var _ = Describe("Helper", func() {
 			Expect(GetBackupConfigForShoot(shoot, seed)).To(Equal(shootBackup))
 		})
 	})
+
+	Describe("#IsKubeProxyIPVSMode", func() {
+		var shoot *gardencorev1beta1.Shoot
+
+		BeforeEach(func() {
+			shoot = &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{KubeProxy: &gardencorev1beta1.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(gardencorev1beta1.ProxyModeIPVS)}}}}
+		})
+
+		It("should return true if KubeProxy is in IPVS mode", func() {
+			Expect(IsKubeProxyIPVSMode(shoot.Spec.Kubernetes.KubeProxy)).To(BeTrue())
+		})
+
+		It("should return false if KubeProxy is not in IPVS mode", func() {
+			shoot.Spec.Kubernetes.KubeProxy.Mode = ptr.To(gardencorev1beta1.ProxyModeIPTables)
+			Expect(IsKubeProxyIPVSMode(shoot.Spec.Kubernetes.KubeProxy)).To(BeFalse())
+		})
+	})
 })

--- a/pkg/apis/core/v1beta1/helper/shoot_test.go
+++ b/pkg/apis/core/v1beta1/helper/shoot_test.go
@@ -1567,5 +1567,4 @@ var _ = Describe("Helper", func() {
 		Entry("with control plane version 1.34 and one worker pool with lower version", semver.MustParse("1.34.0"), []gardencorev1beta1.Worker{{Kubernetes: &gardencorev1beta1.WorkerKubernetes{Version: ptr.To("1.31.0")}}}, true),
 		Entry("with control plane version 1.34 and one worker pool with lower version", semver.MustParse("1.34.0"), []gardencorev1beta1.Worker{{Kubernetes: &gardencorev1beta1.WorkerKubernetes{Version: ptr.To("1.34.0")}}}, false),
 	)
-
 })

--- a/pkg/apis/core/v1beta1/helper/shoot_test.go
+++ b/pkg/apis/core/v1beta1/helper/shoot_test.go
@@ -1562,4 +1562,15 @@ var _ = Describe("Helper", func() {
 			Expect(IsKubeProxyIPVSMode(shoot.Spec.Kubernetes.KubeProxy)).To(BeFalse())
 		})
 	})
+
+	DescribeTable("#IsKubeProxyIPVSMode",
+		func(kubeProxyConfig *gardencorev1beta1.KubeProxyConfig, expected bool) {
+			Expect(IsKubeProxyIPVSMode(kubeProxyConfig)).To(Equal(expected))
+		},
+		Entry("with KubeProxy in IPVS mode", nil, false),
+		Entry("with KubeProxy in IPVS mode", &gardencorev1beta1.KubeProxyConfig{}, false),
+		Entry("with KubeProxy in IPVS mode", &gardencorev1beta1.KubeProxyConfig{Enabled: ptr.To(false), Mode: ptr.To(gardencorev1beta1.ProxyModeIPVS)}, false),
+		Entry("with KubeProxy in IPVS mode", &gardencorev1beta1.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(gardencorev1beta1.ProxyModeIPVS)}, true),
+		Entry("with KubeProxy in IPTables mode", &gardencorev1beta1.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(gardencorev1beta1.ProxyModeIPTables)}, false),
+	)
 })

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -751,8 +751,8 @@ func validateNodeLocalDNSUpdate(newSpec, oldSpec *core.ShootSpec, fldPath *field
 				return field.ErrorList{field.Invalid(fldPath, "", fmt.Sprintf("failed to calculate effective Kubernetes version for worker %q: %v", worker.Name, err))}
 			}
 
-			if helper.IsUpdateStrategyInPlace(worker.UpdateStrategy) && (versionutils.ConstraintK8sLess134.Check(workerK8sVersion) ||
-				helper.IsUpdateStrategyInPlace(worker.UpdateStrategy) && helper.IsKubeProxyIPVSMode(oldSpec.Kubernetes.KubeProxy)) {
+			if (helper.IsUpdateStrategyInPlace(worker.UpdateStrategy) && (versionutils.ConstraintK8sLess134.Check(workerK8sVersion))) ||
+				(helper.IsUpdateStrategyInPlace(worker.UpdateStrategy) && helper.IsKubeProxyIPVSMode(oldSpec.Kubernetes.KubeProxy)) {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("systemComponents", "nodeLocalDNS"), "the node-local-dns setting cannot be changed if the shoot has at least one worker pool with an update strategy of either AutoInPlaceUpdate or ManualInPlaceUpdate, and is running a Kubernetes version below 1.34.0 or if kube-proxy runs in IPVS mode."))
 				break
 			}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -740,13 +740,13 @@ func validateNodeLocalDNSUpdate(newSpec, oldSpec *core.ShootSpec, fldPath *field
 	)
 
 	if oldNodeLocalDNSEnabled != newNodeLocalDNSEnabled {
-		parsedVersion, err := semver.NewVersion(oldSpec.Kubernetes.Version)
+		defaultVersion, err := semver.NewVersion(oldSpec.Kubernetes.Version)
 		if err != nil {
 			return field.ErrorList{field.Invalid(fldPath, oldSpec.Kubernetes.Version, fmt.Sprintf("failed to parse old Kubernetes version %q: %v", oldSpec.Kubernetes.Version, err))}
 		}
 
 		for _, worker := range oldSpec.Provider.Workers {
-			workerK8sVersion, err := helper.CalculateEffectiveKubernetesVersion(parsedVersion, worker.Kubernetes)
+			workerK8sVersion, err := helper.CalculateEffectiveKubernetesVersion(defaultVersion, worker.Kubernetes)
 			if err != nil {
 				return field.ErrorList{field.Invalid(fldPath, "", fmt.Sprintf("failed to calculate effective Kubernetes version for worker %q: %v", worker.Name, err))}
 			}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -25,8 +25,10 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -36,6 +38,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -737,12 +740,27 @@ func validateNodeLocalDNSUpdate(newSpec, oldSpec *core.ShootSpec, fldPath *field
 		allErrs                = field.ErrorList{}
 		oldNodeLocalDNSEnabled = oldSpec.SystemComponents != nil && oldSpec.SystemComponents.NodeLocalDNS != nil && oldSpec.SystemComponents.NodeLocalDNS.Enabled
 		newNodeLocalDNSEnabled = newSpec.SystemComponents != nil && newSpec.SystemComponents.NodeLocalDNS != nil && newSpec.SystemComponents.NodeLocalDNS.Enabled
+		parsedVersion          *semver.Version
+		err                    error
 	)
+	scheme := runtime.NewScheme()
+	utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
 
 	if oldNodeLocalDNSEnabled != newNodeLocalDNSEnabled {
 		for _, worker := range oldSpec.Provider.Workers {
-			if helper.IsUpdateStrategyInPlace(worker.UpdateStrategy) {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("systemComponents", "nodeLocalDNS"), "node-local-dns setting can not be changed if shoot has at least one worker pool with update strategy AutoInPlaceUpdate/ManualInPlaceUpdate"))
+			if worker.Kubernetes != nil && worker.Kubernetes.Version != nil {
+				parsedVersion, err = semver.NewVersion(*worker.Kubernetes.Version)
+				if err != nil {
+					return field.ErrorList{field.Invalid(fldPath, *worker.Kubernetes.Version, fmt.Sprintf("failed to parse Kubernetes version: %v for worker %q", err, worker.Name))}
+				}
+			} else {
+				parsedVersion, err = semver.NewVersion(oldSpec.Kubernetes.Version)
+				if err != nil {
+					return field.ErrorList{field.Invalid(fldPath, oldSpec.Kubernetes.Version, fmt.Sprintf("failed to parse Kubernetes version: %v", err))}
+				}
+			}
+			if helper.IsUpdateStrategyInPlace(worker.UpdateStrategy) && parsedVersion.LessThan(semver.MustParse("1.34.0")) {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("systemComponents", "nodeLocalDNS"), "the node-local-dns setting cannot be changed if the shoot has at least one worker pool with an update strategy of either AutoInPlaceUpdate or ManualInPlaceUpdate, and is running a Kubernetes version below 1.34.0."))
 				break
 			}
 		}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5942,7 +5942,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
 			})
 
-			It("should allow toggling the node-local-dns if one of the worker pool has updateStrategy AutoInPlaceUpdate/ManualInPlaceUpdate and k8s version >= 1.34.0", func() {
+			It("should allow toggling the node-local-dns if one of the worker pool has updateStrategy AutoInPlaceUpdate/ManualInPlaceUpdate but k8s version >= 1.34.0", func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.InPlaceNodeUpdates, true))
 				shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers[0])
 				shoot.Spec.Provider.Workers[1].Name = "worker-2"

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5891,7 +5891,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		Context("node-local-dns update", func() {
-			It("the node-local-dns setting cannot be changed if the shoot has at least one worker pool with an update strategy of either AutoInPlaceUpdate or ManualInPlaceUpdate, and is running a Kubernetes version below 1.34.0.", func() {
+			It("the node-local-dns setting cannot be changed if the shoot has at least one worker pool with an update strategy of either AutoInPlaceUpdate or ManualInPlaceUpdate, and is running a Kubernetes version below 1.34.0 or if kube-proxy runs in IPVS mode.", func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.InPlaceNodeUpdates, true))
 				shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers[0])
 				shoot.Spec.Provider.Workers[1].Name = "worker-2"
@@ -5908,7 +5908,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(ValidateShootUpdate(newShoot, shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.systemComponents.nodeLocalDNS"),
-					"Detail": Equal("the node-local-dns setting cannot be changed if the shoot has at least one worker pool with an update strategy of either AutoInPlaceUpdate or ManualInPlaceUpdate, and is running a Kubernetes version below 1.34.0."),
+					"Detail": Equal("the node-local-dns setting cannot be changed if the shoot has at least one worker pool with an update strategy of either AutoInPlaceUpdate or ManualInPlaceUpdate, and is running a Kubernetes version below 1.34.0 or if kube-proxy runs in IPVS mode."),
 				}))))
 
 				shoot.Spec.SystemComponents = &core.SystemComponents{
@@ -5923,7 +5923,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(ValidateShootUpdate(newShoot, shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.systemComponents.nodeLocalDNS"),
-					"Detail": Equal("the node-local-dns setting cannot be changed if the shoot has at least one worker pool with an update strategy of either AutoInPlaceUpdate or ManualInPlaceUpdate, and is running a Kubernetes version below 1.34.0."),
+					"Detail": Equal("the node-local-dns setting cannot be changed if the shoot has at least one worker pool with an update strategy of either AutoInPlaceUpdate or ManualInPlaceUpdate, and is running a Kubernetes version below 1.34.0 or if kube-proxy runs in IPVS mode."),
 				}))))
 			})
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5954,9 +5954,17 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}
 				shoot.Spec.Kubernetes.KubeAPIServer = nil
 				shoot.Spec.Kubernetes.Version = "1.34.0"
+				shoot.Spec.CloudProfileName = nil
+				cloudProfileRef := &core.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "my-profile",
+				}
+				shoot.Spec.CloudProfile = cloudProfileRef
 
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.SystemComponents.NodeLocalDNS.Enabled = true
+				newShoot.Spec.CloudProfileName = nil
+				newShoot.Spec.CloudProfile = cloudProfileRef
 
 				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
 			})

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -1084,10 +1084,8 @@ func KeyV2(
 		}
 	}
 
-	if kubernetesVersion.LessThan(semver.MustParse("1.34")) {
-		if nodeLocalDNSEnabled {
-			data = append(data, "node-local-dns")
-		}
+	if version.ConstraintK8sLess134.Check(kubernetesVersion) && nodeLocalDNSEnabled {
+		data = append(data, "node-local-dns")
 	}
 
 	data = append(data, gardenerutils.CalculateDataStringForKubeletConfiguration(kubeletConfiguration)...)

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -1093,7 +1093,7 @@ func KeyV2(
 	}
 
 	if version.ConstraintK8sLess134.Check(kubernetesVersion) && nodeLocalDNSEnabled ||
-		kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled && kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS && nodeLocalDNSEnabled {
+		v1beta1helper.IsKubeProxyIPVSMode(kubeProxyConfig) && nodeLocalDNSEnabled {
 		data = append(data, "node-local-dns")
 	}
 

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -1084,8 +1084,10 @@ func KeyV2(
 		}
 	}
 
-	if nodeLocalDNSEnabled {
-		data = append(data, "node-local-dns")
+	if kubernetesVersion.LessThan(semver.MustParse("1.34")) {
+		if nodeLocalDNSEnabled {
+			data = append(data, "node-local-dns")
+		}
 	}
 
 	data = append(data, gardenerutils.CalculateDataStringForKubeletConfiguration(kubeletConfiguration)...)

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -1092,8 +1092,8 @@ func KeyV2(
 		}
 	}
 
-	if version.ConstraintK8sLess134.Check(kubernetesVersion) && nodeLocalDNSEnabled ||
-		v1beta1helper.IsKubeProxyIPVSMode(kubeProxyConfig) && nodeLocalDNSEnabled {
+	if (version.ConstraintK8sLess134.Check(kubernetesVersion) && nodeLocalDNSEnabled) ||
+		(v1beta1helper.IsKubeProxyIPVSMode(kubeProxyConfig) && nodeLocalDNSEnabled) {
 		data = append(data, "node-local-dns")
 	}
 

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -150,6 +150,8 @@ type OriginalValues struct {
 	NodeLocalDNSEnabled bool
 	// PrimaryIPFamily represents the preferred IP family (IPv4 or IPv6) to be used.
 	PrimaryIPFamily gardencorev1beta1.IPFamily
+	// KubeProxyConfig is the configuration for kube-proxy.
+	KubeProxyConfig *gardencorev1beta1.KubeProxyConfig
 }
 
 // New creates a new instance of Interface.
@@ -990,8 +992,12 @@ func (o *operatingSystemConfig) calculateKeyForVersion(version int, worker *gard
 		return "", err
 	}
 	kubeletConfiguration := v1beta1helper.CalculateEffectiveKubeletConfiguration(o.values.KubeletConfig, worker.Kubernetes)
+	kubeProxyConfig := &gardencorev1beta1.KubeProxyConfig{}
+	if o.values.KubeProxyConfig != nil {
+		kubeProxyConfig = o.values.KubeProxyConfig
+	}
 
-	return CalculateKeyForVersion(version, kubernetesVersion, o.values, worker, kubeletConfiguration)
+	return CalculateKeyForVersion(version, kubernetesVersion, o.values, worker, kubeletConfiguration, kubeProxyConfig)
 }
 
 // CalculateKeyForVersion is exposed for testing purposes only
@@ -1003,6 +1009,7 @@ func calculateKeyForVersion(
 	values *Values,
 	worker *gardencorev1beta1.Worker,
 	kubeletConfiguration *gardencorev1beta1.KubeletConfig,
+	kubeProxyConfig *gardencorev1beta1.KubeProxyConfig,
 ) (
 	string,
 	error,
@@ -1012,7 +1019,7 @@ func calculateKeyForVersion(
 		// TODO(MichaelEischer): Remove KeyV1 after support for Kubernetes 1.30 is dropped
 		return KeyV1(worker.Name, kubernetesVersion, worker.CRI), nil
 	case 2:
-		return KeyV2(kubernetesVersion, values.CredentialsRotationStatus, worker, values.NodeLocalDNSEnabled, kubeletConfiguration), nil
+		return KeyV2(kubernetesVersion, values.CredentialsRotationStatus, worker, values.NodeLocalDNSEnabled, kubeletConfiguration, kubeProxyConfig), nil
 	default:
 		return "", fmt.Errorf("unsupported osc key hash version %v", version)
 	}
@@ -1046,6 +1053,7 @@ func KeyV2(
 	worker *gardencorev1beta1.Worker,
 	nodeLocalDNSEnabled bool,
 	kubeletConfiguration *gardencorev1beta1.KubeletConfig,
+	kubeProxyConfig *gardencorev1beta1.KubeProxyConfig,
 ) string {
 	if kubernetesVersion == nil {
 		return ""
@@ -1084,7 +1092,8 @@ func KeyV2(
 		}
 	}
 
-	if version.ConstraintK8sLess134.Check(kubernetesVersion) && nodeLocalDNSEnabled {
+	if version.ConstraintK8sLess134.Check(kubernetesVersion) && nodeLocalDNSEnabled ||
+		kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled && kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS && nodeLocalDNSEnabled {
 		data = append(data, "node-local-dns")
 	}
 

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -185,7 +185,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					caBundle = fmt.Sprintf("%s\n%s", caBundle, *worker.CABundle)
 				}
 
-				key := KeyV2(k8sVersion, values.CredentialsRotationStatus, &worker, values.NodeLocalDNSEnabled, kubeletConfig)
+				key := KeyV2(k8sVersion, values.CredentialsRotationStatus, &worker, values.NodeLocalDNSEnabled, kubeletConfig, nil)
 				if inPlaceUpdate {
 					key = fmt.Sprintf("gardener-node-agent-%s", worker.Name)
 				}
@@ -875,7 +875,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					if worker.Kubernetes != nil && worker.Kubernetes.Version != nil {
 						k8sVersion = semver.MustParse(*worker.Kubernetes.Version)
 					}
-					key := KeyV2(k8sVersion, values.CredentialsRotationStatus, &worker, values.NodeLocalDNSEnabled, kubeletConfig)
+					key := KeyV2(k8sVersion, values.CredentialsRotationStatus, &worker, values.NodeLocalDNSEnabled, kubeletConfig, nil)
 
 					extensions = append(extensions,
 						gardencorev1beta1.ExtensionResourceState{

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -1787,6 +1787,15 @@ var _ = Describe("OperatingSystemConfig", func() {
 					EphemeralStorage: ptr.To(resource.MustParse("100Gi")),
 				}
 			})
+
+			It("when node-local-dns enabled and changing kubernetesVersion >= 1.34 from below", func() {
+				values.NodeLocalDNSEnabled = true
+				var err error
+				kubernetesVersion = semver.MustParse("1.33")
+				hash, err = CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				Expect(err).ToNot(HaveOccurred())
+				kubernetesVersion = semver.MustParse("1.34")
+			})
 		})
 	})
 })

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -1788,13 +1788,27 @@ var _ = Describe("OperatingSystemConfig", func() {
 				}
 			})
 
-			It("when node-local-dns enabled and changing kubernetesVersion >= 1.34 from below", func() {
-				values.NodeLocalDNSEnabled = true
+			It("when node-local-dns gets enabled and kubernetes version is equal or larger than 1.34", func() {
+				values.NodeLocalDNSEnabled = false
 				var err error
-				kubernetesVersion = semver.MustParse("1.33")
-				hash, err = CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
-				Expect(err).ToNot(HaveOccurred())
 				kubernetesVersion = semver.MustParse("1.34")
+				hash1, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				Expect(err).ToNot(HaveOccurred())
+				values.NodeLocalDNSEnabled = true
+				hash2, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hash1).To(Equal(hash2))
+			})
+			It("when node-local-dns gets enabled and kubernetes version is lower than 1.34", func() {
+				values.NodeLocalDNSEnabled = false
+				var err error
+				kubernetesVersion = semver.MustParse("1.31")
+				hash1, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				Expect(err).ToNot(HaveOccurred())
+				values.NodeLocalDNSEnabled = true
+				hash2, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hash1).ToNot(Equal(hash2))
 			})
 		})
 	})

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -523,6 +523,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				_ *Values,
 				worker *gardencorev1beta1.Worker,
 				_ *gardencorev1beta1.KubeletConfig,
+				_ *gardencorev1beta1.KubeProxyConfig,
 			) (
 				string,
 				error,
@@ -605,6 +606,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				_ *Values,
 				worker *gardencorev1beta1.Worker,
 				_ *gardencorev1beta1.KubeletConfig,
+				_ *gardencorev1beta1.KubeProxyConfig,
 			) (string, error) {
 				switch oscVersion {
 				case 1:
@@ -1436,14 +1438,14 @@ var _ = Describe("OperatingSystemConfig", func() {
 							Version: ptr.To("12.34"),
 						},
 					},
-				}, nil)
+				}, nil, nil)
 			Expect(err).To(Succeed())
 			Expect(key).To(Equal("gardener-node-agent-" + workerName + "-77ac3"))
 		})
 
 		It("should return an error for unknown versions", func() {
 			for _, version := range []int{0, 3} {
-				_, err := CalculateKeyForVersion(version, semver.MustParse(kubernetesVersion), nil, nil, nil)
+				_, err := CalculateKeyForVersion(version, semver.MustParse(kubernetesVersion), nil, nil, nil, nil)
 				Expect(err).NotTo(Succeed())
 			}
 		})
@@ -1506,14 +1508,23 @@ var _ = Describe("OperatingSystemConfig", func() {
 				CPUManagerPolicy: nil,
 			}
 
+			kubeProxyConfig := &gardencorev1beta1.KubeProxyConfig{
+				Mode:    ptr.To(gardencorev1beta1.ProxyModeIPTables),
+				Enabled: ptr.To(false),
+			}
+
 			var err error
-			hash, err = CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+			hash, err = CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, kubeProxyConfig)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("hash value should not change", func() {
 			AfterEach(func() {
-				actual, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				kubeProxyConfig := &gardencorev1beta1.KubeProxyConfig{
+					Mode:    ptr.To(gardencorev1beta1.ProxyModeIPTables),
+					Enabled: ptr.To(false),
+				}
+				actual, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, kubeProxyConfig)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(actual).To(Equal(hash))
 			})
@@ -1652,7 +1663,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 		Context("hash value should change", func() {
 			AfterEach(func() {
-				actual, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				actual, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(actual).NotTo(Equal(hash))
 			})
@@ -1699,7 +1710,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				var err error
 				credentialStatusWithInitiatedRotation := values.CredentialsRotationStatus.CertificateAuthorities.DeepCopy()
 				values.CredentialsRotationStatus.CertificateAuthorities = nil
-				hash, err = CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				hash, err = CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				values.CredentialsRotationStatus.CertificateAuthorities = credentialStatusWithInitiatedRotation
@@ -1714,7 +1725,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				var err error
 				credentialStatusWithInitiatedRotation := values.CredentialsRotationStatus.ServiceAccountKey.DeepCopy()
 				values.CredentialsRotationStatus.ServiceAccountKey = nil
-				hash, err = CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				hash, err = CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				values.CredentialsRotationStatus.ServiceAccountKey = credentialStatusWithInitiatedRotation
@@ -1792,21 +1803,36 @@ var _ = Describe("OperatingSystemConfig", func() {
 				values.NodeLocalDNSEnabled = false
 				var err error
 				kubernetesVersion = semver.MustParse("1.34")
-				hash1, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				hash1, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, nil)
 				Expect(err).ToNot(HaveOccurred())
 				values.NodeLocalDNSEnabled = true
-				hash2, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				hash2, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hash1).To(Equal(hash2))
+			})
+			It("when node-local-dns gets disabled and kube-proxy runs in ipvs mode", func() {
+				values.NodeLocalDNSEnabled = true
+				var err error
+				kubernetesVersion = semver.MustParse("1.34")
+				kubeProxyConfig := &gardencorev1beta1.KubeProxyConfig{
+					Mode:    ptr.To(gardencorev1beta1.ProxyModeIPVS),
+					Enabled: ptr.To(true),
+				}
+				hash1, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, kubeProxyConfig)
+				Expect(err).ToNot(HaveOccurred())
+				values.NodeLocalDNSEnabled = false
+				hash2, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, kubeProxyConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hash1).ToNot(Equal(hash2))
 			})
 			It("when node-local-dns gets enabled and kubernetes version is lower than 1.34", func() {
 				values.NodeLocalDNSEnabled = false
 				var err error
 				kubernetesVersion = semver.MustParse("1.31")
-				hash1, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				hash1, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, nil)
 				Expect(err).ToNot(HaveOccurred())
 				values.NodeLocalDNSEnabled = true
-				hash2, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig)
+				hash2, err := CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hash1).ToNot(Equal(hash2))
 			})

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -1810,6 +1810,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hash1).To(Equal(hash2))
 			})
+
 			It("when node-local-dns gets disabled and kube-proxy runs in ipvs mode", func() {
 				values.NodeLocalDNSEnabled = true
 				var err error
@@ -1825,6 +1826,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hash1).ToNot(Equal(hash2))
 			})
+
 			It("when node-local-dns gets enabled and kubernetes version is lower than 1.34", func() {
 				values.NodeLocalDNSEnabled = false
 				var err error

--- a/pkg/component/networking/nodelocaldns/mock/mocks.go
+++ b/pkg/component/networking/nodelocaldns/mock/mocks.go
@@ -14,7 +14,9 @@ import (
 	reflect "reflect"
 
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	kubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
 	nodelocaldns "github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
+	logr "github.com/go-logr/logr"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -104,6 +106,30 @@ func (m *MockInterface) SetIPFamilies(arg0 []v1beta1.IPFamily) {
 func (mr *MockInterfaceMockRecorder) SetIPFamilies(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIPFamilies", reflect.TypeOf((*MockInterface)(nil).SetIPFamilies), arg0)
+}
+
+// SetLogger mocks base method.
+func (m *MockInterface) SetLogger(arg0 logr.Logger) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLogger", arg0)
+}
+
+// SetLogger indicates an expected call of SetLogger.
+func (mr *MockInterfaceMockRecorder) SetLogger(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogger", reflect.TypeOf((*MockInterface)(nil).SetLogger), arg0)
+}
+
+// SetShootClientSet mocks base method.
+func (m *MockInterface) SetShootClientSet(arg0 kubernetes.Interface) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetShootClientSet", arg0)
+}
+
+// SetShootClientSet indicates an expected call of SetShootClientSet.
+func (mr *MockInterfaceMockRecorder) SetShootClientSet(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShootClientSet", reflect.TypeOf((*MockInterface)(nil).SetShootClientSet), arg0)
 }
 
 // SetWorkerPools mocks base method.

--- a/pkg/component/networking/nodelocaldns/mock/mocks.go
+++ b/pkg/component/networking/nodelocaldns/mock/mocks.go
@@ -15,7 +15,6 @@ import (
 
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	kubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
-	nodelocaldns "github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
 	logr "github.com/go-logr/logr"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -130,18 +129,6 @@ func (m *MockInterface) SetShootClientSet(arg0 kubernetes.Interface) {
 func (mr *MockInterfaceMockRecorder) SetShootClientSet(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShootClientSet", reflect.TypeOf((*MockInterface)(nil).SetShootClientSet), arg0)
-}
-
-// SetWorkerPools mocks base method.
-func (m *MockInterface) SetWorkerPools(arg0 []nodelocaldns.WorkerPool) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetWorkerPools", arg0)
-}
-
-// SetWorkerPools indicates an expected call of SetWorkerPools.
-func (mr *MockInterfaceMockRecorder) SetWorkerPools(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkerPools", reflect.TypeOf((*MockInterface)(nil).SetWorkerPools), arg0)
 }
 
 // Wait mocks base method.

--- a/pkg/component/networking/nodelocaldns/mock/mocks.go
+++ b/pkg/component/networking/nodelocaldns/mock/mocks.go
@@ -15,7 +15,6 @@ import (
 
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	kubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
-	logr "github.com/go-logr/logr"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -105,30 +104,6 @@ func (m *MockInterface) SetIPFamilies(arg0 []v1beta1.IPFamily) {
 func (mr *MockInterfaceMockRecorder) SetIPFamilies(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIPFamilies", reflect.TypeOf((*MockInterface)(nil).SetIPFamilies), arg0)
-}
-
-// SetLogger mocks base method.
-func (m *MockInterface) SetLogger(arg0 logr.Logger) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetLogger", arg0)
-}
-
-// SetLogger indicates an expected call of SetLogger.
-func (mr *MockInterfaceMockRecorder) SetLogger(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogger", reflect.TypeOf((*MockInterface)(nil).SetLogger), arg0)
-}
-
-// SetSeedClientSet mocks base method.
-func (m *MockInterface) SetSeedClientSet(arg0 kubernetes.Interface) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSeedClientSet", arg0)
-}
-
-// SetSeedClientSet indicates an expected call of SetSeedClientSet.
-func (mr *MockInterfaceMockRecorder) SetSeedClientSet(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSeedClientSet", reflect.TypeOf((*MockInterface)(nil).SetSeedClientSet), arg0)
 }
 
 // SetShootClientSet mocks base method.

--- a/pkg/component/networking/nodelocaldns/mock/mocks.go
+++ b/pkg/component/networking/nodelocaldns/mock/mocks.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	nodelocaldns "github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -103,6 +104,18 @@ func (m *MockInterface) SetIPFamilies(arg0 []v1beta1.IPFamily) {
 func (mr *MockInterfaceMockRecorder) SetIPFamilies(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIPFamilies", reflect.TypeOf((*MockInterface)(nil).SetIPFamilies), arg0)
+}
+
+// SetWorkerPools mocks base method.
+func (m *MockInterface) SetWorkerPools(arg0 []nodelocaldns.WorkerPool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetWorkerPools", arg0)
+}
+
+// SetWorkerPools indicates an expected call of SetWorkerPools.
+func (mr *MockInterfaceMockRecorder) SetWorkerPools(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkerPools", reflect.TypeOf((*MockInterface)(nil).SetWorkerPools), arg0)
 }
 
 // Wait mocks base method.

--- a/pkg/component/networking/nodelocaldns/mock/mocks.go
+++ b/pkg/component/networking/nodelocaldns/mock/mocks.go
@@ -119,6 +119,18 @@ func (mr *MockInterfaceMockRecorder) SetLogger(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogger", reflect.TypeOf((*MockInterface)(nil).SetLogger), arg0)
 }
 
+// SetSeedClientSet mocks base method.
+func (m *MockInterface) SetSeedClientSet(arg0 kubernetes.Interface) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSeedClientSet", arg0)
+}
+
+// SetSeedClientSet indicates an expected call of SetSeedClientSet.
+func (mr *MockInterfaceMockRecorder) SetSeedClientSet(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSeedClientSet", reflect.TypeOf((*MockInterface)(nil).SetSeedClientSet), arg0)
+}
+
 // SetShootClientSet mocks base method.
 func (m *MockInterface) SetShootClientSet(arg0 kubernetes.Interface) {
 	m.ctrl.T.Helper()

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -92,8 +92,6 @@ type Interface interface {
 	SetDNSServers([]string)
 	SetIPFamilies([]gardencorev1beta1.IPFamily)
 	SetShootClientSet(kubernetes.Interface)
-	SetSeedClientSet(kubernetes.Interface)
-	SetLogger(logr.Logger)
 }
 
 // Values is a set of configuration values for the node-local-dns component.
@@ -114,8 +112,6 @@ type Values struct {
 	IPFamilies []gardencorev1beta1.IPFamily
 	// ShootClient is the client used to interact with the shoot cluster.
 	ShootClient client.Client
-	// SeedClient is the client used to interact with the seed cluster.
-	SeedClient client.Client
 	// Log is the logger used for logging.
 	Log logr.Logger
 	// Workers is the group of workers for which node-local-dns is deployed.
@@ -375,14 +371,6 @@ func (n *nodeLocalDNS) SetIPFamilies(ipfamilies []gardencorev1beta1.IPFamily) {
 
 func (n *nodeLocalDNS) SetShootClientSet(set kubernetes.Interface) {
 	n.values.ShootClient = set.Client()
-}
-
-func (n *nodeLocalDNS) SetSeedClientSet(set kubernetes.Interface) {
-	n.values.SeedClient = set.Client()
-}
-
-func (n *nodeLocalDNS) SetLogger(log logr.Logger) {
-	n.values.Log = log
 }
 
 func (n *nodeLocalDNS) getIPVSAddress() (ipvsAddress string) {

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -251,6 +251,11 @@ func (n *nodeLocalDNS) Destroy(ctx context.Context) error {
 		return err
 	}
 
+	if shoot.Spec.Kubernetes.KubeProxy != nil && shoot.Spec.Kubernetes.KubeProxy.Enabled != nil && *shoot.Spec.Kubernetes.KubeProxy.Enabled &&
+		shoot.Spec.Kubernetes.KubeProxy.Mode != nil && *shoot.Spec.Kubernetes.KubeProxy.Mode == gardencorev1beta1.ProxyModeIPVS {
+		return nil
+	}
+
 	// Wait until the managed resource is successfully deleted and check for recently joined nodes within the last three minutes (TimeoutWaitForManagedResource + 1 min buffer) that do not have the label, label them, and add to nodeList
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -234,6 +234,11 @@ var _ = Describe("NodeLocalDNS", func() {
 			Image:       image,
 			AlpineImage: alpineImage,
 			IPFamilies:  []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+			Workers: []gardencorev1beta1.Worker{
+				{
+					Name: "worker-aaaa",
+				},
+			},
 		}
 
 		managedResource = &resourcesv1alpha1.ManagedResource{

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -1254,7 +1254,7 @@ ip6.arpa:53 {
 					}
 					return nil
 				}).AnyTimes()
-			shootClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DaemonSet{})).Return(nil).AnyTimes()
+			shootClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			shootClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).Return(nil).AnyTimes()
 			shootClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			shootClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -225,9 +224,8 @@ var _ = Describe("NodeLocalDNS", func() {
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 		values = Values{
-			Image:             image,
-			KubernetesVersion: semver.MustParse("1.31.1"),
-			IPFamilies:        []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+			Image:      image,
+			IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
 		}
 
 		managedResource = &resourcesv1alpha1.ManagedResource{

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
@@ -35,6 +34,7 @@ import (
 	. "github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
@@ -269,10 +269,9 @@ var _ = Describe("NodeLocalDNS", func() {
 				},
 			},
 		}
-		encoder := &jsonserializer.Serializer{}
-		rawShoot, err := runtime.Encode(encoder, shoot)
+		shootYAML, err := kubernetesutils.Serialize(shoot, kubernetes.GardenScheme)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(rawShoot).ToNot(BeEmpty())
+		Expect(shootYAML).ToNot(BeEmpty())
 
 		cluster = &extensionsv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -280,7 +279,7 @@ var _ = Describe("NodeLocalDNS", func() {
 			},
 			Spec: extensionsv1alpha1.ClusterSpec{
 				Shoot: runtime.RawExtension{
-					Raw:    rawShoot,
+					Raw:    []byte(shootYAML),
 					Object: shoot,
 				},
 				Seed: runtime.RawExtension{

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -1239,6 +1239,7 @@ ip6.arpa:53 {
 			shootClientSet.EXPECT().Client().Return(shootClient).AnyTimes()
 			shootClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			shootClient.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			shootClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			seedClient := mockclient.NewMockClient(ctrl)
 			seedClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).
 				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -222,6 +222,7 @@ var _ = Describe("NodeLocalDNS", func() {
 	)
 
 	BeforeEach(func() {
+
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 		values = Values{
 			Image:      image,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/networking/nodelocaldns/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -138,7 +137,7 @@ ip6.arpa:53 {
 	return serviceAccount, configMap, service, nil
 }
 
-func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAccount, configMap *corev1.ConfigMap, service *corev1.Service, shoot *gardencorev1beta1.Shoot) (clientObjects []client.Object) {
+func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAccount, configMap *corev1.ConfigMap, service *corev1.Service) (clientObjects []client.Object) {
 	var (
 		maxUnavailable       = intstr.FromString("10%")
 		hostPathFileOrCreate = corev1.HostPathFileOrCreate
@@ -147,7 +146,7 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 	)
 
 	clientObjects = []client.Object{serviceAccount, configMap, service}
-	for _, worker := range shoot.Spec.Provider.Workers {
+	for _, worker := range n.values.Workers {
 		daemonSet = &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "node-local-dns-" + worker.Name,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nodelocaldns
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/networking/nodelocaldns/constants"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+func (n *nodeLocalDNS) computeResourcesData() (*corev1.ServiceAccount, *corev1.ConfigMap, *corev1.Service, error) {
+	if n.getHealthAddress() == "" {
+		return nil, nil, nil, errors.New("empty IPVSAddress")
+	}
+
+	var (
+		serviceAccount = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node-local-dns",
+				Namespace: metav1.NamespaceSystem,
+			},
+			AutomountServiceAccountToken: ptr.To(false),
+		}
+
+		configMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node-local-dns",
+				Namespace: metav1.NamespaceSystem,
+				Labels: map[string]string{
+					labelKey: nodelocaldnsconstants.LabelValue,
+				},
+			},
+			Data: map[string]string{
+				configDataKey: domain + `:53 {
+    errors
+    cache {
+            success 9984 30
+            denial 9984 5
+    }
+    reload
+    loop
+    bind ` + n.bindIP() + `
+    forward . ` + strings.Join(n.values.ClusterDNS, " ") + ` {
+            ` + n.forceTcpToClusterDNS() + `
+    }
+    prometheus :` + strconv.Itoa(prometheusPort) + `
+    health ` + n.getHealthAddress() + `:` + strconv.Itoa(livenessProbePort) + `
+    }
+in-addr.arpa:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind ` + n.bindIP() + `
+    forward . ` + strings.Join(n.values.ClusterDNS, " ") + ` {
+            ` + n.forceTcpToClusterDNS() + `
+    }
+    prometheus :` + strconv.Itoa(prometheusPort) + `
+    }
+ip6.arpa:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind ` + n.bindIP() + `
+    forward . ` + strings.Join(n.values.ClusterDNS, " ") + ` {
+            ` + n.forceTcpToClusterDNS() + `
+    }
+    prometheus :` + strconv.Itoa(prometheusPort) + `
+    }
+.:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind ` + n.bindIP() + `
+    forward . ` + n.upstreamDNSAddress() + ` {
+            ` + n.forceTcpToUpstreamDNS() + `
+    }
+    prometheus :` + strconv.Itoa(prometheusPort) + `
+    }
+`,
+			},
+		}
+	)
+
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+
+	var (
+		service = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: metav1.NamespaceSystem,
+				Labels: map[string]string{
+					"k8s-app": "kube-dns-upstream",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{"k8s-app": "kube-dns"},
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "dns",
+						Port:       int32(portServiceServer),
+						TargetPort: intstr.FromInt32(portServer),
+						Protocol:   corev1.ProtocolUDP,
+					},
+					{
+						Name:       "dns-tcp",
+						Port:       int32(portServiceServer),
+						TargetPort: intstr.FromInt32(portServer),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+	)
+
+	return serviceAccount, configMap, service, nil
+}
+
+func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAccount, configMap *corev1.ConfigMap, service *corev1.Service, shoot *gardencorev1beta1.Shoot) (clientObjects []client.Object) {
+	var (
+		maxUnavailable       = intstr.FromString("10%")
+		hostPathFileOrCreate = corev1.HostPathFileOrCreate
+		vpa                  *vpaautoscalingv1.VerticalPodAutoscaler
+		daemonSet            *appsv1.DaemonSet
+	)
+
+	clientObjects = []client.Object{serviceAccount, configMap, service}
+	for _, worker := range shoot.Spec.Provider.Workers {
+		daemonSet = &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node-local-dns-" + worker.Name,
+				Namespace: metav1.NamespaceSystem,
+				Labels: map[string]string{
+					labelKey:                                    nodelocaldnsconstants.LabelValue,
+					v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleSystemComponent,
+					managedresources.LabelKeyOrigin:             managedresources.LabelValueGardener,
+					v1beta1constants.LabelNodeCriticalComponent: "true",
+				},
+			},
+			Spec: appsv1.DaemonSetSpec{
+				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+						MaxUnavailable: &maxUnavailable,
+					},
+				},
+				RevisionHistoryLimit: ptr.To[int32](2),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						labelKey: nodelocaldnsconstants.LabelValue,
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							labelKey:                                    nodelocaldnsconstants.LabelValue,
+							v1beta1constants.LabelNetworkPolicyToDNS:    "allowed",
+							v1beta1constants.LabelNodeCriticalComponent: "true",
+						},
+						Annotations: map[string]string{
+							"prometheus.io/port":   strconv.Itoa(prometheusPort),
+							"prometheus.io/scrape": strconv.FormatBool(prometheusScrape),
+						},
+					},
+					Spec: corev1.PodSpec{
+						PriorityClassName:  "system-node-critical",
+						ServiceAccountName: serviceAccount.Name,
+						HostNetwork:        true,
+						DNSPolicy:          corev1.DNSDefault,
+						SecurityContext: &corev1.PodSecurityContext{
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
+						Tolerations: []corev1.Toleration{
+							{
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoExecute,
+							},
+							{
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoSchedule,
+							},
+						},
+						NodeSelector: map[string]string{
+							v1beta1constants.LabelNodeLocalDNS: "true",
+							v1beta1constants.LabelWorkerPool:   worker.Name,
+						},
+						Containers: []corev1.Container{
+							{
+								Name:  containerName,
+								Image: n.values.Image,
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("25m"),
+										corev1.ResourceMemory: resource.MustParse("25Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceMemory: resource.MustParse("200Mi"),
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptr.To(false),
+									Capabilities: &corev1.Capabilities{
+										Add: []corev1.Capability{"NET_ADMIN"},
+									},
+								},
+								Args: []string{
+									"-localip",
+									n.containerArg(),
+									"-conf",
+									"/etc/Corefile",
+									"-upstreamsvc",
+									serviceName,
+									"-health-port",
+									strconv.Itoa(livenessProbePort),
+								},
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: int32(53),
+										Name:          "dns",
+										Protocol:      corev1.ProtocolUDP,
+									},
+									{
+										ContainerPort: int32(53),
+										Name:          "dns-tcp",
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										ContainerPort: int32(prometheusPort),
+										Name:          metricsPortName,
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										ContainerPort: int32(prometheusErrorPort),
+										Name:          errorMetricsPortName,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+								LivenessProbe: &corev1.Probe{
+									ProbeHandler: corev1.ProbeHandler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Host: n.getIPVSAddress(),
+											Path: "/health",
+											Port: intstr.FromInt32(livenessProbePort),
+										},
+									},
+									InitialDelaySeconds: int32(60),
+									TimeoutSeconds:      int32(5),
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										MountPath: "/run/xtables.lock",
+										Name:      "xtables-lock",
+										ReadOnly:  false,
+									},
+									{
+										MountPath: "/etc/coredns",
+										Name:      "config-volume",
+									},
+									{
+										MountPath: "/etc/kube-dns",
+										Name:      "kube-dns-config",
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "xtables-lock",
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										Path: "/run/xtables.lock",
+										Type: &hostPathFileOrCreate,
+									},
+								},
+							},
+							{
+								Name: "kube-dns-config",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "kube-dns",
+										},
+										Optional: ptr.To(true),
+									},
+								},
+							},
+							{
+								Name: "config-volume",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: configMap.Name,
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  configDataKey,
+												Path: "Corefile.base",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		utilruntime.Must(references.InjectAnnotations(daemonSet))
+		clientObjects = append(clientObjects, daemonSet)
+
+		if n.values.VPAEnabled {
+			vpaUpdateMode := vpaautoscalingv1.UpdateModeAuto
+			vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node-local-dns-" + worker.Name,
+					Namespace: metav1.NamespaceSystem,
+				},
+				Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+						Kind:       "DaemonSet",
+						Name:       daemonSet.Name,
+					},
+					UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+						UpdateMode: &vpaUpdateMode,
+					},
+					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+							ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+						}},
+					},
+				},
+			}
+			clientObjects = append(clientObjects, vpa)
+		}
+	}
+	return clientObjects
+}

--- a/pkg/component/networking/nodelocaldns/resources/cleanup.sh
+++ b/pkg/component/networking/nodelocaldns/resources/cleanup.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Check if the nodelocaldns interface exists
+if ip link show nodelocaldns > /dev/null 2>&1; then
+    ip link delete nodelocaldns
+    # Check if the operation was successful
+    if [ $? -eq 0 ]; then
+        echo "Nodelocaldns interface deleted successfully."
+    else
+        echo "An error occurred while deleting nodelocaldns interface."
+        exit 1
+    fi
+else
+    echo "Nodelocaldns interface does not exist. Skipping deletion."
+fi
+
+# Define the comment to search for
+COMMENT="NodeLocal DNS Cache:"
+
+# Delete all iptables rules with the specified comment
+rules=$(iptables-legacy-save | grep -- "--comment \"$COMMENT\"")
+if [ -n "$rules" ]; then
+    echo "$rules" | while read -r line; do
+        rule=$(echo "$line" | sed -e 's/^-A/-D/')
+        if ! iptables $rule; then
+            echo "Failed to delete iptables rule: $rule" >&2
+            exit 1
+        fi
+    done
+    echo "All iptables rules with the comment \"$COMMENT\" have been deleted successfully."
+else
+    echo "No iptables rules with the comment \"$COMMENT\" found for nodelocaldns. Skipping deletion."
+fi
+touch /tmp/healthy
+sleep infinity

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -125,6 +125,7 @@ func (b *Botanist) isNodeLocalDNSStillDesired(ctx context.Context) (bool, error)
 func hasKubernetesVersionsBelowAndAbove134(controlPlaneVersion *semver.Version, workers []gardencorev1beta1.Worker) (bool, error) {
 	hasLower134 := false
 	hasGreaterOrEqual134 := false
+	controlPlaneIsLower134 := versionutils.ConstraintK8sLess134.Check(controlPlaneVersion)
 	for _, worker := range workers {
 		if worker.Kubernetes != nil && worker.Kubernetes.Version != nil {
 			kubernetesVersion, err := semver.NewVersion(*worker.Kubernetes.Version)
@@ -138,7 +139,7 @@ func hasKubernetesVersionsBelowAndAbove134(controlPlaneVersion *semver.Version, 
 				hasGreaterOrEqual134 = true
 			}
 		} else {
-			if versionutils.ConstraintK8sLess134.Check(controlPlaneVersion) {
+			if controlPlaneIsLower134 {
 				hasLower134 = true
 			} else {
 				hasGreaterOrEqual134 = true

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -88,7 +88,6 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 		if parsedVersion.LessThan(semver.MustParse("1.34.0")) {
 			stillRequired = true
 		}
-
 	}
 	if stillDesired, err := b.isNodeLocalDNSStillDesired(ctx); err != nil {
 		return err
@@ -155,7 +154,8 @@ func (b *Botanist) computeWorkerPoolsForNodeLocalDNS(ctx context.Context) ([]nod
 	return workerPools, nil
 }
 
-func (b *Botanist) SetShootClient(ctx context.Context) (kubernetes.Interface, error) {
+// SetShootClient sets the Shoot client for the Botanist.
+func (b *Botanist) SetShootClient() (kubernetes.Interface, error) {
 	if b.ShootClientSet == nil {
 		return nil, fmt.Errorf("ShootClientSet is nil")
 	}

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -9,17 +9,16 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	nodelocaldns "github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
+	"github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // DefaultNodeLocalDNS returns a deployer for the node-local-dns.
@@ -29,13 +28,19 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 		return nil, err
 	}
 
+	imageAlpine, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameAlpineIptables, imagevectorutils.RuntimeVersion(b.ShootVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
+	if err != nil {
+		return nil, err
+	}
+
 	return nodelocaldns.New(
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		nodelocaldns.Values{
-			Image:      image.String(),
-			VPAEnabled: b.Shoot.WantsVerticalPodAutoscaler,
-			Config:     v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
+			Image:       image.String(),
+			AlpineImage: imageAlpine.String(),
+			VPAEnabled:  b.Shoot.WantsVerticalPodAutoscaler,
+			Config:      v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
 		},
 	), nil
 }
@@ -55,43 +60,34 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 	} else {
 		dnsServers = coreDNS
 	}
-	workerPools, err := b.computeWorkerPoolsForNodeLocalDNS(ctx)
-	if err != nil {
-		return err
-	}
 
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetClusterDNS(clusterDNS)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetDNSServers(dnsServers)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetIPFamilies(b.Shoot.GetInfo().Spec.Networking.IPFamilies)
-	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetWorkerPools(workerPools)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetShootClientSet(b.ShootClientSet)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetLogger(b.Logger)
 	if b.Shoot.NodeLocalDNSEnabled {
 		return b.Shoot.Components.SystemComponents.NodeLocalDNS.Deploy(ctx)
 	}
 
-	stillRequired := false
-	var parsedVersion *semver.Version
-	for _, workerPool := range workerPools {
-		if workerPool.KubernetesVersion != nil {
-			parsedVersion, err = semver.NewVersion(workerPool.KubernetesVersion.String())
-			if err != nil {
-				return fmt.Errorf("failed to parse Kubernetes version %q: %w", workerPool.KubernetesVersion.String(), err)
-			}
-		} else {
-			parsedVersion, err = semver.NewVersion(b.Shoot.KubernetesVersion.String())
-			if err != nil {
-				return fmt.Errorf("failed to parse Kubernetes version %q: %w", b.Shoot.KubernetesVersion.String(), err)
-			}
+	atLeastOnePoolLowerKubernetes134 := false
+	// Check if at least one worker pool has a Kubernetes version lower than 1.34.
+	// If so, we cannot remove NodeLocalDNS components yet, as they are still required
+	// for nodes running that version.
+	for _, worker := range b.Shoot.GetInfo().Spec.Provider.Workers {
+		kubernetesVersion, err := v1beta1helper.CalculateEffectiveKubernetesVersion(b.Shoot.KubernetesVersion, worker.Kubernetes)
+		if err != nil {
+			return fmt.Errorf("failed to calculate effective Kubernetes version for worker %q: %w", worker.Name, err)
 		}
 
-		if parsedVersion.LessThan(semver.MustParse("1.34.0")) {
-			stillRequired = true
+		if versionutils.ConstraintK8sLess134.Check(kubernetesVersion) {
+			atLeastOnePoolLowerKubernetes134 = true
 		}
 	}
+
 	if stillDesired, err := b.isNodeLocalDNSStillDesired(ctx); err != nil {
 		return err
-	} else if stillDesired && stillRequired {
+	} else if stillDesired && atLeastOnePoolLowerKubernetes134 {
 		// Leave NodeLocalDNS components in the cluster until all nodes have been rolled
 		return nil
 	}
@@ -105,59 +101,4 @@ func (b *Botanist) isNodeLocalDNSStillDesired(ctx context.Context) (bool, error)
 	return kubernetesutils.ResourcesExist(ctx, b.ShootClientSet.Client(), &corev1.NodeList{}, b.ShootClientSet.Client().Scheme(), client.MatchingLabels{
 		v1beta1constants.LabelNodeLocalDNS: strconv.FormatBool(true),
 	})
-}
-
-func (b *Botanist) computeWorkerPoolsForNodeLocalDNS(ctx context.Context) ([]nodelocaldns.WorkerPool, error) {
-	poolKeyToPoolInfo := make(map[string]nodelocaldns.WorkerPool)
-
-	for _, worker := range b.Shoot.GetInfo().Spec.Provider.Workers {
-		kubernetesVersion, err := v1beta1helper.CalculateEffectiveKubernetesVersion(b.Shoot.KubernetesVersion, worker.Kubernetes)
-		if err != nil {
-			return nil, err
-		}
-
-		key := workerPoolKey(worker.Name, kubernetesVersion.String())
-		poolKeyToPoolInfo[key] = nodelocaldns.WorkerPool{
-			Name:              worker.Name,
-			KubernetesVersion: kubernetesVersion,
-		}
-	}
-
-	nodeList := &corev1.NodeList{}
-	if err := b.ShootClientSet.Client().List(ctx, nodeList); err != nil {
-		return nil, err
-	}
-
-	for _, node := range nodeList.Items {
-		poolName, ok1 := node.Labels[v1beta1constants.LabelWorkerPool]
-		kubernetesVersionString, ok2 := node.Labels[v1beta1constants.LabelWorkerKubernetesVersion]
-		if !ok1 || !ok2 {
-			continue
-		}
-		kubernetesVersion, err := semver.NewVersion(kubernetesVersionString)
-		if err != nil {
-			return nil, err
-		}
-
-		key := workerPoolKey(poolName, kubernetesVersionString)
-		poolKeyToPoolInfo[key] = nodelocaldns.WorkerPool{
-			Name:              poolName,
-			KubernetesVersion: kubernetesVersion,
-		}
-	}
-
-	var workerPools []nodelocaldns.WorkerPool
-	for _, poolInfo := range poolKeyToPoolInfo {
-		workerPools = append(workerPools, poolInfo)
-	}
-
-	return workerPools, nil
-}
-
-// SetShootClient sets the Shoot client for the Botanist.
-func (b *Botanist) SetShootClient() (kubernetes.Interface, error) {
-	if b.ShootClientSet == nil {
-		return nil, fmt.Errorf("ShootClientSet is nil")
-	}
-	return b.ShootClientSet, nil
 }

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -45,6 +45,7 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 			Config:          v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
 			Workers:         b.Shoot.GetInfo().Spec.Provider.Workers,
 			KubeProxyConfig: b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
+			Log:             b.Logger,
 		},
 	), nil
 }
@@ -69,8 +70,6 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetDNSServers(dnsServers)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetIPFamilies(b.Shoot.GetInfo().Spec.Networking.IPFamilies)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetShootClientSet(b.ShootClientSet)
-	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetSeedClientSet(b.SeedClientSet)
-	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetLogger(b.Logger)
 	if b.Shoot.NodeLocalDNSEnabled {
 		return b.Shoot.Components.SystemComponents.NodeLocalDNS.Deploy(ctx)
 	}

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -65,6 +65,7 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetDNSServers(dnsServers)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetIPFamilies(b.Shoot.GetInfo().Spec.Networking.IPFamilies)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetShootClientSet(b.ShootClientSet)
+	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetSeedClientSet(b.SeedClientSet)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetLogger(b.Logger)
 	if b.Shoot.NodeLocalDNSEnabled {
 		return b.Shoot.Components.SystemComponents.NodeLocalDNS.Deploy(ctx)
@@ -82,6 +83,7 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 
 		if versionutils.ConstraintK8sLess134.Check(kubernetesVersion) {
 			atLeastOnePoolLowerKubernetes134 = true
+			break
 		}
 	}
 
@@ -92,7 +94,6 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 		return nil
 	}
 
-	b.Logger.Info("NodeLocalDNS is disabled, removing NodeLocalDNS components")
 	return b.Shoot.Components.SystemComponents.NodeLocalDNS.Destroy(ctx)
 }
 

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -37,10 +37,12 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		nodelocaldns.Values{
-			Image:       image.String(),
-			AlpineImage: imageAlpine.String(),
-			VPAEnabled:  b.Shoot.WantsVerticalPodAutoscaler,
-			Config:      v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
+			Image:           image.String(),
+			AlpineImage:     imageAlpine.String(),
+			VPAEnabled:      b.Shoot.WantsVerticalPodAutoscaler,
+			Config:          v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
+			Workers:         b.Shoot.GetInfo().Spec.Provider.Workers,
+			KubeProxyConfig: b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
 		},
 	), nil
 }

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
@@ -86,10 +87,11 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 			break
 		}
 	}
-
+	kubeProxyConfig := b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy
 	if stillDesired, err := b.isNodeLocalDNSStillDesired(ctx); err != nil {
 		return err
-	} else if stillDesired && atLeastOnePoolLowerKubernetes134 {
+	} else if stillDesired && (atLeastOnePoolLowerKubernetes134 ||
+		kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled && kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS) {
 		// Leave NodeLocalDNS components in the cluster until all nodes have been rolled
 		return nil
 	}

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -13,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
@@ -90,8 +89,7 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 	kubeProxyConfig := b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy
 	if stillDesired, err := b.isNodeLocalDNSStillDesired(ctx); err != nil {
 		return err
-	} else if stillDesired && (atLeastOnePoolLowerKubernetes134 ||
-		kubeProxyConfig != nil && kubeProxyConfig.Enabled != nil && *kubeProxyConfig.Enabled && kubeProxyConfig.Mode != nil && *kubeProxyConfig.Mode == gardencorev1beta1.ProxyModeIPVS) {
+	} else if stillDesired && (atLeastOnePoolLowerKubernetes134 || v1beta1helper.IsKubeProxyIPVSMode(kubeProxyConfig)) {
 		// Leave NodeLocalDNS components in the cluster until all nodes have been rolled
 		return nil
 	}

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -74,10 +74,8 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 		return b.Shoot.Components.SystemComponents.NodeLocalDNS.Deploy(ctx)
 	}
 
-	atLeastOnePoolLowerKubernetes134 := false
-	var err error
-
-	if atLeastOnePoolLowerKubernetes134, err = v1beta1helper.IsOneWorkerPoolLowerKubernetes134(b.Shoot.KubernetesVersion, b.Shoot.GetInfo().Spec.Provider.Workers); err != nil {
+	atLeastOnePoolLowerKubernetes134, err := v1beta1helper.IsOneWorkerPoolLowerKubernetes134(b.Shoot.KubernetesVersion, b.Shoot.GetInfo().Spec.Provider.Workers)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/gardenlet/operation/botanist/nodelocaldns_test.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns_test.go
@@ -121,6 +121,7 @@ var _ = Describe("NodeLocalDNS", func() {
 			shootClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			shootClient.EXPECT().Scheme().Return(kubernetes.ShootScheme).AnyTimes()
 			nodelocaldns.EXPECT().SetShootClientSet(gomock.Any())
+			nodelocaldns.EXPECT().SetSeedClientSet(gomock.Any())
 			nodelocaldns.EXPECT().SetLogger(gomock.Any())
 			botanist.ShootClientSet = kubernetesClient
 			botanist.Shoot.Components = &shootpkg.Components{

--- a/pkg/gardenlet/operation/botanist/nodelocaldns_test.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns_test.go
@@ -120,7 +120,6 @@ var _ = Describe("NodeLocalDNS", func() {
 			}).AnyTimes()
 			shootClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			shootClient.EXPECT().Scheme().Return(kubernetes.ShootScheme).AnyTimes()
-			nodelocaldns.EXPECT().SetWorkerPools(gomock.Any())
 			nodelocaldns.EXPECT().SetShootClientSet(gomock.Any())
 			nodelocaldns.EXPECT().SetLogger(gomock.Any())
 			botanist.ShootClientSet = kubernetesClient
@@ -193,7 +192,6 @@ var _ = Describe("NodeLocalDNS", func() {
 					nodelocaldns.EXPECT().Destroy(ctx).Return(nil)
 
 					Expect(botanist.ReconcileNodeLocalDNS(ctx)).To(Succeed())
-
 				})
 
 				It("label disabled", func() {

--- a/pkg/gardenlet/operation/botanist/nodelocaldns_test.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns_test.go
@@ -121,8 +121,6 @@ var _ = Describe("NodeLocalDNS", func() {
 			shootClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			shootClient.EXPECT().Scheme().Return(kubernetes.ShootScheme).AnyTimes()
 			nodelocaldns.EXPECT().SetShootClientSet(gomock.Any())
-			nodelocaldns.EXPECT().SetSeedClientSet(gomock.Any())
-			nodelocaldns.EXPECT().SetLogger(gomock.Any())
 			botanist.ShootClientSet = kubernetesClient
 			botanist.Shoot.Components = &shootpkg.Components{
 				SystemComponents: &shootpkg.SystemComponents{

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -77,6 +77,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				NodeLocalDNSEnabled:    v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents),
 				NodeMonitorGracePeriod: *b.Shoot.GetInfo().Spec.Kubernetes.KubeControllerManager.NodeMonitorGracePeriod,
 				PrimaryIPFamily:        b.Shoot.GetInfo().Spec.Networking.IPFamilies[0],
+				KubeProxyConfig:        b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
 			},
 		},
 		operatingsystemconfig.DefaultInterval,

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -148,6 +148,7 @@ build:
             - pkg/component/networking/nodelocaldns/constants
             - pkg/component/networking/vpn/envoy
             - pkg/component/networking/vpn/envoy/templates/envoy.yaml.tpl
+            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/seedserver
             - pkg/component/networking/vpn/shoot
             - pkg/component/nodemanagement/dependencywatchdog

--- a/skaffold-seed.yaml
+++ b/skaffold-seed.yaml
@@ -174,6 +174,7 @@ build:
             - pkg/component/networking/nodelocaldns/constants
             - pkg/component/networking/vpn/envoy
             - pkg/component/networking/vpn/envoy/templates/envoy.yaml.tpl
+            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/seedserver
             - pkg/component/networking/vpn/shoot
             - pkg/component/nodemanagement/dependencywatchdog

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1096,6 +1096,7 @@ build:
             - pkg/component/networking/nodelocaldns/constants
             - pkg/component/networking/vpn/envoy
             - pkg/component/networking/vpn/envoy/templates/envoy.yaml.tpl
+            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/seedserver
             - pkg/component/networking/vpn/shoot
             - pkg/component/nodemanagement/dependencywatchdog


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Starting from Kubernetes version 1.34, enabling or disabling node-local-dns will no longer trigger node rolling (except kube-proxy is running in IPVS mode). Instead, a cleanup job will be executed. Additionally, node-local-dns is deployed per WorkerPool and node-local-dns is removed from OSC and wokerPoolHash calculation.
Many infrastructures struggle to handle a large number of TCP connections for DNS queries, often resulting in rate throttling leading to "connection timeout" issues during DNS resolution. To address this, UDP connections will be preferred when communicating with the upstream DNS server.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Starting from Kubernetes version 1.34, enabling or disabling node-local-dns will no longer trigger node rolling (except kube-proxy is running in IPVS mode). Instead, a cleanup job will be executed. Additionally, node-local-dns is deployed per WorkerPool and node-local-dns will use UDP as default protocol for DNS queries to the upstream DNS server.
```
```breaking operator
A separate `node-local-dns` `DaemonSet` is deployed for each worker pool such that each `DaemonSet` has the name `node-local-dns-<worker-pool-name>`.
If you are using `gardener-extension-networking-cilium` in your landscape, it is required to update it to a version which supports these new names for the `DaemonSet`s. 
Support is added with https://github.com/gardener/gardener-extension-networking-cilium/pull/622 and included in versions starting from: [`v1.42.1`](https://github.com/gardener/gardener-extension-networking-cilium/releases/tag/v1.42.1), [`v1.41.3`](https://github.com/gardener/gardener-extension-networking-cilium/releases/tag/v1.41.3) and [`v1.40.4`](https://github.com/gardener/gardener-extension-networking-cilium/releases/tag/v1.40.4)
```
