### PR TITLE
Forbid container privilege escalation for otel-operator

### DIFF
--- a/pkg/component/observability/opentelemetry/operator/operator.go
+++ b/pkg/component/observability/opentelemetry/operator/operator.go
@@ -350,6 +350,9 @@ func (o *openTelemetryOperator) deployment() *appsv1.Deployment {
 									},
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/pkg/component/observability/opentelemetry/operator/operator.go
+++ b/pkg/component/observability/opentelemetry/operator/operator.go
@@ -350,14 +350,14 @@ func (o *openTelemetryOperator) deployment() *appsv1.Deployment {
 									},
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
 									corev1.ResourceMemory: resource.MustParse("64Mi"),
 								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
 							},
 						},
 					},

--- a/pkg/component/observability/opentelemetry/operator/operator_test.go
+++ b/pkg/component/observability/opentelemetry/operator/operator_test.go
@@ -283,14 +283,14 @@ var _ = Describe("OpenTelemetry Operator", func() {
 										},
 									},
 								},
-								SecurityContext: &corev1.SecurityContext{
-									AllowPrivilegeEscalation: ptr.To(false),
-								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("10m"),
 										corev1.ResourceMemory: resource.MustParse("64Mi"),
 									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptr.To(false),
 								},
 							},
 						},

--- a/pkg/component/observability/opentelemetry/operator/operator_test.go
+++ b/pkg/component/observability/opentelemetry/operator/operator_test.go
@@ -283,6 +283,9 @@ var _ = Describe("OpenTelemetry Operator", func() {
 										},
 									},
 								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: ptr.To(false),
+								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("10m"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
New occurrence of https://github.com/gardener/gardener/issues/11139

**Special notes for your reviewer**:
/cc @rrhubenov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
