### PR TITLE
e2e tests: Bump the Shoot Kubernetes version to 1.33.0

### DIFF
--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -38,7 +38,7 @@ func baseShoot(name string) *gardencorev1beta1.Shoot {
 				Name: "local",
 			},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:       "1.32.0",
+				Version:       "1.33.0",
 				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 			},
 			Provider: gardencorev1beta1.Provider{

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -35,8 +35,8 @@ import (
 const (
 	// Explicitly use one version below the latest supported minor version
 	// so that Kubernetes version update test can be performed.
-	kubernetesTargetVersion = "1.31.1"
-	kubernetesSourceVersion = "1.30.0"
+	kubernetesTargetVersion = "1.32.0"
+	kubernetesSourceVersion = "1.31.1"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Since https://github.com/gardener/gardener/pull/12216, Gardener supports Kubernetes v1.33. This PR updates the Shoot Kubernetes version in the e2e test to use v1.33.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11933
Follow-up after https://github.com/gardener/gardener/pull/12216

**Special notes for your reviewer**:
Same changes as:
- https://github.com/gardener/gardener/pull/10704
- https://github.com/gardener/gardener/pull/11510

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
