### PR TITLE
Enhance docs for dual-stack migration and add validation for update of ipFamilies.

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -9373,7 +9373,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+<p>IPFamilies specifies the IP protocol versions to use for shoot networking.
 See <a href="https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md">https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md</a>.
 Defaults to [&ldquo;IPv4&rdquo;].</p>
 </td>

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -17,7 +17,7 @@ Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protoco
 
 ### Key Considerations
 
-- A dual-stack cluster can not be migrated to single-stack. Migration from single-stack to dual-stack is a one-way process and cannot be undone.
+- A dual-stack cluster cannot be migrated to single-stack. Migration from single-stack to dual-stack is a one-way process and cannot be undone.
 - Adding a new protocol is only allowed as the second element in the array, ensuring the primary protocol remains unchanged.
 - Migration involves multiple reconciliation runs to ensure a smooth transition without disruptions.
 

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -5,7 +5,7 @@ description: Migrate IPv4 shoots to dual-stack IPv4,IPv6 network
 
 # Dual-Stack Network Migration
 
-This document provides a guide for migrating IPv4-only or IPv6-only Gardener shoot clusters to dual-stack networking (IPv4 and IPv6).
+This document provides a guide for migrating IPv4-only Gardener shoot clusters to dual-stack networking (IPv4 and IPv6).
 
 ## Overview
 
@@ -17,8 +17,9 @@ Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protoco
 
 ### Key Considerations
 
+- Single stack IPv4 clusters can be migrated to  dual-stack by adding IPv6 as second element.
+-The migration of single stack IPv6 clusters to dual-stack is not supported.
 - A dual-stack cluster cannot be migrated to single-stack. Migration from single-stack to dual-stack is a one-way process and cannot be undone.
-- Adding a new protocol is only allowed as the second element in the array, ensuring the primary protocol remains unchanged.
 - Migration involves multiple reconciliation runs to ensure a smooth transition without disruptions.
 
 ## Preconditions

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -18,7 +18,7 @@ Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protoco
 ### Key Considerations
 
 - Single stack IPv4 clusters can be migrated to  dual-stack by adding IPv6 as second element.
--The migration of single stack IPv6 clusters to dual-stack is not supported.
+- The migration of single stack IPv6 clusters to dual-stack is not supported.
 - A dual-stack cluster cannot be migrated to single-stack. Migration from single-stack to dual-stack is a one-way process and cannot be undone.
 - Migration involves multiple reconciliation runs to ensure a smooth transition without disruptions.
 

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -17,6 +17,7 @@ Dual-stack networking allows clusters to operate with both IPv4 and IPv6 protoco
 
 ### Key Considerations
 
+- A dual-stack cluster can not be migrated to single-stack. Migration from single-stack to dual-stack is a one-way process and cannot be undone.
 - Adding a new protocol is only allowed as the second element in the array, ensuring the primary protocol remains unchanged.
 - Migration involves multiple reconciliation runs to ensure a smooth transition without disruptions.
 

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -1164,7 +1164,7 @@ type Networking struct {
 	Nodes *string
 	// Services is the CIDR of the service network. This field is immutable.
 	Services *string
-	// IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+	// IPFamilies specifies the IP protocol versions to use for shoot networking.
 	// See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md.
 	// Defaults to ["IPv4"].
 	IPFamilies []IPFamily

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2169,7 +2169,7 @@ message Networking {
   // +optional
   optional string services = 5;
 
-  // IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+  // IPFamilies specifies the IP protocol versions to use for shoot networking.
   // See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md.
   // Defaults to ["IPv4"].
   // +optional

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1526,7 +1526,7 @@ type Networking struct {
 	// Services is the CIDR of the service network. This field is immutable.
 	// +optional
 	Services *string `json:"services,omitempty" protobuf:"bytes,5,opt,name=services"`
-	// IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+	// IPFamilies specifies the IP protocol versions to use for shoot networking.
 	// See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md.
 	// Defaults to ["IPv4"].
 	// +optional

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -744,6 +744,26 @@ func validateNetworkingUpdate(newNetworking, oldNetworking *core.Networking, fld
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Services, oldNetworking.Services, fldPath.Child("services"))...)
 	}
 
+	allErrs = append(allErrs, validateIPFamiliesUpdate(newNetworking.IPFamilies, oldNetworking.IPFamilies, fldPath.Child("ipFamilies"))...)
+	return allErrs
+}
+
+func validateIPFamiliesUpdate(newIPFamilies, oldIPFamilies []core.IPFamily, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(oldIPFamilies) == 1 &&
+		oldIPFamilies[0] == core.IPFamilyIPv4 &&
+		len(newIPFamilies) == 2 &&
+		newIPFamilies[0] == core.IPFamilyIPv4 &&
+		newIPFamilies[1] == core.IPFamilyIPv6 {
+		return allErrs
+	}
+
+	if !apiequality.Semantic.DeepEqual(newIPFamilies, oldIPFamilies) {
+		allErrs = append(allErrs, field.Forbidden(fldPath,
+			fmt.Sprintf("unsupported IP family update: oldIPFamilies=%v, newIPFamilies=%v", oldIPFamilies, newIPFamilies)))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3931,6 +3931,18 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShootUpdate(newShoot, shoot)
 				Expect(errorList).To(BeEmpty())
 			})
+			It("should forbid changing ipfamilies from dual-stack to single-stack", func() {
+				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
+
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4}
+				errorList := ValidateShootUpdate(newShoot, shoot)
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.networking.ipFamilies"),
+					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4 IPv6], newIPFamilies=[IPv4]"),
+				}))))
+			})
 		})
 
 		Context("dual-stack", func() {

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -134,9 +134,10 @@ func ValidateIPFamiliesUpdate(newIPFamilies, oldIPFamilies []extensionsv1alpha1.
 	allErrs := field.ErrorList{}
 
 	if len(oldIPFamilies) == 1 &&
-		((oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 && len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv6 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv4) ||
-			(oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 && len(newIPFamilies) == 2 && newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 && newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv6)) {
-		// Allow transition from [IPv6] to [IPv6, IPv4] or [IPv4] to [IPv4, IPv6]
+		oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 &&
+		len(newIPFamilies) == 2 &&
+		newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 &&
+		newIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv6 {
 		return allErrs
 	}
 

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -244,14 +244,19 @@ var _ = Describe("Network validation tests", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should allow updating ipFamilies from IPv6 to dual-stack [IPv6, IPv4]", func() {
+		It("should not allow updating ipFamilies from IPv6 to dual-stack [IPv6, IPv4]", func() {
 			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6}
 			newNetwork := prepareNetworkForUpdate(network)
 			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6, extensionsv1alpha1.IPFamilyIPv4}
 
 			errorList := ValidateNetworkUpdate(newNetwork, network)
 
-			Expect(errorList).To(BeEmpty())
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.ipFamilies"),
+				})),
+			))
 		})
 
 		It("should not allow updating ipFamilies from dual-stack [IPv4, IPv6] to [IPv6, IPv4]", func() {

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -6422,7 +6422,7 @@ func schema_pkg_apis_core_v1beta1_Networking(ref common.ReferenceCallback) commo
 					},
 					"ipFamilies": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable. See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md. Defaults to [\"IPv4\"].",
+							Description: "IPFamilies specifies the IP protocol versions to use for shoot networking. See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md. Defaults to [\"IPv4\"].",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Emphasize that migration to dual-stack can't be reverted.
Add validation for updates to spec.networking.ipFamilies.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Updates to `spec.networking.ipFamiles` are now validated.
```
