### PR TITLE
[GEP-28] `make gardenadm-up SCENARIO=connect` deploys a Gardener locally

### DIFF
--- a/dev-setup/garden.sh
+++ b/dev-setup/garden.sh
@@ -24,7 +24,7 @@ case "$COMMAND" in
     # down or not yet available.
     TIMEOUT=60 SKIP_LAST_OPERATION_CHECK=true "$(dirname "$0")"/../hack/usage/wait-for.sh extop provider-local AdmissionHealthy
     # Export kubeconfig for the virtual garden cluster
-    "$(dirname "$0")"/../hack/usage/generate-virtual-garden-admin-kubeconf.sh > "$VIRTUAL_GARDEN_KUBECONFIG"
+    "$(dirname "$0")"/../hack/usage/generate-virtual-garden-admin-kubeconf.sh "$KUBECONFIG" > "$VIRTUAL_GARDEN_KUBECONFIG"
     ;;
 
   down)

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -153,6 +153,28 @@ $ go run ./cmd/gardenadm bootstrap -d ./dev-setup/gardenadm/resources/generated/
 Command is work in progress
 ```
 
+## Connecting the Autonomous Shoot Cluster to Gardener
+
+After you have successfully bootstrapped an autonomous shoot cluster (either via the [high touch](#high-touch-scenario) or the [medium touch](#medium-touch-scenario) scenario), you can connect it to an existing Gardener system.
+For this, you need to have a Gardener running locally in your KinD cluster.
+In order to deploy it, you can run
+
+```shell
+make gardenadm-up SCENARIO=connect
+```
+
+This will deploy [`gardener-operator`](../concepts/operator.md) and create a `Garden` resource (which will then be reconciled and results in a full Gardener deployment).
+Find all information about it [here](getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
+Note, that in this setup, no `Seed` will be registered in the Gardener - it's just a plain garden cluster without the ability to create regular shoot clusters.
+
+Once above command is finished, you can connect the autonomous shoot cluster to this Gardener instance:
+
+```shell
+$ kubectl -n gardenadm-high-touch exec -it machine-0 -- bash
+root@machine-0:/# gardenadm connect
+2025-07-03T12:21:49.586Z	INFO	Command is work in progress
+```
+
 ## Running E2E Tests for `gardenadm`
 
 Based on the described setup, you can execute the e2e test suite for `gardenadm`:

--- a/hack/usage/generate-virtual-garden-admin-kubeconf.sh
+++ b/hack/usage/generate-virtual-garden-admin-kubeconf.sh
@@ -6,6 +6,9 @@
 
 set -euo pipefail
 
+# TODO(rfranzke): Remove this once we store the kind/runtime cluster kubeconfig at a fixed location.
+RUNTIME_CLUSTER_KUBECONFIG="${1:-"$(dirname "$0")/../../example/gardener-local/kind/multi-zone/kubeconfig"}"
+
 USER_NAME="admin-user"
 CLUSTER_NAME="virtual-garden"
 
@@ -18,7 +21,7 @@ CLIENT_CA_CERT_FILE="${TMP_DIR}/client-ca.crt"
 CLIENT_CA_KEY_FILE="${TMP_DIR}/client-ca.key"
 KUBECONFIG_FILE="${TMP_DIR}/kubeconfig"
 
-cp "$(dirname "$0")/../../example/gardener-local/kind/multi-zone/kubeconfig" "${KUBECONFIG_FILE}"
+cp "$RUNTIME_CLUSTER_KUBECONFIG" "${KUBECONFIG_FILE}"
 kubectl --kubeconfig "${KUBECONFIG_FILE}" -n garden get secret -l name=ca        -o jsonpath='{..data.ca\.crt}' | base64 -d > "${CLUSTER_CA_CERT_FILE}"
 kubectl --kubeconfig "${KUBECONFIG_FILE}" -n garden get secret -l name=ca-client -o jsonpath='{..data.ca\.crt}' | base64 -d > "${CLIENT_CA_CERT_FILE}"
 kubectl --kubeconfig "${KUBECONFIG_FILE}" -n garden get secret -l name=ca-client -o jsonpath='{..data.ca\.key}' | base64 -d > "${CLIENT_CA_KEY_FILE}"

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -47,6 +47,6 @@ gardenadm connect`,
 }
 
 func run(_ context.Context, opts *Options) error {
-	opts.Log.Info("Not implemented")
+	opts.Log.Info("Command is work in progress")
 	return nil
 }

--- a/pkg/gardenadm/cmd/connect/connect_test.go
+++ b/pkg/gardenadm/cmd/connect/connect_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Connect", func() {
 		It("should return the expected output", func() {
 			Expect(command.RunE(command, nil)).To(Succeed())
 
-			Eventually(stdErr).Should(Say("Not implemented"))
+			Eventually(stdErr).Should(Say("Command is work in progress"))
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
In preparation for [`gardenadm connect`](https://github.com/gardener/gardener/blob/master/docs/proposals/28-autonomous-shoot-clusters.md#gardenadm-connect), this PR introduces a new scenario for `make gardenadm-up`. It deploys `gardener-operator` and a `Garden` resource (which brings up a Gardener). This Gardener deployment can be later used to connect autonomous shoot clusters to.

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:
/cc @ScheererJ 

The virtual cluster is currently not accessible because `make kind-up` does not map the needed ports to the host machine. Eventually, this will resolve automatically once progress on https://github.com/gardener/gardener/issues/11958 continues.

Nevertheless, a component running inside the machine pods (i.e., inside the automous shoot cluster) should still be able to communicate to the virtual cluster (via cluster-internal communication).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
