### PR TITLE
Add validation for `Quota.spec.clusterLifetimeDays`

### DIFF
--- a/pkg/apis/core/helper/quota.go
+++ b/pkg/apis/core/helper/quota.go
@@ -11,16 +11,25 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var (
+	// ProjectGVK is the GroupVersionKind for Gardener Project resources.
+	ProjectGVK = schema.GroupVersionKind{Group: "core.gardener.cloud", Version: "v1beta1", Kind: "Project"}
+	// SecretGVK is the GroupVersionKind for Kubernetes Secret resources.
+	SecretGVK = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
+	// WorkloadIdentityGVK is the GroupVersionKind for Gardener WorkloadIdentity resources.
+	WorkloadIdentityGVK = schema.GroupVersionKind{Group: "security.gardener.cloud", Version: "v1alpha1", Kind: "WorkloadIdentity"}
+)
+
 // QuotaScope returns the scope of a quota scope reference.
 func QuotaScope(scopeRef corev1.ObjectReference) (string, error) {
-	if gvk := schema.FromAPIVersionAndKind(scopeRef.APIVersion, scopeRef.Kind); gvk.Group == "core.gardener.cloud" && gvk.Kind == "Project" {
+	switch schema.FromAPIVersionAndKind(scopeRef.APIVersion, scopeRef.Kind) {
+	case ProjectGVK:
 		return "project", nil
-	}
-	if scopeRef.APIVersion == "v1" && scopeRef.Kind == "Secret" {
+	case SecretGVK:
 		return "credentials", nil
-	}
-	if gvk := schema.FromAPIVersionAndKind(scopeRef.APIVersion, scopeRef.Kind); gvk.Group == "security.gardener.cloud" && gvk.Kind == "WorkloadIdentity" {
+	case WorkloadIdentityGVK:
 		return "credentials", nil
+	default:
+		return "", errors.New("unknown quota scope")
 	}
-	return "", errors.New("unknown quota scope")
 }

--- a/pkg/apis/core/validation/quota.go
+++ b/pkg/apis/core/validation/quota.go
@@ -43,8 +43,8 @@ func ValidateQuotaSpec(quotaSpec *core.QuotaSpec, fldPath *field.Path) field.Err
 	}
 
 	scopeRef := quotaSpec.Scope
-	if scope, err := helper.QuotaScope(scopeRef); err != nil {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scope, []string{"project", "secret", "workloadidentity"}))
+	if _, err := helper.QuotaScope(scopeRef); err != nil {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scopeRef.GroupVersionKind().String(), []string{helper.ProjectGVK.String(), helper.SecretGVK.String(), helper.WorkloadIdentityGVK.String()}))
 	}
 
 	metricsFldPath := fldPath.Child("metrics")

--- a/pkg/apis/core/validation/quota.go
+++ b/pkg/apis/core/validation/quota.go
@@ -38,6 +38,10 @@ func ValidateQuotaUpdate(newQuota, oldQuota *core.Quota) field.ErrorList {
 func ValidateQuotaSpec(quotaSpec *core.QuotaSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	if quotaSpec.ClusterLifetimeDays != nil && *quotaSpec.ClusterLifetimeDays < 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterLifetimeDays"), quotaSpec.ClusterLifetimeDays, "must be greater than 0"))
+	}
+
 	scopeRef := quotaSpec.Scope
 	if _, err := helper.QuotaScope(scopeRef); err != nil {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scopeRef, []string{"project", "secret", "workloadidentity"}))

--- a/pkg/apis/core/validation/quota.go
+++ b/pkg/apis/core/validation/quota.go
@@ -43,8 +43,8 @@ func ValidateQuotaSpec(quotaSpec *core.QuotaSpec, fldPath *field.Path) field.Err
 	}
 
 	scopeRef := quotaSpec.Scope
-	if _, err := helper.QuotaScope(scopeRef); err != nil {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scopeRef, []string{"project", "secret", "workloadidentity"}))
+	if scope, err := helper.QuotaScope(scopeRef); err != nil {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scope, []string{"project", "secret", "workloadidentity"}))
 	}
 
 	metricsFldPath := fldPath.Child("metrics")

--- a/pkg/apis/core/validation/quota_test.go
+++ b/pkg/apis/core/validation/quota_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/gardener/gardener/pkg/apis/core/validation"
@@ -118,6 +119,17 @@ var _ = Describe("Quota Validation Tests ", func() {
 					"Field": Equal("spec.metrics[key]"),
 				})),
 			))
+		})
+
+		It("should forbid Quota with negative cluster lifetime days", func() {
+			quota.Spec.ClusterLifetimeDays = ptr.To(int32(-1))
+
+			errorList := ValidateQuota(quota)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("spec.clusterLifetimeDays"),
+			}))))
 		})
 
 		It("should allow quota scope referencing WorkloadIdentity", func() {

--- a/pkg/apis/core/validation/quota_test.go
+++ b/pkg/apis/core/validation/quota_test.go
@@ -121,8 +121,8 @@ var _ = Describe("Quota Validation Tests ", func() {
 			))
 		})
 
-		It("should forbid Quota with negative cluster lifetime days", func() {
-			quota.Spec.ClusterLifetimeDays = ptr.To(int32(-1))
+		DescribeTable("cluster lifetime days", func(clusterLifeTimeDays int) {
+			quota.Spec.ClusterLifetimeDays = ptr.To(int32(clusterLifeTimeDays))
 
 			errorList := ValidateQuota(quota)
 
@@ -130,7 +130,10 @@ var _ = Describe("Quota Validation Tests ", func() {
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.clusterLifetimeDays"),
 			}))))
-		})
+		},
+			Entry("should forbid negative cluster lifetime days", -1),
+			Entry("should forbid zero cluster lifetime days", 0),
+		)
 
 		It("should allow quota scope referencing WorkloadIdentity", func() {
 			quota.Spec.Scope = corev1.ObjectReference{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Until now, we did not check whether the `Quota.spec.clusterLifetimeDays` field is positive.
IIUC, this could lead to `Shoot`s being immediately being deleted, when this field is something like `-1`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A new validation for Quota `.spec.clusterLifetimeDays` field is added. The field value must be greater than 0.
```
