### PR TITLE
fix: remove limits on vpn-shoot

### DIFF
--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -634,7 +634,6 @@ func (v *vpnShoot) container(secrets []vpnSecret, index *int) *corev1.Container 
 				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("100Mi"),
 			},
-			Limits: v.getResourceLimits(),
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged:               ptr.To(false),
@@ -657,9 +656,6 @@ func (v *vpnShoot) tunnelControllerContainer() *corev1.Container {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("10Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("20Mi"),
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
@@ -809,17 +805,6 @@ func (v *vpnShoot) getEnvVars(index *int) []corev1.EnvVar {
 	return envVariables
 }
 
-func (v *vpnShoot) getResourceLimits() corev1.ResourceList {
-	if v.values.VPAEnabled {
-		return corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("100Mi"),
-		}
-	}
-	return corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("120Mi"),
-	}
-}
-
 func (v *vpnShoot) getVolumeMounts(secrets []vpnSecret) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{}
 	for _, item := range secrets {
@@ -940,9 +925,6 @@ func (v *vpnShoot) getInitContainers() []corev1.Container {
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("30m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:

- Ongoing effort to remove meaningless resource limits as discussed in 2024
- VPN Shoot had some limits left, now removed
- Requests usually handled by VPA

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Resource limits on vpn-shoot have been removed.
```
