### PR TITLE
Deflake `pkg/utils/publicip` unit test

### DIFF
--- a/pkg/utils/publicip/detector.go
+++ b/pkg/utils/publicip/detector.go
@@ -37,13 +37,15 @@ func (i IpifyDetector) DetectPublicIPs(ctx context.Context, parentLog logr.Logge
 		errs error
 	)
 
-	for ipFamily, host := range map[string]string{
-		"IPv4": "api4.ipify.org",
-		"IPv6": "api6.ipify.org",
+	for _, api := range []struct {
+		ipFamily, host string
+	}{
+		{"IPv4", "api4.ipify.org"},
+		{"IPv6", "api6.ipify.org"},
 	} {
-		log := parentLog.WithValues("ipFamily", ipFamily)
+		log := parentLog.WithValues("ipFamily", api.ipFamily)
 
-		if ip, err := i.getPublicIP(ctx, log, ipFamily, host); err != nil {
+		if ip, err := i.getPublicIP(ctx, log, api.ipFamily, api.host); err != nil {
 			log.V(1).Info("No public IP detected or detection failed", "err", err)
 			errs = multierror.Append(errs, err)
 		} else {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

This PR deflakes the `pkg/utils/publicip` unit test by ensuring a stable order of execution in `IpifyDetector.DetectPublicIPs` (maps are unsorted in Go).

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/12469

**Special notes for your reviewer**:

With this PR:
```
$ stress -p 16 ./pkg/utils/publicip/publicip.test
...
1m35s: 71212 runs so far, 0 failures, 16 active
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
