### PR TITLE
Improve defaulting of `maxSurge` and `maxUnavailable` fields for in-place update strategies

### DIFF
--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -10,7 +10,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -290,33 +289,36 @@ func SetDefaults_VerticalPodAutoscaler(obj *VerticalPodAutoscaler) {
 
 // SetDefaults_Worker sets default values for Worker objects.
 func SetDefaults_Worker(obj *Worker) {
-	if obj.MaxSurge == nil {
-		obj.MaxSurge = &DefaultWorkerMaxSurge
-	}
-	if obj.MaxUnavailable == nil {
-		obj.MaxUnavailable = &DefaultWorkerMaxUnavailable
-	}
-	if obj.SystemComponents == nil {
-		obj.SystemComponents = &WorkerSystemComponents{
-			Allow: DefaultWorkerSystemComponentsAllow,
-		}
-	}
 	if obj.UpdateStrategy == nil {
 		obj.UpdateStrategy = ptr.To(AutoRollingUpdate)
 	}
 
 	if *obj.UpdateStrategy == AutoInPlaceUpdate || *obj.UpdateStrategy == ManualInPlaceUpdate {
+		if obj.MaxSurge == nil {
+			obj.MaxSurge = &DefaultInPlaceWorkerMaxSurge
+		}
+		if obj.MaxUnavailable == nil {
+			obj.MaxUnavailable = &DefaultInPlaceWorkerMaxUnavailable
+		}
 		if obj.MachineControllerManagerSettings == nil {
 			obj.MachineControllerManagerSettings = &MachineControllerManagerSettings{}
 		}
 		if obj.MachineControllerManagerSettings.DisableHealthTimeout == nil {
 			obj.MachineControllerManagerSettings.DisableHealthTimeout = ptr.To(true)
 		}
+	} else {
+		if obj.MaxSurge == nil {
+			obj.MaxSurge = &DefaultWorkerMaxSurge
+		}
 
-		// In case of manual in-place update, we set the MaxSurge to 0 and MaxUnavailable to 1.
-		if *obj.UpdateStrategy == ManualInPlaceUpdate {
-			obj.MaxSurge = ptr.To(intstr.FromInt32(0))
-			obj.MaxUnavailable = ptr.To(intstr.FromInt32(1))
+		if obj.MaxUnavailable == nil {
+			obj.MaxUnavailable = &DefaultWorkerMaxUnavailable
+		}
+	}
+
+	if obj.SystemComponents == nil {
+		obj.SystemComponents = &WorkerSystemComponents{
+			Allow: DefaultWorkerSystemComponentsAllow,
 		}
 	}
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1882,8 +1882,12 @@ type SSHAccess struct {
 var (
 	// DefaultWorkerMaxSurge is the default value for Worker MaxSurge.
 	DefaultWorkerMaxSurge = intstr.FromInt32(1)
+	// DefaultInPlaceWorkerMaxSurge is the default value for In-Place Worker MaxSurge.
+	DefaultInPlaceWorkerMaxSurge = intstr.FromInt32(0)
 	// DefaultWorkerMaxUnavailable is the default value for Worker MaxUnavailable.
 	DefaultWorkerMaxUnavailable = intstr.FromInt32(0)
+	// DefaultInPlaceWorkerMaxUnavailable is the default value for In-Place Worker MaxUnavailable.
+	DefaultInPlaceWorkerMaxUnavailable = intstr.FromInt32(1)
 	// DefaultWorkerSystemComponentsAllow is the default value for Worker AllowSystemComponents
 	DefaultWorkerSystemComponentsAllow = true
 )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Currently, the defaulting is a bit wrong, with
- `maxSurge` not defaulted to 0 and `maxUnavailable` not defaulted to 1 for `AutoInPlaceUpdate` strategy
- `maxSurge` and `maxUnavailable` are always getting overwritten for `ManualInPlaceUpdate` strategy

We already have validation to prevent `maxSurge` from being set > 0 for `ManualInPlaceUpdate` strategy, https://github.com/gardener/gardener/blob/95b87f347aa49ecf4fafb03acca2d7a33b1b6ce2/pkg/apis/core/validation/shoot.go#L1808-L1811. Previously, this was never reached because of the overwriting in defaulting.

**Which issue(s) this PR fixes**:
Part of #10219 

**Special notes for your reviewer**:
/cc @ary1992 @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
For worker pools with in-place update strategies, the `maxSurge` and `maxUnavailable` fields are now correctly defaulted to `0` and `1` respectively.
```
```bugfix user
A bug causing the `maxSurge` and `maxUnavailable` fields for worker pools with update strategy `ManualInPlaceUpdate` always getting overwritten is now fixed.
```