### PR TITLE
Extend the `/etc/hosts` file to contain records for missing e2e test Shoot

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -294,6 +294,8 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 api.e2e-auth-one.local.internal.local.gardener.cloud
 172.18.255.1 api.e2e-auth-two.local.external.local.gardener.cloud
 172.18.255.1 api.e2e-auth-two.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-layer4-lb.local.internal.local.gardener.cloud
+172.18.255.1 api.e2e-layer4-lb.local.external.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rotate.ingress.local.seed.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rotate-wl.ingress.local.seed.local.gardener.cloud
 172.18.255.1 gu-local--e2e-rot-noroll.ingress.local.seed.local.gardener.cloud


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
I am executing locally:
```
% make ci-e2e-kind-ha-multi-zone-upgrade
```

and it fails with:
```
Running gardener pre-upgrade tests
./hack/test-e2e-local.sh --procs=5 --label-filter="pre-upgrade" ./test/e2e/gardener/...
> E2E Tests
Hostnames for the following Shoots are missing in /etc/hosts:
 - 172.18.255.1 api.e2e-layer4-lb.local.internal.local.gardener.cloud
 - 172.18.255.1 api.e2e-layer4-lb.local.external.local.gardener.cloud
To access shoot clusters and run e2e tests, you have to extend your /etc/hosts file.
Please refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster
```

I have the same records from https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster in my `/etc/hosts` file.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/11555

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
