### PR TITLE
Deflake `utils/publicip/detector` unit test

### DIFF
--- a/pkg/utils/publicip/detector_test.go
+++ b/pkg/utils/publicip/detector_test.go
@@ -81,9 +81,10 @@ var _ = Describe("IpifyDetector", func() {
 		})
 
 		It("should return only the available IP", func() {
-			Expect(detector.DetectPublicIPs(ctx, log)).Error().To(MatchError(
-				MatchRegexp(`.*IPv4.*: foo.*\n.*IPv6.*: context deadline exceeded.*`),
-			))
+			Expect(detector.DetectPublicIPs(ctx, log)).Error().To(MatchError(And(
+				MatchRegexp(`error determining public IPv4 address: .*: foo`),
+				MatchRegexp(`error determining public IPv6 address: .*: context deadline exceeded`),
+			)))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

This PR introduces an additional `MatchRegexp` matcher to the public IP detector [unit tests](https://github.com/gardener/gardener/blob/master/pkg/utils/publicip/detector_test.go) as the order of the returned [multierror](https://pkg.go.dev/github.com/hashicorp/go-multierror#pkg-index) errors by

https://github.com/gardener/gardener/blob/5d16197e67558738964ceac00aa255c2c4d279e7/pkg/utils/publicip/detector.go#L34

is not guaranteed and the current regular expression

```
.*IPv4.*: foo.*\n.*IPv6.*: context deadline exceeded.*
```

does not cover the case when the `IPv6` error is retuned before the `IPv4` one.

The following snippets illustrate the two distinct outputs that could be generated by the `multiline.Error` [.Error()](https://pkg.go.dev/github.com/hashicorp/go-multierror#Error.Error) function 

```go
Expect(detector.DetectPublicIPs(ctx, log)).Error()
```

during the _matching_ phase, when the [Error](https://pkg.go.dev/github.com/hashicorp/go-multierror#Error)' `string` value is compared:

- Having `IPv4` as first entry ( test __passes__ )
  ```txt
   2 errors occurred:
         * error determining public IPv4 address: Get "https://api4.ipify.org/": foo
         * error determining public IPv6 address: Get "https://api6.ipify.org/": context deadline exceeded
  ```
- Having `IPv6` as first entry (test __fails__)
  ```txt
    2 errors occurred:
        * error determining public IPv6 address: Get "https://api6.ipify.org/": context deadline exceeded
        * error determining public IPv4 address: Get "https://api4.ipify.org/": foo
   ```

---

The below snippets show the outputs retuned by the [stress](https://pkg.go.dev/golang.org/x/tools/cmd/stress) tool when _focusing_ on the `should return only the available IP` unit test when building the code from the __master__ branch:

```sh
➜ gardener git:(master) ✗ ginkgo build ./pkg/utils/publicip
2025/07/09 12:20:45 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
Compiled pkg/utils/publicip/publicip.test
➜ gardener git:(master) ✗ stress -p 1 $(pwd)/pkg/utils/publicip/publicip.test -ginkgo.focus "should return only the available IP"
.
.
.
  [FAILED] Expected
      <*multierror.Error | 0x140000797e0>:
      2 errors occurred:
        * error determining public IPv6 address: Get "https://api6.ipify.org/": context deadline exceeded
        * error determining public IPv4 address: Get "https://api4.ipify.org/": foo


      {
          Errors: [
              <*fmt.wrapError | 0x14000079780>{
                  msg: "error determining public IPv6 address: Get \"https://api6.ipify.org/\": context deadline exceeded",
                  err: <*url.Error | 0x140001d9050>{
                      Op: "Get",
                      URL: "https://api6.ipify.org/",
                      Err: <context.deadlineExceededError>{},
                  },
              },
              <*fmt.wrapError | 0x14000079880>{
                  msg: "error determining public IPv4 address: Get \"https://api4.ipify.org/\": foo",
                  err: <*url.Error | 0x140001d90e0>{
                      Op: "Get",
                      URL: "https://api4.ipify.org/",
                      Err: <*errors.errorString | 0x14000031ea0>{s: "foo"},
                  },
              },
          ],
          ErrorFormat: nil,
      }
  to match error
      <*matchers.MatchRegexpMatcher | 0x140001d9110>: {
          Regexp: ".*IPv4.*: foo.*\\n.*IPv6.*: context deadline exceeded.*",
          Args: nil,
      }
  In [It] at: /Users/I759218/
…
5s: 708 runs so far, 67 failures (9.46%), 1 active
```

with a __9.46% failure rate for 5s run__, and when building the code introduced in this PR:

```sh
➜ gardener git:(deflake/utils-publicip-detector) ✗ ginkgo build ./pkg/utils/publicip
2025/07/09 12:27:22 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
Compiled pkg/utils/publicip/publicip.test
➜ gardener git:(deflake/utils-publicip-detector) ✗ stress -p 1 $(pwd)/pkg/utils/publicip/publicip.test -ginkgo.focus "should return only the available IP"
5s: 663 runs so far, 0 failures, 1 active
10s: 1389 runs so far, 0 failures, 1 active
15s: 2104 runs so far, 0 failures, 1 active
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/gardener/gardener/issues/12469

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
