### PR TITLE
Improve Input Validation of Networking-related `Shoot` fields

### DIFF
--- a/pkg/apis/core/validation/exposureclass.go
+++ b/pkg/apis/core/validation/exposureclass.go
@@ -17,6 +17,8 @@ import (
 func ValidateExposureClass(exposureClass *core.ExposureClass) field.ErrorList {
 	var allErrs = field.ErrorList{}
 
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&exposureClass.ObjectMeta, false, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+
 	handlerNameLength := len(exposureClass.Handler)
 
 	for _, errorMessage := range validation.IsDNS1123Label(exposureClass.Handler) {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -284,6 +284,12 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 	allErrs = append(allErrs, ValidateTolerations(spec.Tolerations, fldPath.Child("tolerations"))...)
 	allErrs = append(allErrs, ValidateSystemComponents(spec.SystemComponents, fldPath.Child("systemComponents"), workerless)...)
 
+	if spec.ExposureClassName != nil {
+		for _, err := range validation.IsDNS1123Subdomain(*spec.ExposureClassName) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("exposureClassName"), *spec.ExposureClassName, fmt.Sprintf("exposureClassName is not a valid DNS subdomain: %q", err)))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2586,6 +2586,10 @@ func ValidateCoreDNSRewritingCommonSuffixes(commonSuffixes []string, fldPath *fi
 		} else {
 			suffixes[s] = struct{}{}
 		}
+
+		if len(validation.IsDNS1123Subdomain(strings.TrimSuffix(s, "."))) != 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "must be a valid DNS subdomain"))
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -520,6 +520,10 @@ func validateAddons(addons *core.Addons, purpose *core.ShootPurpose, workerless 
 	}
 
 	if helper.NginxIngressEnabled(addons) {
+		for i, sourceRange := range addons.NginxIngress.LoadBalancerSourceRanges {
+			allErrs = append(allErrs, validation.IsValidCIDR(fldPath.Child("nginxIngress", "loadBalancerSourceRanges").Index(i), sourceRange)...)
+		}
+
 		if policy := addons.NginxIngress.ExternalTrafficPolicy; policy != nil {
 			if !availableNginxIngressExternalTrafficPolicies.Has(string(*policy)) {
 				allErrs = append(allErrs, field.NotSupported(fldPath.Child("nginxIngress", "externalTrafficPolicy"), *policy, sets.List(availableNginxIngressExternalTrafficPolicies)))

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -955,8 +955,12 @@ func validateNetworking(networking *core.Networking, workerless bool, fldPath *f
 			return allErrs
 		}
 
+		path := fldPath.Child("type")
 		if len(ptr.Deref(networking.Type, "")) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("type"), "networking type must be provided"))
+			allErrs = append(allErrs, field.Required(path, "networking type must be provided"))
+		} else if len(metav1validation.ValidateLabelName(v1beta1constants.LabelExtensionNetworkingTypePrefix+ptr.Deref(networking.Type, ""), path)) > 0 {
+			// The original errors returned by ValidateLabelName may be irritating due to the label prefix.
+			allErrs = append(allErrs, field.Invalid(path, networking.Type, "type must be a valid label name"))
 		}
 	}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3732,6 +3732,28 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
+			It("should forbid specifying a networking type with invalid characters", func() {
+				shoot.Spec.Networking.Type = ptr.To("$/()[]{}")
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.networking.type"),
+				}))))
+			})
+
+			It("should forbid specifying a very long networking type", func() {
+				shoot.Spec.Networking.Type = ptr.To("my-extremely-long-networking-type-that-exceeds-the-maximum-length")
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.networking.type"),
+				}))))
+			})
+
 			It("should forbid changing the networking type", func() {
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.Networking.Type = ptr.To("some-other-type")

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -599,6 +599,23 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		Context("exposure class", func() {
+			It("should forbid invalid exposure class names", func() {
+				shoot.Spec.ExposureClassName = ptr.To("$invalid.class.[]name{}/")
+				errorList := ValidateShoot(shoot)
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.exposureClassName"),
+					})),
+				))
+			})
+
+			It("should allow valid exposure class name", func() {
+				shoot.Spec.ExposureClassName = ptr.To("exposure-class-1")
+				errorList := ValidateShoot(shoot)
+				Expect(errorList).To(BeEmpty())
+			})
+
 			It("should pass as exposure class is not changed", func() {
 				shoot.Spec.ExposureClassName = ptr.To("exposure-class-1")
 				newShoot := prepareShootForUpdate(shoot)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -697,6 +697,37 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
+			It("should allow valid load balancer source ranges for nginx-ingress", func() {
+				shoot.Spec.Addons.NginxIngress.LoadBalancerSourceRanges = []string{"192.168.123.56/32", "2001:db8::/64"}
+				errorList := ValidateShoot(shoot)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should forbid invalid load balancer source ranges for nginx-ingress", func() {
+				shoot.Spec.Addons.NginxIngress.LoadBalancerSourceRanges = []string{"", "invalid-source-range", "192.168.123.56/33", "2001:db.8::/64"}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.addons.nginxIngress.loadBalancerSourceRanges[0]"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.addons.nginxIngress.loadBalancerSourceRanges[1]"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.addons.nginxIngress.loadBalancerSourceRanges[2]"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.addons.nginxIngress.loadBalancerSourceRanges[3]"),
+					})),
+				))
+			})
+
 			It("should allow external traffic policies 'Cluster' for nginx-ingress", func() {
 				v := corev1.ServiceExternalTrafficPolicyCluster
 				shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -4101,6 +4101,18 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"BadValue": Equal("foo.bar."),
 					})),
 				)),
+				Entry("should not allow extremely long domains", []string{"extremely-long-domain-name-with-repeating-subdomains.extremely-long-domain-name-with-repeating-subdomains.extremely-long-domain-name-with-repeating-subdomains.extremely-long-domain-name-with-repeating-subdomains.extremely-long-domain-name-with-repeating-subdomains.bar"}, ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Detail": ContainSubstring("must be a valid DNS subdomain"),
+					})),
+				)),
+				Entry("should not allow invalid characters", []string{"foo/$()[]{}.bar"}, ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Detail": ContainSubstring("must be a valid DNS subdomain"),
+					})),
+				)),
 			)
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area quality
/area robustness
/area security
/kind enhancement

**What this PR does / why we need it**:

Validating the input provided for `Shoot` resources and returning errors early helps cluster owners understand the issues better. Some of the networking-related `Shoot` fields lacked proper validation so that a user received an early error. Most of the issues addressed in this pull request would have led to errors during `Shoot` reconciliation later on, but the error messages might not have been good. Therefore, it is better to check properly during admission and return understandable errors related to the corresponding input.

The following `Shoot` fields have more validation with this change:
- `spec.networking.type`
- `spec.systemComponents.coreDNS.rewriting.commonSuffixes`
- `spec.addons.nginxIngress.loadBalancerSourceRanges`
- `spec.addons.nginxIngress.config`
- `spec.exposureClassName`

In addition to that, `ObjectMeta` of `ExposureClass` resource is now checked properly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The additional validation of `ExposureClass` is potentially more breaking than the other validations. However, it is considered to be very unlikely that it will actually cause any issues as the `ExposureClass` feature is not widely used.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The name of `ExposureClass` resources is now properly checked to be compliant to the DNS label rules.
```
```breaking operator
`spec.networking.type` is now validated as being a label name.
```
```breaking operator
`spec.systemComponents.coreDNS.rewriting.commonSuffixes` are now validated against DNS rules.
```
```breaking operator
`spec.addons.nginxIngress.loadBalancerSourceRanges` are now validated as CIDRs.
```
```breaking operator
`spec.addons.nginxIngress.config` is now validated as conforming to config map data rules.
```