### PR TITLE
Add strict decoding to component checklist

### DIFF
--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -127,7 +127,7 @@ This document provides a checklist for them that you can walk through.
 
 9. **Use strict mode when decoding data** ([example](https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/provider-local/controller/worker/actuator.go#L52))
 
-   Stict mode forces [additional verifications](https://github.com/kubernetes-sigs/json/blob/cfa47c3a1cc8ff0eff148aa9ec5b0226d0909e87/json.go#L89-L91) on the decoded data such as:
+   Strict mode forces [additional verifications](https://github.com/kubernetes-sigs/json/blob/cfa47c3a1cc8ff0eff148aa9ec5b0226d0909e87/json.go#L89-L91) on the decoded data such as:
    - ensures no duplicate fields
    - ensures no unknown fields when decoding into typed structs
 

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -125,7 +125,7 @@ This document provides a checklist for them that you can walk through.
 
    <sub>[*] It is required because if a component deployed in the Shoot cluster does not specify a Seccomp profile and cannot run with the `RuntimeDefault` Seccomp profile, then enabling the `.spec.kubernetes.kubelet.seccompDefault` field in the Shoot spec would break the corresponding component.</sub>
 
-9. **Use strict mode when decoding data** [example](https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/provider-local/controller/worker/actuator.go#L52)
+9. **Use strict mode when decoding data** ([example](https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/provider-local/controller/worker/actuator.go#L52))
 
    Stict mode forces [additional verifications](https://github.com/kubernetes-sigs/json/blob/cfa47c3a1cc8ff0eff148aa9ec5b0226d0909e87/json.go#L89-L91) on the decoded data such as:
    - ensures no duplicate fields

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -125,6 +125,12 @@ This document provides a checklist for them that you can walk through.
 
    <sub>[*] It is required because if a component deployed in the Shoot cluster does not specify a Seccomp profile and cannot run with the `RuntimeDefault` Seccomp profile, then enabling the `.spec.kubernetes.kubelet.seccompDefault` field in the Shoot spec would break the corresponding component.</sub>
 
+9. **Use strict mode when decoding data** [example](https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/provider-local/controller/worker/actuator.go#L52)
+
+   Stict mode forces [additional verifications](https://github.com/kubernetes-sigs/json/blob/cfa47c3a1cc8ff0eff148aa9ec5b0226d0909e87/json.go#L89-L91) on the decoded data such as:
+   - ensures no duplicate fields
+   - ensures no unknown fields when decoding into typed structs
+
 ## High Availability / Stability
 
 1. **Specify the component type label for high availability** ([example](https://github.com/gardener/gardener/blob/b0de7db96ad436fe32c25daae5e8cb552dac351f/pkg/component/kubescheduler/kube_scheduler.go#L241))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security dev-productivity documentation
/kind enhancement

**What this PR does / why we need it**:
Strict mode ensures two additional checks on decoded data:
- no duplicate fields
- no unknown fields when decoding into typed structs

Unexpected fields can be relevant to security if such fields can alter the behaviour of a program in an unpredictable for the developer way.

Note: Maybe this rule is better suited for a "code-guidelines.md" file, but as I did not find a better place for it I put it into the component checklist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
