### PR TITLE
[GEP-33] Introduce Capabilities validation during Shoot admission

### DIFF
--- a/pkg/apis/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile.go
@@ -586,6 +586,8 @@ func GetCapabilitySetsWithAppliedDefaults(capabilitySets []gardencorev1beta1.Cap
 }
 
 // GetCapabilitiesIntersection returns the intersection of capabilities from a list of capabilities.
+// All Capabilities objects should be defaulted before calling this function.
+// This can be achieved by calling GetCapabilitiesWithAppliedDefaults on each capabilities object.
 func GetCapabilitiesIntersection(capabilitiesList ...gardencorev1beta1.Capabilities) gardencorev1beta1.Capabilities {
 	intersection := make(gardencorev1beta1.Capabilities)
 
@@ -628,7 +630,7 @@ func intersectSlices(slice1, slice2 []string) []string {
 	return intersection
 }
 
-// AreCapabilitiesSupportedByCapabilitySets checks if the given capabilities are supported by at least set of the provided capability sets.
+// AreCapabilitiesSupportedByCapabilitySets checks if the given capabilities are supported by at least one of the provided capability sets.
 func AreCapabilitiesSupportedByCapabilitySets(
 	capabilities gardencorev1beta1.Capabilities, capabilitySets []gardencorev1beta1.CapabilitySet, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
 ) bool {

--- a/pkg/apis/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile.go
@@ -6,6 +6,7 @@ package helper
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -596,9 +597,7 @@ func GetCapabilitiesIntersection(capabilitiesList ...gardencorev1beta1.Capabilit
 	}
 
 	// Initialize intersection with the first capabilities object
-	for key, values := range capabilitiesList[0] {
-		intersection[key] = values
-	}
+	maps.Copy(intersection, capabilitiesList[0])
 
 	// Iterate through the remaining capabilities objects and refine the intersection
 	for _, capabilities := range capabilitiesList[1:] {
@@ -612,22 +611,10 @@ func GetCapabilitiesIntersection(capabilitiesList ...gardencorev1beta1.Capabilit
 
 // intersectSlices returns the intersection of two slices.
 func intersectSlices(slice1, slice2 []string) []string {
-	elementSet := make(map[string]struct{})
-	intersection := []string{}
+	elementSet1 := sets.New(slice1...)
+	elementSet2 := sets.New(slice2...)
 
-	// Add elements of the first slice to the map.
-	for _, elem := range slice1 {
-		elementSet[elem] = struct{}{}
-	}
-
-	// Check if elements of the second slice exist in the map.
-	for _, elem := range slice2 {
-		if _, exists := elementSet[elem]; exists {
-			intersection = append(intersection, elem)
-		}
-	}
-
-	return intersection
+	return elementSet1.Intersection(elementSet2).UnsortedList()
 }
 
 // AreCapabilitiesSupportedByCapabilitySets checks if the given capabilities are supported by at least one of the provided capability sets.

--- a/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
@@ -1619,6 +1619,16 @@ var _ = Describe("CloudProfile Helper", func() {
 				result := GetCapabilitiesIntersection(capabilities1, capabilities2)
 				Expect(result).To(Equal(expectedIntersection))
 			})
+
+			It("should return the capabilities of only one parameter was provided", func() {
+				capabilities := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value1"},
+					"capability2": []string{"value1", "value2"},
+				}
+
+				result := GetCapabilitiesIntersection(capabilities)
+				Expect(result).To(Equal(capabilities))
+			})
 		})
 
 		Describe("#AreCapabilitiesSupportedByCapabilitySets", func() {
@@ -1634,7 +1644,7 @@ var _ = Describe("CloudProfile Helper", func() {
 				}
 				capabilitySets := []gardencorev1beta1.CapabilitySet{
 					{Capabilities: gardencorev1beta1.Capabilities{
-						"capability1": []string{"value1", "value2"},
+						"capability1": []string{"value2"},
 						"capability2": []string{"value3", "value4"},
 					}},
 					{Capabilities: gardencorev1beta1.Capabilities{
@@ -1653,7 +1663,6 @@ var _ = Describe("CloudProfile Helper", func() {
 				}
 				capabilitySets := []gardencorev1beta1.CapabilitySet{
 					{Capabilities: gardencorev1beta1.Capabilities{
-						"capability1": []string{"value1", "value2"},
 						"capability2": []string{"value3", "value4"},
 					}},
 					{Capabilities: gardencorev1beta1.Capabilities{

--- a/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
@@ -1579,5 +1579,113 @@ var _ = Describe("CloudProfile Helper", func() {
 				}))
 			})
 		})
+
+		Describe("#GetCapabilitiesIntersection", func() {
+			It("should return the intersection of multiple capabilities", func() {
+				capabilities1 := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value1", "value2"},
+					"capability2": []string{"value3"},
+				}
+				capabilities2 := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value2", "value3", "value4"},
+					"capability2": []string{"value3", "value4"},
+					"capability3": []string{"value4"},
+				}
+				capabilities3 := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value2", "value4"},
+					"capability2": []string{"value3", "value4"},
+					"capability3": []string{"value5"},
+				}
+				expectedIntersection := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value2"},
+					"capability2": []string{"value3"},
+				}
+
+				result := GetCapabilitiesIntersection(capabilities1, capabilities2, capabilities3)
+				Expect(result).To(Equal(expectedIntersection))
+			})
+
+			It("should return an empty intersection when no capabilities match", func() {
+				capabilities1 := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value1"},
+				}
+				capabilities2 := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value2"},
+				}
+				expectedIntersection := gardencorev1beta1.Capabilities{
+					"capability1": []string{},
+				}
+
+				result := GetCapabilitiesIntersection(capabilities1, capabilities2)
+				Expect(result).To(Equal(expectedIntersection))
+			})
+		})
+
+		Describe("#AreCapabilitiesSupportedByCapabilitySets", func() {
+			capabilityDefinitions := []gardencorev1beta1.CapabilityDefinition{
+				{Name: "capability1", Values: []string{"value1", "value2"}},
+				{Name: "capability2", Values: []string{"value3", "value4"}},
+			}
+
+			It("should return true when capabilities are supported by a capability set", func() {
+				capabilities := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value1"},
+					"capability2": []string{"value3"},
+				}
+				capabilitySets := []gardencorev1beta1.CapabilitySet{
+					{Capabilities: gardencorev1beta1.Capabilities{
+						"capability1": []string{"value1", "value2"},
+						"capability2": []string{"value3", "value4"},
+					}},
+					{Capabilities: gardencorev1beta1.Capabilities{
+						"capability1": []string{"value1"},
+					}},
+				}
+
+				result := AreCapabilitiesSupportedByCapabilitySets(capabilities, capabilitySets, capabilityDefinitions)
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return false when capabilities are not supported by any capability set", func() {
+				capabilities := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value1"},
+					"capability2": []string{"value5"},
+				}
+				capabilitySets := []gardencorev1beta1.CapabilitySet{
+					{Capabilities: gardencorev1beta1.Capabilities{
+						"capability1": []string{"value1", "value2"},
+						"capability2": []string{"value3", "value4"},
+					}},
+					{Capabilities: gardencorev1beta1.Capabilities{
+						"capability1": []string{"value1", "value2"},
+						"capability2": []string{"value3", "value6"},
+					}},
+				}
+				result := AreCapabilitiesSupportedByCapabilitySets(capabilities, capabilitySets, capabilityDefinitions)
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return true when CapabilitySets are not defined and defaults are used", func() {
+				capabilities := gardencorev1beta1.Capabilities{
+					"capability1": []string{"value1"},
+				}
+				capabilitySets := []gardencorev1beta1.CapabilitySet{}
+
+				result := AreCapabilitiesSupportedByCapabilitySets(capabilities, capabilitySets, capabilityDefinitions)
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return true when Capabilities are not defined and defaults are used", func() {
+				capabilities := gardencorev1beta1.Capabilities{}
+				capabilitySets := []gardencorev1beta1.CapabilitySet{
+					{Capabilities: gardencorev1beta1.Capabilities{
+						"capability1": []string{"value1"},
+						"capability2": []string{"value3"},
+					}},
+				}
+				result := AreCapabilitiesSupportedByCapabilitySets(capabilities, capabilitySets, capabilityDefinitions)
+				Expect(result).To(BeTrue())
+			})
+		})
 	})
 })

--- a/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
@@ -1620,7 +1620,7 @@ var _ = Describe("CloudProfile Helper", func() {
 				Expect(result).To(Equal(expectedIntersection))
 			})
 
-			It("should return the capabilities of only one parameter was provided", func() {
+			It("should return the capabilities of a single parameter provided", func() {
 				capabilities := gardencorev1beta1.Capabilities{
 					"capability1": []string{"value1"},
 					"capability2": []string{"value1", "value2"},

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1112,26 +1112,36 @@ func (c *validationContext) validateWorkerMachine(idxPath *field.Path, worker, o
 	if worker.Machine.Architecture != nil && !slices.Contains(v1beta1constants.ValidArchitectures, *worker.Machine.Architecture) {
 		return field.NotSupported(idxPath.Child("machine", "architecture"), *worker.Machine.Architecture, v1beta1constants.ValidArchitectures)
 	}
-
-	isMachinePresentInCloudprofile, architectureSupported, availableInAllZones, isUsableMachine, supportedMachineTypes := validateMachineTypes(c.cloudProfileSpec.MachineTypes, worker.Machine, oldWorker.Machine, c.cloudProfileSpec.Regions, c.shoot.Spec.Region, worker.Zones)
-	if !isMachinePresentInCloudprofile {
-		return field.NotSupported(idxPath.Child("machine", "type"), worker.Machine.Type, supportedMachineTypes)
+	if err := c.validateMachineType(idxPath, worker, oldWorker); err != nil {
+		return err
 	}
 
-	if !architectureSupported || !availableInAllZones || !isUsableMachine {
-		detail := fmt.Sprintf("machine type %q ", worker.Machine.Type)
-		if !isUsableMachine {
-			detail += "is unusable, "
-		}
-		if !availableInAllZones {
-			detail += "is unavailable in at least one zone, "
-		}
-		if !architectureSupported {
-			detail += fmt.Sprintf("does not support CPU architecture %q, ", *worker.Machine.Architecture)
-		}
-		return field.Invalid(idxPath.Child("machine", "type"), worker.Machine.Type, fmt.Sprintf("%ssupported types are %+v", detail, supportedMachineTypes))
+	if err := c.validateMachineImage(idxPath, worker, oldWorker, isNewWorkerPool, a); err != nil {
+		return err
 	}
 
+	if err := c.validateMachineCapabilities(idxPath, worker); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *validationContext) validateMachineCapabilities(path *field.Path, worker core.Worker) *field.Error {
+	if len(c.cloudProfileSpec.Capabilities) == 0 {
+		return nil
+	}
+
+	machineImageVersion, _ := v1beta1helper.FindMachineImageVersion(c.cloudProfileSpec.MachineImages, worker.Machine.Image.Name, worker.Machine.Image.Version)
+	machineType := v1beta1helper.FindMachineTypeByName(c.cloudProfileSpec.MachineTypes, worker.Machine.Type)
+
+	if !v1beta1helper.AreCapabilitiesSupportedByCapabilitySets(machineType.Capabilities, machineImageVersion.CapabilitySets, c.cloudProfileSpec.Capabilities) {
+		return field.Invalid(path.Child("machine", "image", "version"), worker.Machine.Image.Version, fmt.Sprintf("machine capabilities %v of machine type %q are not supported by machine image %v:%v", machineType.Capabilities, worker.Machine.Type, worker.Machine.Image.Name, worker.Machine.Image.Version))
+	}
+
+	return nil
+}
+
+func (c *validationContext) validateMachineImage(idxPath *field.Path, worker core.Worker, oldWorker core.Worker, isNewWorkerPool bool, a admission.Attributes) *field.Error {
 	isUpdateStrategyInPlace := helper.IsUpdateStrategyInPlace(worker.UpdateStrategy)
 	isMachineImagePresentInCloudprofile, architectureSupported, activeMachineImageVersion, inPlaceUpdateSupported, validMachineImageVersions := validateMachineImagesConstraints(a, c.cloudProfileSpec.MachineImages, isNewWorkerPool, isUpdateStrategyInPlace, worker.Machine, oldWorker.Machine)
 	if !isMachineImagePresentInCloudprofile {
@@ -1156,6 +1166,28 @@ func (c *validationContext) validateWorkerMachine(idxPath *field.Path, worker, o
 		return field.Invalid(idxPath.Child("machine", "image"), worker.Machine.Image, fmt.Sprintf("%ssupported machine image versions are: %+v", detail, validMachineImageVersions))
 	}
 
+	return nil
+}
+
+func (c *validationContext) validateMachineType(idxPath *field.Path, worker core.Worker, oldWorker core.Worker) *field.Error {
+	isMachinePresentInCloudprofile, architectureSupported, availableInAllZones, isUsableMachine, supportedMachineTypes := validateMachineTypes(c.cloudProfileSpec.MachineTypes, worker.Machine, oldWorker.Machine, c.cloudProfileSpec.Regions, c.shoot.Spec.Region, worker.Zones)
+	if !isMachinePresentInCloudprofile {
+		return field.NotSupported(idxPath.Child("machine", "type"), worker.Machine.Type, supportedMachineTypes)
+	}
+
+	if !architectureSupported || !availableInAllZones || !isUsableMachine {
+		detail := fmt.Sprintf("machine type %q ", worker.Machine.Type)
+		if !isUsableMachine {
+			detail += "is unusable, "
+		}
+		if !availableInAllZones {
+			detail += "is unavailable in at least one zone, "
+		}
+		if !architectureSupported {
+			detail += fmt.Sprintf("does not support CPU architecture %q, ", *worker.Machine.Architecture)
+		}
+		return field.Invalid(idxPath.Child("machine", "type"), worker.Machine.Type, fmt.Sprintf("%ssupported types are %+v", detail, supportedMachineTypes))
+	}
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area usability
/area os

**What this PR does / why we need it**:
Implementation as part of [GEP-33](https://github.com/gardener/gardener/blob/master/docs/proposals/33-machine-image-capabilities.md).

Adds a validation in the shoot admission. The validation checks if the capabilities of the machine type and image version are compatible. 

Note: The defaulting of worker machine images versions will be part of a follow up PR to keep the PRs concise.

**Which issue(s) this PR fixes**:
Part of #11301

**Special notes for your reviewer**:
@LucaBernstein  @timuthy 
