### PR TITLE
[GEP-28] `gardenadm bootstrap`: return `Machine` addresses in provider-local

### DIFF
--- a/pkg/provider-local/machine-provider/local/create_machine.go
+++ b/pkg/provider-local/machine-provider/local/create_machine.go
@@ -71,10 +71,7 @@ func (d *localDriver) CreateMachine(ctx context.Context, req *driver.CreateMachi
 	return &driver.CreateMachineResponse{
 		ProviderID: pod.Name,
 		NodeName:   pod.Name,
-		Addresses: []corev1.NodeAddress{{
-			Type:    corev1.NodeInternalIP,
-			Address: pod.Status.PodIP,
-		}},
+		Addresses:  addressesFromStatus(pod.Status),
 	}, nil
 }
 

--- a/pkg/provider-local/machine-provider/local/create_machine.go
+++ b/pkg/provider-local/machine-provider/local/create_machine.go
@@ -71,6 +71,10 @@ func (d *localDriver) CreateMachine(ctx context.Context, req *driver.CreateMachi
 	return &driver.CreateMachineResponse{
 		ProviderID: pod.Name,
 		NodeName:   pod.Name,
+		Addresses: []corev1.NodeAddress{{
+			Type:    corev1.NodeInternalIP,
+			Address: pod.Status.PodIP,
+		}},
 	}, nil
 }
 

--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -100,3 +100,22 @@ func getNamespaceForMachine(machine *machinev1alpha1.Machine, machineClass *mach
 	}
 	return machineClass.Namespace
 }
+
+func addressesFromStatus(podStatus corev1.PodStatus) []corev1.NodeAddress {
+	if len(podStatus.PodIPs) == 0 {
+		return []corev1.NodeAddress{{
+			Type:    corev1.NodeInternalIP,
+			Address: podStatus.PodIP,
+		}}
+	}
+
+	// the 0th entry must matche the podIP field, so we don't need to add it.
+	addresses := make([]corev1.NodeAddress, 0, len(podStatus.PodIPs))
+	for _, podIP := range podStatus.PodIPs {
+		addresses = append(addresses, corev1.NodeAddress{
+			Type:    corev1.NodeInternalIP,
+			Address: podIP.IP,
+		})
+	}
+	return addresses
+}

--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -102,14 +102,6 @@ func getNamespaceForMachine(machine *machinev1alpha1.Machine, machineClass *mach
 }
 
 func addressesFromStatus(podStatus corev1.PodStatus) []corev1.NodeAddress {
-	if len(podStatus.PodIPs) == 0 {
-		return []corev1.NodeAddress{{
-			Type:    corev1.NodeInternalIP,
-			Address: podStatus.PodIP,
-		}}
-	}
-
-	// the 0th entry must matche the podIP field, so we don't need to add it.
 	addresses := make([]corev1.NodeAddress, 0, len(podStatus.PodIPs))
 	for _, podIP := range podStatus.PodIPs {
 		addresses = append(addresses, corev1.NodeAddress{

--- a/pkg/provider-local/machine-provider/local/get_machine_status.go
+++ b/pkg/provider-local/machine-provider/local/get_machine_status.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,9 +37,6 @@ func (d *localDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 	return &driver.GetMachineStatusResponse{
 		ProviderID: pod.Name,
 		NodeName:   pod.Name,
-		Addresses: []corev1.NodeAddress{{
-			Type:    corev1.NodeInternalIP,
-			Address: pod.Status.PodIP,
-		}},
+		Addresses:  addressesFromStatus(pod.Status),
 	}, nil
 }

--- a/pkg/provider-local/machine-provider/local/get_machine_status.go
+++ b/pkg/provider-local/machine-provider/local/get_machine_status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,5 +38,9 @@ func (d *localDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 	return &driver.GetMachineStatusResponse{
 		ProviderID: pod.Name,
 		NodeName:   pod.Name,
+		Addresses: []corev1.NodeAddress{{
+			Type:    corev1.NodeInternalIP,
+			Address: pod.Status.PodIP,
+		}},
 	}, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR builds on https://github.com/gardener/gardener/pull/12307 and demonstrates what https://github.com/gardener/machine-controller-manager/pull/1012 looks like in practice. The MCM interaction with the target cluster is disabled, and therefore a new status field is returned:

```yaml
status:
  addresses:
  - address: machine-shoot--garden--root-control-plane-695dc-tr9jl
    type: Hostname
  - address: 10.1.130.204
    type: InternalIP
```

The relevant changes are in the last commit: 6b3ba18627e318fe2dd5eaabc688ab2d770d45a4

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
In draft until the following PRs are merged:
- [x] https://github.com/gardener/gardener/pull/12307
- [x] https://github.com/gardener/machine-controller-manager/pull/1012
- [x] https://github.com/gardener/gardener/pull/12842

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
