### PR TITLE
[Fix] Allow Uppercase region names

### DIFF
--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -211,7 +211,7 @@ func AddIstioIngressGateway(
 // In case the zone name is too long the first five characters of the hash of the zone are used as zone identifiers.
 func GetIstioNamespaceForZone(defaultNamespace string, zone string) string {
 	const format = "%s--%s"
-	if ns := fmt.Sprintf(format, defaultNamespace, zone); len(ns) <= validation.DNS1035LabelMaxLength {
+	if ns := fmt.Sprintf(format, defaultNamespace, zone); len(ns) <= validation.DNS1035LabelMaxLength && zone == strings.ToLower(zone) {
 		return ns
 	}
 	// Use the first five characters of the hash of the zone

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -501,6 +501,7 @@ var _ = Describe("Istio", func() {
 		},
 
 		Entry("short namespace and zone", "default-namespace", "my-zone", Equal("default-namespace--my-zone")),
+		Entry("short namespace and uppercase zone", "default-namespace", "MyUpCaseZone", Equal("default-namespace--38e28")),
 		Entry("empty namespace and zone", "", "", Equal("--")),
 		Entry("empty namespace and valid zone", "", "my-zone", Equal("--my-zone")),
 		Entry("valid namespace and empty zone", "default-namespace", "", Equal("default-namespace--")),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:

On Cloud regions with uppercase characters the creation of the istio ingress will fail.

**Which issue(s) this PR fixes**:
Fixes #12232

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix istio creation on cloud regions with uppercase characters
```
