### PR TITLE
Fix missing traffic distribution policy for `istio-ingress-gateway` internal service on certain Kubernetes versions

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/service-internal.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/service-internal.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     networking.resources.gardener.cloud/from-world-to-ports: '[{"port":9443,"protocol":"TCP"}]'
     networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"gardener.cloud/role":"extension"}},{"matchLabels":{"gardener.cloud/role":"shoot"}},{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
-{{- if semverCompare "< 1.31.0" .Values.kubernetesVersion }}
+{{- if semverCompare "< 1.31-0" .Values.kubernetesVersion }}
     service.kubernetes.io/topology-mode: "auto"
 {{- end }}
 {{- if .Values.annotations }}
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
   labels:
     app.kubernetes.io/version: {{ .Values.ingressVersion }}
-{{- if semverCompare "< 1.31.0" .Values.kubernetesVersion }}
+{{- if semverCompare "< 1.31-0" .Values.kubernetesVersion }}
     endpoint-slice-hints.resources.gardener.cloud/consider: "true"
 {{- end }}
 {{ .Values.labels | toYaml | indent 4 }}
@@ -32,6 +32,6 @@ spec:
   - IPv4
   ipFamilyPolicy: PreferDualStack
 {{- end }}
-{{- if semverCompare ">= 1.31.0" .Values.kubernetesVersion }}
+{{- if semverCompare ">= 1.31-0" .Values.kubernetesVersion }}
   trafficDistribution: PreferClose
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug with `semverCompare` in the `istio-ingress` helm chart which could lead to a missing traffic distribution policy in the internal istio-ingressgateway service.
The bug occurred when the Kubernetes version of the cluster had a format like `v1.23.4-abc`.

**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the `istio-ingress` helm chart which could lead to a missing traffic distribution policy in the internal istio-ingressgateway service on certain Kubernetes versions has been fixed.
```
