### PR TITLE
Fix BackupBucket reconciliation error by replacing `StrategicMergePatch` with `MergePatch`

### DIFF
--- a/pkg/component/garden/backupbucket/backupbucket.go
+++ b/pkg/component/garden/backupbucket/backupbucket.go
@@ -88,7 +88,7 @@ type backupBucket struct {
 
 // Deploy uses the garden client to create or update the BackupBucket resource in the Garden.
 func (b *backupBucket) Deploy(ctx context.Context) error {
-	_, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, b.client, b.backupBucket, func() error {
+	_, err := controllerutils.CreateOrGetAndMergePatch(ctx, b.client, b.backupBucket, func() error {
 		metav1.SetMetaDataAnnotation(&b.backupBucket.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 		metav1.SetMetaDataAnnotation(&b.backupBucket.ObjectMeta, v1beta1constants.GardenerTimestamp, b.values.Clock.Now().UTC().Format(time.RFC3339Nano))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind regression

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/12123 reverted the patch behaviour changed with https://github.com/gardener/gardener/pull/10904. This PR reinstates this behaviour.
Basically, `StrategicMergePatch` requires schema information to process fields, but `runtime.RawExtension` lacks schema due to its nature of holding arbitrary JSON data.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @seshachalam-yv @rfranzke @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an error in `BackupBucket` reconciliation by replacing `StrategicMergePatch` with `MergePatch` to properly handle `runtime.RawExtension` fields.
```
