### PR TITLE
Remove outdated field `_type` from testdata reporter

### DIFF
--- a/test/framework/reporter/esreporter.go
+++ b/test/framework/reporter/esreporter.go
@@ -211,7 +211,7 @@ func getShortName(name string) string {
 
 // getESIndexString returns a bulk index configuration string for an index.
 func getESIndexString(index string) string {
-	format := `{ "index": { "_index": "%s", "_type": "_doc" } }`
+	format := `{ "index": { "_index": "%s" } }`
 	return fmt.Sprintf(format, index)
 }
 

--- a/test/framework/reporter/esreporter_test.go
+++ b/test/framework/reporter/esreporter_test.go
@@ -57,7 +57,7 @@ var _ = Describe("processReport tests", func() {
 	})
 
 	It("should setup test suite metadata correctly", func() {
-		expectedIndex := append([]byte(fmt.Sprintf(`{ "index": { "_index": "%s", "_type": "_doc" } }`, indexName)), []byte("\n")...)
+		expectedIndex := append([]byte(fmt.Sprintf(`{ "index": { "_index": "%s" } }`, indexName)), []byte("\n")...)
 		mockReport.PreRunStats.SpecsThatWillRun = 0
 
 		reporter.processReport(mockReport)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
The [testframework](https://github.com/gardener/gardener/blob/master/test/framework/reporter/esreporter.go) consists of a reporter to generate extra data that can be ingested into elasticsearch/opensearch.
The particular field `_type` however was deprecated a long time ago and meanwhile removed with elasticsearch 8 / opensearch 2, hence such documents as generated by the testframework are rejected.

As this field must not be present upon data ingestion anymore, it needs to be removed from data generation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing reporting data generated by the testframework to be incompatible with recent elasticsearch/opensearch versions is now fixed.
```
