### PR TITLE
Exclude `gardener-resource-manager` from `pod-kube-apiserver-load-balancing` webhook when running in runtime cluster

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -348,6 +348,15 @@ var _ = Describe("ResourceManager", func() {
 					{
 						KubeAPIServerNamePrefix: "virtual-garden-",
 						NamespaceSelector:       map[string]string{"barbaz": "bazbar"},
+						ObjectSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: "NotIn",
+									Values:   []string{"gardener-resource-manager"},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1161,6 +1170,15 @@ var _ = Describe("ResourceManager", func() {
 						NamespaceSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"barbaz": "bazbar"},
 						},
+						ObjectSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      v1beta1constants.LabelApp,
+									Operator: metav1.LabelSelectorOpNotIn,
+									Values:   []string{"gardener-resource-manager"},
+								},
+							},
+						},
 						ClientConfig: admissionregistrationv1.WebhookClientConfig{
 							Service: &admissionregistrationv1.ServiceReference{
 								Name:      "gardener-resource-manager",
@@ -1462,8 +1480,11 @@ webhooks:
     matchLabels:
       barbaz: bazbar
   objectSelector:
-    matchLabels:
-      networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
+    matchExpressions:
+	- key: app
+	  operator: NotIn
+	  values:
+	  - gardener-resource-manager
   rules:
   - apiGroups:
     - ""

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -415,6 +415,15 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 				}, {
 					KubeAPIServerNamePrefix: namePrefix,
 					NamespaceSelector:       map[string]string{"kubernetes.io/metadata.name": v1beta1constants.GardenNamespace},
+					ObjectSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      v1beta1constants.LabelApp,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{resourcemanager.LabelValue},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/test/integration/resourcemanager/podkubeapiserverloadbalancing/podkubeapiserverloadbalancing_suite_test.go
+++ b/test/integration/resourcemanager/podkubeapiserverloadbalancing/podkubeapiserverloadbalancing_suite_test.go
@@ -152,7 +152,7 @@ func getMutatingWebhookConfigurations(testID string) []*admissionregistrationv1.
 			},
 			Webhooks: []admissionregistrationv1.MutatingWebhook{
 				resourcemanager.NewPodKubeAPIServerLoadBalancingMutatingWebhook(
-					&metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: testID}}, "", nil, func(_ *corev1.Secret, path string) admissionregistrationv1.WebhookClientConfig {
+					&metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: testID}}, nil, "", nil, func(_ *corev1.Secret, path string) admissionregistrationv1.WebhookClientConfig {
 						return admissionregistrationv1.WebhookClientConfig{
 							Service: &admissionregistrationv1.ServiceReference{
 								Path: &path,


### PR DESCRIPTION
…
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind bug

**What this PR does / why we need it**:
PR #12260 introduced a race condition to reconciliation of Garden which could lead to a stuck reconciliation.
`gardener-resource-manager` serves `pod-kube-apiserver-load-balancing` webhook and was not excluded from the mutating webhook configuration yet. Thus, in case the mutating webhook configuration has been applied before the new `gardener-resource-manager` pod started, it prevented creation of new GRM pods. In this case the Garden reconciliation was stuck and required a manual intervention.

This bug has been fixed by excluding GRM from configuration of the mutating webhook.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardener-resource-manager` is now excluded from `pod-kube-apiserver-load-balancing` webhook when running in garden runtime cluster.
```
