### PR TITLE
Remove `ShootAPIServerProxyUsesHTTPProxy` constraint

### DIFF
--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -2005,9 +2005,6 @@ const (
 	// ShootCRDsWithProblematicConversionWebhooks is a constant for a condition type indicating that the Shoot cluster has
 	// CRDs with conversion webhooks and multiple stored versions which can break the reconciliation flow of the cluster.
 	ShootCRDsWithProblematicConversionWebhooks ConditionType = "CRDsWithProblematicConversionWebhooks"
-	// ShootAPIServerProxyUsesHTTPProxy is a constant for a constraint type indicating that the Shoot cluster uses
-	// the new HTTP proxy connection method for in-cluster API server traffic (See https://github.com/gardener/gardener/blob/master/docs/proposals/30-apiserver-proxy.md)
-	ShootAPIServerProxyUsesHTTPProxy ConditionType = "APIServerProxyUsesHTTPProxy"
 	// ShootManualInPlaceWorkersUpdated is a constant for a condition type indicating that the Shoot cluster does not have
 	// any worker pools with update strategy "ManualInPlaceUpdate" and pending update.
 	ShootManualInPlaceWorkersUpdated ConditionType = "ManualInPlaceWorkersUpdated"

--- a/pkg/gardenlet/operation/botanist/apiserverproxy.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy.go
@@ -53,16 +53,6 @@ func (b *Botanist) DeployAPIServerProxy(ctx context.Context) error {
 	if !b.ShootUsesDNS() {
 		return b.Shoot.Components.SystemComponents.APIServerProxy.Destroy(ctx)
 	}
-
 	b.Shoot.Components.SystemComponents.APIServerProxy.SetAdvertiseIPAddress(b.APIServerClusterIP)
-
-	if err := b.Shoot.Components.SystemComponents.APIServerProxy.Deploy(ctx); err != nil {
-		return err
-	}
-
-	// TODO(Wieneo): Remove this after Gardener v1.123
-	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
-		shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootAPIServerProxyUsesHTTPProxy)
-		return nil
-	})
+	return b.Shoot.Components.SystemComponents.APIServerProxy.Deploy(ctx)
 }

--- a/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
@@ -11,11 +11,9 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
@@ -23,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation/garden"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("APIServerProxy", func() {
@@ -92,20 +89,8 @@ var _ = Describe("APIServerProxy", func() {
 	})
 
 	Describe("#DeployAPIServerProxy", func() {
-		It("should deploy apiserverproxy and remove ShootAPIServerProxyUsesHTTPProxy constraint", func() {
-			Expect(botanist.Shoot.UpdateInfoStatus(ctx, botanist.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
-				condition := v1beta1helper.GetOrInitConditionWithClock(botanist.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootAPIServerProxyUsesHTTPProxy)
-				condition = v1beta1helper.UpdatedConditionWithClock(botanist.Clock, condition, gardencorev1beta1.ConditionTrue, "APIServerProxyUsesHTTPProxy", "The API server proxy was reconfigured to use the HTTP proxy method.")
-				shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
-				return nil
-			})).To(Succeed())
-
+		It("should deploy apiserverproxy", func() {
 			Expect(botanist.DeployAPIServerProxy(ctx)).To(Succeed())
-			Expect(botanist.GardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
-
-			Expect(shoot.Status.Constraints).NotTo(ContainCondition(
-				OfType(gardencorev1beta1.ShootAPIServerProxyUsesHTTPProxy),
-			))
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR removes the remaining constraint handling after https://github.com/gardener/gardener/pull/12406.
Now that the feature gate went GA and Gardener 1.123 removes the constraint from all shoots, we can drop the constraint handling in Gardener 1.124.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
