### PR TITLE
Allow `gardener-metrics-exporter` to access `CredentialsBindings`

### DIFF
--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -24,6 +24,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/gardenermetricsexporter"
@@ -170,6 +171,13 @@ var _ = Describe("GardenerMetricsExporter", func() {
 					APIGroups: []string{seedmanagementv1alpha1.GroupName},
 					Resources: []string{
 						"managedseeds",
+					},
+					Verbs: []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{securityv1alpha1.GroupName},
+					Resources: []string{
+						"credentialsbindings",
 					},
 					Verbs: []string{"get", "list", "watch"},
 				},

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/rbac.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/rbac.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 )
 
@@ -38,6 +39,13 @@ func (g *gardenerMetricsExporter) clusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{seedmanagementv1alpha1.GroupName},
 				Resources: []string{
 					"managedseeds",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{securityv1alpha1.GroupName},
+				Resources: []string{
+					"credentialsbindings",
 				},
 				Verbs: []string{"get", "list", "watch"},
 			},


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

- This PR adds a commit to https://github.com/gardener/gardener/pull/12441. The new version of `gardener-metrics-exporter` needs permissions to read `CredentialsBindings`

**Special notes for your reviewer**:

/cc @istvanballok @shafeeqes 

**Release note**:

```other operator
NONE
```
